### PR TITLE
fix: await actor scheduler shutdown in ClusteringRule to prevent SIGSEGV in reused forks

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -313,7 +313,16 @@ public class ClusteringRule extends ExternalResource {
               return null;
             })
         .join();
-    systemContexts.values().forEach(ctx -> ctx.getScheduler().stop());
+    systemContexts
+        .values()
+        .forEach(
+            ctx -> {
+              try {
+                ctx.getScheduler().close();
+              } catch (final Exception e) {
+                LOG.error("Failed to close scheduler", e);
+              }
+            });
     systemContexts.clear();
     brokers.clear();
     brokerCfgs.clear();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RestoreTest.java
@@ -66,15 +66,16 @@ public final class RestoreTest {
     // then
     final var leaderLogStream = clusteringRule.getLogStream(1);
 
-    final var reader = leaderLogStream.newLogStreamReader();
-    reader.seekToFirstEvent();
-    assertThat(reader.hasNext()).isTrue();
+    try (final var reader = leaderLogStream.newLogStreamReader()) {
+      reader.seekToFirstEvent();
+      assertThat(reader.hasNext()).isTrue();
 
-    var previousPosition = -1L;
-    while (reader.hasNext()) {
-      final var position = reader.next().getPosition();
-      assertThat(position).isGreaterThan(previousPosition);
-      previousPosition = position;
+      var previousPosition = -1L;
+      while (reader.hasNext()) {
+        final var position = reader.next().getPosition();
+        assertThat(position).isGreaterThan(previousPosition);
+        previousPosition = position;
+      }
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/SingleBrokerDataDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/SingleBrokerDataDeletionTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordAssert;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.snapshots.SnapshotId;
 import io.camunda.zeebe.stream.impl.records.CopiedRecords;
 import java.time.Duration;
 import java.util.Collections;
@@ -66,34 +67,35 @@ public class SingleBrokerDataDeletionTest {
     // given - an exporter which does not update its own position and filters everything but
     // deployment commands
     final LogStream logStream = clusteringRule.getLogStream(1);
-    final LogStreamReader reader = logStream.newLogStreamReader();
-    ControllableExporter.updatePosition(false);
-    ControllableExporter.RECORD_TYPE_FILTER.set(t -> t == RecordType.COMMAND);
-    ControllableExporter.VALUE_TYPE_FILTER.set(t -> t == ValueType.DEPLOYMENT);
+    try (final LogStreamReader reader = logStream.newLogStreamReader()) {
+      ControllableExporter.updatePosition(false);
+      ControllableExporter.RECORD_TYPE_FILTER.set(t -> t == RecordType.COMMAND);
+      ControllableExporter.VALUE_TYPE_FILTER.set(t -> t == ValueType.DEPLOYMENT);
 
-    // when - filling up the log with messages and NO deployments
-    publishEnoughMessagesForCompaction();
-    deployDummyProcess();
-    await("until at least one record is exported")
-        .atMost(Duration.ofSeconds(5))
-        .untilAsserted(
-            () -> assertThat(ControllableExporter.EXPORTED_RECORDS).hasValueGreaterThan(0));
+      // when - filling up the log with messages and NO deployments
+      publishEnoughMessagesForCompaction();
+      deployDummyProcess();
+      await("until at least one record is exported")
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(
+              () -> assertThat(ControllableExporter.EXPORTED_RECORDS).hasValueGreaterThan(0));
 
-    // memorize first position pre compaction to compare later on
-    reader.seekToFirstEvent();
-    final long firstPositionPreCompaction = reader.getPosition();
+      // memorize first position pre compaction to compare later on
+      reader.seekToFirstEvent();
+      final long firstPositionPreCompaction = reader.getPosition();
 
-    // then - enforce compaction and make sure we have less records than we previously did
-    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(0));
-    await("until some data before the deployment command was compacted")
-        .untilAsserted(
-            () -> {
-              reader.seekToFirstEvent();
-              final long firstPositionPostCompaction = reader.getPosition();
-              assertThat(firstPositionPostCompaction).isGreaterThan(firstPositionPreCompaction);
-              assertContainsDeploymentCommand(reader);
-            });
+      // then - enforce compaction and make sure we have less records than we previously did
+      clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
+      clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(0));
+      await("until some data before the deployment command was compacted")
+          .untilAsserted(
+              () -> {
+                reader.seekToFirstEvent();
+                final long firstPositionPostCompaction = reader.getPosition();
+                assertThat(firstPositionPostCompaction).isGreaterThan(firstPositionPreCompaction);
+                assertContainsDeploymentCommand(reader);
+              });
+    }
   }
 
   @Test
@@ -101,72 +103,74 @@ public class SingleBrokerDataDeletionTest {
     // given - an exporter which does not update its own position and only accepts deployment
     // commands
     final LogStream logStream = clusteringRule.getLogStream(PARTITION_ID);
-    final LogStreamReader reader = logStream.newLogStreamReader();
-    ControllableExporter.updatePosition(false);
-    ControllableExporter.RECORD_TYPE_FILTER.set(t -> t == RecordType.COMMAND);
-    ControllableExporter.VALUE_TYPE_FILTER.set(t -> t == ValueType.DEPLOYMENT);
+    try (final LogStreamReader reader = logStream.newLogStreamReader()) {
+      ControllableExporter.updatePosition(false);
+      ControllableExporter.RECORD_TYPE_FILTER.set(t -> t == RecordType.COMMAND);
+      ControllableExporter.VALUE_TYPE_FILTER.set(t -> t == ValueType.DEPLOYMENT);
 
-    // when - filling up the log with messages and a single deployment
-    publishEnoughMessagesForCompaction();
-    deployDummyProcess();
-    publishEnoughMessagesForCompaction();
-    await("until at least one record is exported")
-        .atMost(Duration.ofSeconds(5))
-        .untilAsserted(
-            () -> assertThat(ControllableExporter.EXPORTED_RECORDS).hasValueGreaterThan(0));
+      // when - filling up the log with messages and a single deployment
+      publishEnoughMessagesForCompaction();
+      deployDummyProcess();
+      publishEnoughMessagesForCompaction();
+      await("until at least one record is exported")
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(
+              () -> assertThat(ControllableExporter.EXPORTED_RECORDS).hasValueGreaterThan(0));
 
-    // memorize first position pre compaction to compare later on
-    reader.seekToFirstEvent();
-    final long firstPositionPreCompaction = reader.getPosition();
+      // memorize first position pre compaction to compare later on
+      reader.seekToFirstEvent();
+      final long firstPositionPreCompaction = reader.getPosition();
 
-    // then - enforce compaction and ensure the accepted deployment is still present on the log
-    // after compaction
-    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(0));
-    await("until some data before the deployment command was compacted")
-        .atMost(Duration.ofSeconds(5))
-        .untilAsserted(
-            () -> {
-              reader.seekToFirstEvent();
-              final long firstPositionPostCompaction = reader.getPosition();
-              assertThat(firstPositionPostCompaction).isGreaterThan(firstPositionPreCompaction);
-              assertContainsDeploymentCommand(reader);
-            });
+      // then - enforce compaction and ensure the accepted deployment is still present on the log
+      // after compaction
+      clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
+      clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(0));
+      await("until some data before the deployment command was compacted")
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(
+              () -> {
+                reader.seekToFirstEvent();
+                final long firstPositionPostCompaction = reader.getPosition();
+                assertThat(firstPositionPostCompaction).isGreaterThan(firstPositionPreCompaction);
+                assertContainsDeploymentCommand(reader);
+              });
+    }
   }
 
   @Test
   public void shouldNotCompactNotExportedEvents() {
     // given
     final LogStream logStream = clusteringRule.getLogStream(1);
-    final LogStreamReader reader = logStream.newLogStreamReader();
-    final Broker broker = clusteringRule.getBroker(0);
-    ControllableExporter.updatePosition(true);
+    try (final LogStreamReader reader = logStream.newLogStreamReader()) {
+      final Broker broker = clusteringRule.getBroker(0);
+      ControllableExporter.updatePosition(true);
 
-    // when - filling the log with messages (updating the position), then a single deployment
-    // command, and more messages (all of which do not update the position)
-    publishEnoughMessagesForCompaction();
-    ControllableExporter.updatePosition(false);
-    deployDummyProcess();
-    publishEnoughMessagesForCompaction();
+      // when - filling the log with messages (updating the position), then a single deployment
+      // command, and more messages (all of which do not update the position)
+      publishEnoughMessagesForCompaction();
+      ControllableExporter.updatePosition(false);
+      deployDummyProcess();
+      publishEnoughMessagesForCompaction();
 
-    // then - force compaction and ensure we compacted only things before our sentinel command
-    reader.seekToFirstEvent();
-    long firstPositionPreCompaction = reader.getPosition();
-    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    final var firstSnapshot = clusteringRule.waitForSnapshotAtBroker(broker);
-    awaitUntilCompaction(reader, firstPositionPreCompaction);
-    assertContainsDeploymentCommand(reader);
+      // then - force compaction and ensure we compacted only things before our sentinel command
+      reader.seekToFirstEvent();
+      long firstPositionPreCompaction = reader.getPosition();
+      clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
+      final var firstSnapshot = clusteringRule.waitForSnapshotAtBroker(broker);
+      awaitUntilCompaction(reader, firstPositionPreCompaction);
+      assertContainsDeploymentCommand(reader);
 
-    // when - re-enabling updating the position
-    ControllableExporter.updatePosition(true);
-    publishEnoughMessagesForCompaction();
+      // when - re-enabling updating the position
+      ControllableExporter.updatePosition(true);
+      publishEnoughMessagesForCompaction();
 
-    // then - ensure we can still compact
-    reader.seekToFirstEvent();
-    firstPositionPreCompaction = reader.getPosition();
-    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    clusteringRule.waitForNewSnapshotAtBroker(broker, firstSnapshot);
-    awaitUntilCompaction(reader, firstPositionPreCompaction);
+      // then - ensure we can still compact
+      reader.seekToFirstEvent();
+      firstPositionPreCompaction = reader.getPosition();
+      clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
+      clusteringRule.waitForNewSnapshotAtBroker(broker, firstSnapshot);
+      awaitUntilCompaction(reader, firstPositionPreCompaction);
+    }
   }
 
   @Ignore("until https://github.com/camunda/camunda/issues/35321")
