### PR TITLE
fix: fix-jdk21-support

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -99,6 +99,12 @@ runs:
         go-version: ">=1.23.1"
         cache: false # disabling since not working anyways without a cache-dependency-path specified
 
+    - name: Setup Java
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        distribution: "temurin"
+        java-version: "21"
+
     - uses: ./.github/actions/setup-build
       if: ${{ inputs.source-build == 'true' }}
       with:

--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -196,15 +196,12 @@ runs:
       working-directory: ./c8run
       env:
         JAVA_HOME: /usr/lib/jvm/temurin-21-jdk-amd64
-        JAVA_VERSION: 21.0.3
 
     - if: ${{ startsWith(inputs.os, 'macos') }}
       name: Mac - Run c8run
       shell: bash
       run: ./c8run start --config e2e_tests/prefix-config.yaml
       working-directory: ./c8run
-      env:
-        JAVA_VERSION: 21.0.3
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -156,7 +156,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, macos-15-intel]
     name: C8Run Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: camunda-dist-build
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -246,7 +246,7 @@ jobs:
   test_c8run_e2e_on_windows:
     name: C8Run Test Windows
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: camunda-dist-build
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -269,6 +269,12 @@ jobs:
           go-version: ${{ env.GO_VERSION}}
           cache: false # disabling since not working anyways without a cache-dependency-path specified
 
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Download Camunda Core Dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -318,8 +324,6 @@ jobs:
         run: bash -c './c8run.exe start --config e2e_tests/prefix-config.yaml'
         working-directory: ./c8run
         shell: bash
-        env:
-          JAVA_VERSION: "22.0.2"
 
       - name: Install jq
         run: choco install jq

--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -139,6 +139,13 @@ jobs:
         with:
           go-version: ">=1.23.1"
           cache: false # disabling since not working anyways without a cache-dependency-path specified
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Build artifact runtime distro
         working-directory: ${{ matrix.os.workingDir }}
         run: go build -o ${{ matrix.os.c8runArtifactName }} ./cmd/c8run

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -22,6 +22,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const javaHelperReleaseVersion = "21"
+
 func Clean(camundaVersion string) {
 	// Older C8Run builds extracted Elasticsearch locally. Remove any leftovers so they cannot be
 	// picked up by later packaging runs after Elasticsearch was removed from the distribution.
@@ -198,21 +200,22 @@ func createZipArchive(filesToArchive []string, outputPath, sourceRoot, targetRoo
 }
 
 func BuildJavaScripts() error {
-	javaVersionCmd := exec.Command("javac", "JavaVersion.java")
+	for _, javaFile := range []string{"JavaVersion.java", "JavaHome.java"} {
+		if err := compileJavaHelper(javaFile); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func compileJavaHelper(javaFile string) error {
+	javaCmd := exec.Command("javac", "--release", javaHelperReleaseVersion, javaFile)
 	var out strings.Builder
 	var stderr strings.Builder
-	javaVersionCmd.Stdout = &out
-	javaVersionCmd.Stderr = &stderr
-	err := javaVersionCmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to compile JavaVersion : %w", err)
-	}
-	javaHomeCmd := exec.Command("javac", "JavaHome.java")
-	javaHomeCmd.Stdout = &out
-	javaHomeCmd.Stderr = &stderr
-	err = javaHomeCmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to compile JavaHome : %w", err)
+	javaCmd.Stdout = &out
+	javaCmd.Stderr = &stderr
+	if err := javaCmd.Run(); err != nil {
+		return fmt.Errorf("failed to compile %s: %w\n%s", javaFile, err, stderr.String())
 	}
 	return nil
 }

--- a/c8run/internal/start/startuphandler.go
+++ b/c8run/internal/start/startuphandler.go
@@ -47,17 +47,24 @@ func printSystemInformation(javaVersion, javaHome, javaOpts string) {
 }
 
 func getJavaVersion(javaBinary string) (string, error) {
-	javaVersionCmd := exec.Command(javaBinary, "JavaVersion")
+	return runJavaHelper(javaBinary, "JavaVersion")
+}
+
+func runJavaHelper(javaBinary, helperClass string) (string, error) {
+	javaCmd := exec.Command(javaBinary, helperClass)
 	var out strings.Builder
 	var stderr strings.Builder
-	javaVersionCmd.Stdout = &out
-	javaVersionCmd.Stderr = &stderr
-	err := javaVersionCmd.Run()
-	if err != nil {
-		return "", fmt.Errorf("failed to run java version command: %w", err)
+	javaCmd.Stdout = &out
+	javaCmd.Stderr = &stderr
+	if err := javaCmd.Run(); err != nil {
+		return "", fmt.Errorf(
+			"failed to run java helper %s with %s: %w\n%s",
+			helperClass,
+			javaBinary,
+			err,
+			strings.TrimSpace(stderr.String()))
 	}
-	javaVersionOutput := out.String()
-	return javaVersionOutput, nil
+	return out.String(), nil
 }
 
 type StartupHandler struct {
@@ -126,17 +133,7 @@ func (s *StartupHandler) startApplication(cmd *exec.Cmd, pid string, logPath str
 }
 
 func getJavaHome(javaBinary string) (string, error) {
-	javaHomeCmd := exec.Command(javaBinary, "JavaHome")
-	var out strings.Builder
-	var stderr strings.Builder
-	javaHomeCmd.Stdout = &out
-	javaHomeCmd.Stderr = &stderr
-	err := javaHomeCmd.Run()
-	if err != nil {
-		return "", fmt.Errorf("failed to run java version command: %w", err)
-	}
-	javaHomeOutput := out.String()
-	return javaHomeOutput, nil
+	return runJavaHelper(javaBinary, "JavaHome")
 }
 
 func resolveJavaHomeAndBinary() (string, string, error) {
@@ -160,7 +157,7 @@ func resolveJavaHomeAndBinary() (string, string, error) {
 	if javaHome == "" {
 		javaHome, err = getJavaHome(javaBinary)
 		if err != nil {
-			return "", "", fmt.Errorf("failed to get JAVA_HOME")
+			return "", "", fmt.Errorf("failed to get JAVA_HOME: %w", err)
 		}
 	}
 
@@ -249,7 +246,7 @@ func (s *StartupHandler) StartCommand(wg *sync.WaitGroup, ctx context.Context, s
 	if javaVersion == "" {
 		javaVersion, err = getJavaVersion(javaBinary)
 		if err != nil {
-			fmt.Println("Failed to get Java version")
+			fmt.Printf("Failed to get Java version: %v\n", err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
fixes: #54749 

Root cause is confirmed: the C8Run Java helper classes were compiled without a fixed target release, so the bytecode depended on the JDK used by the packaging
  job. For the 8.9.6 RC they were compiled with JDK 25, producing class major version 69, which Java 21 cannot load.

  The fix is to compile JavaVersion.class and JavaHome.class with `javac --release 21`, so the artifact remains compatible with Java 21 even if the package is
  built using JDK 25. I rebuilt and verified the packaged helpers are class major version 65, and C8Run starts/stops successfully with both Java 21 and Java 25.