### PR TITLE
ci: set up Java 21 before c8run packager on stable/8.9

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -165,6 +165,12 @@ runs:
       shell: bash
       working-directory: ./c8run
 
+    - name: Set up Java 21 for C8Run packaging
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        distribution: "temurin"
+        java-version: "21"
+
     - name: Build c8run packager
       run: go build -o packager ./cmd/packager
       shell: bash

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -289,6 +289,11 @@ jobs:
         run: go build -o c8run.exe ./cmd/c8run
         working-directory: .\c8run
 
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Build c8run packager
         run: go build -o packager.exe ./cmd/packager
         working-directory: .\c8run


### PR DESCRIPTION
## Context

PR #54867 added `--release 21` to the `javac` calls in `BuildJavaScripts()`. However, the CI runners on `stable/8.9` don't have an explicit `setup-java` step before the packager runs. The runner's default javac (< 21) rejects `--release 21` with exit status 2.

## Changes

- `.github/actions/setup-c8run/action.yml`: add `setup-java` (temurin 21) before building and running the packager
- `.github/workflows/c8run-build.yaml`: same fix for the Windows job

## Validation

Tested locally — `JavaVersion.class` compiles to class file version 65 (Java 21) and runs on Java 21–25.

Closes #54867 CI regression.