@@ -213,39 +217,44 @@ public class SingleBrokerDataDeletionTest {
   public void shouldNotCompactWhenExporterHasBeenRemovedFromConfig() {
     // given - an exporter which updates its position and accepts all records
     final int nodeId = 0;
-    LogStreamReader reader = clusteringRule.getLogStream(1).newLogStreamReader();
     final Broker broker = clusteringRule.getBroker(nodeId);
     ControllableExporter.updatePosition(true);
+    final SnapshotId firstSnapshot;
 
-    // when - filling the log with messages
-    publishEnoughMessagesForCompaction();
-    deployDummyProcess();
+    try (final LogStreamReader reader = clusteringRule.getLogStream(1).newLogStreamReader()) {
+      // when - filling the log with messages
+      publishEnoughMessagesForCompaction();
+      deployDummyProcess();
 
-    // then - force compaction and ensure we compacted only things before our sentinel command
-    reader.seekToFirstEvent();
-    final long firstPositionPreCompaction = reader.getPosition();
-    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    final var firstSnapshot = clusteringRule.waitForSnapshotAtBroker(broker);
-    awaitUntilCompaction(reader, firstPositionPreCompaction);
-    assertContainsDeploymentCommand(reader);
+      // then - force compaction and ensure we compacted only things before our sentinel command
+      reader.seekToFirstEvent();
+      final long firstPositionPreCompaction = reader.getPosition();
+      clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
+      firstSnapshot = clusteringRule.waitForSnapshotAtBroker(broker);
+      awaitUntilCompaction(reader, firstPositionPreCompaction);
+      assertContainsDeploymentCommand(reader);
 
-    // when - restarting without the exporter
-    final var brokerCfg = clusteringRule.getBrokerCfg(nodeId);
-    brokerCfg.setExporters(Collections.emptyMap());
-    clusteringRule.stopBroker(nodeId);
-    clusteringRule.startBroker(nodeId);
-    publishEnoughMessagesForCompaction();
+      // when - restarting without the exporter
+      final var brokerCfg = clusteringRule.getBrokerCfg(nodeId);
+      brokerCfg.setExporters(Collections.emptyMap());
+      clusteringRule.stopBroker(nodeId);
+      clusteringRule.startBroker(nodeId);
+      publishEnoughMessagesForCompaction();
+    }
 
     // then - force compaction
-    reader = clusteringRule.getLogStream(1).newLogStreamReader();
-    final long newFirstPositionPreSnapshot = reader.getPosition();
-    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    clusteringRule.waitForNewSnapshotAtBroker(clusteringRule.getBroker(0), firstSnapshot);
-    reader = clusteringRule.getLogStream(1).newLogStreamReader();
-    final long newFirstPositionPostSnapshot = reader.getPosition();
-    assertThat(newFirstPositionPostSnapshot)
-        .describedAs("Not compacted")
-        .isEqualTo(newFirstPositionPreSnapshot);
+    try (final LogStreamReader reader = clusteringRule.getLogStream(1).newLogStreamReader()) {
+      final long newFirstPositionPreSnapshot = reader.getPosition();
+      clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
+      clusteringRule.waitForNewSnapshotAtBroker(clusteringRule.getBroker(0), firstSnapshot);
+      try (final LogStreamReader readerAfterSnapshot =
+          clusteringRule.getLogStream(1).newLogStreamReader()) {
+        final long newFirstPositionPostSnapshot = readerAfterSnapshot.getPosition();
+        assertThat(newFirstPositionPostSnapshot)
+            .describedAs("Not compacted")
+            .isEqualTo(newFirstPositionPreSnapshot);
+      }
+    }
   }
 
   private void awaitUntilCompaction(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ControlledActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ControlledActorClockEndpointIT.java
@@ -49,7 +49,7 @@ final class ControlledActorClockEndpointIT {
 
   @AutoClose private final CamundaClient camundaClient = broker.newClientBuilder().build();
 
-  private final HttpClient httpClient = HttpClient.newHttpClient();
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @Test
   void testPinningTime() throws IOException, InterruptedException {


### PR DESCRIPTION
## Description

The CI job "Zeebe / Integration / Zeebe Cluster QA ITs (1)" crashes intermittently with a
**SIGSEGV** (signal 11) during test execution in reused Surefire forks.

### Root cause

Analysis of the `hs_err_pid15541.log` crash dump from
[run 27125231283](https://github.com/camunda/camunda/actions/runs/27125231283/job/80052096928)
reveals:

- **Crash site:** `ProcessingStateMachine.tryToReadNextRecord()` (C2-compiled) on thread
  `zb-actors-1` — the engine reads from a journal buffer whose underlying memory-mapped segment
  has already been unmapped (`SEGV_MAPERR` at `0x00007aad43013e95`).
- **Preceding RocksDB errors:** 20 `RocksDBException`s thrown on the same thread within 1 ms
  before the crash — RocksDB native resources are already closed/freed.
- **Leaked daemon threads:** The thread dump shows **20+ pairs of `zb-actors-*` threads** still
  alive from previous test classes that ran in the same fork.

`ClusteringRule.after()` calls `ctx.getScheduler().stop()` **without awaiting** the returned
`Future<Void>`. `ActorScheduler.stop()` sets the internal state to `TERMINATING` and returns a
future that completes when the threads actually terminate — but since nobody joins it, the actor
threads (daemon threads) continue running after `after()` returns. These orphaned threads hold
references to already-freed native resources (memory-mapped journal segments, RocksDB column
family handles), and when they try to access them, the JVM crashes with SIGSEGV.

`ClusteringRule.stopBroker()` already handles this correctly by calling `scheduler.stop().get()`
— only the `after()` teardown path was missing the `.get()`.

**Thread leak evidence:**

The thread dump shows `zb-actors-*` pairs from at least 10 previous broker instances
(tids 58955–85297), all in `_thread_blocked` state — the `ClusteringRule.after()` returned
without waiting for them to terminate.

### Changes

1. **`ClusteringRule.after()`** — Await each scheduler's `stop()` future with `.get()` (matching
   what `stopBroker()` already does), so actor threads are fully terminated before the test
   framework proceeds to the next test class.

2. **`SingleBrokerDataDeletionTest` / `RestoreTest`** — Wrap `LogStreamReader` instances in
   try-with-resources to prevent resource leaks (hygiene — these tests ran in different forks from
   the crash, but the unclosed readers leak `AtomixLogStorageReader` → `RaftLogReader` references).

3. **`ControlledActorClockEndpointIT`** — Add `@AutoClose` to `HttpClient` field (hygiene).