### PR TITLE
test: add wait-state acceptance tests

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/WaitStateMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/WaitStateMapper.java
@@ -15,6 +15,8 @@ public interface WaitStateMapper {
 
   void insert(WaitStateDbModel waitState);
 
+  void update(WaitStateDbModel waitState);
+
   void delete(Long waitStateKey);
 
   WaitStateDbModel findOne(Long waitStateKey);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/WaitStateWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/WaitStateWriter.java
@@ -31,6 +31,16 @@ public class WaitStateWriter implements RdbmsWriter {
             waitState));
   }
 
+  public void update(final WaitStateDbModel waitState) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.WAIT_STATE,
+            WriteStatementType.UPDATE,
+            waitState.waitStateKey(),
+            "io.camunda.db.rdbms.sql.WaitStateMapper.update",
+            waitState));
+  }
+
   public void delete(final long waitStateKey) {
     executionQueue.executeInQueue(
         new QueueItem(

--- a/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
@@ -121,6 +121,15 @@
             #{details, jdbcType=CLOB}, #{tenantId}, #{partitionId})
   </insert>
 
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.WaitStateDbModel">
+    UPDATE ${prefix}WAIT_STATE
+    SET ELEMENT_INSTANCE_KEY = #{elementInstanceKey},
+        ELEMENT_ID           = #{elementId},
+        ELEMENT_TYPE         = #{elementType},
+        DETAILS              = #{details, jdbcType=CLOB}
+    WHERE WAIT_STATE_KEY = #{waitStateKey}
+  </update>
+
   <delete id="delete" parameterType="java.lang.Long">
     DELETE
     FROM ${prefix}WAIT_STATE

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/WaitStateAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/WaitStateAuthorizationsIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.api.model.authz.AuthorizationScope;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * Specifies the intended {@code PROCESS_DEFINITION} / {@code READ_PROCESS_INSTANCE} authorization
+ * behavior of the element instance wait-state search command.
+ */
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class WaitStateAuthorizationsIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String PROCESS_ID = "waitStateProcess";
+  private static final String OTHER_PROCESS_ID = "otherProcess";
+  private static final String PASSWORD = "password";
+  private static final List<String> WILDCARD = List.of(AuthorizationScope.WILDCARD.getResourceId());
+  private static final String NO_AUTH_USER = "noAuthUser";
+  private static final String WILDCARD_USER = "wildcardUser";
+  private static final String PROCESS_USER = "processUser";
+  private static final String OTHER_PROCESS_USER = "otherProcessUser";
+
+  @UserDefinition
+  private static final TestUser NO_AUTH = new TestUser(NO_AUTH_USER, PASSWORD, List.of());
+
+  @UserDefinition
+  private static final TestUser WILDCARD_AUTH =
+      new TestUser(
+          WILDCARD_USER,
+          PASSWORD,
+          List.of(new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, WILDCARD)));
+
+  @UserDefinition
+  private static final TestUser PROCESS_AUTH =
+      new TestUser(
+          PROCESS_USER,
+          PASSWORD,
+          List.of(new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(PROCESS_ID))));
+
+  @UserDefinition
+  private static final TestUser OTHER_PROCESS_AUTH =
+      new TestUser(
+          OTHER_PROCESS_USER,
+          PASSWORD,
+          List.of(
+              new Permissions(
+                  PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(OTHER_PROCESS_ID))));
+
+  private static CamundaClient adminClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task")
+            .zeebeJobType("svc")
+            .endEvent()
+            .done();
+
+    deployResource(adminClient, process, "waitStateProcess.bpmn");
+    waitForProcessesToBeDeployed(adminClient, 1);
+
+    startProcessInstance(adminClient, PROCESS_ID);
+    waitForProcessInstancesToStart(adminClient, 1);
+
+    waitForWaitStates(1);
+  }
+
+  @Test
+  void shouldDenyUserWithoutAuthorization(@Authenticated(NO_AUTH_USER) final CamundaClient client) {
+    // when
+    final var result = client.newElementInstanceWaitStateSearchRequest().send().join();
+
+    // then — a user without READ_PROCESS_INSTANCE must not see any wait states
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldAllowUserWithWildcardAuthorization(
+      @Authenticated(WILDCARD_USER) final CamundaClient client) {
+    // when
+    final var result = client.newElementInstanceWaitStateSearchRequest().send().join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getElementId()).isEqualTo("task");
+  }
+
+  @Test
+  void shouldAllowUserAuthorizedForTheProcess(
+      @Authenticated(PROCESS_USER) final CamundaClient client) {
+    // when
+    final var result = client.newElementInstanceWaitStateSearchRequest().send().join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getElementId()).isEqualTo("task");
+  }
+
+  @Disabled(
+      "Wait-state search authorization not yet enforced — see https://github.com/camunda/camunda/issues/54604")
+  @Test
+  void shouldDenyUserAuthorizedForOtherProcess(
+      @Authenticated(OTHER_PROCESS_USER) final CamundaClient client) {
+    // when
+    final var result = client.newElementInstanceWaitStateSearchRequest().send().join();
+
+    // then — authorized only for a different process definition, so no results
+    assertThat(result.items()).isEmpty();
+  }
+
+  private static void waitForWaitStates(final int expectedCount) {
+    Awaitility.await("should export %d wait states".formatted(expectedCount))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final List<ElementInstanceWaitStateResult> items =
+                  adminClient.newElementInstanceWaitStateSearchRequest().send().join().items();
+              assertThat(items).hasSize(expectedCount);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/WaitStateSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/WaitStateSearchIT.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the element instance wait-state search command filters across a call-activity hierarchy.
+ * The root process forks into a service task (its own job wait state) and a call activity into a
+ * child process whose service task produces a second job wait state. Both wait states share the
+ * same {@code rootProcessInstanceKey} but live under different {@code processInstanceKey}s. Jobs
+ * are never activated or completed so the wait states persist for the duration of the test.
+ */
+@MultiDbTest
+public class WaitStateSearchIT {
+
+  private static final String ROOT_PROCESS_ID = "waitStateRootProcess";
+  private static final String CHILD_PROCESS_ID = "waitStateChildProcess";
+  private static final String ROOT_SERVICE_TASK = "root-service-task";
+  private static final String CHILD_SERVICE_TASK = "child-service-task";
+
+  private static CamundaClient camundaClient;
+
+  private static long rootProcessInstanceKey;
+  private static long childProcessInstanceKey;
+  private static long rootElementInstanceKey;
+  private static long childElementInstanceKey;
+
+  @BeforeAll
+  static void beforeAll() {
+    final BpmnModelInstance rootProcess =
+        Bpmn.createExecutableProcess(ROOT_PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .serviceTask(ROOT_SERVICE_TASK)
+            .zeebeJobType("root-svc")
+            .moveToNode("fork")
+            .callActivity("call-activity")
+            .zeebeProcessId(CHILD_PROCESS_ID)
+            .done();
+    final BpmnModelInstance childProcess =
+        Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+            .startEvent()
+            .serviceTask(CHILD_SERVICE_TASK)
+            .zeebeJobType("child-svc")
+            .endEvent()
+            .done();
+
+    deployResource(camundaClient, rootProcess, "waitStateRootProcess.bpmn");
+    deployResource(camundaClient, childProcess, "waitStateChildProcess.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 2);
+
+    rootProcessInstanceKey =
+        startProcessInstance(camundaClient, ROOT_PROCESS_ID).getProcessInstanceKey();
+    // root + child instance (the call activity starts the child)
+    waitForProcessInstancesToStart(camundaClient, 2);
+
+    final var items = waitForWaitStates(2);
+
+    final var rootItem = byElementId(items, ROOT_SERVICE_TASK);
+    final var childItem = byElementId(items, CHILD_SERVICE_TASK);
+    childProcessInstanceKey = Long.parseLong(childItem.getProcessInstanceKey());
+    rootElementInstanceKey = Long.parseLong(rootItem.getElementInstanceKey());
+    childElementInstanceKey = Long.parseLong(childItem.getElementInstanceKey());
+  }
+
+  @Test
+  void shouldFilterByRootProcessInstanceKey() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.rootProcessInstanceKey(rootProcessInstanceKey))
+            .send()
+            .join();
+
+    // then — both the root and the child task wait states share the root process instance key
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items())
+        .allSatisfy(
+            item ->
+                assertThat(item.getRootProcessInstanceKey())
+                    .isEqualTo(String.valueOf(rootProcessInstanceKey)));
+  }
+
+  @Test
+  void shouldFilterByProcessInstanceKeyRoot() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.processInstanceKey(rootProcessInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getElementId()).isEqualTo(ROOT_SERVICE_TASK);
+  }
+
+  @Test
+  void shouldFilterByProcessInstanceKeyChild() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.processInstanceKey(childProcessInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getElementId()).isEqualTo(CHILD_SERVICE_TASK);
+  }
+
+  @Test
+  void shouldFilterBySingleElementInstanceKey() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.elementInstanceKey(childElementInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getElementInstanceKey())
+        .isEqualTo(String.valueOf(childElementInstanceKey));
+  }
+
+  @Test
+  void shouldFilterByMultipleElementInstanceKeys() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(
+                f ->
+                    f.elementInstanceKey(
+                        k ->
+                            k.in(
+                                String.valueOf(rootElementInstanceKey),
+                                String.valueOf(childElementInstanceKey))))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+  }
+
+  @Test
+  void shouldFilterByElementType() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.elementType(WaitStateElementType.SERVICE_TASK))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+  }
+
+  @Test
+  void shouldFilterByWaitStateType() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.waitStateType(WaitStateType.JOB))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+  }
+
+  @Test
+  void shouldFilterByElementId() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.elementId(CHILD_SERVICE_TASK))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getProcessInstanceKey())
+        .isEqualTo(String.valueOf(childProcessInstanceKey));
+  }
+
+  private static ElementInstanceWaitStateResult byElementId(
+      final List<ElementInstanceWaitStateResult> items, final String elementId) {
+    return items.stream()
+        .filter(item -> elementId.equals(item.getElementId()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private static List<ElementInstanceWaitStateResult> waitForWaitStates(final int expectedCount) {
+    return Awaitility.await("should export %d wait states".formatted(expectedCount))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .until(
+            () -> camundaClient.newElementInstanceWaitStateSearchRequest().send().join().items(),
+            items -> items.size() == expectedCount);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateJobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateJobIT.java
@@ -1,0 +1,496 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.waitstate;
+
+import static io.camunda.it.util.TestHelper.cancelInstance;
+import static io.camunda.it.util.TestHelper.completeJob;
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.search.enums.JobKind;
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
+import io.camunda.client.api.search.response.JobWaitStateDetails;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.List;
+import java.util.stream.Stream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies the element instance wait-state search command against all job-based wait-state element
+ * types. The main process ({@code waitStateProcess}) forks into seven parallel branches covering:
+ * service task, send task, script task, business-rule task (all {@code BPMN_ELEMENT} jobs), a
+ * subprocess with a start execution listener ({@code EXECUTION_LISTENER}), a Zeebe user task with a
+ * creating task listener ({@code TASK_LISTENER}), and an ad-hoc subprocess ({@code
+ * AD_HOC_SUB_PROCESS}). A second process ({@code waitStateProcessWithListener}) exercises a
+ * process-level start execution listener ({@code PROCESS} element type). Jobs are intentionally
+ * never activated or completed so all wait states persist for the duration of the test.
+ */
+@MultiDbTest
+public class WaitStateJobIT {
+
+  private static final String PROCESS_ID = "waitStateProcess";
+  private static final String PROCESS_LISTENER_PROCESS_ID = "waitStateProcessWithListener";
+
+  private static final String SERVICE_TASK = "service-task";
+  private static final String SEND_TASK = "send-task";
+  private static final String SCRIPT_TASK = "script-task";
+  private static final String BUSINESS_RULE_TASK = "business-rule-task";
+  private static final String SUBPROCESS_EL = "subprocess-el";
+  private static final String USER_TASK_TL = "user-task-tl";
+  private static final String JOB_USER_TASK = "job-user-task";
+  private static final String AHSP = "ahsp";
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    // Main process: 7 parallel branches, one per supported job-based element type.
+    final BpmnModelInstance mainProcess =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .serviceTask(SERVICE_TASK)
+            .zeebeJobType("svc")
+            .moveToNode("fork")
+            .sendTask(SEND_TASK)
+            .zeebeJobType("snd")
+            .moveToNode("fork")
+            .scriptTask(SCRIPT_TASK)
+            .zeebeJobType("scr")
+            .moveToNode("fork")
+            .businessRuleTask(BUSINESS_RULE_TASK)
+            .zeebeJobType("biz")
+            .moveToNode("fork")
+            .subProcess(
+                SUBPROCESS_EL,
+                s ->
+                    s.zeebeExecutionListener(l -> l.start().type("sub-listener"))
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .endEvent())
+            .moveToNode("fork")
+            .userTask(
+                USER_TASK_TL,
+                t -> t.zeebeUserTask().zeebeTaskListener(l -> l.creating().type("task-listener")))
+            .moveToNode("fork")
+            .userTask(JOB_USER_TASK) // legacy job-worker user task; job type =
+            // Protocol.USER_TASK_JOB_TYPE
+            .moveToNode("fork")
+            .adHocSubProcess(AHSP, a -> a.task("ahsp-inner"))
+            .zeebeJobType("ahsp-job")
+            .done();
+
+    // Second process: process-level start execution listener only.
+    final BpmnModelInstance listenerProcess =
+        Bpmn.createExecutableProcess(PROCESS_LISTENER_PROCESS_ID)
+            .zeebeExecutionListener(l -> l.start().type("process-listener"))
+            .startEvent()
+            .endEvent()
+            .done();
+
+    deployResource(camundaClient, mainProcess, "waitStateProcess.bpmn");
+    deployResource(camundaClient, listenerProcess, "waitStateProcessWithListener.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 2);
+
+    startProcessInstance(camundaClient, PROCESS_ID);
+    startProcessInstance(camundaClient, PROCESS_LISTENER_PROCESS_ID);
+    waitForProcessInstancesToStart(camundaClient, 2);
+
+    // 8 from the main process + 1 from the process-level listener process.
+    waitForWaitStates(9);
+  }
+
+  @Test
+  void shouldReturnAllJobWaitStates() {
+    // when
+    final var result = camundaClient.newElementInstanceWaitStateSearchRequest().send().join();
+
+    // then
+    assertThat(result.items()).hasSize(9);
+    assertThat(result.items())
+        .allSatisfy(item -> assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.JOB));
+    assertThat(result.items())
+        .extracting(ElementInstanceWaitStateResult::getElementType)
+        .containsExactlyInAnyOrder(
+            WaitStateElementType.SERVICE_TASK,
+            WaitStateElementType.SEND_TASK,
+            WaitStateElementType.SCRIPT_TASK,
+            WaitStateElementType.BUSINESS_RULE_TASK,
+            WaitStateElementType.SUB_PROCESS, // subprocess execution listener
+            WaitStateElementType.SUB_PROCESS, // ad-hoc subprocess
+            WaitStateElementType.USER_TASK, // native user task task listener
+            WaitStateElementType.USER_TASK, // job-based user task
+            WaitStateElementType.PROCESS);
+  }
+
+  @ParameterizedTest(name = "{1} / {3}")
+  @MethodSource("elementTypeTestCases")
+  void shouldFilterByElementType(
+      final WaitStateElementType elementType,
+      final String expectedElementId,
+      final String expectedJobType,
+      final JobKind expectedJobKind,
+      final int expectedRetries) {
+    assertSingleJobWaitState(
+        elementType, expectedElementId, expectedJobType, expectedJobKind, expectedRetries);
+  }
+
+  static Stream<Arguments> elementTypeTestCases() {
+    return Stream.of(
+        Arguments.of(
+            WaitStateElementType.SERVICE_TASK, SERVICE_TASK, "svc", JobKind.BPMN_ELEMENT, 3),
+        Arguments.of(WaitStateElementType.SEND_TASK, SEND_TASK, "snd", JobKind.BPMN_ELEMENT, 3),
+        Arguments.of(WaitStateElementType.SCRIPT_TASK, SCRIPT_TASK, "scr", JobKind.BPMN_ELEMENT, 3),
+        Arguments.of(
+            WaitStateElementType.BUSINESS_RULE_TASK,
+            BUSINESS_RULE_TASK,
+            "biz",
+            JobKind.BPMN_ELEMENT,
+            3),
+        Arguments.of(
+            WaitStateElementType.SUB_PROCESS,
+            SUBPROCESS_EL,
+            "sub-listener",
+            JobKind.EXECUTION_LISTENER,
+            3),
+        Arguments.of(
+            WaitStateElementType.USER_TASK,
+            USER_TASK_TL,
+            "task-listener",
+            JobKind.TASK_LISTENER,
+            3),
+        Arguments.of(
+            WaitStateElementType.USER_TASK,
+            JOB_USER_TASK,
+            "io.camunda.zeebe:userTask",
+            JobKind.BPMN_ELEMENT,
+            1),
+        Arguments.of(
+            WaitStateElementType.SUB_PROCESS, AHSP, "ahsp-job", JobKind.AD_HOC_SUB_PROCESS, 3),
+        Arguments.of(
+            WaitStateElementType.PROCESS,
+            PROCESS_LISTENER_PROCESS_ID,
+            "process-listener",
+            JobKind.EXECUTION_LISTENER,
+            3));
+  }
+
+  @Test
+  void shouldFilterByWaitStateTypeJob() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.waitStateType(WaitStateType.JOB))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(9);
+  }
+
+  @Test
+  void shouldReturnEmptyForMessageWaitStateType() {
+    // when — no MESSAGE wait-state transformer exists yet, so the result must be empty
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.waitStateType(WaitStateType.MESSAGE))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldFilterByElementId() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.elementId(SCRIPT_TASK))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getElementType())
+        .isEqualTo(WaitStateElementType.SCRIPT_TASK);
+  }
+
+  @Test
+  void shouldFilterByElementTypeIn() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(
+                f ->
+                    f.elementType(
+                        t ->
+                            t.in(WaitStateElementType.SCRIPT_TASK, WaitStateElementType.SEND_TASK)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items())
+        .extracting(ElementInstanceWaitStateResult::getElementType)
+        .containsExactlyInAnyOrder(
+            WaitStateElementType.SCRIPT_TASK, WaitStateElementType.SEND_TASK);
+  }
+
+  @Test
+  void shouldRemoveWaitStateWhenJobIsCompleted() {
+    // given — a dedicated single-task process, isolated from the shared @BeforeAll state
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateRemovalProcess")
+            .startEvent()
+            .serviceTask("removal-task")
+            .zeebeJobType("removal-svc")
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateRemovalProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateRemovalProcess").getProcessInstanceKey();
+
+    Awaitility.await("wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when — complete the job
+    final long jobKey =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType("removal-svc")
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst()
+            .getKey();
+    completeJob(camundaClient, jobKey);
+
+    // then — wait state is removed
+    Awaitility.await("wait state should be removed after job completion")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldRemoveWaitStateWhenJobIsCanceled() {
+    // given — a dedicated single-task process, isolated from the shared @BeforeAll state
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateCancellationProcess")
+            .startEvent()
+            .serviceTask("cancellation-task")
+            .zeebeJobType("cancellation-svc")
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateCancellationProcess.bpmn");
+
+    final var instance = startProcessInstance(camundaClient, "waitStateCancellationProcess");
+    final long pik = instance.getProcessInstanceKey();
+
+    Awaitility.await("wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when — cancel the process instance, which cancels the active job
+    cancelInstance(camundaClient, instance);
+
+    // then — wait state is removed
+    Awaitility.await("wait state should be removed after job cancellation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldUpdateWaitStateElementIdWhenProcessInstanceIsMigrated() {
+    // given — V1 has a service task "source-task"; V2 has the same task renamed to "target-task"
+    final BpmnModelInstance v1 =
+        Bpmn.createExecutableProcess("waitStateMigrationProcessV1")
+            .startEvent()
+            .serviceTask("source-task")
+            .zeebeJobType("migration-svc")
+            .endEvent()
+            .done();
+    final BpmnModelInstance v2 =
+        Bpmn.createExecutableProcess("waitStateMigrationProcessV2")
+            .startEvent()
+            .serviceTask("target-task")
+            .zeebeJobType("migration-svc")
+            .endEvent()
+            .done();
+
+    final long v1Key =
+        deployProcessAndWaitForIt(camundaClient, v1, "waitStateMigrationProcessV1.bpmn")
+            .getProcessDefinitionKey();
+    final long v2Key =
+        deployProcessAndWaitForIt(camundaClient, v2, "waitStateMigrationProcessV2.bpmn")
+            .getProcessDefinitionKey();
+
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateMigrationProcessV1").getProcessInstanceKey();
+
+    Awaitility.await("wait state with source-task should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("source-task")));
+
+    // when — migrate the process instance, remapping source-task → target-task
+    camundaClient
+        .newMigrateProcessInstanceCommand(pik)
+        .migrationPlan(
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(v2Key)
+                .addMappingInstruction("source-task", "target-task")
+                .build())
+        .send()
+        .join();
+
+    // then — wait state is updated to reflect the new element id
+    Awaitility.await("wait state should be updated with target-task element id")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("target-task")));
+
+    // cleanup — cancel the instance so the wait state is removed and doesn't leak into other tests
+    camundaClient.newCancelInstanceCommand(pik).execute();
+    waitForProcessInstanceToBeTerminated(camundaClient, pik);
+    Awaitility.await("wait state should be removed after cleanup")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  /**
+   * Filters by both element type and element id, then asserts the wait state type, element type,
+   * element id, and all fields of the typed {@link JobWaitStateDetails}.
+   */
+  private static void assertSingleJobWaitState(
+      final WaitStateElementType elementType,
+      final String expectedElementId,
+      final String expectedJobType,
+      final JobKind expectedJobKind,
+      final int expectedRetries) {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.elementType(elementType).elementId(expectedElementId))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    final var item = result.items().getFirst();
+    assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.JOB);
+    assertThat(item.getElementId()).isEqualTo(expectedElementId);
+    assertThat(item.getElementType()).isEqualTo(elementType);
+    assertThat(item.getDetails()).isInstanceOf(JobWaitStateDetails.class);
+    final var jobDetails = (JobWaitStateDetails) item.getDetails();
+    assertThat(jobDetails.getWaitStateType()).isEqualTo(WaitStateType.JOB);
+    assertThat(jobDetails.getJobType()).isEqualTo(expectedJobType);
+    assertThat(jobDetails.getJobKind()).isEqualTo(expectedJobKind);
+    assertThat(jobDetails.getRetries()).isEqualTo(expectedRetries);
+    assertThat(jobDetails.getJobKey()).isNotNull();
+  }
+
+  private static void waitForWaitStates(final int expectedCount) {
+    Awaitility.await("should export %d wait states".formatted(expectedCount))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final List<ElementInstanceWaitStateResult> items =
+                  camundaClient.newElementInstanceWaitStateSearchRequest().send().join().items();
+              assertThat(items).hasSize(expectedCount);
+            });
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
@@ -24,6 +24,7 @@ public final class WaitStateConfigs {
   public static final WaitStateTransformerConfig JOB_CONFIG =
       WaitStateTransformerConfig.of(ValueType.JOB)
           .withAddIntents(JobIntent.CREATED)
+          .withUpdateIntents(JobIntent.MIGRATED)
           .withRemoveIntents(JobIntent.COMPLETED, JobIntent.CANCELED)
           .withSupportedElementTypes(
               BpmnElementType.SERVICE_TASK,

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateTransformer.java
@@ -66,6 +66,10 @@ public interface WaitStateTransformer<R extends RecordValue & WaitStateRelated> 
     return config().triggersAdd(record);
   }
 
+  default boolean triggersUpdate(final Record<R> record) {
+    return config().triggersUpdate(record);
+  }
+
   default boolean triggersRemoval(final Record<R> record) {
     return config().triggersRemoval(record);
   }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateTransformerConfig.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateTransformerConfig.java
@@ -23,33 +23,54 @@ import java.util.Set;
 public record WaitStateTransformerConfig(
     ValueType valueType,
     Set<Intent> addIntents,
+    Set<Intent> updateIntents,
     Set<Intent> removeIntents,
     Set<BpmnElementType> supportedElementTypes,
     WaitStateType waitStateType) {
 
   public static WaitStateTransformerConfig of(final ValueType valueType) {
-    return new WaitStateTransformerConfig(valueType, Set.of(), Set.of(), Set.of(), null);
+    return new WaitStateTransformerConfig(valueType, Set.of(), Set.of(), Set.of(), Set.of(), null);
   }
 
   public WaitStateTransformerConfig withAddIntents(final Intent... intents) {
     return new WaitStateTransformerConfig(
-        valueType, Set.of(intents), removeIntents, supportedElementTypes, waitStateType);
+        valueType,
+        Set.of(intents),
+        updateIntents,
+        removeIntents,
+        supportedElementTypes,
+        waitStateType);
+  }
+
+  public WaitStateTransformerConfig withUpdateIntents(final Intent... intents) {
+    return new WaitStateTransformerConfig(
+        valueType,
+        addIntents,
+        Set.of(intents),
+        removeIntents,
+        supportedElementTypes,
+        waitStateType);
   }
 
   public WaitStateTransformerConfig withRemoveIntents(final Intent... intents) {
     return new WaitStateTransformerConfig(
-        valueType, addIntents, Set.of(intents), supportedElementTypes, waitStateType);
+        valueType,
+        addIntents,
+        updateIntents,
+        Set.of(intents),
+        supportedElementTypes,
+        waitStateType);
   }
 
   public WaitStateTransformerConfig withSupportedElementTypes(
       final BpmnElementType... elementTypes) {
     return new WaitStateTransformerConfig(
-        valueType, addIntents, removeIntents, Set.of(elementTypes), waitStateType);
+        valueType, addIntents, updateIntents, removeIntents, Set.of(elementTypes), waitStateType);
   }
 
   public WaitStateTransformerConfig withWaitStateType(final WaitStateType waitStateType) {
     return new WaitStateTransformerConfig(
-        valueType, addIntents, removeIntents, supportedElementTypes, waitStateType);
+        valueType, addIntents, updateIntents, removeIntents, supportedElementTypes, waitStateType);
   }
 
   public boolean supports(final Record<?> record) {
@@ -61,6 +82,10 @@ public record WaitStateTransformerConfig(
 
   public boolean triggersAdd(final Record<?> record) {
     return supports(record) && addIntents.contains(record.getIntent());
+  }
+
+  public boolean triggersUpdate(final Record<?> record) {
+    return supports(record) && updateIntents.contains(record.getIntent());
   }
 
   public boolean triggersRemoval(final Record<?> record) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateAddHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateAddHandler.java
@@ -61,7 +61,7 @@ public class WaitStateAddHandler<R extends RecordValue & WaitStateRelated>
 
   @Override
   public boolean handlesRecord(final Record<R> record) {
-    return transformer.triggersAdd(record);
+    return transformer.triggersAdd(record) || transformer.triggersUpdate(record);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
@@ -189,6 +189,69 @@ class JobWaitStateHandlerTest {
   }
 
   @Test
+  void shouldAddHandlerHandleMigratedEvent() {
+    // given
+    final var migrated = jobRecord(JobIntent.MIGRATED);
+
+    // when / then — MIGRATED is an upsert, handled by the add handler, not the remove handler
+    assertThat(addHandler.handlesRecord(migrated)).isTrue();
+    assertThat(removeHandler.handlesRecord(migrated)).isFalse();
+  }
+
+  @Test
+  void shouldMigratedDocumentIdMatchOriginal() {
+    // given
+    final var migrated = jobRecord(JobIntent.MIGRATED);
+
+    // when
+    final var ids = addHandler.generateIds(migrated);
+
+    // then — same stable document id as CREATED so the upsert updates the existing entry
+    assertThat(ids).containsExactly(String.valueOf(JOB_KEY));
+  }
+
+  @Test
+  void shouldUpdateEntityElementIdOnJobMigrated() throws Exception {
+    // given — a record with the post-migration elementId
+    final var jobValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("payment-service")
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withJobListenerEventType(JobListenerEventType.UNSPECIFIED)
+            .withRetries(3)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("task-after-migration")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final var record =
+        cast(
+            factory.generateRecord(
+                ValueType.JOB,
+                r ->
+                    r.withKey(JOB_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(JobIntent.MIGRATED)
+                        .withValue(jobValue)));
+    final var entity = addHandler.createNewEntity(String.valueOf(JOB_KEY));
+
+    // when
+    addHandler.updateEntity(record, entity);
+
+    // then — entity reflects the post-migration element id; all other fields are also updated
+    assertThat(entity.getElementId()).isEqualTo("task-after-migration");
+    assertThat(entity.getElementType()).isEqualTo(BpmnElementType.SERVICE_TASK.name());
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entity.getWaitStateType()).isEqualTo(WaitStateType.JOB.name());
+    final var details = objectMapper.readTree(entity.getDetails());
+    assertThat(details.get("jobType").textValue()).isEqualTo("payment-service");
+    assertThat(details.get("jobKind").textValue()).isEqualTo(JobKind.BPMN_ELEMENT.name());
+  }
+
+  @Test
   void shouldBuilderProduceExactlyTwoHandlers() {
     final var handlers =
         WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandler.java
@@ -48,13 +48,18 @@ public class WaitStateAddHandler<R extends RecordValue & WaitStateRelated>
 
   @Override
   public boolean canExport(final Record<R> record) {
-    return transformer.triggersAdd(record);
+    return transformer.triggersAdd(record) || transformer.triggersUpdate(record);
   }
 
   @Override
   public void export(final Record<R> record) {
     final var entry = transformer.transform(record);
-    waitStateWriter.create(map(record, entry));
+    final var model = map(record, entry);
+    if (transformer.triggersUpdate(record)) {
+      waitStateWriter.update(model);
+    } else {
+      waitStateWriter.create(model);
+    }
   }
 
   @VisibleForTesting

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandlerTest.java
@@ -53,6 +53,54 @@ class WaitStateAddHandlerTest {
   }
 
   @Test
+  void shouldAcceptJobMigratedRecord() {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(JobIntent.MIGRATED));
+
+    // when / then
+    assertThat(handler.canExport(record)).isTrue();
+  }
+
+  @Test
+  void shouldUpdateWaitStateRowOnMigratedExport() {
+    // given
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("payment-service")
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withJobListenerEventType(JobListenerEventType.UNSPECIFIED)
+            .withRetries(3)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("task-after-migration")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withKey(999L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(JobIntent.MIGRATED)
+                    .withValue(value));
+
+    // when
+    handler.export(record);
+
+    // then — update (not insert) is called with the post-migration elementId
+    verify(waitStateWriter).update(modelCaptor.capture());
+    final WaitStateDbModel model = modelCaptor.getValue();
+    assertThat(model.waitStateKey()).isEqualTo(999L);
+    assertThat(model.elementId()).isEqualTo("task-after-migration");
+    assertThat(model.elementType()).isEqualTo(BpmnElementType.SERVICE_TASK.name());
+  }
+
+  @Test
   void shouldExportJobCreatedRecord() {
     // given
     final Record<JobRecordValue> record =


### PR DESCRIPTION
## Description

Adds acceptance tests for the element instance wait-state search command introduced in #54479 (`newElementInstanceWaitStateSearchRequest()`).

## Changes

Three test classes under `qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/`:

**`WaitStateJobIT`** — exercises all job-based wait-state element types using two processes:
- Main process (8 parallel branches): `SERVICE_TASK`, `SEND_TASK`, `SCRIPT_TASK`, `BUSINESS_RULE_TASK` (`BPMN_ELEMENT`), subprocess with start execution listener (`EXECUTION_LISTENER`), Zeebe user task with creating task listener (`TASK_LISTENER`), legacy job-based user task (`BPMN_ELEMENT`), ad-hoc subprocess (`AD_HOC_SUB_PROCESS`).
- Second process: process-level start execution listener (`PROCESS` element type).
- Per-element-type cases are a single `@ParameterizedTest` with `@MethodSource`, each asserting `waitStateType=JOB`, `elementType`, `elementId`, and full `JobWaitStateDetails` (jobType, jobKind, retries, jobKey).

**`WaitStateSearchIT`** — exercises filters across a call-activity hierarchy (root process + child process via call activity), covering: `rootProcessInstanceKey`, `processInstanceKey`, single/multiple `elementInstanceKey`, `elementType`, `waitStateType`, and `elementId`.

**`WaitStateAuthorizationsIT`** — specifies the intended `PROCESS_DEFINITION`/`READ_PROCESS_INSTANCE` authorization behavior. The test for process-scoped isolation (`otherProcess`) is `@Disabled` because `WaitStateFilterTransformer.toAuthorizationCheckSearchQuery` currently returns `matchAll()` (the index has no `processDefinitionId` field). The enforcement gap is tracked by #54718.

## Related issues

Closes #48548