### PR TITLE
fix: log a clear warning instead of an error for records from other broker versions

### DIFF
--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -146,6 +146,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-commons</artifactId>
       <scope>test</scope>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -113,6 +113,10 @@ public final class ProcessingStateMachine {
       "Expected to process record '{} {}' successfully on stream processor, but caught recoverable exception. Retry processing.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_UNRECOVERABLE =
       "Expected to process record '{} {}' successfully on stream processor, but caught unrecoverable exception.";
+  private static final String WARN_MESSAGE_PROCESSING_RECORD_FROM_DIFFERENT_VERSION =
+      "Stopping processing because record '{} {}' could not be processed by this broker version. "
+          + "This is expected during a rolling upgrade; this broker will step down so a node on a "
+          + "compatible version can take over.";
   private static final String NOTIFY_PROCESSED_LISTENER_ERROR_MESSAGE =
       "Expected to invoke processed listener for record {} successfully, but exception was thrown.";
   private static final String NOTIFY_SKIPPED_LISTENER_ERROR_MESSAGE =
@@ -308,6 +312,19 @@ public final class ProcessingStateMachine {
           metadata,
           recoverableException);
       actor.schedule(PROCESSING_RETRY_DELAY, () -> processCommand(currentRecord));
+    } catch (final NoSuchProcessorException noSuchProcessorException) {
+      // a record written by a different broker version is expected during a rolling upgrade: log a
+      // clear message without a stack trace but still propagate so this broker steps down
+      if (!RecordMetadata.CURRENT_BROKER_VERSION.equals(metadata.getBrokerVersion())) {
+        LOG.warn(WARN_MESSAGE_PROCESSING_RECORD_FROM_DIFFERENT_VERSION, loggedEvent, metadata);
+      } else {
+        LOG.error(
+            ERROR_MESSAGE_PROCESSING_FAILED_UNRECOVERABLE,
+            loggedEvent,
+            metadata,
+            noSuchProcessorException);
+      }
+      throw noSuchProcessorException;
     } catch (final UnrecoverableException unrecoverableException) {
       LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_UNRECOVERABLE, loggedEvent, metadata);
       throw unrecoverableException;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -44,6 +44,10 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
 
   private static final String LOG_STMT_REPLAY_FINISHED = "Processor finished replay, with {}";
+  private static final String LOG_STMT_REPLAY_STOPPED_DIFFERENT_VERSION =
+      "Stopping at record [position: {}, valueType: {}] written by a different broker version ({}); "
+          + "this broker is {}. This is expected during a rolling upgrade.";
+  private static final String ERROR_NO_PROCESSOR = "No processor registered for {} of type {}";
   private static final String ERROR_INCONSISTENT_LOG =
       "Expected that position '%d' of current event is higher then position '%d' of last event, but was not. Inconsistent log detected!";
   private static final String ERROR_MSG_EXPECTED_TO_READ_METADATA =
@@ -242,7 +246,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
           recordProcessors.stream()
               .filter(p -> p.accepts(currentTypedEvent.getValueType()))
               .findFirst()
-              .orElseThrow(() -> NoSuchProcessorException.forRecord(currentTypedEvent));
+              .orElseThrow(() -> noProcessorRegistered(currentTypedEvent));
 
       processor.replay(currentTypedEvent);
       lastReplayedEventPosition = currentTypedEvent.getPosition();
@@ -271,6 +275,28 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
 
     LOG.info(LOG_STMT_REPLAY_FINISHED, lastProcessingPositions);
     recoveryFuture.complete(lastProcessingPositions);
