### PR TITLE
feat: guard the existing liquibase files with a GoldenTest

### DIFF
--- a/db/rdbms-schema/pom.xml
+++ b/db/rdbms-schema/pom.xml
@@ -47,6 +47,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/ChangelogGoldenFilesTest.java
+++ b/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/ChangelogGoldenFilesTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies that frozen Liquibase changeset files are never modified after release.
+ *
+ * <p>Liquibase stores a checksum of every executed changeset in {@code DATABASECHANGELOG}. On every
+ * subsequent startup it recomputes and compares the checksum; a mismatch causes the application to
+ * refuse to start on existing installations. Any modification to a released changeset — even
+ * whitespace — is therefore a breaking change for existing users.
+ *
+ * <p>This test byte-compares each file in the {@code golden/} directory against its counterpart in
+ * the main resources. Adding a golden file for a version is the only step needed to freeze it — no
+ * code changes are required. To freeze a new version at release time:
+ *
+ * <pre>{@code
+ * cp db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml \
+ *    db/rdbms-schema/src/test/resources/db/changelog/rdbms-exporter/changesets/golden/8.10.0.xml
+ * }</pre>
+ *
+ * <p>If this test fails, do not update the golden file. Instead, revert the change to the frozen
+ * changeset and introduce your schema change as a new versioned changeset file.
+ */
+class ChangelogGoldenFilesTest {
+
+  // Surefire runs from the module directory (db/rdbms-schema/), so these are module-relative.
+  private static final String CHANGESETS_SOURCE =
+      "src/main/resources/db/changelog/rdbms-exporter/changesets";
+  private static final String GOLDEN_DIR =
+      "src/test/resources/db/changelog/rdbms-exporter/changesets/golden";
+
+  // Repo-root-relative paths, used only in error messages.
+  private static final String MODULE_PATH = "db/rdbms-schema/";
+
+  static Stream<Path> frozenChangesets() throws IOException {
+    return Files.list(Paths.get(GOLDEN_DIR)).filter(p -> p.toString().endsWith(".xml")).sorted();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("frozenChangesets")
+  void shouldNotChangeFrozenChangeset(final Path goldenFilePath) throws IOException {
+    final var filename = goldenFilePath.getFileName().toString();
+    final var sourceFilePath = Paths.get(CHANGESETS_SOURCE).resolve(filename);
+
+    final var repoSourcePath = MODULE_PATH + CHANGESETS_SOURCE + "/" + filename;
+    final var repoGoldenPath = MODULE_PATH + GOLDEN_DIR + "/" + filename;
+
+    // given
+    assertThat(sourceFilePath.toFile())
+        .describedAs(
+            """
+            Frozen changeset '%s' no longer exists in the source tree.
+            Deleting a released changeset breaks existing installations — restore it.""",
+            filename)
+        .exists();
+
+    // when / then
+    final var goldenContents = Files.readString(goldenFilePath);
+    final var sourceContents = Files.readString(sourceFilePath);
+
+    assertThat(sourceContents)
+        .describedAs(
+            """
+            Frozen changeset '%s' must not be modified after release.
+            Liquibase stores a checksum of every executed changeset; changing the file \
+            causes a checksum mismatch on existing installations.
+            To add new schema changes, create a new versioned changeset file instead.
+            If you are certain this change is safe, update the golden file with:
+              cp %s %s""",
+            filename, repoSourcePath, repoGoldenPath)
+        .isEqualTo(goldenContents);
+  }
+}

--- a/db/rdbms-schema/src/test/resources/db/changelog/rdbms-exporter/changesets/golden/8.9.0.xml
+++ b/db/rdbms-schema/src/test/resources/db/changelog/rdbms-exporter/changesets/golden/8.9.0.xml
@@ -1,0 +1,2201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!--suppress LiquibaseXmlUnresolvedProperty -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+  <property name="timestampWithTimeZone.type" value="DATETIMEOFFSET" dbms="mssql"/>
+
+  <changeSet id="create_exporter_position_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}EXPORTER_POSITION"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}EXPORTER_POSITION">
+      <column name="PARTITION_ID" type="NUMBER">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="EXPORTER" type="VARCHAR(200)"/>
+      <column name="LAST_EXPORTED_POSITION" type="BIGINT"/>
+      <column name="CREATED" type="DATETIME"/>
+      <column name="LAST_UPDATED" type="DATETIME"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_process_definition_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}PROCESS_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}PROCESS_DEFINITION">
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="RESOURCE_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="BPMN_XML" type="CLOB"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="VERSION" type="SMALLINT"/>
+      <column name="VERSION_TAG" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="FORM_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_process_definition_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_PROCESS_DEFINITION_ID"
+          tableName="${prefix}PROCESS_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}PROCESS_DEFINITION"
+      indexName="${prefix}IDX_PROCESS_DEFINITION_ID">
+      <column name="PROCESS_DEFINITION_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_process_instance_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}PROCESS_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}PROCESS_INSTANCE">
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="STATE" type="VARCHAR(20)"/>
+      <column name="START_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="END_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PARENT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PARENT_ELEMENT_INSTANCE_KEY" type="BIGINT"/>
+      <column name="NUM_INCIDENTS" type="SMALLINT"/>
+      <column name="VERSION" type="SMALLINT"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="TREE_PATH" type="VARCHAR(${treePathSize})"/>
+      <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="BUSINESS_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_process_instance_hist_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_PROCESS_INSTANCE_HIST"
+          tableName="${prefix}PROCESS_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}PROCESS_INSTANCE"
+      indexName="${prefix}IDX_PROCESS_INSTANCE_HIST">
+      <column name="PARTITION_ID"/>
+      <column name="HISTORY_CLEANUP_DATE"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_process_instance_pd_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_PROCESS_INSTANCE_PD_KEY"
+          tableName="${prefix}PROCESS_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}PROCESS_INSTANCE"
+      indexName="${prefix}IDX_PROCESS_INSTANCE_PD_KEY">
+      <column name="PROCESS_DEFINITION_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_root_process_instance_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_ROOT_PROCESS_INSTANCE_KEY"
+          tableName="${prefix}PROCESS_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}PROCESS_INSTANCE"
+      indexName="${prefix}IDX_ROOT_PROCESS_INSTANCE_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_process_instance_tag_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}PROCESS_INSTANCE_TAG"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}PROCESS_INSTANCE_TAG">
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT">
+        <constraints primaryKey="true"
+          foreignKeyName="${prefix}FK_PROCESS_INSTANCE_TAG_PROCESS_INSTANCE"
+          referencedTableName="${prefix}PROCESS_INSTANCE"
+          referencedColumnNames="PROCESS_INSTANCE_KEY" deleteCascade="true"/>
+      </column>
+      <column name="TAG_VALUE" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_process_instance_tag_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_PROCESS_INSTANCE_TAG_KEY"
+          tableName="${prefix}PROCESS_INSTANCE_TAG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}PROCESS_INSTANCE_TAG"
+      indexName="${prefix}IDX_PROCESS_INSTANCE_TAG_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_variable_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}VARIABLE"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}VARIABLE">
+      <column name="VAR_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="SCOPE_KEY" type="BIGINT"/>
+      <column name="TYPE" type="VARCHAR(255)"/>
+      <column name="VAR_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="DOUBLE_VALUE" type="DOUBLE"/>
+      <column name="LONG_VALUE" type="BIGINT"/>
+      <column name="VAR_VALUE" type="VARCHAR(8192)"/>
+      <column name="VAR_FULL_VALUE" type="CLOB"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="IS_PREVIEW" type="BOOLEAN"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="ELEMENT_INSTANCE_KEY" type="BIGINT"/>
+    </createTable>
+
+    <modifySql dbms="oracle">
+      <!-- Oracle only supports a size 4000 characters in varchar2 -->
+      <replace replace="VARCHAR2(8192)" with="VARCHAR2(4000)"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_variable_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_VARIABLE_PROCESS_INSTANCE_KEY"
+          tableName="${prefix}VARIABLE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}VARIABLE"
+      indexName="${prefix}IDX_VARIABLE_PROCESS_INSTANCE_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_variable_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_VARIABLE_ROOT_PROCESS_INSTANCE_KEY"
+          tableName="${prefix}VARIABLE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}VARIABLE"
+      indexName="${prefix}IDX_VARIABLE_ROOT_PROCESS_INSTANCE_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_variable_tenant_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_VARIABLE_TENANT_ID" tableName="${prefix}VARIABLE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}VARIABLE" indexName="${prefix}IDX_VARIABLE_TENANT_ID">
+      <column name="TENANT_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_flow_node_instance_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}FLOW_NODE_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}FLOW_NODE_INSTANCE">
+      <column name="FLOW_NODE_INSTANCE_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="FLOW_NODE_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="FLOW_NODE_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="FLOW_NODE_SCOPE_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="TYPE" type="VARCHAR(100)"/>
+      <column name="STATE" type="VARCHAR(20)"/>
+      <column name="START_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="END_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="TREE_PATH" type="VARCHAR(${treePathSize})"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="INCIDENT_KEY" type="BIGINT"/>
+      <column name="NUM_SUBPROCESS_INCIDENTS" type="SMALLINT"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_flow_node_instance_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_FLOW_NODE_INSTANCE_PI_KEY"
+          tableName="${prefix}FLOW_NODE_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}FLOW_NODE_INSTANCE"
+      indexName="${prefix}IDX_FLOW_NODE_INSTANCE_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_flow_node_instance_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_FLOW_NODE_INSTANCE_RPI_KEY"
+          tableName="${prefix}FLOW_NODE_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}FLOW_NODE_INSTANCE"
+      indexName="${prefix}IDX_FLOW_NODE_INSTANCE_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet author="camunda" id="create_user_task_table">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}USER_TASK"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}USER_TASK">
+      <column name="USER_TASK_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="ELEMENT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="CREATION_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="COMPLETION_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="ASSIGNEE" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="STATE" type="VARCHAR(20)"/>
+      <column name="FORM_KEY" type="BIGINT"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ELEMENT_INSTANCE_KEY" type="BIGINT"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="DUE_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="FOLLOW_UP_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="EXTERNAL_FORM_REFERENCE" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_VERSION" type="SMALLINT"/>
+      <column name="CUSTOM_HEADERS" type="CLOB"/>
+      <column name="PRIORITY" type="INT"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet author="camunda" id="create_user_task_pi_key_index">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_USER_TASK_PI_KEY" tableName="${prefix}USER_TASK"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}USER_TASK" indexName="${prefix}IDX_USER_TASK_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet author="camunda" id="create_user_task_rpi_key_index">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_USER_TASK_RPI_KEY" tableName="${prefix}USER_TASK"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}USER_TASK" indexName="${prefix}IDX_USER_TASK_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet author="camunda" id="create_user_task_fni_key_index">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_USER_TASK_FNI_KEY" tableName="${prefix}USER_TASK"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}USER_TASK" indexName="${prefix}IDX_USER_TASK_FNI_KEY">
+      <column name="ELEMENT_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet author="camunda" id="create_candidate_user_table">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}CANDIDATE_USER"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}CANDIDATE_USER">
+      <column name="USER_TASK_KEY" type="BIGINT">
+        <constraints foreignKeyName="${prefix}FK_CANDIDATE_USER_USER_TASK"
+          referencedTableName="${prefix}USER_TASK" referencedColumnNames="USER_TASK_KEY"
+          deleteCascade="true"/>
+      </column>
+      <column name="CANDIDATE_USER" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet author="camunda" id="create_candidate_group_table">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}CANDIDATE_GROUP"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}CANDIDATE_GROUP">
+      <column name="USER_TASK_KEY" type="BIGINT">
+        <constraints foreignKeyName="${prefix}FK_CANDIDATE_GROUP_USER_TASK"
+          referencedTableName="${prefix}USER_TASK" referencedColumnNames="USER_TASK_KEY"
+          deleteCascade="true"/>
+      </column>
+      <column name="CANDIDATE_GROUP" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet author="camunda" id="create_user_task_tag_table">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}USER_TASK_TAG"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}USER_TASK_TAG">
+      <column name="USER_TASK_KEY" type="BIGINT">
+        <constraints primaryKey="true" foreignKeyName="${prefix}FK_USER_TASK_TAG_USER_TASK"
+          referencedTableName="${prefix}USER_TASK" referencedColumnNames="USER_TASK_KEY"
+          deleteCascade="true"/>
+      </column>
+      <column name="TAG_VALUE" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+
+  <changeSet author="camunda" id="create_candidate_user_task_key_index">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_CANDIDATE_USER_USER_TASK_KEY"
+          tableName="${prefix}CANDIDATE_USER"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}CANDIDATE_USER"
+      indexName="${prefix}IDX_CANDIDATE_USER_USER_TASK_KEY">
+      <column name="USER_TASK_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet author="camunda" id="create_candidate_group_user_task_key_index">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_CANDIDATE_GROUP_USER_TASK_KEY"
+          tableName="${prefix}CANDIDATE_GROUP"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}CANDIDATE_GROUP"
+      indexName="${prefix}IDX_CANDIDATE_GROUP_USER_TASK_KEY">
+      <column name="USER_TASK_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet author="camunda" id="create_user_task_tag_user_task_key_index">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_USER_TASK_TAG_USER_TASK_KEY"
+          tableName="${prefix}USER_TASK_TAG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}USER_TASK_TAG"
+      indexName="${prefix}IDX_USER_TASK_TAG_USER_TASK_KEY">
+      <column name="USER_TASK_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_incident_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}INCIDENT"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}INCIDENT">
+      <column name="INCIDENT_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="FLOW_NODE_INSTANCE_KEY" type="BIGINT"/>
+      <column name="FLOW_NODE_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="ERROR_MESSAGE" type="VARCHAR(${errorMessageSize})"/>
+      <column name="ERROR_MESSAGE_HASH" type="INT"/>
+      <column name="ERROR_TYPE" type="VARCHAR(100)"/>
+      <column name="STATE" type="VARCHAR(20)"/>
+      <column name="CREATION_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="TREE_PATH" type="VARCHAR(${treePathSize})"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="JOB_KEY" type="BIGINT"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_incident_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_INCIDENT_PI_KEY" tableName="${prefix}INCIDENT"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}INCIDENT" indexName="${prefix}IDX_INCIDENT_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_incident_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_INCIDENT_RPI_KEY" tableName="${prefix}INCIDENT"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}INCIDENT" indexName="${prefix}IDX_INCIDENT_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_definition_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}DECISION_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}DECISION_DEFINITION">
+      <column name="DECISION_DEFINITION_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="DECISION_DEFINITION_ID" type="NVARCHAR(255)"/>
+      <column name="NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="VERSION" type="SMALLINT"/>
+      <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT"/>
+      <column name="DECISION_REQUIREMENTS_ID" type="NVARCHAR(255)"/>
+      <column name="DECISION_REQUIREMENTS_NAME" type="NVARCHAR(255)"/>
+      <column name="DECISION_REQUIREMENTS_VERSION" type="SMALLINT"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_decision_definition_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_DEFINITION_ID"
+          tableName="${prefix}DECISION_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_DEFINITION"
+      indexName="${prefix}IDX_DECISION_DEFINITION_ID">
+      <column name="DECISION_DEFINITION_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_requirements_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_REQUIREMENTS_KEY"
+          tableName="${prefix}DECISION_DEFINITION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_DEFINITION"
+      indexName="${prefix}IDX_DECISION_REQUIREMENTS_KEY">
+      <column name="DECISION_REQUIREMENTS_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_requirements_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}DECISION_REQUIREMENTS"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}DECISION_REQUIREMENTS">
+      <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="DECISION_REQUIREMENTS_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="VERSION" type="SMALLINT"/>
+      <column name="RESOURCE_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="XML" type="CLOB"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_decision_requirements_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_REQUIREMENTS_ID"
+          tableName="${prefix}DECISION_REQUIREMENTS"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_REQUIREMENTS"
+      indexName="${prefix}IDX_DECISION_REQUIREMENTS_ID">
+      <column name="DECISION_REQUIREMENTS_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}DECISION_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}DECISION_INSTANCE">
+      <column name="DECISION_INSTANCE_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="DECISION_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="DECISION_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="DECISION_DEFINITION_KEY" type="BIGINT"/>
+      <column name="DECISION_REQUIREMENTS_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT"/>
+      <column name="FLOW_NODE_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="FLOW_NODE_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_DECISION_DEFINITION_KEY" type="BIGINT"/>
+      <column name="EVALUATION_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="TYPE" type="VARCHAR(255)"/>
+      <column name="STATE" type="VARCHAR(255)"/>
+      <column name="RESULT" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="EVALUATION_FAILURE" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="EVALUATION_FAILURE_MESSAGE" type="VARCHAR(4000)"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_INSTANCE_PI_KEY"
+          tableName="${prefix}DECISION_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_INSTANCE"
+      indexName="${prefix}IDX_DECISION_INSTANCE_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_INSTANCE_RPI_KEY"
+          tableName="${prefix}DECISION_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_INSTANCE"
+      indexName="${prefix}IDX_DECISION_INSTANCE_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_INSTANCE_KEY"
+          tableName="${prefix}DECISION_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_INSTANCE"
+      indexName="${prefix}IDX_DECISION_INSTANCE_KEY">
+      <column name="DECISION_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_dd_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_INSTANCE_DD_KEY"
+          tableName="${prefix}DECISION_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_INSTANCE"
+      indexName="${prefix}IDX_DECISION_INSTANCE_DD_KEY">
+      <column name="DECISION_DEFINITION_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_fni_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_INSTANCE_FNI_KEY"
+          tableName="${prefix}DECISION_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_INSTANCE"
+      indexName="${prefix}IDX_DECISION_INSTANCE_FNI_KEY">
+      <column name="FLOW_NODE_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_hist_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_INSTANCE_HIST"
+          tableName="${prefix}DECISION_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_INSTANCE"
+      indexName="${prefix}IDX_DECISION_INSTANCE_HIST">
+      <column name="PARTITION_ID"/>
+      <column name="HISTORY_CLEANUP_DATE"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_input_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}DECISION_INSTANCE_INPUT"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}DECISION_INSTANCE_INPUT">
+      <column name="DECISION_INSTANCE_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints foreignKeyName="${prefix}FK_DEC_INST_INPUT_DEC_INST"
+          referencedTableName="${prefix}DECISION_INSTANCE"
+          referencedColumnNames="DECISION_INSTANCE_ID" deleteCascade="true"/>
+      </column>
+      <column name="INPUT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="INPUT_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="INPUT_VALUE" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_input_instance_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_INSTANCE_INPUT_INSTANCE_ID"
+          tableName="${prefix}DECISION_INSTANCE_INPUT"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_INSTANCE_INPUT"
+      indexName="${prefix}IDX_DECISION_INSTANCE_INPUT_INSTANCE_ID">
+      <column name="DECISION_INSTANCE_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_output_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}DECISION_INSTANCE_OUTPUT"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}DECISION_INSTANCE_OUTPUT">
+      <column name="DECISION_INSTANCE_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints foreignKeyName="${prefix}FK_DEC_INST_OUTPUT_DEC_INST"
+          referencedTableName="${prefix}DECISION_INSTANCE"
+          referencedColumnNames="DECISION_INSTANCE_ID" deleteCascade="true"/>
+      </column>
+      <column name="OUTPUT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="RULE_INDEX" type="SMALLINT"/>
+      <column name="OUTPUT_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="OUTPUT_VALUE" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="RULE_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_output_instance_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_DECISION_INSTANCE_OUTPUT_INSTANCE_ID"
+          tableName="${prefix}DECISION_INSTANCE_OUTPUT"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}DECISION_INSTANCE_OUTPUT"
+      indexName="${prefix}IDX_DECISION_INSTANCE_OUTPUT_INSTANCE_ID">
+      <column name="DECISION_INSTANCE_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_user_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}USER_"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}USER_">
+      <column name="USERNAME" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="USER_KEY" type="BIGINT"/>
+      <column name="NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="EMAIL" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PASSWORD" type="VARCHAR(${userCharColumnSize})"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_user_user_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_USER_USER_KEY" tableName="${prefix}USER_"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}USER_"
+      indexName="${prefix}IDX_USER_USER_KEY">
+      <column name="USER_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_form_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}FORM"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}FORM">
+      <column name="FORM_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="FORM_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="SCHEMA_XML" type="CLOB"/>
+      <column name="VERSION" type="BIGINT"/>
+      <column name="IS_DELETED" type="BOOLEAN"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_form_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_FORM_ID" tableName="${prefix}FORM"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}FORM" indexName="${prefix}IDX_FORM_ID">
+      <column name="FORM_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_form_tenant_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_FORM_TENANT_ID" tableName="${prefix}FORM"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}FORM" indexName="${prefix}IDX_FORM_TENANT_ID">
+      <column name="TENANT_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_tenant_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}TENANT"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}TENANT">
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="TENANT_KEY" type="BIGINT"/>
+      <column name="NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="DESCRIPTION" type="CLOB"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_tenant_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_TENANT_TENANT_KEY" tableName="${prefix}TENANT"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}TENANT"
+      indexName="${prefix}IDX_TENANT_TENANT_KEY">
+      <column name="TENANT_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_tenant_member_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}TENANT_MEMBER"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}TENANT_MEMBER">
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ENTITY_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ENTITY_TYPE" type="VARCHAR(255)"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_tenant_member_tenant_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}idx_tenant_member_tenant_id"
+          tableName="${prefix}TENANT_MEMBER"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}TENANT_MEMBER"
+      indexName="${prefix}idx_tenant_member_tenant_id">
+      <column name="TENANT_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_tenant_member_entity_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}idx_tenant_member_entity_id"
+          tableName="${prefix}TENANT_MEMBER"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}TENANT_MEMBER"
+      indexName="${prefix}idx_tenant_member_entity_id">
+      <column name="ENTITY_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_role_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}ROLES"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}ROLES">
+      <column name="ROLE_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="ROLE_KEY" type="BIGINT"/>
+      <column name="NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="DESCRIPTION" type="CLOB"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_role_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_ROLE_ROLE_KEY" tableName="${prefix}ROLES"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}ROLES"
+      indexName="${prefix}IDX_ROLE_ROLE_KEY">
+      <column name="ROLE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_role_member_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}ROLE_MEMBER"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}ROLE_MEMBER">
+      <column name="ROLE_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ENTITY_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ENTITY_TYPE" type="VARCHAR(255)"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_role_member_role_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}idx_role_member_role_id" tableName="${prefix}ROLE_MEMBER"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}ROLE_MEMBER" indexName="${prefix}idx_role_member_role_id">
+      <column name="ROLE_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_role_member_entity_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}idx_role_member_entity_id"
+          tableName="${prefix}ROLE_MEMBER"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}ROLE_MEMBER" indexName="${prefix}idx_role_member_entity_id">
+      <column name="ENTITY_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_group_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}GROUP_"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}GROUP_">
+      <column name="GROUP_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="GROUP_KEY" type="BIGINT"/>
+      <column name="NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="DESCRIPTION" type="CLOB"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_group_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_GROUP_GROUP_KEY" tableName="${prefix}GROUP_"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}GROUP_"
+      indexName="${prefix}IDX_GROUP_GROUP_KEY">
+      <column name="GROUP_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_group_member_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}GROUP_MEMBER"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}GROUP_MEMBER">
+      <column name="GROUP_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ENTITY_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ENTITY_TYPE" type="VARCHAR(255)"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_group_member_group_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}idx_group_member_group_id"
+          tableName="${prefix}GROUP_MEMBER"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}GROUP_MEMBER" indexName="${prefix}idx_group_member_group_id">
+      <column name="GROUP_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_group_member_entity_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}idx_group_member_entity_id"
+          tableName="${prefix}GROUP_MEMBER"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}GROUP_MEMBER" indexName="${prefix}idx_group_member_entity_id">
+      <column name="ENTITY_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_authorizations_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}AUTHORIZATIONS"/>
+      </not>
+    </preConditions>
+    <!-- no PK possible, would have too many columns (ALL) -->
+    <createTable tableName="${prefix}AUTHORIZATIONS">
+      <column name="AUTHORIZATION_KEY" type="BIGINT"/>
+      <column name="OWNER_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="OWNER_TYPE" type="VARCHAR(255)"/>
+      <column name="RESOURCE_TYPE" type="VARCHAR(255)"/>
+      <column name="RESOURCE_MATCHER" type="SMALLINT"/>
+      <column name="RESOURCE_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="RESOURCE_PROPERTY_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PERMISSION_TYPE" type="VARCHAR(255)"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_authorizations_auth_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUTHORIZATIONS_AUTHORIZATION_KEY"
+          tableName="${prefix}AUTHORIZATIONS"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUTHORIZATIONS"
+      indexName="${prefix}IDX_AUTHORIZATIONS_AUTHORIZATION_KEY">
+      <column name="AUTHORIZATION_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_authorizations_owner_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUTHORIZATIONS_OWNER_ID"
+          tableName="${prefix}AUTHORIZATIONS"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUTHORIZATIONS"
+      indexName="${prefix}IDX_AUTHORIZATIONS_OWNER_ID">
+      <column name="OWNER_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_authorizations_owner_type_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUTHORIZATIONS_OWNER_TYPE"
+          tableName="${prefix}AUTHORIZATIONS"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUTHORIZATIONS"
+      indexName="${prefix}IDX_AUTHORIZATIONS_OWNER_TYPE">
+      <column name="OWNER_TYPE"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_authorizations_resource_type_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUTHORIZATIONS_RESOURCE_TYPE"
+          tableName="${prefix}AUTHORIZATIONS"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUTHORIZATIONS"
+      indexName="${prefix}IDX_AUTHORIZATIONS_RESOURCE_TYPE">
+      <column name="RESOURCE_TYPE"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_batch_operation_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}BATCH_OPERATION"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}BATCH_OPERATION">
+      <column name="BATCH_OPERATION_KEY" type="VARCHAR(255)">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="STATE" type="VARCHAR(255)"/>
+      <column name="OPERATION_TYPE" type="VARCHAR(255)"/>
+      <column name="START_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="END_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="OPERATIONS_TOTAL_COUNT" type="INT"/>
+      <column name="OPERATIONS_FAILED_COUNT" type="INT"/>
+      <column name="OPERATIONS_COMPLETED_COUNT" type="INT"/>
+      <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="ACTOR_TYPE" type="VARCHAR(50)"/>
+      <column name="ACTOR_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_batch_operation_item_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}BATCH_OPERATION_ITEM"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}BATCH_OPERATION_ITEM">
+      <column name="BATCH_OPERATION_KEY" type="VARCHAR(255)">
+        <constraints primaryKey="true" nullable="false"
+          foreignKeyName="${prefix}FK_BATCH_OPERATION_ITEM_BATCH_OPERATION"
+          referencedTableName="${prefix}BATCH_OPERATION" referencedColumnNames="BATCH_OPERATION_KEY"
+          deleteCascade="true"/>
+      </column>
+      <column name="ITEM_KEY" type="BIGINT">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESSED_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="ERROR_MESSAGE" type="VARCHAR(${errorMessageSize})"/>
+      <column name="STATE" type="VARCHAR(20)" defaultValue="ACTIVE"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_batch_operation_item_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_BATCH_OPERATION_ITEM_PI_KEY"
+          tableName="${prefix}BATCH_OPERATION_ITEM"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}BATCH_OPERATION_ITEM"
+      indexName="${prefix}IDX_BATCH_OPERATION_ITEM_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_batch_operation_item_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_BATCH_OPERATION_ITEM_RPI_KEY"
+          tableName="${prefix}BATCH_OPERATION_ITEM"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}BATCH_OPERATION_ITEM"
+      indexName="${prefix}IDX_BATCH_OPERATION_ITEM_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_batch_operation_error_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}BATCH_OPERATION_ERROR"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}BATCH_OPERATION_ERROR">
+      <column name="BATCH_OPERATION_KEY" type="VARCHAR(255)">
+        <constraints foreignKeyName="${prefix}FK_BATCH_OPERATION_ERROR_BATCH_OPERATION"
+          referencedTableName="${prefix}BATCH_OPERATION" referencedColumnNames="BATCH_OPERATION_KEY"
+          deleteCascade="true"/>
+      </column>
+      <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="TYPE" type="VARCHAR(255)"/>
+      <column name="MESSAGE" type="VARCHAR(${errorMessageSize})"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_batch_operation_error_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_BATCH_OPERATION_ERROR_KEY"
+          tableName="${prefix}BATCH_OPERATION_ERROR"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}BATCH_OPERATION_ERROR"
+      indexName="${prefix}IDX_BATCH_OPERATION_ERROR_KEY">
+      <column name="BATCH_OPERATION_KEY"/>
+      <column name="PARTITION_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_job_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}JOB"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}JOB">
+      <column name="JOB_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ELEMENT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ELEMENT_INSTANCE_KEY" type="BIGINT"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TYPE" type="VARCHAR(255)"/>
+      <column name="WORKER" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="STATE" type="VARCHAR(20)"/>
+      <column name="KIND" type="VARCHAR(50)"/>
+      <column name="LISTENER_EVENT_TYPE" type="VARCHAR(50)"/>
+      <column name="ERROR_MESSAGE" type="VARCHAR(${errorMessageSize})"/>
+      <column name="ERROR_CODE" type="VARCHAR(255)"/>
+      <column name="DEADLINE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="END_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="CUSTOM_HEADERS" type="CLOB"/>
+      <column name="RETRIES" type="SMALLINT"/>
+      <column name="HAS_FAILED_WITH_RETRIES_LEFT" type="BOOLEAN"/>
+      <column name="IS_DENIED" type="BOOLEAN"/>
+      <column name="DENIED_REASON" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="CREATION_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="LAST_UPDATE_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_job_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_JOB_PI_KEY" tableName="${prefix}JOB"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}JOB" indexName="${prefix}IDX_JOB_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_job_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_JOB_RPI_KEY" tableName="${prefix}JOB"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}JOB" indexName="${prefix}IDX_JOB_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_job_fni_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_JOB_FNI_KEY" tableName="${prefix}JOB"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}JOB" indexName="${prefix}IDX_JOB_FNI_KEY">
+      <column name="ELEMENT_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_sequence_flow_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}SEQUENCE_FLOW"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}SEQUENCE_FLOW">
+      <column name="FLOW_NODE_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_sequence_flow_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_SEQUENCE_FLOW_PROCESS_INSTANCE_KEY"
+          tableName="${prefix}SEQUENCE_FLOW"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}SEQUENCE_FLOW"
+      indexName="${prefix}IDX_SEQUENCE_FLOW_PROCESS_INSTANCE_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_sequence_flow_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_SEQUENCE_FLOW_ROOT_PROCESS_INSTANCE_KEY"
+          tableName="${prefix}SEQUENCE_FLOW"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}SEQUENCE_FLOW"
+      indexName="${prefix}IDX_SEQUENCE_FLOW_ROOT_PROCESS_INSTANCE_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_usage_metric_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}USAGE_METRIC"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}USAGE_METRIC">
+      <column name="USAGE_METRIC_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="START_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="END_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="EVENT_TYPE" type="INTEGER"/>
+      <column name="EVENT_VALUE" type="BIGINT"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_usage_metric_end_time_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_USAGE_METRIC_END_TIME"
+          tableName="${prefix}USAGE_METRIC"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}USAGE_METRIC" indexName="${prefix}IDX_USAGE_METRIC_END_TIME">
+      <column name="END_TIME"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_usage_metric_tu_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}USAGE_METRIC_TU"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}USAGE_METRIC_TU">
+      <column name="USAGE_METRIC_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="START_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="END_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="ASSIGNEE_HASH" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="PARTITION_ID" type="NUMBER"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_usage_metric_tu_end_time_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_USAGE_METRIC_TU_END_TIME"
+          tableName="${prefix}USAGE_METRIC_TU"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}USAGE_METRIC_TU"
+      indexName="${prefix}IDX_USAGE_METRIC_TU_END_TIME">
+      <column name="END_TIME"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_mapping_rule_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}MAPPING_RULES"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}MAPPING_RULES">
+      <column name="MAPPING_RULE_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="MAPPING_RULE_KEY" type="BIGINT"/>
+      <column name="CLAIM_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="CLAIM_VALUE" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="NAME" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_mapping_rules_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_MAPPING_RULES_MAPPING_RULE_KEY"
+          tableName="${prefix}MAPPING_RULES"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}MAPPING_RULES"
+      indexName="${prefix}IDX_MAPPING_RULES_MAPPING_RULE_KEY">
+      <column name="MAPPING_RULE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_message_subscription_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}MESSAGE_SUBSCRIPTION"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}MESSAGE_SUBSCRIPTION">
+      <column name="MESSAGE_SUBSCRIPTION_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="FLOW_NODE_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="FLOW_NODE_INSTANCE_KEY" type="BIGINT"/>
+      <column name="MESSAGE_SUBSCRIPTION_STATE" type="VARCHAR(20)"/>
+      <column name="DATE_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="MESSAGE_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="CORRELATION_KEY" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_message_subscription_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_MESSAGE_SUBSCRIPTION_PI_KEY"
+          tableName="${prefix}MESSAGE_SUBSCRIPTION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}MESSAGE_SUBSCRIPTION"
+      indexName="${prefix}IDX_MESSAGE_SUBSCRIPTION_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_message_subscription_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_MESSAGE_SUBSCRIPTION_RPI_KEY"
+          tableName="${prefix}MESSAGE_SUBSCRIPTION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}MESSAGE_SUBSCRIPTION"
+      indexName="${prefix}IDX_MESSAGE_SUBSCRIPTION_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_message_subscription_fni_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_MESSAGE_SUBSCRIPTION_FNI_KEY"
+          tableName="${prefix}MESSAGE_SUBSCRIPTION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}MESSAGE_SUBSCRIPTION"
+      indexName="${prefix}IDX_MESSAGE_SUBSCRIPTION_FNI_KEY">
+      <column name="FLOW_NODE_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_correlated_message_subscription_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}CORRELATED_MESSAGE_SUBSCRIPTION"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}CORRELATED_MESSAGE_SUBSCRIPTION">
+      <column name="CORRELATION_KEY" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="CORRELATION_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="FLOW_NODE_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="FLOW_NODE_INSTANCE_KEY" type="BIGINT"/>
+      <column name="MESSAGE_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="MESSAGE_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="SUBSCRIPTION_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="SUBSCRIPTION_TYPE" type="VARCHAR(255)"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_correlated_message_subscription_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_CORRELATED_MESSAGE_SUBSCRIPTION_PI_KEY"
+          tableName="${prefix}CORRELATED_MESSAGE_SUBSCRIPTION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}CORRELATED_MESSAGE_SUBSCRIPTION"
+      indexName="${prefix}IDX_CORRELATED_MESSAGE_SUBSCRIPTION_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_correlated_message_subscription_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_CORRELATED_MESSAGE_SUBSCRIPTION_RPI_KEY"
+          tableName="${prefix}CORRELATED_MESSAGE_SUBSCRIPTION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}CORRELATED_MESSAGE_SUBSCRIPTION"
+      indexName="${prefix}IDX_CORRELATED_MESSAGE_SUBSCRIPTION_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_correlated_message_subscription_fni_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_CORRELATED_MESSAGE_SUBSCRIPTION_FNI_KEY"
+          tableName="${prefix}CORRELATED_MESSAGE_SUBSCRIPTION"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}CORRELATED_MESSAGE_SUBSCRIPTION"
+      indexName="${prefix}IDX_CORRELATED_MESSAGE_SUBSCRIPTION_FNI_KEY">
+      <column name="FLOW_NODE_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_cluster_variable_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}CLUSTER_VARIABLE"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}CLUSTER_VARIABLE">
+      <column name="CLUSTER_VARIABLE_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="VAR_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TYPE" type="VARCHAR(255)"/>
+      <column name="DOUBLE_VALUE" type="DOUBLE"/>
+      <column name="LONG_VALUE" type="BIGINT"/>
+      <column name="VAR_VALUE" type="VARCHAR(8192)"/>
+      <column name="VAR_FULL_VALUE" type="CLOB"/>
+      <column name="IS_PREVIEW" type="BOOLEAN"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="SCOPE" type="VARCHAR(255)"/>
+    </createTable>
+
+    <modifySql dbms="oracle">
+      <!-- Oracle only supports a size 4000 characters in varchar2 -->
+      <replace replace="VARCHAR2(8192)" with="VARCHAR2(4000)"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_cluster_variable_tenant_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_CLUSTER_VARIABLE_TENANT_ID"
+          tableName="${prefix}CLUSTER_VARIABLE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}CLUSTER_VARIABLE"
+      indexName="${prefix}IDX_CLUSTER_VARIABLE_TENANT_ID">
+      <column name="TENANT_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_cluster_variable_scope_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_CLUSTER_VARIABLE_SCOPE"
+          tableName="${prefix}CLUSTER_VARIABLE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}CLUSTER_VARIABLE"
+      indexName="${prefix}IDX_CLUSTER_VARIABLE_SCOPE">
+      <column name="SCOPE"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_audit_log_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}AUDIT_LOG">
+      <column name="AUDIT_LOG_KEY" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="ENTITY_KEY" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ENTITY_TYPE" type="VARCHAR(50)"/>
+      <column name="OPERATION_TYPE" type="VARCHAR(50)"/>
+      <column name="ENTITY_VERSION" type="INT"/>
+      <column name="ENTITY_VALUE_TYPE" type="SMALLINT"/>
+      <column name="ENTITY_OPERATION_INTENT" type="SMALLINT"/>
+      <column name="BATCH_OPERATION_KEY" type="BIGINT"/>
+      <column name="BATCH_OPERATION_TYPE" type="VARCHAR(50)"/>
+      <column name="TIMESTAMP" type="TIMESTAMP WITH TIME ZONE(3)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="ACTOR_TYPE" type="VARCHAR(50)"/>
+      <column name="ACTOR_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TENANT_SCOPE" type="VARCHAR(50)"/>
+      <column name="RESULT" type="VARCHAR(50)"/>
+      <column name="CATEGORY" type="VARCHAR(50)"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="DECISION_REQUIREMENTS_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="DECISION_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ELEMENT_INSTANCE_KEY" type="BIGINT"/>
+      <column name="JOB_KEY" type="BIGINT"/>
+      <column name="USER_TASK_KEY" type="BIGINT"/>
+      <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT"/>
+      <column name="DECISION_DEFINITION_KEY" type="BIGINT"/>
+      <column name="DECISION_EVALUATION_KEY" type="BIGINT"/>
+      <column name="DEPLOYMENT_KEY" type="BIGINT"/>
+      <column name="FORM_KEY" type="BIGINT"/>
+      <column name="RESOURCE_KEY" type="BIGINT"/>
+      <column name="RELATED_ENTITY_TYPE" type="VARCHAR(50)"/>
+      <column name="RELATED_ENTITY_KEY" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ENTITY_DESCRIPTION" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="AGENT_ELEMENT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_audit_log_hist_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_HIST" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_HIST">
+      <column name="PARTITION_ID"/>
+      <column name="HISTORY_CLEANUP_DATE"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_audit_log_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_PI_KEY" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_audit_log_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_RPI_KEY" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_history_deletion_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}HISTORY_DELETION"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}HISTORY_DELETION">
+      <column name="RESOURCE_KEY" type="BIGINT">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="BATCH_OPERATION_KEY" type="BIGINT">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="RESOURCE_TYPE" type="VARCHAR(50)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="PARTITION_ID" type="NUMBER">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_web_session_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}WEB_SESSION"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}WEB_SESSION">
+      <column name="SESSION_ID" type="NVARCHAR(255)">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="CREATION_TIME" type="BIGINT"/>
+      <column name="LAST_ACCESSED_TIME" type="BIGINT"/>
+      <column name="MAX_INACTIVE_INTERVAL_IN_SECONDS" type="BIGINT"/>
+      <column name="ATTRIBUTES" type="BLOB"/>
+    </createTable>
+    <modifySql dbms="h2">
+      <replace replace="BLOB" with="BINARY LARGE OBJECT"/>
+    </modifySql>
+    <modifySql dbms="postgresql">
+      <replace replace="OID" with="BYTEA"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_audit_log_category_index" author="camunda">
+    <!-- Index for filtering by CATEGORY (used in authorization checks for AUDIT_LOG resource type
+         and USER_TASKS filtering) -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_CATEGORY" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_CATEGORY">
+      <column name="CATEGORY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_audit_log_proc_def_id_index" author="camunda">
+    <!-- Index for filtering by PROCESS_DEFINITION_ID (used in authorization checks for
+         process instance and user task access, including IS NOT NULL checks) -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_PROC_DEF_ID" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_PROC_DEF_ID">
+      <column name="PROCESS_DEFINITION_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_audit_log_cat_proc_def_id_index" author="camunda">
+    <!-- Composite index for efficient filtering of USER_TASKS by specific process definition IDs
+         (covers the compound condition: CATEGORY = 'USER_TASKS' AND PROCESS_DEFINITION_ID IN (...)) -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_CAT_PROC_DEF_ID"
+          tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_CAT_PROC_DEF_ID">
+      <column name="CATEGORY"/>
+      <column name="PROCESS_DEFINITION_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_job_metrics_batch_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}JOB_METRICS_BATCH"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}JOB_METRICS_BATCH">
+      <column name="JOB_METRICS_BATCH_KEY" type="VARCHAR(255)">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="START_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="END_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="INCOMPLETE_BATCH" type="BOOLEAN"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="FAILED_COUNT" type="INT"/>
+      <column name="LAST_FAILED_AT" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="COMPLETED_COUNT" type="INT"/>
+      <column name="LAST_COMPLETED_AT" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="CREATED_COUNT" type="INT"/>
+      <column name="LAST_CREATED_AT" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="JOB_TYPE" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="WORKER" type="NVARCHAR(${userCharColumnSize})"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_job_metrics_batch_tenant_time_index" author="camunda">
+    <!-- Index for global job statistics queries filtering by tenant and time range -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_JOB_METRICS_BATCH_TENANT_TIME"
+          tableName="${prefix}JOB_METRICS_BATCH"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}JOB_METRICS_BATCH"
+      indexName="${prefix}IDX_JOB_METRICS_BATCH_TENANT_TIME">
+      <column name="TENANT_ID"/>
+      <column name="START_TIME"/>
+      <column name="END_TIME"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_job_metrics_batch_end_time_index" author="camunda">
+    <!-- Index for cleanup operations filtering by end time -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_JOB_METRICS_BATCH_END_TIME"
+          tableName="${prefix}JOB_METRICS_BATCH"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}JOB_METRICS_BATCH"
+      indexName="${prefix}IDX_JOB_METRICS_BATCH_END_TIME">
+      <column name="END_TIME"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_job_metrics_batch_job_type_index" author="camunda">
+    <!-- Index for filtering by job type -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_JOB_METRICS_BATCH_JOB_TYPE"
+          tableName="${prefix}JOB_METRICS_BATCH"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}JOB_METRICS_BATCH"
+      indexName="${prefix}IDX_JOB_METRICS_BATCH_JOB_TYPE">
+      <column name="JOB_TYPE"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_global_listener_table" author="camunda">
+    <!-- Global listener table -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}GLOBAL_LISTENER"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}GLOBAL_LISTENER">
+      <column name="ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="LISTENER_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="TYPE" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="RETRIES" type="SMALLINT"/>
+      <column name="AFTER_NON_GLOBAL" type="BOOLEAN"/>
+      <column name="PRIORITY" type="INT"/>
+      <column name="SOURCE" type="VARCHAR(50)"/>
+      <column name="LISTENER_TYPE" type="VARCHAR(50)"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_global_listener_event_type_table" author="camunda">
+    <!-- Global listener event type table: manages collection of event types for global listeners -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}GLOBAL_LISTENER_EVENT_TYPE"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}GLOBAL_LISTENER_EVENT_TYPE">
+      <column name="GLOBAL_LISTENER_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints foreignKeyName="${prefix}FK_EVENT_TYPE_GLOBAL_LISTENER"
+          referencedTableName="${prefix}GLOBAL_LISTENER" referencedColumnNames="ID"
+          deleteCascade="true"/>
+      </column>
+      <column name="EVENT_TYPE" type="VARCHAR(50)"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_global_listener_event_type_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_GLOBAL_LISTENER_EVENT_TYPE_ID"
+          tableName="${prefix}GLOBAL_LISTENER_EVENT_TYPE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}GLOBAL_LISTENER_EVENT_TYPE"
+      indexName="${prefix}IDX_GLOBAL_LISTENER_EVENT_TYPE_ID">
+      <column name="GLOBAL_LISTENER_ID"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_variable_name_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_VARIABLE_NAME" tableName="${prefix}VARIABLE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}VARIABLE" indexName="${prefix}IDX_VARIABLE_NAME">
+      <column name="VAR_NAME"/>
+    </createIndex>
+  </changeSet>
+
+  <!-- audit logs are always sorted by timestamp, so we add this index as a fallback
+  when no other index is selective enough to prevent full-table-scans -->
+  <changeSet id="create_audit_log_timestamp_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_TIMESTAMP" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_TIMESTAMP">
+      <column name="TIMESTAMP"/>
+    </createIndex>
+  </changeSet>
+
+  <!-- CATEGORY is already covered in other index -->
+  <changeSet id="drop_audit_log_category_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <indexExists indexName="${prefix}IDX_AUDIT_LOG_CATEGORY" tableName="${prefix}AUDIT_LOG"/>
+    </preConditions>
+    <dropIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_CATEGORY"/>
+  </changeSet>
+
+  <!-- The most common queries are on ACTIVE process instances -->
+  <changeSet id="create_process_instance_state_active_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_PROCESS_INSTANCE_STATE_ACTIVE"
+          tableName="${prefix}PROCESS_INSTANCE"/>
+      </not>
+    </preConditions>
+    <sql dbms="mysql,mariadb,h2">
+      CREATE INDEX ${prefix}IDX_PROCESS_INSTANCE_STATE_ACTIVE
+        ON ${prefix}PROCESS_INSTANCE (STATE)
+    </sql>
+    <sql dbms="postgresql,mssql">
+      CREATE INDEX ${prefix}IDX_PROCESS_INSTANCE_STATE_ACTIVE
+        ON ${prefix}PROCESS_INSTANCE (STATE) WHERE STATE = 'ACTIVE'
+    </sql>
+    <sql dbms="oracle">
+      CREATE INDEX ${prefix}IDX_PROCESS_INSTANCE_STATE_ACTIVE
+        ON ${prefix}PROCESS_INSTANCE (CASE WHEN STATE = 'ACTIVE' THEN STATE END)
+    </sql>
+  </changeSet>
+
+  <!-- The most common queries are on process instances with incident -->
+  <changeSet id="create_process_instance_has_incident_index" author="camunda">
+    <!-- mariadb and h2 do not support partial indices and a regular index would
+    have very bad performance due to the very poor selectivity -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_PROCESS_INSTANCE_HAS_INCIDENT"
+          tableName="${prefix}PROCESS_INSTANCE"/>
+      </not>
+    </preConditions>
+    <sql dbms="mysql">
+      CREATE INDEX ${prefix}IDX_PROCESS_INSTANCE_HAS_INCIDENT
+        ON ${prefix}PROCESS_INSTANCE ((NUM_INCIDENTS > 0))
+    </sql>
+    <sql dbms="postgresql,mssql">
+      CREATE INDEX ${prefix}IDX_PROCESS_INSTANCE_HAS_INCIDENT
+        ON ${prefix}PROCESS_INSTANCE (NUM_INCIDENTS) WHERE NUM_INCIDENTS > 0
+    </sql>
+    <sql dbms="oracle">
+      CREATE INDEX ${prefix}IDX_PROCESS_INSTANCE_HAS_INCIDENT
+        ON ${prefix}PROCESS_INSTANCE (CASE WHEN NUM_INCIDENTS > 0 THEN NUM_INCIDENTS END)
+    </sql>
+  </changeSet>
+
+  <!-- Default sort column for process_instance is start_date so we index it to enable index-sort-scans -->
+  <changeSet id="create_index_process_instance_start_date" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_PROCESS_INSTANCE_START_DATE"
+          tableName="${prefix}PROCESS_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}PROCESS_INSTANCE"
+      indexName="${prefix}IDX_PROCESS_INSTANCE_START_DATE">
+      <column name="START_DATE"/>
+    </createIndex>
+  </changeSet>
+
+  <!-- The most common queries are on ACTIVE flow node instances -->
+  <changeSet id="create_flow_node_instance_state_active_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_FNI_STATE_ACTIVE"
+          tableName="${prefix}FLOW_NODE_INSTANCE"/>
+      </not>
+    </preConditions>
+    <sql dbms="mysql,mariadb,h2">
+      CREATE INDEX ${prefix}IDX_FNI_STATE_ACTIVE
+        ON ${prefix}FLOW_NODE_INSTANCE (STATE)
+    </sql>
+    <sql dbms="postgresql,mssql">
+      CREATE INDEX ${prefix}IDX_FNI_STATE_ACTIVE
+        ON ${prefix}FLOW_NODE_INSTANCE (STATE) WHERE STATE = 'ACTIVE'
+    </sql>
+    <sql dbms="oracle">
+      CREATE INDEX ${prefix}IDX_FNI_STATE_ACTIVE
+        ON ${prefix}FLOW_NODE_INSTANCE (CASE WHEN STATE = 'ACTIVE' THEN STATE END)
+    </sql>
+  </changeSet>
+
+  <!-- The most common queries are on ACTIVE incidents -->
+  <changeSet id="create_incident_state_active_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_INCIDENT_STATE_ACTIVE" tableName="${prefix}INCIDENT"/>
+      </not>
+    </preConditions>
+    <sql dbms="mariadb,mysql,h2">
+      CREATE INDEX ${prefix}IDX_INCIDENT_STATE_ACTIVE
+        ON ${prefix}INCIDENT (STATE)
+    </sql>
+    <sql dbms="postgresql,mssql">
+      CREATE INDEX ${prefix}IDX_INCIDENT_STATE_ACTIVE
+        ON ${prefix}INCIDENT (STATE) WHERE STATE = 'ACTIVE'
+    </sql>
+    <sql dbms="oracle">
+      CREATE INDEX ${prefix}IDX_INCIDENT_STATE_ACTIVE
+        ON ${prefix}INCIDENT (CASE WHEN STATE = 'ACTIVE' THEN STATE END)
+    </sql>
+  </changeSet>
+
+  <changeSet id="create_audit_log_element_instance_key_index" author="camunda">
+    <!-- Index for ELEMENT_INSTANCE_KEY - optimizes querying for the Operate PI detailed view,
+         when a single process element is selected -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_EI_KEY" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_EI_KEY">
+      <column name="ELEMENT_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_audit_log_user_task_key_index" author="camunda">
+    <!-- Index for USER_TASK_KEY - optimizes querying for the Tasklist history view -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_UT_KEY" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <sql dbms="mysql,mariadb,h2,oracle">
+      CREATE INDEX ${prefix}IDX_AUDIT_LOG_UT_KEY
+        ON ${prefix}AUDIT_LOG (USER_TASK_KEY)
+    </sql>
+    <!-- Since the user task key is sparse, we allow Postgres and MSSQL to exclude null values -->
+    <sql dbms="postgresql,mssql">
+      CREATE INDEX ${prefix}IDX_AUDIT_LOG_UT_KEY
+        ON ${prefix}AUDIT_LOG (USER_TASK_KEY) WHERE USER_TASK_KEY IS NOT NULL
+    </sql>
+  </changeSet>
+
+  <changeSet id="create_audit_log_process_definition_key_index" author="camunda">
+    <!-- Index for PROCESS_DEFINITION_KEY - optimizes querying for the process instances -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_PD_KEY" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_PD_KEY">
+      <column name="PROCESS_DEFINITION_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_audit_log_entity_key_index" author="camunda">
+    <!-- Index for ENTITY_KEY - optimizes history cleanup as the entityKey is a central column there -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_ENTITY_KEY" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_ENTITY_KEY">
+      <column name="ENTITY_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_audit_log_actor_id_index" author="camunda">
+    <!-- Index for ACTOR_ID - optimizes querying audit log entries by actor -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_ACTOR_ID" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <sql dbms="mysql,mariadb,h2,oracle">
+      CREATE INDEX ${prefix}IDX_AUDIT_LOG_ACTOR_ID
+        ON ${prefix}AUDIT_LOG (ACTOR_ID)
+    </sql>
+    <!-- Since actor_id is sparse (nullable), we allow Postgres and MSSQL to exclude null values -->
+    <sql dbms="postgresql,mssql">
+      CREATE INDEX ${prefix}IDX_AUDIT_LOG_ACTOR_ID
+        ON ${prefix}AUDIT_LOG (ACTOR_ID) WHERE ACTOR_ID IS NOT NULL
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Description

Introduces a `golden` file concept for Liquibase to prevent unintentional changes of already published Liquibase scripts (like the `8.9.0.xml`).

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51261 