### PR TITLE
backport(#47493): add CAMUNDA_MODE and overridable SPRING_PROFILES_ACTIVE to docker-compose.yml [stable/8.9]

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -101,7 +101,11 @@ services:
     environment:
       - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx1g'
       - ZEEBE_BROKER_NETWORK_HOST=camunda
-      - SPRING_PROFILES_ACTIVE=e2e-test,consolidated-auth,tasklist,broker,operate,admin
+      # CAMUNDA_MODE can be set externally to control the runtime mode
+      - CAMUNDA_MODE=${CAMUNDA_MODE:-}
+      # Default Spring profiles for the e2e orchestration cluster test suite.
+      # Can be overridden by setting SPRING_PROFILES_ACTIVE externally.
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-e2e-test,consolidated-auth,tasklist,broker,operate,admin}
       - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
       - CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED=true
       - CAMUNDA_SECURITY_AUTHENTICATION_METHOD=BASIC
@@ -129,6 +133,7 @@ services:
       - CAMUNDA_DATA_AUDITLOG_USER_EXCLUDES_1=BATCH
       - CAMUNDA_DATA_AUDITLOG_CLIENT_CATEGORIES_0=ADMIN
       - CAMUNDA_DATA_AUDITLOG_CLIENT_EXCLUDES_0=PROCESS_INSTANCE
+      - CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED=true
     ports:
       - 26500:26500
       - 9600:9600


### PR DESCRIPTION
## Backport of #47493

Backports the `docker-compose.yml` changes from #47493 to `stable/8.9` as requested by @hilalbursalii.

### Changes
- Add `CAMUNDA_MODE=${CAMUNDA_MODE:-}` env var to the `camunda` service (externally settable, defaults to empty)
- Make `SPRING_PROFILES_ACTIVE` overridable via env while keeping the same default profile list
- Add `CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED=true`

### Related
- Parent PR: #47493