### PR TITLE
deps: bump elasticsearch client to 8.19.16

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
@@ -52,7 +52,7 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -293,7 +293,7 @@ public class BackupControllerIT {
                 b.index("1")
                     .indexUuid("uuid")
                     .nodeId("someNodeId1")
-                    .shardId("someIndex1" + UUID.randomUUID() + 1)
+                    .shardId(ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE))
                     .status("FAILURE")
                     .reason("Shard 1 is not allocated"));
     final SnapshotShardFailure failure2 =
@@ -302,7 +302,7 @@ public class BackupControllerIT {
                 b.index("2")
                     .indexUuid("uuid2")
                     .nodeId("someNodeId2")
-                    .shardId("someIndex2" + UUID.randomUUID() + 2)
+                    .shardId(ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE))
                     .status("FAILURE")
                     .reason("Shard 2 is not allocated"));
     final List<SnapshotShardFailure> shardFailures = asList(failure1, failure2);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/util/DateHistogramFilterUtilES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/util/DateHistogramFilterUtilES.java
@@ -188,19 +188,17 @@ public final class DateHistogramFilterUtilES {
                             FieldDateMath.of(
                                 f ->
                                     f.value(
-                                        (double)
-                                            start
-                                                .atZoneSameInstant(context.getTimezone())
-                                                .toInstant()
-                                                .toEpochMilli())))
+                                        start
+                                            .atZoneSameInstant(context.getTimezone())
+                                            .toInstant()
+                                            .toEpochMilli())))
                         .max(
                             FieldDateMath.of(
                                 f ->
                                     f.value(
-                                        (double)
-                                            filterEnd
-                                                .atZoneSameInstant(context.getTimezone())
-                                                .toInstant()
-                                                .toEpochMilli())))));
+                                        filterEnd
+                                            .atZoneSameInstant(context.getTimezone())
+                                            .toInstant()
+                                            .toEpochMilli())))));
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/service/DateAggregationServiceES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/service/DateAggregationServiceES.java
@@ -203,8 +203,8 @@ public class DateAggregationServiceES extends DateAggregationService {
 
       builder.extendedBounds(
           e ->
-              e.min(FieldDateMath.of(f -> f.value(context.getMinMaxStats().getMin())))
-                  .max(FieldDateMath.of(f -> f.value(context.getMinMaxStats().getMax()))));
+              e.min(FieldDateMath.of(f -> f.value((long) context.getMinMaxStats().getMin())))
+                  .max(FieldDateMath.of(f -> f.value((long) context.getMinMaxStats().getMax()))));
     }
 
     return Pair.of(context.getDateAggregationName().orElse(DATE_AGGREGATION), builder);

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -60,7 +60,7 @@
 
     <!-- DATABASE -->
     <!-- Elasticsearch-->
-    <version.elasticsearch>8.16.6</version.elasticsearch>
+    <version.elasticsearch>8.19.16</version.elasticsearch>
     <!-- The least supported elasticsearch version we should test against-->
     <elasticsearch.test.version>8.16.6</elasticsearch.test.version>
     <!-- The ElasticSearch version of the previous Optimize version -->

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/DefaultIndexMappingCreator.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/DefaultIndexMappingCreator.java
@@ -14,10 +14,10 @@ import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
 import co.elastic.clients.elasticsearch._types.mapping.DynamicTemplate;
 import co.elastic.clients.elasticsearch._types.mapping.IndexOptions;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.clients.util.NamedValue;
 import io.camunda.optimize.service.db.es.schema.PropertiesAppender;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.io.IOException;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +59,7 @@ public abstract class DefaultIndexMappingCreator<TBuilder>
 
   protected TypeMapping.Builder addDynamicTemplates(final TypeMapping.Builder builder) {
     return builder.dynamicTemplates(
-        Map.of(
+        NamedValue.of(
             "string_template",
             DynamicTemplate.of(
                 t ->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
     <version.commons-text>1.14.0</version.commons-text>
     <version.cron-utils>9.2.1</version.cron-utils>
     <version.docker-java-api>3.7.1</version.docker-java-api>
-    <version.elasticsearch>8.16.6</version.elasticsearch>
+    <version.elasticsearch>8.19.16</version.elasticsearch>
     <version.error-prone>2.41.0</version.error-prone>
     <version.grpc>1.76.3</version.grpc>
     <version.gson>2.13.2</version.gson>

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
@@ -208,7 +208,7 @@ public class ElasticsearchDataStoreClientTest {
   }
 
   private SearchResponse<TestDocument> createDefaultSearchResponse(
-      long totalHits, TotalHitsRelation totalHitsRelation) {
+      final long totalHits, final TotalHitsRelation totalHitsRelation) {
     return SearchResponse.of(
         (f) ->
             f.took(122)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Bump Elasticsearch client to `8.19.16` to fix the serialization issue reported [here](https://github.com/camunda/camunda/issues/45809).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #45809 
