### PR TITLE
feat: add zeebeVersionTagExpression() to AbstractBusinessRuleTaskBuilder

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBusinessRuleTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBusinessRuleTaskBuilder.java
@@ -107,4 +107,15 @@ public abstract class AbstractBusinessRuleTaskBuilder<B extends AbstractBusiness
     calledDecision.setVersionTag(versionTag);
     return myself;
   }
+
+  /**
+   * Sets a dynamic version tag for the decision that is called. The version tag is retrieved from
+   * the given expression.
+   *
+   * @param versionTagExpression the expression for the version tag of the decision
+   * @return the builder object
+   */
+  public B zeebeVersionTagExpression(final String versionTagExpression) {
+    return zeebeVersionTag(asZeebeExpression(versionTagExpression));
+  }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BusinessRuleTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BusinessRuleTaskBuilderTest.java
@@ -189,4 +189,23 @@ public class BusinessRuleTaskBuilderTest {
         .extracting(ZeebeCalledDecision::getVersionTag)
         .containsExactly("v1");
   }
+
+  @Test
+  void shouldSetVersionTagExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask("task", task -> task.zeebeVersionTagExpression("myversion"))
+            .done();
+
+    // then
+    final ModelElementInstance businessRuleTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) businessRuleTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledDecision.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledDecision::getVersionTag)
+        .containsExactly("=myversion");
+  }
 }


### PR DESCRIPTION
## Description

Adds `zeebeVersionTagExpression()` to `AbstractBusinessRuleTaskBuilder`, allowing a process variable or expression to dynamically determine the version tag of the called decision in a Business Rule Task.

```java
.businessRuleTask("task", t -> t
    .zeebeBindingType(ZeebeBindingType.versionTag)
    .zeebeVersionTagExpression("myVersionTagVariable")
    .zeebeResultVariable("result"))
```

This produces `versionTag="=myVersionTagVariable"` in the BPMN XML, consistent with how other expression-based builder methods work (e.g. `zeebeCalledDecisionIdExpression`).

## Changes

- `AbstractBusinessRuleTaskBuilder`: added `zeebeVersionTagExpression(String)` method
- `BusinessRuleTaskBuilderTest`: added `shouldSetVersionTagExpression()` test verifying the `=` prefix is applied

## Related issues

Closes #52908