### PR TITLE
test: fix migration incident verification for multi-incident instance

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -1006,7 +1006,10 @@ class OperateProcessInstancePage {
       await this.clickOnElementInDiagram(elementId);
     }
     await this.clickIncidentsTab();
-    await this.verifyIncidentCount(errorTypes.length);
+    // The incidents view header always reports the instance-wide incident
+    // total and is not filtered by the selected flow node, so it cannot be
+    // compared against the per-element errorTypes length. Verify instead that
+    // each expected incident row is present for the migrated instance.
     for (const errorType of errorTypes) {
       const incidentRow = await this.getIncidentRowByErrorType(errorType);
       await expect(incidentRow).toBeVisible({timeout: 30000});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -1006,10 +1006,14 @@ class OperateProcessInstancePage {
       await this.clickOnElementInDiagram(elementId);
     }
     await this.clickIncidentsTab();
-    // The incidents view header always reports the instance-wide incident
-    // total and is not filtered by the selected flow node, so it cannot be
-    // compared against the per-element errorTypes length. Verify instead that
-    // each expected incident row is present for the migrated instance.
+    // When a flow node is selected the incidents view switches to the
+    // element-scoped query, so the header count reflects only the selected
+    // element's incidents. That query may still be resolving (the header can
+    // briefly show the stale instance-wide total), so poll the count until it
+    // settles instead of reading it once.
+    await expect
+      .poll(() => this.getIncidentCount(), {timeout: 30000})
+      .toBe(errorTypes.length);
     for (const errorType of errorTypes) {
       const incidentRow = await this.getIncidentRowByErrorType(errorType);
       await expect(incidentRow).toBeVisible({timeout: 30000});


### PR DESCRIPTION
## Problem

The nightly `Migrated process instances` E2E test (`tests/operate/processInstanceMigration.spec.ts`) failed with:

```
Error: expect(received).toBe(expected) // Object.is equality
Expected: 1
Received: 2
```

at the `Verify Business rule task incident migration` step.

## Root cause

The migrated instance legitimately has **two** incidents:

- `Called decision error.` on **Business rule task 2** (`BusinessRuleTask2`)
- `Extract value error.` on **Exclusive gateway 2** (`ExclusiveGateway2`)

`verifyIncidents(errorTypes, elementId)` clicks the element in the diagram, opens the Incidents tab, then asserts the incidents-view header count equals `errorTypes.length` (1).

The header count **is** supposed to be per-element: when a flow node is selected, the Incidents tab switches from the process-instance incidents query to the **element-instance** incidents query (`useGetIncidentsByElementInstancePaginated`), so the `"N results"` header reflects only the selected element's incidents — which is `1` for `BusinessRuleTask2`. The expected value of `1` is therefore correct.

The failure was a **race**, not a wrong expectation: `getIncidentCount()` read the header once with a non-retrying `innerText()`, capturing the **stale instance-wide total (2)** before the element-scoped query had resolved.

## Fix

Replace the one-shot read with a retrying `expect.poll(...)` of `getIncidentCount()` so the assertion waits for the element-scoped query to settle before comparing against the per-element `errorTypes.length`. This fixes the flakiness while **preserving** the per-element count check (rather than dropping it). `getIncidentCount`/`verifyIncidentCount` remain unchanged for their other callers.

Nightly run: https://github.com/camunda/camunda/actions/runs/27178981212

## Validation
https://github.com/camunda/camunda/actions/runs/27193479538/job/80279446156 🟢 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
