### PR TITLE
fix: sign bundled JRE Mach-O binaries with JIT entitlements on macOS

### DIFF
--- a/.github/actions/sign-and-notarize/sign_and_notarize.sh
+++ b/.github/actions/sign-and-notarize/sign_and_notarize.sh
@@ -96,7 +96,7 @@ done
 # Without allow-jit the hardened runtime blocks pthread_jit_write_protect_np,
 # which crashes libjvm.dylib during Threads::create_vm.
 ##############################################
-JRE_ENTITLEMENTS="$(mktemp --suffix=.plist)"
+JRE_ENTITLEMENTS="$(mktemp "${TMPDIR:-/tmp}/jre-entitlements.XXXXXX").plist"
 cat > "$JRE_ENTITLEMENTS" << 'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/.github/actions/sign-and-notarize/sign_and_notarize.sh
+++ b/.github/actions/sign-and-notarize/sign_and_notarize.sh
@@ -92,6 +92,27 @@ find "$C8RUN_DIR" -maxdepth 1 \( -type f -o -type d \) -print0 | while IFS= read
 done
 
 ##############################################
+# JRE entitlements — required for JVM JIT on Apple Silicon.
+# Without allow-jit the hardened runtime blocks pthread_jit_write_protect_np,
+# which crashes libjvm.dylib during Threads::create_vm.
+##############################################
+JRE_ENTITLEMENTS="$(mktemp).plist"
+cat > "$JRE_ENTITLEMENTS" << 'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+
+##############################################
 # B) Functions to sign Mach-O + jars
 ##############################################
 sign_macho_in_folder() {
@@ -120,7 +141,14 @@ sign_macho_in_folder() {
       fi
       if file -b "$candidate" | grep -q "Mach-O"; then
         echo "    Signing Mach-O: $candidate"
-        if codesign --verbose=4 --force --options runtime --timestamp --sign "$CERT_NAME" "$candidate"; then
+        # Binaries inside the bundled JRE need JIT entitlements so the JVM can
+        # call pthread_jit_write_protect_np under the hardened runtime on Apple Silicon.
+        local entitlements_flag=()
+        if [[ "$candidate" == */jre/* ]]; then
+          entitlements_flag=(--entitlements "$JRE_ENTITLEMENTS")
+        fi
+        if codesign --verbose=4 --force --options runtime --timestamp \
+            "${entitlements_flag[@]}" --sign "$CERT_NAME" "$candidate"; then
           ((signed_count++))
         else
           echo "[Error] Mach-O sign failed: $candidate"
@@ -221,7 +249,7 @@ echo "All done. Final archive with excluded items is: $FINAL_ZIP"
 ##############################################
 # Cleanup
 ##############################################
-rm -rf "$TMP_EXCLUDE_DIR" "$TMP_NOTARIZE_DIR"
+rm -rf "$TMP_EXCLUDE_DIR" "$TMP_NOTARIZE_DIR" "$JRE_ENTITLEMENTS"
 
 cat <<EOM
 Note: c8run_complete.zip includes the previously excluded items, which remain

--- a/.github/actions/sign-and-notarize/sign_and_notarize.sh
+++ b/.github/actions/sign-and-notarize/sign_and_notarize.sh
@@ -96,7 +96,7 @@ done
 # Without allow-jit the hardened runtime blocks pthread_jit_write_protect_np,
 # which crashes libjvm.dylib during Threads::create_vm.
 ##############################################
-JRE_ENTITLEMENTS="$(mktemp).plist"
+JRE_ENTITLEMENTS="$(mktemp --suffix=.plist)"
 cat > "$JRE_ENTITLEMENTS" << 'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">


### PR DESCRIPTION
## Summary

- The jlink-produced JRE (introduced in #54850) is signed with the hardened runtime but **no entitlements**
- On Apple Silicon, `libjvm.dylib` crashes with `EXC_BREAKPOINT` (`signal: trace/BPT trap`) during `Threads::create_vm` because the hardened runtime blocks `pthread_jit_write_protect_np` without `com.apple.security.cs.allow-jit`
- Crash confirmed via `~/Library/Logs/DiagnosticReports/` — faulting frame: `pthread_jit_write_protect_np → Threads::create_vm → JNI_CreateJavaVM`

Fixes the `sign_and_notarize.sh` to add a JRE-specific entitlements plist (`allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`) and apply it when signing any Mach-O under a `jre/` path. This matches what Temurin, Zulu, and Corretto use for their signed macOS ARM64 distributions.

## Test plan

- [ ] Trigger `c8run-release.yaml` manually against this branch (or a test branch) to produce a signed macOS artifact
- [ ] Download `darwin-aarch64.zip` on an Apple Silicon Mac and run `./start.sh` — should no longer crash with `signal: trace/BPT trap`
- [ ] Verify `codesign -d --entitlements - jre/bin/java` shows `allow-jit` in the signed artifact

Closes #25177 (related — original signing tracking issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)