### PR TITLE
docs: add packaging validation checks to c8run testing guide

### DIFF
--- a/c8run/docs/testing-guide.md
+++ b/c8run/docs/testing-guide.md
@@ -31,14 +31,19 @@ For packaging changes:
 - Verify the archive file list — the expected set of files must be present
 - Verify that runtime artifacts (PID files, `log/`, `camunda-data/`, `jre/`, extracted dirs, built binaries) are not included in the archive
 - Verify `JavaVersion.class` is compiled at class file version 65 (Java 21), not the version of whatever javac happened to be in PATH:
+
   ```bash
   file c8run/JavaVersion.class | grep "version 65.0"
   ```
+
   A higher version (e.g. 69 = Java 25) means `BuildJavaScripts()` ran without `--release 21` or without a pinned Java version before the packager step. The artifact will crash with `UnsupportedClassVersionError` on users with Java 21–24. Two conditions must both hold: `BuildJavaScripts()` must pass `--release 21` to `javac`, and the packaging step in both `.github/actions/setup-c8run/action.yml` and `.github/workflows/c8run-build.yaml` must call `setup-java` (temurin 21) **before** invoking the packager — relying on the runner default is not safe.
+
 - For macOS builds, verify the bundled JRE is signed with JIT entitlements (required for JVM JIT under the hardened runtime on Apple Silicon):
+
   ```bash
   codesign -d --entitlements - c8run/jre/bin/java 2>&1 | grep "allow-jit"
   ```
+
   Missing entitlements cause an immediate `EXC_BREAKPOINT` crash (`signal: trace/BPT trap`) during `Threads::create_vm` on M-series Macs. See `.github/actions/sign-and-notarize/sign_and_notarize.sh` for the required entitlements plist.
 
 ## E2E Tests

--- a/c8run/docs/testing-guide.md
+++ b/c8run/docs/testing-guide.md
@@ -30,6 +30,16 @@ For packaging changes:
 
 - Verify the archive file list — the expected set of files must be present
 - Verify that runtime artifacts (PID files, `log/`, `camunda-data/`, `jre/`, extracted dirs, built binaries) are not included in the archive
+- Verify `JavaVersion.class` is compiled at class file version 65 (Java 21), not the version of whatever javac happened to be in PATH:
+  ```bash
+  file c8run/JavaVersion.class | grep "version 65.0"
+  ```
+  A higher version (e.g. 69 = Java 25) means the packager ran without an explicit `setup-java` step and the artifact will crash with `UnsupportedClassVersionError` on users with Java 21–24. The packaging step in both `setup-c8run/action.yml` and `c8run-build.yaml` must run `setup-java` (temurin 21) **before** invoking the packager.
+- For macOS builds, verify the bundled JRE is signed with JIT entitlements (required for JVM JIT under the hardened runtime on Apple Silicon):
+  ```bash
+  codesign -d --entitlements - c8run/jre/bin/java 2>&1 | grep "allow-jit"
+  ```
+  Missing entitlements cause an immediate `EXC_BREAKPOINT` crash (`signal: trace/BPT trap`) during `Threads::create_vm` on M-series Macs. See `sign_and_notarize.sh` for the required plist.
 
 ## E2E Tests
 

--- a/c8run/docs/testing-guide.md
+++ b/c8run/docs/testing-guide.md
@@ -34,12 +34,12 @@ For packaging changes:
   ```bash
   file c8run/JavaVersion.class | grep "version 65.0"
   ```
-  A higher version (e.g. 69 = Java 25) means the packager ran without an explicit `setup-java` step and the artifact will crash with `UnsupportedClassVersionError` on users with Java 21–24. The packaging step in both `setup-c8run/action.yml` and `c8run-build.yaml` must run `setup-java` (temurin 21) **before** invoking the packager.
+  A higher version (e.g. 69 = Java 25) means `BuildJavaScripts()` ran without `--release 21` or without a pinned Java version before the packager step. The artifact will crash with `UnsupportedClassVersionError` on users with Java 21–24. Two conditions must both hold: `BuildJavaScripts()` must pass `--release 21` to `javac`, and the packaging step in both `.github/actions/setup-c8run/action.yml` and `.github/workflows/c8run-build.yaml` must call `setup-java` (temurin 21) **before** invoking the packager — relying on the runner default is not safe.
 - For macOS builds, verify the bundled JRE is signed with JIT entitlements (required for JVM JIT under the hardened runtime on Apple Silicon):
   ```bash
   codesign -d --entitlements - c8run/jre/bin/java 2>&1 | grep "allow-jit"
   ```
-  Missing entitlements cause an immediate `EXC_BREAKPOINT` crash (`signal: trace/BPT trap`) during `Threads::create_vm` on M-series Macs. See `sign_and_notarize.sh` for the required plist.
+  Missing entitlements cause an immediate `EXC_BREAKPOINT` crash (`signal: trace/BPT trap`) during `Threads::create_vm` on M-series Macs. See `.github/actions/sign-and-notarize/sign_and_notarize.sh` for the required entitlements plist.
 
 ## E2E Tests
 


### PR DESCRIPTION
## Summary

Adds two packaging validation checks to `docs/testing-guide.md` following the June 2026 release incident where c8run artifacts shipped broken for users on Java 21–24 (class file version mismatch) and crashed on Apple Silicon macOS (missing JIT entitlements).

- Document how to verify `JavaVersion.class` is at class file version 65 (Java 21), and explain the root cause when it's not
- Document how to verify the bundled JRE is signed with JIT entitlements on macOS, and explain the crash it prevents

Relates to #54876 and #54877.