### PR TITLE
ci: pass step outputs via env vars to prevent script injection attacks

### DIFF
--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -184,7 +184,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          ISSUE_DATA='${{ steps.fetch_data.outputs.issue_data }}'
+          ISSUE_DATA='${STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA}'
 
           # Extract issue type and labels
           ISSUE_TYPE=$(echo "$ISSUE_DATA" | jq -r '.issueType.name // empty')
@@ -234,14 +234,16 @@ jobs:
             echo "when=$when"
             echo "has_urgency_locked=$has_urgency_locked"
           } >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA: ${{ steps.fetch_data.outputs.issue_data }}
 
       - name: Calculate urgency from severity
         id: calculate_urgency_from_severity
         if: steps.check_labels.outputs.severity != ''
         run: |
           set -euo pipefail
-          SEVERITY='${{ steps.check_labels.outputs.severity }}'
-          LIKELIHOOD='${{ steps.check_labels.outputs.likelihood }}'
+          SEVERITY='${STEPS_CHECK_LABELS_OUTPUTS_SEVERITY}'
+          LIKELIHOOD='${STEPS_CHECK_LABELS_OUTPUTS_LIKELIHOOD}'
 
           # Default missing or unknown likelihood to low
           if [[ -z "$LIKELIHOOD" || "$LIKELIHOOD" == "unknown" ]]; then
@@ -278,14 +280,17 @@ jobs:
 
           echo "🎯 Urgency (from severity/likelihood): $URGENCY"
           echo "urgency=$URGENCY" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_CHECK_LABELS_OUTPUTS_SEVERITY: ${{ steps.check_labels.outputs.severity }}
+          STEPS_CHECK_LABELS_OUTPUTS_LIKELIHOOD: ${{ steps.check_labels.outputs.likelihood }}
 
       - name: Calculate urgency from impact
         id: calculate_urgency_from_impact
         if: steps.check_labels.outputs.impact != ''
         run: |
           set -euo pipefail
-          IMPACT='${{ steps.check_labels.outputs.impact }}'
-          WHEN='${{ steps.check_labels.outputs.when }}'
+          IMPACT='${STEPS_CHECK_LABELS_OUTPUTS_IMPACT}'
+          WHEN='${STEPS_CHECK_LABELS_OUTPUTS_WHEN}'
 
           # Default when to later if not set
           if [[ -z "$WHEN" ]]; then
@@ -321,14 +326,17 @@ jobs:
 
           echo "🎯 Urgency (from impact/when): $URGENCY"
           echo "urgency=$URGENCY" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_CHECK_LABELS_OUTPUTS_IMPACT: ${{ steps.check_labels.outputs.impact }}
+          STEPS_CHECK_LABELS_OUTPUTS_WHEN: ${{ steps.check_labels.outputs.when }}
 
       - name: Validate urgency
         id: validate_urgency
         if: steps.calculate_urgency_from_severity.outputs.urgency != '' || steps.calculate_urgency_from_impact.outputs.urgency != ''
         run: |
           set -euo pipefail
-          URGENCY_FROM_SEVERITY='${{ steps.calculate_urgency_from_severity.outputs.urgency }}'
-          URGENCY_FROM_IMPACT='${{ steps.calculate_urgency_from_impact.outputs.urgency }}'
+          URGENCY_FROM_SEVERITY='${STEPS_CALCULATE_URGENCY_FROM_SEVERITY_OUTPUTS_URGENCY}'
+          URGENCY_FROM_IMPACT='${STEPS_CALCULATE_URGENCY_FROM_IMPACT_OUTPUTS_URGENCY}'
 
           # Urgency priority: immediate > next > planned > someday
           # Use case statement for bash 3.2+ compatibility
@@ -361,18 +369,24 @@ jobs:
           fi
 
           echo "urgency=$URGENCY" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_CALCULATE_URGENCY_FROM_SEVERITY_OUTPUTS_URGENCY: ${{ steps.calculate_urgency_from_severity.outputs.urgency }}
