### PR TITLE
feat(oidc): adopt CSL issuer-aware JwtDecoder; remove redundant monorepo beans (#221)

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -26,7 +26,6 @@ import io.camunda.security.spring.converter.OidcTokenAuthenticationConverter;
 import io.camunda.security.spring.converter.OidcUserAuthenticationConverter;
 import io.camunda.security.spring.handler.OAuth2AuthenticationExceptionHandler;
 import io.camunda.security.spring.oidc.AssertionJwkProvider;
-import io.camunda.security.spring.oidc.JWSKeySelectorFactory;
 import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
 import io.camunda.security.spring.oidc.TokenValidatorFactory;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
@@ -43,8 +42,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -76,9 +73,7 @@ import org.springframework.security.oauth2.core.http.converter.OAuth2AccessToken
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
-import org.springframework.security.oauth2.jwt.SupplierJwtDecoder;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
@@ -244,20 +239,6 @@ public class OidcOverrideBeansConfiguration {
         buildPreferIdTokenClaimsByRegistrationId(oidcProviderRepository));
   }
 
-  private List<ClientRegistration> extractClientRegistrations(
-      final ClientRegistrationRepository clientRegistrationRepository) {
-    if (!(clientRegistrationRepository instanceof final Iterable<?> iterableRepository)) {
-      throw new IllegalStateException(
-          "Unable to extract OAuth 2.0 client registrations as clientRegistrationRepository %s is not iterable"
-              .formatted(clientRegistrationRepository.getClass()));
-    }
-
-    return StreamSupport.stream(iterableRepository.spliterator(), false)
-        .filter(ClientRegistration.class::isInstance)
-        .map(ClientRegistration.class::cast)
-        .toList();
-  }
-
   @Bean
   public TokenValidatorFactory tokenValidatorFactory(
       final CamundaSecurityLibraryProperties cslProperties,
@@ -301,52 +282,6 @@ public class OidcOverrideBeansConfiguration {
       throw new IllegalStateException("Unsupported signature algorithm: " + algorithm);
     }
     return value;
-  }
-
-  @Bean
-  public JWSKeySelectorFactory jwsKeySelectorFactory() {
-    return new JWSKeySelectorFactory();
-  }
-
-  @Bean
-  public OidcAccessTokenDecoderFactory accessTokenDecoderFactory(
-      final JWSKeySelectorFactory jwsKeySelectorFactory,
-      final TokenValidatorFactory tokenValidatorFactory) {
-    return new OidcAccessTokenDecoderFactory(jwsKeySelectorFactory, tokenValidatorFactory);
-  }
-
-  @Bean
-  public JwtDecoder jwtDecoder(
-      final OidcAccessTokenDecoderFactory oidcAccessTokenDecoderFactory,
-      final ClientRegistrationRepository clientRegistrationRepository,
-      final OidcProviderConfigurationPort oidcProviderRepository) {
-    final var clientRegistrations = extractClientRegistrations(clientRegistrationRepository);
-
-    final var additionalJwkSetUrisByIssuer =
-        buildAdditionalJwkSetUrisByIssuer(oidcProviderRepository);
-
-    if (clientRegistrations.size() == 1) {
-      final var clientRegistration = clientRegistrations.getFirst();
-      final var additionalUris =
-          additionalJwkSetUrisByIssuer.get(clientRegistration.getProviderDetails().getIssuerUri());
-      LOG.info(
-          "Create Access Token JWT Decoder for OIDC Provider: {}",
-          clientRegistration.getRegistrationId());
-      return new SupplierJwtDecoder(
-          () ->
-              oidcAccessTokenDecoderFactory.createAccessTokenDecoder(
-                  clientRegistration, additionalUris));
-    } else {
-      LOG.info(
-          "Create Issuer Aware JWT Decoder for multiple OIDC Providers: [{}]",
-          clientRegistrations.stream()
-              .map(ClientRegistration::getRegistrationId)
-              .collect(Collectors.joining(", ")));
-      return new SupplierJwtDecoder(
-          () ->
-              oidcAccessTokenDecoderFactory.createIssuerAwareAccessTokenDecoder(
-                  clientRegistrations, additionalJwkSetUrisByIssuer));
-    }
   }
 
   private Map<String, List<String>> buildAdditionalJwkSetUrisByIssuer(

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
@@ -15,12 +15,24 @@ import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import io.camunda.service.registry.DefaultServiceRegistry;
+import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 /** Additional dependency beans for the OIDC setup */
 @Configuration
 public class WebSecurityOidcTestContext {
+
+  /**
+   * No-op {@link JwtDecoder} mock. These tests configure a non-functional JWK URI (e.g. {@code
+   * jwks.example.com}) and do not exercise JWT validation — they test filter-chain behaviour only.
+   * CSL's {@code @ConditionalOnMissingBean} default backs off when this bean is present.
+   */
+  @Bean
+  public JwtDecoder testJwtDecoder() {
+    return Mockito.mock(JwtDecoder.class);
+  }
 
   @Bean
   public MappingRuleServices createMappingRuleServices(

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha25</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha27</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Summary

- Removes the now-redundant `JWSKeySelectorFactory`, `OidcAccessTokenDecoderFactory`, and `JwtDecoder` beans from `OidcOverrideBeansConfiguration` — CSL `0.1.0-alpha27` ships these as `@ConditionalOnMissingBean` defaults (camunda-security-library#221 / https://github.com/camunda/camunda-security-library/pull/373)
- Retains the monorepo's `TokenValidatorFactory` override, which adds `OrganizationValidator` + `ClusterValidator` for SaaS — CSL's decoder chain picks it up automatically via `@ConditionalOnMissingBean` back-off
- Adds a plain `JwtDecoder` mock to `WebSecurityOidcTestContext` so CSL's eagerly-initialising default backs off for tests that configure non-functional JWK URIs
- Bumps `version.camunda-security-library` to `0.1.0-alpha27`

## Motivation

Closes #221 (monorepo side). Any OC deployment with multiple configured IdPs previously failed at CSL filter-chain startup because CSL refused to build a multi-issuer decoder. CSL `0.1.0-alpha27` ships an issuer-aware `JwtDecoder` by default; this PR removes the now-duplicate overrides so the monorepo benefits from that fix without carrying its own copy.

## Changes

**`OidcOverrideBeansConfiguration`**
- Removed `@Bean JWSKeySelectorFactory jwsKeySelectorFactory()`
- Removed `@Bean OidcAccessTokenDecoderFactory accessTokenDecoderFactory(...)`
- Removed `@Bean JwtDecoder jwtDecoder(...)` and the `extractClientRegistrations` helper it relied on
- `@Bean TokenValidatorFactory tokenValidatorFactory(...)` retained — adds `OrganizationValidator` + `ClusterValidator` for SaaS; CSL injects it automatically via `@ConditionalOnMissingBean`
- `buildAdditionalJwkSetUrisByIssuer` retained — still called by `oidcUserAuthenticationConverter`

**`WebSecurityOidcTestContext`**
- Added `@Bean JwtDecoder testJwtDecoder()` mock — CSL's `@ConditionalOnMissingBean` default backs off when this bean is present, so tests that use non-functional JWK URIs continue to work

**`parent/pom.xml`**
- `version.camunda-security-library` bumped to `0.1.0-alpha27`

🤖 Generated with [Claude Code](https://claude.com/claude-code)