### PR TITLE
fix: restore getMessageKeys on MessageBatchRecordValue

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
@@ -7,13 +7,37 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.message;
 
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public final class MessageBatchRecord extends UnifiedRecordValue
     implements MessageBatchRecordValue {
 
+  // Static StringValue key to avoid memory waste
+  private static final StringValue MESSAGE_KEYS_KEY = new StringValue("messageKeys");
+
+  // Retained for backwards compatibility: 8.10+ no longer writes message keys onto the batch
+  // command (the expiry processor queries the message state directly), but the property is kept so
+  // records written by earlier versions still deserialize and the public getMessageKeys() contract
+  // holds.
+  private final ArrayProperty<LongValue> messageKeysProp =
+      new ArrayProperty<>(MESSAGE_KEYS_KEY, LongValue::new);
+
   public MessageBatchRecord() {
-    super(0);
+    super(1);
+    declareProperty(messageKeysProp);
+  }
+
+  @Override
+  public List<Long> getMessageKeys() {
+    return StreamSupport.stream(messageKeysProp.spliterator(), false)
+        .map(LongValue::getValue)
+        .collect(Collectors.toList());
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1313,7 +1313,9 @@ final class JsonSerializableToJsonTest {
         "MessageBatchRecord",
         (Supplier<UnifiedRecordValue>) MessageBatchRecord::new,
         """
-                {}
+                {
+                  "messageKeys": []
+                }
                 """
       },
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageBatchRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageBatchRecord.golden
@@ -7,13 +7,37 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.message;
 
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public final class MessageBatchRecord extends UnifiedRecordValue
     implements MessageBatchRecordValue {
 
+  // Static StringValue key to avoid memory waste
+  private static final StringValue MESSAGE_KEYS_KEY = new StringValue("messageKeys");
+
+  // Retained for backwards compatibility: 8.10+ no longer writes message keys onto the batch
+  // command (the expiry processor queries the message state directly), but the property is kept so
+  // records written by earlier versions still deserialize and the public getMessageKeys() contract
+  // holds.
+  private final ArrayProperty<LongValue> messageKeysProp =
+      new ArrayProperty<>(MESSAGE_KEYS_KEY, LongValue::new);
+
   public MessageBatchRecord() {
-    super(0);
+    super(1);
+    declareProperty(messageKeysProp);
+  }
+
+  @Override
+  public List<Long> getMessageKeys() {
+    return StreamSupport.stream(messageKeysProp.spliterator(), false)
+        .map(LongValue::getValue)
+        .collect(Collectors.toList());
   }
 }

--- a/zeebe/protocol/ignored-changes.json
+++ b/zeebe/protocol/ignored-changes.json
@@ -327,54 +327,6 @@
           "old": "class io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationMoveInstructionValue",
           "new": "class io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationMoveInstructionValue",
           "justification": "Interface is generalized in and moved to the ProcessInstanceModificationRecordValue."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method java.util.List<java.lang.Long> io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue::getMessageKeys()",
-          "justification": "MessageBatchRecord no longer carries message keys. The batch expiry processor now queries state directly instead of reading keys from the command record. Old records with keys deserialize safely as unknown properties are ignored."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method java.util.List<java.lang.Long> io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue::getMessageKeys()",
-          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue::withMessageKeys(java.lang.Iterable<? extends java.lang.Long>)",
-          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue::withMessageKeys(java.lang.Long[])",
-          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder::addAllMessageKeys(java.lang.Iterable<? extends java.lang.Long>)",
-          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder::addMessageKey(java.lang.Long)",
-          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder::addMessageKeys(java.lang.Long[])",
-          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder::withMessageKeys(java.lang.Iterable<? extends java.lang.Long>)",
-          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
         }
       ]
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageBatchRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageBatchRecordValue.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
 import org.immutables.value.Value;
 
 /**
@@ -26,4 +27,15 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableMessageBatchRecordValue.Builder.class)
-public interface MessageBatchRecordValue extends RecordValue {}
+public interface MessageBatchRecordValue extends RecordValue {
+
+  /**
+   * @return list of the keys from the messages assigned to this batch
+   * @deprecated since 8.10. The batch expiry processor now queries the message state directly
+   *     instead of carrying the keys on the command record, so records produced by 8.10+ always
+   *     return an empty list. The method is retained for backwards compatibility with exporters and
+   *     to deserialize records written by earlier versions.
+   */
+  @Deprecated
+  List<Long> getMessageKeys();
+}


### PR DESCRIPTION
Restores the `getMessageKeys()` method and `messageKeys` field on the public `MessageBatchRecordValue` protocol interface, which were removed in #50346.

#50346 removed the field and suppressed the resulting `revapi` failure with bypass entries in `ignored-changes.json`. The justification only accounted for Zeebe's own log replay — old records decode fine because unknown MessagePack fields are ignored — but it missed the exporter API contract. Record implementations are exported directly, so any custom exporter calling `getMessageKeys()` breaks with a `NoSuchMethodError` after upgrading the `zeebe-protocol` dependency, which a customer hit (SUPPORT-33187). This contradicts the documented MessagePack rule that existing fields cannot be removed.

This restores the field and the method, marks `getMessageKeys()` as `@Deprecated` since records produced by 8.10+ no longer carry keys (the batch expiry processor now queries the message state directly), and removes the now-unnecessary `ignored-changes.json` bypasses. New records return an empty list while records written by earlier versions still deserialize their keys. The serialization tests and the `RecordGoldenFilesTest` golden file are restored to match.

closes #54823