### PR TITLE
Introduce top-level DocumentReferenceValue and use for agent history document references

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryMessageContent.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryMessageContent.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.document.DocumentReference;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryMessageContentValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -29,8 +30,8 @@ public final class AgentHistoryMessageContent extends ObjectValue
       new EnumProperty<>(
           "contentType", AgentHistoryContentType.class, AgentHistoryContentType.UNSPECIFIED);
   private final StringProperty textProp = new StringProperty("text", "");
-  private final ObjectProperty<AgentHistoryDocumentReference> documentReferenceProp =
-      new ObjectProperty<>("documentReference", new AgentHistoryDocumentReference());
+  private final ObjectProperty<DocumentReference> documentReferenceProp =
+      new ObjectProperty<>("documentReference", new DocumentReference());
   private final DocumentProperty objectProp = new DocumentProperty("object");
 
   public AgentHistoryMessageContent() {
@@ -62,7 +63,7 @@ public final class AgentHistoryMessageContent extends ObjectValue
   }
 
   @Override
-  public AgentHistoryDocumentReference getDocumentReference() {
+  public DocumentReference getDocumentReference() {
     return documentReferenceProp.getValue();
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/document/DocumentReference.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/document/DocumentReference.java
@@ -5,25 +5,30 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.protocol.impl.record.value.agenthistory;
+package io.camunda.zeebe.protocol.impl.record.value.document;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
-import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryDocumentReferenceValue;
+import io.camunda.zeebe.protocol.record.value.DocumentReferenceValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 @JsonIgnoreProperties({"encodedLength", "empty"})
-public final class AgentHistoryDocumentReference extends ObjectValue
-    implements AgentHistoryDocumentReferenceValue {
+public final class DocumentReference extends ObjectValue implements DocumentReferenceValue {
 
   private final StringProperty documentIdProp = new StringProperty("documentId", "");
   private final StringProperty storeIdProp = new StringProperty("storeId", "");
   private final StringProperty contentHashProp = new StringProperty("contentHash", "");
+  private final ObjectProperty<DocumentReferenceMetadata> metadataProp =
+      new ObjectProperty<>("metadata", new DocumentReferenceMetadata());
 
-  public AgentHistoryDocumentReference() {
-    super(3);
-    declareProperty(documentIdProp).declareProperty(storeIdProp).declareProperty(contentHashProp);
+  public DocumentReference() {
+    super(4);
+    declareProperty(documentIdProp)
+        .declareProperty(storeIdProp)
+        .declareProperty(contentHashProp)
+        .declareProperty(metadataProp);
   }
 
   @Override
@@ -31,7 +36,7 @@ public final class AgentHistoryDocumentReference extends ObjectValue
     return BufferUtil.bufferAsString(documentIdProp.getValue());
   }
 
-  public AgentHistoryDocumentReference setDocumentId(final String documentId) {
+  public DocumentReference setDocumentId(final String documentId) {
     documentIdProp.setValue(documentId);
     return this;
   }
@@ -41,7 +46,7 @@ public final class AgentHistoryDocumentReference extends ObjectValue
     return BufferUtil.bufferAsString(storeIdProp.getValue());
   }
 
-  public AgentHistoryDocumentReference setStoreId(final String storeId) {
+  public DocumentReference setStoreId(final String storeId) {
     storeIdProp.setValue(storeId);
     return this;
   }
@@ -51,14 +56,20 @@ public final class AgentHistoryDocumentReference extends ObjectValue
     return BufferUtil.bufferAsString(contentHashProp.getValue());
   }
 
-  public AgentHistoryDocumentReference setContentHash(final String contentHash) {
+  public DocumentReference setContentHash(final String contentHash) {
     contentHashProp.setValue(contentHash);
     return this;
   }
 
-  public void copy(final AgentHistoryDocumentReferenceValue other) {
+  @Override
+  public DocumentReferenceMetadata getMetadata() {
+    return metadataProp.getValue();
+  }
+
+  public void copy(final DocumentReferenceValue other) {
     setDocumentId(other.getDocumentId());
     setStoreId(other.getStoreId());
     setContentHash(other.getContentHash());
+    getMetadata().copy(other.getMetadata());
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/document/DocumentReferenceMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/document/DocumentReferenceMetadata.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.document;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.DocumentReferenceValue.DocumentReferenceMetadataValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+@JsonIgnoreProperties({"encodedLength", "empty"})
+public final class DocumentReferenceMetadata extends ObjectValue
+    implements DocumentReferenceMetadataValue {
+
+  private final StringProperty contentTypeProp = new StringProperty("contentType", "");
+  private final StringProperty fileNameProp = new StringProperty("fileName", "");
+  private final LongProperty expiresAtProp = new LongProperty("expiresAt", -1L);
+  private final LongProperty sizeProp = new LongProperty("size", -1L);
+  private final StringProperty processDefinitionIdProp =
+      new StringProperty("processDefinitionId", "");
+  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
+  private final DocumentProperty customPropertiesProp = new DocumentProperty("customProperties");
+
+  public DocumentReferenceMetadata() {
+    super(7);
+    declareProperty(contentTypeProp)
+        .declareProperty(fileNameProp)
+        .declareProperty(expiresAtProp)
+        .declareProperty(sizeProp)
+        .declareProperty(processDefinitionIdProp)
+        .declareProperty(processInstanceKeyProp)
+        .declareProperty(customPropertiesProp);
+  }
+
+  @Override
+  public String getContentType() {
+    return BufferUtil.bufferAsString(contentTypeProp.getValue());
+  }
+
+  public DocumentReferenceMetadata setContentType(final String contentType) {
+    contentTypeProp.setValue(contentType);
+    return this;
+  }
+
+  @Override
+  public String getFileName() {
+    return BufferUtil.bufferAsString(fileNameProp.getValue());
+  }
+
+  public DocumentReferenceMetadata setFileName(final String fileName) {
+    fileNameProp.setValue(fileName);
+    return this;
+  }
+
+  @Override
+  public long getExpiresAt() {
+    return expiresAtProp.getValue();
+  }
+
+  public DocumentReferenceMetadata setExpiresAt(final long expiresAt) {
+    expiresAtProp.setValue(expiresAt);
+    return this;
+  }
+
+  @Override
+  public long getSize() {
+    return sizeProp.getValue();
+  }
+
+  public DocumentReferenceMetadata setSize(final long size) {
+    sizeProp.setValue(size);
+    return this;
+  }
+
+  @Override
+  public String getProcessDefinitionId() {
+    return BufferUtil.bufferAsString(processDefinitionIdProp.getValue());
+  }
+
+  public DocumentReferenceMetadata setProcessDefinitionId(final String processDefinitionId) {
+    processDefinitionIdProp.setValue(processDefinitionId);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public DocumentReferenceMetadata setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getCustomProperties() {
+    return MsgPackConverter.convertToMap(customPropertiesProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getCustomPropertiesBuffer() {
+    return customPropertiesProp.getValue();
+  }
+
+  public DocumentReferenceMetadata setCustomProperties(final DirectBuffer customProperties) {
+    customPropertiesProp.setValue(customProperties);
+    return this;
+  }
+
+  public DocumentReferenceMetadata setCustomProperties(final Map<String, Object> customProperties) {
+    customPropertiesProp.setValue(
+        BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(customProperties)));
+    return this;
+  }
+
+  public void copy(final DocumentReferenceMetadataValue other) {
+    setContentType(other.getContentType());
+    setFileName(other.getFileName());
+    setExpiresAt(other.getExpiresAt());
+    setSize(other.getSize());
+    setProcessDefinitionId(other.getProcessDefinitionId());
+    setProcessInstanceKey(other.getProcessInstanceKey());
+    setCustomProperties(other.getCustomProperties());
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4818,6 +4818,24 @@ final class JsonSerializableToJsonTest {
                   .setStoreId("gcs-store")
                   .setContentHash("sha256-doc001");
               record.addContent(docContent);
+              final var docContentWithMetadata =
+                  new AgentHistoryMessageContent().setContentType(AgentHistoryContentType.DOCUMENT);
+              docContentWithMetadata
+                  .getDocumentReference()
+                  .setDocumentId("doc-002")
+                  .setStoreId("s3-store")
+                  .setContentHash("sha256-doc002");
+              docContentWithMetadata
+                  .getDocumentReference()
+                  .getMetadata()
+                  .setContentType("application/pdf")
+                  .setFileName("invoice.pdf")
+                  .setExpiresAt(1748860800000L)
+                  .setSize(10240L)
+                  .setProcessDefinitionId("order-process")
+                  .setProcessInstanceKey(2251799813685249L)
+                  .setCustomProperties(Map.of("region", "eu-west", "version", 2, "active", true));
+              record.addContent(docContentWithMetadata);
               record.addContent(
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.OBJECT)
@@ -4847,19 +4865,25 @@ final class JsonSerializableToJsonTest {
             {
               "contentType": "TEXT",
               "text": "I will extract the line items from the invoice.",
-              "documentReference": { "documentId": "", "storeId": "", "contentHash": "" },
+              "documentReference": { "documentId": "", "storeId": "", "contentHash": "", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
               "object": {}
             },
             {
               "contentType": "DOCUMENT",
               "text": "",
-              "documentReference": { "documentId": "doc-001", "storeId": "gcs-store", "contentHash": "sha256-doc001" },
+              "documentReference": { "documentId": "doc-001", "storeId": "gcs-store", "contentHash": "sha256-doc001", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
+              "object": {}
+            },
+            {
+              "contentType": "DOCUMENT",
+              "text": "",
+              "documentReference": { "documentId": "doc-002", "storeId": "s3-store", "contentHash": "sha256-doc002", "metadata": { "contentType": "application/pdf", "fileName": "invoice.pdf", "expiresAt": 1748860800000, "size": 10240, "processDefinitionId": "order-process", "processInstanceKey": 2251799813685249, "customProperties": { "region": "eu-west", "version": 2, "active": true } } },
               "object": {}
             },
             {
               "contentType": "OBJECT",
               "text": "",
-              "documentReference": { "documentId": "", "storeId": "", "contentHash": "" },
+              "documentReference": { "documentId": "", "storeId": "", "contentHash": "", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
               "object": { "page": 1 }
             }
           ],

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/document/DocumentReferenceTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/document/DocumentReferenceTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class DocumentReferenceTest {
+
+  @Test
+  void shouldExposeDefaults() {
+    // given
+    final var ref = new DocumentReference();
+
+    // then
+    assertThat(ref.getDocumentId()).isEmpty();
+    assertThat(ref.getStoreId()).isEmpty();
+    assertThat(ref.getContentHash()).isEmpty();
+    assertThat(ref.getMetadata().getContentType()).isEmpty();
+    assertThat(ref.getMetadata().getFileName()).isEmpty();
+    assertThat(ref.getMetadata().getExpiresAt()).isEqualTo(-1L);
+    assertThat(ref.getMetadata().getSize()).isEqualTo(-1L);
+    assertThat(ref.getMetadata().getProcessDefinitionId()).isEmpty();
+    assertThat(ref.getMetadata().getProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(ref.getMetadata().getCustomProperties()).isEmpty();
+  }
+
+  @Test
+  void shouldRoundTripScalarFieldsViaMsgPack() {
+    // given
+    final var original =
+        new DocumentReference()
+            .setDocumentId("doc-001")
+            .setStoreId("gcs-store")
+            .setContentHash("sha256-abc");
+
+    // when
+    final var copy = new DocumentReference();
+    copy.copy(original);
+
+    // then
+    assertThat(copy.getDocumentId()).isEqualTo("doc-001");
+    assertThat(copy.getStoreId()).isEqualTo("gcs-store");
+    assertThat(copy.getContentHash()).isEqualTo("sha256-abc");
+  }
+
+  @Test
+  void shouldRoundTripAllMetadataFieldsViaMsgPack() {
+    // given
+    final var original =
+        new DocumentReference()
+            .setDocumentId("doc-001")
+            .setStoreId("gcs-store")
+            .setContentHash("sha256-abc");
+    original
+        .getMetadata()
+        .setContentType("application/pdf")
+        .setFileName("report.pdf")
+        .setExpiresAt(1720000000000L)
+        .setSize(4096L)
+        .setProcessDefinitionId("order-process")
+        .setProcessInstanceKey(2251799813685260L)
+        .setCustomProperties(Map.of("region", "eu-west"));
+
+    // when
+    final var copy = new DocumentReference();
+    copy.copy(original);
+
+    // then
+    assertThat(copy.getDocumentId()).isEqualTo("doc-001");
+    assertThat(copy.getStoreId()).isEqualTo("gcs-store");
+    assertThat(copy.getContentHash()).isEqualTo("sha256-abc");
+    final var m = copy.getMetadata();
+    assertThat(m.getContentType()).isEqualTo("application/pdf");
+    assertThat(m.getFileName()).isEqualTo("report.pdf");
+    assertThat(m.getExpiresAt()).isEqualTo(1720000000000L);
+    assertThat(m.getSize()).isEqualTo(4096L);
+    assertThat(m.getProcessDefinitionId()).isEqualTo("order-process");
+    assertThat(m.getProcessInstanceKey()).isEqualTo(2251799813685260L);
+    assertThat(m.getCustomProperties()).isEqualTo(Map.of("region", "eu-west"));
+  }
+
+  @Test
+  void shouldRoundTripCustomPropertiesViaMsgPack() {
+    // given
+    final Map<String, Object> customProps = Map.of("key1", "value1", "key2", 42, "key3", true);
+    final var original = new DocumentReference();
+    original.getMetadata().setCustomProperties(customProps);
+
+    // when
+    final var copy = new DocumentReference();
+    copy.copy(original);
+
+    // then
+    assertThat(copy.getMetadata().getCustomProperties()).isEqualTo(customProps);
+  }
+
+  @Test
+  void shouldCopyFromAnotherDocumentReference() {
+    // given
+    final var source = new DocumentReference();
+    source.setDocumentId("src-doc").setStoreId("src-store").setContentHash("src-hash");
+    source.getMetadata().setFileName("source.txt").setSize(512L).setExpiresAt(1700000000000L);
+
+    // when
+    final var target = new DocumentReference();
+    target.copy(source);
+
+    // then
+    assertThat(target.getDocumentId()).isEqualTo("src-doc");
+    assertThat(target.getStoreId()).isEqualTo("src-store");
+    assertThat(target.getContentHash()).isEqualTo("src-hash");
+    assertThat(target.getMetadata().getFileName()).isEqualTo("source.txt");
+    assertThat(target.getMetadata().getSize()).isEqualTo(512L);
+    assertThat(target.getMetadata().getExpiresAt()).isEqualTo(1700000000000L);
+  }
+}

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryMessageContent.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryMessageContent.golden
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.document.DocumentReference;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryMessageContentValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -29,8 +30,8 @@ public final class AgentHistoryMessageContent extends ObjectValue
       new EnumProperty<>(
           "contentType", AgentHistoryContentType.class, AgentHistoryContentType.UNSPECIFIED);
   private final StringProperty textProp = new StringProperty("text", "");
-  private final ObjectProperty<AgentHistoryDocumentReference> documentReferenceProp =
-      new ObjectProperty<>("documentReference", new AgentHistoryDocumentReference());
+  private final ObjectProperty<DocumentReference> documentReferenceProp =
+      new ObjectProperty<>("documentReference", new DocumentReference());
   private final DocumentProperty objectProp = new DocumentProperty("object");
 
   public AgentHistoryMessageContent() {
@@ -62,7 +63,7 @@ public final class AgentHistoryMessageContent extends ObjectValue
   }
 
   @Override
-  public AgentHistoryDocumentReference getDocumentReference() {
+  public DocumentReference getDocumentReference() {
     return documentReferenceProp.getValue();
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DocumentReference.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DocumentReference.golden
@@ -5,25 +5,30 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.protocol.impl.record.value.agenthistory;
+package io.camunda.zeebe.protocol.impl.record.value.document;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
-import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryDocumentReferenceValue;
+import io.camunda.zeebe.protocol.record.value.DocumentReferenceValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 @JsonIgnoreProperties({"encodedLength", "empty"})
-public final class AgentHistoryDocumentReference extends ObjectValue
-    implements AgentHistoryDocumentReferenceValue {
+public final class DocumentReference extends ObjectValue implements DocumentReferenceValue {
 
   private final StringProperty documentIdProp = new StringProperty("documentId", "");
   private final StringProperty storeIdProp = new StringProperty("storeId", "");
   private final StringProperty contentHashProp = new StringProperty("contentHash", "");
+  private final ObjectProperty<DocumentReferenceMetadata> metadataProp =
+      new ObjectProperty<>("metadata", new DocumentReferenceMetadata());
 
-  public AgentHistoryDocumentReference() {
-    super(3);
-    declareProperty(documentIdProp).declareProperty(storeIdProp).declareProperty(contentHashProp);
+  public DocumentReference() {
+    super(4);
+    declareProperty(documentIdProp)
+        .declareProperty(storeIdProp)
+        .declareProperty(contentHashProp)
+        .declareProperty(metadataProp);
   }
 
   @Override
@@ -31,7 +36,7 @@ public final class AgentHistoryDocumentReference extends ObjectValue
     return BufferUtil.bufferAsString(documentIdProp.getValue());
   }
 
-  public AgentHistoryDocumentReference setDocumentId(final String documentId) {
+  public DocumentReference setDocumentId(final String documentId) {
     documentIdProp.setValue(documentId);
     return this;
   }
@@ -41,7 +46,7 @@ public final class AgentHistoryDocumentReference extends ObjectValue
     return BufferUtil.bufferAsString(storeIdProp.getValue());
   }
 
-  public AgentHistoryDocumentReference setStoreId(final String storeId) {
+  public DocumentReference setStoreId(final String storeId) {
     storeIdProp.setValue(storeId);
     return this;
   }
@@ -51,14 +56,20 @@ public final class AgentHistoryDocumentReference extends ObjectValue
     return BufferUtil.bufferAsString(contentHashProp.getValue());
   }
 
-  public AgentHistoryDocumentReference setContentHash(final String contentHash) {
+  public DocumentReference setContentHash(final String contentHash) {
     contentHashProp.setValue(contentHash);
     return this;
   }
 
-  public void copy(final AgentHistoryDocumentReferenceValue other) {
+  @Override
+  public DocumentReferenceMetadata getMetadata() {
+    return metadataProp.getValue();
+  }
+
+  public void copy(final DocumentReferenceValue other) {
     setDocumentId(other.getDocumentId());
     setStoreId(other.getStoreId());
     setContentHash(other.getContentHash());
+    getMetadata().copy(other.getMetadata());
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DocumentReferenceMetadata.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DocumentReferenceMetadata.golden
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.document;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.DocumentReferenceValue.DocumentReferenceMetadataValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+@JsonIgnoreProperties({"encodedLength", "empty"})
+public final class DocumentReferenceMetadata extends ObjectValue
+    implements DocumentReferenceMetadataValue {
+
+  private final StringProperty contentTypeProp = new StringProperty("contentType", "");
+  private final StringProperty fileNameProp = new StringProperty("fileName", "");
+  private final LongProperty expiresAtProp = new LongProperty("expiresAt", -1L);
+  private final LongProperty sizeProp = new LongProperty("size", -1L);
+  private final StringProperty processDefinitionIdProp =
+      new StringProperty("processDefinitionId", "");
+  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
+  private final DocumentProperty customPropertiesProp = new DocumentProperty("customProperties");
+
+  public DocumentReferenceMetadata() {
+    super(7);
+    declareProperty(contentTypeProp)
+        .declareProperty(fileNameProp)
+        .declareProperty(expiresAtProp)
+        .declareProperty(sizeProp)
+        .declareProperty(processDefinitionIdProp)
+        .declareProperty(processInstanceKeyProp)
+        .declareProperty(customPropertiesProp);
+  }
+
+  @Override
+  public String getContentType() {
+    return BufferUtil.bufferAsString(contentTypeProp.getValue());
+  }
+
+  public DocumentReferenceMetadata setContentType(final String contentType) {
+    contentTypeProp.setValue(contentType);
+    return this;
+  }
+
+  @Override
+  public String getFileName() {
+    return BufferUtil.bufferAsString(fileNameProp.getValue());
+  }
+
+  public DocumentReferenceMetadata setFileName(final String fileName) {
+    fileNameProp.setValue(fileName);
+    return this;
+  }
+
+  @Override
+  public long getExpiresAt() {
+    return expiresAtProp.getValue();
+  }
+
+  public DocumentReferenceMetadata setExpiresAt(final long expiresAt) {
+    expiresAtProp.setValue(expiresAt);
+    return this;
+  }
+
+  @Override
+  public long getSize() {
+    return sizeProp.getValue();
+  }
+
+  public DocumentReferenceMetadata setSize(final long size) {
+    sizeProp.setValue(size);
+    return this;
+  }
+
+  @Override
+  public String getProcessDefinitionId() {
+    return BufferUtil.bufferAsString(processDefinitionIdProp.getValue());
+  }
+
+  public DocumentReferenceMetadata setProcessDefinitionId(final String processDefinitionId) {
+    processDefinitionIdProp.setValue(processDefinitionId);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public DocumentReferenceMetadata setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getCustomProperties() {
+    return MsgPackConverter.convertToMap(customPropertiesProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getCustomPropertiesBuffer() {
+    return customPropertiesProp.getValue();
+  }
+
+  public DocumentReferenceMetadata setCustomProperties(final DirectBuffer customProperties) {
+    customPropertiesProp.setValue(customProperties);
+    return this;
+  }
+
+  public DocumentReferenceMetadata setCustomProperties(final Map<String, Object> customProperties) {
+    customPropertiesProp.setValue(
+        BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(customProperties)));
+    return this;
+  }
+
+  public void copy(final DocumentReferenceMetadataValue other) {
+    setContentType(other.getContentType());
+    setFileName(other.getFileName());
+    setExpiresAt(other.getExpiresAt());
+    setSize(other.getSize());
+    setProcessDefinitionId(other.getProcessDefinitionId());
+    setProcessInstanceKey(other.getProcessInstanceKey());
+    setCustomProperties(other.getCustomProperties());
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -79,27 +79,6 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   /** Returns the metrics captured for this history entry. */
   AgentHistoryMetricsValue getMetrics();
 
-  /** Represents a document reference associated with a content block. */
-  @Value.Immutable
-  @ImmutableProtocol(builder = ImmutableAgentHistoryDocumentReferenceValue.Builder.class)
-  interface AgentHistoryDocumentReferenceValue {
-    /** Returns the unique identifier of the document. */
-    String getDocumentId();
-
-    /** Returns the identifier of the store where the document is held. */
-    String getStoreId();
-
-    /**
-     * Returns the content hash of the document.
-     *
-     * <p>Required to construct the document download URL via the Camunda Document Store REST API
-     * ({@code GET /v2/documents/{documentId}}). Without this hash the document cannot be retrieved
-     * from the record alone, because it is not derivable from {@code documentId} or {@code storeId}
-     * after the fact.
-     */
-    String getContentHash();
-  }
-
   /** Represents a single content block in a history entry message. */
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableAgentHistoryMessageContentValue.Builder.class)
@@ -111,7 +90,7 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
     String getText();
 
     /** Returns the document reference; populated when contentType is DOCUMENT. */
-    AgentHistoryDocumentReferenceValue getDocumentReference();
+    DocumentReferenceValue getDocumentReference();
 
     /** Returns the structured object payload; populated when contentType is OBJECT. */
     Map<String, Object> getObject();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DocumentReferenceValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DocumentReferenceValue.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import java.util.Map;
+import org.immutables.value.Value;
+
+/**
+ * Represents a reference to a Camunda document, mirroring the {@code DocumentReference} schema in
+ * {@code documents.yaml}. This top-level value type can be reused across record types that need to
+ * reference a stored document.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableDocumentReferenceValue.Builder.class)
+public interface DocumentReferenceValue {
+
+  /** Returns the unique identifier of the document. */
+  String getDocumentId();
+
+  /** Returns the identifier of the store where the document is held. */
+  String getStoreId();
+
+  /**
+   * Returns the content hash of the document.
+   *
+   * <p>Required to construct the document download URL via the Camunda Document Store REST API
+   * ({@code GET /v2/documents/{documentId}}). Without this hash the document cannot be retrieved
+   * from the record alone.
+   */
+  String getContentHash();
+
+  /** Returns the metadata associated with this document reference. */
+  DocumentReferenceMetadataValue getMetadata();
+
+  /**
+   * Represents the metadata of a document, mirroring the {@code DocumentMetadataResponse} schema in
+   * {@code documents.yaml}.
+   */
+  @Value.Immutable
+  @ImmutableProtocol(builder = ImmutableDocumentReferenceMetadataValue.Builder.class)
+  interface DocumentReferenceMetadataValue {
+
+    /** Returns the MIME content type of the document (e.g. {@code application/pdf}). */
+    String getContentType();
+
+    /** Returns the file name of the document. */
+    String getFileName();
+
+    /**
+     * Returns the epoch-millis timestamp at which this document expires, or {@code -1} if the
+     * document does not expire.
+     */
+    long getExpiresAt();
+
+    /** Returns the size of the document in bytes, or {@code -1} if unknown. */
+    long getSize();
+
+    /**
+     * Returns the ID of the process definition that created this document, or an empty string if
+     * not set.
+     */
+    String getProcessDefinitionId();
+
+    /**
+     * Returns the key of the process instance that created this document, or {@code -1} if not set.
+     */
+    long getProcessInstanceKey();
+
+    /** Returns the custom properties associated with this document. */
+    Map<String, Object> getCustomProperties();
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -95,6 +95,7 @@ import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.DocumentReferenceValue;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue;
@@ -604,8 +605,9 @@ public class CompactRecordLogger {
           }
           case DOCUMENT -> {
             final var docRef = block.getDocumentReference();
-            if (docRef != null && !StringUtils.isEmpty(docRef.getDocumentId())) {
-              result.append(indent).append("doc:").append(docRef.getDocumentId());
+            final var docSummary = summarizeDocumentReference(docRef);
+            if (!docSummary.isEmpty()) {
+              result.append(indent).append(docSummary);
             }
           }
           case OBJECT -> {
@@ -630,6 +632,22 @@ public class CompactRecordLogger {
     }
 
     return result.toString();
+  }
+
+  private String summarizeDocumentReference(final DocumentReferenceValue ref) {
+    if (ref == null || StringUtils.isEmpty(ref.getDocumentId())) {
+      return "";
+    }
+    final var sb =
+        new StringBuilder()
+            .append("doc:")
+            .append(StringUtils.isEmpty(ref.getStoreId()) ? "" : ref.getStoreId() + "/")
+            .append(ref.getDocumentId());
+    final var meta = ref.getMetadata();
+    if (meta != null && !StringUtils.isEmpty(meta.getFileName())) {
+      sb.append(" (").append(meta.getFileName()).append(")");
+    }
+    return sb.toString();
   }
 
   private String summarizeDeployment(final Record<?> record) {

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
@@ -18,6 +18,8 @@ import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryEmbeddedToolC
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMessageContentValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMetricsValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDocumentReferenceMetadataValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDocumentReferenceValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableUsageMetricRecordValue;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
@@ -233,6 +235,63 @@ class CompactRecordLoggerTest {
               """
               K1#3 TOOL_RESULT COMMITTED @K2 K3#1
                      {orderId=12345}""");
+    }
+
+    @Test
+    void shouldSummarizeAgentHistoryDocumentContent() {
+      // given
+      final var logger = new CompactRecordLogger(List.of());
+      final var record =
+          ImmutableRecord.builder()
+              .withValueType(ValueType.AGENT_HISTORY)
+              .withValue(
+                  ImmutableAgentHistoryRecordValue.builder()
+                      .withAgentInstanceKey(1L)
+                      .withElementInstanceKey(2L)
+                      .withJobKey(3L)
+                      .withRole(AgentHistoryRole.ASSISTANT)
+                      .withCommitStatus(AgentHistoryCommitStatus.COMMITTED)
+                      .withJobLease("1")
+                      .withIteration(1)
+                      .addContent(
+                          ImmutableAgentHistoryMessageContentValue.builder()
+                              .withContentType(AgentHistoryContentType.DOCUMENT)
+                              .withDocumentReference(
+                                  ImmutableDocumentReferenceValue.builder()
+                                      .withDocumentId("doc-001")
+                                      .withStoreId("gcs-store")
+                                      .withContentHash("sha256-abc")
+                                      .withMetadata(
+                                          ImmutableDocumentReferenceMetadataValue.builder()
+                                              .withFileName("invoice.pdf")
+                                              .build())
+                                      .build())
+                              .build())
+                      .addContent(
+                          ImmutableAgentHistoryMessageContentValue.builder()
+                              .withContentType(AgentHistoryContentType.DOCUMENT)
+                              .withDocumentReference(
+                                  ImmutableDocumentReferenceValue.builder()
+                                      .withDocumentId("doc-002")
+                                      .withStoreId("s3-store")
+                                      .withContentHash("sha256-xyz")
+                                      .withMetadata(
+                                          ImmutableDocumentReferenceMetadataValue.builder().build())
+                                      .build())
+                              .build())
+                      .build())
+              .build();
+
+      // when
+      final String result = logger.summarizeAgentHistory(record);
+
+      // then
+      assertThat(result)
+          .isEqualTo(
+              """
+              K1#1 ASSISTANT COMMITTED @K2 K3#1
+                     doc:gcs-store/doc-001 (invoice.pdf)
+                     doc:s3-store/doc-002""");
     }
   }
 }


### PR DESCRIPTION
## Description

### Overview

Introduces a top-level, reusable `DocumentReferenceValue` interface (and its msgpack implementation `DocumentReference` + `DocumentReferenceMetadata`) that fully mirrors the `DocumentReference` + `DocumentMetadataResponse` schemas defined in `documents.yaml`. The existing one-off nested type `AgentHistoryDocumentReferenceValue` is removed and replaced with the new top-level type throughout.

### Why

The previous `AgentHistoryDocumentReferenceValue` was a nested interface inside `AgentHistoryRecordValue` with only three fields (`documentId`, `storeId`, `contentHash`). This had two problems:

1. **Reusability** — any future record type needing a document reference would have to define its own custom type, leading to inconsistency across the codebase.
2. **Incomplete model** — the `DocumentReference` schema in `documents.yaml` includes a `metadata` object (`DocumentMetadataResponse`) with seven additional fields that were not captured in the Zeebe record at all.

By introducing `DocumentReferenceValue` at the top level, future record types can reuse it directly and the full document metadata is now available from the record (including `fileName`, `contentType`, `expiresAt` as epoch-millis, `size`, `processDefinitionId`, `processInstanceKey`, `customProperties`). The `expiresAt` field uses the same `long` epoch-millis convention as `AgentHistoryRecordValue#getProducedAt` for consistency.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54912