### PR TITLE
Kpi execution tiles

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/DashboardRestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/DashboardRestService.java
@@ -136,6 +136,16 @@ public class DashboardRestService {
     return dashboardDefinition;
   }
 
+  @GetMapping(path = "/agentic")
+  public AuthorizedDashboardDefinitionResponseDto getAgenticDashboard(
+      final HttpServletRequest request) {
+    final AuthorizedDashboardDefinitionResponseDto dashboardDefinition =
+        dashboardService.getAgenticDashboard();
+    dashboardRestMapper.prepareRestResponse(
+        dashboardDefinition, request.getHeader(X_OPTIMIZE_CLIENT_LOCALE));
+    return dashboardDefinition;
+  }
+
   @PutMapping(path = "/{id}")
   public void updateDashboard(
       @PathVariable("id") final String dashboardId,

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/ReportRestMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/ReportRestMapper.java
@@ -227,10 +227,9 @@ public class ReportRestMapper {
     if (!(reportDefinitionDto instanceof SingleProcessReportDefinitionRequestDto)) {
       return false;
     }
-    final var data = ((SingleProcessReportDefinitionRequestDto) reportDefinitionDto).getData();
-    return data.isManagementReport()
-        || data.isInstantPreviewReport()
-        || data.isAgenticControlReport();
+    return ((SingleProcessReportDefinitionRequestDto) reportDefinitionDto)
+        .getData()
+        .isSystemGeneratedReport();
   }
 
   private void localizeReportData(

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/ReportRestMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/ReportRestMapper.java
@@ -105,8 +105,7 @@ public class ReportRestMapper {
       final LocalizationService localizationService) {
     if (isManagementOrInstantPreviewOrAgenticReport(reportDefinitionDto)) {
       final String validLocale = localizationService.validateAndReturnValidLocale(locale);
-      final var data =
-          ((SingleProcessReportDefinitionRequestDto) reportDefinitionDto).getData();
+      final var data = ((SingleProcessReportDefinitionRequestDto) reportDefinitionDto).getData();
       if (data.isManagementReport()) {
         Optional.ofNullable(
                 localizationService.getLocalizationForManagementReportCode(
@@ -229,7 +228,9 @@ public class ReportRestMapper {
       return false;
     }
     final var data = ((SingleProcessReportDefinitionRequestDto) reportDefinitionDto).getData();
-    return data.isManagementReport() || data.isInstantPreviewReport() || data.isAgenticControlReport();
+    return data.isManagementReport()
+        || data.isInstantPreviewReport()
+        || data.isAgenticControlReport();
   }
 
   private void localizeReportData(

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/ReportRestMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/ReportRestMapper.java
@@ -103,17 +103,26 @@ public class ReportRestMapper {
       final ReportDefinitionDto<?> reportDefinitionDto,
       final String locale,
       final LocalizationService localizationService) {
-    if (isManagementOrInstantPreviewReport(reportDefinitionDto)) {
+    if (isManagementOrInstantPreviewOrAgenticReport(reportDefinitionDto)) {
       final String validLocale = localizationService.validateAndReturnValidLocale(locale);
-      if (((SingleProcessReportDefinitionRequestDto) reportDefinitionDto)
-          .getData()
-          .isManagementReport()) {
+      final var data =
+          ((SingleProcessReportDefinitionRequestDto) reportDefinitionDto).getData();
+      if (data.isManagementReport()) {
         Optional.ofNullable(
                 localizationService.getLocalizationForManagementReportCode(
                     validLocale, reportDefinitionDto.getName()))
             .ifPresent(reportDefinitionDto::setName);
         Optional.ofNullable(
                 localizationService.getLocalizationForManagementReportCode(
+                    validLocale, reportDefinitionDto.getDescription()))
+            .ifPresent(reportDefinitionDto::setDescription);
+      } else if (data.isAgenticControlReport()) {
+        Optional.ofNullable(
+                localizationService.getLocalizationForAgenticControlReportCode(
+                    validLocale, reportDefinitionDto.getName()))
+            .ifPresent(reportDefinitionDto::setName);
+        Optional.ofNullable(
+                localizationService.getLocalizationForAgenticControlReportCode(
                     validLocale, reportDefinitionDto.getDescription()))
             .ifPresent(reportDefinitionDto::setDescription);
       } else {
@@ -214,15 +223,13 @@ public class ReportRestMapper {
         .ifPresent(reportDefinitionDto::setLastModifier);
   }
 
-  private static boolean isManagementOrInstantPreviewReport(
+  private static boolean isManagementOrInstantPreviewOrAgenticReport(
       final ReportDefinitionDto<?> reportDefinitionDto) {
-    return reportDefinitionDto instanceof SingleProcessReportDefinitionRequestDto
-        && (((SingleProcessReportDefinitionRequestDto) reportDefinitionDto)
-                .getData()
-                .isManagementReport()
-            || ((SingleProcessReportDefinitionRequestDto) reportDefinitionDto)
-                .getData()
-                .isInstantPreviewReport());
+    if (!(reportDefinitionDto instanceof SingleProcessReportDefinitionRequestDto)) {
+      return false;
+    }
+    final var data = ((SingleProcessReportDefinitionRequestDto) reportDefinitionDto).getData();
+    return data.isManagementReport() || data.isInstantPreviewReport() || data.isAgenticControlReport();
   }
 
   private void localizeReportData(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/LocalizationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/LocalizationService.java
@@ -107,6 +107,11 @@ public class LocalizationService implements ConfigurationReloadable {
         localeCode, MANAGEMENT_DASHBOARD_FIELD, REPORT_FIELD, reportCode);
   }
 
+  public String getLocalizationForAgenticControlReportCode(
+      final String localeCode, final String reportCode) {
+    return getNestedMessageForCode(localeCode, AGENTIC_CONTROL_FIELD, REPORT_FIELD, reportCode);
+  }
+
   public String getLocalizationForInstantPreviewReportCode(
       final String localeCode, final String reportCode) {
     return getNestedMessageForCode(localeCode, INSTANT_DASHBOARD_FIELD, REPORT_FIELD, reportCode);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -32,9 +32,11 @@ import io.camunda.optimize.service.db.reader.DashboardReader;
 import io.camunda.optimize.service.db.writer.DashboardWriter;
 import io.camunda.optimize.service.db.writer.ReportWriter;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
@@ -59,6 +61,18 @@ public class AgenticControlDashboardService {
       "agenticKpiExecutionIncidentRateName";
   public static final String KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION =
       "agenticKpiExecutionIncidentRateDescription";
+
+  // Deterministic report IDs — derived from fixed seed strings so IDs are stable across restarts
+  // and DB reimports. Same seed always produces the same UUID (UUID v3 / name-based).
+  public static final String KPI_COMPLETED_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-kpi-completed-instances".getBytes(StandardCharsets.UTF_8))
+          .toString();
+  public static final String KPI_AVG_DURATION_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-kpi-avg-duration".getBytes(StandardCharsets.UTF_8))
+          .toString();
+  public static final String KPI_INCIDENT_RATE_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-kpi-incident-rate".getBytes(StandardCharsets.UTF_8))
+          .toString();
 
   private static final long INSTANCE_END_DATE_ROLLING_DAYS = 30L;
 
@@ -91,11 +105,16 @@ public class AgenticControlDashboardService {
   }
 
   public void reconcile() {
+    // Always upsert the three KPI reports so config changes are applied on every restart.
+    // Report IDs are deterministic so upserts are safe and tile references never orphan.
+    final List<DashboardReportTileDto> tiles = new ArrayList<>();
+    tiles.add(buildCompletedInstancesReport());
+    tiles.add(buildAvgDurationReport());
+    tiles.add(buildIncidentRateReport());
+
+    // Only create the dashboard itself if it is absent — the stable tile IDs mean we never
+    // need to recreate it just to keep tile→report references consistent.
     if (dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID).isEmpty()) {
-      final List<DashboardReportTileDto> tiles = new ArrayList<>();
-      tiles.add(buildCompletedInstancesReport());
-      tiles.add(buildAvgDurationReport());
-      tiles.add(buildIncidentRateReport());
       dashboardWriter.saveDashboard(buildAgentDashboard(tiles));
     }
   }
@@ -117,16 +136,14 @@ public class AgenticControlDashboardService {
                     .buildList())
             .agenticControlReport(true)
             .build();
-    final String id =
-        reportWriter
-            .createNewSingleProcessReport(
-                null,
-                reportData,
-                KPI_EXECUTION_COMPLETED_NAME,
-                KPI_EXECUTION_COMPLETED_DESCRIPTION,
-                null)
-            .getId();
-    return buildTile(id, new PositionDto(0, 0), new DimensionDto(6, 2));
+    reportWriter.createOrUpdateSingleProcessReport(
+        KPI_COMPLETED_REPORT_ID,
+        null,
+        reportData,
+        KPI_EXECUTION_COMPLETED_NAME,
+        KPI_EXECUTION_COMPLETED_DESCRIPTION,
+        null);
+    return buildTile(KPI_COMPLETED_REPORT_ID, new PositionDto(0, 0), new DimensionDto(6, 2));
   }
 
   private DashboardReportTileDto buildAvgDurationReport() {
@@ -146,23 +163,21 @@ public class AgenticControlDashboardService {
                     .buildList())
             .agenticControlReport(true)
             .build();
-    final String id =
-        reportWriter
-            .createNewSingleProcessReport(
-                null,
-                reportData,
-                KPI_EXECUTION_AVG_DURATION_NAME,
-                KPI_EXECUTION_AVG_DURATION_DESCRIPTION,
-                null)
-            .getId();
-    return buildTile(id, new PositionDto(6, 0), new DimensionDto(6, 2));
+    reportWriter.createOrUpdateSingleProcessReport(
+        KPI_AVG_DURATION_REPORT_ID,
+        null,
+        reportData,
+        KPI_EXECUTION_AVG_DURATION_NAME,
+        KPI_EXECUTION_AVG_DURATION_DESCRIPTION,
+        null);
+    return buildTile(KPI_AVG_DURATION_REPORT_ID, new PositionDto(6, 0), new DimensionDto(6, 2));
   }
 
   private DashboardReportTileDto buildIncidentRateReport() {
     final ProcessReportDataDto reportData =
         ProcessReportDataDto.builder()
             .definitions(Collections.emptyList())
-            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.FREQUENCY))
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.PERCENTAGE))
             .groupBy(new NoneGroupByDto())
             .distributedBy(new NoneDistributedByDto())
             .visualization(ProcessVisualization.NUMBER)
@@ -177,16 +192,14 @@ public class AgenticControlDashboardService {
                     .buildList())
             .agenticControlReport(true)
             .build();
-    final String id =
-        reportWriter
-            .createNewSingleProcessReport(
-                null,
-                reportData,
-                KPI_EXECUTION_INCIDENT_RATE_NAME,
-                KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION,
-                null)
-            .getId();
-    return buildTile(id, new PositionDto(12, 0), new DimensionDto(6, 2));
+    reportWriter.createOrUpdateSingleProcessReport(
+        KPI_INCIDENT_RATE_REPORT_ID,
+        null,
+        reportData,
+        KPI_EXECUTION_INCIDENT_RATE_NAME,
+        KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION,
+        null);
+    return buildTile(KPI_INCIDENT_RATE_REPORT_ID, new PositionDto(12, 0), new DimensionDto(6, 2));
   }
 
   private DashboardDefinitionRestDto buildAgentDashboard(final List<DashboardReportTileDto> tiles) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -14,13 +14,26 @@ import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardProcessS
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.data.DashboardDateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.data.DashboardProcessScopeFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardTileType;
+import io.camunda.optimize.dto.optimize.query.dashboard.tile.DimensionDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.tile.PositionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RollingDateFilterDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessVisualization;
+import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.NoneDistributedByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.util.ProcessFilterBuilder;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.NoneGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
 import io.camunda.optimize.service.db.reader.DashboardReader;
 import io.camunda.optimize.service.db.writer.DashboardWriter;
+import io.camunda.optimize.service.db.writer.ReportWriter;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -36,6 +49,17 @@ public class AgenticControlDashboardService {
   // LocalizationService.
   public static final String AGENTIC_DASHBOARD_NAME = "agenticControlPlaneDashboardName";
 
+  public static final String KPI_EXECUTION_COMPLETED_NAME = "agenticKpiExecutionCompletedName";
+  public static final String KPI_EXECUTION_COMPLETED_DESCRIPTION =
+      "agenticKpiExecutionCompletedDescription";
+  public static final String KPI_EXECUTION_AVG_DURATION_NAME = "agenticKpiExecutionAvgDurationName";
+  public static final String KPI_EXECUTION_AVG_DURATION_DESCRIPTION =
+      "agenticKpiExecutionAvgDurationDescription";
+  public static final String KPI_EXECUTION_INCIDENT_RATE_NAME =
+      "agenticKpiExecutionIncidentRateName";
+  public static final String KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION =
+      "agenticKpiExecutionIncidentRateDescription";
+
   private static final long INSTANCE_END_DATE_ROLLING_DAYS = 30L;
 
   private static final Logger LOG =
@@ -43,14 +67,17 @@ public class AgenticControlDashboardService {
 
   private final DashboardWriter dashboardWriter;
   private final DashboardReader dashboardReader;
+  private final ReportWriter reportWriter;
   private final ConfigurationService configurationService;
 
   public AgenticControlDashboardService(
       final DashboardWriter dashboardWriter,
       final DashboardReader dashboardReader,
+      final ReportWriter reportWriter,
       final ConfigurationService configurationService) {
     this.dashboardWriter = dashboardWriter;
     this.dashboardReader = dashboardReader;
+    this.reportWriter = reportWriter;
     this.configurationService = configurationService;
   }
 
@@ -64,10 +91,102 @@ public class AgenticControlDashboardService {
   }
 
   public void reconcile() {
-    final var existing = dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID);
-    if (existing.isEmpty()) {
-      dashboardWriter.saveDashboard(buildAgentDashboard(List.of()));
+    if (dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID).isEmpty()) {
+      final List<DashboardReportTileDto> tiles = new ArrayList<>();
+      tiles.add(buildCompletedInstancesReport());
+      tiles.add(buildAvgDurationReport());
+      tiles.add(buildIncidentRateReport());
+      dashboardWriter.saveDashboard(buildAgentDashboard(tiles));
     }
+  }
+
+  private DashboardReportTileDto buildCompletedInstancesReport() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.FREQUENCY))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.NUMBER)
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .buildList())
+            .agenticControlReport(true)
+            .build();
+    final String id =
+        reportWriter
+            .createNewSingleProcessReport(
+                null,
+                reportData,
+                KPI_EXECUTION_COMPLETED_NAME,
+                KPI_EXECUTION_COMPLETED_DESCRIPTION,
+                null)
+            .getId();
+    return buildTile(id, new PositionDto(0, 0), new DimensionDto(6, 2));
+  }
+
+  private DashboardReportTileDto buildAvgDurationReport() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.DURATION))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.NUMBER)
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .buildList())
+            .agenticControlReport(true)
+            .build();
+    final String id =
+        reportWriter
+            .createNewSingleProcessReport(
+                null,
+                reportData,
+                KPI_EXECUTION_AVG_DURATION_NAME,
+                KPI_EXECUTION_AVG_DURATION_DESCRIPTION,
+                null)
+            .getId();
+    return buildTile(id, new PositionDto(6, 0), new DimensionDto(6, 2));
+  }
+
+  private DashboardReportTileDto buildIncidentRateReport() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.FREQUENCY))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.NUMBER)
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .withResolvedIncident()
+                    .add()
+                    .buildList())
+            .agenticControlReport(true)
+            .build();
+    final String id =
+        reportWriter
+            .createNewSingleProcessReport(
+                null,
+                reportData,
+                KPI_EXECUTION_INCIDENT_RATE_NAME,
+                KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION,
+                null)
+            .getId();
+    return buildTile(id, new PositionDto(12, 0), new DimensionDto(6, 2));
   }
 
   private DashboardDefinitionRestDto buildAgentDashboard(final List<DashboardReportTileDto> tiles) {
@@ -93,5 +212,15 @@ public class AgenticControlDashboardService {
     availableFilters.add(endDateFilter);
     availableFilters.add(processScopeFilter);
     return availableFilters;
+  }
+
+  private DashboardReportTileDto buildTile(
+      final String reportId, final PositionDto position, final DimensionDto dimensions) {
+    return DashboardReportTileDto.builder()
+        .id(reportId)
+        .type(DashboardTileType.OPTIMIZE_REPORT)
+        .position(position)
+        .dimensions(dimensions)
+        .build();
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/DashboardService.java
@@ -364,6 +364,12 @@ public class DashboardService implements ReportReferencingService, CollectionRef
     return new AuthorizedDashboardDefinitionResponseDto(RoleType.VIEWER, dashboard);
   }
 
+  public AuthorizedDashboardDefinitionResponseDto getAgenticDashboard() {
+    final DashboardDefinitionRestDto dashboard =
+        getDashboardDefinitionAsService(AgenticControlDashboardService.AGENTIC_DASHBOARD_ID);
+    return new AuthorizedDashboardDefinitionResponseDto(RoleType.VIEWER, dashboard);
+  }
+
   public void verifyUserHasAccessToDashboardCollection(
       final String userId, final DashboardDefinitionRestDto dashboard) {
     getUserRoleType(userId, dashboard);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/HasAgentInstancesQueryFilterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/HasAgentInstancesQueryFilterES.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.filter;
+
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.AGENT_INSTANCES;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.data.HasAgentInstancesFilterDataDto;
+import io.camunda.optimize.service.db.filter.FilterContext;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.List;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class HasAgentInstancesQueryFilterES
+    implements QueryFilterES<HasAgentInstancesFilterDataDto> {
+
+  @Override
+  public void addFilters(
+      final BoolQuery.Builder query,
+      final List<HasAgentInstancesFilterDataDto> filterData,
+      final FilterContext filterContext) {
+    if (filterData != null && !filterData.isEmpty()) {
+      query.filter(
+          f ->
+              f.nested(
+                  n ->
+                      n.path(AGENT_INSTANCES)
+                          .query(q -> q.matchAll(m -> m))
+                          .scoreMode(ChildScoreMode.None)));
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/ProcessQueryFilterEnhancerES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/ProcessQueryFilterEnhancerES.java
@@ -27,6 +27,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.filter.Filte
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeDurationFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeEndDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeStartDateFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.HasAgentInstancesFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceEndDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceStartDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.MultipleVariableFilterDto;
@@ -91,6 +92,7 @@ public class ProcessQueryFilterEnhancerES implements QueryFilterEnhancerES<Proce
   private final InstancesContainingUserTasksFilterES instancesContainingUserTasksFilter;
   private final FlowNodeStartDateQueryFilterES flowNodeStartDateQueryFilter;
   private final FlowNodeEndDateQueryFilterES flowNodeEndDateQueryFilter;
+  private final HasAgentInstancesQueryFilterES hasAgentInstancesQueryFilter;
 
   public ProcessQueryFilterEnhancerES(
       final ConfigurationService configurationService,
@@ -123,7 +125,8 @@ public class ProcessQueryFilterEnhancerES implements QueryFilterEnhancerES<Proce
           completedOrCanceledFlowNodesOnlyQueryFilter,
       final InstancesContainingUserTasksFilterES instancesContainingUserTasksFilter,
       final FlowNodeStartDateQueryFilterES flowNodeStartDateQueryFilter,
-      final FlowNodeEndDateQueryFilterES flowNodeEndDateQueryFilter) {
+      final FlowNodeEndDateQueryFilterES flowNodeEndDateQueryFilter,
+      final HasAgentInstancesQueryFilterES hasAgentInstancesQueryFilter) {
     this.configurationService = configurationService;
     this.environment = environment;
     this.instanceStartDateQueryFilter = instanceStartDateQueryFilter;
@@ -154,6 +157,7 @@ public class ProcessQueryFilterEnhancerES implements QueryFilterEnhancerES<Proce
     this.instancesContainingUserTasksFilter = instancesContainingUserTasksFilter;
     this.flowNodeStartDateQueryFilter = flowNodeStartDateQueryFilter;
     this.flowNodeEndDateQueryFilter = flowNodeEndDateQueryFilter;
+    this.hasAgentInstancesQueryFilter = hasAgentInstancesQueryFilter;
   }
 
   @Override
@@ -242,6 +246,8 @@ public class ProcessQueryFilterEnhancerES implements QueryFilterEnhancerES<Proce
           query, extractInstanceFilters(filters, FlowNodeStartDateFilterDto.class), filterContext);
       flowNodeEndDateQueryFilter.addFilters(
           query, extractInstanceFilters(filters, FlowNodeEndDateFilterDto.class), filterContext);
+      hasAgentInstancesQueryFilter.addFilters(
+          query, extractInstanceFilters(filters, HasAgentInstancesFilterDto.class), filterContext);
     }
     addInstanceFilterForViewLevelMatching(query, filters, filterContext);
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportWriterES.java
@@ -144,7 +144,19 @@ public class ReportWriterES implements ReportWriter {
       final String reportName,
       final String description,
       final String collectionId) {
-    LOG.debug("Writing new single report to Elasticsearch");
+    return createOrUpdateSingleProcessReport(
+        IdGenerator.getNextId(), userId, reportData, reportName, description, collectionId);
+  }
+
+  @Override
+  public IdResponseDto createOrUpdateSingleProcessReport(
+      final String reportId,
+      final String userId,
+      final ProcessReportDataDto reportData,
+      final String reportName,
+      final String description,
+      final String collectionId) {
+    LOG.debug("Writing single process report with id [{}] to Elasticsearch", reportId);
 
     if (reportData == null) {
       throw new OptimizeRuntimeException("reportData is null");
@@ -153,10 +165,9 @@ public class ReportWriterES implements ReportWriter {
       throw new OptimizeRuntimeException("reportName is null");
     }
 
-    final String id = IdGenerator.getNextId();
     final SingleProcessReportDefinitionRequestDto reportDefinitionDto =
         new SingleProcessReportDefinitionRequestDto();
-    reportDefinitionDto.setId(id);
+    reportDefinitionDto.setId(reportId);
     final OffsetDateTime now = LocalDateUtil.getCurrentDateTime();
     reportDefinitionDto.setCreated(now);
     reportDefinitionDto.setLastModified(now);
@@ -173,20 +184,23 @@ public class ReportWriterES implements ReportWriter {
               OptimizeIndexRequestBuilderES.of(
                   i ->
                       i.optimizeIndex(esClient, SINGLE_PROCESS_REPORT_INDEX_NAME)
-                          .id(id)
+                          .id(reportId)
                           .document(reportDefinitionDto)
                           .refresh(Refresh.True)));
 
-      if (!indexResponse.result().equals(Result.Created)) {
-        final String message = "Could not write single process report to Elasticsearch.";
+      if (!indexResponse.result().equals(Result.Created)
+          && !indexResponse.result().equals(Result.Updated)) {
+        final String message =
+            String.format(
+                "Could not write single process report with id [%s] to Elasticsearch.", reportId);
         LOG.error(message);
         throw new OptimizeRuntimeException(message);
       }
 
-      LOG.debug("Single process report with id [{}] has successfully been created.", id);
-      return new IdResponseDto(id);
+      LOG.debug("Single process report with id [{}] has successfully been written.", reportId);
+      return new IdResponseDto(reportId);
     } catch (final IOException e) {
-      final String errorMessage = "Was not able to insert single process report.";
+      final String errorMessage = "Was not able to write single process report.";
       LOG.error(errorMessage, e);
       throw new OptimizeRuntimeException(errorMessage, e);
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/filter/HasAgentInstancesQueryFilterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/filter/HasAgentInstancesQueryFilterOS.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.filter;
+
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.matchAll;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.nested;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.AGENT_INSTANCES;
+
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.data.HasAgentInstancesFilterDataDto;
+import io.camunda.optimize.service.db.filter.FilterContext;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.List;
+import org.opensearch.client.opensearch._types.query_dsl.ChildScoreMode;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class HasAgentInstancesQueryFilterOS
+    implements QueryFilterOS<HasAgentInstancesFilterDataDto> {
+
+  @Override
+  public List<Query> filterQueries(
+      final List<HasAgentInstancesFilterDataDto> filterData, final FilterContext filterContext) {
+    return filterData != null && !filterData.isEmpty()
+        ? List.of(nested(AGENT_INSTANCES, matchAll(), ChildScoreMode.None))
+        : List.of();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/filter/ProcessQueryFilterEnhancerOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/filter/ProcessQueryFilterEnhancerOS.java
@@ -26,6 +26,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.filter.Filte
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeDurationFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeEndDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeStartDateFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.HasAgentInstancesFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceEndDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceStartDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.MultipleVariableFilterDto;
@@ -95,6 +96,7 @@ public class ProcessQueryFilterEnhancerOS implements QueryFilterEnhancerOS<Proce
   private final InstancesContainingUserTasksFilterOS instancesContainingUserTasksFilter;
   private final FlowNodeStartDateQueryFilterOS flowNodeStartDateQueryFilter;
   private final FlowNodeEndDateQueryFilterOS flowNodeEndDateQueryFilter;
+  private final HasAgentInstancesQueryFilterOS hasAgentInstancesQueryFilter;
 
   public ProcessQueryFilterEnhancerOS(
       final ConfigurationService configurationService,
@@ -127,7 +129,8 @@ public class ProcessQueryFilterEnhancerOS implements QueryFilterEnhancerOS<Proce
           completedOrCanceledFlowNodesOnlyQueryFilter,
       final InstancesContainingUserTasksFilterOS instancesContainingUserTasksFilter,
       final FlowNodeStartDateQueryFilterOS flowNodeStartDateQueryFilter,
-      final FlowNodeEndDateQueryFilterOS flowNodeEndDateQueryFilter) {
+      final FlowNodeEndDateQueryFilterOS flowNodeEndDateQueryFilter,
+      final HasAgentInstancesQueryFilterOS hasAgentInstancesQueryFilter) {
     this.configurationService = configurationService;
     this.environment = environment;
     this.instanceStartDateQueryFilter = instanceStartDateQueryFilter;
@@ -158,6 +161,7 @@ public class ProcessQueryFilterEnhancerOS implements QueryFilterEnhancerOS<Proce
     this.instancesContainingUserTasksFilter = instancesContainingUserTasksFilter;
     this.flowNodeStartDateQueryFilter = flowNodeStartDateQueryFilter;
     this.flowNodeEndDateQueryFilter = flowNodeEndDateQueryFilter;
+    this.hasAgentInstancesQueryFilter = hasAgentInstancesQueryFilter;
   }
 
   @Override
@@ -235,7 +239,9 @@ public class ProcessQueryFilterEnhancerOS implements QueryFilterEnhancerOS<Proce
         flowNodeStartDateQueryFilter.filterQueries(
             extractInstanceFilters(filters, FlowNodeStartDateFilterDto.class), filterContext),
         flowNodeEndDateQueryFilter.filterQueries(
-            extractInstanceFilters(filters, FlowNodeEndDateFilterDto.class), filterContext));
+            extractInstanceFilters(filters, FlowNodeEndDateFilterDto.class), filterContext),
+        hasAgentInstancesQueryFilter.filterQueries(
+            extractInstanceFilters(filters, HasAgentInstancesFilterDto.class), filterContext));
   }
 
   @SuppressWarnings(UNCHECKED_CAST)

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportWriterOS.java
@@ -133,6 +133,18 @@ public class ReportWriterOS implements ReportWriter {
       final String reportName,
       final String description,
       final String collectionId) {
+    return createOrUpdateSingleProcessReport(
+        IdGenerator.getNextId(), userId, reportData, reportName, description, collectionId);
+  }
+
+  @Override
+  public IdResponseDto createOrUpdateSingleProcessReport(
+      final String reportId,
+      final String userId,
+      final ProcessReportDataDto reportData,
+      final String reportName,
+      final String description,
+      final String collectionId) {
     if (reportData == null) {
       throw new OptimizeRuntimeException("reportData is null");
     }
@@ -140,13 +152,12 @@ public class ReportWriterOS implements ReportWriter {
       throw new OptimizeRuntimeException("reportName is null");
     }
 
-    LOG.debug("Writing new single report to OpenSearch");
+    LOG.debug("Writing single process report with id [{}] to OpenSearch", reportId);
 
-    final String id = IdGenerator.getNextId();
     final SingleProcessReportDefinitionRequestDto reportDefinitionDto =
         new SingleProcessReportDefinitionRequestDto();
 
-    reportDefinitionDto.setId(id);
+    reportDefinitionDto.setId(reportId);
     final OffsetDateTime now = LocalDateUtil.getCurrentDateTime();
     reportDefinitionDto.setCreated(now);
     reportDefinitionDto.setLastModified(now);
@@ -160,23 +171,24 @@ public class ReportWriterOS implements ReportWriter {
     final IndexRequest.Builder<SingleProcessReportDefinitionRequestDto> request =
         new IndexRequest.Builder<SingleProcessReportDefinitionRequestDto>()
             .index(SINGLE_PROCESS_REPORT_INDEX_NAME)
-            .id(id)
+            .id(reportId)
             .document(reportDefinitionDto)
             .refresh(Refresh.True);
 
     final IndexResponse indexResponse = osClient.index(request);
 
-    if (!indexResponse.result().equals(Result.Created)) {
+    if (!indexResponse.result().equals(Result.Created)
+        && !indexResponse.result().equals(Result.Updated)) {
       final String message =
           String.format(
               "Could not write single process report with id [%s] and name [%s] to OpenSearch.",
-              id, reportName);
+              reportId, reportName);
       LOG.error(message);
       throw new OptimizeRuntimeException(message);
     }
 
-    LOG.debug("Single process report with id [{}] has successfully been created.", id);
-    return new IdResponseDto(id);
+    LOG.debug("Single process report with id [{}] has successfully been written.", reportId);
+    return new IdResponseDto(reportId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ReportWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ReportWriter.java
@@ -61,6 +61,14 @@ public interface ReportWriter {
       final String description,
       final String collectionId);
 
+  IdResponseDto createOrUpdateSingleProcessReport(
+      final String reportId,
+      final String userId,
+      final ProcessReportDataDto reportData,
+      final String reportName,
+      final String description,
+      final String collectionId);
+
   IdResponseDto createNewSingleDecisionReport(
       final String userId,
       final DecisionReportDataDto reportData,

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -1540,7 +1540,15 @@
     }
   },
   "agenticControl": {
-    "agenticControlPlaneDashboardName": "Agentic Control Dashboard"
+    "agenticControlPlaneDashboardName": "Agentic Control Dashboard",
+    "report": {
+      "agenticKpiExecutionCompletedName": "Abgeschlossene Agenten-Läufe",
+      "agenticKpiExecutionCompletedDescription": "Gesamtanzahl der abgeschlossenen agentischen Prozessinstanzen im gewählten Zeitraum.",
+      "agenticKpiExecutionAvgDurationName": "Durchschnittliche Ausführungsdauer",
+      "agenticKpiExecutionAvgDurationDescription": "Durchschnittliche Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum.",
+      "agenticKpiExecutionIncidentRateName": "Vorfallsrate",
+      "agenticKpiExecutionIncidentRateDescription": "Anzahl der abgeschlossenen agentischen Prozessinstanzen mit einem gelösten Vorfall im gewählten Zeitraum."
+    }
   },
   "managementDashboard": {
     "dashboardName": "Adoption",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -1540,7 +1540,15 @@
     }
   },
   "agenticControl": {
-    "agenticControlPlaneDashboardName": "Agentic Control Dashboard"
+    "agenticControlPlaneDashboardName": "Agentic Control Dashboard",
+    "report": {
+      "agenticKpiExecutionCompletedName": "Completed agent runs",
+      "agenticKpiExecutionCompletedDescription": "Total number of completed agentic process instances in the selected period.",
+      "agenticKpiExecutionAvgDurationName": "Avg execution duration",
+      "agenticKpiExecutionAvgDurationDescription": "Average execution duration of completed agentic process instances in the selected period.",
+      "agenticKpiExecutionIncidentRateName": "Incident rate",
+      "agenticKpiExecutionIncidentRateDescription": "Number of completed agentic process instances that encountered a resolved incident in the selected period."
+    }
   },
   "managementDashboard": {
     "dashboardName": "Adoption",

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -57,8 +57,11 @@ public class AgenticControlDashboardServiceTest {
 
   @BeforeEach
   void setUp() {
-    when(reportWriter.createNewSingleProcessReport(isNull(), any(), any(), any(), isNull()))
-        .thenReturn(new IdResponseDto("report-stub-id"));
+    // createOrUpdateSingleProcessReport is called with (reportId, userId, data, name, desc,
+    // collectionId)
+    when(reportWriter.createOrUpdateSingleProcessReport(
+            any(), isNull(), any(), any(), any(), isNull()))
+        .thenAnswer(invocation -> new IdResponseDto(invocation.getArgument(0)));
   }
 
   @Test
@@ -79,16 +82,17 @@ public class AgenticControlDashboardServiceTest {
   }
 
   @Test
-  void shouldSeedThreeKpiReportsOnColdStart() {
+  void shouldSeedThreeKpiReportsWithDeterministicIdsOnColdStart() {
     // given
     when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
 
     // when
     underTest.reconcile();
 
-    // then three reports are created
+    // then three reports are upserted with deterministic IDs and correct localization keys
     verify(reportWriter)
-        .createNewSingleProcessReport(
+        .createOrUpdateSingleProcessReport(
+            org.mockito.ArgumentMatchers.eq(AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID),
             isNull(),
             any(),
             org.mockito.ArgumentMatchers.eq(
@@ -97,7 +101,9 @@ public class AgenticControlDashboardServiceTest {
                 AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_DESCRIPTION),
             isNull());
     verify(reportWriter)
-        .createNewSingleProcessReport(
+        .createOrUpdateSingleProcessReport(
+            org.mockito.ArgumentMatchers.eq(
+                AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID),
             isNull(),
             any(),
             org.mockito.ArgumentMatchers.eq(
@@ -106,7 +112,9 @@ public class AgenticControlDashboardServiceTest {
                 AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_DESCRIPTION),
             isNull());
     verify(reportWriter)
-        .createNewSingleProcessReport(
+        .createOrUpdateSingleProcessReport(
+            org.mockito.ArgumentMatchers.eq(
+                AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID),
             isNull(),
             any(),
             org.mockito.ArgumentMatchers.eq(
@@ -114,6 +122,47 @@ public class AgenticControlDashboardServiceTest {
             org.mockito.ArgumentMatchers.eq(
                 AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION),
             isNull());
+  }
+
+  @Test
+  void shouldUpsertReportDefinitionsOnWarmRestart() {
+    // given — dashboard already exists (warm restart)
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID))
+        .thenReturn(Optional.of(new DashboardDefinitionRestDto()));
+
+    // when — reconcile is called twice (simulating two restarts)
+    underTest.reconcile();
+    underTest.reconcile();
+
+    // then — reports are upserted on every call, dashboard is never recreated
+    verify(reportWriter, org.mockito.Mockito.times(2))
+        .createOrUpdateSingleProcessReport(
+            org.mockito.ArgumentMatchers.eq(AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+    verify(dashboardWriter, never()).saveDashboard(any());
+  }
+
+  @Test
+  void shouldUseDeterministicTileIdsMatchingReportIds() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then tile IDs in the saved dashboard match the deterministic report ID constants
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    assertThat(saved.getTiles())
+        .extracting(
+            io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto::getId)
+        .containsExactlyInAnyOrder(
+            AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID,
+            AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID,
+            AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID);
   }
 
   @Test
@@ -165,19 +214,20 @@ public class AgenticControlDashboardServiceTest {
   }
 
   @Test
-  void shouldNotCreateOrMutateWhenDashboardAlreadyPresent() {
-    // given the dashboard already exists
+  void shouldUpsertReportsButNotRecreateDashboardOnWarmRestart() {
+    // given the dashboard already exists (warm restart)
     when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID))
         .thenReturn(Optional.of(new DashboardDefinitionRestDto()));
 
     // when
     underTest.reconcile();
 
-    // then nothing is written
+    // then reports are upserted (so config changes are applied) but dashboard is not touched
+    verify(reportWriter, org.mockito.Mockito.times(3))
+        .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
     verify(dashboardWriter, never()).saveDashboard(any());
     verify(dashboardWriter, never()).updateDashboard(any(), any());
     verify(dashboardWriter, never()).deleteDashboard(any());
-    verifyNoInteractions(reportWriter);
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.service.dashboard.AgenticControlDashboardServi
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.query.IdResponseDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardFilterDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardInstanceEndDateFilterDto;
@@ -30,12 +32,14 @@ import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.Rol
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RollingDateFilterDataDto;
 import io.camunda.optimize.service.db.reader.DashboardReader;
 import io.camunda.optimize.service.db.writer.DashboardWriter;
+import io.camunda.optimize.service.db.writer.ReportWriter;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.EntityConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -43,11 +47,19 @@ public class AgenticControlDashboardServiceTest {
 
   private final DashboardWriter dashboardWriter = mock(DashboardWriter.class);
   private final DashboardReader dashboardReader = mock(DashboardReader.class);
+  private final ReportWriter reportWriter = mock(ReportWriter.class);
   private final ConfigurationService configurationService = mock(ConfigurationService.class);
   private final EntityConfiguration entityConfiguration = mock(EntityConfiguration.class);
 
   private final AgenticControlDashboardService underTest =
-      new AgenticControlDashboardService(dashboardWriter, dashboardReader, configurationService);
+      new AgenticControlDashboardService(
+          dashboardWriter, dashboardReader, reportWriter, configurationService);
+
+  @BeforeEach
+  void setUp() {
+    when(reportWriter.createNewSingleProcessReport(isNull(), any(), any(), any(), isNull()))
+        .thenReturn(new IdResponseDto("report-stub-id"));
+  }
 
   @Test
   void shouldCreateDashboardWithExpectedShapeOnColdStart() {
@@ -63,7 +75,45 @@ public class AgenticControlDashboardServiceTest {
     assertThat(saved.isAgenticControlDashboard()).isTrue();
     assertThat(saved.isManagementDashboard()).isFalse();
     assertThat(saved.getCollectionId()).isNull();
-    assertThat(saved.getTiles()).isEmpty();
+    assertThat(saved.getTiles()).hasSize(3);
+  }
+
+  @Test
+  void shouldSeedThreeKpiReportsOnColdStart() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then three reports are created
+    verify(reportWriter)
+        .createNewSingleProcessReport(
+            isNull(),
+            any(),
+            org.mockito.ArgumentMatchers.eq(
+                AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_NAME),
+            org.mockito.ArgumentMatchers.eq(
+                AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_DESCRIPTION),
+            isNull());
+    verify(reportWriter)
+        .createNewSingleProcessReport(
+            isNull(),
+            any(),
+            org.mockito.ArgumentMatchers.eq(
+                AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_NAME),
+            org.mockito.ArgumentMatchers.eq(
+                AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_DESCRIPTION),
+            isNull());
+    verify(reportWriter)
+        .createNewSingleProcessReport(
+            isNull(),
+            any(),
+            org.mockito.ArgumentMatchers.eq(
+                AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_NAME),
+            org.mockito.ArgumentMatchers.eq(
+                AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION),
+            isNull());
   }
 
   @Test
@@ -127,6 +177,7 @@ public class AgenticControlDashboardServiceTest {
     verify(dashboardWriter, never()).saveDashboard(any());
     verify(dashboardWriter, never()).updateDashboard(any(), any());
     verify(dashboardWriter, never()).deleteDashboard(any());
+    verifyNoInteractions(reportWriter);
   }
 
   @Test
@@ -155,6 +206,7 @@ public class AgenticControlDashboardServiceTest {
     // then nothing is read or written
     verifyNoInteractions(dashboardReader);
     verifyNoInteractions(dashboardWriter);
+    verifyNoInteractions(reportWriter);
   }
 
   @Test
@@ -168,7 +220,6 @@ public class AgenticControlDashboardServiceTest {
     // then seeding stays isolated from the management dashboard lifecycle
     verify(dashboardWriter, never()).deleteManagementDashboard();
     verify(dashboardWriter, never()).deleteDashboard(any());
-    // and it only ever touches its own dashboard id
     final DashboardDefinitionRestDto saved = captureSavedDashboard();
     assertThat(saved.getId()).isEqualTo(AGENTIC_DASHBOARD_ID);
   }
@@ -181,7 +232,7 @@ public class AgenticControlDashboardServiceTest {
     // when
     underTest.reconcile();
 
-    // then
+    // then the tile list is mutable (can be extended)
     final DashboardDefinitionRestDto saved = captureSavedDashboard();
     assertThatNoException().isThrownBy(() -> saved.getTiles().add(new DashboardReportTileDto()));
   }
@@ -194,6 +245,24 @@ public class AgenticControlDashboardServiceTest {
           .as("locale '%s' must define agenticControl.%s", locale, AGENTIC_DASHBOARD_NAME)
           .containsKey(AGENTIC_DASHBOARD_NAME);
       assertThat(agenticControl.get(AGENTIC_DASHBOARD_NAME)).isEqualTo("Agentic Control Dashboard");
+    }
+  }
+
+  @Test
+  void shouldResolveKpiReportLocalizationCodesInEveryLocale() throws IOException {
+    for (final String locale : new String[] {"en", "de"}) {
+      final Map<String, Object> agenticControl = readAgenticControlLocalization(locale);
+      @SuppressWarnings("unchecked")
+      final Map<String, Object> report = (Map<String, Object>) agenticControl.get("report");
+      assertThat(report)
+          .as("locale '%s' must define all KPI report localization codes", locale)
+          .containsKeys(
+              AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_NAME,
+              AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_DESCRIPTION,
+              AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_NAME,
+              AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_DESCRIPTION,
+              AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_NAME,
+              AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION);
     }
   }
 

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.js
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.js
@@ -44,16 +44,12 @@ export function AgenticControlPlane() {
   }, [mightFail]);
 
   const selectedPreset = DATE_PRESETS.find((p) => p.id === preset);
+  const definitions = processScope ? [{key: processScope, versions: ['all']}] : [];
   const filter = [presetToFilter(selectedPreset)];
 
   const scopedEvaluateReport = useCallback(
-    (id, tileFilter, query) =>
-      evaluateReport(
-        id,
-        tileFilter,
-        query,
-        processScope ? [{key: processScope, versions: ['all']}] : []
-      ),
+    (id, tileFilter, query) => evaluateReport(id, tileFilter, query, definitions),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [processScope]
   );
 
@@ -83,7 +79,12 @@ export function AgenticControlPlane() {
         processScope={processScope}
         onProcessScopeChange={setProcessScope}
       />
-      <DashboardRenderer loadTile={scopedEvaluateReport} tiles={visibleTiles} filter={filter} />
+      <DashboardRenderer
+        key={processScope ?? '__all__'}
+        loadTile={scopedEvaluateReport}
+        tiles={visibleTiles}
+        filter={filter}
+      />
     </div>
   );
 }

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.js
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.js
@@ -20,7 +20,12 @@ export const DATE_PRESETS = [
   {id: '30d', translationKey: 'agenticControlPlane.presets.last30Days', value: 30, unit: 'days'},
   {id: '3m', translationKey: 'agenticControlPlane.presets.last3Months', value: 3, unit: 'months'},
   {id: '6m', translationKey: 'agenticControlPlane.presets.last6Months', value: 6, unit: 'months'},
-  {id: '12m', translationKey: 'agenticControlPlane.presets.last12Months', value: 12, unit: 'months'},
+  {
+    id: '12m',
+    translationKey: 'agenticControlPlane.presets.last12Months',
+    value: 12,
+    unit: 'months',
+  },
 ];
 
 export function FilterBar({preset, onPresetChange, processScope, onProcessScopeChange}) {

--- a/optimize/client/src/components/AgenticControlPlane/service.js
+++ b/optimize/client/src/components/AgenticControlPlane/service.js
@@ -6,16 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-// TODO: Replace stub with real API call once AgentDashboardService is ready:
-// import {get} from 'request';
-// export async function loadAgenticDashboard() {
-//   const response = await get('api/dashboard/agentic-control-plane-dashboard');
-//   return response.json();
-// }
+import {get} from 'request';
 
 export async function loadAgenticDashboard() {
-  return {
-    availableFilters: [{type: 'processScope'}],
-    tiles: [],
-  };
+  const response = await get('api/dashboard/agentic');
+  return response.json();
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessReportDataDto.java
@@ -364,6 +364,11 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
     this.agenticControlReport = agenticControlReport;
   }
 
+  @JsonIgnore
+  public boolean isSystemGeneratedReport() {
+    return managementReport || instantPreviewReport || agenticControlReport;
+  }
+
   protected boolean canEqual(final Object other) {
     return other instanceof ProcessReportDataDto;
   }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/HasAgentInstancesFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/HasAgentInstancesFilterDto.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.report.single.process.filter;
+
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.data.HasAgentInstancesFilterDataDto;
+import java.util.Collections;
+import java.util.List;
+
+public class HasAgentInstancesFilterDto extends ProcessFilterDto<HasAgentInstancesFilterDataDto> {
+
+  @Override
+  public List<FilterApplicationLevel> validApplicationLevels() {
+    return Collections.singletonList(FilterApplicationLevel.INSTANCE);
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/ProcessFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/ProcessFilterDto.java
@@ -60,7 +60,8 @@ import java.util.Objects;
   @JsonSubTypes.Type(value = CanceledFlowNodesOnlyFilterDto.class, name = "canceledFlowNodesOnly"),
   @JsonSubTypes.Type(
       value = CompletedOrCanceledFlowNodesOnlyFilterDto.class,
-      name = "completedOrCanceledFlowNodesOnly")
+      name = "completedOrCanceledFlowNodesOnly"),
+  @JsonSubTypes.Type(value = HasAgentInstancesFilterDto.class, name = "hasAgentInstances")
 })
 public abstract class ProcessFilterDto<DATA extends FilterDataDto> {
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/HasAgentInstancesFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/HasAgentInstancesFilterDataDto.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data;
+
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
+
+public class HasAgentInstancesFilterDataDto implements FilterDataDto {}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/util/HasAgentInstancesFilterBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/util/HasAgentInstancesFilterBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.report.single.process.filter.util;
+
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FilterApplicationLevel;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.HasAgentInstancesFilterDto;
+import java.util.List;
+import java.util.Optional;
+
+public final class HasAgentInstancesFilterBuilder {
+
+  private final ProcessFilterBuilder filterBuilder;
+  private FilterApplicationLevel filterLevel = FilterApplicationLevel.INSTANCE;
+  private List<String> appliedTo;
+
+  private HasAgentInstancesFilterBuilder(final ProcessFilterBuilder filterBuilder) {
+    this.filterBuilder = filterBuilder;
+  }
+
+  public static HasAgentInstancesFilterBuilder construct(final ProcessFilterBuilder filterBuilder) {
+    return new HasAgentInstancesFilterBuilder(filterBuilder);
+  }
+
+  public HasAgentInstancesFilterBuilder filterLevel(final FilterApplicationLevel filterLevel) {
+    this.filterLevel = filterLevel;
+    return this;
+  }
+
+  public HasAgentInstancesFilterBuilder appliedTo(final String appliedTo) {
+    return appliedTo(List.of(appliedTo));
+  }
+
+  public HasAgentInstancesFilterBuilder appliedTo(final List<String> appliedTo) {
+    this.appliedTo = appliedTo;
+    return this;
+  }
+
+  public ProcessFilterBuilder add() {
+    final HasAgentInstancesFilterDto filter = new HasAgentInstancesFilterDto();
+    filter.setFilterLevel(filterLevel);
+    Optional.ofNullable(appliedTo).ifPresent(value -> filter.setAppliedTo(appliedTo));
+    filterBuilder.addFilter(filter);
+    return filterBuilder;
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/util/ProcessFilterBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/util/ProcessFilterBuilder.java
@@ -57,6 +57,10 @@ public class ProcessFilterBuilder {
     return RunningInstancesOnlyFilterBuilder.construct(this);
   }
 
+  public HasAgentInstancesFilterBuilder hasAgentInstances() {
+    return HasAgentInstancesFilterBuilder.construct(this);
+  }
+
   public DeletedIncidentFilterBuilder withDeletedIncident() {
     return DeletedIncidentFilterBuilder.construct(this);
   }


### PR DESCRIPTION
## Description

- **Seed three KPI report tiles** into the agentic control plane dashboard on startup (`AgenticControlDashboardService`): total completed agentic instances, avg execution duration, and incident rate — each scoped to completed instances with the `hasAgentInstances` filter and `agenticControlReport: true`
- **Fixed tile refresh on process selection** in the FilterBar — added `key={processScope ?? '__all__'}` to `DashboardRenderer` to force remount when the process scope changes, since `loadTile` identity changes alone didn't trigger a reload
- **Scoped report evaluation to selected process** — `evaluateReport` now passes `definitions` derived from the selected `processScope`, enabling per-process filtering of the KPI tiles
- **Suppressed ESLint `react-hooks/exhaustive-deps` warning** in `useCallback` — `definitions` is always derived from `processScope` so `[processScope]` is the correct dependency; the lint suppression is intentional and documented inline
- **Frontend UI polish pending** — tile labels and descriptions shown in the KPI tiles need to be updated to display user-friendly text (localization keys are in place, visual presentation still needs refinement) - #53304
- Incident rate logic needs to be updated with a new process execution plan to support rate logic.

## Screenshots

<img width="2993" height="672" alt="Screenshot 2026-06-08 at 12 23 30 PM" src="https://github.com/user-attachments/assets/e4c2f5bf-95d3-4608-9151-b307759038a9" />
<img width="2995" height="623" alt="Screenshot 2026-06-08 at 12 23 10 PM" src="https://github.com/user-attachments/assets/f46b9ed7-309e-471e-8d29-c280bc99587c" />
<img width="3003" height="811" alt="Screenshot 2026-06-08 at 12 22 58 PM" src="https://github.com/user-attachments/assets/fb3ba67b-938b-461d-b379-dd33450fa9ae" />


## Related issues

closes #54627
