### PR TITLE
refactor: PartitionDistributor is injected into transformers

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -41,7 +41,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 public final class ClusterConfigurationManagerService
     implements ClusterConfigurationUpdateNotifier, AsyncClosable {
@@ -62,6 +64,7 @@ public final class ClusterConfigurationManagerService
   private final ClusterChangeExecutor clusterChangeExecutor;
   private final TopologyMetrics topologyMetrics;
   private final TopologyManagerMetrics topologyManagerMetrics;
+  private @Nullable volatile PartitionDistributor partitionDistributor;
 
   public ClusterConfigurationManagerService(
       final Path dataRootDirectory,
@@ -107,7 +110,10 @@ public final class ClusterConfigurationManagerService
             communicationService,
             new ProtoBufSerializer(),
             new ClusterConfigurationManagementRequestsHandler(
-                configurationChangeCoordinator, localMemberId, managerActor));
+                configurationChangeCoordinator,
+                () -> Objects.requireNonNull(partitionDistributor, "partitionDistributor is null"),
+                localMemberId,
+                managerActor));
 
     clusterConfigurationManager.setConfigurationGossiper(
         clusterConfigurationGossiper::updateClusterConfiguration);
@@ -178,6 +184,8 @@ public final class ClusterConfigurationManagerService
   public ActorFuture<Void> start(
       final ActorSchedulingService actorSchedulingService,
       final StaticConfiguration staticConfiguration) {
+    // TODO this needs to change once the partition distribution config is in ClusterConfiguration
+    partitionDistributor = staticConfiguration.partitionDistributor();
     return startGossiper(actorSchedulingService)
         .andThen(
             () -> startClusterTopologyServices(actorSchedulingService, staticConfiguration),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.PartitionDistributor;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
@@ -36,6 +37,7 @@ import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Handles the requests for the configuration management. This is expected be running on the
@@ -44,14 +46,17 @@ import java.util.function.Function;
 public final class ClusterConfigurationManagementRequestsHandler
     implements ClusterConfigurationManagementApi {
   private final ConfigurationChangeCoordinator coordinator;
+  private final Supplier<PartitionDistributor> partitionDistributor;
   private final ConcurrencyControl executor;
   private final MemberId localMemberId;
 
   public ClusterConfigurationManagementRequestsHandler(
       final ConfigurationChangeCoordinator coordinator,
+      final Supplier<PartitionDistributor> partitionDistributor,
       final MemberId localMemberId,
       final ConcurrencyControl executor) {
     this.coordinator = coordinator;
+    this.partitionDistributor = partitionDistributor;
     this.executor = executor;
     this.localMemberId = localMemberId;
   }
@@ -105,7 +110,8 @@ public final class ClusterConfigurationManagementRequestsHandler
       final ReassignPartitionsRequest reassignPartitionsRequest) {
     return handleRequest(
         reassignPartitionsRequest.dryRun(),
-        new PartitionReassignRequestTransformer(reassignPartitionsRequest.members()));
+        new PartitionReassignRequestTransformer(
+            partitionDistributor, reassignPartitionsRequest.members()));
   }
 
   @Override
@@ -113,7 +119,8 @@ public final class ClusterConfigurationManagementRequestsHandler
       final BrokerScaleRequest scaleRequest) {
     return handleRequest(
         scaleRequest.dryRun(),
-        new ScaleRequestTransformer(scaleRequest.members(), scaleRequest.newReplicationFactor()));
+        new ScaleRequestTransformer(
+            partitionDistributor, scaleRequest.members(), scaleRequest.newReplicationFactor()));
   }
 
   @Override
@@ -143,6 +150,7 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         clusterScaleRequest.dryRun(),
         new ClusterScaleRequestTransformer(
+            partitionDistributor,
             clusterScaleRequest.newClusterSize(),
             clusterScaleRequest.newPartitionCount(),
             clusterScaleRequest.newReplicationFactor()));
