### PR TITLE
feat: migrate notifications to unified webapp

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -35,6 +35,7 @@
 		"react-dom": "19.2.6",
 		"react-final-form": "7.0.1",
 		"react-i18next": "17.0.8",
+		"react-transition-group": "4.4.5",
 		"sass": "1.100.0",
 		"zod": "4.4.3"
 	},
@@ -49,6 +50,7 @@
 		"@types/node": "25.9.1",
 		"@types/react": "19.2.15",
 		"@types/react-dom": "19.2.3",
+		"@types/react-transition-group": "4.4.12",
 		"@vitejs/plugin-react": "6.0.2",
 		"@vitest/browser-playwright": "4.1.7",
 		"@vitest/ui": "4.1.7",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/__root.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/__root.tsx
@@ -13,6 +13,8 @@ import {ReactQueryDevtoolsPanel} from '@tanstack/react-query-devtools';
 import type {QueryClient} from '@tanstack/react-query';
 import {NotFoundPage} from '#/shared/pages/NotFoundPage';
 import {GenericErrorPage} from '#/shared/pages/GenericErrorPage';
+import {Notifications} from '#/shared/notifications/components/Notifications';
+import {NetworkStatusWatcher} from '#/shared/notifications/components/NetworkStatusWatcher';
 
 export const Route = createRootRouteWithContext<{
 	queryClient: QueryClient;
@@ -40,6 +42,8 @@ function RootDocument() {
 	return (
 		<>
 			<HeadContent />
+			<Notifications />
+			<NetworkStatusWatcher />
 			<Outlet />
 			<TanStackDevtools
 				config={{position: 'bottom-right'}}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/auth/components/SessionWatcher.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/auth/components/SessionWatcher.tsx
@@ -8,22 +8,45 @@
 
 import {observer} from 'mobx-react-lite';
 import {Navigate, useLocation} from '@tanstack/react-router';
+import {useEffect, useRef} from 'react';
+import {useTranslation} from 'react-i18next';
 import {authenticationStore} from '#/shared/auth/authentication.store';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
 
 const SessionWatcher: React.FC = observer(() => {
 	const location = useLocation();
 	const {status} = authenticationStore;
+	const removeNotification = useRef<(() => void) | null>(null);
+	const {t} = useTranslation();
 
 	const isSessionExpired =
 		status === 'logged-out' ||
 		status === 'session-expired' ||
 		(status === 'session-invalid' && location.pathname !== '/');
 
+	useEffect(() => {
+		if (location.pathname === '/login') {
+			return;
+		}
+
+		if (status === 'session-expired' || status === 'session-invalid') {
+			removeNotification.current = notificationsStore.displayNotification({
+				kind: 'info',
+				title: t('sessionWatcherExpiredTitle'),
+				isDismissable: true,
+			});
+		}
+	}, [status, t, location.pathname]);
+
+	useEffect(() => {
+		if (status === 'logged-in') {
+			removeNotification.current?.();
+		}
+	}, [status]);
+
 	if (isSessionExpired) {
 		return <Navigate to="/login" search={location.href === '/' ? {} : {redirect: location.href}} replace />;
 	}
-
-	// TODO: show a session-expired notification once a notifications module is available
 
 	return null;
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/header/components/Header.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/header/components/Header.tsx
@@ -15,6 +15,7 @@ import {C3Navigation} from '@camunda/camunda-composite-components';
 import type {CurrentUser, License} from '@camunda/camunda-api-zod-schemas/8.10';
 import {themeStore} from '#/shared/theme/theme';
 import {authenticationStore} from '#/shared/auth/authentication.store';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
 import {tracking} from '#/shared/tracking';
 import {getClientConfig} from '#/shared/config/getClientConfig';
 import {getBootConfig} from '#/shared/config/getBootConfig';
@@ -78,6 +79,16 @@ const Header: React.FC<Props> = observer(({currentUser, license}) => {
 	const {displayName, salesPlanType} = currentUser;
 	const [isAppBarOpen, setIsAppBarOpen] = useState(false);
 	const {app, elements} = useNavbar(currentUser);
+
+	const logoutWithNotification = () => {
+		notificationsStore.displayNotification({
+			kind: 'info',
+			title: t('notificationLogOutTitle'),
+			subtitle: t('notificationLogOutSubtitle'),
+			isDismissable: true,
+		});
+		setTimeout(authenticationStore.handleLogout, 1000);
+	};
 
 	return (
 		<C3Navigation
@@ -173,7 +184,7 @@ const Header: React.FC<Props> = observer(({currentUser, license}) => {
 								label: t('headerLogOutLabel'),
 								renderIcon: ArrowRight,
 								kind: 'ghost',
-								onClick: () => authenticationStore.handleLogout(),
+								onClick: logoutWithNotification,
 							},
 						]
 					: undefined,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -357,6 +357,7 @@
 		"variableEditorOpenJsonLabel": "JSON-Code-Editor öffnen",
 		"variableEditorNamePlaceholder": "Name",
 		"sessionWatcherExpiredTitle": "Sitzung abgelaufen",
+		"networkStatusOfflineTitle": "Internetverbindung unterbrochen",
 		"languageSelectorLabel": "Sprache wählen",
 		"languageSelectorTitle": "Sprache",
 		"relativeDateJustNow": "Gerade eben",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -369,6 +369,7 @@
 		"variableEditorOpenJsonLabel": "Open JSON code editor",
 		"variableEditorNamePlaceholder": "Name",
 		"sessionWatcherExpiredTitle": "Session expired",
+		"networkStatusOfflineTitle": "Internet connection lost",
 		"languageSelectorLabel": "Choose a language",
 		"languageSelectorTitle": "Language",
 		"relativeDateJustNow": "Just now",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -357,6 +357,7 @@
 		"variableEditorOpenJsonLabel": "Abrir editor de código JSON",
 		"variableEditorNamePlaceholder": "Nombre",
 		"sessionWatcherExpiredTitle": "Sesión expirada",
+		"networkStatusOfflineTitle": "Conexión a internet perdida",
 		"languageSelectorLabel": "Elige un idioma",
 		"languageSelectorTitle": "Idioma",
 		"relativeDateJustNow": "Justo ahora",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -360,6 +360,7 @@
 		"variableEditorOpenJsonLabel": "Ouvrir l'éditeur de code JSON",
 		"variableEditorNamePlaceholder": "Nom",
 		"sessionWatcherExpiredTitle": "Session expirée",
+		"networkStatusOfflineTitle": "Connexion internet perdue",
 		"languageSelectorLabel": "Choisissez une langue",
 		"languageSelectorTitle": "Langue",
 		"relativeDateJustNow": "À l'instant",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/components/NetworkStatusWatcher.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/components/NetworkStatusWatcher.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect, useRef} from 'react';
+import {useTranslation} from 'react-i18next';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
+
+const NetworkStatusWatcher: React.FC = () => {
+	const removeNotification = useRef<(() => void) | null>(null);
+	const {t} = useTranslation();
+
+	useEffect(() => {
+		function handleDisconnection() {
+			removeNotification.current = notificationsStore.displayNotification({
+				kind: 'info',
+				title: t('networkStatusOfflineTitle'),
+				isDismissable: false,
+				autoRemove: false,
+			});
+		}
+
+		function handleReconnection() {
+			removeNotification.current?.();
+		}
+
+		if (!window.navigator.onLine) {
+			handleDisconnection();
+		}
+
+		window.addEventListener('offline', handleDisconnection);
+		window.addEventListener('online', handleReconnection);
+
+		return () => {
+			window.removeEventListener('offline', handleDisconnection);
+			window.removeEventListener('online', handleReconnection);
+		};
+	}, [t]);
+
+	return null;
+};
+
+export {NetworkStatusWatcher};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/components/Notification.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/components/Notification.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ActionableNotification, ToastNotification} from '@carbon/react';
+import {CSSTransition} from 'react-transition-group';
+import {observer} from 'mobx-react-lite';
+import {useRef} from 'react';
+import {useTranslation} from 'react-i18next';
+import type {Notification as NotificationType} from '#/shared/notifications/notifications.store';
+import {useRelativeDate} from '#/shared/notifications/useRelativeDate';
+import styles from '#/shared/notifications/components/Notifications.module.scss';
+
+type Props = {
+	notification: NotificationType;
+};
+
+const Notification: React.FC<Props> = observer(
+	({
+		notification: {
+			kind,
+			title,
+			subtitle,
+			isDismissable,
+			date,
+			hideNotification,
+			isActionable,
+			actionButtonLabel,
+			onActionButtonClick,
+		},
+		...props
+	}) => {
+		const {t} = useTranslation();
+		const nodeRef = useRef<HTMLDivElement | null>(null);
+		const relativeDate = useRelativeDate(date);
+
+		return (
+			<CSSTransition
+				timeout={300}
+				classNames={{
+					enter: styles['toastEnter']!,
+					enterActive: styles['toastEnterActive']!,
+					exitActive: styles['toastExitActive']!,
+					exitDone: styles['toastExitDone']!,
+				}}
+				nodeRef={nodeRef}
+				{...props}
+			>
+				<div ref={nodeRef}>
+					{isActionable ? (
+						<ActionableNotification
+							className={styles['notification']!}
+							kind={kind}
+							lowContrast={false}
+							title={title}
+							subtitle={subtitle}
+							hideCloseButton={!isDismissable}
+							onClose={() => {
+								hideNotification();
+								return false;
+							}}
+							actionButtonLabel={actionButtonLabel ? t('notificationActionButtonLabel') : ''}
+							onActionButtonClick={onActionButtonClick}
+						/>
+					) : (
+						<ToastNotification
+							className={styles['notification']!}
+							kind={kind}
+							lowContrast={false}
+							title={title}
+							caption={relativeDate}
+							subtitle={subtitle}
+							hideCloseButton={!isDismissable}
+							onClose={() => {
+								hideNotification();
+								return false;
+							}}
+						/>
+					)}
+				</div>
+			</CSSTransition>
+		);
+	},
+);
+
+export {Notification};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/components/Notifications.module.scss
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/components/Notifications.module.scss
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+@use '@carbon/layout';
+
+.container {
+	position: absolute;
+	top: layout.to-rem(56px);
+	z-index: 1000;
+	right: var(--cds-spacing-03);
+}
+
+.notification {
+	margin-top: var(--cds-spacing-03);
+}
+
+.toastEnter {
+	transform: translateX(120%);
+}
+
+.toastEnterActive {
+	transform: translateX(0);
+	transition: transform 300ms ease-in-out;
+}
+
+.toastExitActive {
+	transform: translateX(120%);
+	transition: transform 300ms ease-in-out;
+}
+
+.toastExitDone {
+	display: none;
+}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/components/Notifications.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/components/Notifications.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {observer} from 'mobx-react-lite';
+import {TransitionGroup} from 'react-transition-group';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
+import {Notification} from '#/shared/notifications/components/Notification';
+import styles from '#/shared/notifications/components/Notifications.module.scss';
+
+const Notifications: React.FC = observer(() => {
+	const {notifications} = notificationsStore;
+
+	return (
+		<TransitionGroup className={styles['container']!}>
+			{notifications.map((notification) => (
+				<Notification key={notification.id} notification={notification} />
+			))}
+		</TransitionGroup>
+	);
+});
+
+export {Notifications};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/notifications.store.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/notifications.store.test.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect, beforeEach, afterEach, vi} from 'vitest';
+import {it} from '#/vitest-modules/test-extend';
+import {notificationsStore} from './notifications.store';
+
+describe('notifications store', () => {
+	beforeEach(() => {
+		notificationsStore.reset();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should display a notification and add it to the visible list', () => {
+		expect(notificationsStore.notifications).toHaveLength(0);
+
+		notificationsStore.displayNotification({
+			kind: 'success',
+			title: 'Task completed',
+			isDismissable: true,
+		});
+
+		expect(notificationsStore.notifications).toHaveLength(1);
+		expect(notificationsStore.notifications[0]).toMatchObject({
+			kind: 'success',
+			title: 'Task completed',
+			isDismissable: true,
+		});
+	});
+
+	it('should return a cleanup function that hides the notification', () => {
+		const hide = notificationsStore.displayNotification({
+			kind: 'info',
+			title: 'Test',
+			isDismissable: false,
+		});
+
+		expect(notificationsStore.notifications).toHaveLength(1);
+
+		hide();
+
+		expect(notificationsStore.notifications).toHaveLength(0);
+	});
+
+	it('should prepend new notifications to the list (most recent first)', () => {
+		notificationsStore.displayNotification({kind: 'info', title: 'First', isDismissable: true});
+		notificationsStore.displayNotification({kind: 'info', title: 'Second', isDismissable: true});
+
+		expect(notificationsStore.notifications[0]!.title).toBe('Second');
+		expect(notificationsStore.notifications[1]!.title).toBe('First');
+	});
+
+	it('should auto-remove a notification after 5 seconds', () => {
+		notificationsStore.displayNotification({
+			kind: 'success',
+			title: 'Auto-remove me',
+			isDismissable: false,
+			autoRemove: true,
+		});
+
+		expect(notificationsStore.notifications).toHaveLength(1);
+
+		vi.advanceTimersByTime(5100);
+
+		expect(notificationsStore.notifications).toHaveLength(0);
+	});
+
+	it('should not auto-remove a notification', () => {
+		notificationsStore.displayNotification({
+			kind: 'info',
+			title: 'Persistent',
+			isDismissable: false,
+			autoRemove: false,
+		});
+
+		vi.advanceTimersByTime(10000);
+
+		expect(notificationsStore.notifications).toHaveLength(1);
+	});
+
+	it('should queue notifications when max visible notifications is reached', () => {
+		for (let i = 1; i <= 5; i++) {
+			notificationsStore.displayNotification({
+				kind: 'info',
+				title: `Notification ${i}`,
+				isDismissable: true,
+				autoRemove: false,
+			});
+		}
+
+		expect(notificationsStore.notifications).toHaveLength(5);
+
+		notificationsStore.displayNotification({
+			kind: 'info',
+			title: 'Queued notification',
+			isDismissable: true,
+			autoRemove: false,
+		});
+
+		expect(notificationsStore.notifications).toHaveLength(5);
+		expect(notificationsStore.notifications.find((n) => n.title === 'Queued notification')).toBeUndefined();
+	});
+
+	it('should dequeue and show the next notification when a visible one is hidden', () => {
+		for (let i = 1; i <= 5; i++) {
+			notificationsStore.displayNotification({
+				kind: 'info',
+				title: `Notification ${i}`,
+				isDismissable: true,
+				autoRemove: false,
+			});
+		}
+
+		notificationsStore.displayNotification({
+			kind: 'success',
+			title: 'Queued',
+			isDismissable: true,
+			autoRemove: false,
+		});
+
+		notificationsStore.notifications[0]!.hideNotification();
+
+		expect(notificationsStore.notifications).toHaveLength(5);
+		expect(notificationsStore.notifications.find((n) => n.title === 'Queued')).toBeDefined();
+	});
+
+	it('should reset all notifications', () => {
+		notificationsStore.displayNotification({kind: 'info', title: 'A', isDismissable: true});
+		notificationsStore.displayNotification({kind: 'info', title: 'B', isDismissable: true});
+
+		expect(notificationsStore.notifications).toHaveLength(2);
+
+		notificationsStore.reset();
+
+		expect(notificationsStore.notifications).toHaveLength(0);
+	});
+
+	it('should assign an id and a date to each notification', () => {
+		notificationsStore.displayNotification({
+			kind: 'warning',
+			title: 'With metadata',
+			isDismissable: true,
+		});
+
+		const notification = notificationsStore.notifications[0]!;
+
+		expect(notification.id).toBeTruthy();
+		expect(notification.date).toBeGreaterThan(0);
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/notifications.store.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/notifications.store.ts
@@ -105,6 +105,7 @@ class Notifications {
 
 	reset = () => {
 		this.notifications = [];
+		this.#notificationsQueue = [];
 	};
 }
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/notifications.store.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/notifications.store.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {action, observable, makeObservable} from 'mobx';
+import {ToastNotification} from '@carbon/react';
+
+const NOTIFICATION_TIMEOUT = 5000;
+const MAX_VISIBLE_NOTIFICATIONS = 5;
+
+type Notification = {
+	id: string;
+	title: string;
+	subtitle?: string;
+	date: number;
+	isDismissable: boolean;
+	kind: NonNullable<React.ComponentProps<typeof ToastNotification>['kind']>;
+	hideNotification: () => void;
+	isActionable?: boolean;
+	actionButtonLabel?: string;
+	onActionButtonClick?: () => void;
+	autoRemove?: boolean;
+};
+
+class Notifications {
+	notifications: Notification[] = [];
+	#notificationsQueue: Notification[] = [];
+
+	constructor() {
+		makeObservable(this, {
+			displayNotification: action,
+			hideNotification: action,
+			notifications: observable,
+			reset: action,
+		});
+	}
+
+	displayNotification = (notification: Omit<Notification, 'date' | 'id' | 'hideNotification'>) => {
+		const notificationId = `${Date.now()}${Math.random()}`;
+		const hideNotification = () => {
+			this.hideNotification(notificationId);
+		};
+		const newNotification: Notification = {
+			autoRemove: true,
+			...notification,
+			date: Date.now(),
+			id: notificationId,
+			hideNotification,
+		};
+
+		if (this.notifications.length >= MAX_VISIBLE_NOTIFICATIONS) {
+			this.#enqueueNotification(newNotification);
+		} else {
+			if (newNotification.autoRemove) {
+				this.#addAutoRemovalInterval(newNotification);
+			}
+			this.notifications.unshift(newNotification);
+		}
+
+		return newNotification.hideNotification;
+	};
+
+	#enqueueNotification = (notification: Notification) => {
+		this.#notificationsQueue.unshift(notification);
+	};
+
+	#dequeueNotification = () => {
+		return this.#notificationsQueue.shift();
+	};
+
+	#addAutoRemovalInterval = (notification: Notification) => {
+		const delta = 100;
+		let time = NOTIFICATION_TIMEOUT;
+
+		const intervalId = setInterval(function () {
+			if (document.hidden) {
+				return;
+			}
+
+			time -= delta;
+
+			if (time <= 0) {
+				clearInterval(intervalId);
+				notification.hideNotification();
+			}
+		}, delta);
+	};
+
+	hideNotification = (notificationId: string) => {
+		const queuedNotification = this.#dequeueNotification();
+
+		this.notifications = this.notifications.filter(({id}) => id !== notificationId);
+
+		if (queuedNotification !== undefined) {
+			if (queuedNotification.autoRemove) {
+				this.#addAutoRemovalInterval(queuedNotification);
+			}
+			this.notifications.unshift(queuedNotification);
+		}
+	};
+
+	reset = () => {
+		this.notifications = [];
+	};
+}
+
+const notificationsStore = new Notifications();
+
+export {notificationsStore};
+export type {Notification};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/useRelativeDate.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/notifications/useRelativeDate.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {differenceInHours, differenceInSeconds, format, formatDistanceToNowStrict} from 'date-fns';
+import {getCurrentDateLocale} from '#/shared/i18n/index';
+import {useEffect, useState} from 'react';
+import {t} from 'i18next';
+
+function getRelativeDate(date: number): string {
+	if (differenceInSeconds(Date.now(), date) <= 10) {
+		return t('relativeDateJustNow');
+	}
+
+	if (differenceInHours(date, Date.now()) > 0) {
+		return format(new Date(date), 'dd MMM yyyy - p', {
+			locale: getCurrentDateLocale(),
+		});
+	}
+
+	return formatDistanceToNowStrict(date, {locale: getCurrentDateLocale()});
+}
+
+function useRelativeDate(targetDate: number): string {
+	const [relativeDate, setRelativeDate] = useState(getRelativeDate(targetDate));
+
+	useEffect(() => {
+		const intervalID = setInterval(() => {
+			setRelativeDate(getRelativeDate(targetDate));
+		}, 1000);
+
+		return () => {
+			clearInterval(intervalID);
+		};
+	}, [targetDate]);
+
+	return relativeDate;
+}
+
+export {useRelativeDate};

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/header.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/header.test.ts
@@ -35,7 +35,11 @@ test.beforeEach(({network}) => {
 });
 
 test.describe('logout', () => {
-	test('should redirect to login page after clicking logout', async ({network, tasklistIndexPage, page}) => {
+	test('should show a notification and redirect to login page after clicking logout', async ({
+		network,
+		tasklistIndexPage,
+		page,
+	}) => {
 		network.use(
 			mockLogoutEndpoint({
 				successResponse: new HttpResponse(null, {status: 204}),
@@ -53,7 +57,31 @@ test.describe('logout', () => {
 
 		await tasklistIndexPage.header.logoutButton.click();
 
+		const logoutNotification = tasklistIndexPage.header.notifications.getByNotificationTitle('Log Out');
+		await expect(logoutNotification).toBeVisible();
+		await expect(logoutNotification).toContainText('You are being logged out...');
+
 		await expect(page).toHaveURL(/\/login/);
+	});
+});
+
+test.describe('notifications', () => {
+	test('should show a notification when going offline and dismiss it when reconnecting', async ({
+		tasklistIndexPage,
+		page,
+	}) => {
+		await tasklistIndexPage.goto();
+		await expect(tasklistIndexPage.heading).toBeVisible();
+
+		await page.context().setOffline(true);
+		await expect(
+			tasklistIndexPage.header.notifications.getByNotificationTitle('Internet connection lost'),
+		).toBeVisible();
+
+		await page.context().setOffline(false);
+		await expect(
+			tasklistIndexPage.header.notifications.getByNotificationTitle('Internet connection lost'),
+		).not.toBeVisible();
 	});
 });
 

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/Header.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/Header.ts
@@ -7,14 +7,17 @@
  */
 
 import {type Page} from '@playwright/test';
+import {Notifications} from './Notifications';
 import {View} from './BasePage';
 
 class Header extends View {
 	private brandingName: string | undefined;
+	readonly notifications: Notifications;
 
 	constructor(page: Page, brandingName?: string) {
 		super(page);
 		this.brandingName = brandingName;
+		this.notifications = new Notifications(page);
 	}
 
 	get branding() {

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/Login.page.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/Login.page.ts
@@ -6,14 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type Page} from '@playwright/test';
 import {BasePage} from './BasePage';
 
 class LoginPage extends BasePage {
-	constructor(page: Page) {
-		super(page);
-	}
-
 	async goto() {
 		return this.page.goto('/login');
 	}

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/Notifications.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/Notifications.ts
@@ -6,14 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type Page} from '@playwright/test';
 import {View} from './BasePage';
 
 class Notifications extends View {
-	constructor(page: Page) {
-		super(page);
-	}
-
 	getByNotificationTitle(title: string) {
 		return this.page.getByRole('status').filter({hasText: title});
 	}

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/Notifications.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/Notifications.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type Page} from '@playwright/test';
+
+class Notifications {
+	private page: Page;
+
+	constructor(page: Page) {
+		this.page = page;
+	}
+
+	getByNotificationTitle(title: string) {
+		return this.page.getByRole('status').filter({hasText: title});
+	}
+}
+
+export {Notifications};

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/Notifications.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/Notifications.ts
@@ -7,12 +7,11 @@
  */
 
 import {type Page} from '@playwright/test';
+import {View} from './BasePage';
 
-class Notifications {
-	private page: Page;
-
+class Notifications extends View {
 	constructor(page: Page) {
-		this.page = page;
+		super(page);
 	}
 
 	getByNotificationTitle(title: string) {

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -40,6 +40,7 @@
 				"react-dom": "19.2.6",
 				"react-final-form": "7.0.1",
 				"react-i18next": "17.0.8",
+				"react-transition-group": "4.4.5",
 				"sass": "1.100.0",
 				"zod": "4.4.3"
 			},
@@ -54,6 +55,7 @@
 				"@types/node": "25.9.1",
 				"@types/react": "19.2.15",
 				"@types/react-dom": "19.2.3",
+				"@types/react-transition-group": "4.4.12",
 				"@vitejs/plugin-react": "6.0.2",
 				"@vitest/browser-playwright": "4.1.7",
 				"@vitest/ui": "4.1.7",
@@ -3238,6 +3240,16 @@
 				"@types/react": "^19.2.0"
 			}
 		},
+		"node_modules/@types/react-transition-group": {
+			"version": "4.4.12",
+			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+			"integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*"
+			}
+		},
 		"node_modules/@types/set-cookie-parser": {
 			"version": "2.4.10",
 			"resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
@@ -4664,6 +4676,16 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/dom-helpers": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/dom-serializer": {
@@ -7740,6 +7762,22 @@
 			"peerDependencies": {
 				"@types/react": ">=18",
 				"react": ">=18"
+			}
+		},
+		"node_modules/react-transition-group": {
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+			"integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
+			},
+			"peerDependencies": {
+				"react": ">=16.6.0",
+				"react-dom": ">=16.6.0"
 			}
 		},
 		"node_modules/readdirp": {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR migrates the notifications implementation of Tasklist into the unified webapp

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53821
