### PR TITLE
feat: expose priority on ActivatedJob in the Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -80,6 +80,11 @@ public interface ActivatedJob {
   int getRetries();
 
   /**
+   * @return the priority of the job; higher values indicate higher priority
+   */
+  int getPriority();
+
+  /**
    * @return the unix timestamp until when the job is exclusively assigned to this worker (time unit
    *     * is milliseconds since unix epoch). If the deadline is exceeded, it can happen that the
    *     job is handed to another worker and the work is performed twice.

--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -82,9 +82,7 @@ public interface ActivatedJob {
   /**
    * @return the priority of the job; higher values indicate higher priority
    */
-  default int getPriority() {
-    return 0;
-  }
+  int getPriority();
 
   /**
    * @return the unix timestamp until when the job is exclusively assigned to this worker (time unit

--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -82,7 +82,9 @@ public interface ActivatedJob {
   /**
    * @return the priority of the job; higher values indicate higher priority
    */
-  int getPriority();
+  default int getPriority() {
+    return 0;
+  }
 
   /**
    * @return the unix timestamp until when the job is exclusively assigned to this worker (time unit

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
@@ -51,6 +51,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final String tenantId;
   private final String worker;
   private final int retries;
+  private final int priority;
   private final long deadline;
   private final String variables;
   private final UserTaskProperties userTask;
@@ -74,6 +75,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
         customHeaders.isEmpty() ? new HashMap<>() : jsonMapper.fromJsonAsStringMap(customHeaders);
     worker = job.getWorker();
     retries = job.getRetries();
+    priority = job.getPriority();
     deadline = job.getDeadline();
     variables = job.getVariables();
     processInstanceKey = job.getProcessInstanceKey();
@@ -110,6 +112,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
                                 : jsonMapper.toJson(e.getValue())));
     worker = getOrEmpty(job.getWorker());
     retries = getOrEmpty(job.getRetries());
+    priority = getOrZero(job.getPriority());
     deadline = getOrEmpty(job.getDeadline());
     variablesAsMap = job.getVariables() == null ? new HashMap<>() : job.getVariables();
     variables = jsonMapper.toJson(variablesAsMap);
@@ -184,6 +187,11 @@ public final class ActivatedJobImpl implements ActivatedJob {
   @Override
   public int getRetries() {
     return retries;
+  }
+
+  @Override
+  public int getPriority() {
+    return priority;
   }
 
   @Override
@@ -276,6 +284,10 @@ public final class ActivatedJobImpl implements ActivatedJob {
 
   private static Integer getOrEmpty(final Integer value) {
     return value == null ? -1 : value;
+  }
+
+  private static int getOrZero(final Integer value) {
+    return value == null ? 0 : value;
   }
 
   private static Long parseLongOrEmpty(final String value) {

--- a/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
@@ -59,6 +59,7 @@ public final class ActivateJobsTest extends ClientTest {
             .setCustomHeaders("{\"version\": \"1\"}")
             .setWorker("worker1")
             .setRetries(34)
+            .setPriority(15)
             .setDeadline(1231)
             .setVariables("{\"key\": \"val\"}")
             .setTenantId("test-tenant-1")
@@ -79,6 +80,7 @@ public final class ActivateJobsTest extends ClientTest {
             .setCustomHeaders("{\"key\": \"value\"}")
             .setWorker("worker1")
             .setRetries(334)
+            .setPriority(-3)
             .setDeadline(3131)
             .setVariables("{\"bar\": 3}")
             .setTenantId("test-tenant-2")
@@ -116,6 +118,7 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getCustomHeaders()).isEqualTo(fromJsonAsMap(activatedJob1.getCustomHeaders()));
     assertThat(job.getWorker()).isEqualTo(activatedJob1.getWorker());
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
+    assertThat(job.getPriority()).isEqualTo(activatedJob1.getPriority());
     assertThat(job.getDeadline()).isEqualTo(activatedJob1.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob1.getVariables());
     assertThat(job.getUserTask()).isNull();
@@ -143,6 +146,7 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getCustomHeaders()).isEqualTo(fromJsonAsMap(activatedJob2.getCustomHeaders()));
     assertThat(job.getWorker()).isEqualTo(activatedJob2.getWorker());
     assertThat(job.getRetries()).isEqualTo(activatedJob2.getRetries());
+    assertThat(job.getPriority()).isEqualTo(activatedJob2.getPriority());
     assertThat(job.getDeadline()).isEqualTo(activatedJob2.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob2.getVariables());
     assertThat(job.getUserTask()).isNull();

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -74,7 +74,8 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .tenantId("test-tenant-1")
             .kind(JobKindEnum.BPMN_ELEMENT)
             .listenerEventType(JobListenerEventTypeEnum.START)
-            .rootProcessInstanceKey("321");
+            .rootProcessInstanceKey("321")
+            .priority(15);
 
     final ActivatedJobResult activatedJob2 =
         new ActivatedJobResult()
@@ -94,7 +95,8 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .tenantId("test-tenant-2")
             .kind(JobKindEnum.BPMN_ELEMENT)
             .listenerEventType(JobListenerEventTypeEnum.END)
-            .rootProcessInstanceKey("444");
+            .rootProcessInstanceKey("444")
+            .priority(-3);
 
     gatewayService.onActivateJobsRequest(
         new JobActivationResult().addJobsItem(activatedJob1).addJobsItem(activatedJob2));
@@ -132,6 +134,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(job.getCustomHeaders()).isEqualTo(activatedJob1.getCustomHeaders());
     assertThat(job.getWorker()).isEqualTo(activatedJob1.getWorker());
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
+    assertThat(job.getPriority()).isEqualTo(activatedJob1.getPriority());
     assertThat(job.getDeadline()).isEqualTo(activatedJob1.getDeadline());
     assertThat(job.getVariablesAsMap()).isEqualTo(activatedJob1.getVariables());
     assertThat(job.getUserTask()).isNull();
@@ -158,6 +161,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(job.getCustomHeaders()).isEqualTo(activatedJob2.getCustomHeaders());
     assertThat(job.getWorker()).isEqualTo(activatedJob2.getWorker());
     assertThat(job.getRetries()).isEqualTo(activatedJob2.getRetries());
+    assertThat(job.getPriority()).isEqualTo(activatedJob2.getPriority());
     assertThat(job.getDeadline()).isEqualTo(activatedJob2.getDeadline());
     assertThat(job.getVariablesAsMap()).isEqualTo(activatedJob2.getVariables());
     assertThat(job.getUserTask()).isNull();
@@ -356,6 +360,18 @@ public final class ActivateJobsRestTest extends ClientRestTest {
 
     // then
     assertThat(request.getRequestTimeout()).isEqualTo(requestTimeout.toMillis());
+  }
+
+  @Test
+  void shouldReturnZeroPriorityWhenNotSet() {
+    // given
+    final ActivatedJobResult activatedJob = new ActivatedJobResult();
+
+    // when
+    final ActivatedJobImpl job = new ActivatedJobImpl(new CamundaObjectMapper(), activatedJob);
+
+    // then
+    assertThat(job.getPriority()).isEqualTo(0);
   }
 
   @Test


### PR DESCRIPTION
## Description

Expose job priority on `ActivatedJob` in the Java client so users can read it from the gRPC and REST activation responses.

- Added `int getPriority()` to the public `ActivatedJob` interface.
- Wired the value through `ActivatedJobImpl` for both gRPC (primitive `int`) and REST (boxed `Integer`, defaulting to `0` on null via a new `getOrZero` helper — matches the protobuf `int32` default).
- Extended `ActivateJobsTest` and `ActivateJobsRestTest` to assert the round-tripped priority (including a negative value), plus a `shouldReturnZeroPriorityWhenNotSet` REST test covering the null-priority path.


## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53836