### PR TITLE
Add missing test coverage for AgentInstance feature

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentInstanceCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentInstanceCommandTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.response.CreateAgentInstanceResponse;
+import io.camunda.client.protocol.rest.AgentInstanceCreationRequest;
+import io.camunda.client.protocol.rest.AgentInstanceCreationResult;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CreateAgentInstanceCommandTest extends ClientRestTest {
+
+  private static final long ELEMENT_INSTANCE_KEY = 2251799813685248L;
+  private static final String MODEL = "gpt-4o";
+  private static final String PROVIDER = "openai";
+  private static final String SYSTEM_PROMPT = "You are a helpful assistant.";
+
+  // ── Happy-path: request body ──────────────────────────────────────────────
+
+  @Test
+  void shouldSendPostToCorrectUrl() {
+    // given
+    gatewayService.onCreateAgentInstanceRequest(
+        new AgentInstanceCreationResult().agentInstanceKey("1"));
+
+    // when
+    client
+        .newCreateAgentInstanceCommand()
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .model(MODEL)
+        .provider(PROVIDER)
+        .systemPrompt(SYSTEM_PROMPT)
+        .execute();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(request.getUrl()).isEqualTo("/v2/agent-instances");
+  }
+
+  @Test
+  void shouldSendRequiredFieldsInRequestBody() {
+    // given
+    gatewayService.onCreateAgentInstanceRequest(
+        new AgentInstanceCreationResult().agentInstanceKey("1"));
+
+    // when
+    client
+        .newCreateAgentInstanceCommand()
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .model(MODEL)
+        .provider(PROVIDER)
+        .systemPrompt(SYSTEM_PROMPT)
+        .execute();
+
+    // then
+    final AgentInstanceCreationRequest body =
+        gatewayService.getLastRequest(AgentInstanceCreationRequest.class);
+    assertThat(body.getElementInstanceKey()).isEqualTo(String.valueOf(ELEMENT_INSTANCE_KEY));
+    assertThat(body.getDefinition().getModel()).isEqualTo(MODEL);
+    assertThat(body.getDefinition().getProvider()).isEqualTo(PROVIDER);
+    assertThat(body.getDefinition().getSystemPrompt()).isEqualTo(SYSTEM_PROMPT);
+    assertThat(body.getLimits()).isNull();
+  }
+
+  @Test
+  void shouldSendRequiredAndOptionalFieldsInRequestBody() {
+    // given
+    gatewayService.onCreateAgentInstanceRequest(
+        new AgentInstanceCreationResult().agentInstanceKey("3"));
+
+    // when
+    client
+        .newCreateAgentInstanceCommand()
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .model(MODEL)
+        .provider(PROVIDER)
+        .systemPrompt(SYSTEM_PROMPT)
+        .maxTokens(5000L)
+        .maxModelCalls(10)
+        .maxToolCalls(20)
+        .execute();
+
+    // then
+    final AgentInstanceCreationRequest body =
+        gatewayService.getLastRequest(AgentInstanceCreationRequest.class);
+    assertThat(body.getLimits()).isNotNull();
+    assertThat(body.getLimits().getMaxTokens()).isEqualTo(5000L);
+    assertThat(body.getLimits().getMaxModelCalls()).isEqualTo(10);
+    assertThat(body.getLimits().getMaxToolCalls()).isEqualTo(20);
+  }
+
+  @Test
+  void shouldAcceptMinusOneAsNoLimitSentinel() {
+    // given
+    gatewayService.onCreateAgentInstanceRequest(
+        new AgentInstanceCreationResult().agentInstanceKey("4"));
+
+    // when / then — -1 is the "no limit" sentinel and must not throw
+    client
+        .newCreateAgentInstanceCommand()
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .model(MODEL)
+        .provider(PROVIDER)
+        .systemPrompt(SYSTEM_PROMPT)
+        .maxTokens(-1L)
+        .maxModelCalls(-1)
+        .maxToolCalls(-1)
+        .execute();
+  }
+
+  @Test
+  void shouldParseAgentInstanceKeyFromResponse() {
+    // given
+    gatewayService.onCreateAgentInstanceRequest(
+        new AgentInstanceCreationResult().agentInstanceKey("9876543210"));
+
+    // when
+    final CreateAgentInstanceResponse response =
+        client
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+            .model(MODEL)
+            .provider(PROVIDER)
+            .systemPrompt(SYSTEM_PROMPT)
+            .execute();
+
+    // then
+    assertThat(response.getAgentInstanceKey()).isEqualTo(9876543210L);
+  }
+
+  // ── Argument validation: elementInstanceKey ───────────────────────────────
+
+  @ParameterizedTest(name = "elementInstanceKey={0} should be rejected")
+  @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+  void shouldRejectNonPositiveElementInstanceKey(final long invalidKey) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentInstanceCommand()
+                    .elementInstanceKey(invalidKey)
+                    .model(MODEL)
+                    .provider(PROVIDER)
+                    .systemPrompt(SYSTEM_PROMPT)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("elementInstanceKey must be greater than 0");
+  }
+
+  // ── Argument validation: required String fields ───────────────────────────
+
+  @ParameterizedTest(name = "model=''{0}'' should be rejected")
+  @MethodSource("nullAndEmpty")
+  void shouldRejectNullOrEmptyModel(final String model) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentInstanceCommand()
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .model(model)
+                    .provider(PROVIDER)
+                    .systemPrompt(SYSTEM_PROMPT)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest(name = "provider=''{0}'' should be rejected")
+  @MethodSource("nullAndEmpty")
+  void shouldRejectNullOrEmptyProvider(final String provider) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentInstanceCommand()
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .model(MODEL)
+                    .provider(provider)
+                    .systemPrompt(SYSTEM_PROMPT)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest(name = "systemPrompt=''{0}'' should be rejected")
+  @MethodSource("nullAndEmpty")
+  void shouldRejectNullOrEmptySystemPrompt(final String systemPrompt) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentInstanceCommand()
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .model(MODEL)
+                    .provider(PROVIDER)
+                    .systemPrompt(systemPrompt)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  // ── Argument validation: limit lower-bounds ───────────────────────────────
+
+  @ParameterizedTest(name = "maxTokens={0} should be rejected")
+  @ValueSource(longs = {-2L, Long.MIN_VALUE})
+  void shouldRejectTooSmallMaxTokens(final long maxTokens) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentInstanceCommand()
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .model(MODEL)
+                    .provider(PROVIDER)
+                    .systemPrompt(SYSTEM_PROMPT)
+                    .maxTokens(maxTokens)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("maxTokens must be greater than -2");
+  }
+
+  @ParameterizedTest(name = "maxModelCalls={0} should be rejected")
+  @ValueSource(ints = {-2, Integer.MIN_VALUE})
+  void shouldRejectTooSmallMaxModelCalls(final int maxModelCalls) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentInstanceCommand()
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .model(MODEL)
+                    .provider(PROVIDER)
+                    .systemPrompt(SYSTEM_PROMPT)
+                    .maxModelCalls(maxModelCalls)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("maxModelCalls must be greater than -2");
+  }
+
+  @ParameterizedTest(name = "maxToolCalls={0} should be rejected")
+  @ValueSource(ints = {-2, Integer.MIN_VALUE})
+  void shouldRejectTooSmallMaxToolCalls(final int maxToolCalls) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentInstanceCommand()
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .model(MODEL)
+                    .provider(PROVIDER)
+                    .systemPrompt(SYSTEM_PROMPT)
+                    .maxToolCalls(maxToolCalls)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("maxToolCalls must be greater than -2");
+  }
+
+  static String[] nullAndEmpty() {
+    return new String[] {null, ""};
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
@@ -46,25 +46,12 @@ class SearchAgentInstanceTest extends ClientRestTest {
   @Test
   void shouldSearchAgentInstances() {
     // when
-    client
-        .newAgentInstanceSearchRequest()
-        .filter(f -> f.status(AgentInstanceStatus.IDLE))
-        .sort(s -> s.creationDate().asc())
-        .send()
-        .join();
+    client.newAgentInstanceSearchRequest().send().join();
 
     // then
     final LoggedRequest restRequest = RestGatewayService.getLastRequest();
     assertThat(restRequest.getMethod()).isEqualTo(RequestMethod.POST);
     assertThat(restRequest.getUrl()).isEqualTo("/v2/agent-instances/search");
-  }
-
-  @Test
-  void shouldSearchAgentInstancesWithoutFilter() {
-    // when
-    client.newAgentInstanceSearchRequest().send().join();
-
-    // then
     final AgentInstanceSearchQuery request =
         gatewayService.getLastRequest(AgentInstanceSearchQuery.class);
     assertThat(request.getFilter()).isNull();

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.command.AgentInstanceUpdateStatus;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
+import io.camunda.client.protocol.rest.AgentInstanceUpdateRequest;
+import io.camunda.client.protocol.rest.AgentInstanceUpdateStatusEnum;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UpdateAgentInstanceCommandTest extends ClientRestTest {
+
+  private static final long AGENT_INSTANCE_KEY = 1234L;
+  private static final long ELEMENT_INSTANCE_KEY = 5678L;
+
+  // ── Happy-path: request routing ───────────────────────────────────────────
+
+  @Test
+  void shouldSendPatchToCorrectUrl() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .execute();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.PATCH);
+    assertThat(request.getUrl()).isEqualTo("/v2/agent-instances/1234");
+  }
+
+  @Test
+  void shouldSendAllOptionalFieldsInRequestBody() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .status(AgentInstanceUpdateStatus.THINKING)
+        .inputTokens(100L)
+        .outputTokens(200L)
+        .modelCalls(3)
+        .toolCalls(2)
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getElementInstanceKey()).isEqualTo(String.valueOf(ELEMENT_INSTANCE_KEY));
+    assertThat(body.getStatus()).isEqualTo(AgentInstanceUpdateStatusEnum.THINKING);
+    assertThat(body.getMetrics().getInputTokens()).isEqualTo(100L);
+    assertThat(body.getMetrics().getOutputTokens()).isEqualTo(200L);
+    assertThat(body.getMetrics().getModelCalls()).isEqualTo(3);
+    assertThat(body.getMetrics().getToolCalls()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldSendOnlyElementInstanceKeyWhenNoOtherFieldsSet() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getElementInstanceKey()).isEqualTo(String.valueOf(ELEMENT_INSTANCE_KEY));
+    assertThat(body.getStatus()).isNull();
+    assertThat(body.getMetrics()).isNull();
+    assertThat(body.getTools()).isNull();
+  }
+
+  // ── Tools mapping ─────────────────────────────────────────────────────────
+
+  @Test
+  void shouldMapToolsWithAllFields() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .tools(Arrays.asList(AgentTool.of("search", "A web search tool", "searchTask")))
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getTools())
+        .singleElement()
+        .satisfies(
+            tool -> {
+              assertThat(tool.getName()).isEqualTo("search");
+              assertThat(tool.getDescription()).isEqualTo("A web search tool");
+              assertThat(tool.getElementId()).isEqualTo("searchTask");
+            });
+  }
+
+  @Test
+  void shouldMapToolWithNameOnlyOmittingNullOptionalFields() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .tools(Arrays.asList(AgentTool.of("summarize")))
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getTools()).hasSize(1);
+    final io.camunda.client.protocol.rest.AgentTool tool = body.getTools().get(0);
+    assertThat(tool.getName()).isEqualTo("summarize");
+    assertThat(tool.getDescription()).isNull();
+    assertThat(tool.getElementId()).isNull();
+  }
+
+  @Test
+  void shouldSendEmptyToolsList() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .tools(Collections.emptyList())
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getTools()).isEmpty();
+  }
+
+  @Test
+  void shouldMapMultipleToolsMixingOptionalFields() {
+    // given
+    gatewayService.onUpdateAgentInstanceRequest(AGENT_INSTANCE_KEY);
+
+    // when
+    client
+        .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .tools(
+            Arrays.asList(
+                AgentTool.of("search", "Search the web", "searchTask"), AgentTool.of("summarize")))
+        .execute();
+
+    // then
+    final AgentInstanceUpdateRequest body =
+        gatewayService.getLastRequest(AgentInstanceUpdateRequest.class);
+    assertThat(body.getTools())
+        .extracting(
+            io.camunda.client.protocol.rest.AgentTool::getName,
+            io.camunda.client.protocol.rest.AgentTool::getDescription,
+            io.camunda.client.protocol.rest.AgentTool::getElementId)
+        .containsExactly(
+            tuple("search", "Search the web", "searchTask"), tuple("summarize", null, null));
+  }
+
+  // ── Argument validation: agentInstanceKey ────────────────────────────────
+
+  @ParameterizedTest(name = "agentInstanceKey={0} should be rejected")
+  @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+  void shouldRejectNonPositiveAgentInstanceKey(final long invalidKey) {
+    assertThatThrownBy(() -> client.newUpdateAgentInstanceCommand(invalidKey))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("agentInstanceKey must be greater than 0");
+  }
+
+  // ── Argument validation: elementInstanceKey ───────────────────────────────
+
+  @ParameterizedTest(name = "elementInstanceKey={0} should be rejected")
+  @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+  void shouldRejectNonPositiveElementInstanceKey(final long invalidKey) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAgentInstanceCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(invalidKey)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("elementInstanceKey must be greater than 0");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -21,6 +21,7 @@ public class RestGatewayPaths {
 
   private static final String URL_AUTHORIZATION = REST_API_PATH + "/authorizations/%s";
   private static final String URL_AUTHORIZATIONS = REST_API_PATH + "/authorizations";
+  private static final String URL_AGENT_INSTANCES = REST_API_PATH + "/agent-instances";
   private static final String URL_AGENT_INSTANCE = REST_API_PATH + "/agent-instances/%s";
   private static final String URL_AGENT_INSTANCES_SEARCH =
       REST_API_PATH + "/agent-instances/search";
@@ -493,6 +494,10 @@ public class RestGatewayPaths {
 
   public static String getJobErrorStatisticsUrl() {
     return URL_JOB_ERROR_STATISTICS;
+  }
+
+  public static String getAgentInstancesUrl() {
+    return URL_AGENT_INSTANCES;
   }
 
   public static String getAgentInstanceUrl(final long agentInstanceKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.protocol.rest.AgentInstanceCreationResult;
 import io.camunda.client.protocol.rest.AgentInstanceResult;
 import io.camunda.client.protocol.rest.AgentInstanceSearchQueryResult;
 import io.camunda.client.protocol.rest.AuditLogResult;
@@ -365,6 +366,19 @@ public class RestGatewayService {
   public void onBatchOperationRequest(
       final String batchOperationKey, final BatchOperationResponse response) {
     registerGet(RestGatewayPaths.getBatchOperationUrl(batchOperationKey), response);
+  }
+
+  public void onCreateAgentInstanceRequest(final AgentInstanceCreationResult response) {
+    registerPost(RestGatewayPaths.getAgentInstancesUrl(), response);
+  }
+
+  public void onUpdateAgentInstanceRequest(final long agentInstanceKey) {
+    mockInfo
+        .getWireMock()
+        .register(
+            WireMock.patch(
+                    WireMock.urlEqualTo(RestGatewayPaths.getAgentInstanceUrl(agentInstanceKey)))
+                .willReturn(WireMock.noContent()));
   }
 
   public void onAgentInstanceGetRequest(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.UPDATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class AgentInstanceAuthorizationIT {
+
+  private static final String AGENT_ELEMENT_ID = "agentAuthElement";
+  private static final String PROCESS_ID_1 = "agentAuthProcess1";
+  private static final String PROCESS_ID_2 = "agentAuthProcess2";
+  private static final String PROCESS_ID_3 = "agentAuthProcess3";
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String USER3 = "user3";
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER =
+      new TestUser(
+          ADMIN,
+          "password",
+          List.of(
+              new Permissions(RESOURCE, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, UPDATE_PROCESS_INSTANCE, List.of("*"))));
+
+  // user1 may read agent instances of PROCESS_ID_1 only
+  @UserDefinition
+  private static final TestUser USER1_USER =
+      new TestUser(
+          USER1,
+          "password",
+          List.of(
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(PROCESS_ID_1))));
+
+  // user2 may read agent instances of PROCESS_ID_2 only
+  @UserDefinition
+  private static final TestUser USER2_USER =
+      new TestUser(
+          USER2,
+          "password",
+          List.of(
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(PROCESS_ID_2))));
+
+  // user3 may update agent instances of PROCESS_ID_3 only
+  @UserDefinition
+  private static final TestUser USER3_USER =
+      new TestUser(
+          USER3,
+          "password",
+          List.of(
+              new Permissions(PROCESS_DEFINITION, UPDATE_PROCESS_INSTANCE, List.of(PROCESS_ID_3))));
+
+  private static long agentInstanceKey1;
+  private static long agentInstanceKey2;
+  private static long agentInstanceKey3;
+  private static long elementInstanceKey1;
+  private static long elementInstanceKey3;
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    final var result1 = createAgentInstance(adminClient, PROCESS_ID_1);
+    agentInstanceKey1 = result1.agentInstanceKey();
+    elementInstanceKey1 = result1.elementInstanceKey();
+
+    agentInstanceKey2 = createAgentInstance(adminClient, PROCESS_ID_2).agentInstanceKey();
+    final var result3 = createAgentInstance(adminClient, PROCESS_ID_3);
+
+    agentInstanceKey3 = result3.agentInstanceKey();
+    elementInstanceKey3 = result3.elementInstanceKey();
+    waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey1);
+    waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey2);
+    waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey3);
+  }
+
+  // ── search ────────────────────────────────────────────────────────────────
+
+  @Test
+  void searchShouldReturnOnlyAuthorizedAgentInstances(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentInstanceSearchRequest().execute();
+
+    // then
+    assertThat(result.items())
+        .singleElement()
+        .satisfies(
+            instance -> assertThat(instance.getAgentInstanceKey()).isEqualTo(agentInstanceKey1));
+  }
+
+  @Test
+  void searchShouldNotReturnUnauthorizedAgentInstances(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when — user1 filters explicitly on the process they cannot read
+    final var result =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(PROCESS_ID_2))
+            .execute();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void searchShouldReturnAllAgentInstancesForAdmin(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentInstanceSearchRequest().execute();
+
+    // then — admin sees all three instances
+    assertThat(result.items())
+        .extracting(AgentInstance::getAgentInstanceKey)
+        .containsExactlyInAnyOrder(agentInstanceKey1, agentInstanceKey2, agentInstanceKey3);
+  }
+
+  // ── getByKey ──────────────────────────────────────────────────────────────
+
+  @Test
+  void getByKeyShouldReturnAuthorizedAgentInstance(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentInstanceGetRequest(agentInstanceKey2).execute();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getAgentInstanceKey()).isEqualTo(agentInstanceKey2);
+    assertThat(result.getProcessDefinitionId()).isEqualTo(PROCESS_ID_2);
+  }
+
+  @Test
+  void getByKeyShouldReturn403ForUnauthorizedAgentInstance(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final ThrowingCallable executeGet =
+        () -> camundaClient.newAgentInstanceGetRequest(agentInstanceKey2).execute();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource"
+                + " 'PROCESS_DEFINITION'");
+  }
+
+  // ── create ────────────────────────────────────────────────────────────────
+
+  @Test
+  void createShouldReturn403WhenUnauthorized(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given — user1 has READ_PROCESS_INSTANCE on PROCESS_ID_1 but not UPDATE_PROCESS_INSTANCE
+    final ThrowingCallable execute =
+        () ->
+            camundaClient
+                .newCreateAgentInstanceCommand()
+                .elementInstanceKey(elementInstanceKey1)
+                .model("gpt-4o")
+                .provider("openai")
+                .systemPrompt("You are a helpful assistant.")
+                .execute();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(execute).actual();
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .contains(
+            "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  @Test
+  void createShouldReturnExistingKeyWhenAlreadyExistsForAuthorizedUser(
+      @Authenticated(USER3) final CamundaClient camundaClient) {
+    // given — user3 has UPDATE_PROCESS_INSTANCE on PROCESS_ID_3, and an agent instance was
+    // already created for elementInstanceKey3 by admin in setUp
+
+    // when
+    final var response =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(elementInstanceKey3)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are a helpful assistant.")
+            .execute();
+
+    // then — idempotent CREATE returns the existing key
+    assertThat(response.getAgentInstanceKey()).isEqualTo(agentInstanceKey3);
+  }
+
+  // ── update ────────────────────────────────────────────────────────────────
+
+  @Test
+  void updateShouldReturn403WhenUnauthorized(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given — user1 has READ_PROCESS_INSTANCE on PROCESS_ID_1 but not UPDATE_PROCESS_INSTANCE
+    final ThrowingCallable execute =
+        () ->
+            camundaClient
+                .newUpdateAgentInstanceCommand(agentInstanceKey1)
+                .elementInstanceKey(elementInstanceKey1)
+                .execute();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(execute).actual();
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail()).contains("'UPDATE_PROCESS_INSTANCE'");
+  }
+
+  @Test
+  void updateShouldSucceedWhenUserHasUpdatePermission(
+      @Authenticated(USER3) final CamundaClient camundaClient) {
+    // given — user3 has UPDATE_PROCESS_INSTANCE on PROCESS_ID_3
+
+    // when / then — no exception means the command was accepted
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                camundaClient
+                    .newUpdateAgentInstanceCommand(agentInstanceKey3)
+                    .elementInstanceKey(elementInstanceKey3)
+                    .execute());
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private static AgentInstanceCreationResult createAgentInstance(
+      final CamundaClient adminClient, final String processId) {
+    final var processModel =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
+            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(adminClient, processModel, processId + ".bpmn");
+
+    final var pi = startProcessInstance(adminClient, processId);
+    final long processInstanceKey = pi.getProcessInstanceKey();
+
+    waitForElementInstances(
+        adminClient, f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey), 1);
+
+    final var elementInstanceKey =
+        adminClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    final var agentInstanceKey =
+        adminClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(elementInstanceKey)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are a helpful assistant.")
+            .execute()
+            .getAgentInstanceKey();
+
+    return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey);
+  }
+
+  private record AgentInstanceCreationResult(long agentInstanceKey, long elementInstanceKey) {}
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -57,7 +57,6 @@ public class AgentInstanceFetchIT {
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
             .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
-            .moveToActivity(AGENT_ELEMENT_ID)
             .endEvent("end")
             .done();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
@@ -54,7 +54,6 @@ public class AgentInstanceSearchIT {
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
             .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
-            .moveToActivity(AGENT_ELEMENT_ID)
             .endEvent("end")
             .done();
 
@@ -69,7 +68,6 @@ public class AgentInstanceSearchIT {
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
             .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
-            .moveToActivity(AGENT_ELEMENT_ID)
             .endEvent("end")
             .done();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static io.camunda.it.util.TestHelper.deployProcessForTenantAndWaitForIt;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class AgentInstanceTenancyIT {
+
+  private static final String AGENT_ELEMENT_ID = "agentTenancyElement";
+  private static final String PROCESS_ID = "agentTenancyProcess";
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  /** user1 is assigned to TENANT_A only. */
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  /** user2 is not assigned to any tenant. */
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  private static long agentInstanceKeyA;
+  private static long agentInstanceKeyB;
+  private static long elementInstanceKeyB;
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    final BpmnModelInstance processModel =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
+            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .endEvent()
+            .done();
+
+    // Deploy the same process in both tenants
+    deployProcessForTenant(adminClient, processModel, TENANT_A);
+    deployProcessForTenant(adminClient, processModel, TENANT_B);
+
+    agentInstanceKeyA = createAgentInstance(adminClient, TENANT_A);
+    final var resultB = createAgentInstanceWithResult(adminClient, TENANT_B);
+    agentInstanceKeyB = resultB.agentInstanceKey();
+    elementInstanceKeyB = resultB.elementInstanceKey();
+
+    waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyA);
+    waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyB);
+  }
+
+  // ── search ────────────────────────────────────────────────────────────────
+
+  @Test
+  void searchShouldReturnAllAgentInstancesForAdminWithBothTenants(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentInstanceSearchRequest().execute();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().stream().map(ai -> ai.getTenantId()).toList())
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  void searchShouldReturnOnlyTenantAAgentInstancesForUser1(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentInstanceSearchRequest().execute();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getTenantId()).isEqualTo(TENANT_A);
+    assertThat(result.items().getFirst().getAgentInstanceKey()).isEqualTo(agentInstanceKeyA);
+  }
+
+  @Test
+  void searchShouldReturnNoAgentInstancesForUserWithNoTenantAccess(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentInstanceSearchRequest().execute();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  // ── getByKey ──────────────────────────────────────────────────────────────
+
+  @Test
+  void getByKeyShouldReturnAgentInstanceWithinAccessibleTenant(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentInstanceGetRequest(agentInstanceKeyA).execute();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getAgentInstanceKey()).isEqualTo(agentInstanceKeyA);
+    assertThat(result.getTenantId()).isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void getByKeyShouldReturn404ForAgentInstanceOutsideAccessibleTenant(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when — user1 has no access to TENANT_B
+    final var exception =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(() -> camundaClient.newAgentInstanceGetRequest(agentInstanceKeyB).execute())
+            .actual();
+
+    // then — tenant boundary surfaced as 404, not 403
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+    assertThat(exception.details().getDetail())
+        .contains("Agent Instance with key '%d' not found".formatted(agentInstanceKeyB));
+  }
+
+  // ── create ────────────────────────────────────────────────────────────────
+
+  @Test
+  void createShouldReturn404ForCrossTenantRequest(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given — user1 belongs to TENANT_A only; elementInstanceKeyB is in TENANT_B
+    // with withAuthenticatedAccess() the engine surfaces cross-tenant violations as 404,
+    // consistent with how getByKey hides cross-tenant records
+    final var exception =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newCreateAgentInstanceCommand()
+                        .elementInstanceKey(elementInstanceKeyB)
+                        .model("gpt-4o")
+                        .provider("openai")
+                        .systemPrompt("You are a helpful assistant.")
+                        .execute())
+            .actual();
+
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+  }
+
+  // ── update ────────────────────────────────────────────────────────────────
+
+  @Test
+  void updateShouldReturn404ForCrossTenantRequest(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given — user1 belongs to TENANT_A only; agentInstanceKeyB is in TENANT_B
+    final var exception =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newUpdateAgentInstanceCommand(agentInstanceKeyB)
+                        .elementInstanceKey(elementInstanceKeyB)
+                        .execute())
+            .actual();
+
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private static void createTenant(final CamundaClient client, final String tenantId) {
+    client.newCreateTenantCommand().tenantId(tenantId).name(tenantId).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient client, final String username, final String tenantId) {
+    client.newAssignUserToTenantCommand().username(username).tenantId(tenantId).send().join();
+  }
+
+  private static void deployProcessForTenant(
+      final CamundaClient client, final BpmnModelInstance model, final String tenantId) {
+    final String filename = PROCESS_ID + "-" + tenantId + ".bpmn";
+    deployProcessForTenantAndWaitForIt(client, model, filename, tenantId);
+  }
+
+  private static long createAgentInstance(final CamundaClient client, final String tenantId) {
+    return createAgentInstanceWithResult(client, tenantId).agentInstanceKey();
+  }
+
+  private static AgentInstanceCreationResult createAgentInstanceWithResult(
+      final CamundaClient client, final String tenantId) {
+    // Start process instance in the given tenant
+    final var pi =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .tenantId(tenantId)
+            .execute();
+    final long processInstanceKey = pi.getProcessInstanceKey();
+
+    waitForElementInstances(
+        client, f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey), 1);
+
+    final var elementInstanceKey =
+        client
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    final var agentInstanceKey =
+        client
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(elementInstanceKey)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are a helpful assistant.")
+            .execute()
+            .getAgentInstanceKey();
+
+    return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey);
+  }
+
+  private record AgentInstanceCreationResult(long agentInstanceKey, long elementInstanceKey) {}
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateAgentInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateAgentInstanceRequest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
@@ -22,9 +21,6 @@ public class BrokerUpdateAgentInstanceRequest extends BrokerExecuteCommand<Agent
     super(ValueType.AGENT_INSTANCE, AgentInstanceIntent.UPDATE);
     requestDto = record;
     request.setKey(record.getAgentInstanceKey());
