### PR TITLE
fix: Increase HTTP timeout for App Integration transport tests

### DIFF
--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportTest.java
@@ -37,7 +37,7 @@ public class HttpTransportTest {
   @BeforeEach
   public void beforeAll() {
     url = "http://localhost:" + wireMock.getPort();
-    final var httpConfig = new HttpTransportConfig(url, new ApiKey("test-key"), 2, 50, 500);
+    final var httpConfig = new HttpTransportConfig(url, new ApiKey("test-key"), 2, 50, 5000);
     final var jsonMapper = SubscriptionFactory.createJsonMapper();
     transport = new HttpTransportImpl(jsonMapper, httpConfig);
   }


### PR DESCRIPTION
## Description

- Increased the HTTP request timeout in the `HttpTransportTest` setup from 500ms to 5000ms to allow more time for requests during tests (`HttpTransportTest.java`).

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Fixes the flakiness of this test in CI: https://camunda.slack.com/archives/C071KP5BTHB/p1780559391281489
