### PR TITLE
fix: supply Nexus credentials to maven-dependency-snapshot workflow

### DIFF
--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -34,6 +34,17 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
       # Scope to shipped modules only (mirrors JAVA_PROJECTS in zeebe-snyk.yml).
       # -am resolves the full transitive tree including BOM-pinned versions.
       - name: Submit Maven dependency snapshot
@@ -41,10 +52,14 @@ jobs:
         with:
           token: ${{ github.token }}
           maven-args: >-
+            -s maven-settings.xml
             -pl bom,clients/java,clients/camunda-spring-boot-starter,zeebe/bpmn-model,zeebe/exporter-api,zeebe/gateway-protocol-impl,zeebe/protocol
             -am
             -Dquickly
           correlator: ${{ github.job }}-maven
+        env:
+          NEXUS_USR: ${{ steps.secrets.outputs.NEXUS_USR }}
+          NEXUS_PSW: ${{ steps.secrets.outputs.NEXUS_PSW }}
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -45,6 +45,17 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
+      - name: Configure Maven credentials
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+              "id": "camunda-nexus",
+              "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
+              "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
+            }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       # Scope to shipped modules only (mirrors JAVA_PROJECTS in zeebe-snyk.yml).
       # -am resolves the full transitive tree including BOM-pinned versions.
       - name: Submit Maven dependency snapshot
@@ -52,14 +63,10 @@ jobs:
         with:
           token: ${{ github.token }}
           maven-args: >-
-            -s maven-settings.xml
             -pl bom,clients/java,clients/camunda-spring-boot-starter,zeebe/bpmn-model,zeebe/exporter-api,zeebe/gateway-protocol-impl,zeebe/protocol
             -am
             -Dquickly
           correlator: ${{ github.job }}-maven
-        env:
-          NEXUS_USR: ${{ steps.secrets.outputs.NEXUS_USR }}
-          NEXUS_PSW: ${{ steps.secrets.outputs.NEXUS_PSW }}
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -28,6 +28,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write  # required by the Dependency Submission API
+      id-token: write  # Vault OIDC/JWT auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -39,9 +39,11 @@ jobs:
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          method: jwt
+          role: ${{ secrets.VAULT_JWT_ROLE }}
+          path: ${{ secrets.VAULT_JWT_PATH }}
+          jwtGithubAudience: ${{ secrets.VAULT_JWT_AUDIENCE }}
+          exportEnv: false
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;


### PR DESCRIPTION
## Summary

- `maven-dependency-snapshot.yml` was failing with HTTP 401 when resolving `camunda-security-library-api` from `artifacts.camunda.com/artifactory/zeebe-io/` (requires Nexus auth)
- Root cause: the workflow had no Nexus credentials; all other workflows that run Maven fetch `NEXUS_USR`/`NEXUS_PSW` from Vault
- Fix: fetch credentials from Vault, then use `s4u/maven-settings-action` to configure `~/.m2/settings.xml` with the `nexus.camunda.cloud` mirror — the same pattern used by `operate-e2e-tests.yml` and `data-layer-nightly-tests.yml`

**Note:** The repo's `maven-settings.xml` was considered but can't be used here — its mirror points to `artifacts.camunda.com/artifactory/internal/` which doesn't proxy Maven Central, causing build extensions like `incremental-module-builder:0.2.0` to fail to resolve (verified in run https://github.com/camunda/camunda/actions/runs/27135769073).

Related: #54772 (bumped `camunda-security-library` to `0.1.0-alpha27`, triggering the first cold-cache download of the private artifact)

Failing run: https://github.com/camunda/camunda/actions/runs/27131912967/job/80074690192

## Test plan

- [ ] Trigger `Maven Dependency Snapshot` workflow on this branch via `workflow_dispatch` and verify it succeeds