### PR TITLE
fix: compile JavaVersion helper with --release 21 and set up Java before packager on stable/8.7

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -175,6 +175,12 @@ runs:
       shell: bash
       working-directory: ./c8run
 
+    - name: Set up Java 21 for C8Run packaging
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        distribution: "temurin"
+        java-version: "21"
+
     - name: Build c8run packager
       run: go build -o packager ./cmd/packager
       shell: bash

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -220,6 +220,11 @@ jobs:
         run: go build -o c8run.exe .\cmd\c8run
         working-directory: .\c8run
 
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Build c8run packager
         run: go build -o packager.exe .\cmd\packager
         working-directory: .\c8run

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -142,7 +142,7 @@ func createZipArchive(filesToArchive []string, outputPath, sourceRoot, targetRoo
 }
 
 func BuildJavaScripts() error {
-	javaVersionCmd := exec.Command("javac", "JavaVersion.java")
+	javaVersionCmd := exec.Command("javac", "--release", "21", "JavaVersion.java")
 	var out strings.Builder
 	var stderr strings.Builder
 	javaVersionCmd.Stdout = &out
@@ -151,7 +151,7 @@ func BuildJavaScripts() error {
 	if err != nil {
 		return fmt.Errorf("failed to compile JavaVersion : %w", err)
 	}
-	javaHomeCmd := exec.Command("javac", "JavaHome.java")
+	javaHomeCmd := exec.Command("javac", "--release", "21", "JavaHome.java")
 	javaHomeCmd.Stdout = &out
 	javaHomeCmd.Stderr = &stderr
 	err = javaHomeCmd.Run()


### PR DESCRIPTION
## Problem

If 8.7 is repackaged today, `macos-latest` runners default to Java 25, causing `JavaVersion.class` to be compiled at class file version 69. Users on Java 21–23 (the only supported range for 8.7, since ES 8.13.4 caps at Java 23) would hit `UnsupportedClassVersionError` at startup.

Same regression that hit 8.8.25 and 8.9.6 in June 2026 (#54876). 8.7.30 was unaffected only because it was packaged before the runner upgrade.

## Changes

- `c8run/internal/packages/package.go`: add `--release 21` to both `javac` calls in `BuildJavaScripts()`
- `.github/actions/setup-c8run/action.yml`: add `setup-java` (temurin 21) before the packager
- `.github/workflows/c8run-build.yaml`: same fix for the Windows job

## Related PRs (same fix, other stable branches)

- stable/8.8: #54866 (merged)
- stable/8.9 `--release 21`: #54867 (merged)
- stable/8.9 CI `setup-java`: #54868 (merged)

## Relates to

#54876