### PR TITLE
feat: add native user task wait state tracking

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/UserTaskWaitStateDetails.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/UserTaskWaitStateDetails.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.enums;
+package io.camunda.client.api.search.response;
 
-public enum WaitStateType {
-  JOB,
-  MESSAGE,
-  USER_TASK,
-  UNKNOWN_ENUM_VALUE;
+/** Details of an element instance waiting on a native Camunda user task. */
+public interface UserTaskWaitStateDetails extends WaitStateDetails {
+
+  String getTaskKey();
+
+  String getDueDate();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
@@ -61,6 +61,9 @@ public class ElementInstanceWaitStateResultImpl implements ElementInstanceWaitSt
       case MESSAGE:
         return new MessageWaitStateDetailsImpl(
             (io.camunda.client.protocol.rest.MessageWaitStateDetails) item);
+      case USER_TASK:
+        return new UserTaskWaitStateDetailsImpl(
+            (io.camunda.client.protocol.rest.UserTaskWaitStateDetails) item);
       default:
         return null;
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskWaitStateDetailsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskWaitStateDetailsImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.UserTaskWaitStateDetails;
+
+public class UserTaskWaitStateDetailsImpl implements UserTaskWaitStateDetails {
+
+  private final String taskKey;
+  private final String dueDate;
+
+  public UserTaskWaitStateDetailsImpl(
+      final io.camunda.client.protocol.rest.UserTaskWaitStateDetails details) {
+    taskKey = details.getTaskKey();
+    dueDate = details.getDueDate();
+  }
+
+  @Override
+  public WaitStateType getWaitStateType() {
+    return WaitStateType.USER_TASK;
+  }
+
+  @Override
+  public String getTaskKey() {
+    return taskKey;
+  }
+
+  @Override
+  public String getDueDate() {
+    return dueDate;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/elementinstancewaitstate/SearchElementInstanceWaitStatesTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstancewaitstate/SearchElementInstanceWaitStatesTest.java
@@ -27,6 +27,7 @@ import io.camunda.client.api.search.enums.WaitStateType;
 import io.camunda.client.api.search.response.JobWaitStateDetails;
 import io.camunda.client.api.search.response.MessageWaitStateDetails;
 import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.response.UserTaskWaitStateDetails;
 import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
 import io.camunda.client.protocol.rest.ElementInstanceWaitStateFilter;
@@ -245,6 +246,42 @@ public class SearchElementInstanceWaitStatesTest extends ClientRestTest {
     assertThat(details.getWaitStateType()).isEqualTo(WaitStateType.MESSAGE);
     assertThat(details.getMessageName()).isEqualTo("order-received");
     assertThat(details.getCorrelationKey()).isEqualTo("order-42");
+  }
+
+  @Test
+  public void shouldMapUserTaskResponseFields() {
+    // given
+    final io.camunda.client.protocol.rest.UserTaskWaitStateDetails userTaskDetails =
+        new io.camunda.client.protocol.rest.UserTaskWaitStateDetails();
+    userTaskDetails.setTaskKey("999");
+    userTaskDetails.setDueDate("2026-10-13T10:00:00+01:00");
+
+    final io.camunda.client.protocol.rest.ElementInstanceWaitStateResult item =
+        new io.camunda.client.protocol.rest.ElementInstanceWaitStateResult();
+    item.setProcessInstanceKey("200");
+    item.setElementInstanceKey("300");
+    item.setElementId("approve-1");
+    item.setTenantId("<default>");
+    item.setDetails(userTaskDetails);
+
+    final ElementInstanceWaitStateQueryResult response = buildEmptyResponse();
+    response.addItemsItem(item);
+    gatewayService.onSearchElementInstanceWaitStatesRequest(response);
+
+    // when
+    final SearchResponse<io.camunda.client.api.search.response.ElementInstanceWaitStateResult>
+        result = client.newElementInstanceWaitStateSearchRequest().send().join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    final io.camunda.client.api.search.response.ElementInstanceWaitStateResult mapped =
+        result.items().get(0);
+    assertThat(mapped.getWaitStateType()).isEqualTo(WaitStateType.USER_TASK);
+    assertThat(mapped.getDetails()).isInstanceOf(UserTaskWaitStateDetails.class);
+    final UserTaskWaitStateDetails details = (UserTaskWaitStateDetails) mapped.getDetails();
+    assertThat(details.getWaitStateType()).isEqualTo(WaitStateType.USER_TASK);
+    assertThat(details.getTaskKey()).isEqualTo("999");
+    assertThat(details.getDueDate()).isEqualTo("2026-10-13T10:00:00+01:00");
   }
 
   private static ElementInstanceWaitStateQueryResult buildEmptyResponse() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.WaitStateDetails.WaitStateType;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
+import io.camunda.search.entities.WaitStateUserTaskDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +58,7 @@ public class WaitStateEntityMapper {
       return switch (type) {
         case JOB -> OBJECT_MAPPER.readValue(detailsJson, WaitStateJobDetails.class);
         case MESSAGE -> OBJECT_MAPPER.readValue(detailsJson, WaitStateMessageDetails.class);
+        case USER_TASK -> OBJECT_MAPPER.readValue(detailsJson, WaitStateUserTaskDetails.class);
       };
     } catch (final Exception e) {
       LOG.warn("Failed to parse wait state details for type {}: {}", waitStateType, e.getMessage());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -153,6 +153,7 @@ import io.camunda.gateway.protocol.model.UserSearchResult;
 import io.camunda.gateway.protocol.model.UserTaskResult;
 import io.camunda.gateway.protocol.model.UserTaskSearchQueryResult;
 import io.camunda.gateway.protocol.model.UserTaskStateEnum;
+import io.camunda.gateway.protocol.model.UserTaskWaitStateDetails;
 import io.camunda.gateway.protocol.model.VariableResult;
 import io.camunda.gateway.protocol.model.VariableSearchQueryResult;
 import io.camunda.gateway.protocol.model.VariableSearchResult;
@@ -211,6 +212,7 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
+import io.camunda.search.entities.WaitStateUserTaskDetails;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.api.model.user.CamundaUserDTO;
@@ -703,6 +705,14 @@ public final class SearchQueryResponseMapper {
                       .waitStateType(WaitStateTypeEnum.MESSAGE.name())
                       .messageName(messageName)
                       .correlationKey(correlationKey)
+                      .build())
+              .build();
+      case WaitStateUserTaskDetails(final var taskKey, final var dueDate) ->
+          base.details(
+                  UserTaskWaitStateDetails.Builder.create()
+                      .waitStateType(WaitStateTypeEnum.USER_TASK.name())
+                      .taskKey(keyToString(taskKey))
+                      .dueDate(dueDate == null || dueDate.isBlank() ? null : dueDate)
                       .build())
               .build();
     };

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateUserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateUserTaskIT.java
@@ -141,6 +141,11 @@ public class WaitStateUserTaskIT {
               assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.USER_TASK);
               assertThat(item.getRootProcessInstanceKey())
                   .isEqualTo(String.valueOf(rootProcessInstanceKey));
+              // root-task and child-task have no due date configured — dueDate must be null,
+              // not an empty string
+              assertThat(item.getDetails())
+                  .isInstanceOfSatisfying(
+                      UserTaskWaitStateDetails.class, d -> assertThat(d.getDueDate()).isNull());
             });
     assertThat(byRoot.items())
         .extracting(ElementInstanceWaitStateResult::getElementId)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateUserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateUserTaskIT.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.waitstate;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
+import io.camunda.client.api.search.response.UserTaskWaitStateDetails;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the element instance wait-state search command against native Camunda user tasks (tasks
+ * declared with {@code zeebeUserTask()}). A native user task does not create a BPMN_ELEMENT job, so
+ * it produces a dedicated {@code USER_TASK} wait state carrying the task key and due date.
+ *
+ * <p>The shared {@code @BeforeAll} fixture starts a single-instance process and a root → child
+ * call-activity hierarchy, exercising single-instance and cross-process-instance tracking.
+ * Migration and removal (complete/cancel) are exercised in self-contained tests with dedicated
+ * processes.
+ */
+@MultiDbTest
+public class WaitStateUserTaskIT {
+
+  private static final String SINGLE_PROCESS_ID = "waitStateUserTaskSingle";
+  private static final String ROOT_PROCESS_ID = "waitStateUserTaskRoot";
+  private static final String CHILD_PROCESS_ID = "waitStateUserTaskChild";
+
+  private static final String SINGLE_TASK = "single-task";
+  private static final String ROOT_TASK = "root-task";
+  private static final String CHILD_TASK = "child-task";
+
+  private static final String DUE_DATE = "2026-10-13T10:00:00Z";
+
+  private static CamundaClient camundaClient;
+
+  private static long rootProcessInstanceKey;
+
+  @BeforeAll
+  static void beforeAll() {
+    final BpmnModelInstance singleProcess =
+        Bpmn.createExecutableProcess(SINGLE_PROCESS_ID)
+            .startEvent()
+            .userTask(SINGLE_TASK, t -> t.zeebeUserTask().zeebeDueDate(DUE_DATE))
+            .endEvent()
+            .done();
+
+    // Root process: one branch is a native user task, another calls the child process.
+    final BpmnModelInstance rootProcess =
+        Bpmn.createExecutableProcess(ROOT_PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .userTask(ROOT_TASK, t -> t.zeebeUserTask())
+            .moveToNode("fork")
+            .callActivity("call-activity")
+            .zeebeProcessId(CHILD_PROCESS_ID)
+            .done();
+    final BpmnModelInstance childProcess =
+        Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+            .startEvent()
+            .userTask(CHILD_TASK, t -> t.zeebeUserTask())
+            .endEvent()
+            .done();
+
+    deployResource(camundaClient, singleProcess, "waitStateUserTaskSingle.bpmn");
+    deployResource(camundaClient, rootProcess, "waitStateUserTaskRoot.bpmn");
+    deployResource(camundaClient, childProcess, "waitStateUserTaskChild.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 3);
+
+    startProcessInstance(camundaClient, SINGLE_PROCESS_ID);
+    rootProcessInstanceKey =
+        startProcessInstance(camundaClient, ROOT_PROCESS_ID).getProcessInstanceKey();
+    // single instance + root instance + child instance (via call activity)
+    waitForProcessInstancesToStart(camundaClient, 3);
+
+    // single-task + root-task + child-task
+    waitForWaitStates(3);
+  }
+
+  @Test
+  void shouldReturnUserTaskWaitStateForSingleInstance() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.elementId(SINGLE_TASK))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    final var item = result.items().getFirst();
+    assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.USER_TASK);
+    assertThat(item.getElementType()).isEqualTo(WaitStateElementType.USER_TASK);
+    assertThat(item.getElementId()).isEqualTo(SINGLE_TASK);
+    assertThat(item.getDetails()).isInstanceOf(UserTaskWaitStateDetails.class);
+    final var details = (UserTaskWaitStateDetails) item.getDetails();
+    assertThat(details.getWaitStateType()).isEqualTo(WaitStateType.USER_TASK);
+    assertThat(details.getTaskKey()).isNotNull();
+    assertThat(OffsetDateTime.parse(details.getDueDate()))
+        .isEqualTo(OffsetDateTime.parse(DUE_DATE));
+  }
+
+  @Test
+  void shouldTrackUserTaskWaitStatesAcrossCallActivity() {
+    // when — both root and child user tasks share the root process instance key
+    final var byRoot =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.rootProcessInstanceKey(rootProcessInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(byRoot.items()).hasSize(2);
+    assertThat(byRoot.items())
+        .allSatisfy(
+            item -> {
+              assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.USER_TASK);
+              assertThat(item.getRootProcessInstanceKey())
+                  .isEqualTo(String.valueOf(rootProcessInstanceKey));
+            });
+    assertThat(byRoot.items())
+        .extracting(ElementInstanceWaitStateResult::getElementId)
+        .containsExactlyInAnyOrder(ROOT_TASK, CHILD_TASK);
+
+    // when — the child user task lives in its own (child) process instance
+    final var child = byElementId(byRoot.items(), CHILD_TASK);
+    final long childProcessInstanceKey = Long.parseLong(child.getProcessInstanceKey());
+    assertThat(childProcessInstanceKey).isNotEqualTo(rootProcessInstanceKey);
+
+    final var byChild =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.processInstanceKey(childProcessInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(byChild.items()).hasSize(1);
+    assertThat(byChild.items().getFirst().getElementId()).isEqualTo(CHILD_TASK);
+  }
+
+  @Test
+  void shouldRemoveWaitStateWhenUserTaskIsCompleted() {
+    // given — a dedicated single-task process, isolated from the shared @BeforeAll state
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateUserTaskRemoval")
+            .startEvent()
+            .userTask("removal-task", t -> t.zeebeUserTask())
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateUserTaskRemoval.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateUserTaskRemoval").getProcessInstanceKey();
+
+    final long userTaskKey = awaitSingleWaitStateTaskKey(pik);
+
+    // when — complete the user task
+    camundaClient.newCompleteUserTaskCommand(userTaskKey).send().join();
+
+    // then — wait state is removed
+    awaitNoWaitState(pik);
+  }
+
+  @Test
+  void shouldRemoveWaitStateWhenUserTaskInstanceIsCanceled() {
+    // given — a dedicated single-task process, isolated from the shared @BeforeAll state
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateUserTaskCancellation")
+            .startEvent()
+            .userTask("cancellation-task", t -> t.zeebeUserTask())
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateUserTaskCancellation.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateUserTaskCancellation")
+            .getProcessInstanceKey();
+    awaitSingleWaitStateTaskKey(pik);
+
+    // when — cancel the process instance, which cancels the active user task
+    camundaClient.newCancelInstanceCommand(pik).send().join();
+
+    // then — wait state is removed
+    awaitNoWaitState(pik);
+  }
+
+  @Test
+  void shouldUpdateWaitStateDueDateWhenUserTaskIsUpdated() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateUserTaskUpdate")
+            .startEvent()
+            .userTask("update-task", t -> t.zeebeUserTask().zeebeDueDate(DUE_DATE))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateUserTaskUpdate.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateUserTaskUpdate").getProcessInstanceKey();
+    final long userTaskKey = awaitSingleWaitStateTaskKey(pik);
+
+    final String newDueDate = "2027-01-01T00:00:00Z";
+
+    // when — update the user task due date
+    camundaClient.newUpdateUserTaskCommand(userTaskKey).dueDate(newDueDate).send().join();
+
+    // then — the wait state details reflect the new due date
+    Awaitility.await("wait state due date should be updated")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.processInstanceKey(pik))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+              assertThat(items.getFirst().getDetails())
+                  .isInstanceOfSatisfying(
+                      UserTaskWaitStateDetails.class,
+                      d ->
+                          assertThat(OffsetDateTime.parse(d.getDueDate()))
+                              .isEqualTo(OffsetDateTime.parse(newDueDate)));
+            });
+
+    // cleanup
+    camundaClient.newCancelInstanceCommand(pik).send().join();
+    waitForProcessInstanceToBeTerminated(camundaClient, pik);
+    awaitNoWaitState(pik);
+  }
+
+  @Test
+  void shouldUpdateWaitStateElementIdWhenProcessInstanceIsMigrated() {
+    // given — V1 has a user task "source-task"; V2 has the same task renamed to "target-task"
+    final BpmnModelInstance v1 =
+        Bpmn.createExecutableProcess("waitStateUserTaskMigrationV1")
+            .startEvent()
+            .userTask("source-task", t -> t.zeebeUserTask())
+            .endEvent()
+            .done();
+    final BpmnModelInstance v2 =
+        Bpmn.createExecutableProcess("waitStateUserTaskMigrationV2")
+            .startEvent()
+            .userTask("target-task", t -> t.zeebeUserTask())
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, v1, "waitStateUserTaskMigrationV1.bpmn");
+    final long v2Key =
+        deployProcessAndWaitForIt(camundaClient, v2, "waitStateUserTaskMigrationV2.bpmn")
+            .getProcessDefinitionKey();
+
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateUserTaskMigrationV1").getProcessInstanceKey();
+
+    Awaitility.await("wait state with source-task should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("source-task")));
+
+    // when — migrate the process instance, remapping source-task → target-task
+    camundaClient
+        .newMigrateProcessInstanceCommand(pik)
+        .migrationPlan(
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(v2Key)
+                .addMappingInstruction("source-task", "target-task")
+                .build())
+        .send()
+        .join();
+
+    // then — wait state is updated to reflect the new element id
+    Awaitility.await("wait state should be updated with target-task element id")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("target-task")));
+
+    // cleanup — cancel the instance so the wait state doesn't leak into other assertions
+    camundaClient.newCancelInstanceCommand(pik).send().join();
+    waitForProcessInstanceToBeTerminated(camundaClient, pik);
+    awaitNoWaitState(pik);
+  }
+
+  private static long awaitSingleWaitStateTaskKey(final long processInstanceKey) {
+    Awaitility.await("wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(processInstanceKey))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+    final var item =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.processInstanceKey(processInstanceKey))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    return Long.parseLong(((UserTaskWaitStateDetails) item.getDetails()).getTaskKey());
+  }
+
+  private static void awaitNoWaitState(final long processInstanceKey) {
+    Awaitility.await("wait state should be removed")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(processInstanceKey))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  private static ElementInstanceWaitStateResult byElementId(
+      final List<ElementInstanceWaitStateResult> items, final String elementId) {
+    return items.stream().filter(i -> elementId.equals(i.getElementId())).findFirst().orElseThrow();
+  }
+
+  private static void waitForWaitStates(final int expectedCount) {
+    Awaitility.await("should export %d wait states".formatted(expectedCount))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final List<ElementInstanceWaitStateResult> items =
+                  camundaClient.newElementInstanceWaitStateSearchRequest().send().join().items();
+              assertThat(items).hasSize(expectedCount);
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.WaitStateDetails.WaitStateType;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
+import io.camunda.search.entities.WaitStateUserTaskDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +60,7 @@ public class WaitStateEntityTransformer
       return switch (WaitStateType.valueOf(waitStateType)) {
         case JOB -> OBJECT_MAPPER.readValue(detailsJson, WaitStateJobDetails.class);
         case MESSAGE -> OBJECT_MAPPER.readValue(detailsJson, WaitStateMessageDetails.class);
+        case USER_TASK -> OBJECT_MAPPER.readValue(detailsJson, WaitStateUserTaskDetails.class);
       };
     } catch (final Exception e) {
       LOG.warn("Failed to parse wait state details for type {}: {}", waitStateType, e.getMessage());

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateDetails.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateDetails.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.search.entities;
 
-public sealed interface WaitStateDetails permits WaitStateJobDetails, WaitStateMessageDetails {
+public sealed interface WaitStateDetails
+    permits WaitStateJobDetails, WaitStateMessageDetails, WaitStateUserTaskDetails {
 
   WaitStateType waitStateType();
 
   enum WaitStateType {
     JOB,
-    MESSAGE
+    MESSAGE,
+    USER_TASK
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateUserTaskDetails.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateUserTaskDetails.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.util.ObjectBuilder;
+import org.jspecify.annotations.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WaitStateUserTaskDetails(@Nullable Long taskKey, @Nullable String dueDate)
+    implements WaitStateDetails {
+
+  @Override
+  public WaitStateDetails.WaitStateType waitStateType() {
+    return WaitStateDetails.WaitStateType.USER_TASK;
+  }
+
+  public static class Builder implements ObjectBuilder<WaitStateUserTaskDetails> {
+    private @Nullable Long taskKey;
+    private @Nullable String dueDate;
+
+    public Builder taskKey(final @Nullable Long taskKey) {
+      this.taskKey = taskKey;
+      return this;
+    }
+
+    public Builder dueDate(final @Nullable String dueDate) {
+      this.dueDate = dueDate;
+      return this;
+    }
+
+    @Override
+    public WaitStateUserTaskDetails build() {
+      return new WaitStateUserTaskDetails(taskKey, dueDate);
+    }
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.common.waitstate;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
 /**
  * Predefined {@link WaitStateTransformerConfig}s for common use cases, e.g. for jobs. These can be
@@ -26,6 +27,13 @@ public final class WaitStateConfigs {
           .withUpdateIntents(JobIntent.MIGRATED)
           .withRemoveIntents(JobIntent.COMPLETED, JobIntent.CANCELED)
           .withWaitStateType(WaitStateType.JOB);
+
+  public static final WaitStateTransformerConfig USER_TASK_CONFIG =
+      WaitStateTransformerConfig.of(ValueType.USER_TASK)
+          .withAddIntents(UserTaskIntent.CREATED)
+          .withUpdateIntents(UserTaskIntent.MIGRATED, UserTaskIntent.UPDATED)
+          .withRemoveIntents(UserTaskIntent.COMPLETED, UserTaskIntent.CANCELED)
+          .withWaitStateType(WaitStateType.USER_TASK);
 
   private WaitStateConfigs() {}
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/UserTaskBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/UserTaskBasedWaitStateTransformer.java
@@ -27,8 +27,10 @@ public class UserTaskBasedWaitStateTransformer
   @Override
   public void extract(final Record<UserTaskRecordValue> record, final WaitStateEntry entry) {
     final UserTaskRecordValue value = record.getValue();
+    final String rawDueDate = value.getDueDate();
+    final String dueDate = rawDueDate == null || rawDueDate.isBlank() ? null : rawDueDate;
     entry
         .setElementType(BpmnElementType.USER_TASK)
-        .setDetails(new UserTaskWaitStateDetails(value.getUserTaskKey(), value.getDueDate()));
+        .setDetails(new UserTaskWaitStateDetails(value.getUserTaskKey(), dueDate));
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/UserTaskBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/UserTaskBasedWaitStateTransformer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import static io.camunda.zeebe.exporter.common.waitstate.WaitStateConfigs.USER_TASK_CONFIG;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformerConfig;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+
+public class UserTaskBasedWaitStateTransformer
+    implements WaitStateTransformer<UserTaskRecordValue> {
+
+  @Override
+  public WaitStateTransformerConfig config() {
+    return USER_TASK_CONFIG;
+  }
+
+  @Override
+  public void extract(final Record<UserTaskRecordValue> record, final WaitStateEntry entry) {
+    final UserTaskRecordValue value = record.getValue();
+    entry
+        .setElementType(BpmnElementType.USER_TASK)
+        .setDetails(new UserTaskWaitStateDetails(value.getUserTaskKey(), value.getDueDate()));
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/UserTaskWaitStateDetails.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/UserTaskWaitStateDetails.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
+
+/** Wait-state details for native Camunda user task waits. */
+public record UserTaskWaitStateDetails(long taskKey, String dueDate) implements WaitStateDetails {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
@@ -24,7 +24,7 @@ public final class WaitStateTransformerRegistry {
    */
   public static List<Supplier<WaitStateTransformer<?>>>
       getAllPartitionWaitStateTransformerSuppliers() {
-    return List.of(JobBasedWaitStateTransformer::new);
+    return List.of(JobBasedWaitStateTransformer::new, UserTaskBasedWaitStateTransformer::new);
   }
 
   /**

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/UserTaskBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/UserTaskBasedWaitStateTransformerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class UserTaskBasedWaitStateTransformerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final UserTaskBasedWaitStateTransformer transformer =
+      new UserTaskBasedWaitStateTransformer();
+
+  @Test
+  void shouldExtractDetailsFromUserTaskCreatedRecord() {
+    // given
+    final UserTaskRecordValue value =
+        ImmutableUserTaskRecordValue.builder()
+            .from(factory.generateObject(UserTaskRecordValue.class))
+            .withUserTaskKey(999L)
+            .withDueDate("2026-10-13T10:00:00+01:00")
+            .withElementId("approve-task")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withKey(999L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(UserTaskIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then — identity fields from WaitStateRelated
+    assertThat(entry.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entry.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entry.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entry.getElementId()).isEqualTo("approve-task");
+    assertThat(entry.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(entry.getPartitionId()).isEqualTo(record.getPartitionId());
+
+    // then — classification set by config and extract
+    assertThat(entry.getWaitStateType()).isEqualTo(WaitStateType.USER_TASK);
+    assertThat(entry.getElementType()).isEqualTo(BpmnElementType.USER_TASK);
+
+    // then — user-task-specific details
+    assertThat(entry.getDetails()).isInstanceOf(UserTaskWaitStateDetails.class);
+    final var details = (UserTaskWaitStateDetails) entry.getDetails();
+    assertThat(details.taskKey()).isEqualTo(999L);
+    assertThat(details.dueDate()).isEqualTo("2026-10-13T10:00:00+01:00");
+  }
+
+  @Test
+  void shouldTriggerAddOnUserTaskCreated() {
+    // given
+    final Record<UserTaskRecordValue> record = userTaskRecord(UserTaskIntent.CREATED);
+
+    // when / then
+    assertThat(transformer.supports(record)).isTrue();
+    assertThat(transformer.triggersAdd(record)).isTrue();
+    assertThat(transformer.triggersUpdate(record)).isFalse();
+    assertThat(transformer.triggersRemoval(record)).isFalse();
+  }
+
+  @Test
+  void shouldTriggerUpdateOnUserTaskMigratedAndUpdated() {
+    // given
+    final Record<UserTaskRecordValue> migrated = userTaskRecord(UserTaskIntent.MIGRATED);
+    final Record<UserTaskRecordValue> updated = userTaskRecord(UserTaskIntent.UPDATED);
+
+    // when / then
+    assertThat(transformer.triggersUpdate(migrated)).isTrue();
+    assertThat(transformer.triggersUpdate(updated)).isTrue();
+    assertThat(transformer.triggersAdd(migrated)).isFalse();
+    assertThat(transformer.triggersRemoval(migrated)).isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldTriggerRemovalOnUserTaskCompletedAndCanceled() {
+    // given
+    final Record<UserTaskRecordValue> completed = userTaskRecord(UserTaskIntent.COMPLETED);
+    final Record<UserTaskRecordValue> canceled = userTaskRecord(UserTaskIntent.CANCELED);
+
+    // when / then
+    assertThat(transformer.triggersRemoval(completed)).isTrue();
+    assertThat(transformer.triggersRemoval(canceled)).isTrue();
+    assertThat(transformer.triggersAdd(completed)).isFalse();
+    assertThat(transformer.triggersAdd(canceled)).isFalse();
+  }
+
+  private Record<UserTaskRecordValue> userTaskRecord(final UserTaskIntent intent) {
+    return factory.generateRecord(
+        ValueType.USER_TASK, r -> r.withRecordType(RecordType.EVENT).withIntent(intent));
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/UserTaskBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/UserTaskBasedWaitStateTransformerTest.java
@@ -99,7 +99,6 @@ class UserTaskBasedWaitStateTransformerTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   void shouldTriggerRemovalOnUserTaskCompletedAndCanceled() {
     // given
     final Record<UserTaskRecordValue> completed = userTaskRecord(UserTaskIntent.COMPLETED);
@@ -110,6 +109,38 @@ class UserTaskBasedWaitStateTransformerTest {
     assertThat(transformer.triggersRemoval(canceled)).isTrue();
     assertThat(transformer.triggersAdd(completed)).isFalse();
     assertThat(transformer.triggersAdd(canceled)).isFalse();
+  }
+
+  @Test
+  void shouldNormalizeEmptyDueDateToNull() {
+    // given — protocol default for dueDate is "" when not configured
+    final UserTaskRecordValue value =
+        ImmutableUserTaskRecordValue.builder()
+            .from(factory.generateObject(UserTaskRecordValue.class))
+            .withUserTaskKey(999L)
+            .withDueDate("")
+            .withElementId("no-due-date-task")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withKey(999L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(UserTaskIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then — empty string must be normalised to null so consumers can safely parse dueDate
+    final var details = (UserTaskWaitStateDetails) entry.getDetails();
+    assertThat(details.dueDate()).isNull();
   }
 
   private Record<UserTaskRecordValue> userTaskRecord(final UserTaskIntent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/UserTaskWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/UserTaskWaitStateHandlerTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.UserTaskBasedWaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end integration test for the native user task wait-state handler pair produced by {@link
+ * WaitStateHandlerBuilder} with {@link UserTaskBasedWaitStateTransformer}.
+ *
+ * <p>Validates the full lifecycle: a {@code USER_TASK.CREATED} event writes the wait-state entry,
+ * {@code MIGRATED}/{@code UPDATED} upsert it, and {@code COMPLETED}/{@code CANCELED} remove it
+ * using the same stable document id (the userTaskKey).
+ */
+class UserTaskWaitStateHandlerTest {
+
+  private static final String INDEX_NAME = "test-wait-state";
+  private static final long USER_TASK_KEY = 999L;
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private WaitStateAddHandler<UserTaskRecordValue> addHandler;
+  private WaitStateRemoveHandler<UserTaskRecordValue> removeHandler;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new UserTaskBasedWaitStateTransformer())
+            .build();
+
+    addHandler =
+        (WaitStateAddHandler<UserTaskRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateAddHandler)
+                .findFirst()
+                .orElseThrow();
+    removeHandler =
+        (WaitStateRemoveHandler<UserTaskRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateRemoveHandler)
+                .findFirst()
+                .orElseThrow();
+  }
+
+  @Test
+  void shouldAddHandlerHandleCreatedAndRemoveHandlerNotHandle() {
+    // given
+    final var created = userTaskRecord(UserTaskIntent.CREATED);
+    final var completed = userTaskRecord(UserTaskIntent.COMPLETED);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(created)).isTrue();
+    assertThat(addHandler.handlesRecord(completed)).isFalse();
+    assertThat(removeHandler.handlesRecord(created)).isFalse();
+    assertThat(removeHandler.handlesRecord(completed)).isTrue();
+  }
+
+  @Test
+  void shouldAddHandlerHandleMigratedAndUpdatedEvents() {
+    // given
+    final var migrated = userTaskRecord(UserTaskIntent.MIGRATED);
+    final var updated = userTaskRecord(UserTaskIntent.UPDATED);
+
+    // when / then — MIGRATED and UPDATED are upserts, handled by the add handler
+    assertThat(addHandler.handlesRecord(migrated)).isTrue();
+    assertThat(addHandler.handlesRecord(updated)).isTrue();
+    assertThat(removeHandler.handlesRecord(migrated)).isFalse();
+    assertThat(removeHandler.handlesRecord(updated)).isFalse();
+  }
+
+  @Test
+  void shouldBothHandlersUseTheSameDocumentId() {
+    // given
+    final var created = userTaskRecord(UserTaskIntent.CREATED);
+    final var completed = userTaskRecord(UserTaskIntent.COMPLETED);
+
+    // when
+    final var addIds = addHandler.generateIds(created);
+    final var removeIds = removeHandler.generateIds(completed);
+
+    // then — same stable document id (userTaskKey) used for write and delete
+    assertThat(addIds).containsExactly(String.valueOf(USER_TASK_KEY));
+    assertThat(removeIds).containsExactly(String.valueOf(USER_TASK_KEY));
+  }
+
+  @Test
+  void shouldWriteFullyPopulatedEntityOnUserTaskCreated() throws Exception {
+    // given
+    final var record = userTaskRecordWithDetails(UserTaskIntent.CREATED, "approve-task");
+    final var entity = addHandler.createNewEntity(String.valueOf(USER_TASK_KEY));
+
+    // when
+    addHandler.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entity.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entity.getElementId()).isEqualTo("approve-task");
+    assertThat(entity.getElementType()).isEqualTo(BpmnElementType.USER_TASK.name());
+    assertThat(entity.getWaitStateType()).isEqualTo(WaitStateType.USER_TASK.name());
+    assertThat(entity.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    // then — details serialised as JSON with all fields
+    final var details = objectMapper.readTree(entity.getDetails());
+    assertThat(details.get("taskKey").longValue()).isEqualTo(USER_TASK_KEY);
+    assertThat(details.get("dueDate").textValue()).isEqualTo("2026-10-13T10:00:00+01:00");
+  }
+
+  @Test
+  void shouldUpdateEntityElementIdOnUserTaskMigrated() throws Exception {
+    // given — a record with the post-migration elementId
+    final var record = userTaskRecordWithDetails(UserTaskIntent.MIGRATED, "task-after-migration");
+    final var entity = addHandler.createNewEntity(String.valueOf(USER_TASK_KEY));
+
+    // when
+    addHandler.updateEntity(record, entity);
+
+    // then — entity reflects the post-migration element id; all other fields are also updated
+    assertThat(entity.getElementId()).isEqualTo("task-after-migration");
+    assertThat(entity.getElementType()).isEqualTo(BpmnElementType.USER_TASK.name());
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entity.getWaitStateType()).isEqualTo(WaitStateType.USER_TASK.name());
+    final var details = objectMapper.readTree(entity.getDetails());
+    assertThat(details.get("taskKey").longValue()).isEqualTo(USER_TASK_KEY);
+  }
+
+  @Test
+  void shouldFlushAddEntityToIndex() throws PersistenceException {
+    // given
+    final var entity = new WaitStateEntity().setId(String.valueOf(USER_TASK_KEY));
+    final var batchRequest = mock(BatchRequest.class);
+
+    // when
+    addHandler.flush(entity, batchRequest);
+
+    // then
+    verify(batchRequest).add(eq(INDEX_NAME), eq(entity));
+  }
+
+  @Test
+  void shouldFlushRemoveDeleteFromIndexBySameId() throws PersistenceException {
+    // given
+    final var entity = new WaitStateEntity().setId(String.valueOf(USER_TASK_KEY));
+    final var batchRequest = mock(BatchRequest.class);
+
+    // when
+    removeHandler.flush(entity, batchRequest);
+
+    // then
+    verify(batchRequest).delete(INDEX_NAME, String.valueOf(USER_TASK_KEY));
+  }
+
+  @Test
+  void shouldRemoveHandlerAlsoHandleCanceledEvent() {
+    // given
+    final var canceled = userTaskRecord(UserTaskIntent.CANCELED);
+
+    // when / then
+    assertThat(removeHandler.handlesRecord(canceled)).isTrue();
+    assertThat(addHandler.handlesRecord(canceled)).isFalse();
+  }
+
+  @Test
+  void shouldBuilderProduceExactlyTwoHandlers() {
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new UserTaskBasedWaitStateTransformer())
+            .build();
+
+    assertThat(handlers).hasSize(2);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateAddHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateRemoveHandler).count())
+        .isEqualTo(1);
+  }
+
+  private Record<UserTaskRecordValue> userTaskRecordWithDetails(
+      final UserTaskIntent intent, final String elementId) {
+    final var value =
+        ImmutableUserTaskRecordValue.builder()
+            .from(factory.generateObject(UserTaskRecordValue.class))
+            .withUserTaskKey(USER_TASK_KEY)
+            .withDueDate("2026-10-13T10:00:00+01:00")
+            .withElementId(elementId)
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    return cast(
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withKey(USER_TASK_KEY)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(intent)
+                    .withValue(value)));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Record<UserTaskRecordValue> userTaskRecord(final UserTaskIntent intent) {
+    return (Record<UserTaskRecordValue>)
+        (Record<? extends RecordValue>)
+            factory.generateRecord(
+                ValueType.USER_TASK,
+                r -> r.withKey(USER_TASK_KEY).withRecordType(RecordType.EVENT).withIntent(intent));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<UserTaskRecordValue> cast(final Record<? extends RecordValue> record) {
+    return (Record<UserTaskRecordValue>) record;
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandlerTest.java
@@ -15,16 +15,20 @@ import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
 import io.camunda.db.rdbms.write.service.WaitStateWriter;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
 import io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.UserTaskBasedWaitStateTransformer;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -169,5 +173,67 @@ class WaitStateAddHandlerTest {
         .contains("\"jobType\":\"payment-service\"")
         .contains("\"jobKind\":\"BPMN_ELEMENT\"")
         .contains("\"retries\":3");
+  }
+
+  @Test
+  void shouldInsertWaitStateRowOnUserTaskCreated() {
+    // given
+    final WaitStateAddHandler<UserTaskRecordValue> userTaskHandler =
+        new WaitStateAddHandler<>(
+            waitStateWriter, new UserTaskBasedWaitStateTransformer(), objectMapper);
+    final Record<UserTaskRecordValue> record =
+        userTaskRecord(UserTaskIntent.CREATED, "approve-task");
+
+    // when
+    userTaskHandler.export(record);
+
+    // then
+    verify(waitStateWriter).create(modelCaptor.capture());
+    final WaitStateDbModel model = modelCaptor.getValue();
+    assertThat(model.waitStateKey()).isEqualTo(999L);
+    assertThat(model.elementId()).isEqualTo("approve-task");
+    assertThat(model.elementType()).isEqualTo(BpmnElementType.USER_TASK.name());
+    assertThat(model.waitStateType()).isEqualTo(WaitStateType.USER_TASK.name());
+    assertThat(model.details())
+        .contains("\"taskKey\":999")
+        .contains("\"dueDate\":\"2026-10-13T10:00:00+01:00\"");
+  }
+
+  @Test
+  void shouldUpdateWaitStateRowOnUserTaskUpdated() {
+    // given
+    final WaitStateAddHandler<UserTaskRecordValue> userTaskHandler =
+        new WaitStateAddHandler<>(
+            waitStateWriter, new UserTaskBasedWaitStateTransformer(), objectMapper);
+    final Record<UserTaskRecordValue> record =
+        userTaskRecord(UserTaskIntent.UPDATED, "approve-task");
+
+    // when
+    userTaskHandler.export(record);
+
+    // then — UPDATED is an update intent, so update (not insert) is called
+    verify(waitStateWriter).update(modelCaptor.capture());
+    final WaitStateDbModel model = modelCaptor.getValue();
+    assertThat(model.waitStateKey()).isEqualTo(999L);
+    assertThat(model.elementId()).isEqualTo("approve-task");
+    assertThat(model.waitStateType()).isEqualTo(WaitStateType.USER_TASK.name());
+  }
+
+  private Record<UserTaskRecordValue> userTaskRecord(
+      final UserTaskIntent intent, final String elementId) {
+    final UserTaskRecordValue value =
+        ImmutableUserTaskRecordValue.builder()
+            .from(factory.generateObject(UserTaskRecordValue.class))
+            .withUserTaskKey(999L)
+            .withDueDate("2026-10-13T10:00:00+01:00")
+            .withElementId(elementId)
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    return factory.generateRecord(
+        ValueType.USER_TASK,
+        r -> r.withKey(999L).withRecordType(RecordType.EVENT).withIntent(intent).withValue(value));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateRemoveHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateRemoveHandlerTest.java
@@ -12,11 +12,14 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.db.rdbms.write.service.WaitStateWriter;
 import io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.UserTaskBasedWaitStateTransformer;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,5 +87,29 @@ class WaitStateRemoveHandlerTest {
 
     // then
     verify(waitStateWriter).delete(777L);
+  }
+
+  @Test
+  void shouldExportUserTaskCompletedAndCanceledRecords() {
+    // given
+    final WaitStateRemoveHandler<UserTaskRecordValue> userTaskHandler =
+        new WaitStateRemoveHandler<>(waitStateWriter, new UserTaskBasedWaitStateTransformer());
+    final Record<UserTaskRecordValue> completed =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(UserTaskIntent.COMPLETED));
+    final Record<UserTaskRecordValue> canceled =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(UserTaskIntent.CANCELED));
+    final Record<UserTaskRecordValue> created =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(UserTaskIntent.CREATED));
+
+    // when / then
+    assertThat(userTaskHandler.canExport(completed)).isTrue();
+    assertThat(userTaskHandler.canExport(canceled)).isTrue();
+    assertThat(userTaskHandler.canExport(created)).isFalse();
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -846,9 +846,11 @@ components:
         mapping:
           JOB: '#/components/schemas/JobWaitStateDetails'
           MESSAGE: '#/components/schemas/MessageWaitStateDetails'
+          USER_TASK: '#/components/schemas/UserTaskWaitStateDetails'
       oneOf:
         - $ref: '#/components/schemas/JobWaitStateDetails'
         - $ref: '#/components/schemas/MessageWaitStateDetails'
+        - $ref: '#/components/schemas/UserTaskWaitStateDetails'
 
     WaitStateTypeEnum:
       description: The type of waiting state an element instance is in.
@@ -856,6 +858,7 @@ components:
       enum:
         - JOB
         - MESSAGE
+        - USER_TASK
 
     BaseWaitStateDetails:
       description: Common fields shared by all wait-state details variants.
@@ -917,6 +920,25 @@ components:
           description: The correlation key for the message subscription (null for start events).
           nullable: true
           type: string
+
+    UserTaskWaitStateDetails:
+      type: object
+      required:
+        - waitStateType
+        - taskKey
+        - dueDate
+      allOf:
+        - $ref: '#/components/schemas/BaseWaitStateDetails'
+      properties:
+        taskKey:
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/UserTaskKey'
+          description: The key of the user task.
+        dueDate:
+          description: The due date of the user task, if set.
+          nullable: true
+          type: string
+          format: date-time
 
     AdHocSubProcessActivateActivityReference:
       type: object

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
@@ -34,6 +34,7 @@ public interface UserTaskRecordValue
     extends RecordValueWithVariables,
         ProcessInstanceRelated,
         AuditLogProcessInstanceRelated,
+        WaitStateRelated,
         TenantOwned {
 
   long getUserTaskKey();


### PR DESCRIPTION
## Summary

Implements the remaining "Inspect a User Task" acceptance criteria from the Wait States epic.

Native Camunda user tasks (`zeebeUserTask()`) don't create BPMN_ELEMENT jobs, so job-based wait states don't cover them. This PR tracks them with a dedicated `USER_TASK` wait state carrying `taskKey` and `dueDate`.

- **Protocol**: `UserTaskRecordValue` now implements `WaitStateRelated` (all required methods pre-existed)
- **Exporter**: `UserTaskBasedWaitStateTransformer` registered in `WaitStateTransformerRegistry` — intents: add=`CREATED`, update=`MIGRATED`/`UPDATED`, remove=`COMPLETED`/`CANCELED`
- **Read model**: `WaitStateUserTaskDetails` added to the sealed `WaitStateDetails` interface; `USER_TASK` deserialization case added to both the RDBMS mapper and ES/OS entity transformer
- **API**: `UserTaskWaitStateDetails` schema and `USER_TASK` enum value in `element-instances.yaml`; corresponding arm in `SearchQueryResponseMapper`
- **Java client**: `WaitStateType.USER_TASK`, `UserTaskWaitStateDetails` interface + impl, `extractDetails` case
- **Tests**: transformer unit tests, handler lifecycle tests (camunda-exporter + rdbms-exporter), client deserialization test, and 6 `@MultiDbTest` acceptance tests (single instance, call activity, PI migration, dueDate update, completion removal, cancellation removal)

## Test plan

- [ ] Unit tests pass: `./mvnw verify -pl zeebe/exporter-common,zeebe/exporters/camunda-exporter,zeebe/exporters/rdbms-exporter,clients/java -DskipTests=false -DskipITs -Dquickly`
- [ ] Acceptance tests pass: `./mvnw verify -pl qa/acceptance-tests -Dit.test=WaitStateUserTaskIT -DskipUTs -DskipTests=false -DskipChecks`
- [ ] Full repo compiles: `./mvnw install -Dquickly -T1C`


Closes #48556

🤖 Generated with [Claude Code](https://claude.com/claude-code)