### PR TITLE
Backport working Keycloak smoke-test config to release/optimize-8.7.22

### DIFF
--- a/.github/actions/compose/docker-compose.smoketest.yml
+++ b/.github/actions/compose/docker-compose.smoketest.yml
@@ -100,20 +100,27 @@ services:
       - elasticsearch
   keycloak:
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9
+    image: camunda/keycloak:quay-26@sha256:3eba2912da4668619c8a7b6cdc00138d20a1f293ce3fcba980ce70ec2ed7f8d0
+    command: [ start ]
     ports:
       - "18080:8080"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/auth"]
-      interval: 30s
-      timeout: 15s
-      retries: 5
-      start_period: 30s
     environment:
-      KEYCLOAK_ADMIN_USER: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      KEYCLOAK_DATABASE_VENDOR: dev-file
-      KEYCLOAK_HTTP_RELATIVE_PATH: /auth
+      KC_DB: dev-file
+      KC_CACHE: ispn
+      KC_HTTP_ENABLED: "true"
+      KC_HTTP_RELATIVE_PATH: /auth
+      KC_HEALTH_ENABLED: "true"
+      KC_HOSTNAME_STRICT: "false"
+    healthcheck:
+      test: >
+        bash -c "echo -e 'GET /auth HTTP/1.1\r\nHost: localhost\r\n\r\n' >/dev/tcp/127.0.0.1/8080 || exit 1"
+      interval: 30s
+      timeout: 5s
+      retries: 3
   identity:
     depends_on:
       - keycloak


### PR DESCRIPTION
# Description

Backports the working Keycloak smoke-test config from `main` to `release/optimize-8.7.22`. The Optimize 8.7 release smoke test runs `docker-compose.smoketest.yml` from the release branch, whose Keycloak service predates the Keycloak migration (deprecated `KEYCLOAK_ADMIN*` vars / pre-quay image). Keycloak fails to bootstrap (`bootstrap-admin-username available only when bootstrap admin password is set`), so Identity can't resolve `keycloak` and Optimize never becomes healthy — failing the Start Smoketest step. This aligns the keycloak service to main's working config (`camunda/keycloak:quay-26`, `command: [ start ]`, `KC_BOOTSTRAP_ADMIN_USERNAME`/`KC_BOOTSTRAP_ADMIN_PASSWORD`). No workflow or release code changes.

Release-branch backport — do NOT auto-merge or squash into stable/optimize-8.7 or stable/8.7.

# Checklist

- [ ] Enable backports when necessary (fex. for bug fixes, for CI changes, or for documentation changes).
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the on-demand workflow before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

# Related issues

closes #
