### PR TITLE
fix: use ServiceRegistry in DevDataGeneratorAbstract instead of singleton beans

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -417,11 +417,6 @@ public class CamundaServicesConfiguration {
         PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID);
   }
 
-  @Bean
-  public ResourceServices resourceServices(final ServiceRegistry serviceRegistry) {
-    return serviceRegistry.resourceServices(PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID);
-  }
-
   // This is required by BrokerModuleConfiguration that requires UserServices for Basic auth
   // TODO we need to make it physical tenant aware
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -417,6 +417,11 @@ public class CamundaServicesConfiguration {
         PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID);
   }
 
+  @Bean
+  public ResourceServices resourceServices(final ServiceRegistry serviceRegistry) {
+    return serviceRegistry.resourceServices(PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
   // This is required by BrokerModuleConfiguration that requires UserServices for Basic auth
   // TODO we need to make it physical tenant aware
   @Bean

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/DevDataGeneratorAbstract.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/DevDataGeneratorAbstract.java
@@ -13,10 +13,9 @@ import static io.camunda.zeebe.protocol.record.value.TenantOwned.DEFAULT_TENANT_
 import io.camunda.client.impl.command.StreamUtil;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
-import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
-import io.camunda.service.ResourceServices;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
+import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.PayloadUtil;
@@ -46,13 +45,13 @@ public abstract class DevDataGeneratorAbstract implements DataGenerator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DevDataGeneratorAbstract.class);
 
+  private static final String DEFAULT_PHYSICAL_TENANT_ID = "default";
+
   @Autowired protected TasklistProperties tasklistProperties;
 
   @Autowired private PayloadUtil payloadUtil;
 
-  @Autowired private ResourceServices resourceServices;
-
-  @Autowired private ProcessInstanceServices processInstanceServices;
+  @Autowired private ServiceRegistry serviceRegistry;
 
   @Autowired private CamundaAuthenticationProvider authenticationProvider;
 
@@ -272,9 +271,11 @@ public abstract class DevDataGeneratorAbstract implements DataGenerator {
         final byte[] bytes = StreamUtil.readInputStream(resourceStream);
         executeCamundaServiceAnonymously(
             (authentication) ->
-                resourceServices.deployResources(
-                    new DeployResourcesRequest(Map.of(classpathResource, bytes), tenantId),
-                    authentication));
+                serviceRegistry
+                    .resourceServices(DEFAULT_PHYSICAL_TENANT_ID)
+                    .deployResources(
+                        new DeployResourcesRequest(Map.of(classpathResource, bytes), tenantId),
+                        authentication));
       } else {
         throw new FileNotFoundException(classpathResource);
       }
@@ -289,22 +290,24 @@ public abstract class DevDataGeneratorAbstract implements DataGenerator {
       final String bpmnProcessId, final Map<String, Object> variables, final String tenantId) {
     return executeCamundaServiceAnonymously(
         (authentication) ->
-            processInstanceServices.createProcessInstance(
-                new ProcessInstanceCreateRequest(
-                    -1L,
-                    bpmnProcessId,
-                    -1,
-                    variables,
-                    tenantId,
-                    null,
-                    null,
-                    null,
-                    List.of(),
-                    List.of(),
-                    null,
-                    Set.of(),
-                    null),
-                authentication));
+            serviceRegistry
+                .processInstanceServices(DEFAULT_PHYSICAL_TENANT_ID)
+                .createProcessInstance(
+                    new ProcessInstanceCreateRequest(
+                        -1L,
+                        bpmnProcessId,
+                        -1,
+                        variables,
+                        tenantId,
+                        null,
+                        null,
+                        null,
+                        List.of(),
+                        List.of(),
+                        null,
+                        Set.of(),
+                        null),
+                    authentication));
   }
 
   private <T> T executeCamundaServiceAnonymously(


### PR DESCRIPTION
## Description

Refactors `DevDataGeneratorAbstract` to obtain `ResourceServices` and `ProcessInstanceServices` from the `ServiceRegistry` directly, instead of relying on `@Autowired` singleton beans.

### Why

Since `34678717d07` ("refactor: move TopologyService to tenant level services", May 30), the `@Bean ResourceServices` method was removed from `CamundaServicesConfiguration`. The instantiation moved into the per-tenant `ServiceRegistry` builder, but a standalone bean was no longer exposed.

This breaks startup when the `dev-data` Spring profile is active, because `DevDataGeneratorAbstract` used `@Autowired private ResourceServices resourceServices` — which requires a bean to be present in the context.

**Error:**
```
No qualifying bean of type 'io.camunda.service.ResourceServices' available:
expected at least 1 bean which qualifies as autowire candidate.
```

### Fix

Rather than re-adding a singleton bean that will be removed in the near future, this PR:

1. Replaces the `@Autowired ResourceServices` and `@Autowired ProcessInstanceServices` fields in `DevDataGeneratorAbstract` with a single `@Autowired ServiceRegistry`.
2. Obtains the services via `serviceRegistry.resourceServices(DEFAULT_PHYSICAL_TENANT_ID)` and `serviceRegistry.processInstanceServices(DEFAULT_PHYSICAL_TENANT_ID)` at call sites.

This is the long-term approach — the data generator no longer depends on singleton service beans that are being phased out.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #