### PR TITLE
fix: remove supportedElementTypes from WaitStateTransformerConfig

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.exporter.common.waitstate;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 
 /**
  * Predefined {@link WaitStateTransformerConfig}s for common use cases, e.g. for jobs. These can be
@@ -26,11 +25,6 @@ public final class WaitStateConfigs {
           .withAddIntents(JobIntent.CREATED)
           .withUpdateIntents(JobIntent.MIGRATED)
           .withRemoveIntents(JobIntent.COMPLETED, JobIntent.CANCELED)
-          .withSupportedElementTypes(
-              BpmnElementType.SERVICE_TASK,
-              BpmnElementType.SCRIPT_TASK,
-              BpmnElementType.SEND_TASK,
-              BpmnElementType.BUSINESS_RULE_TASK)
           .withWaitStateType(WaitStateType.JOB);
 
   private WaitStateConfigs() {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateTransformer.java
@@ -49,12 +49,6 @@ public interface WaitStateTransformer<R extends RecordValue & WaitStateRelated> 
           e);
     }
 
-    final var elementType = waitStateEntry.getElementType();
-    if (elementType == null || !config().supportedElementTypes().contains(elementType)) {
-      final var errorMsg = "Undefined or unsupported element type: %s".formatted(elementType);
-      LOG.error(errorMsg);
-    }
-
     return waitStateEntry;
   }
 

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateTransformerConfig.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateTransformerConfig.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Set;
 
 /**
@@ -25,52 +24,30 @@ public record WaitStateTransformerConfig(
     Set<Intent> addIntents,
     Set<Intent> updateIntents,
     Set<Intent> removeIntents,
-    Set<BpmnElementType> supportedElementTypes,
     WaitStateType waitStateType) {
 
   public static WaitStateTransformerConfig of(final ValueType valueType) {
-    return new WaitStateTransformerConfig(valueType, Set.of(), Set.of(), Set.of(), Set.of(), null);
+    return new WaitStateTransformerConfig(valueType, Set.of(), Set.of(), Set.of(), null);
   }
 
   public WaitStateTransformerConfig withAddIntents(final Intent... intents) {
     return new WaitStateTransformerConfig(
-        valueType,
-        Set.of(intents),
-        updateIntents,
-        removeIntents,
-        supportedElementTypes,
-        waitStateType);
+        valueType, Set.of(intents), updateIntents, removeIntents, waitStateType);
   }
 
   public WaitStateTransformerConfig withUpdateIntents(final Intent... intents) {
     return new WaitStateTransformerConfig(
-        valueType,
-        addIntents,
-        Set.of(intents),
-        removeIntents,
-        supportedElementTypes,
-        waitStateType);
+        valueType, addIntents, Set.of(intents), removeIntents, waitStateType);
   }
 
   public WaitStateTransformerConfig withRemoveIntents(final Intent... intents) {
     return new WaitStateTransformerConfig(
-        valueType,
-        addIntents,
-        updateIntents,
-        Set.of(intents),
-        supportedElementTypes,
-        waitStateType);
-  }
-
-  public WaitStateTransformerConfig withSupportedElementTypes(
-      final BpmnElementType... elementTypes) {
-    return new WaitStateTransformerConfig(
-        valueType, addIntents, updateIntents, removeIntents, Set.of(elementTypes), waitStateType);
+        valueType, addIntents, updateIntents, Set.of(intents), waitStateType);
   }
 
   public WaitStateTransformerConfig withWaitStateType(final WaitStateType waitStateType) {
     return new WaitStateTransformerConfig(
-        valueType, addIntents, updateIntents, removeIntents, supportedElementTypes, waitStateType);
+        valueType, addIntents, updateIntents, removeIntents, waitStateType);
   }
 
   public boolean supports(final Record<?> record) {


### PR DESCRIPTION
## Summary

- Removes `supportedElementTypes` from `WaitStateTransformerConfig` — the field served as a static allowlist of `BpmnElementType` values, but execution/task listener jobs carry the *host* element's type (e.g. `PROCESS`, `SUB_PROCESS`, `USER_TASK`, `CALL_ACTIVITY`), none of which were in the list
- Removes the `LOG.error("Undefined or unsupported element type: %s")` call in `WaitStateTransformer.transform()` that fired for every such record, causing false alerts in monitoring systems
- The allowlist provided no safety value: `triggersAdd`/`triggersUpdate` already gate on record intent; all element types that produce `JOB` records with those intents are valid wait-state candidates

## Test plan

- [ ] `zeebe/exporter-common` unit tests pass (285 tests, verified locally)
- [ ] No new ERROR log for processes with execution listeners on `PROCESS`, `SUB_PROCESS`, or task listeners on `USER_TASK`

Closes #54652

🤖 Generated with [Claude Code](https://claude.com/claude-code)