### PR TITLE
fix: restart port-forward in verify-test loop if it dies

### DIFF
--- a/load-tests/docs/scripts/verify-test.sh
+++ b/load-tests/docs/scripts/verify-test.sh
@@ -101,6 +101,13 @@ attempts=0
 verified=false
 
 while [[ $attempts -lt $max_attempts ]]; do
+  if ! kill -0 "$pf_pid" 2>/dev/null; then
+    echo "Port-forward died, restarting..."
+    kubectl port-forward "svc/clients" "${local_port}:${METRICS_PORT}" -n "$NAMESPACE" &
+    pf_pid=$!
+    sleep 5
+  fi
+
   count=$( { curl -s "http://localhost:${local_port}/metrics" 2>/dev/null || true; } \
     | { grep '^app_connected ' || true; } \
     | awk '{print $2}' \


### PR DESCRIPTION
## Summary

- `verify-test.sh` starts a single `kubectl port-forward` before the connectivity poll loop
- Without readiness probes on starter/worker pods, K8s marks pods Ready as soon as the container starts — port 9600 (metrics) may not be bound yet
- Port-forward connects and immediately gets `connection refused` inside the pod, exits, and all subsequent curl attempts silently fail against the dead tunnel
- Fix: check port-forward liveness (`kill -0`) at the top of each loop iteration and restart it if the process has died

## Test plan

- [ ] Trigger a load test run and confirm "Port-forward died, restarting..." appears in logs on first iteration
- [ ] Confirm script eventually logs `client connected to gateway (app.connected=N)` and exits with success