### PR TITLE
ci: replace 8-SNAPSHOT Optimize docker tag with SNAPSHOT

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -742,7 +742,7 @@ jobs:
                       "operateVersion": "SNAPSHOT",
                       "tasklistVersion": "SNAPSHOT",
                       "connectorsVersion": "SNAPSHOT",
-                      "optimizeVersion": "8-SNAPSHOT"
+                      "optimizeVersion": "SNAPSHOT"
                   }
                 }'
 


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `8-SNAPSHOT` Optimize image tag in `camunda-helm-integration.yml` with the same dynamic `snapshot_tag` output already used by Zeebe, Operate, and Tasklist.
- Replaces `"8-SNAPSHOT"` with `"SNAPSHOT"` for `optimizeVersion` in `docker-build-helm-integration.yml`.

Now that Optimize is built in the unified CI, its snapshot tags follow the same scheme as other components. The `8-SNAPSHOT` tag is no longer updated; `SNAPSHOT` always tracks the latest main build, and `X.Y-SNAPSHOT` is pinned to a specific minor line.

relates to #40846

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7vzpeKyfqFe5jNCebH4c6)_