### PR TITLE
fix: added commit to DDL statements - for postgres and mssql

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/ScriptBasedSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/ScriptBasedSchemaManager.java
@@ -15,6 +15,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.sql.DataSource;
 import liquibase.exception.LiquibaseException;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -24,6 +26,7 @@ import org.springframework.beans.factory.annotation.Value;
  * (e.g. Oracle).
  */
 public class ScriptBasedSchemaManager implements RdbmsSchemaManagerRegistry, InitializingBean {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ScriptBasedSchemaManager.class);
 
   private static final ConcurrentHashMap<String, String> SCRIPT_CACHE = new ConcurrentHashMap<>();
 
@@ -77,7 +80,11 @@ public class ScriptBasedSchemaManager implements RdbmsSchemaManagerRegistry, Ini
       for (final String stmt : sql.split(";")) {
         final String trimmed = stmt.strip();
         if (!trimmed.isEmpty()) {
+          LOGGER.info(
+              "Executing DDL statement: {}...",
+              trimmed.substring(0, Math.min(trimmed.length(), 50)));
           conn.createStatement().execute(trimmed);
+          conn.commit();
         }
       }
     }


### PR DESCRIPTION
## Description

With the recent PR https://github.com/camunda/camunda/pull/54468 we have fixed transaction issues with RDBMS. We especially fixed the auto-commit setting of the datasource. This now introduced a new bug for the MultiDB tests in PostgreSQL and MSSQL. These DBs need to explicitly commit DDL changes.

- add explicit commit in the `ScriptBasedSchemaManager`
- add some logging for the `ScriptBasedSchemaManager`

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
