### PR TITLE
fix: compile JavaVersion helper with --release 21 for Java 21-25 compatibility

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -165,6 +165,12 @@ runs:
       shell: bash
       working-directory: ./c8run
 
+    - name: Set up Java 21 for C8Run packaging
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        distribution: "temurin"
+        java-version: "21"
+
     - name: Build c8run packager
       run: go build -o packager ./cmd/packager
       shell: bash

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -289,6 +289,11 @@ jobs:
         run: go build -o c8run.exe ./cmd/c8run
         working-directory: .\c8run
 
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Build c8run packager
         run: go build -o packager.exe ./cmd/packager
         working-directory: .\c8run

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -168,7 +168,7 @@ func createZipArchive(filesToArchive []string, outputPath, sourceRoot, targetRoo
 }
 
 func BuildJavaScripts() error {
-	javaVersionCmd := exec.Command("javac", "JavaVersion.java")
+	javaVersionCmd := exec.Command("javac", "--release", "21", "JavaVersion.java")
 	var out strings.Builder
 	var stderr strings.Builder
 	javaVersionCmd.Stdout = &out
@@ -177,7 +177,7 @@ func BuildJavaScripts() error {
 	if err != nil {
 		return fmt.Errorf("failed to compile JavaVersion : %w", err)
 	}
-	javaHomeCmd := exec.Command("javac", "JavaHome.java")
+	javaHomeCmd := exec.Command("javac", "--release", "21", "JavaHome.java")
 	javaHomeCmd.Stdout = &out
 	javaHomeCmd.Stderr = &stderr
 	err = javaHomeCmd.Run()


### PR DESCRIPTION
## Problem

When packaging C8Run on macOS runners that have Java 25 installed (following the `macos-latest` runner upgrade), `javac` compiles `JavaVersion.java` and `JavaHome.java` targeting the host JDK version (class file version 69 = Java 25). The resulting `.class` files cannot be loaded on user machines running Java 21–24, breaking startup with `UnsupportedClassVersionError` for the majority of self-managed users.

## Fix

Add `--release 21` to both `javac` invocations in `BuildJavaScripts()` so the compiled helpers always target Java 21, regardless of the JDK version used during packaging. The `--release` flag ensures compatibility with Java 21, 22, 23, 24, and 25.

## Verification

After re-releasing 8.8.25 with this fix, `JavaVersion.class` will be class file version 65 (Java 21) and run correctly on any JVM 21+.