### PR TITLE
test: select migration target explicitly in Auto mapping migration

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
@@ -103,6 +103,16 @@ export class OperateProcessMigrationModePage {
     }
   }
 
+  async waitForFlowNodeAutoMapping(
+    label: string | RegExp,
+    targetValue: string,
+    timeout = 60000,
+  ): Promise<void> {
+    await expect(this.page.getByLabel(label)).toHaveValue(targetValue, {
+      timeout,
+    });
+  }
+
   async migrateProcess(version?: string): Promise<void> {
     await this.clickTargetVersionCombo();
     if (version) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -145,10 +145,23 @@ test.describe.serial('Process Instance Migration', () => {
       await sleep(3000);
     });
 
-    await test.step('Verify target process is preselected with auto-mapping and Complete Migration', async () => {
+    await test.step('Select target process and verify auto-mapping, then Complete Migration', async () => {
+      await operateProcessMigrationModePage.targetProcessCombobox.click();
+      await operateProcessMigrationModePage
+        .getOptionByName(targetBpmnProcessId)
+        .click();
+
       await expect(
         operateProcessMigrationModePage.targetProcessCombobox,
       ).toHaveValue(targetBpmnProcessId, {timeout: 60000});
+
+      // Selecting the target process auto-selects the latest version, which
+      // triggers auto-mapping of flow nodes once the target diagram has loaded.
+      // Wait for the first mapping before verifying the full set.
+      await operateProcessMigrationModePage.waitForFlowNodeAutoMapping(
+        'Target flow node for Check payment',
+        'checkPayment',
+      );
 
       await operateProcessMigrationModePage.verifyFlowNodeMappings([
         {
@@ -648,7 +661,9 @@ test.describe.serial('Process Instance Migration', () => {
       await waitForAssertion({
         assertion: async () => {
           await operateDiagramPage.clickFlowNode('BusinessRuleTask2');
-          await operateDiagramPage.verifyIncidentInPopover(/invalid.*decision/i);
+          await operateDiagramPage.verifyIncidentInPopover(
+            /invalid.*decision/i,
+          );
         },
         onFailure: async () => {
           await page.reload();


### PR DESCRIPTION
## Problem

The **Auto mapping migration** Operate E2E test
(`tests/operate/processInstanceMigration.spec.ts`) fails on every `stable/8.7`
nightly run:

```
expect(locator).toHaveValue(expected) failed
Locator:  getByRole('combobox', { name: 'Target', exact: true })
Expected: "orderProcessMigration"
Received: ""
Timeout:  60000ms
```

The test assumed the migration view **auto-preselects** the target process
after migration starts. Operate 8.7 does not do this — `TargetProcessField`
renders the combobox with `value={selectedTargetProcess?.key ?? ''}` and there
is no preselection effect, so the Target combobox stays empty
("Search by process name") until the user selects a process. The screenshot
artifact confirms the empty combobox.

Only the **flow-node** auto-mapping (matching ids/types) is automatic in 8.7,
and it runs in `BottomPanel` *after* a target process + version is selected.

## Fix

Mirror the actual product flow (as the sibling "Manual mapping migration" test
already does): explicitly select the target process — which auto-selects the
latest version and triggers flow-node auto-mapping — then verify the auto-mapped
flow nodes and complete the migration. A small `waitForFlowNodeAutoMapping`
page-object helper waits for the target diagram to load before asserting the
full mapping set.

No product code changed; this is a test-only correction. The flow-node
auto-mapping behaviour is still fully asserted.

Nightly run: https://github.com/camunda/camunda/actions/runs/27110911344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/27130190144
