### PR TITLE
feat: use waitStatesEnabled config

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -21,6 +21,7 @@ import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 import {mockSearchUserTasks} from 'modules/mocks/api/v2/userTasks/searchUserTasks';
 import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
+import {mockSearchElementInstanceInspection} from 'modules/mocks/api/v2/elementInstanceInspection/searchElementInstanceInspection';
 import {searchResult} from 'modules/testUtils';
 import * as clientConfig from 'modules/utils/getClientConfig';
 import type {
@@ -883,5 +884,59 @@ describe('<DetailsTab />', () => {
 
     expect(await screen.findByText('Element Instance Key')).toBeInTheDocument();
     expect(screen.getByText('child-1')).toBeInTheDocument();
+  });
+
+  it('should not render WaitingStatus when waitStatesEnabled is false', async () => {
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
+      waitStatesEnabled: false,
+    });
+
+    mockFetchElementInstance('123456789').withSuccess({
+      ...mockElementInstance,
+      state: 'ACTIVE',
+      endDate: null,
+    });
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Element Instance Key')).toBeInTheDocument();
+    expect(screen.queryByTestId('waiting-status')).not.toBeInTheDocument();
+  });
+
+  it('should render WaitingStatus with wait states when waitStatesEnabled is true and element is ACTIVE', async () => {
+    mockFetchElementInstance('123456789').withSuccess({
+      ...mockElementInstance,
+      state: 'ACTIVE',
+      endDate: null,
+    });
+    mockSearchElementInstanceInspection().withSuccess({
+      items: [
+        {
+          rootProcessInstanceKey: PROCESS_INSTANCE_ID,
+          processInstanceKey: PROCESS_INSTANCE_ID,
+          elementInstanceKey: '123456789',
+          elementId: 'Task_1',
+          elementType: 'SERVICE_TASK',
+          waitStateType: 'JOB',
+          details: {jobType: 'customJob'},
+        },
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByTestId('waiting-status')).toBeInTheDocument();
+    expect(screen.getByText('Waiting for job: customJob')).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -76,6 +76,7 @@ const DetailsTab: React.FC = () => {
     processInstanceKey: processInstanceId,
     elementInstanceKey: elementInstanceKey ?? undefined,
     enabled:
+      clientConfig.waitStatesEnabled &&
       !!elementInstanceKey &&
       processInstance?.state === 'ACTIVE' &&
       resolvedElementInstance?.state === 'ACTIVE',
@@ -526,7 +527,9 @@ const DetailsTab: React.FC = () => {
           isError={isAgentError}
         />
       )}
-      <WaitingStatus waitStates={elementWaitStates} />
+      {clientConfig.waitStatesEnabled && (
+        <WaitingStatus waitStates={elementWaitStates} />
+      )}
     </Container>
   );
 };

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -72,6 +72,7 @@ import {isRequestError} from 'modules/request';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {useDrillDownNavigation} from 'modules/hooks/useDrilldownNavigation';
 import {getAncestorScopeType} from 'modules/utils/processInstanceDetailsDiagram';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const OVERLAY_TYPE_STATE = 'elementState';
 const OVERLAY_TYPE_MODIFICATIONS_BADGE = 'modificationsBadge';
@@ -94,6 +95,7 @@ type ModificationBadgePayload = {
 };
 
 const TopPanel: React.FC = observer(() => {
+  const clientConfig = getClientConfig();
   const {
     clearSelection,
     selectedElementId,
@@ -123,7 +125,8 @@ const TopPanel: React.FC = observer(() => {
   const {data: processInstance} = useProcessInstance();
   const {data: inspectionData} = useElementInstanceInspection({
     processInstanceKey: processInstanceId,
-    enabled: processInstance?.state === 'ACTIVE',
+    enabled:
+      clientConfig.waitStatesEnabled && processInstance?.state === 'ACTIVE',
   });
   const {data: agentInstancesData} = useProcessInstanceAgentInstances();
   const modificationsByElement = useModificationsByElement();

--- a/operate/client/src/modules/types/global.d.ts
+++ b/operate/client/src/modules/types/global.d.ts
@@ -43,6 +43,7 @@ export declare global {
        */
       resourcePermissionsEnabled?: boolean;
       multiTenancyEnabled?: boolean;
+      waitStatesEnabled?: boolean;
     };
     Osano?: {
       cm?: {

--- a/operate/client/src/modules/utils/getClientConfig.ts
+++ b/operate/client/src/modules/utils/getClientConfig.ts
@@ -22,6 +22,7 @@ const ClientConfigSchema = z.object({
   resourcePermissionsEnabled: z.boolean().optional().default(false),
   multiTenancyEnabled: z.boolean().optional().default(false),
   databaseType: z.string().optional().default('document-store'),
+  waitStatesEnabled: z.boolean().optional().default(true),
 });
 
 const DEFAULT_CLIENT_CONFIG = ClientConfigSchema.safeParse({}).data!;


### PR DESCRIPTION
## Description

- Exposes backend flag via client config schema
- Gates inspection query and WaitingStatus rendering on the flag in TopPanel and DetailsTab

## Related issues

closes https://github.com/camunda/camunda/issues/54605
