### PR TITLE
fix: compile JavaVersion helper with --release 21 for Java 21-25 compatibility

### DIFF
--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -198,7 +198,7 @@ func createZipArchive(filesToArchive []string, outputPath, sourceRoot, targetRoo
 }
 
 func BuildJavaScripts() error {
-	javaVersionCmd := exec.Command("javac", "JavaVersion.java")
+	javaVersionCmd := exec.Command("javac", "--release", "21", "JavaVersion.java")
 	var out strings.Builder
 	var stderr strings.Builder
 	javaVersionCmd.Stdout = &out
@@ -207,7 +207,7 @@ func BuildJavaScripts() error {
 	if err != nil {
 		return fmt.Errorf("failed to compile JavaVersion : %w", err)
 	}
-	javaHomeCmd := exec.Command("javac", "JavaHome.java")
+	javaHomeCmd := exec.Command("javac", "--release", "21", "JavaHome.java")
 	javaHomeCmd.Stdout = &out
 	javaHomeCmd.Stderr = &stderr
 	err = javaHomeCmd.Run()


### PR DESCRIPTION
## Problem

When packaging C8Run on macOS runners that have Java 25 installed (following the `macos-latest` runner upgrade), `javac` compiles `JavaVersion.java` and `JavaHome.java` targeting the host JDK version (class file version 69 = Java 25). The resulting `.class` files cannot be loaded on user machines running Java 21–24, breaking startup with `UnsupportedClassVersionError` for the majority of self-managed users.

## Fix

Add `--release 21` to both `javac` invocations in `BuildJavaScripts()` so the compiled helpers always target Java 21, regardless of the JDK version used during packaging. The `--release` flag ensures compatibility with Java 21, 22, 23, 24, and 25.

## Verification

After re-releasing 8.9.6 with this fix, `JavaVersion.class` will be class file version 65 (Java 21) and run correctly on any JVM 21+.