### PR TITLE
feat: add agentic dashboard service and seeding

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/dashboard/DashboardDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/dashboard/DashboardDefinitionExportDto.java
@@ -29,6 +29,7 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
   @NotNull private List<DashboardFilterDto<?>> availableFilters = new ArrayList<>();
   private String collectionId;
   private boolean isInstantPreviewDashboard = false;
+  private boolean isAgenticControlDashboard = false;
 
   public DashboardDefinitionExportDto(final DashboardDefinitionRestDto dashboardDefinition) {
     super(
@@ -92,6 +93,14 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
     this.isInstantPreviewDashboard = isInstantPreviewDashboard;
   }
 
+  public boolean isAgenticControlDashboard() {
+    return isAgenticControlDashboard;
+  }
+
+  public void setAgenticControlDashboard(final boolean isAgenticControlDashboard) {
+    this.isAgenticControlDashboard = isAgenticControlDashboard;
+  }
+
   @Override
   protected boolean canEqual(final Object other) {
     return other instanceof DashboardDefinitionExportDto;
@@ -100,7 +109,12 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
   @Override
   public int hashCode() {
     return Objects.hash(
-        super.hashCode(), tiles, availableFilters, collectionId, isInstantPreviewDashboard);
+        super.hashCode(),
+        tiles,
+        availableFilters,
+        collectionId,
+        isInstantPreviewDashboard,
+        isAgenticControlDashboard);
   }
 
   @Override
@@ -116,6 +130,7 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
     }
     final DashboardDefinitionExportDto that = (DashboardDefinitionExportDto) o;
     return isInstantPreviewDashboard == that.isInstantPreviewDashboard
+        && isAgenticControlDashboard == that.isAgenticControlDashboard
         && Objects.equals(tiles, that.tiles)
         && Objects.equals(availableFilters, that.availableFilters)
         && Objects.equals(collectionId, that.collectionId);
@@ -131,6 +146,8 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
         + getCollectionId()
         + ", isInstantPreviewDashboard="
         + isInstantPreviewDashboard()
+        + ", isAgenticControlDashboard="
+        + isAgenticControlDashboard()
         + ")";
   }
 
@@ -141,5 +158,6 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
     public static final String availableFilters = "availableFilters";
     public static final String collectionId = "collectionId";
     public static final String isInstantPreviewDashboard = "isInstantPreviewDashboard";
