### PR TITLE
Fix codeql issues history cleanup it

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
@@ -25,6 +25,7 @@ import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.BatchOperationType;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -228,7 +229,7 @@ public class HistoryCleanupIT {
   public void shouldDeleteStandaloneDecisionAuditLogDuringCleanup() {
     // GIVEN - Create a standalone decision audit log with an expired cleanup date
     final var evaluationDate = OffsetDateTime.now().minusDays(40);
-    final var processInstanceKey = Math.abs(new java.util.Random().nextLong());
+    final var processInstanceKey = Math.abs(ThreadLocalRandom.current().nextLong());
     final var auditLog =
         AuditLogFixtures.createRandomized(
             b ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
@@ -222,7 +222,7 @@ public class HistoryCleanupIT {
   public void shouldDeleteStandaloneDecisionAuditLogDuringCleanup() {
     // GIVEN - Create a standalone decision audit log with an expired cleanup date
     final var evaluationDate = OffsetDateTime.now().minusDays(40);
-    final var processInstanceKey = Math.abs(ThreadLocalRandom.current().nextLong());
+    final var processInstanceKey = ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE);
     final var auditLog =
         AuditLogFixtures.createRandomized(
             b ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
@@ -74,11 +74,9 @@ public class HistoryCleanupIT {
 
     final var historyCleanupDate1 =
         jdbcTemplate.queryForObject(
-            "SELECT HISTORY_CLEANUP_DATE FROM "
-                + "PROCESS_INSTANCE"
-                + " WHERE PROCESS_INSTANCE_KEY = "
-                + processInstanceKey,
-            OffsetDateTime.class);
+            "SELECT HISTORY_CLEANUP_DATE FROM PROCESS_INSTANCE WHERE PROCESS_INSTANCE_KEY = ?",
+            OffsetDateTime.class,
+            processInstanceKey);
 
     assertThat(historyCleanupDate1)
         .describedAs("should update the history cleanup date for PROCESS_INSTANCE but date is null")
@@ -103,11 +101,9 @@ public class HistoryCleanupIT {
     // THEN
     final var historyCleanupDate =
         jdbcTemplate.queryForObject(
-            "SELECT HISTORY_CLEANUP_DATE FROM "
-                + "PROCESS_INSTANCE"
-                + " WHERE PROCESS_INSTANCE_KEY = "
-                + processInstanceKey,
-            OffsetDateTime.class);
+            "SELECT HISTORY_CLEANUP_DATE FROM PROCESS_INSTANCE WHERE PROCESS_INSTANCE_KEY = ?",
+            OffsetDateTime.class,
+            processInstanceKey);
 
     assertThat(historyCleanupDate)
         .describedAs(
@@ -155,11 +151,9 @@ public class HistoryCleanupIT {
 
   private OffsetDateTime getBatchOperationHistoryCleanupDate(final String batchOperationKey) {
     return jdbcTemplate.queryForObject(
-        "SELECT HISTORY_CLEANUP_DATE FROM BATCH_OPERATION "
-            + "WHERE BATCH_OPERATION_KEY = '"
-            + batchOperationKey
-            + "'",
-        OffsetDateTime.class);
+        "SELECT HISTORY_CLEANUP_DATE FROM BATCH_OPERATION WHERE BATCH_OPERATION_KEY = ?",
+        OffsetDateTime.class,
+        batchOperationKey);
   }
 
   @Test
@@ -177,10 +171,9 @@ public class HistoryCleanupIT {
     // THEN - verify cleanup date is calculated correctly
     final OffsetDateTime cleanupDate =
         jdbcTemplate.queryForObject(
-            "SELECT HISTORY_CLEANUP_DATE FROM DECISION_INSTANCE "
-                + "WHERE DECISION_INSTANCE_KEY = "
-                + decisionInstance.decisionInstanceKey(),
-            OffsetDateTime.class);
+            "SELECT HISTORY_CLEANUP_DATE FROM DECISION_INSTANCE WHERE DECISION_INSTANCE_KEY = ?",
+            OffsetDateTime.class,
+            decisionInstance.decisionInstanceKey());
 
     // The cleanup date should be evaluationDate + decisionInstanceTTL (default 30 days)
     final var expectedCleanupDate = evaluationDate.plusDays(30);
@@ -204,9 +197,9 @@ public class HistoryCleanupIT {
     // Verify it was created
     final var countBefore =
         jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM DECISION_INSTANCE WHERE DECISION_INSTANCE_KEY = "
-                + decisionInstance.decisionInstanceKey(),
-            Integer.class);
+            "SELECT COUNT(*) FROM DECISION_INSTANCE WHERE DECISION_INSTANCE_KEY = ?",
+            Integer.class,
+            decisionInstance.decisionInstanceKey());
     assertThat(countBefore).isEqualTo(1);
 
     // WHEN - Run cleanup with a date that should trigger deletion
@@ -217,9 +210,9 @@ public class HistoryCleanupIT {
     // THEN - Verify the standalone decision instance was deleted
     final var countAfter =
         jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM DECISION_INSTANCE WHERE DECISION_INSTANCE_KEY = "
-                + decisionInstance.decisionInstanceKey(),
-            Integer.class);
+            "SELECT COUNT(*) FROM DECISION_INSTANCE WHERE DECISION_INSTANCE_KEY = ?",
+            Integer.class,
+            decisionInstance.decisionInstanceKey());
     assertThat(countAfter)
         .describedAs("Standalone decision instance should be deleted during cleanup")
         .isEqualTo(0);
@@ -243,8 +236,9 @@ public class HistoryCleanupIT {
     // Verify it was created
     final var countBefore =
         jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM AUDIT_LOG WHERE AUDIT_LOG_KEY = '" + auditLog.auditLogKey() + "'",
-            Integer.class);
+            "SELECT COUNT(*) FROM AUDIT_LOG WHERE AUDIT_LOG_KEY = ?",
+            Integer.class,
+            auditLog.auditLogKey());
     assertThat(countBefore).isEqualTo(1);
 
     // WHEN - Run cleanup with a date that should trigger deletion
@@ -255,8 +249,9 @@ public class HistoryCleanupIT {
     // THEN - Verify the standalone decision audit log was deleted
     final var countAfter =
         jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM AUDIT_LOG WHERE AUDIT_LOG_KEY = '" + auditLog.auditLogKey() + "'",
-            Integer.class);
+            "SELECT COUNT(*) FROM AUDIT_LOG WHERE AUDIT_LOG_KEY = ?",
+            Integer.class,
+            auditLog.auditLogKey());
     assertThat(countAfter)
         .describedAs("Standalone decision audit log should be deleted during cleanup")
         .isEqualTo(0);
@@ -279,9 +274,9 @@ public class HistoryCleanupIT {
     // Verify it was created
     final var countBefore =
         jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM DECISION_INSTANCE WHERE DECISION_INSTANCE_KEY = "
-                + decisionInstance.decisionInstanceKey(),
-            Integer.class);
+            "SELECT COUNT(*) FROM DECISION_INSTANCE WHERE DECISION_INSTANCE_KEY = ?",
+            Integer.class,
+            decisionInstance.decisionInstanceKey());
     assertThat(countBefore).isEqualTo(1);
 
     // WHEN - Run cleanup with a date that should trigger deletion
@@ -292,9 +287,9 @@ public class HistoryCleanupIT {
     // THEN - Verify the decision instance with PI was NOT deleted by standalone cleanup
     final var countAfter =
         jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM DECISION_INSTANCE WHERE DECISION_INSTANCE_KEY = "
-                + decisionInstance.decisionInstanceKey(),
-            Integer.class);
+            "SELECT COUNT(*) FROM DECISION_INSTANCE WHERE DECISION_INSTANCE_KEY = ?",
+            Integer.class,
+            decisionInstance.decisionInstanceKey());
     assertThat(countAfter)
         .describedAs(
             "Decision instance with process instance should NOT be deleted by standalone cleanup")


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fix for CodeQL findings for `qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java` described in https://github.com/camunda/camunda/issues/52689 and https://github.com/camunda/camunda/issues/52692.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52689 and #52692 
