### PR TITLE
feat: Enable Reindex by ID as Default Archiver

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -24,7 +24,9 @@ public class DocumentBasedHistory {
   private static final String DEFAULT_HISTORY_POLICY_NAME = "camunda-retention-policy";
   private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
+  /* This should be kept in sync with CamundaBackgroundTaskManagerFactory.DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE */
   private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
+  /* This should be kept in sync with CamundaBackgroundTaskManagerFactory.DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE */
   private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE = 500;
   private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_REINDEX_BATCH_SIZE = 2500;
   private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_MAX_RETRY_ATTEMPTS = 3;

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -20,12 +20,13 @@ public class DocumentBasedHistory {
   private static final boolean DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED = true;
   private static final ProcessInstanceRetentionMode
       DEFAULT_HISTORY_PROCESS_INSTANCE_RETENTION_MODE = ProcessInstanceRetentionMode.PI_HIERARCHY;
-  private static final boolean DEFAULT_HISTORY_ARCHIVE_BY_ID_ENABLED = false;
+  private static final boolean DEFAULT_HISTORY_ARCHIVE_BY_ID_ENABLED = true;
   private static final String DEFAULT_HISTORY_POLICY_NAME = "camunda-retention-policy";
   private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
   private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
-  private static final int DEFAULT_HISTORY_REINDEX_BATCH_SIZE = 2500;
+  private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE = 500;
+  private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_REINDEX_BATCH_SIZE = 2500;
   private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_MAX_RETRY_ATTEMPTS = 3;
   private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_RETRY_DELAY_MS = 1000;
   private static final String DEFAULT_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING = "1h";
@@ -63,10 +64,10 @@ public class DocumentBasedHistory {
   private String rolloverInterval = DEFAULT_HISTORY_ROLLOVER_INTERVAL;
 
   /** Maximum number of process instances per archiving batch */
-  private int rolloverBatchSize = DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE;
+  private Integer rolloverBatchSize;
 
   /** Maximum number of docs reindexed/deleted in a batch */
-  private int reindexBatchSize = DEFAULT_HISTORY_REINDEX_BATCH_SIZE;
+  private int reindexBatchSize = DEFAULT_HISTORY_ARCHIVE_BY_ID_REINDEX_BATCH_SIZE;
 
   /**
    * Grace period before archiving completed processes. Processes finished within this window are
@@ -159,6 +160,14 @@ public class DocumentBasedHistory {
   }
 
   public int getRolloverBatchSize() {
+    if (rolloverBatchSize == null) {
+      if (archiveByIdEnabled) {
+        rolloverBatchSize = DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE;
+      } else {
+        rolloverBatchSize = DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE;
+      }
+    }
+
     return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".rollover-batch-size",
         rolloverBatchSize,

--- a/configuration/src/test/java/io/camunda/configuration/HistoryElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/HistoryElasticsearchTest.java
@@ -35,6 +35,8 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 public class HistoryElasticsearchTest {
 
   private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
+  private static final boolean EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED = false;
+  private static final int EXPECTED_HISTORY_ARCHIVER_ROLLOVER_BATCH_SIZE = 199;
   private static final String EXPECTED_HISTORY_POLICY_NAME = "policy-name-foo";
   private static final String EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE = "PI";
 
@@ -56,6 +58,10 @@ public class HistoryElasticsearchTest {
         "camunda.data.secondary-storage.type=elasticsearch",
         "camunda.data.secondary-storage.elasticsearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
+        "camunda.data.secondary-storage.elasticsearch.history.archive-by-id-enabled="
+            + EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED,
+        "camunda.data.secondary-storage.elasticsearch.history.rollover-batch-size="
+            + EXPECTED_HISTORY_ARCHIVER_ROLLOVER_BATCH_SIZE,
         "camunda.data.secondary-storage.elasticsearch.history.policy-name="
             + EXPECTED_HISTORY_POLICY_NAME,
         "camunda.data.secondary-storage.elasticsearch.history.process-instance-retention-mode="
@@ -85,6 +91,10 @@ public class HistoryElasticsearchTest {
 
       assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
           .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
+      assertThat(exporterConfiguration.getHistory().isArchiveByIdEnabled())
+          .isEqualTo(EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED);
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize())
+          .isEqualTo(EXPECTED_HISTORY_ARCHIVER_ROLLOVER_BATCH_SIZE);
       assertThat(exporterConfiguration.getHistory().getRetention())
           .returns(EXPECTED_HISTORY_POLICY_NAME, RetentionConfiguration::getPolicyName);
       assertThat(exporterConfiguration.getHistory().getProcessInstanceRetentionMode())
@@ -103,6 +113,8 @@ public class HistoryElasticsearchTest {
         // process instance retention mode
         "camunda.data.secondary-storage.elasticsearch.history.process-instance-retention-mode="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE,
+        "zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize="
+            + EXPECTED_HISTORY_ARCHIVER_ROLLOVER_BATCH_SIZE,
         "zeebe.broker.exporters.camundaexporter.args.history.processInstanceRetentionMode="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE
       })
@@ -132,6 +144,54 @@ public class HistoryElasticsearchTest {
           .isEqualTo(EXPECTED_HISTORY_POLICY_NAME);
       assertThat(exporterConfiguration.getHistory().getProcessInstanceRetentionMode())
           .isEqualTo(ProcessInstanceRetentionMode.PI);
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize())
+          .isEqualTo(EXPECTED_HISTORY_ARCHIVER_ROLLOVER_BATCH_SIZE);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.elasticsearch.history.archive-by-id-enabled=false",
+        "camunda.data.secondary-storage.type=elasticsearch",
+      })
+  class WithDefaultValuesWhenArchiveByIdDisabled {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithDefaultValuesWhenArchiveByIdDisabled(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldDefaultArchiveByIdEnabledToTrue() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getHistory().isArchiveByIdEnabled()).isFalse();
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize()).isEqualTo(100);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+      })
+  class WithDefaultValues {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithDefaultValues(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldDefaultArchiveByIdEnabledToTrue() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getHistory().isArchiveByIdEnabled()).isTrue();
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize()).isEqualTo(500);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/HistoryOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/HistoryOpensearchTest.java
@@ -35,6 +35,8 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 public class HistoryOpensearchTest {
 
   private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
+  private static final boolean EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED = false;
+  private static final int EXPECTED_HISTORY_ARCHIVER_ROLLOVER_BATCH_SIZE = 199;
   private static final String EXPECTED_HISTORY_POLICY_NAME = "policy-name-foo";
   private static final String EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE = "PI";
 
@@ -56,6 +58,10 @@ public class HistoryOpensearchTest {
         "camunda.data.secondary-storage.type=opensearch",
         "camunda.data.secondary-storage.opensearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
+        "camunda.data.secondary-storage.opensearch.history.archive-by-id-enabled="
+            + EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED,
+        "camunda.data.secondary-storage.opensearch.history.rollover-batch-size="
+            + EXPECTED_HISTORY_ARCHIVER_ROLLOVER_BATCH_SIZE,
         "camunda.data.secondary-storage.opensearch.history.policy-name="
             + EXPECTED_HISTORY_POLICY_NAME,
         "camunda.data.secondary-storage.opensearch.history.process-instance-retention-mode="
@@ -85,6 +91,10 @@ public class HistoryOpensearchTest {
 
       assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
           .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
+      assertThat(exporterConfiguration.getHistory().isArchiveByIdEnabled())
+          .isEqualTo(EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED);
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize())
+          .isEqualTo(EXPECTED_HISTORY_ARCHIVER_ROLLOVER_BATCH_SIZE);
       assertThat(exporterConfiguration.getHistory().getRetention().getPolicyName())
           .isEqualTo(EXPECTED_HISTORY_POLICY_NAME);
       assertThat(exporterConfiguration.getHistory().getProcessInstanceRetentionMode())
@@ -103,6 +113,8 @@ public class HistoryOpensearchTest {
         // process instance retention mode
         "camunda.data.secondary-storage.opensearch.history.process-instance-retention-mode="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE,
+        "zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize="
+            + EXPECTED_HISTORY_ARCHIVER_ROLLOVER_BATCH_SIZE,
         "zeebe.broker.exporters.camundaexporter.args.history.processInstanceRetentionMode="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE
       })
@@ -132,6 +144,54 @@ public class HistoryOpensearchTest {
           .returns(EXPECTED_HISTORY_POLICY_NAME, RetentionConfiguration::getPolicyName);
       assertThat(exporterConfiguration.getHistory().getProcessInstanceRetentionMode())
           .isEqualTo(ProcessInstanceRetentionMode.PI);
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize())
+          .isEqualTo(EXPECTED_HISTORY_ARCHIVER_ROLLOVER_BATCH_SIZE);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.opensearch.history.archive-by-id-enabled=false",
+        "camunda.data.secondary-storage.type=opensearch",
+      })
+  class WithDefaultValuesWhenArchiveByIdDisabled {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithDefaultValuesWhenArchiveByIdDisabled(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldDefaultArchiveByIdEnabledToTrue() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getHistory().isArchiveByIdEnabled()).isFalse();
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize()).isEqualTo(100);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=opensearch",
+      })
+  class WithDefaultValues {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithDefaultValues(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldDefaultArchiveByIdEnabledToTrue() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getHistory().isArchiveByIdEnabled()).isTrue();
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize()).isEqualTo(500);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -65,6 +65,7 @@ public class SecondaryStorageElasticsearchTest {
   private static final Map<String, Integer> EXPECTED_SHARDS_BY_INDEX_NAME = Map.of("my-index", 2);
 
   private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
+  private static final boolean EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED = false;
   private static final String EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "foo";
   private static final String EXPECTED_HISTORY_ROLLOVER_INTERVAL = "5d";
   private static final int EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE = 200;
@@ -125,6 +126,8 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.data.secondary-storage.elasticsearch.number-of-shards-per-index.my-index=2",
         "camunda.data.secondary-storage.elasticsearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
+        "camunda.data.secondary-storage.elasticsearch.history.archive-by-id-enabled="
+            + EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED,
         "camunda.data.secondary-storage.elasticsearch.date-format=" + EXPECTED_DATE_FORMAT,
         "camunda.data.secondary-storage.elasticsearch.socket-timeout="
             + EXPECTED_SOCKET_TIMEOUT
@@ -285,6 +288,8 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_VARIABLE_SIZE_THRESHOLD);
       assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
           .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
+      assertThat(exporterConfiguration.getHistory().isArchiveByIdEnabled())
+          .isEqualTo(EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED);
       assertThat(exporterConfiguration.getHistory().getElsRolloverDateFormat())
           .isEqualTo(EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT);
       assertThat(exporterConfiguration.getHistory().getRolloverInterval())

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -64,6 +64,7 @@ public class SecondaryStorageOpensearchTest {
   private static final Map<String, Integer> EXPECTED_SHARDS_BY_INDEX_NAME = Map.of("my-index", 2);
 
   private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
+  private static final boolean EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED = false;
   private static final String EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "foo";
   private static final String EXPECTED_HISTORY_ROLLOVER_INTERVAL = "5d";
   private static final int EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE = 200;
@@ -123,6 +124,8 @@ public class SecondaryStorageOpensearchTest {
         "camunda.data.secondary-storage.opensearch.number-of-shards-per-index.my-index=2",
         "camunda.data.secondary-storage.opensearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
+        "camunda.data.secondary-storage.opensearch.history.archive-by-id-enabled="
+            + EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED,
         "camunda.data.secondary-storage.opensearch.date-format=" + EXPECTED_DATE_FORMAT,
         "camunda.data.secondary-storage.opensearch.socket-timeout="
             + EXPECTED_SOCKET_TIMEOUT
@@ -286,6 +289,8 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
       assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
           .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
+      assertThat(exporterConfiguration.getHistory().isArchiveByIdEnabled())
+          .isEqualTo(EXPECTED_HISTORY_ARCHIVE_BY_ID_ENABLED);
       assertThat(exporterConfiguration.getHistory().getElsRolloverDateFormat())
           .isEqualTo(EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT);
       assertThat(exporterConfiguration.getHistory().getRolloverInterval())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -257,7 +257,7 @@ public class ExporterConfiguration {
     private boolean processInstanceEnabled = true;
     private ProcessInstanceRetentionMode processInstanceRetentionMode =
         ProcessInstanceRetentionMode.PI_HIERARCHY;
-    private boolean archiveByIdEnabled = false;
+    private boolean archiveByIdEnabled = true;
     private String elsRolloverDateFormat = "date";
     private String rolloverInterval = "1d";
     private String usageMetricsRolloverInterval = "1M";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
@@ -77,6 +78,11 @@ import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.slf4j.Logger;
 
 public final class CamundaBackgroundTaskManagerFactory {
+  /* This should be kept in sync with DocumentBasedHistory.DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE */
+  private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE = 500;
+  /* This should be kept in sync with DocumentBasedHistory.DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE */
+  private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
+
   private final int partitionId;
   private final String exporterId;
   private final ExporterConfiguration config;
@@ -406,11 +412,19 @@ public final class CamundaBackgroundTaskManagerFactory {
         .forEach(dependantTemplates::add);
 
     final ProcessInstanceArchiverJob piArchiverJob;
-
+    final HistoryConfiguration history = config.getHistory();
     if (config.getHistory().isArchiveByIdEnabled()) {
+      if (history.getRolloverBatchSize() < DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE) {
+        logger.warn(
+            "Creating process instance archiver job with a roll-over batch size lower than "
+                + "recommended (recommended minimum: {}, configured batch size:{}) ",
+            DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE,
+            history.getRolloverBatchSize());
+      }
+
       piArchiverJob =
           new ProcessInstanceByIdArchiverJob(
-              config.getHistory(),
+              history,
               archiverRepository,
               resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
               dependantTemplates,
@@ -418,9 +432,17 @@ public final class CamundaBackgroundTaskManagerFactory {
               logger,
               executor);
     } else {
+      if (history.getRolloverBatchSize() > DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE) {
+        logger.warn(
+            "Creating process instance archiver job with a roll-over batch size higher than "
+                + "recommended (recommended: {}, configured batch size:{}) ",
+            DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE,
+            history.getRolloverBatchSize());
+      }
+
       piArchiverJob =
           new ProcessInstanceArchiverJob(
-              config.getHistory(),
+              history,
               archiverRepository,
               resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
               dependantTemplates,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
@@ -21,10 +21,10 @@ import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 
 /**
- * This is an experimental archiver job for handling process instance data where we reindex
- * documents by id. Similar to the {@link ProcessInstanceArchiverJob} this job handles the archiving
- * of the process instance records itself and also delegates to the repository to move dependent
- * records (decisions, flow node instances, variable updates, etc).
+ * This is an archiver job for archiving process instance data where we reindex documents by id.
+ * Similar to the {@link ProcessInstanceArchiverJob} this job handles the archiving of the process
+ * instance records itself and also delegates to the repository to move dependent records
+ * (decisions, flow node instances, variable updates, etc).
  */
 public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/CamundaCamundaBackgroundTaskManagerFactoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/CamundaCamundaBackgroundTaskManagerFactoryTest.java
@@ -19,6 +19,7 @@ import io.camunda.exporter.tasks.archiver.AuditLogArchiverJob;
 import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
 import io.camunda.exporter.tasks.archiver.JobBatchMetricsArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
+import io.camunda.exporter.tasks.archiver.ProcessInstanceByIdArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
 import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricArchiverJob;
@@ -66,6 +67,7 @@ class CamundaCamundaBackgroundTaskManagerFactoryTest {
   void shouldScheduleProcessInstanceArchiverTaskWhenConfigEnabled() {
     // given
     config.getHistory().setProcessInstanceEnabled(true);
+    config.getHistory().setArchiveByIdEnabled(false);
 
     // when
     final var taskManager = factory.build();
@@ -75,6 +77,22 @@ class CamundaCamundaBackgroundTaskManagerFactoryTest {
     assertThat(tasks)
         .as("Should contain ProcessInstancesArchiverJob when config is enabled")
         .anyMatch(task -> isProcessInstanceArchiverTask(task));
+  }
+
+  @Test
+  void shouldScheduleProcessInstanceByIdArchiverJobTaskWhenConfigEnabled() {
+    // given
+    config.getHistory().setProcessInstanceEnabled(true);
+    config.getHistory().setArchiveByIdEnabled(true);
+
+    // when
+    final var taskManager = factory.build();
+
+    // then
+    final var tasks = getTasksFromManager(taskManager);
+    assertThat(tasks)
+        .as("Should contain ProcessInstanceByIdArchiverJob when config is enabled")
+        .anyMatch(task -> isProcessInstanceByIdArchiverTask(task));
   }
 
   @Test
@@ -154,8 +172,8 @@ class CamundaCamundaBackgroundTaskManagerFactoryTest {
     // then
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
-        .as("Should contain both PI archiver and count tasks when all configs are enabled")
-        .anyMatch(task -> isProcessInstanceArchiverTask(task))
+        .as("Should contain both PI by ID archiver and count tasks when all configs are enabled")
+        .anyMatch(task -> isProcessInstanceByIdArchiverTask(task))
         .anyMatch(task -> isProcessInstanceToBeArchivedCountTask(task));
   }
 
@@ -238,6 +256,10 @@ class CamundaCamundaBackgroundTaskManagerFactoryTest {
 
   private boolean isProcessInstanceArchiverTask(final RunnableTask task) {
     return isTaskOfType(task, ProcessInstanceArchiverJob.class);
+  }
+
+  private boolean isProcessInstanceByIdArchiverTask(final RunnableTask task) {
+    return isTaskOfType(task, ProcessInstanceByIdArchiverJob.class);
   }
 
   private boolean isProcessInstanceToBeArchivedCountTask(final RunnableTask task) {


### PR DESCRIPTION

## Description

Enable the reindex by ID as the default archiving mode for process instances.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #50588 
