### PR TITLE
fix: prevent premature endDate when partition exporters lag behind

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
@@ -11,7 +11,6 @@ import static io.camunda.webapps.schema.descriptors.template.BatchOperationTempl
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.OPERATIONS_COMPLETED_COUNT;
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.OPERATIONS_FAILED_COUNT;
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.OPERATIONS_FINISHED_COUNT;
-import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.OPERATIONS_TOTAL_COUNT;
 import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.BATCH_OPERATION_ID;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
@@ -165,8 +164,6 @@ public class ElasticsearchBatchOperationUpdateRepository extends ElasticsearchRe
             update.failedOperationsCount(),
             OPERATIONS_COMPLETED_COUNT,
             update.completedOperationsCount(),
-            OPERATIONS_TOTAL_COUNT,
-            update.totalOperationsCount(),
             END_DATE,
             OffsetDateTime.now());
 
@@ -186,13 +183,17 @@ public class ElasticsearchBatchOperationUpdateRepository extends ElasticsearchRe
             .collect(Collectors.toMap(Map.Entry::getKey, e -> JsonData.of(e.getValue())));
     return new Script.Builder()
         .source(
-            "if ((ctx._source.state == null || ctx._source.state == 'COMPLETED') "
-                + " && params.operationsTotalCount <= params.operationsFinishedCount) { "
-                + "   ctx._source.endDate = params.endDate; "
-                + "} "
-                + "ctx._source.operationsFinishedCount = params.operationsFinishedCount;"
-                + "ctx._source.operationsCompletedCount = params.operationsCompletedCount;"
-                + "ctx._source.operationsFailedCount = params.operationsFailedCount;")
+            """
+            def storedTotal = ctx._source.operationsTotalCount;
+            if (ctx._source.state == 'COMPLETED'
+                && storedTotal != null
+                && storedTotal <= params.operationsFinishedCount) {
+              ctx._source.endDate = params.endDate;
+            }
+            ctx._source.operationsFinishedCount = params.operationsFinishedCount;
+            ctx._source.operationsCompletedCount = params.operationsCompletedCount;
+            ctx._source.operationsFailedCount = params.operationsFailedCount;
+            """)
         .lang("painless")
         .params(parameters)
         .build();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
@@ -11,7 +11,6 @@ import static io.camunda.webapps.schema.descriptors.template.BatchOperationTempl
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.OPERATIONS_COMPLETED_COUNT;
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.OPERATIONS_FAILED_COUNT;
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.OPERATIONS_FINISHED_COUNT;
-import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.OPERATIONS_TOTAL_COUNT;
 import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.BATCH_OPERATION_ID;
 
 import io.camunda.exporter.tasks.util.OpensearchRepository;
@@ -151,8 +150,6 @@ public class OpensearchBatchOperationUpdateRepository extends OpensearchReposito
             update.failedOperationsCount(),
             OPERATIONS_COMPLETED_COUNT,
             update.completedOperationsCount(),
-            OPERATIONS_TOTAL_COUNT,
-            update.totalOperationsCount(),
             END_DATE,
             OffsetDateTime.now());
     return new UpdateOperation.Builder<>()
@@ -172,13 +169,17 @@ public class OpensearchBatchOperationUpdateRepository extends OpensearchReposito
         .inline(
             s ->
                 s.source(
-                        "if ((ctx._source.state == null || ctx._source.state == 'COMPLETED') "
-                            + " && params.operationsTotalCount <= params.operationsFinishedCount) { "
-                            + "   ctx._source.endDate = params.endDate; "
-                            + "} "
-                            + "ctx._source.operationsFinishedCount = params.operationsFinishedCount;"
-                            + "ctx._source.operationsCompletedCount = params.operationsCompletedCount;"
-                            + "ctx._source.operationsFailedCount = params.operationsFailedCount;")
+                        """
+                    def storedTotal = ctx._source.operationsTotalCount;
+                    if (ctx._source.state == 'COMPLETED'
+                        && storedTotal != null
+                        && storedTotal <= params.operationsFinishedCount) {
+                      ctx._source.endDate = params.endDate;
+                    }
+                    ctx._source.operationsFinishedCount = params.operationsFinishedCount;
+                    ctx._source.operationsCompletedCount = params.operationsCompletedCount;
+                    ctx._source.operationsFailedCount = params.operationsFailedCount;
+                    """)
                     .lang(ScriptLanguage.builder().builtin(BuiltinScriptLanguage.Painless).build())
                     .params(parameters))
         .build();


### PR DESCRIPTION
## Description

The BatchOperationUpdateTask's Painless script previously used params.operationsTotalCount (derived from OperationsAggData.getTotalOperationsCount — the sum of item records currently in the operations index) to decide when to set endDate on a batch operation.

In multi-partition setups this causes a permanent stuck state: if the lead partition's BATCH_OPERATION COMPLETED event is exported before a lagging partition's item records arrive, the aggregated total is temporarily lower than the real total (e.g. 7 instead of 10). The condition 7 <= 7 fires, endDate is set, and the update task's `mustNot(exists(endDate))` filter permanently excludes the operation, so the completed-count never reaches the true total.

Fix: `read ctx._source.operationsTotalCount` (the authoritative value stored in the batch-operation document when chunks were created) instead of computing it from the operations index. This value is always correct regardless of export lag. A `storedTotal != 0` guard prevents false completion if the field is absent.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53703
