### PR TITLE
ci: Fix CPT workflow trigger

### DIFF
--- a/.github/workflows/camunda-process-test-compatibility-trigger.yml
+++ b/.github/workflows/camunda-process-test-compatibility-trigger.yml
@@ -32,7 +32,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run .github/workflows/camunda-process-test-compatibility.yml \
-            --ref ${{ matrix.branch }} \
             -f branch=${{ matrix.branch }} \
             -f camunda_image_version=${{ matrix.camunda_image_version }} \
             -f connectors_image_version=${{ matrix.connectors_image_version }} \


### PR DESCRIPTION
## Description

We want to run the CPT workflow always on the main branch. The workflow itself contains a Git checkout of the given branch.

Currently, the CI job fails because we changed the CPT workflow only on the main branch.  

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Failed CI job: https://github.com/camunda/camunda/actions/runs/27181350066/job/80240901153