+  }
+
+  /**
+   * Logs why no processor accepts the record and returns the exception to throw. A record written
+   * by a newer broker version is expected during a rolling upgrade and is logged as a warning
+   * without a stack trace; any other case is a genuine error and is logged loudly. The replay then
+   * fails as usual: {@link StreamProcessor} does not log this failure again (see its handling of
+   * {@link NoSuchProcessorException}).
+   */
+  private NoSuchProcessorException noProcessorRegistered(final TypedRecord<?> record) {
+    final var exception = NoSuchProcessorException.forRecord(record);
+    if (!RecordMetadata.CURRENT_BROKER_VERSION.equals(metadata.getBrokerVersion())) {
+      LOG.warn(
+          LOG_STMT_REPLAY_STOPPED_DIFFERENT_VERSION,
+          record.getPosition(),
+          record.getValueType(),
+          record.getBrokerVersion(),
+          RecordMetadata.CURRENT_BROKER_VERSION);
+    } else {
+      LOG.error(ERROR_NO_PROCESSOR, record.getRecordType(), record.getValueType(), exception);
+    }
+    return exception;
   }
 
   /**

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -210,7 +210,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
         replayCompletedFuture.onComplete(
             (v, error) -> {
               if (error != null) {
-                LOG.error("The replay of events failed.", error);
+                logReplayFailed(error);
                 onFailure(error);
               }
             });
@@ -219,7 +219,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
         replayCompletedFuture.onComplete(
             (lastProcessingPositions, error) -> {
               if (error != null) {
-                LOG.error("The replay of events failed.", error);
+                logReplayFailed(error);
                 onFailure(error);
               } else {
                 onRecovered(lastProcessingPositions);
@@ -386,8 +386,32 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             actor);
   }
 
+  private static boolean alreadyLoggedByProcessor(final Throwable error) {
+    for (Throwable cause = error; cause != null; cause = cause.getCause()) {
+      if (cause instanceof NoSuchProcessorException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void logReplayFailed(final Throwable error) {
+    if (alreadyLoggedByProcessor(error)) {
+      // a missing processor has already been logged by the replay state machine (as a warning for a
+      // record from a newer broker, or as an error otherwise); avoid repeating it here
+      LOG.debug("The replay of events stopped.", error);
+    } else {
+      LOG.error("The replay of events failed.", error);
+    }
+  }
+
   private void onFailure(final Throwable throwable) {
-    LOG.error("Actor {} failed in phase {}.", actorName, actor.getLifecyclePhase(), throwable);
+    if (alreadyLoggedByProcessor(throwable)) {
+      // see logReplayFailed: the missing processor was already logged at the appropriate level
+      LOG.debug("Actor {} stopped in phase {}.", actorName, actor.getLifecyclePhase(), throwable);
+    } else {
+      LOG.error("Actor {} failed in phase {}.", actorName, actor.getLifecyclePhase(), throwable);
+    }
 
     asyncScheduleServiceContext
         .closeActors(actor)

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorUnknownRecordTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorUnknownRecordTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.stream.api.RecordProcessor;
+import io.camunda.zeebe.stream.util.RecordToWrite;
+import io.camunda.zeebe.stream.util.Records;
+import io.camunda.zeebe.test.util.logging.RecordingAppender;
+import java.util.List;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Verifies how records that no processor accepts are logged. When such a record was written by a
+ * newer broker version (expected during a rolling upgrade) the misleading {@code
+ * NoSuchProcessorException} error with a stack trace is replaced by a clear warning. When the
+ * record did not come from a newer broker it is a genuine bug and is still logged loudly. In all
+ * cases the stream processor fails as before.
+ */
+@ExtendWith(StreamPlatformExtension.class)
+final class StreamProcessorUnknownRecordTest {
+
+  @SuppressWarnings("unused") // injected by the extension
+  private StreamPlatform streamPlatform;
+
+  private final RecordingAppender recorder = new RecordingAppender();
+  private final Logger processorLog = (Logger) LogManager.getLogger("io.camunda.zeebe.processor");
+  private final Logger logStreamLog = (Logger) LogManager.getLogger("io.camunda.zeebe.logstreams");
+  private Level previousProcessorLevel;
+  private Level previousLogStreamLevel;
+
+  @BeforeEach
+  void beforeEach() {
+    final RecordProcessor recordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    // no processor accepts a value type unknown to this version
+    when(recordProcessor.accepts(ValueType.NULL_VAL)).thenReturn(false);
+    when(recordProcessor.accepts(ValueType.SBE_UNKNOWN)).thenReturn(false);
+
+    previousProcessorLevel = processorLog.getLevel();
+    previousLogStreamLevel = logStreamLog.getLevel();
+    processorLog.setLevel(Level.WARN);
+    logStreamLog.setLevel(Level.WARN);
+    recorder.start();
+    processorLog.addAppender(recorder);
+    logStreamLog.addAppender(recorder);
+  }
+
+  @AfterEach
+  void afterEach() {
+    processorLog.removeAppender(recorder);
+    logStreamLog.removeAppender(recorder);
+    recorder.stop();
+    processorLog.setLevel(previousProcessorLevel);
+    logStreamLog.setLevel(previousLogStreamLevel);
+  }
+
+  @Test
+  void shouldWarnWhenReplayReachesRecordFromNewerVersion() {
+    // given
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.event().fromNewerBrokerVersion().causedBy(0));
+
+    // when - a follower replays (replay-only mode)
+    final var streamProcessor = streamPlatform.startStreamProcessorInReplayOnlyMode();
+
+    // then - replay fails, but with a friendly warning instead of the scary error
+    Awaitility.await("replay fails on a record from a newer version")
+        .until(() -> streamProcessor.getHealthReport().isUnhealthy());
+    assertFriendlyVersionSkewWarning();
+  }
+
+  @Test
+  void shouldStepDownWhenReplayReachesRecordFromNewerVersion() {
+    // given
+    final RecordProcessor recordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.event().fromNewerBrokerVersion().causedBy(0));
+
+    // when - a leader replays (processing mode); recovery never completes, so do not await opening
+    final var streamProcessor = streamPlatform.startStreamProcessorNotAwaitOpening();
+
+    // then - the leader steps down and never starts processing, with a friendly warning
+    Awaitility.await("leader steps down when replay reaches a record from a newer version")
+        .until(() -> streamProcessor.getHealthReport().isUnhealthy());
+    verify(recordProcessor, never()).process(any(), any());
+    assertFriendlyVersionSkewWarning();
+  }
+
+  @Test
+  void shouldWarnWhenProcessingCommandFromNewerVersion() {
+    // given
+    final RecordProcessor recordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    streamPlatform.writeBatch(RecordToWrite.command().fromNewerBrokerVersion());
+
+    // when - the leader replays (the command is skipped) and then tries to process it
+    final var streamProcessor = streamPlatform.startStreamProcessor();
+
+    // then - the leader steps down without processing the command, with a friendly warning
+    Awaitility.await("leader steps down when processing a command from a newer version")
+        .until(() -> streamProcessor.getHealthReport().isUnhealthy());
+    verify(recordProcessor, never()).process(any(), any());
+    assertFriendlyVersionSkewWarning();
+  }
+
+  @Test
+  void shouldLogErrorWhenRecordIsNotFromNewerVersion() {
+    // given - an unprocessable record that did NOT come from a newer broker (a genuine bug)
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.event().unknownValueType().causedBy(0));
+
+    // when
+    final var streamProcessor = streamPlatform.startStreamProcessorNotAwaitOpening();
+
+    // then - it is still reported loudly as a NoSuchProcessorException, not a rolling-upgrade
+    // warning
+    Awaitility.await("replay fails on a genuinely unprocessable record")
+        .until(() -> streamProcessor.getHealthReport().isUnhealthy());
+    final List<LogEvent> events = recorder.getAppendedEvents();
+    assertThat(events)
+        .as("a genuine missing processor is still logged loudly with the exception")
+        .anyMatch(e -> e.getLevel() == Level.ERROR && hasCause(e, NoSuchProcessorException.class));
+    assertThat(events)
+        .as("no rolling-upgrade warning for a record that is not from a newer broker")
+        .noneMatch(e -> e.getMessage().getFormattedMessage().contains("rolling upgrade"));
+  }
+
+  /**
+   * Asserts the behaviour the issue is actually about: the misleading {@code
+   * NoSuchProcessorException} error with a stack trace is gone, replaced by a clear warning about
+   * the rolling upgrade.
+   */
+  private void assertFriendlyVersionSkewWarning() {
+    final List<LogEvent> events = recorder.getAppendedEvents();
+    assertThat(events)
+        .as("the misleading NoSuchProcessorException is not logged as an error with a stack trace")
+        .noneMatch(e -> e.getLevel() == Level.ERROR && hasCause(e, NoSuchProcessorException.class))
+        .noneMatch(e -> e.getMessage().getFormattedMessage().contains("No processor registered"));
+    assertThat(events)
+        .as("a friendly warning explains that this is expected during a rolling upgrade")
+        .anyMatch(
+            e ->
+                e.getLevel() == Level.WARN
+                    && e.getMessage().getFormattedMessage().contains("rolling upgrade"));
+  }
+
+  private static boolean hasCause(final LogEvent event, final Class<?> type) {
+    for (Throwable cause = event.getThrown(); cause != null; cause = cause.getCause()) {
+      if (type.isInstance(cause)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.stream.util;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.VersionInfo;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
@@ -143,6 +144,35 @@ public final class RecordToWrite implements LogAppendEntry {
         .valueType(ValueType.PROCESS_INSTANCE_MODIFICATION)
         .intent(ProcessInstanceModificationIntent.MODIFY);
     unifiedRecordValue = (ProcessInstanceModificationRecord) value;
+    return this;
+  }
+
+  /**
+   * Simulates a record whose value type is unknown to the current version: the SBE codec decodes
+   * such a value type as {@link ValueType#SBE_UNKNOWN}, which round-trips to {@link
+   * ValueType#NULL_VAL}. A concrete value is attached only so the record can be serialized; on read
+   * its value is {@code null}. The broker version is left at the current version, so this
+   * represents a record no processor accepts that did <em>not</em> come from a newer broker.
+   */
+  public RecordToWrite unknownValueType() {
+    recordMetadata
+        .valueType(ValueType.SBE_UNKNOWN)
+        .intent(ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    unifiedRecordValue = new ProcessInstanceRecord();
+    return this;
+  }
+
+  /**
+   * Simulates a record written by a newer broker version during a rolling upgrade: an {@link
+   * #unknownValueType()} record additionally stamped with a broker version newer than the current
+   * one.
+   */
+  public RecordToWrite fromNewerBrokerVersion() {
+    unknownValueType();
+    final var current = RecordMetadata.CURRENT_BROKER_VERSION;
+    recordMetadata.brokerVersion(
+        new VersionInfo(
+            current.getMajorVersion() + 1, current.getMinorVersion(), current.getPatchVersion()));
     return this;
   }
 


### PR DESCRIPTION
During a rolling upgrade an older broker may replay or process a record written by another broker whose value type it does not know. The processor lookup throws `NoSuchProcessorException`, which surfaced as an alarming error log with a full stack trace (`No processor registered for event type SBE_UNKNOWN`), falsely suggesting a serious problem even though the situation is harmless.

This keeps the existing failure behavior and only changes the logging. At the point where the missing processor is detected (in `ReplayStateMachine` and in `ProcessingStateMachine`, where the record is available) the broker version stamped on the record is compared against this broker's version (`RecordMetadata.CURRENT_BROKER_VERSION`). A record written by a different broker version is logged as a clear warning explaining that this is expected during a rolling upgrade; a record from this broker's own version is a genuine bug and is still logged loudly with its stack trace. `StreamProcessor` no longer repeats the failure log once the state machine has already logged it (it falls back to debug when the cause is a `NoSuchProcessorException`). The comparison uses the stored broker version representation rather than the raw build version so a development `SNAPSHOT` matches the records it writes.

closes #49368