-    // Route to the partition that owns the agent instance, decoded from the key.
-    // All keys in Zeebe encode the owning partition in their high bits.
-    request.setPartitionId(Protocol.decodePartitionId(record.getAgentInstanceKey()));
   }
 
   @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.client.command;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public final class CreateAgentInstanceTest {
+
+  @TestZeebe
+  private static final TestStandaloneBroker ZEEBE =
+      new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+
+  @AutoClose CamundaClient client;
+  ZeebeResourcesHelper resourcesHelper;
+
+  @BeforeEach
+  public void init() {
+    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+  }
+
+  @Test
+  public void shouldReturnUnavailableWhenElementInstanceKeyEncodesNonExistentPartition() {
+    // given
+    // Keys encode the target partition in their upper 13 bits; a key for a non-existent partition
+    // yields 503 UNAVAILABLE (PartitionNotFoundException).
+    final long elementInstanceKey = Protocol.encodePartitionId(999, 1);
+
+    // when
+    final var responseFuture =
+        client
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(elementInstanceKey)
+            .model("test-model")
+            .provider("test-provider")
+            .systemPrompt("You are a helpful assistant.")
+            .send();
+
+    // then
+    assertThatThrownBy(responseFuture::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAVAILABLE")
+        .hasMessageContaining("status: 503")
+        .hasMessageContaining("Expected to handle request, but request could not be delivered");
+  }
+
+  @Test
+  public void shouldReturnNotFoundWhenElementInstanceDoesNotExistOnExistingPartition() {
+    // given
+    final int partition = resourcesHelper.getPartitions().getFirst();
+    final long nonExistingKey = Protocol.encodePartitionId(partition, 2);
+
+    // when
+    final var responseFuture =
+        client
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(nonExistingKey)
+            .model("test-model")
+            .provider("test-provider")
+            .systemPrompt("You are a helpful assistant.")
+            .send();
+
+    // then
+    assertThatThrownBy(responseFuture::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: NOT_FOUND")
+        .hasMessageContaining("status: 404")
+        .hasMessageContaining(
+            "Expected to create agent instance for element instance with key '%d', but no such element instance was found."
+                .formatted(nonExistingKey));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateAgentInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateAgentInstanceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.client.command;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public final class UpdateAgentInstanceTest {
+
+  @TestZeebe
+  private static final TestStandaloneBroker ZEEBE =
+      new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+
+  @AutoClose CamundaClient client;
+  ZeebeResourcesHelper resourcesHelper;
+
+  @BeforeEach
+  public void init() {
+    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+  }
+
+  @Test
+  public void shouldReturnUnavailableWhenAgentInstanceKeyEncodesNonExistentPartition() {
+    // given
+    // Keys encode the target partition in their upper 13 bits; a key for a non-existent partition
+    // yields 503 UNAVAILABLE (PartitionNotFoundException).
+    final long agentInstanceKey = Protocol.encodePartitionId(999, 1);
+
+    // when
+    final var responseFuture =
+        client.newUpdateAgentInstanceCommand(agentInstanceKey).elementInstanceKey(1L).send();
+
+    // then
+    assertThatThrownBy(responseFuture::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAVAILABLE")
+        .hasMessageContaining("status: 503")
+        .hasMessageContaining("Expected to handle request, but request could not be delivered");
+  }
+
+  @Test
+  public void shouldReturnNotFoundWhenAgentInstanceDoesNotExistOnExistingPartition() {
+    // given
+    final int partition = resourcesHelper.getPartitions().getFirst();
+    final long nonExistingKey = Protocol.encodePartitionId(partition, 2);
+
+    // when
+    final var responseFuture =
+        client.newUpdateAgentInstanceCommand(nonExistingKey).elementInstanceKey(1L).send();
+
+    // then
+    assertThatThrownBy(responseFuture::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: NOT_FOUND")
+        .hasMessageContaining("status: 404")
+        .hasMessageContaining(
+            "Expected to update agent instance with key '%d', but no such agent instance was found."
+                .formatted(nonExistingKey));
+  }
+}


### PR DESCRIPTION
## Description

This PR adds missing test coverage for the AgentInstance feature (issue #54094), split into focused commits across the relevant test layers.

### New test classes

**`CreateAgentInstanceCommandTest` / `UpdateAgentInstanceCommandTest`** (`clients/java`)
Unit tests for the Java client command builders. Cover serialization of all required and optional fields (model, provider, systemPrompt, limits, tools) into the REST request body, and verify that omitting optional fields produces the expected null values in the payload.

**`AgentInstanceAuthorizationIT`** (`qa/acceptance-tests`)
Acceptance tests verifying that the AgentInstance create, update, and search endpoints enforce authorization correctly — unauthorized clients receive 403, and authorized clients succeed.

**`AgentInstanceTenancyIT`** (`qa/acceptance-tests`)
Acceptance tests verifying multi-tenancy isolation for AgentInstance operations — instances created under one tenant are not visible to another tenant, and cross-tenant mutations are rejected.

**`CreateAgentInstanceTest` / `UpdateAgentInstanceTest`** (`zeebe/qa/integration-tests`)
Integration tests for engine-level error handling on the create and update AgentInstance commands. Cover two error scenarios:
- a key encoding a non-existent partition → 503 UNAVAILABLE (request cannot be routed)
- a key encoding a valid partition but no matching entity → 404 NOT_FOUND with the precise engine rejection message

### Improvements

**Refactor: remove redundant `setPartitionId` in `BrokerUpdateAgentInstanceRequest`**
`ExecuteCommandRequest.setKey()` already extracts and sets the partition ID from the encoded key. The explicit `setPartitionId(Protocol.decodePartitionId(key))` call that followed was a no-op and has been removed to avoid confusion.

**Minor: simplify AgentInstance search and fetch tests** (deferred from PR #54036)
- `shouldSearchAgentInstances` and `shouldSearchAgentInstancesWithoutFilter` were merged into a single test — the status filter in the first test was irrelevant to what it verified (HTTP method + URL).
- Redundant `.moveToActivity(AGENT_ELEMENT_ID)` calls were also removed from the BPMN builder chains in `AgentInstanceFetchIT` and `AgentInstanceSearchIT`; the builder cursor is already positioned at that element after `adHocSubProcess(...)`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54094