+          STEPS_CALCULATE_URGENCY_FROM_IMPACT_OUTPUTS_URGENCY: ${{ steps.calculate_urgency_from_impact.outputs.urgency }}
 
       - name: Update org-level Urgency field
         if: steps.validate_urgency.outputs.urgency != ''
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA: ${{ steps.fetch_data.outputs.issue_data }}
+          STEPS_VALIDATE_URGENCY_OUTPUTS_URGENCY: ${{ steps.validate_urgency.outputs.urgency }}
+          STEPS_CHECK_LABELS_OUTPUTS_HAS_URGENCY_LOCKED: ${{ steps.check_labels.outputs.has_urgency_locked }}
         run: |
           set -euo pipefail
 
-          ISSUE_DATA='${{ steps.fetch_data.outputs.issue_data }}'
+          ISSUE_DATA='${STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA}'
           ISSUE_ID=$(echo "$ISSUE_DATA" | jq -r '.id')
-          NEW_URGENCY='${{ steps.validate_urgency.outputs.urgency }}'
-          HAS_URGENCY_LOCKED='${{ steps.check_labels.outputs.has_urgency_locked }}'
+          NEW_URGENCY='${STEPS_VALIDATE_URGENCY_OUTPUTS_URGENCY}'
+          HAS_URGENCY_LOCKED='${STEPS_CHECK_LABELS_OUTPUTS_HAS_URGENCY_LOCKED}'
 
           # Org-level urgency field option IDs
           declare -A OPTION_IDS=(
@@ -448,12 +462,15 @@ jobs:
         if: steps.validate_urgency.outputs.urgency != ''
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA: ${{ steps.fetch_data.outputs.issue_data }}
+          STEPS_CHECK_LABELS_OUTPUTS_HAS_URGENCY_LOCKED: ${{ steps.check_labels.outputs.has_urgency_locked }}
+          STEPS_VALIDATE_URGENCY_OUTPUTS_URGENCY: ${{ steps.validate_urgency.outputs.urgency }}
         run: |
           set -euo pipefail
 
-          ISSUE_DATA='${{ steps.fetch_data.outputs.issue_data }}'
+          ISSUE_DATA='${STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA}'
           URGENCY_FIELD_NAME='Urgency'
-          HAS_URGENCY_LOCKED='${{ steps.check_labels.outputs.has_urgency_locked }}'
+          HAS_URGENCY_LOCKED='${STEPS_CHECK_LABELS_OUTPUTS_HAS_URGENCY_LOCKED}'
 
           # For locked issues, use the current org-level value instead of the calculated one
           if [[ "$HAS_URGENCY_LOCKED" == "true" ]]; then
@@ -465,7 +482,7 @@ jobs:
             fi
             echo "🔒 urgency-locked — syncing org-level value '$NEW_URGENCY' to project"
           else
-            NEW_URGENCY='${{ steps.validate_urgency.outputs.urgency }}'
+            NEW_URGENCY='${STEPS_VALIDATE_URGENCY_OUTPUTS_URGENCY}'
           fi
 
           if [[ "$DRY_RUN" == "true" ]]; then

--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -184,7 +184,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          ISSUE_DATA='${STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA}'
+          ISSUE_DATA="${STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA}"
 
           # Extract issue type and labels
           ISSUE_TYPE=$(echo "$ISSUE_DATA" | jq -r '.issueType.name // empty')
@@ -242,8 +242,8 @@ jobs:
         if: steps.check_labels.outputs.severity != ''
         run: |
           set -euo pipefail
-          SEVERITY='${STEPS_CHECK_LABELS_OUTPUTS_SEVERITY}'
-          LIKELIHOOD='${STEPS_CHECK_LABELS_OUTPUTS_LIKELIHOOD}'
+          SEVERITY="${STEPS_CHECK_LABELS_OUTPUTS_SEVERITY}"
+          LIKELIHOOD="${STEPS_CHECK_LABELS_OUTPUTS_LIKELIHOOD}"
 
           # Default missing or unknown likelihood to low
           if [[ -z "$LIKELIHOOD" || "$LIKELIHOOD" == "unknown" ]]; then
@@ -289,8 +289,8 @@ jobs:
         if: steps.check_labels.outputs.impact != ''
         run: |
           set -euo pipefail
-          IMPACT='${STEPS_CHECK_LABELS_OUTPUTS_IMPACT}'
-          WHEN='${STEPS_CHECK_LABELS_OUTPUTS_WHEN}'
+          IMPACT="${STEPS_CHECK_LABELS_OUTPUTS_IMPACT}"
+          WHEN="${STEPS_CHECK_LABELS_OUTPUTS_WHEN}"
 
           # Default when to later if not set
           if [[ -z "$WHEN" ]]; then
@@ -335,8 +335,8 @@ jobs:
         if: steps.calculate_urgency_from_severity.outputs.urgency != '' || steps.calculate_urgency_from_impact.outputs.urgency != ''
         run: |
           set -euo pipefail
-          URGENCY_FROM_SEVERITY='${STEPS_CALCULATE_URGENCY_FROM_SEVERITY_OUTPUTS_URGENCY}'
-          URGENCY_FROM_IMPACT='${STEPS_CALCULATE_URGENCY_FROM_IMPACT_OUTPUTS_URGENCY}'
+          URGENCY_FROM_SEVERITY="${STEPS_CALCULATE_URGENCY_FROM_SEVERITY_OUTPUTS_URGENCY}"
+          URGENCY_FROM_IMPACT="${STEPS_CALCULATE_URGENCY_FROM_IMPACT_OUTPUTS_URGENCY}"
 
           # Urgency priority: immediate > next > planned > someday
           # Use case statement for bash 3.2+ compatibility
@@ -383,10 +383,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          ISSUE_DATA='${STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA}'
+          ISSUE_DATA="${STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA}"
           ISSUE_ID=$(echo "$ISSUE_DATA" | jq -r '.id')
-          NEW_URGENCY='${STEPS_VALIDATE_URGENCY_OUTPUTS_URGENCY}'
-          HAS_URGENCY_LOCKED='${STEPS_CHECK_LABELS_OUTPUTS_HAS_URGENCY_LOCKED}'
+          NEW_URGENCY="${STEPS_VALIDATE_URGENCY_OUTPUTS_URGENCY}"
+          HAS_URGENCY_LOCKED="${STEPS_CHECK_LABELS_OUTPUTS_HAS_URGENCY_LOCKED}"
 
           # Org-level urgency field option IDs
           declare -A OPTION_IDS=(
@@ -468,9 +468,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          ISSUE_DATA='${STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA}'
+          ISSUE_DATA="${STEPS_FETCH_DATA_OUTPUTS_ISSUE_DATA}"
           URGENCY_FIELD_NAME='Urgency'
-          HAS_URGENCY_LOCKED='${STEPS_CHECK_LABELS_OUTPUTS_HAS_URGENCY_LOCKED}'
+          HAS_URGENCY_LOCKED="${STEPS_CHECK_LABELS_OUTPUTS_HAS_URGENCY_LOCKED}"
 
           # For locked issues, use the current org-level value instead of the calculated one
           if [[ "$HAS_URGENCY_LOCKED" == "true" ]]; then
@@ -482,7 +482,7 @@ jobs:
             fi
             echo "🔒 urgency-locked — syncing org-level value '$NEW_URGENCY' to project"
           else
-            NEW_URGENCY='${STEPS_VALIDATE_URGENCY_OUTPUTS_URGENCY}'
+            NEW_URGENCY="${STEPS_VALIDATE_URGENCY_OUTPUTS_URGENCY}"
           fi
 
           if [[ "$DRY_RUN" == "true" ]]; then

--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -101,10 +101,10 @@ jobs:
           vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           vault-url: ${{ secrets.VAULT_ADDR }}
       - name: Dump event issue JSON
+        env:
+          ISSUE_JSON: ${{ toJSON(github.event.issue) }}
         run: |
-          cat << 'EOF'
-          ${{ toJSON(github.event.issue) }}
-          EOF
+          echo "$ISSUE_JSON"
       - name: Fetch issue data
         id: fetch_data
         env:


### PR DESCRIPTION

## Description

Fix script injection vulnerabilities in urgency workflow by passing `${{ steps.*.outputs.* }}` expressions through env: variables instead of interpolating them directly into shell scripts. This prevents malicious issue content from breaking out of the shell context.

Slack [incident channel](https://camunda.slack.com/archives/C0B79DRFRBR)

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
