### PR TITLE
feat: add expired tags to expired documents

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/DocumentListModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/DocumentListModal.tsx
@@ -7,7 +7,7 @@
  */
 
 import {useMemo} from 'react';
-import {Modal} from '@carbon/react';
+import {Modal, Tag} from '@carbon/react';
 import type {StateProps} from 'modules/components/ModalStateManager';
 import {useVariable} from 'modules/queries/variables/useVariable';
 import {
@@ -86,6 +86,11 @@ const DocumentListModal: React.FC<StateProps & Props> = ({
                 {middleTruncate(document.fileName)}
               </DocumentFileName>
               <DocumentSize>{toHumanReadableBytes(document.size)}</DocumentSize>
+              {document.isExpired && (
+                <Tag type="red" size="sm">
+                  Expired
+                </Tag>
+              )}
             </DocumentInfoBlock>
             <PreviewDocumentButton
               document={document}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
@@ -24,6 +24,7 @@ const preparsedDocuments: DocumentInfo[] = [
     type: 'image',
     contentType: 'image/png',
     size: 1024,
+    isExpired: false,
   },
   {
     link: '/v2/documents/2',
@@ -31,6 +32,7 @@ const preparsedDocuments: DocumentInfo[] = [
     type: 'unknown',
     contentType: 'application/pdf',
     size: 2048,
+    isExpired: false,
   },
   {
     link: '/v2/documents/3',
@@ -38,6 +40,7 @@ const preparsedDocuments: DocumentInfo[] = [
     type: 'unknown',
     contentType: 'text/plain',
     size: 256,
+    isExpired: false,
   },
 ];
 
@@ -270,6 +273,7 @@ describe('<ViewDocumentListButton />', () => {
             type: 'unknown',
             contentType: 'application/octet-stream',
             size: 1024,
+            isExpired: false,
           },
         ]}
         isLowerBound={false}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/styled.tsx
@@ -31,10 +31,13 @@ const DocumentListItem = styled.li`
 const DocumentInfo = styled.div`
   flex: 1;
   min-width: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--cds-spacing-01);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  grid-auto-flow: column;
+  column-gap: var(--cds-spacing-03);
+  row-gap: var(--cds-spacing-01);
+  justify-items: start;
 `;
 
 const DocumentFileName = styled.span`

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/styled.tsx
@@ -33,6 +33,7 @@ const DocumentInfo = styled.div`
   min-width: 0;
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: var(--cds-spacing-01);
 `;
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
@@ -27,6 +27,7 @@ const imageDocument: DocumentInfo = {
   type: 'image',
   contentType: 'image/png',
   size: 1024,
+  isExpired: false,
 };
 
 const pdfDocument: DocumentInfo = {
@@ -35,6 +36,7 @@ const pdfDocument: DocumentInfo = {
   type: 'pdf',
   contentType: 'application/pdf',
   size: 2048,
+  isExpired: false,
 };
 
 const jsonDocument: DocumentInfo = {
@@ -43,6 +45,7 @@ const jsonDocument: DocumentInfo = {
   type: 'json',
   contentType: 'application/json',
   size: 256,
+  isExpired: false,
 };
 
 const unknownDocument: DocumentInfo = {
@@ -51,6 +54,7 @@ const unknownDocument: DocumentInfo = {
   type: 'unknown',
   contentType: 'application/zip',
   size: 4096,
+  isExpired: false,
 };
 
 describe('<PreviewDocumentButton />', () => {
@@ -186,6 +190,25 @@ describe('<PreviewDocumentButton />', () => {
     ).toBeInTheDocument();
   });
 
+  it('should render a disabled preview button with expired tooltip when document is expired', () => {
+    const expiredDocument: DocumentInfo = {
+      link: '/v2/documents/pdf',
+      fileName: 'expired.pdf',
+      type: 'pdf',
+      contentType: 'application/pdf',
+      size: 1024,
+      isExpired: true,
+    };
+
+    render(
+      <PreviewDocumentButton document={expiredDocument} variableName="myDoc" />,
+    );
+
+    const button = screen.getByLabelText('Preview document for variable myDoc');
+    expect(button).toBeDisabled();
+    expect(screen.getByText('Document has expired')).toBeInTheDocument();
+  });
+
   it('should render a disabled preview button when document has no link', () => {
     const noLinkDocument: DocumentInfo = {
       link: null,
@@ -193,6 +216,7 @@ describe('<PreviewDocumentButton />', () => {
       type: 'pdf',
       contentType: 'application/pdf',
       size: 1024,
+      isExpired: false,
     };
 
     render(

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.tsx
@@ -13,19 +13,28 @@ import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
 import {DocumentPreviewModal} from './DocumentPreviewModal';
 import {tracking} from 'modules/tracking';
 
+function getTooltipText(document: DocumentInfo): string {
+  switch (true) {
+    case document.isExpired:
+      return 'Document has expired';
+    case document.link === null:
+      return 'Preview not available for this document';
+    case document.type === 'unknown':
+      return 'Preview not available for this document type';
+    default:
+      return 'Preview';
+  }
+}
+
 type Props = {
   document: DocumentInfo;
   variableName: string;
 };
 
 const PreviewDocumentButton: React.FC<Props> = ({document, variableName}) => {
-  const isDisabled = document.link === null || document.type === 'unknown';
-  const tooltipText =
-    document.link === null
-      ? 'Preview not available for this document'
-      : document.type !== 'unknown'
-        ? 'Preview'
-        : 'Preview not available for this document type';
+  const isDisabled =
+    document.link === null || document.isExpired || document.type === 'unknown';
+  const tooltipText = getTooltipText(document);
 
   return (
     <ModalStateManager

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
@@ -135,7 +135,7 @@ describe('<DocumentValueCell />', () => {
     expect(screen.getByTitle('my-important-file.pdf')).toBeInTheDocument();
   });
 
-  it('should render an expired tag for an expired documents', () => {
+  it('should render an expired tag for expired documents', () => {
     const result: DocumentParseResult = {
       type: 'single',
       document: {
@@ -153,7 +153,7 @@ describe('<DocumentValueCell />', () => {
     expect(screen.getByText('Expired')).toBeInTheDocument();
   });
 
-  it('should not render an expired tag for a non-expired documents', () => {
+  it('should not render an expired tag for non-expired documents', () => {
     const result: DocumentParseResult = {
       type: 'single',
       document: {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
@@ -20,6 +20,7 @@ describe('<DocumentValueCell />', () => {
         type: 'image',
         contentType: 'image/png',
         size: 112640,
+        isExpired: false,
       },
     };
 
@@ -39,6 +40,7 @@ describe('<DocumentValueCell />', () => {
         type: 'unknown',
         contentType: 'application/octet-stream',
         size: 1000,
+        isExpired: false,
       },
     };
 
@@ -59,6 +61,7 @@ describe('<DocumentValueCell />', () => {
           type: 'unknown',
           contentType: 'application/octet-stream',
           size: 1000,
+          isExpired: false,
         },
         {
           link: '/v2/documents/doc-2',
@@ -66,6 +69,7 @@ describe('<DocumentValueCell />', () => {
           type: 'unknown',
           contentType: 'application/octet-stream',
           size: 2000,
+          isExpired: false,
         },
         {
           link: '/v2/documents/doc-3',
@@ -73,6 +77,7 @@ describe('<DocumentValueCell />', () => {
           type: 'unknown',
           contentType: 'application/octet-stream',
           size: 3000,
+          isExpired: false,
         },
       ],
       isLowerBound: false,
@@ -93,6 +98,7 @@ describe('<DocumentValueCell />', () => {
           type: 'unknown',
           contentType: 'application/octet-stream',
           size: 1000,
+          isExpired: false,
         },
         {
           link: '/v2/documents/doc-2',
@@ -100,6 +106,7 @@ describe('<DocumentValueCell />', () => {
           type: 'unknown',
           contentType: 'application/octet-stream',
           size: 2000,
+          isExpired: false,
         },
       ],
       isLowerBound: true,
@@ -119,11 +126,48 @@ describe('<DocumentValueCell />', () => {
         type: 'unknown',
         contentType: 'application/octet-stream',
         size: 5000,
+        isExpired: false,
       },
     };
 
     render(<DocumentValueCell result={result} />);
 
     expect(screen.getByTitle('my-important-file.pdf')).toBeInTheDocument();
+  });
+
+  it('should render an expired tag for an expired documents', () => {
+    const result: DocumentParseResult = {
+      type: 'single',
+      document: {
+        link: '/v2/documents/doc',
+        fileName: 'old.pdf',
+        type: 'pdf',
+        contentType: 'application/pdf',
+        size: 1024,
+        isExpired: true,
+      },
+    };
+
+    render(<DocumentValueCell result={result} />);
+
+    expect(screen.getByText('Expired')).toBeInTheDocument();
+  });
+
+  it('should not render an expired tag for a non-expired documents', () => {
+    const result: DocumentParseResult = {
+      type: 'single',
+      document: {
+        link: '/v2/documents/doc',
+        fileName: 'current.pdf',
+        type: 'pdf',
+        contentType: 'application/pdf',
+        size: 1024,
+        isExpired: false,
+      },
+    };
+
+    render(<DocumentValueCell result={result} />);
+
+    expect(screen.queryByText('Expired')).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.tsx
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {Tag} from '@carbon/react';
 import {Document} from '@carbon/react/icons';
 import {
   toHumanReadableBytes,
@@ -26,7 +27,7 @@ type Props = {
 
 const DocumentValueCell: React.FC<Props> = ({result}) => {
   if (result.type === 'single') {
-    const {fileName, size} = result.document;
+    const {fileName, size, isExpired} = result.document;
     return (
       <DocumentCellContainer data-testid="document-value-cell">
         <DocumentIcon>
@@ -36,6 +37,11 @@ const DocumentValueCell: React.FC<Props> = ({result}) => {
           {middleTruncate(fileName)}
         </DocumentFileName>
         <DocumentSize>{toHumanReadableBytes(size)}</DocumentSize>
+        {isExpired && (
+          <Tag type="red" size="sm">
+            Expired
+          </Tag>
+        )}
       </DocumentCellContainer>
     );
   }

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -45,6 +45,7 @@ describe('parseDocumentVariable', () => {
         type: 'image',
         contentType: 'image/png',
         size: 109748,
+        isExpired: false,
       },
     });
   });
@@ -61,6 +62,7 @@ describe('parseDocumentVariable', () => {
         type: 'image',
         contentType: 'image/png',
         size: 109748,
+        isExpired: false,
       },
     });
   });
@@ -106,6 +108,7 @@ describe('parseDocumentVariable', () => {
           type: 'pdf',
           contentType: 'application/pdf',
           size: 1000,
+          isExpired: false,
         },
         {
           link: '/v2/documents/doc-124?storeId=in-memory&contentHash=sha256%3Aabc',
@@ -113,6 +116,7 @@ describe('parseDocumentVariable', () => {
           type: 'json',
           contentType: 'application/json',
           size: 500,
+          isExpired: false,
         },
         {
           link: '/v2/documents/doc-125?storeId=in-memory&contentHash=sha256%3Aabc',
@@ -120,6 +124,7 @@ describe('parseDocumentVariable', () => {
           type: 'unknown',
           contentType: 'text/plain',
           size: 200,
+          isExpired: false,
         },
       ],
       isLowerBound: false,
@@ -143,8 +148,60 @@ describe('parseDocumentVariable', () => {
         type: 'image',
         contentType: 'image/png',
         size: 109748,
+        isExpired: false,
       },
     });
+  });
+
+  it('should set isExpired=true when expiresAt is in the past', () => {
+    vi.setSystemTime('2026-06-01T00:00:00.000Z');
+    const value = JSON.stringify(
+      makeDocRef({
+        metadata: {
+          ...makeDocRef().metadata,
+          expiresAt: '2026-05-01T00:00:00.000Z',
+        },
+      }),
+    );
+    const result = parseDocumentVariable(value, false);
+
+    assert(
+      result !== null && result.type === 'single',
+      'Expected a single parsing result.',
+    );
+    expect(result.document.isExpired).toBe(true);
+  });
+
+  it('should set isExpired=false when expiresAt is in the future', () => {
+    vi.setSystemTime('2026-06-01T00:00:00.000Z');
+    const value = JSON.stringify(
+      makeDocRef({
+        metadata: {
+          ...makeDocRef().metadata,
+          expiresAt: '2026-06-04T00:00:00.000Z',
+        },
+      }),
+    );
+    const result = parseDocumentVariable(value, false);
+
+    assert(
+      result !== null && result.type === 'single',
+      'Expected a single parsing result.',
+    );
+    expect(result.document.isExpired).toBe(false);
+  });
+
+  it('should set isExpired=false when expiresAt is null', () => {
+    const value = JSON.stringify(
+      makeDocRef({metadata: {...makeDocRef().metadata, expiresAt: null}}),
+    );
+    const result = parseDocumentVariable(value, false);
+
+    assert(
+      result !== null && result.type === 'single',
+      'Expected a single parsing result.',
+    );
+    expect(result.document.isExpired).toBe(false);
   });
 
   it('should parse a image document type for supported image formats', () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -24,6 +24,7 @@ type DocumentInfo = {
   type: DocumentType;
   contentType: string;
   size: number;
+  isExpired: boolean;
 };
 
 type DocumentParseResult =
@@ -60,12 +61,17 @@ function toDocumentInfo(ref: DocumentReference): DocumentInfo {
         )
       : null;
 
+  const isExpired =
+    ref.metadata.expiresAt !== null &&
+    Date.parse(ref.metadata.expiresAt) < Date.now();
+
   return {
     link,
     fileName: ref.metadata.fileName ?? ref.documentId,
     type: getDocumentType(ref.metadata.contentType),
     contentType: ref.metadata.contentType,
     size: ref.metadata.size,
+    isExpired,
   };
 }
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/styled.tsx
@@ -33,8 +33,8 @@ const DocumentFileName = styled.span`
 `;
 
 const DocumentSize = styled.span`
-  ${styles.bodyShort01};
-  color: var(--cds-text-secondary);
+  ${styles.caption01};
+  color: var(--cds-text-helper);
   flex-shrink: 0;
 `;
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.test.tsx
@@ -17,6 +17,7 @@ const pdfDocument: DocumentInfo = {
   type: 'pdf',
   contentType: 'application/pdf',
   size: 2048,
+  isExpired: false,
 };
 
 describe('<DownloadDocumentButton />', () => {
@@ -27,6 +28,7 @@ describe('<DownloadDocumentButton />', () => {
       type: 'pdf',
       contentType: 'application/pdf',
       size: 2048,
+      isExpired: false,
     };
 
     render(
@@ -48,6 +50,31 @@ describe('<DownloadDocumentButton />', () => {
     const link = screen.getByLabelText('Download document for variable myPdf');
     expect(link).toHaveAttribute('href', '/v2/documents/pdf');
     expect(link).toHaveAttribute('download', 'report.pdf');
+  });
+
+  it('should render a disabled button with expired tooltip when document is expired', () => {
+    const expiredDocument: DocumentInfo = {
+      link: '/v2/documents/pdf',
+      fileName: 'expired.pdf',
+      type: 'pdf',
+      contentType: 'application/pdf',
+      size: 2048,
+      isExpired: true,
+    };
+
+    render(
+      <DownloadDocumentButton
+        document={expiredDocument}
+        variableName="myPdf"
+      />,
+    );
+
+    const button = screen.getByLabelText(
+      'Download document for variable myPdf',
+    );
+    expect(button).toBeDisabled();
+    expect(button.tagName).not.toBe('A');
+    expect(screen.getByText('Document has expired')).toBeInTheDocument();
   });
 
   it('should track document-downloaded events', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
@@ -11,13 +11,26 @@ import {Download} from '@carbon/react/icons';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
 import {tracking} from 'modules/tracking';
 
+function getTooltipText(document: DocumentInfo): string {
+  switch (true) {
+    case document.isExpired:
+      return 'Document has expired';
+    case document.link === null:
+      return 'Download not available for this document';
+    default:
+      return 'Download';
+  }
+}
+
 type Props = {
   document: DocumentInfo;
   variableName: string;
 };
 
 const DownloadDocumentButton: React.FC<Props> = ({document, variableName}) => {
-  const isDisabled = document.link === null;
+  const isDisabled = document.link === null || document.isExpired;
+  const tooltipText = getTooltipText(document);
+
   return (
     <Button
       as={isDisabled ? undefined : 'a'}
@@ -28,9 +41,7 @@ const DownloadDocumentButton: React.FC<Props> = ({document, variableName}) => {
       size="sm"
       hasIconOnly
       renderIcon={Download}
-      iconDescription={
-        isDisabled ? 'Download not available for this document' : 'Download'
-      }
+      iconDescription={tooltipText}
       tooltipPosition="top"
       tooltipAlignment="end"
       // @ts-expect-error - Solves rendering issues in `DocumentListModal`. Not exposed through TS but used at runtime.

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
@@ -210,6 +210,62 @@ describe('VariablesTab document variables', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should show Expired badge and disable buttons for expired documents', async () => {
+    vi.setSystemTime('2026-06-01T00:00:00.000Z');
+    mockSearchVariables().withSuccess(
+      searchResult([
+        createVariable({
+          name: 'myDocument',
+          value: JSON.stringify(
+            makeDocumentRef({
+              metadata: {expiresAt: '2026-05-01T00:00:00.000Z'},
+            }),
+          ),
+        }),
+      ]),
+    );
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+    await screen.findByTestId('variables-list');
+
+    const variableRow = within(screen.getByTestId('variable-myDocument'));
+    expect(variableRow.getByText('Expired')).toBeInTheDocument();
+    expect(
+      variableRow.getByLabelText('Download document for variable myDocument'),
+    ).toBeDisabled();
+    expect(
+      variableRow.getByLabelText('Preview document for variable myDocument'),
+    ).toBeDisabled();
+  });
+
+  it('should not show Expired badge for non-expired documents', async () => {
+    vi.setSystemTime('2026-06-01T00:00:00.000Z');
+    mockSearchVariables().withSuccess(
+      searchResult([
+        createVariable({
+          name: 'myDocument',
+          value: JSON.stringify(
+            makeDocumentRef({
+              metadata: {expiresAt: '2026-06-04T00:00:00.000Z'},
+            }),
+          ),
+        }),
+      ]),
+    );
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+    await screen.findByTestId('variables-list');
+
+    const variableRow = within(screen.getByTestId('variable-myDocument'));
+    expect(variableRow.queryByText('Expired')).not.toBeInTheDocument();
+    expect(
+      variableRow.getByLabelText('Download document for variable myDocument'),
+    ).toBeEnabled();
+    expect(
+      variableRow.getByLabelText('Preview document for variable myDocument'),
+    ).toBeEnabled();
+  });
+
   it('should not render document-related buttons for regular variables', async () => {
     mockSearchVariables().withSuccess(searchResult([createVariable()]));
 


### PR DESCRIPTION
## Description

Adds an `expired` tag to documents when they have a `expiredAt` date that is in the past. Their preview and download is disabled. Furthermore, it slightly adjust the typography for file sizes in document cells to match the Figma design.

## Related issues

closes #52206
