### PR TITLE
revert: re-enable OpenSearch load test

### DIFF
--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -186,26 +186,25 @@ jobs:
       secondary-storage-type: 'postgresql'
       scenario: realistic
 
-  # Disabled Opensearch load test until https://github.com/camunda/camunda/issues/50527 is resolved
-  # setup-opensearch-realistic-load-test:
-  #   name: OpenSearch realistic load test
-  #   needs:
-  #     - test-data
-  #     - build-camunda-image
-  #     - build-load-test-images
-  #   if: |
-  #     always() &&
-  #     needs.test-data.result == 'success' &&
-  #     (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
-  #     (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
-  #   uses: ./.github/workflows/camunda-load-test.yml
-  #   secrets: inherit
-  #   with:
-  #     name: ${{ needs.test-data.outputs.image-tag }}-opensearch-realistic
-  #     ttl: ${{ fromJSON(inputs.ttl || '28') }}
-  #     reuse-tag: ${{ needs.test-data.outputs.image-tag }}
-  #     secondary-storage-type: 'opensearch'
-  #     scenario: realistic
+  setup-opensearch-realistic-load-test:
+    name: OpenSearch realistic load test
+    needs:
+      - test-data
+      - build-camunda-image
+      - build-load-test-images
+    if: |
+      always() &&
+      needs.test-data.result == 'success' &&
+      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
+      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
+    uses: ./.github/workflows/camunda-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.test-data.outputs.image-tag }}-opensearch-realistic
+      ttl: ${{ fromJSON(inputs.ttl || '28') }}
+      reuse-tag: ${{ needs.test-data.outputs.image-tag }}
+      secondary-storage-type: 'opensearch'
+      scenario: realistic
 
   setup-realistic-test:
     name: Realistic load test
@@ -265,7 +264,7 @@ jobs:
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ build-camunda-image, build-load-test-images, setup-rdbms-realistic-load-test, setup-realistic-test, setup-latency-test, setup-ecs-benchmark ]
+    needs: [ build-camunda-image, build-load-test-images, setup-rdbms-realistic-load-test, setup-opensearch-realistic-load-test, setup-realistic-test, setup-latency-test, setup-ecs-benchmark ]
     if: failure()
     timeout-minutes: 5
     permissions: { }


### PR DESCRIPTION
## Description

Re-enables the `setup-opensearch-realistic-load-test` job that was disabled in #54120 while https://github.com/camunda/camunda/issues/50527 was being resolved.

The OS exporter issues are now fixed (see Slack thread).

## Related issues

Reverts #54120
Closes https://github.com/camunda/camunda/issues/50527

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)