+    public static final String isAgenticControlDashboard = "isAgenticControlDashboard";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/DashboardRestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/DashboardRestService.java
@@ -72,9 +72,10 @@ public class DashboardRestService {
     final String userId = sessionService.getRequestUserOrFailNotAuthorized(request);
     if (dashboardDefinitionDto != null) {
       if (dashboardDefinitionDto.isManagementDashboard()
-          || dashboardDefinitionDto.isInstantPreviewDashboard()) {
+          || dashboardDefinitionDto.isInstantPreviewDashboard()
+          || dashboardDefinitionDto.isAgenticControlDashboard()) {
         throw new OptimizeValidationException(
-            "Management and Instant preview dashboards cannot be created");
+            "Management, Instant preview and Agentic control dashboards cannot be created");
       }
       validateDashboard(dashboardDefinitionDto);
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/DashboardRestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/DashboardRestService.java
@@ -71,11 +71,9 @@ public class DashboardRestService {
       final HttpServletRequest request) {
     final String userId = sessionService.getRequestUserOrFailNotAuthorized(request);
     if (dashboardDefinitionDto != null) {
-      if (dashboardDefinitionDto.isManagementDashboard()
-          || dashboardDefinitionDto.isInstantPreviewDashboard()
-          || dashboardDefinitionDto.isAgenticControlDashboard()) {
+      if (dashboardDefinitionDto.isSystemGeneratedDashboard()) {
         throw new OptimizeValidationException(
-            "Management, Instant preview and Agentic control dashboards cannot be created");
+            DashboardService.SYSTEM_GENERATED_DASHBOARDS_LABEL + " cannot be created");
       }
       validateDashboard(dashboardDefinitionDto);
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/DashboardRestMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/DashboardRestMapper.java
@@ -67,7 +67,8 @@ public class DashboardRestMapper {
   private void localizeDashboard(
       final DashboardDefinitionRestDto dashboardDefinition, final String locale) {
     if (dashboardDefinition.isManagementDashboard()
-        || dashboardDefinition.isInstantPreviewDashboard()) {
+        || dashboardDefinition.isInstantPreviewDashboard()
+        || dashboardDefinition.isAgenticControlDashboard()) {
       final String validLocale = localizationService.validateAndReturnValidLocale(locale);
       if (dashboardDefinition.isManagementDashboard()) {
         Optional.ofNullable(
@@ -76,6 +77,15 @@ public class DashboardRestMapper {
             .ifPresent(dashboardDefinition::setName);
         Optional.ofNullable(
                 localizationService.getLocalizationForManagementDashboardCode(
+                    validLocale, dashboardDefinition.getDescription()))
+            .ifPresent(dashboardDefinition::setDescription);
+      } else if (dashboardDefinition.isAgenticControlDashboard()) {
+        Optional.ofNullable(
+                localizationService.getLocalizationForAgenticControlDashboardCode(
+                    validLocale, dashboardDefinition.getName()))
+            .ifPresent(dashboardDefinition::setName);
+        Optional.ofNullable(
+                localizationService.getLocalizationForAgenticControlDashboardCode(
                     validLocale, dashboardDefinition.getDescription()))
             .ifPresent(dashboardDefinition::setDescription);
       } else {

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/DashboardRestMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/DashboardRestMapper.java
@@ -15,6 +15,7 @@ import io.camunda.optimize.service.dashboard.InstantPreviewDashboardService;
 import io.camunda.optimize.service.identity.AbstractIdentityService;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -66,40 +67,37 @@ public class DashboardRestMapper {
 
   private void localizeDashboard(
       final DashboardDefinitionRestDto dashboardDefinition, final String locale) {
-    if (dashboardDefinition.isManagementDashboard()
-        || dashboardDefinition.isInstantPreviewDashboard()
-        || dashboardDefinition.isAgenticControlDashboard()) {
-      final String validLocale = localizationService.validateAndReturnValidLocale(locale);
-      if (dashboardDefinition.isManagementDashboard()) {
-        Optional.ofNullable(
-                localizationService.getLocalizationForManagementDashboardCode(
-                    validLocale, dashboardDefinition.getName()))
-            .ifPresent(dashboardDefinition::setName);
-        Optional.ofNullable(
-                localizationService.getLocalizationForManagementDashboardCode(
-                    validLocale, dashboardDefinition.getDescription()))
-            .ifPresent(dashboardDefinition::setDescription);
-      } else if (dashboardDefinition.isAgenticControlDashboard()) {
-        Optional.ofNullable(
-                localizationService.getLocalizationForAgenticControlDashboardCode(
-                    validLocale, dashboardDefinition.getName()))
-            .ifPresent(dashboardDefinition::setName);
-        Optional.ofNullable(
-                localizationService.getLocalizationForAgenticControlDashboardCode(
-                    validLocale, dashboardDefinition.getDescription()))
-            .ifPresent(dashboardDefinition::setDescription);
-      } else {
-        Optional.ofNullable(
-                localizationService.getLocalizationForInstantPreviewDashboardCode(
-                    validLocale, dashboardDefinition.getName()))
-            .ifPresent(dashboardDefinition::setName);
-        Optional.ofNullable(
-                localizationService.getLocalizationForInstantPreviewDashboardCode(
-                    validLocale, dashboardDefinition.getDescription()))
-            .ifPresent(dashboardDefinition::setDescription);
-        localizeTextsFromTextTiles(dashboardDefinition, validLocale);
-      }
+    if (!dashboardDefinition.isSystemGeneratedDashboard()) {
+      return;
     }
+    final String validLocale = localizationService.validateAndReturnValidLocale(locale);
+    if (dashboardDefinition.isManagementDashboard()) {
+      localizeNameAndDescription(
+          dashboardDefinition,
+          validLocale,
+          localizationService::getLocalizationForManagementDashboardCode);
+    } else if (dashboardDefinition.isAgenticControlDashboard()) {
+      localizeNameAndDescription(
+          dashboardDefinition,
+          validLocale,
+          localizationService::getLocalizationForAgenticControlDashboardCode);
+    } else {
+      localizeNameAndDescription(
+          dashboardDefinition,
+          validLocale,
+          localizationService::getLocalizationForInstantPreviewDashboardCode);
+      localizeTextsFromTextTiles(dashboardDefinition, validLocale);
+    }
+  }
+
+  private void localizeNameAndDescription(
+      final DashboardDefinitionRestDto dashboardDefinition,
+      final String locale,
+      final BiFunction<String, String, String> resolver) {
+    Optional.ofNullable(resolver.apply(locale, dashboardDefinition.getName()))
+        .ifPresent(dashboardDefinition::setName);
+    Optional.ofNullable(resolver.apply(locale, dashboardDefinition.getDescription()))
+        .ifPresent(dashboardDefinition::setDescription);
   }
 
   private void localizeTextsFromTextTiles(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/LocalizationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/LocalizationService.java
@@ -40,6 +40,7 @@ public class LocalizationService implements ConfigurationReloadable {
   private static final String API_ERRORS_FIELD = "apiErrors";
   private static final String MANAGEMENT_DASHBOARD_FIELD = "managementDashboard";
   private static final String INSTANT_DASHBOARD_FIELD = "instantDashboard";
+  private static final String AGENTIC_CONTROL_FIELD = "agenticControl";
   private static final String JSON_FILE_EXTENSION = "json";
   private static final String REPORT_FIELD = "report";
   private static final String REPORT_GROUPING_FIELD = "groupBy";
@@ -88,6 +89,11 @@ public class LocalizationService implements ConfigurationReloadable {
   public String getLocalizationForManagementDashboardCode(
       final String localeCode, final String dashboardCode) {
     return getMessageForCode(localeCode, MANAGEMENT_DASHBOARD_FIELD, dashboardCode);
+  }
+
+  public String getLocalizationForAgenticControlDashboardCode(
+      final String localeCode, final String dashboardCode) {
+    return getMessageForCode(localeCode, AGENTIC_CONTROL_FIELD, dashboardCode);
   }
 
   public String getLocalizationForInstantPreviewDashboardCode(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardFilterDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardInstanceEndDateFilterDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.filter.data.DashboardDateFilterDataDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto;
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RollingDateFilterDataDto;
+import io.camunda.optimize.service.db.reader.DashboardReader;
+import io.camunda.optimize.service.db.writer.DashboardWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AgenticControlDashboardService {
+
+  public static final String AGENTIC_DASHBOARD_ID = "agentic-control-plane-dashboard";
+
+  // Localization code resolved under the "agenticControl" category by DashboardRestMapper ->
+  // LocalizationService.
+  public static final String AGENTIC_DASHBOARD_NAME = "agenticControlPlaneDashboardName";
+
+  private static final long INSTANCE_END_DATE_ROLLING_DAYS = 30L;
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(AgenticControlDashboardService.class);
+
+  private final DashboardWriter dashboardWriter;
+  private final DashboardReader dashboardReader;
+  private final ConfigurationService configurationService;
+
+  public AgenticControlDashboardService(
+      final DashboardWriter dashboardWriter,
+      final DashboardReader dashboardReader,
+      final ConfigurationService configurationService) {
+    this.dashboardWriter = dashboardWriter;
+    this.dashboardReader = dashboardReader;
+    this.configurationService = configurationService;
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void init() {
+    if (configurationService.getEntityConfiguration().getCreateOnStartup()) {
+      LOG.info("Reconciling Agentic Control Plane dashboard");
+      reconcile();
+      LOG.info("Finished reconciling Agentic Control Plane dashboard");
+    }
+  }
+
+  public void reconcile() {
+    final var existing = dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID);
+    if (existing.isEmpty()) {
+      dashboardWriter.saveDashboard(buildAgentDashboard(List.of()));
+    }
+  }
+
+  private DashboardDefinitionRestDto buildAgentDashboard(final List<DashboardReportTileDto> tiles) {
+    final DashboardDefinitionRestDto dashboard = new DashboardDefinitionRestDto();
+    dashboard.setId(AGENTIC_DASHBOARD_ID);
+    dashboard.setName(AGENTIC_DASHBOARD_NAME);
+    dashboard.setAgenticControlDashboard(true);
+    dashboard.setCollectionId(null);
+    dashboard.setTiles(new ArrayList<>(tiles));
+    dashboard.setAvailableFilters(buildAvailableFilters());
+    return dashboard;
+  }
+
+  private List<DashboardFilterDto<?>> buildAvailableFilters() {
+    final DashboardInstanceEndDateFilterDto endDateFilter = new DashboardInstanceEndDateFilterDto();
+    final RollingDateFilterDataDto rolling =
+        new RollingDateFilterDataDto(
+            new RollingDateFilterStartDto(INSTANCE_END_DATE_ROLLING_DAYS, DateUnit.DAYS));
+    endDateFilter.setData(new DashboardDateFilterDataDto(rolling));
+    final List<DashboardFilterDto<?>> availableFilters = new ArrayList<>();
+    availableFilters.add(endDateFilter);
+    return availableFilters;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -10,7 +10,9 @@ package io.camunda.optimize.service.dashboard;
 import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardFilterDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardInstanceEndDateFilterDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardProcessScopeFilterDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.data.DashboardDateFilterDataDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.filter.data.DashboardProcessScopeFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
@@ -85,8 +87,11 @@ public class AgenticControlDashboardService {
         new RollingDateFilterDataDto(
             new RollingDateFilterStartDto(INSTANCE_END_DATE_ROLLING_DAYS, DateUnit.DAYS));
     endDateFilter.setData(new DashboardDateFilterDataDto(rolling));
+    final DashboardProcessScopeFilterDto processScopeFilter = new DashboardProcessScopeFilterDto();
+    processScopeFilter.setData(new DashboardProcessScopeFilterDataDto(null));
     final List<DashboardFilterDto<?>> availableFilters = new ArrayList<>();
     availableFilters.add(endDateFilter);
+    availableFilters.add(processScopeFilter);
     return availableFilters;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
@@ -70,6 +70,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class DashboardService implements ReportReferencingService, CollectionReferencingService {
 
+  public static final String SYSTEM_GENERATED_DASHBOARDS_LABEL =
+      "Management, Instant preview and Agentic control dashboards";
+
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(DashboardService.class);
   private final DashboardWriter dashboardWriter;
   private final DashboardReader dashboardReader;
@@ -209,11 +212,9 @@ public class DashboardService implements ReportReferencingService, CollectionRef
     final AuthorizedDashboardDefinitionResponseDto authorizedDashboard =
         getDashboardDefinition(dashboardId, userId);
     final DashboardDefinitionRestDto dashboardDefinition = authorizedDashboard.getDefinitionDto();
-    if (dashboardDefinition.isManagementDashboard()
-        || dashboardDefinition.isInstantPreviewDashboard()
-        || dashboardDefinition.isAgenticControlDashboard()) {
+    if (dashboardDefinition.isSystemGeneratedDashboard()) {
       throw new OptimizeValidationException(
-          "Management, Instant preview and Agentic control dashboards cannot be copied");
+          SYSTEM_GENERATED_DASHBOARDS_LABEL + " cannot be copied");
     }
 
     collectionService.verifyUserAuthorizedToEditCollectionResources(userId, collectionId);
@@ -371,9 +372,7 @@ public class DashboardService implements ReportReferencingService, CollectionRef
   private RoleType getUserRoleType(
       final String userId, final DashboardDefinitionRestDto dashboard) {
     RoleType currentUserRole = null;
-    if (dashboard.isManagementDashboard()
-        || dashboard.isInstantPreviewDashboard()
-        || dashboard.isAgenticControlDashboard()) {
+    if (dashboard.isSystemGeneratedDashboard()) {
       currentUserRole = RoleType.VIEWER;
     } else if (dashboard.getCollectionId() != null) {
       currentUserRole =
@@ -422,11 +421,9 @@ public class DashboardService implements ReportReferencingService, CollectionRef
     final AuthorizedDashboardDefinitionResponseDto dashboardWithEditAuthorization =
         getDashboardWithEditAuthorization(dashboardId, userId);
     if (dashboardWithEditAuthorization.getDefinitionDto() != null) {
-      if (dashboardWithEditAuthorization.getDefinitionDto().isManagementDashboard()
-          || dashboardWithEditAuthorization.getDefinitionDto().isInstantPreviewDashboard()
-          || dashboardWithEditAuthorization.getDefinitionDto().isAgenticControlDashboard()) {
+      if (dashboardWithEditAuthorization.getDefinitionDto().isSystemGeneratedDashboard()) {
         throw new OptimizeValidationException(
-            "Management, Instant preview and Agentic control dashboards cannot be edited");
+            SYSTEM_GENERATED_DASHBOARDS_LABEL + " cannot be edited");
       } else {
         validateEntityEditorAuthorization(
             dashboardWithEditAuthorization.getDefinitionDto().getCollectionId());
@@ -674,11 +671,9 @@ public class DashboardService implements ReportReferencingService, CollectionRef
 
   private void validateEntityCanBeDeletedByUser(
       final DashboardDefinitionRestDto dashboardDefinitionDto) {
-    if (dashboardDefinitionDto.isManagementDashboard()
-        || dashboardDefinitionDto.isInstantPreviewDashboard()
-        || dashboardDefinitionDto.isAgenticControlDashboard()) {
+    if (dashboardDefinitionDto.isSystemGeneratedDashboard()) {
       throw new OptimizeValidationException(
-          "Management, Instant preview and Agentic control dashboards cannot be deleted");
+          SYSTEM_GENERATED_DASHBOARDS_LABEL + " cannot be deleted");
     }
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
@@ -210,9 +210,10 @@ public class DashboardService implements ReportReferencingService, CollectionRef
         getDashboardDefinition(dashboardId, userId);
     final DashboardDefinitionRestDto dashboardDefinition = authorizedDashboard.getDefinitionDto();
     if (dashboardDefinition.isManagementDashboard()
-        || dashboardDefinition.isInstantPreviewDashboard()) {
+        || dashboardDefinition.isInstantPreviewDashboard()
+        || dashboardDefinition.isAgenticControlDashboard()) {
       throw new OptimizeValidationException(
-          "Management and Instant preview dashboards cannot be copied");
+          "Management, Instant preview and Agentic control dashboards cannot be copied");
     }
 
     collectionService.verifyUserAuthorizedToEditCollectionResources(userId, collectionId);
@@ -370,7 +371,9 @@ public class DashboardService implements ReportReferencingService, CollectionRef
   private RoleType getUserRoleType(
       final String userId, final DashboardDefinitionRestDto dashboard) {
     RoleType currentUserRole = null;
-    if (dashboard.isManagementDashboard() || dashboard.isInstantPreviewDashboard()) {
+    if (dashboard.isManagementDashboard()
+        || dashboard.isInstantPreviewDashboard()
+        || dashboard.isAgenticControlDashboard()) {
       currentUserRole = RoleType.VIEWER;
     } else if (dashboard.getCollectionId() != null) {
       currentUserRole =
@@ -420,9 +423,10 @@ public class DashboardService implements ReportReferencingService, CollectionRef
         getDashboardWithEditAuthorization(dashboardId, userId);
     if (dashboardWithEditAuthorization.getDefinitionDto() != null) {
       if (dashboardWithEditAuthorization.getDefinitionDto().isManagementDashboard()
-          || dashboardWithEditAuthorization.getDefinitionDto().isInstantPreviewDashboard()) {
+          || dashboardWithEditAuthorization.getDefinitionDto().isInstantPreviewDashboard()
+          || dashboardWithEditAuthorization.getDefinitionDto().isAgenticControlDashboard()) {
         throw new OptimizeValidationException(
-            "Management and Instant preview dashboards cannot be edited");
+            "Management, Instant preview and Agentic control dashboards cannot be edited");
       } else {
         validateEntityEditorAuthorization(
             dashboardWithEditAuthorization.getDefinitionDto().getCollectionId());
@@ -671,9 +675,10 @@ public class DashboardService implements ReportReferencingService, CollectionRef
   private void validateEntityCanBeDeletedByUser(
       final DashboardDefinitionRestDto dashboardDefinitionDto) {
     if (dashboardDefinitionDto.isManagementDashboard()
-        || dashboardDefinitionDto.isInstantPreviewDashboard()) {
+        || dashboardDefinitionDto.isInstantPreviewDashboard()
+        || dashboardDefinitionDto.isAgenticControlDashboard()) {
       throw new OptimizeValidationException(
-          "Management Dashboards and Instant preview dashboards cannot be deleted");
+          "Management, Instant preview and Agentic control dashboards cannot be deleted");
     }
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DashboardReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DashboardReaderES.java
@@ -57,8 +57,22 @@ public class DashboardReaderES implements DashboardReader {
                 b.optimizeIndex(esClient, DASHBOARD_INDEX_NAME)
                     .query(
                         q ->
-                            q.term(
-                                t -> t.field(DashboardIndex.MANAGEMENT_DASHBOARD).value(false))));
+                            q.bool(
+                                bool ->
+                                    bool.must(
+                                            m ->
+                                                m.term(
+                                                    t ->
+                                                        t.field(DashboardIndex.MANAGEMENT_DASHBOARD)
+                                                            .value(false)))
+                                        .mustNot(
+                                            m ->
+                                                m.term(
+                                                    t ->
+                                                        t.field(
+                                                                DashboardIndex
+                                                                    .AGENTIC_CONTROL_DASHBOARD)
+                                                            .value(true))))));
     try {
       return esClient.count(countRequest).count();
     } catch (final IOException e) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/EntitiesReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/EntitiesReaderES.java
@@ -14,6 +14,7 @@ import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
 import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_DECISION_REPORT_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_PROCESS_REPORT_INDEX_NAME;
 import static io.camunda.optimize.service.db.es.reader.ElasticsearchReaderUtil.atLeastOneResponseExistsForMultiGet;
+import static io.camunda.optimize.service.db.schema.index.DashboardIndex.AGENTIC_CONTROL_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.DashboardIndex.INSTANT_PREVIEW_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.DashboardIndex.MANAGEMENT_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.report.AbstractReportIndex.COLLECTION_ID;
@@ -107,6 +108,7 @@ public class EntitiesReaderES implements EntitiesReader {
                 q.bool(
                     b -> {
                       b.mustNot(m -> m.exists(e -> e.field(COLLECTION_ID)))
+                          .mustNot(m -> m.term(t -> t.field(AGENTIC_CONTROL_DASHBOARD).value(true)))
                           .must(
                               m ->
                                   m.bool(
@@ -431,6 +433,9 @@ public class EntitiesReaderES implements EntitiesReader {
           locale, dashboardEntity.getName());
     } else if (dashboardEntity.isManagementDashboard()) {
       return localizationService.getLocalizationForManagementDashboardCode(
+          locale, dashboardEntity.getName());
+    } else if (dashboardEntity.isAgenticControlDashboard()) {
+      return localizationService.getLocalizationForAgenticControlDashboardCode(
           locale, dashboardEntity.getName());
     }
     return dashboardEntity.getName();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/EntitiesReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/EntitiesReaderES.java
@@ -341,7 +341,8 @@ public class EntitiesReaderES implements EntitiesReader {
 
         if (entityId.equals(requestDto.getDashboardId())) {
           result.setDashboardName(
-              getLocalizedDashboardName((DashboardDefinitionRestDto) entity, locale));
+              getLocalizedDashboardName(
+                  localizationService, (DashboardDefinitionRestDto) entity, locale));
         } else if (entityId.equals(requestDto.getReportId())) {
           result.setReportName(getLocalizedReportName(localizationService, entity, locale));
         }
@@ -424,20 +425,5 @@ public class EntitiesReaderES implements EntitiesReader {
         COMBINED_REPORT_INDEX_NAME,
         DASHBOARD_INDEX_NAME);
     return searchRequest;
-  }
-
-  private String getLocalizedDashboardName(
-      final DashboardDefinitionRestDto dashboardEntity, final String locale) {
-    if (dashboardEntity.isInstantPreviewDashboard()) {
-      return localizationService.getLocalizationForInstantPreviewDashboardCode(
-          locale, dashboardEntity.getName());
-    } else if (dashboardEntity.isManagementDashboard()) {
-      return localizationService.getLocalizationForManagementDashboardCode(
-          locale, dashboardEntity.getName());
-    } else if (dashboardEntity.isAgenticControlDashboard()) {
-      return localizationService.getLocalizationForAgenticControlDashboardCode(
-          locale, dashboardEntity.getName());
-    }
-    return dashboardEntity.getName();
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DashboardReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DashboardReaderOS.java
@@ -48,7 +48,9 @@ public class DashboardReaderOS implements DashboardReader {
     final String errorMessage = "Was not able to retrieve dashboard count!";
     return osClient.count(
         new String[] {DASHBOARD_INDEX_NAME},
-        QueryDSL.term(DashboardIndex.MANAGEMENT_DASHBOARD, false),
+        QueryDSL.and(
+            QueryDSL.term(DashboardIndex.MANAGEMENT_DASHBOARD, false),
+            QueryDSL.not(QueryDSL.term(DashboardIndex.AGENTIC_CONTROL_DASHBOARD, true))),
         errorMessage);
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/EntitiesReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/EntitiesReaderOS.java
@@ -15,6 +15,7 @@ import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_DECISION_R
 import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_PROCESS_REPORT_INDEX_NAME;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.term;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.terms;
+import static io.camunda.optimize.service.db.schema.index.DashboardIndex.AGENTIC_CONTROL_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.DashboardIndex.INSTANT_PREVIEW_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.DashboardIndex.MANAGEMENT_DASHBOARD;
 import static io.camunda.optimize.service.db.schema.index.report.AbstractReportIndex.COLLECTION_ID;
@@ -105,6 +106,7 @@ public class EntitiesReaderOS implements EntitiesReader {
     final BoolQuery.Builder query =
         new BoolQuery.Builder()
             .mustNot(QueryDSL.exists(COLLECTION_ID))
+            .mustNot(term(AGENTIC_CONTROL_DASHBOARD, true))
             .must(
                 new BoolQuery.Builder()
                     .minimumShouldMatch("1")
@@ -335,6 +337,9 @@ public class EntitiesReaderOS implements EntitiesReader {
           locale, dashboardEntity.getName());
     } else if (dashboardEntity.isManagementDashboard()) {
       return localizationService.getLocalizationForManagementDashboardCode(
+          locale, dashboardEntity.getName());
+    } else if (dashboardEntity.isAgenticControlDashboard()) {
+      return localizationService.getLocalizationForAgenticControlDashboardCode(
           locale, dashboardEntity.getName());
     }
     return dashboardEntity.getName();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/EntitiesReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/EntitiesReaderOS.java
@@ -259,7 +259,8 @@ public class EntitiesReaderOS implements EntitiesReader {
               }
               if (entityId.equals(requestDto.getDashboardId())) {
                 result.setDashboardName(
-                    getLocalizedDashboardName((DashboardDefinitionRestDto) entity, locale));
+                    getLocalizedDashboardName(
+                        localizationService, (DashboardDefinitionRestDto) entity, locale));
               } else if (entityId.equals(requestDto.getReportId())) {
                 result.setReportName(getLocalizedReportName(localizationService, entity, locale));
               }
@@ -328,20 +329,5 @@ public class EntitiesReaderOS implements EntitiesReader {
             SINGLE_DECISION_REPORT_INDEX_NAME,
             COMBINED_REPORT_INDEX_NAME,
             DASHBOARD_INDEX_NAME);
-  }
-
-  private String getLocalizedDashboardName(
-      final DashboardDefinitionRestDto dashboardEntity, final String locale) {
-    if (dashboardEntity.isInstantPreviewDashboard()) {
-      return localizationService.getLocalizationForInstantPreviewDashboardCode(
-          locale, dashboardEntity.getName());
-    } else if (dashboardEntity.isManagementDashboard()) {
-      return localizationService.getLocalizationForManagementDashboardCode(
-          locale, dashboardEntity.getName());
-    } else if (dashboardEntity.isAgenticControlDashboard()) {
-      return localizationService.getLocalizationForAgenticControlDashboardCode(
-          locale, dashboardEntity.getName());
-    }
-    return dashboardEntity.getName();
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/EntitiesReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/EntitiesReader.java
@@ -11,6 +11,7 @@ import static io.camunda.optimize.service.db.reader.ReportReader.REPORT_DATA_XML
 
 import io.camunda.optimize.dto.optimize.query.collection.BaseCollectionDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionEntity;
+import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
 import io.camunda.optimize.dto.optimize.query.entity.EntityNameRequestDto;
 import io.camunda.optimize.dto.optimize.query.entity.EntityNameResponseDto;
 import io.camunda.optimize.dto.optimize.query.entity.EntityType;
@@ -54,5 +55,22 @@ public interface EntitiesReader {
       }
     }
     return reportEntity.getName();
+  }
+
+  default String getLocalizedDashboardName(
+      final LocalizationService localizationService,
+      final DashboardDefinitionRestDto dashboardEntity,
+      final String locale) {
+    if (dashboardEntity.isInstantPreviewDashboard()) {
+      return localizationService.getLocalizationForInstantPreviewDashboardCode(
+          locale, dashboardEntity.getName());
+    } else if (dashboardEntity.isManagementDashboard()) {
+      return localizationService.getLocalizationForManagementDashboardCode(
+          locale, dashboardEntity.getName());
+    } else if (dashboardEntity.isAgenticControlDashboard()) {
+      return localizationService.getLocalizationForAgenticControlDashboardCode(
+          locale, dashboardEntity.getName());
+    }
+    return dashboardEntity.getName();
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/entities/EntityImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/entities/EntityImportService.java
@@ -67,6 +67,7 @@ public class EntityImportService {
       final String collectionId, final Set<OptimizeEntityExportDto> entitiesToImport) {
     validateCompletenessOrFail(entitiesToImport);
     validateNoInstantPreviewEntities(entitiesToImport);
+    validateNoAgenticControlEntities(entitiesToImport);
     return importValidatedEntities(collectionId, entitiesToImport);
   }
 
@@ -238,6 +239,17 @@ public class EntityImportService {
                             .isInstantPreviewReport()))) {
       throw new OptimizeValidationException(
           "Cannot import Instant preview dashboards and reports.");
+    }
+  }
+
+  private void validateNoAgenticControlEntities(
+      final Set<OptimizeEntityExportDto> entitiesToImport) {
+    if (entitiesToImport.stream()
+        .anyMatch(
+            exportDto ->
+                (DASHBOARD.equals(exportDto.getExportEntityType())
+                    && ((DashboardDefinitionExportDto) exportDto).isAgenticControlDashboard()))) {
+      throw new OptimizeValidationException("Cannot import agentic control dashboards.");
     }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/entities/dashboard/DashboardImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/entities/dashboard/DashboardImportService.java
@@ -162,6 +162,7 @@ public class DashboardImportService {
     dashboardDefinition.setTiles(dashboardToImport.getTiles());
     dashboardDefinition.setManagementDashboard(false);
     dashboardDefinition.setInstantPreviewDashboard(dashboardToImport.isInstantPreviewDashboard());
+    dashboardDefinition.setAgenticControlDashboard(false);
     return dashboardDefinition;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/SharingService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/SharingService.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.security;
 
+import static io.camunda.optimize.service.dashboard.DashboardService.SYSTEM_GENERATED_DASHBOARDS_LABEL;
+
 import io.camunda.optimize.dto.optimize.query.IdResponseDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
 import io.camunda.optimize.dto.optimize.query.report.AdditionalProcessReportEvaluationFilterDto;
@@ -160,10 +162,9 @@ public class SharingService implements ReportReferencingService, DashboardRefere
     try {
       final DashboardDefinitionRestDto dashboardDefinition =
           dashboardService.getDashboardDefinition(dashboardId, userId).getDefinitionDto();
-      if (dashboardDefinition.isManagementDashboard()
-          || dashboardDefinition.isInstantPreviewDashboard()) {
+      if (dashboardDefinition.isSystemGeneratedDashboard()) {
         throw new OptimizeValidationException(
-            "Management Dashboards or Instant preview dashboards cannot be shared");
+            SYSTEM_GENERATED_DASHBOARDS_LABEL + " cannot be shared");
       }
 
       final Set<String> authorizedReportIdsOnDashboard =

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -1539,6 +1539,9 @@
       }
     }
   },
+  "agenticControl": {
+    "agenticControlPlaneDashboardName": "Agentic Control Dashboard"
+  },
   "managementDashboard": {
     "dashboardName": "Adoption",
     "report": {

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -1539,6 +1539,9 @@
       }
     }
   },
+  "agenticControl": {
+    "agenticControlPlaneDashboardName": "Agentic Control Dashboard"
+  },
   "managementDashboard": {
     "dashboardName": "Adoption",
     "report": {

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/mapper/DashboardRestMapperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/mapper/DashboardRestMapperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
+import io.camunda.optimize.service.LocalizationService;
+import io.camunda.optimize.service.identity.AbstractIdentityService;
+import org.junit.jupiter.api.Test;
+
+public class DashboardRestMapperTest {
+
+  private static final String LOCALE = "en";
+
+  private final AbstractIdentityService identityService = mock(AbstractIdentityService.class);
+  private final LocalizationService localizationService = mock(LocalizationService.class);
+
+  private final DashboardRestMapper underTest =
+      new DashboardRestMapper(identityService, localizationService);
+
+  @Test
+  void shouldLocalizeAgenticControlDashboardNameViaAgenticControlCategory() {
+    // given an agentic control dashboard whose name is a localization code
+    when(localizationService.validateAndReturnValidLocale(LOCALE)).thenReturn(LOCALE);
+    when(localizationService.getLocalizationForAgenticControlDashboardCode(
+            LOCALE, "agenticControlPlaneDashboardName"))
+        .thenReturn("Agentic Control Dashboard");
+
+    final DashboardDefinitionRestDto dashboard = new DashboardDefinitionRestDto();
+    dashboard.setAgenticControlDashboard(true);
+    dashboard.setName("agenticControlPlaneDashboardName");
+
+    // when
+    underTest.prepareRestResponse(dashboard, LOCALE);
+
+    // then the name is resolved via the agentic control category, not the management one
+    assertThat(dashboard.getName()).isEqualTo("Agentic Control Dashboard");
+    verify(localizationService, never()).getLocalizationForManagementDashboardCode(any(), any());
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.AGENTIC_DASHBOARD_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.AGENTIC_DASHBOARD_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardFilterDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardInstanceEndDateFilterDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.filter.data.DashboardDateFilterDataDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto;
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RollingDateFilterDataDto;
+import io.camunda.optimize.service.db.reader.DashboardReader;
+import io.camunda.optimize.service.db.writer.DashboardWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.EntityConfiguration;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class AgenticControlDashboardServiceTest {
+
+  private final DashboardWriter dashboardWriter = mock(DashboardWriter.class);
+  private final DashboardReader dashboardReader = mock(DashboardReader.class);
+  private final ConfigurationService configurationService = mock(ConfigurationService.class);
+  private final EntityConfiguration entityConfiguration = mock(EntityConfiguration.class);
+
+  private final AgenticControlDashboardService underTest =
+      new AgenticControlDashboardService(dashboardWriter, dashboardReader, configurationService);
+
+  @Test
+  void shouldCreateDashboardWithExpectedShapeOnColdStart() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    assertThat(saved.getId()).isEqualTo(AGENTIC_DASHBOARD_ID);
+    assertThat(saved.isAgenticControlDashboard()).isTrue();
+    assertThat(saved.isManagementDashboard()).isFalse();
+    assertThat(saved.getCollectionId()).isNull();
+    assertThat(saved.getTiles()).isEmpty();
+  }
+
+  @Test
+  void shouldSeedExactlyTheInstanceEndDateFilterOnColdStart() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    assertThat(saved.getAvailableFilters())
+        .singleElement()
+        .isInstanceOf(DashboardInstanceEndDateFilterDto.class);
+  }
+
+  @Test
+  void shouldDefaultInstanceEndDateFilterToRollingLast30Days() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then the default range is a rolling last-30-days range
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    final DashboardFilterDto<?> filter = saved.getAvailableFilters().get(0);
+    final DashboardDateFilterDataDto data = (DashboardDateFilterDataDto) filter.getData();
+    assertThat(data.getDefaultValues()).isInstanceOf(RollingDateFilterDataDto.class);
+
+    final RollingDateFilterDataDto rolling = (RollingDateFilterDataDto) data.getDefaultValues();
+    final RollingDateFilterStartDto start = rolling.getStart();
+    assertThat(start.getValue()).isEqualTo(30L);
+    assertThat(start.getUnit()).isEqualTo(DateUnit.DAYS);
+  }
+
+  @Test
+  void shouldNotCreateOrMutateWhenDashboardAlreadyPresent() {
+    // given the dashboard already exists
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID))
+        .thenReturn(Optional.of(new DashboardDefinitionRestDto()));
+
+    // when
+    underTest.reconcile();
+
+    // then nothing is written
+    verify(dashboardWriter, never()).saveDashboard(any());
+    verify(dashboardWriter, never()).updateDashboard(any(), any());
+    verify(dashboardWriter, never()).deleteDashboard(any());
+  }
+
+  @Test
+  void shouldSeedDashboardWhenCreateOnStartupEnabled() {
+    // given the startup flag is enabled and no dashboard exists
+    when(configurationService.getEntityConfiguration()).thenReturn(entityConfiguration);
+    when(entityConfiguration.getCreateOnStartup()).thenReturn(true);
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.init();
+
+    // then the dashboard is seeded
+    verify(dashboardWriter).saveDashboard(any());
+  }
+
+  @Test
+  void shouldSeedNothingWhenCreateOnStartupDisabled() {
+    // given the startup flag is disabled
+    when(configurationService.getEntityConfiguration()).thenReturn(entityConfiguration);
+    when(entityConfiguration.getCreateOnStartup()).thenReturn(false);
+
+    // when
+    underTest.init();
+
+    // then nothing is read or written
+    verifyNoInteractions(dashboardReader);
+    verifyNoInteractions(dashboardWriter);
+  }
+
+  @Test
+  void shouldNotTouchManagementDashboardWhenSeeding() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then seeding stays isolated from the management dashboard lifecycle
+    verify(dashboardWriter, never()).deleteManagementDashboard();
+    verify(dashboardWriter, never()).deleteDashboard(any());
+    // and it only ever touches its own dashboard id
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    assertThat(saved.getId()).isEqualTo(AGENTIC_DASHBOARD_ID);
+  }
+
+  @Test
+  void shouldSeedAppendableTileListForFutureReconcileExtensions() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    assertThatNoException().isThrownBy(() -> saved.getTiles().add(new DashboardReportTileDto()));
+  }
+
+  @Test
+  void shouldResolveDashboardNameLocalizationCodeInEveryLocale() throws IOException {
+    for (final String locale : new String[] {"en", "de"}) {
+      final Map<String, Object> agenticControl = readAgenticControlLocalization(locale);
+      assertThat(agenticControl)
+          .as("locale '%s' must define agenticControl.%s", locale, AGENTIC_DASHBOARD_NAME)
+          .containsKey(AGENTIC_DASHBOARD_NAME);
+      assertThat(agenticControl.get(AGENTIC_DASHBOARD_NAME)).isEqualTo("Agentic Control Dashboard");
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> readAgenticControlLocalization(final String locale)
+      throws IOException {
+    try (final InputStream in =
+        getClass().getClassLoader().getResourceAsStream("localization/" + locale + ".json")) {
+      final Map<String, Object> root = new ObjectMapper().readValue(in, Map.class);
+      return (Map<String, Object>) root.get("agenticControl");
+    }
+  }
+
+  private DashboardDefinitionRestDto captureSavedDashboard() {
+    final ArgumentCaptor<DashboardDefinitionRestDto> captor =
+        ArgumentCaptor.forClass(DashboardDefinitionRestDto.class);
+    verify(dashboardWriter).saveDashboard(captor.capture());
+    return captor.getValue();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardFilterDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardInstanceEndDateFilterDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardProcessScopeFilterDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.data.DashboardDateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
@@ -66,7 +67,7 @@ public class AgenticControlDashboardServiceTest {
   }
 
   @Test
-  void shouldSeedExactlyTheInstanceEndDateFilterOnColdStart() {
+  void shouldSeedInstanceEndDateFilterOnColdStart() {
     // given
     when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
 
@@ -76,8 +77,21 @@ public class AgenticControlDashboardServiceTest {
     // then
     final DashboardDefinitionRestDto saved = captureSavedDashboard();
     assertThat(saved.getAvailableFilters())
-        .singleElement()
-        .isInstanceOf(DashboardInstanceEndDateFilterDto.class);
+        .hasAtLeastOneElementOfType(DashboardInstanceEndDateFilterDto.class);
+  }
+
+  @Test
+  void shouldSeedProcessScopeFilterOnColdStart() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    assertThat(saved.getAvailableFilters())
+        .hasAtLeastOneElementOfType(DashboardProcessScopeFilterDto.class);
   }
 
   @Test

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.dto.optimize.query.dashboard;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardFilterDto;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -117,6 +118,11 @@ public class BaseDashboardDefinitionDto {
 
   public void setAgenticControlDashboard(final boolean agenticControlDashboard) {
     this.agenticControlDashboard = agenticControlDashboard;
+  }
+
+  @JsonIgnore
+  public boolean isSystemGeneratedDashboard() {
+    return managementDashboard || instantPreviewDashboard || agenticControlDashboard;
   }
 
   public List<DashboardFilterDto<?>> getAvailableFilters() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
@@ -25,6 +25,7 @@ public class BaseDashboardDefinitionDto {
   protected String collectionId;
   protected boolean managementDashboard = false;
   protected boolean instantPreviewDashboard = false;
+  protected boolean agenticControlDashboard = false;
   protected List<DashboardFilterDto<?>> availableFilters = new ArrayList<>();
   protected Long refreshRateSeconds;
 
@@ -110,6 +111,14 @@ public class BaseDashboardDefinitionDto {
     this.instantPreviewDashboard = instantPreviewDashboard;
   }
 
+  public boolean isAgenticControlDashboard() {
+    return agenticControlDashboard;
+  }
+
+  public void setAgenticControlDashboard(final boolean agenticControlDashboard) {
+    this.agenticControlDashboard = agenticControlDashboard;
+  }
+
   public List<DashboardFilterDto<?>> getAvailableFilters() {
     return availableFilters;
   }
@@ -138,6 +147,7 @@ public class BaseDashboardDefinitionDto {
     final BaseDashboardDefinitionDto that = (BaseDashboardDefinitionDto) o;
     return managementDashboard == that.managementDashboard
         && instantPreviewDashboard == that.instantPreviewDashboard
+        && agenticControlDashboard == that.agenticControlDashboard
         && Objects.equals(id, that.id)
         && Objects.equals(name, that.name)
         && Objects.equals(description, that.description)
@@ -163,6 +173,7 @@ public class BaseDashboardDefinitionDto {
         collectionId,
         managementDashboard,
         instantPreviewDashboard,
+        agenticControlDashboard,
         availableFilters,
         refreshRateSeconds);
   }
@@ -189,6 +200,8 @@ public class BaseDashboardDefinitionDto {
         + isManagementDashboard()
         + ", instantPreviewDashboard="
         + isInstantPreviewDashboard()
+        + ", agenticControlDashboard="
+        + isAgenticControlDashboard()
         + ", availableFilters="
         + getAvailableFilters()
         + ", refreshRateSeconds="
@@ -209,6 +222,7 @@ public class BaseDashboardDefinitionDto {
     public static final String collectionId = "collectionId";
     public static final String managementDashboard = "managementDashboard";
     public static final String instantPreviewDashboard = "instantPreviewDashboard";
+    public static final String agenticControlDashboard = "agenticControlDashboard";
     public static final String availableFilters = "availableFilters";
     public static final String refreshRateSeconds = "refreshRateSeconds";
   }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/DashboardProcessScopeFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/DashboardProcessScopeFilterDto.java
@@ -9,10 +9,5 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter;
 
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.data.DashboardProcessScopeFilterDataDto;
 
-/**
- * Dashboard filter signalling that the dashboard exposes a process-scope filter — a process
- * ComboBox in the UI used to drill into a single process definition's metrics. Registered as the
- * {@code "processScope"} Jackson subtype on {@link DashboardFilterDto}.
- */
 public class DashboardProcessScopeFilterDto
     extends DashboardFilterDto<DashboardProcessScopeFilterDataDto> {}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardProcessScopeFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardProcessScopeFilterDataDto.java
@@ -8,11 +8,53 @@
 package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
+import java.util.List;
+import java.util.Objects;
 
-/**
- * Marker payload for {@link
- * io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardProcessScopeFilterDto}. The
- * process-scope filter currently has no user-configurable fields; the class exists so future
- * tickets can add fields (e.g. a default process key) without breaking the wire type.
- */
-public class DashboardProcessScopeFilterDataDto implements FilterDataDto {}
+public class DashboardProcessScopeFilterDataDto implements FilterDataDto {
+
+  private List<String> defaultValues;
+
+  public DashboardProcessScopeFilterDataDto(final List<String> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  protected DashboardProcessScopeFilterDataDto() {}
+
+  public List<String> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final List<String> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardProcessScopeFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardProcessScopeFilterDataDto that = (DashboardProcessScopeFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardProcessScopeFilterDataDto(defaultValues=" + getDefaultValues() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
+  public static final class Fields {
+
+    public static final String defaultValues = "defaultValues";
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/DashboardIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/DashboardIndex.java
@@ -38,6 +38,8 @@ public abstract class DashboardIndex<TBuilder> extends DefaultIndexMappingCreato
       BaseDashboardDefinitionDto.Fields.managementDashboard;
   public static final String INSTANT_PREVIEW_DASHBOARD =
       BaseDashboardDefinitionDto.Fields.instantPreviewDashboard;
+  public static final String AGENTIC_CONTROL_DASHBOARD =
+      BaseDashboardDefinitionDto.Fields.agenticControlDashboard;
   public static final String AVAILABLE_FILTERS = BaseDashboardDefinitionDto.Fields.availableFilters;
 
   public static final String POSITION = DashboardReportTileDto.Fields.position;
@@ -101,6 +103,7 @@ public abstract class DashboardIndex<TBuilder> extends DefaultIndexMappingCreato
         .properties(COLLECTION_ID, p -> p.keyword(k -> k))
         .properties(MANAGEMENT_DASHBOARD, p -> p.boolean_(k -> k))
         .properties(INSTANT_PREVIEW_DASHBOARD, p -> p.boolean_(k -> k))
+        .properties(AGENTIC_CONTROL_DASHBOARD, p -> p.boolean_(k -> k))
         .properties(
             AVAILABLE_FILTERS,
             p ->


### PR DESCRIPTION
related to #54527
related to #54528

## Description

Adds AgentDashboardService, a startup seeder that idempotently creates the persistent agentic-control-plane-dashboard (check-then-create, never delete/recreate, so tiles and any alerts on them survive restarts). Introduces a dedicated agenticControlDashboard flag for system-owned-dashboard behaviour instead of reusing managementDashboard. Also adds a  processScope filter (DashboardProcessScopeFilterDto) to available dashboard filters.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Link
[Slack thread](https://camunda.slack.com/archives/C0AJWU3QHGR/p1780538254432539)

## Related issues

closes #54527
closes #54528
