### PR TITLE
feat: update document reference schema in camunda-api-zod-schemas

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.10.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.69",
+        "@camunda/camunda-api-zod-schemas": "0.0.71",
         "@camunda/camunda-composite-components": "0.23.3",
         "@carbon/elements": "11.90.0",
         "@carbon/react": "1.105.0",
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.69.tgz",
-      "integrity": "sha512-M2T2GU8gA7QQQ0t1r70reSmxKw171OErLypoNcVVS/4w7z6AD+TYzH788Ajj/HIkcHQtOuXBnM6Be0F/14MX1A==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.71.tgz",
+      "integrity": "sha512-8m7Tszc36hWN6wD7t7+c4XMfSaFruGvC2cwH3eU6JQQOyuRq5ji+1ibH9hENh6qASLix3qcRq724n5Lk0LSPpw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.69",
+    "@camunda/camunda-api-zod-schemas": "0.0.71",
     "@camunda/camunda-composite-components": "0.23.3",
     "@carbon/elements": "11.90.0",
     "@carbon/react": "1.105.0",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.3",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.70",
+        "@camunda/camunda-api-zod-schemas": "0.0.71",
         "@camunda/camunda-composite-components": "0.23.3",
         "@carbon/elements": "11.90.0",
         "@carbon/react": "1.105.0",
@@ -457,9 +457,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.70.tgz",
-      "integrity": "sha512-6IKxCLhGZNVpcHqkJZkyhJCdmo/eqvkcEKj9JHS8gkQmBQ/Qs4y2Flh5M5gALSIH8Ca5z4c179evQT+OLVSgdw==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.71.tgz",
+      "integrity": "sha512-8m7Tszc36hWN6wD7t7+c4XMfSaFruGvC2cwH3eU6JQQOyuRq5ji+1ibH9hENh6qASLix3qcRq724n5Lk0LSPpw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.3",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.70",
+    "@camunda/camunda-api-zod-schemas": "0.0.71",
     "@camunda/camunda-composite-components": "0.23.3",
     "@carbon/elements": "11.90.0",
     "@carbon/react": "1.105.0",

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.21.3",
         "@bpmn-io/form-js-viewer": "1.21.3",
-        "@camunda/camunda-api-zod-schemas": "0.0.69",
+        "@camunda/camunda-api-zod-schemas": "0.0.71",
         "@camunda/camunda-composite-components": "0.23.3",
         "@carbon/react": "1.105.0",
         "@monaco-editor/react": "4.7.0",
@@ -585,9 +585,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.69.tgz",
-      "integrity": "sha512-M2T2GU8gA7QQQ0t1r70reSmxKw171OErLypoNcVVS/4w7z6AD+TYzH788Ajj/HIkcHQtOuXBnM6Be0F/14MX1A==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.71.tgz",
+      "integrity": "sha512-8m7Tszc36hWN6wD7t7+c4XMfSaFruGvC2cwH3eU6JQQOyuRq5ji+1ibH9hENh6qASLix3qcRq724n5Lk0LSPpw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.21.3",
     "@bpmn-io/form-js-viewer": "1.21.3",
-    "@camunda/camunda-api-zod-schemas": "0.0.69",
+    "@camunda/camunda-api-zod-schemas": "0.0.71",
     "@camunda/camunda-composite-components": "0.23.3",
     "@carbon/react": "1.105.0",
     "@monaco-editor/react": "4.7.0",

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -17,7 +17,7 @@
 		"generate:svg": "svgr --typescript --no-index --out-dir src/modules/svg src/assets/svg"
 	},
 	"dependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.70",
+		"@camunda/camunda-api-zod-schemas": "0.0.71",
 		"@camunda/camunda-composite-components": "0.23.3",
 		"@tanstack/react-query": "5.100.14",
 		"@tanstack/react-query-devtools": "5.100.14",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -22,7 +22,7 @@
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.70",
+				"@camunda/camunda-api-zod-schemas": "0.0.71",
 				"@camunda/camunda-composite-components": "0.23.3",
 				"@tanstack/react-query": "5.100.14",
 				"@tanstack/react-query-devtools": "5.100.14",
