### PR TITLE
fix: add time-range params to Grafana links in daily load test notification

### DIFF
--- a/.github/scripts/post-load-test-results-to-slack.py
+++ b/.github/scripts/post-load-test-results-to-slack.py
@@ -25,6 +25,7 @@ Optional:
 import json
 import os
 import socket
+import time
 import urllib.error
 import urllib.request
 
@@ -81,8 +82,11 @@ rows   = [
 ]
 table  = '\n'.join([header, sep] + rows)
 
-grpc_dash = f'https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace={grpc_ns}'
-rest_dash = f'https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace={rest_ns}'
+soak_end  = int(os.environ.get('SOAK_END_EPOCH') or time.time())
+from_ms   = (soak_end - 10800) * 1000
+to_ms     = soak_end * 1000
+grpc_dash = f'https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace={grpc_ns}&from={from_ms}&to={to_ms}'
+rest_dash = f'https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace={rest_ns}&from={from_ms}&to={to_ms}'
 run_url   = f'https://github.com/{repo}/actions/runs/{run_id}'
 
 payload = {

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -101,9 +101,14 @@ jobs:
     if: needs.setup-max-load-test.result == 'success' || needs.setup-max-rest-load-test.result == 'success'
     timeout-minutes: 195
     permissions: { }
+    outputs:
+      soak_end_epoch: ${{ steps.timing.outputs.soak_end_epoch }}
     steps:
       - name: Wait 3 hours for soak period
         run: sleep 10800
+      - name: Record soak end time
+        id: timing
+        run: echo "soak_end_epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
@@ -128,6 +133,7 @@ jobs:
     with:
       namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}
       duration-seconds: '10800'
+      at: ${{ needs.soak.outputs.soak_end_epoch }}
 
   collect-metrics-rest:
     name: Collect metrics (REST)
@@ -138,6 +144,7 @@ jobs:
     with:
       namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}-rest
       duration-seconds: '10800'
+      at: ${{ needs.soak.outputs.soak_end_epoch }}
 
   # Upload both metrics JSON files as a workflow artifact (90-day retention).
   upload-metrics:
@@ -181,7 +188,7 @@ jobs:
   notify-results:
     name: Notify Slack with results
     runs-on: ubuntu-latest
-    needs: [ benchmark-data, collect-metrics-grpc, collect-metrics-rest ]
+    needs: [ benchmark-data, soak, collect-metrics-grpc, collect-metrics-rest ]
     # Post if at least one side collected metrics; the skipped side renders as n/a.
     if: always() && (needs.collect-metrics-grpc.result == 'success' || needs.collect-metrics-rest.result == 'success')
     timeout-minutes: 5
@@ -209,6 +216,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
+          SOAK_END_EPOCH: ${{ needs.soak.outputs.soak_end_epoch }}
         run: python3 .github/scripts/post-load-test-results-to-slack.py
       - name: Observe build status
         if: always()

--- a/.github/workflows/camunda-load-test-metrics.yaml
+++ b/.github/workflows/camunda-load-test-metrics.yaml
@@ -182,13 +182,11 @@ jobs:
               tableLines.push('| _no metrics scraped_ | - |');
             }
 
-            const endMs   = at ? Number(at) * 1000 : Date.now();
+            // `at` may be a Unix-epoch (seconds) or an RFC3339 string — resolve both to epoch ms.
+            const endMs   = at ? (Number.isNaN(Number(at)) ? Date.parse(at) : Number(at) * 1000) : Date.now();
             const startMs = endMs - durationSeconds * 1000;
             const dashboard = `https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${namespace}&from=${startMs}&to=${endMs}`;
-            // Render a Unix-epoch anchor as ISO 8601; pass an RFC3339 string through unchanged.
-            const atLabel = at
-              ? (Number.isNaN(Number(at)) ? at : new Date(Number(at) * 1000).toISOString())
-              : '';
+            const atLabel = at ? new Date(endMs).toISOString() : '';
             const body = [
               `## 🔍 Load Test Metrics`,
               '',

--- a/.github/workflows/camunda-load-test-metrics.yaml
+++ b/.github/workflows/camunda-load-test-metrics.yaml
@@ -182,11 +182,17 @@ jobs:
               tableLines.push('| _no metrics scraped_ | - |');
             }
 
-            const dashboard = `https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${namespace}`;
+            const endMs   = at ? Number(at) * 1000 : Date.now();
+            const startMs = endMs - durationSeconds * 1000;
+            const dashboard = `https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${namespace}&from=${startMs}&to=${endMs}`;
+            // Render a Unix-epoch anchor as ISO 8601; pass an RFC3339 string through unchanged.
+            const atLabel = at
+              ? (Number.isNaN(Number(at)) ? at : new Date(Number(at) * 1000).toISOString())
+              : '';
             const body = [
               `## 🔍 Load Test Metrics`,
               '',
-              `Namespace: \`${namespace}\` · Window: ${durationSeconds}s${at ? ` ending at \`${at}\`` : ''}`,
+              `Namespace: \`${namespace}\` · Window: ${durationSeconds}s${atLabel ? ` ending at \`${atLabel}\`` : ''}`,
               '',
               ...tableLines,
               '',


### PR DESCRIPTION


## Description

Grafana links in the Slack notification and job summary opened at the default time window instead of the 3-hour soak window. Fix by capturing soak_end_epoch as a soak job output, threading it into collect-metrics-* as the `at` anchor (also corrects Prometheus query timing), and computing from_ms/to_ms in the Slack script and job summary render step.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Closes #54886
