### PR TITLE
feat: support expressions for called decision versionTag

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.dmn.DecisionEvaluationResult;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
@@ -130,7 +131,7 @@ public final class BpmnDecisionBehavior {
   private Either<Failure, PersistedDecision> findCalledDecision(
       final String decisionId,
       final ZeebeBindingType bindingType,
-      final String versionTag,
+      final Expression versionTag,
       final BpmnElementContext context) {
     return switch (bindingType) {
       case deployment -> getDecisionVersionInSameDeployment(decisionId, context);
@@ -156,9 +157,10 @@ public final class BpmnDecisionBehavior {
   }
 
   private Either<Failure, PersistedDecision> getLatestDecisionVersionWithVersionTag(
-      final String decisionId, final String versionTag, final String tenantId) {
+      final String decisionId, final Expression versionTag, final String tenantId) {
+    // TODO(#52910): evaluate versionTag expression against process instance variables
     return decisionBehavior.findDecisionByIdAndVersionTagAndTenant(
-        decisionId, versionTag, tenantId);
+        decisionId, versionTag.getExpression(), tenantId);
   }
 
   private Either<Failure, String> evalDecisionIdExpression(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
@@ -16,7 +16,7 @@ public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask
   private Expression decisionId;
   private String resultVariable;
   private ZeebeBindingType bindingType;
-  private String versionTag;
+  private Expression versionTag;
 
   public ExecutableBusinessRuleTask(final String id) {
     super(id);
@@ -53,12 +53,12 @@ public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask
   }
 
   @Override
-  public String getVersionTag() {
+  public Expression getVersionTag() {
     return versionTag;
   }
 
   @Override
-  public void setVersionTag(final String versionTag) {
+  public void setVersionTag(final Expression versionTag) {
     this.versionTag = versionTag;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCalledDecision.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCalledDecision.java
@@ -25,7 +25,7 @@ public interface ExecutableCalledDecision {
 
   void setBindingType(ZeebeBindingType bindingType);
 
-  String getVersionTag();
+  Expression getVersionTag();
 
-  void setVersionTag(String versionTag);
+  void setVersionTag(Expression versionTag);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
@@ -34,7 +34,9 @@ public final class CalledDecisionTransformer {
     final var bindingType = calledDecision.getBindingType();
     executableElement.setBindingType(bindingType);
 
-    final var versionTag = calledDecision.getVersionTag();
-    executableElement.setVersionTag(versionTag);
+    final var rawVersionTag = calledDecision.getVersionTag();
+    if (rawVersionTag != null) {
+      executableElement.setVersionTag(expressionLanguage.parseExpression(rawVersionTag));
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBusinessRuleTask;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.BusinessRuleTaskBuilder;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+import java.time.InstantSource;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class CalledDecisionTransformerTest {
+
+  private static final String TASK_ID = "business-rule-task";
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
+
+  private BpmnModelInstance processWithBusinessRuleTask(
+      final Consumer<BusinessRuleTaskBuilder> modifier) {
+    return Bpmn.createExecutableProcess().startEvent().businessRuleTask(TASK_ID, modifier).done();
+  }
+
+  private ExecutableBusinessRuleTask transform(final BpmnModelInstance model) {
+    final List<ExecutableProcess> processes = transformer.transformDefinitions(model);
+    return processes.get(0).getElementById(TASK_ID, ExecutableBusinessRuleTask.class);
+  }
+
+  @Test
+  void shouldParseStaticVersionTagAsExpression() {
+    // given
+    final var model =
+        processWithBusinessRuleTask(
+            t ->
+                t.zeebeCalledDecisionId("myDecision")
+                    .zeebeBindingType(ZeebeBindingType.versionTag)
+                    .zeebeVersionTag("v1.0")
+                    .zeebeResultVariable("result"));
+
+    // when
+    final var element = transform(model);
+
+    // then
+    assertThat(element.getVersionTag()).isNotNull();
+    assertThat(element.getVersionTag().isStatic()).isTrue();
+    assertThat(element.getVersionTag().isValid()).isTrue();
+    assertThat(element.getVersionTag().getExpression()).isEqualTo("v1.0");
+  }
+
+  @Test
+  void shouldParseVersionTagExpressionAsFeelExpression() {
+    // given
+    final var model =
+        processWithBusinessRuleTask(
+            t ->
+                t.zeebeCalledDecisionId("myDecision")
+                    .zeebeBindingType(ZeebeBindingType.versionTag)
+                    .zeebeVersionTag("=versionTagVariable")
+                    .zeebeResultVariable("result"));
+
+    // when
+    final var element = transform(model);
+
+    // then
+    assertThat(element.getVersionTag()).isNotNull();
+    assertThat(element.getVersionTag().isStatic()).isFalse();
+    assertThat(element.getVersionTag().isValid()).isTrue();
+    assertThat(element.getVersionTag().getExpression()).isEqualTo("versionTagVariable");
+  }
+
+  @Test
+  void shouldSetNullVersionTagWhenNoCalledDecisionExtension() {
+    // given
+    final var model = processWithBusinessRuleTask(t -> {});
+
+    // when
+    final var element = transform(model);
+
+    // then
+    assertThat(element.getVersionTag()).isNull();
+  }
+}


### PR DESCRIPTION
## Summary

- Change `versionTag` type from `String` to `Expression` in `ExecutableCalledDecision` interface and `ExecutableBusinessRuleTask`
- Update `CalledDecisionTransformer` to parse the raw versionTag string as a FEEL expression (static strings like `v1.0` become `StaticExpression`; `=myVar` becomes `FeelExpression`)
- Update `BpmnDecisionBehavior` method signatures to accept `Expression` instead of `String`; actual expression evaluation stubbed with TODO pointing to #52910

## Why

Enables dynamic version tag resolution via FEEL expressions for called decisions (business rule tasks). Groundwork for #52910, which will implement runtime evaluation against process instance variables.

## Notes for reviewer

- `BpmnDecisionBehavior.getLatestDecisionVersionWithVersionTag` uses `versionTag.getExpression()` as a temporary stub — this returns the raw expression string, which is correct for static values but not for dynamic FEEL expressions. Full evaluation lands in #52910.
- Null guard added in `CalledDecisionTransformer` since `versionTag` is optional in the BPMN model.


## Test plan

- [ ] `CalledDecisionTransformerTest` — new unit tests: static string, FEEL expression, null (no extension)
- [ ] `BusinessRuleTaskTest` — existing version tag tests continue to pass