### PR TITLE
feat: implement WaitStateRelated on ConditionalSubscriptionRecordValue

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -532,7 +532,8 @@ public final class CatchEventBehavior {
         .setCondition(BufferUtil.wrapString(conditional.getCondition()))
         .setVariableNames(conditional.getVariableNames())
         .setVariableEvents(conditional.getVariableEvents())
-        .setTenantId(context.getTenantId());
+        .setTenantId(context.getTenantId())
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
 
     final var subscriptionKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -533,7 +533,8 @@ public final class CatchEventBehavior {
         .setVariableNames(conditional.getVariableNames())
         .setVariableEvents(conditional.getVariableEvents())
         .setTenantId(context.getTenantId())
-        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
+        .setElementType(event.getElementType());
 
     final var subscriptionKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
@@ -12,10 +12,12 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -40,6 +42,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
   // default to -1 for root level start events
   private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY, -1L);
@@ -61,9 +64,11 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final EnumProperty<BpmnElementType> elementTypeProp =
+      new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public ConditionalSubscriptionRecord() {
-    super(12);
+    super(13);
     declareProperty(scopeKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -75,7 +80,8 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(variableNamesProp)
         .declareProperty(variableEventsProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(elementTypeProp);
   }
 
   public void wrap(final ConditionalSubscriptionRecord record) {
@@ -91,6 +97,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     setVariableEvents(record.getVariableEvents());
     tenantIdProp.setValue(record.getTenantId());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    elementTypeProp.setValue(record.getElementType());
   }
 
   /**
@@ -248,5 +255,15 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   @Override
   public String getElementId() {
     return getCatchEventId();
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public ConditionalSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
@@ -38,6 +38,8 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue VARIABLE_NAMES_KEY = new StringValue("variableNames");
   private static final StringValue VARIABLE_EVENTS_KEY = new StringValue("variableEvents");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   // default to -1 for root level start events
   private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY, -1L);
@@ -57,9 +59,11 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
       new ArrayProperty<>(VARIABLE_EVENTS_KEY, StringValue::new);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public ConditionalSubscriptionRecord() {
-    super(11);
+    super(12);
     declareProperty(scopeKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -70,7 +74,8 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(conditionProp)
         .declareProperty(variableNamesProp)
         .declareProperty(variableEventsProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   public void wrap(final ConditionalSubscriptionRecord record) {
@@ -85,6 +90,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     setVariableNames(record.getVariableNames());
     setVariableEvents(record.getVariableEvents());
     tenantIdProp.setValue(record.getTenantId());
+    rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
   }
 
   /**
@@ -227,5 +233,20 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   public ConditionalSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
     return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public ConditionalSubscriptionRecord setRootProcessInstanceKey(final long key) {
+    rootProcessInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return getCatchEventId();
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4299,7 +4299,8 @@ final class JsonSerializableToJsonTest {
                     .setVariableNames(List.of("x", "y"))
                     .setVariableEvents(List.of("CREATED", "UPDATED"))
                     .setInterrupting(true)
-                    .setRootProcessInstanceKey(999L),
+                    .setRootProcessInstanceKey(999L)
+                    .setElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT),
         """
                 {
                   "tenantId":"tenant-1",
@@ -4314,6 +4315,7 @@ final class JsonSerializableToJsonTest {
                   "bpmnProcessId":"process-1",
                   "processDefinitionKey":456,
                   "rootProcessInstanceKey":999,
+                  "elementType":"INTERMEDIATE_CATCH_EVENT",
                   "elementId":"catchEvent"
                 }
                 """
@@ -4341,6 +4343,7 @@ final class JsonSerializableToJsonTest {
                   "bpmnProcessId":"",
                   "processDefinitionKey":-1,
                   "rootProcessInstanceKey":-1,
+                  "elementType":"UNSPECIFIED",
                   "elementId":""
                 }
                 """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4298,7 +4298,8 @@ final class JsonSerializableToJsonTest {
                     .setCondition(BufferUtil.wrapString("=x > 5"))
                     .setVariableNames(List.of("x", "y"))
                     .setVariableEvents(List.of("CREATED", "UPDATED"))
-                    .setInterrupting(true),
+                    .setInterrupting(true)
+                    .setRootProcessInstanceKey(999L),
         """
                 {
                   "tenantId":"tenant-1",
@@ -4311,7 +4312,9 @@ final class JsonSerializableToJsonTest {
                   "variableNames":["x","y"],
                   "variableEvents":["CREATED","UPDATED"],
                   "bpmnProcessId":"process-1",
-                  "processDefinitionKey":456
+                  "processDefinitionKey":456,
+                  "rootProcessInstanceKey":999,
+                  "elementId":"catchEvent"
                 }
                 """
       },
@@ -4336,7 +4339,9 @@ final class JsonSerializableToJsonTest {
                   "variableNames":[],
                   "variableEvents":[],
                   "bpmnProcessId":"",
-                  "processDefinitionKey":-1
+                  "processDefinitionKey":-1,
+                  "rootProcessInstanceKey":-1,
+                  "elementId":""
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalSubscriptionRecord.golden
@@ -12,10 +12,12 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -40,6 +42,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
   // default to -1 for root level start events
   private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY, -1L);
@@ -61,9 +64,11 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final EnumProperty<BpmnElementType> elementTypeProp =
+      new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public ConditionalSubscriptionRecord() {
-    super(12);
+    super(13);
     declareProperty(scopeKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -75,7 +80,8 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(variableNamesProp)
         .declareProperty(variableEventsProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(elementTypeProp);
   }
 
   public void wrap(final ConditionalSubscriptionRecord record) {
@@ -91,6 +97,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     setVariableEvents(record.getVariableEvents());
     tenantIdProp.setValue(record.getTenantId());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    elementTypeProp.setValue(record.getElementType());
   }
 
   /**
@@ -248,5 +255,15 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   @Override
   public String getElementId() {
     return getCatchEventId();
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public ConditionalSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalSubscriptionRecord.golden
@@ -38,6 +38,8 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue VARIABLE_NAMES_KEY = new StringValue("variableNames");
   private static final StringValue VARIABLE_EVENTS_KEY = new StringValue("variableEvents");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   // default to -1 for root level start events
   private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY, -1L);
@@ -57,9 +59,11 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
       new ArrayProperty<>(VARIABLE_EVENTS_KEY, StringValue::new);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public ConditionalSubscriptionRecord() {
-    super(11);
+    super(12);
     declareProperty(scopeKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -70,7 +74,8 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(conditionProp)
         .declareProperty(variableNamesProp)
         .declareProperty(variableEventsProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   public void wrap(final ConditionalSubscriptionRecord record) {
@@ -85,6 +90,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     setVariableNames(record.getVariableNames());
     setVariableEvents(record.getVariableEvents());
     tenantIdProp.setValue(record.getTenantId());
+    rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
   }
 
   /**
@@ -227,5 +233,20 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   public ConditionalSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
     return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public ConditionalSubscriptionRecord setRootProcessInstanceKey(final long key) {
+    rootProcessInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return getCatchEventId();
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ConditionalSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ConditionalSubscriptionRecordValue.java
@@ -95,4 +95,9 @@ public interface ConditionalSubscriptionRecordValue
    * @return true if the condition is interrupting, false otherwise
    */
   boolean isInterrupting();
+
+  /**
+   * @return the BPMN element type of the element this subscription belongs to
+   */
+  BpmnElementType getElementType();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ConditionalSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ConditionalSubscriptionRecordValue.java
@@ -23,7 +23,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableConditionalSubscriptionRecordValue.Builder.class)
 public interface ConditionalSubscriptionRecordValue
-    extends RecordValue, ProcessInstanceRelated, TenantOwned {
+    extends RecordValue, ProcessInstanceRelated, TenantOwned, WaitStateRelated {
 
   /**
    * The key of the scope in which the condition is evaluated. Scopes should be assigned for

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ConditionalSubscriptionRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ConditionalSubscriptionRecordStream.java
@@ -124,4 +124,9 @@ public final class ConditionalSubscriptionRecordStream
   public ConditionalSubscriptionRecordStream withTenantId(final String tenantId) {
     return valueFilter(v -> tenantId.equals(v.getTenantId()));
   }
+
+  public ConditionalSubscriptionRecordStream withRootProcessInstanceKey(
+      final long rootProcessInstanceKey) {
+    return valueFilter(v -> v.getRootProcessInstanceKey() == rootProcessInstanceKey);
+  }
 }


### PR DESCRIPTION
## Summary

- `ConditionalSubscriptionRecordValue` now extends `WaitStateRelated`, satisfying the interface contract with the existing `getProcessInstanceKey`/`getElementInstanceKey`/`getTenantId` and two new members: `getRootProcessInstanceKey()` and `getElementId()` (alias to `catchEventId`)
- `ConditionalSubscriptionRecord` gains a new stored `rootProcessInstanceKey` property (default `-1L`, backward-compatible) and a derived `getElementId()` getter
- `CatchEventBehavior` populates `rootProcessInstanceKey` from context when creating a conditional subscription; start-event subscriptions and migration wrap-copies are handled correctly by the default and `wrap()` respectively
- `ConditionalSubscriptionRecordStream` gains a `withRootProcessInstanceKey` filter
- Protocol golden file and JSON serialization test updated

Closes #51992

## Test plan

- [x] `RecordGoldenFilesTest` — verifies no unintended protocol property changes
- [x] `JsonSerializableToJsonTest` — both populated and empty cases cover the new fields
- [x] `ConditionalSubscriptionTest` + `MigrateConditionalSubscriptionTest` — engine-level behaviour unchanged
- [x] Full-repo `install -Dquickly` — no cross-module compilation breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)