### PR TITLE
Fix scroll flicker in Instance History partial last page

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.test.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.test.ts
@@ -539,6 +539,41 @@ describe.todo('elementInstancesTreeStore', () => {
     expect(count).toBe(0);
   });
 
+  it('should skip fetch and return 0 when remaining items fit in current window', async () => {
+    // Regression: totalItems=53, windowEnd=50. Old guard (windowEnd >= totalItems)
+    // would allow a fetch that replaces 53 items with 3, causing a scroll jump/loop.
+    const items53 = Array.from({length: 53}, (_, i) =>
+      createMockElementInstance({
+        elementInstanceKey: `${2251799813685630 + i}`,
+        elementId: `task_${i}`,
+        startDate: `2023-01-01T10:${String(i).padStart(2, '0')}:00.000Z`,
+      }),
+    );
+    mockSearchElementInstances().withSuccess(createMockResponse(items53, 53));
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    const before = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(before?.pageMetadata.windowEnd).toBe(50);
+    expect(before?.pageMetadata.totalItems).toBe(53);
+
+    const count = await elementInstancesTreeStore.fetchNextPage(
+      mockProcessInstanceKey,
+    );
+
+    expect(count).toBe(0);
+
+    // Guard must have fired: items, metadata, and status are all unchanged.
+    const after = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(after?.items.length).toBe(53);
+    expect(after?.pageMetadata.windowEnd).toBe(50);
+    expect(after?.pageMetadata.totalItems).toBe(53);
+    expect(after?.status).toBe('loaded');
+  });
+
   it('should return -1 when next page fetch fails', async () => {
     mockSearchElementInstances().withSuccess(mockFirstPageResponse);
     await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
@@ -218,10 +218,14 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
       return -1;
     }
 
-    // All remaining items already fit in the second page of the current window
-    // (loaded by the initial 2*PAGE_SIZE fetch). Fetching would remove PAGE_SIZE
-    // items from the top with no compensation, causing a scroll jump and loop.
-    if (nodeData.pageMetadata.windowEnd + PAGE_SIZE >= nodeData.pageMetadata.totalItems) {
+    // Each window holds 2*PAGE_SIZE items. If all remaining items fit in the
+    // second half of the current window, they are already in the DOM — fetching
+    // would replace PAGE_SIZE items from the top with no compensation, causing
+    // a scroll jump and a fetch loop.
+    if (
+      nodeData.pageMetadata.windowEnd + PAGE_SIZE >=
+      nodeData.pageMetadata.totalItems
+    ) {
       return 0;
     }
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
@@ -218,12 +218,15 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
       return -1;
     }
 
-    const nextWindowStart = nodeData.pageMetadata.windowEnd;
-    const nextWindowEnd = nextWindowStart + PAGE_SIZE;
-
-    if (nextWindowStart >= nodeData.pageMetadata.totalItems) {
+    // All remaining items already fit in the second page of the current window
+    // (loaded by the initial 2*PAGE_SIZE fetch). Fetching would remove PAGE_SIZE
+    // items from the top with no compensation, causing a scroll jump and loop.
+    if (nodeData.pageMetadata.windowEnd + PAGE_SIZE >= nodeData.pageMetadata.totalItems) {
       return 0;
     }
+
+    const nextWindowStart = nodeData.pageMetadata.windowEnd;
+    const nextWindowEnd = nextWindowStart + PAGE_SIZE;
 
     this.setNodeStatus(scopeKey, 'loading');
 


### PR DESCRIPTION
## Description

When scrolling the Instance History panel in Operate, reaching the last element instance triggers a visible scroll jump and potentially an infinite loop of API calls, if the total item count is not an exact multiple of the page size (50).

The sliding-window paginator fetches `limit = 100` items from `windowEnd` when the last visible item is reached. For example, with 53 total items and `windowEnd = 50`, the fetch returns only 3 items and replaces the full 53-item DOM list with a 3-item one — dropping 50 rows from the top with no scroll compensation. This leaves only 3 items visible near the top, immediately triggering `fetchPreviousPage`, which restores the 50 items and puts the viewport back near item 50, triggering `fetchNextPage` again in a loop.

The fix skips the fetch entirely when `windowEnd + PAGE_SIZE >= totalItems`, since the initial double-page fetch already loaded all remaining items into the DOM.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54763