### PR TITLE
feat: use camunda-api-zod-schemas for parsing document references

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/DocumentListModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/DocumentListModal.tsx
@@ -85,11 +85,7 @@ const DocumentListModal: React.FC<StateProps & Props> = ({
               >
                 {middleTruncate(document.fileName)}
               </DocumentFileName>
-              {document.size !== undefined && (
-                <DocumentSize>
-                  {toHumanReadableBytes(document.size)}
-                </DocumentSize>
-              )}
+              <DocumentSize>{toHumanReadableBytes(document.size)}</DocumentSize>
             </DocumentInfoBlock>
             <PreviewDocumentButton
               document={document}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
@@ -13,6 +13,7 @@ import {mockGetVariable} from 'modules/mocks/api/v2/variables/getVariable';
 import {createVariable} from 'modules/testUtils';
 import {ViewDocumentListButton} from './ViewDocumentListButton';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
+import type {DocumentReference} from '@camunda/camunda-api-zod-schemas/8.10';
 
 const VARIABLE_KEY = 'variable-key-123';
 
@@ -21,19 +22,22 @@ const preparsedDocuments: DocumentInfo[] = [
     link: '/v2/documents/1',
     fileName: 'photo.png',
     type: 'image',
+    contentType: 'image/png',
     size: 1024,
   },
   {
     link: '/v2/documents/2',
     fileName: 'report.pdf',
     type: 'unknown',
+    contentType: 'application/pdf',
     size: 2048,
   },
   {
     link: '/v2/documents/3',
     fileName: 'notes.txt',
     type: 'unknown',
-    size: undefined,
+    contentType: 'text/plain',
+    size: 256,
   },
 ];
 
@@ -42,11 +46,20 @@ const buildDocumentReference = (
   fileName: string,
   contentType: string,
   size: number,
-) => ({
+): DocumentReference => ({
   'camunda.document.type': 'camunda',
+  storeId: 'in-memory',
   documentId,
   contentHash: `hash-${documentId}`,
-  metadata: {fileName, contentType, size},
+  metadata: {
+    fileName,
+    contentType,
+    size,
+    expiresAt: null,
+    processDefinitionId: null,
+    processInstanceKey: null,
+    customProperties: {},
+  },
 });
 
 const fullVariableValue = JSON.stringify([
@@ -255,6 +268,7 @@ describe('<ViewDocumentListButton />', () => {
             link: '/v2/documents/long',
             fileName: longFileName,
             type: 'unknown',
+            contentType: 'application/octet-stream',
             size: 1024,
           },
         ]}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/DocumentPreviewModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/DocumentPreviewModal.tsx
@@ -36,6 +36,10 @@ const DocumentPreviewModal: React.FC<StateProps & DocumentPreviewProps> = ({
 };
 
 const ModalContent: React.FC<DocumentPreviewProps> = ({document}) => {
+  if (document.link === null) {
+    return <p>Preview not available for document "{document.fileName}".</p>;
+  }
+
   if (document.type === 'image') {
     return <PreviewImage src={document.link} fileName={document.fileName} />;
   }
@@ -45,7 +49,7 @@ const ModalContent: React.FC<DocumentPreviewProps> = ({document}) => {
   }
 
   if (document.type === 'json') {
-    return <PreviewJson document={document} />;
+    return <PreviewJson src={document.link} fileName={document.fileName} />;
   }
 
   return <p>Preview not available for document "{document.fileName}".</p>;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
@@ -49,6 +49,7 @@ const unknownDocument: DocumentInfo = {
   link: '/v2/documents/archive',
   fileName: 'archive.zip',
   type: 'unknown',
+  contentType: 'application/zip',
   size: 4096,
 };
 
@@ -182,6 +183,26 @@ describe('<PreviewDocumentButton />', () => {
 
     expect(
       screen.getByRole('heading', {name: 'Preview: photo.png'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should render a disabled preview button when document has no link', () => {
+    const noLinkDocument: DocumentInfo = {
+      link: null,
+      fileName: 'no-hash.pdf',
+      type: 'pdf',
+      contentType: 'application/pdf',
+      size: 1024,
+    };
+
+    render(
+      <PreviewDocumentButton document={noLinkDocument} variableName="myDoc" />,
+    );
+
+    const button = screen.getByLabelText('Preview document for variable myDoc');
+    expect(button).toBeDisabled();
+    expect(
+      screen.getByText('Preview not available for this document'),
     ).toBeInTheDocument();
   });
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.tsx
@@ -19,10 +19,13 @@ type Props = {
 };
 
 const PreviewDocumentButton: React.FC<Props> = ({document, variableName}) => {
+  const isDisabled = document.link === null || document.type === 'unknown';
   const tooltipText =
-    document.type !== 'unknown'
-      ? 'Preview'
-      : 'Preview not available for this document type';
+    document.link === null
+      ? 'Preview not available for this document'
+      : document.type !== 'unknown'
+        ? 'Preview'
+        : 'Preview not available for this document type';
 
   return (
     <ModalStateManager
@@ -37,13 +40,13 @@ const PreviewDocumentButton: React.FC<Props> = ({document, variableName}) => {
           // @ts-expect-error - Solves rendering issues in `DocumentListModal`. Not exposed through TS but used at runtime.
           autoAlign={true}
           aria-label={`Preview document for variable ${variableName}`}
-          disabled={document.type === 'unknown'}
+          disabled={isDisabled}
           onClick={() => {
             tracking.track({
               eventName: 'document-previewed',
               documentType: document.type,
-              contentType: document.contentType ?? null,
-              size: document.size ?? null,
+              contentType: document.contentType,
+              size: document.size,
             });
             setOpen(true);
           }}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewJson.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewJson.tsx
@@ -10,7 +10,6 @@ import {lazy, Suspense} from 'react';
 import {useQuery} from '@tanstack/react-query';
 import {InlineLoading, InlineNotification} from '@carbon/react';
 import {beautifyJSON} from 'modules/utils/editor/beautifyJSON';
-import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
 import {PreviewJSONContainer} from './styled';
 import {queryKeys} from 'modules/queries/queryKeys';
 
@@ -24,17 +23,18 @@ const RichTextEditor = lazy(async () => {
 });
 
 type PreviewJsonProps = {
-  document: DocumentInfo;
+  src: string;
+  fileName: string;
 };
 
-const PreviewJson: React.FC<PreviewJsonProps> = ({document}) => {
+const PreviewJson: React.FC<PreviewJsonProps> = ({src, fileName}) => {
   const {data, isPending, isError} = useQuery({
-    queryKey: queryKeys.documents.content(document.link),
+    queryKey: queryKeys.documents.content(src),
     staleTime: 'static',
     queryFn: async ({signal}) => {
       // Note: Cannot use one of the request helpers here, because the link is
       // already prefixed with a configured context-path.
-      const response = await fetch(document.link, {
+      const response = await fetch(src, {
         credentials: 'include',
         headers: {Accept: 'application/json'},
         signal,
@@ -59,7 +59,7 @@ const PreviewJson: React.FC<PreviewJsonProps> = ({document}) => {
       {isError && (
         <InlineNotification
           kind="error"
-          subtitle={`Failed to load JSON preview for "${document.fileName}".`}
+          subtitle={`Failed to load JSON preview for "${fileName}".`}
           hideCloseButton
           lowContrast
         />

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
@@ -18,6 +18,7 @@ describe('<DocumentValueCell />', () => {
         link: '/v2/documents/doc',
         fileName: 'photo.png',
         type: 'image',
+        contentType: 'image/png',
         size: 112640,
       },
     };
@@ -28,23 +29,6 @@ describe('<DocumentValueCell />', () => {
     expect(screen.getByText('110 KiB')).toBeInTheDocument();
   });
 
-  it('should render a single document without size', () => {
-    const result: DocumentParseResult = {
-      type: 'single',
-      document: {
-        link: '/v2/documents/doc',
-        fileName: 'report.pdf',
-        type: 'unknown',
-        size: undefined,
-      },
-    };
-
-    render(<DocumentValueCell result={result} />);
-
-    expect(screen.getByText('report.pdf')).toBeInTheDocument();
-    expect(screen.queryByText(/[BKM]B/)).not.toBeInTheDocument();
-  });
-
   it('should middle-truncate a long filename', () => {
     const longName = 'a'.repeat(40) + 'original-middle' + 'z'.repeat(40);
     const result: DocumentParseResult = {
@@ -53,6 +37,7 @@ describe('<DocumentValueCell />', () => {
         link: '/v2/documents/doc',
         fileName: longName,
         type: 'unknown',
+        contentType: 'application/octet-stream',
         size: 1000,
       },
     };
@@ -72,18 +57,21 @@ describe('<DocumentValueCell />', () => {
           link: '/v2/documents/doc-1',
           fileName: 'a.pdf',
           type: 'unknown',
+          contentType: 'application/octet-stream',
           size: 1000,
         },
         {
           link: '/v2/documents/doc-2',
           fileName: 'b.pdf',
           type: 'unknown',
+          contentType: 'application/octet-stream',
           size: 2000,
         },
         {
           link: '/v2/documents/doc-3',
           fileName: 'c.pdf',
           type: 'unknown',
+          contentType: 'application/octet-stream',
           size: 3000,
         },
       ],
@@ -103,12 +91,14 @@ describe('<DocumentValueCell />', () => {
           link: '/v2/documents/doc-1',
           fileName: 'a.pdf',
           type: 'unknown',
+          contentType: 'application/octet-stream',
           size: 1000,
         },
         {
           link: '/v2/documents/doc-2',
           fileName: 'b.pdf',
           type: 'unknown',
+          contentType: 'application/octet-stream',
           size: 2000,
         },
       ],
@@ -127,6 +117,7 @@ describe('<DocumentValueCell />', () => {
         link: '/v2/documents/doc',
         fileName: 'my-important-file.pdf',
         type: 'unknown',
+        contentType: 'application/octet-stream',
         size: 5000,
       },
     };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.tsx
@@ -35,9 +35,7 @@ const DocumentValueCell: React.FC<Props> = ({result}) => {
         <DocumentFileName title={fileName}>
           {middleTruncate(fileName)}
         </DocumentFileName>
-        {size !== undefined && (
-          <DocumentSize>{toHumanReadableBytes(size)}</DocumentSize>
-        )}
+        <DocumentSize>{toHumanReadableBytes(size)}</DocumentSize>
       </DocumentCellContainer>
     );
   }

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -6,13 +6,16 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type {DocumentReference} from '@camunda/camunda-api-zod-schemas/8.10';
 import {
   parseDocumentVariable,
   toHumanReadableBytes,
 } from './parseDocumentVariable';
 import * as clientConfig from 'modules/utils/getClientConfig';
 
-const makeDocRef = (overrides: Record<string, unknown> = {}) => ({
+const makeDocRef = (
+  overrides: Record<string, unknown> = {},
+): DocumentReference => ({
   'camunda.document.type': 'camunda',
   storeId: 'in-memory',
   documentId: 'doc-123',
@@ -243,7 +246,7 @@ describe('parseDocumentVariable', () => {
 
   it('should detect a truncated single document reference', () => {
     const fullJson = JSON.stringify(makeDocRef());
-    const truncated = fullJson.slice(0, fullJson.length - 5);
+    const truncated = fullJson.slice(0, fullJson.length - 2);
     const result = parseDocumentVariable(truncated, true);
 
     assert(
@@ -285,7 +288,7 @@ describe('parseDocumentVariable', () => {
     expect(result).toBeNull();
   });
 
-  it('should detect a document reference without metadata', () => {
+  it('should return null for a document reference without metadata', () => {
     const value = JSON.stringify({
       'camunda.document.type': 'camunda',
       storeId: 'in-memory',
@@ -294,16 +297,7 @@ describe('parseDocumentVariable', () => {
     });
     const result = parseDocumentVariable(value, false);
 
-    expect(result).toEqual({
-      type: 'single',
-      document: {
-        link: '/v2/documents/doc-no-meta?storeId=in-memory&contentHash=sha256%3Aabc',
-        fileName: 'doc-no-meta',
-        type: 'unknown',
-        contentType: undefined,
-        size: undefined,
-      },
-    });
+    expect(result).toBeNull();
   });
 });
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -6,49 +6,31 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {z} from 'zod';
 import {safeJsonParse} from 'modules/utils';
 import {untruncateJson} from 'modules/utils/editor/untruncateJSON';
 import {mergePathname} from 'modules/request/mergePathname';
 import {getClientConfig} from 'modules/utils/getClientConfig';
-import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
+import {
+  endpoints,
+  documentReferenceSchema,
+  type DocumentReference,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 
 type DocumentType = 'image' | 'pdf' | 'json' | 'unknown';
 
 type DocumentInfo = {
   fileName: string;
-  link: string;
+  link: string | null;
   type: DocumentType;
-  contentType?: string | undefined;
-  size?: number | undefined;
+  contentType: string;
+  size: number;
 };
 
 type DocumentParseResult =
   | {type: 'single'; document: DocumentInfo}
   | {type: 'list'; documents: DocumentInfo[]; isLowerBound: boolean};
 
-const documentReferenceSchema = z
-  .object({
-    'camunda.document.type': z.literal('camunda'),
-    documentId: z.string(),
-    storeId: z.string().optional(),
-    contentHash: z.string(),
-    metadata: z
-      .object({
-        fileName: z.string().optional(),
-        contentType: z.string().optional(),
-        size: z.number().optional(),
-      })
-      .catchall(z.unknown())
-      .optional(),
-  })
-  .catchall(z.unknown());
-
-type DetectedDocumentReference = z.infer<typeof documentReferenceSchema>;
-
-function isDocumentReference(
-  value: unknown,
-): value is DetectedDocumentReference {
+function isDocumentReference(value: unknown): value is DocumentReference {
   return documentReferenceSchema.safeParse(value).success;
 }
 
@@ -61,24 +43,29 @@ const MIME_TYPE_MAP: Record<string, DocumentType> = {
   'application/json': 'json',
 };
 
-function getDocumentType(contentType: string | undefined): DocumentType {
-  if (!contentType) {
-    return 'unknown';
-  }
+function getDocumentType(contentType: string): DocumentType {
   return MIME_TYPE_MAP[contentType] ?? 'unknown';
 }
 
-function toDocumentInfo(ref: DetectedDocumentReference): DocumentInfo {
-  const link = mergePathname(
-    getClientConfig().contextPath,
-    endpoints.getDocument.getUrl(ref),
-  );
+function toDocumentInfo(ref: DocumentReference): DocumentInfo {
+  const link =
+    ref.contentHash !== null
+      ? mergePathname(
+          getClientConfig().contextPath,
+          endpoints.getDocument.getUrl({
+            documentId: ref.documentId,
+            storeId: ref.storeId,
+            contentHash: ref.contentHash,
+          }),
+        )
+      : null;
+
   return {
     link,
-    fileName: ref.metadata?.fileName ?? ref.documentId,
-    type: getDocumentType(ref.metadata?.contentType),
-    contentType: ref.metadata?.contentType,
-    size: ref.metadata?.size,
+    fileName: ref.metadata.fileName ?? ref.documentId,
+    type: getDocumentType(ref.metadata.contentType),
+    contentType: ref.metadata.contentType,
+    size: ref.metadata.size,
   };
 }
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.test.tsx
@@ -20,6 +20,26 @@ const pdfDocument: DocumentInfo = {
 };
 
 describe('<DownloadDocumentButton />', () => {
+  it('should render a disabled button when document has no link', () => {
+    const noLinkDocument: DocumentInfo = {
+      link: null,
+      fileName: 'no-hash.pdf',
+      type: 'pdf',
+      contentType: 'application/pdf',
+      size: 2048,
+    };
+
+    render(
+      <DownloadDocumentButton document={noLinkDocument} variableName="myPdf" />,
+    );
+
+    const button = screen.getByLabelText(
+      'Download document for variable myPdf',
+    );
+    expect(button).toBeDisabled();
+    expect(button.tagName).not.toBe('A');
+  });
+
   it('should render a download link with correct href and filename', () => {
     render(
       <DownloadDocumentButton document={pdfDocument} variableName="myPdf" />,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
@@ -17,28 +17,32 @@ type Props = {
 };
 
 const DownloadDocumentButton: React.FC<Props> = ({document, variableName}) => {
+  const isDisabled = document.link === null;
   return (
     <Button
-      as="a"
-      href={document.link}
-      download={document.fileName}
+      as={isDisabled ? undefined : 'a'}
+      href={document.link ?? undefined}
+      download={isDisabled ? undefined : document.fileName}
       rel="noopener"
       kind="ghost"
       size="sm"
       hasIconOnly
       renderIcon={Download}
-      iconDescription="Download"
+      iconDescription={
+        isDisabled ? 'Download not available for this document' : 'Download'
+      }
       tooltipPosition="top"
       tooltipAlignment="end"
       // @ts-expect-error - Solves rendering issues in `DocumentListModal`. Not exposed through TS but used at runtime.
       autoAlign={true}
       aria-label={`Download document for variable ${variableName}`}
+      disabled={isDisabled}
       onClick={() => {
         tracking.track({
           eventName: 'document-downloaded',
           documentType: document.type,
-          contentType: document.contentType ?? null,
-          size: document.size ?? null,
+          contentType: document.contentType,
+          size: document.size,
         });
       }}
     />

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
@@ -13,19 +13,33 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {getWrapper, mockProcessInstance} from './mocks';
+import type {DocumentReference} from '@camunda/camunda-api-zod-schemas/8.10';
 
-const makeDocumentRef = (overrides: Record<string, unknown> = {}) => ({
-  'camunda.document.type': 'camunda',
-  documentId: 'doc-abc',
-  storeId: 'in-memory',
-  contentHash: 'sha256-xyz',
-  metadata: {
-    fileName: 'test-document.pdf',
-    contentType: 'application/pdf',
-    size: 1024,
-  },
-  ...overrides,
-});
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+const makeDocumentRef = (
+  overrides: DeepPartial<DocumentReference> = {},
+): DocumentReference => {
+  return {
+    'camunda.document.type': 'camunda',
+    documentId: 'doc-abc',
+    storeId: 'in-memory',
+    contentHash: 'sha256-xyz',
+    ...overrides,
+    metadata: {
+      fileName: 'test-document.pdf',
+      contentType: 'application/pdf',
+      expiresAt: null,
+      processDefinitionId: null,
+      processInstanceKey: null,
+      size: 1024,
+      customProperties: {},
+      ...overrides.metadata,
+    },
+  } as DocumentReference;
+};
 
 describe('VariablesTab document variables', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Description

This PR updates `parseDocumentVariable` to use the Zod schema from `camunda-api-zod-schemas` instead of its own schema.

The API schema is more strict and requires more fields. This caused some changes to avoid unnecessary null checks.

Furthermore, `contentHash` is `nullable` in the OpenAPI schema, but required to successfully call [`GET /v2/documents/:documentId`](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/get-document/). Without it, requests get rejected. To handle this, the link is now `nullable` so we do not construct non-working links, and the Preview and Download buttons are disabled when the link is missing.

## Related issues

closes #53725