@@ -9567,13 +9567,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.70",
+				"@camunda/camunda-api-zod-schemas": "0.0.71",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.70",
+			"version": "0.0.71",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.9.1",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.70",
+		"@camunda/camunda-api-zod-schemas": "0.0.71",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.0.71
+
+### 🩹 Fixes
+
+- Align `DocumentReference` nullable fields with OpenAPI schema. The following fields are now nullable:
+  - `contentHash`
+  - `metadata.expiresAt`
+  - `metadata.processDefinitionId`
+  - `metadata.processInstanceKey`
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.70
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/document.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/document.ts
@@ -12,10 +12,10 @@ import {API_VERSION, type Endpoint} from './common';
 const documentMetadataSchema = z.object({
 	contentType: z.string(),
 	fileName: z.string(),
-	expiresAt: z.string(),
+	expiresAt: z.string().nullable(),
 	size: z.number(),
-	processDefinitionId: z.string(),
-	processInstanceKey: z.string(),
+	processDefinitionId: z.string().nullable(),
+	processInstanceKey: z.string().nullable(),
 	customProperties: z.record(z.string(), z.unknown()),
 });
 type DocumentMetadata = z.infer<typeof documentMetadataSchema>;
@@ -24,7 +24,7 @@ const documentReferenceSchema = z.object({
 	'camunda.document.type': z.literal('camunda'),
 	storeId: z.string(),
 	documentId: z.string(),
-	contentHash: z.string(),
+	contentHash: z.string().nullable(),
 	metadata: documentMetadataSchema,
 });
 type DocumentReference = z.infer<typeof documentReferenceSchema>;

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.8/document.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.8/document.ts
@@ -12,10 +12,10 @@ import {API_VERSION, type Endpoint} from '../common';
 const documentMetadataSchema = z.object({
 	contentType: z.string(),
 	fileName: z.string(),
-	expiresAt: z.string(),
+	expiresAt: z.string().nullable(),
 	size: z.number(),
-	processDefinitionId: z.string(),
-	processInstanceKey: z.string(),
+	processDefinitionId: z.string().nullable(),
+	processInstanceKey: z.string().nullable(),
 	customProperties: z.record(z.string(), z.unknown()),
 });
 type DocumentMetadata = z.infer<typeof documentMetadataSchema>;
@@ -24,7 +24,7 @@ const documentReferenceSchema = z.object({
 	'camunda.document.type': z.literal('camunda'),
 	storeId: z.string(),
 	documentId: z.string(),
-	contentHash: z.string(),
+	contentHash: z.string().nullable(),
 	metadata: documentMetadataSchema,
 });
 type DocumentReference = z.infer<typeof documentReferenceSchema>;

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.9/document.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.9/document.ts
@@ -12,10 +12,10 @@ import {API_VERSION, type Endpoint} from './common';
 const documentMetadataSchema = z.object({
 	contentType: z.string(),
 	fileName: z.string(),
-	expiresAt: z.string(),
+	expiresAt: z.string().nullable(),
 	size: z.number(),
-	processDefinitionId: z.string(),
-	processInstanceKey: z.string(),
+	processDefinitionId: z.string().nullable(),
+	processInstanceKey: z.string().nullable(),
 	customProperties: z.record(z.string(), z.unknown()),
 });
 type DocumentMetadata = z.infer<typeof documentMetadataSchema>;
@@ -24,7 +24,7 @@ const documentReferenceSchema = z.object({
 	'camunda.document.type': z.literal('camunda'),
 	storeId: z.string(),
 	documentId: z.string(),
-	contentHash: z.string(),
+	contentHash: z.string().nullable(),
 	metadata: documentMetadataSchema,
 });
 type DocumentReference = z.infer<typeof documentReferenceSchema>;

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.70",
+	"version": "0.0.71",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

This PR aligns the Zod schemata with a `DocumentReferenceResponse` in the [OpenAPI schema](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/create-document/). Four fields were not `nullable` even though they are `nullable` in the OpenAPI.

> [!NOTE]
> I adjusted the schema across all versions because the schema appears to be older than 8.7. Let me know if we want to change it to only update 8.10.

## Related issues

relates #53725