@@ -155,6 +163,7 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         clusterPatchRequest.dryRun(),
         new ClusterPatchRequestTransformer(
+            partitionDistributor,
             clusterPatchRequest.membersToAdd(),
             clusterPatchRequest.membersToRemove(),
             clusterPatchRequest.newPartitionCount(),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.PartitionDistributor;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -43,6 +44,15 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
+    // Changing the replication factor on a zone-aware cluster requires adjusting zone specs,
+    // which is not yet supported.
+    if (newReplicationFactor.isPresent()
+        && clusterConfiguration.members().keySet().stream().anyMatch(m -> m.zone() != null)) {
+      return Either.left(
+          new InvalidRequest(
+              "Changing the replication factor is not supported on zone-aware clusters."));
+    }
+
     // if membersToAdd and membersToRemove have common items, reject the request
     if (membersToAdd.stream().anyMatch(membersToRemove::contains)) {
       return Either.left(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.PartitionDistributor;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -16,19 +17,23 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public final class ClusterPatchRequestTransformer implements ConfigurationChangeRequest {
 
+  private final Supplier<PartitionDistributor> partitionDistributor;
   private final Set<MemberId> membersToAdd;
   private final Set<MemberId> membersToRemove;
   private final Optional<Integer> newPartitionCount;
   private final Optional<Integer> newReplicationFactor;
 
   public ClusterPatchRequestTransformer(
+      final Supplier<PartitionDistributor> partitionDistributor,
       final Set<MemberId> membersToAdd,
       final Set<MemberId> membersToRemove,
       final Optional<Integer> newPartitionCount,
       final Optional<Integer> newReplicationFactor) {
+    this.partitionDistributor = partitionDistributor;
     this.membersToAdd = membersToAdd;
     this.membersToRemove = membersToRemove;
     this.newPartitionCount = newPartitionCount;
@@ -50,7 +55,8 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
     newSetOfMembers.addAll(membersToAdd);
     newSetOfMembers.removeAll(membersToRemove);
 
-    return new ScaleRequestTransformer(newSetOfMembers, newReplicationFactor, newPartitionCount)
+    return new ScaleRequestTransformer(
+            partitionDistributor, newSetOfMembers, newReplicationFactor, newPartitionCount)
         .operations(clusterConfiguration);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -8,25 +8,30 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.PartitionDistributor;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public final class ClusterScaleRequestTransformer implements ConfigurationChangeRequest {
 
+  private final Supplier<PartitionDistributor> partitionDistributor;
   private final Optional<Integer> newClusterSize;
   private final Optional<Integer> newPartitionCount;
   private final Optional<Integer> newReplicationFactor;
 
   public ClusterScaleRequestTransformer(
+      final Supplier<PartitionDistributor> partitionDistributor,
       final Optional<Integer> newClusterSize,
       final Optional<Integer> newPartitionCount,
       final Optional<Integer> newReplicationFactor) {
+    this.partitionDistributor = partitionDistributor;
     this.newClusterSize = newClusterSize;
     this.newPartitionCount = newPartitionCount;
     this.newReplicationFactor = newReplicationFactor;
@@ -46,7 +51,8 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
         IntStream.range(0, newClusterSize.orElse(clusterConfiguration.members().size()))
             .mapToObj(i -> MemberId.from(String.valueOf(i)))
             .collect(Collectors.toSet());
-    return new ScaleRequestTransformer(newSetOfMembers, newReplicationFactor, newPartitionCount)
+    return new ScaleRequestTransformer(
+            partitionDistributor, newSetOfMembers, newReplicationFactor, newPartitionCount)
         .operations(clusterConfiguration);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.PartitionDistributor;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -43,6 +44,15 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
     if (newClusterSize.isEmpty() && newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
       // Nothing to change
       return Either.right(List.of());
+    }
+
+    // Count-based scaling generates bare node IDs without zone info, which breaks
+    // zone-aware partition distributors. Reject until zone-aware scaling is implemented.
+    if (clusterConfiguration.members().keySet().stream().anyMatch(m -> m.zone() != null)) {
+      return Either.left(
+          new InvalidRequest(
+              "Scaling a zone-aware cluster by broker count is not supported."
+                  + " Specify broker IDs explicitly instead."));
     }
 
     // replicationFactor and partitionCount is validated in the delegated transformer.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -23,13 +23,13 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.StartPartitionScaleUp;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
-import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -39,21 +39,26 @@ import java.util.stream.Stream;
  * strategy.
  */
 public class PartitionReassignRequestTransformer implements ConfigurationChangeRequest {
+
   final Set<MemberId> members;
+  private final Supplier<PartitionDistributor> partitionDistributor;
   private final Optional<Integer> newReplicationFactor;
   private final Optional<Integer> newPartitionCount;
 
   public PartitionReassignRequestTransformer(
+      final Supplier<PartitionDistributor> partitionDistributor,
       final Set<MemberId> members,
       final Optional<Integer> newReplicationFactor,
       final Optional<Integer> newPartitionCount) {
+    this.partitionDistributor = partitionDistributor;
     this.members = members;
     this.newReplicationFactor = newReplicationFactor;
     this.newPartitionCount = newPartitionCount;
   }
 
-  public PartitionReassignRequestTransformer(final Set<MemberId> members) {
-    this(members, Optional.empty(), Optional.empty());
+  public PartitionReassignRequestTransformer(
+      final Supplier<PartitionDistributor> partitionDistributor, final Set<MemberId> members) {
+    this(partitionDistributor, members, Optional.empty(), Optional.empty());
   }
 
   @Override
@@ -126,13 +131,12 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
                         .toList())
             .orElse(List.of());
 
-    final PartitionDistributor roundRobinDistributor = new RoundRobinPartitionDistributor();
-
     final var allPartitions =
         Stream.of(oldPartitions, newPartitions).flatMap(List::stream).toList();
 
     final var newDistribution =
-        roundRobinDistributor
+        partitionDistributor
+            .get()
             .distributePartitions(brokers, allPartitions, replicationFactor)
             .stream()
             .collect(Collectors.toMap(PartitionMetadata::id, p -> p));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.PartitionDistributor;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class ScaleRequestTransformer implements ConfigurationChangeRequest {
@@ -27,20 +29,26 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
   private final Optional<Integer> newPartitionCount;
   private final ArrayList<ClusterConfigurationChangeOperation> generatedOperations =
       new ArrayList<>();
+  private final Supplier<PartitionDistributor> partitionDistributor;
 
-  public ScaleRequestTransformer(final Set<MemberId> members) {
-    this(members, Optional.empty());
+  public ScaleRequestTransformer(
+      final Supplier<PartitionDistributor> partitionDistributor, final Set<MemberId> members) {
+    this(partitionDistributor, members, Optional.empty());
   }
 
   public ScaleRequestTransformer(
-      final Set<MemberId> members, final Optional<Integer> newReplicationFactor) {
-    this(members, newReplicationFactor, Optional.empty());
+      final Supplier<PartitionDistributor> partitionDistributor,
+      final Set<MemberId> members,
+      final Optional<Integer> newReplicationFactor) {
+    this(partitionDistributor, members, newReplicationFactor, Optional.empty());
   }
 
   public ScaleRequestTransformer(
+      final Supplier<PartitionDistributor> partitionDistributor,
       final Set<MemberId> members,
       final Optional<Integer> newReplicationFactor,
       final Optional<Integer> newPartitionCount) {
+    this.partitionDistributor = partitionDistributor;
     this.members = members;
     this.newReplicationFactor = newReplicationFactor;
     this.newPartitionCount = newPartitionCount;
@@ -69,7 +77,7 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
         .flatMap(
             ignore ->
                 new PartitionReassignRequestTransformer(
-                        members, newReplicationFactor, newPartitionCount)
+                        partitionDistributor, members, newReplicationFactor, newPartitionCount)
                     .operations(clusterConfiguration))
         .map(this::addToOperations)
         // then remove members that are not part of the new configuration

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,7 +115,13 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
                                     localMemberId)));
                         return;
                       }
-                      final var generatedOperations = request.operations(currentClusterTopology);
+                      Either<Exception, List<ClusterConfigurationChangeOperation>>
+                          generatedOperations;
+                      try {
+                        generatedOperations = request.operations(currentClusterTopology);
+                      } catch (final Exception e) {
+                        generatedOperations = Either.left(e);
+                      }
                       if (generatedOperations.isLeft()) {
                         failFuture(future, generatedOperations.getLeft());
                         return;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -46,6 +46,7 @@ import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
@@ -108,7 +109,10 @@ final class ClusterConfigurationManagementApiTest {
             coordinator.getCommunicationService(),
             new ProtoBufSerializer(),
             new ClusterConfigurationManagementRequestsHandler(
-                recordingCoordinator, id0, new TestConcurrencyControl()));
+                recordingCoordinator,
+                RoundRobinPartitionDistributor::new,
+                id0,
+                new TestConcurrencyControl()));
 
     requestServer.start();
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -51,6 +51,7 @@ final class ClusterPatchRequestTransformerTest {
     // when
     final var result =
         new ClusterPatchRequestTransformer(
+                RoundRobinPartitionDistributor::new,
                 patchRequest.membersToAdd(),
                 patchRequest.membersToRemove(),
                 patchRequest.newPartitionCount(),
@@ -76,6 +77,7 @@ final class ClusterPatchRequestTransformerTest {
         new ClusterPatchRequest(Set.of(), Set.of(), Optional.of(1), Optional.empty(), false);
     final var result =
         new ClusterPatchRequestTransformer(
+                RoundRobinPartitionDistributor::new,
                 patchRequest.membersToAdd(),
                 patchRequest.membersToRemove(),
                 patchRequest.newPartitionCount(),
@@ -230,6 +232,7 @@ final class ClusterPatchRequestTransformerTest {
     // when
     final var result =
         new ClusterPatchRequestTransformer(
+                RoundRobinPartitionDistributor::new,
                 patchRequest.membersToAdd(),
                 patchRequest.membersToRemove(),
                 patchRequest.newPartitionCount(),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -165,6 +165,7 @@ final class ClusterScaleRequestTransformerTest {
     // when
     final var result =
         new ClusterScaleRequestTransformer(
+                RoundRobinPartitionDistributor::new,
                 patchRequest.newClusterSize(),
                 patchRequest.newPartitionCount(),
                 patchRequest.newReplicationFactor())

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
@@ -132,7 +132,8 @@ class PartitionReassignRequestTransformerTest {
 
     //  when
     final var operationsEither =
-        new PartitionReassignRequestTransformer(getClusterMembers(newClusterSize))
+        new PartitionReassignRequestTransformer(
+                RoundRobinPartitionDistributor::new, getClusterMembers(newClusterSize))
             .operations(oldClusterTopology);
 
     // then
@@ -201,6 +202,7 @@ class PartitionReassignRequestTransformerTest {
     // when
     final var request =
         new PartitionReassignRequestTransformer(
+            RoundRobinPartitionDistributor::new,
             getClusterMembers(newClusterSize),
             Optional.of(newReplicationFactor),
             Optional.of(newPartitionCount));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -132,7 +132,8 @@ class ScaleRequestTransformerTest {
 
     //  when
     final var operationsEither =
-        new ScaleRequestTransformer(getClusterMembers(newClusterSize))
+        new ScaleRequestTransformer(
+                RoundRobinPartitionDistributor::new, getClusterMembers(newClusterSize))
             .operations(oldClusterTopology);
 
     // then
@@ -166,7 +167,8 @@ class ScaleRequestTransformerTest {
 
     // when
     final var operations =
-        new ScaleRequestTransformer(getClusterMembers(newClusterSize))
+        new ScaleRequestTransformer(
+                RoundRobinPartitionDistributor::new, getClusterMembers(newClusterSize))
             .operations(oldClusterTopology)
             .get();
 
@@ -214,7 +216,10 @@ class ScaleRequestTransformerTest {
         ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "clusterId");
     final var transformer =
         new ScaleRequestTransformer(
-            getClusterMembers(clusterSize), Optional.of(3), Optional.of(desiredPartitionCount));
+            RoundRobinPartitionDistributor::new,
+            getClusterMembers(clusterSize),
+            Optional.of(3),
+            Optional.of(desiredPartitionCount));
     final var operations = transformer.operations(config);
     if (desiredPartitionCount < currentPartitionCount) {
       EitherAssert.assertThat(operations).isLeft();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
@@ -329,6 +329,30 @@ abstract class ClusterEndpointIT {
     }
   }
 
+  protected void assertClusterScaleResponse(
+      final ClusterActuator actuator, final ClusterConfigPatchRequest request) {
+    final var response = actuator.patchCluster(request, true, false);
+    assertThat(response.getExpectedTopology())
+        .describedAs("ClusterSize is " + brokerCount())
+        .hasSize(brokerCount());
+    assertThat(response.getExpectedTopology().getFirst().getPartitions().size())
+        .describedAs("Partitions are evenly distributed")
+        .isEqualTo(response.getExpectedTopology().getLast().getPartitions().size());
+    assertThat(response.getPlannedChanges()).isNotEmpty();
+  }
+
+  protected void assertClusterPatchResponse(
+      final ClusterActuator actuator, final ClusterConfigPatchRequest request) {
+    final var response = actuator.patchCluster(request, true, false);
+    assertThat(response.getExpectedTopology())
+        .describedAs("Cluster has " + brokerCount() + " brokers")
+        .hasSize(brokerCount());
+    assertThat(response.getExpectedTopology().getFirst().getPartitions().size())
+        .describedAs("Partitions are evenly distributed")
+        .isEqualTo(response.getExpectedTopology().getLast().getPartitions().size());
+    assertThat(response.getPlannedChanges()).isNotEmpty();
+  }
+
   @Nested
   final class ClusterPatchRequest {
     @Test
@@ -346,16 +370,8 @@ abstract class ClusterEndpointIT {
                     new ClusterConfigPatchRequestPartitions()
                         .count(partitionCount())
                         .replicationFactor(minReplicationFactor() + 1));
-        final var response = actuator.patchCluster(request, true, false);
         // then
-        assertThat(response.getExpectedTopology())
-            .describedAs("ClusterSize is " + brokerCount())
-            .hasSize(brokerCount());
-        assertThat(response.getExpectedTopology().getFirst().getPartitions().size())
-            .describedAs("Partitions are evenly distributed")
-            .isEqualTo(response.getExpectedTopology().getLast().getPartitions().size());
-
-        assertThat(response.getPlannedChanges()).isNotEmpty();
+        assertClusterScaleResponse(actuator, request);
       }
     }
 
@@ -374,16 +390,8 @@ abstract class ClusterEndpointIT {
                     new ClusterConfigPatchRequestPartitions()
                         .count(partitionCount())
                         .replicationFactor(minReplicationFactor() + 1));
-        final var response = actuator.patchCluster(request, true, false);
         // then
-        assertThat(response.getExpectedTopology())
-            .describedAs("Cluster has " + brokerCount() + " brokers")
-            .hasSize(brokerCount());
-        assertThat(response.getExpectedTopology().getFirst().getPartitions().size())
-            .describedAs("Partitions are evenly distributed")
-            .isEqualTo(response.getExpectedTopology().getLast().getPartitions().size());
-
-        assertThat(response.getPlannedChanges()).isNotEmpty();
+        assertClusterPatchResponse(actuator, request);
       }
     }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -80,6 +80,22 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
         BrokerMemberId.from(ZONES[nodeIdx % ZONES.length], nodeIdx / ZONES.length).toString());
   }
 
+  @Override
+  protected void assertClusterScaleResponse(
+      final ClusterActuator actuator, final ClusterConfigPatchRequest request) {
+    assertThatCode(() -> actuator.patchCluster(request, true, false))
+        .isInstanceOf(FeignException.BadRequest.class)
+        .hasMessageContaining("zone-aware");
+  }
+
+  @Override
+  protected void assertClusterPatchResponse(
+      final ClusterActuator actuator, final ClusterConfigPatchRequest request) {
+    assertThatCode(() -> actuator.patchCluster(request, true, false))
+        .isInstanceOf(FeignException.BadRequest.class)
+        .hasMessageContaining("zone-aware");
+  }
+
   @Test
   void shouldRejectBareIntegersWhenScaling() {
     try (final var cluster = createCluster(brokerCount())) {


### PR DESCRIPTION
## Description
To support `ZoneAwarePartitionDistributor` when multi zone, the `PartitionDistributor` must be injected into transformers at runtime.

Currently it's taken from the static configuration, so it does not support scaling operations, that will be addressed in a follow up PR.

A `Supplier` is required as the `StaticConfiguration` is available after `start()` is called, not in the constructor itself.

Scaling operations (brokers) or Replication factor changes are temporarily disabled as they are not working correctly 
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #53982 
