### PR TITLE
refactor: Add required field to EnableExporterRequest schema

### DIFF
--- a/dist/src/main/resources/api/cluster/exporter-api.yaml
+++ b/dist/src/main/resources/api/cluster/exporter-api.yaml
@@ -139,5 +139,5 @@ components:
       properties:
         initializeFrom:
           type: string
-          description: Id of the exporter to initialize from
+          description: Id of the exporter to initialize from. This property is optional.
           example: "exporter-1"


### PR DESCRIPTION
The documentation points to this spec, and we've had customer feedback that they didn't know `initializeFrom` was optional. This change makes it more explicit, which is helpful if this is the only source of documentation we have for this API.

## Description

Docs issue: https://github.com/camunda/camunda-docs/issues/9018

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.
