### PR TITLE
feat: add agent-instance history API to camunda-api-zod-schema

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.10.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.71",
+        "@camunda/camunda-api-zod-schemas": "0.0.72",
         "@camunda/camunda-composite-components": "0.23.3",
         "@carbon/elements": "11.90.0",
         "@carbon/react": "1.105.0",
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.71",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.71.tgz",
-      "integrity": "sha512-8m7Tszc36hWN6wD7t7+c4XMfSaFruGvC2cwH3eU6JQQOyuRq5ji+1ibH9hENh6qASLix3qcRq724n5Lk0LSPpw==",
+      "version": "0.0.72",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.72.tgz",
+      "integrity": "sha512-ZZmQHnvO2QCjq4sARIdcjNub94mKWKJx2xWfjPGuSjWRaRnZKilhqHLLYVBSvjPla9VgIi6lnYj6QT6iKOR/AQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.71",
+    "@camunda/camunda-api-zod-schemas": "0.0.72",
     "@camunda/camunda-composite-components": "0.23.3",
     "@carbon/elements": "11.90.0",
     "@carbon/react": "1.105.0",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.3",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.71",
+        "@camunda/camunda-api-zod-schemas": "0.0.72",
         "@camunda/camunda-composite-components": "0.23.3",
         "@carbon/elements": "11.90.0",
         "@carbon/react": "1.105.0",
@@ -459,9 +459,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.71",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.71.tgz",
-      "integrity": "sha512-8m7Tszc36hWN6wD7t7+c4XMfSaFruGvC2cwH3eU6JQQOyuRq5ji+1ibH9hENh6qASLix3qcRq724n5Lk0LSPpw==",
+      "version": "0.0.72",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.72.tgz",
+      "integrity": "sha512-ZZmQHnvO2QCjq4sARIdcjNub94mKWKJx2xWfjPGuSjWRaRnZKilhqHLLYVBSvjPla9VgIi6lnYj6QT6iKOR/AQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.3",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.71",
+    "@camunda/camunda-api-zod-schemas": "0.0.72",
     "@camunda/camunda-composite-components": "0.23.3",
     "@carbon/elements": "11.90.0",
     "@carbon/react": "1.105.0",

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.21.3",
         "@bpmn-io/form-js-viewer": "1.21.3",
-        "@camunda/camunda-api-zod-schemas": "0.0.71",
+        "@camunda/camunda-api-zod-schemas": "0.0.72",
         "@camunda/camunda-composite-components": "0.23.3",
         "@carbon/react": "1.105.0",
         "@monaco-editor/react": "4.7.0",
@@ -585,9 +585,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.71",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.71.tgz",
-      "integrity": "sha512-8m7Tszc36hWN6wD7t7+c4XMfSaFruGvC2cwH3eU6JQQOyuRq5ji+1ibH9hENh6qASLix3qcRq724n5Lk0LSPpw==",
+      "version": "0.0.72",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.72.tgz",
+      "integrity": "sha512-ZZmQHnvO2QCjq4sARIdcjNub94mKWKJx2xWfjPGuSjWRaRnZKilhqHLLYVBSvjPla9VgIi6lnYj6QT6iKOR/AQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.21.3",
     "@bpmn-io/form-js-viewer": "1.21.3",
-    "@camunda/camunda-api-zod-schemas": "0.0.71",
+    "@camunda/camunda-api-zod-schemas": "0.0.72",
     "@camunda/camunda-composite-components": "0.23.3",
     "@carbon/react": "1.105.0",
     "@monaco-editor/react": "4.7.0",

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -17,7 +17,7 @@
 		"generate:svg": "svgr --typescript --no-index --out-dir src/shared/svg src/shared/assets/svg"
 	},
 	"dependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.71",
+		"@camunda/camunda-api-zod-schemas": "0.0.72",
 		"@camunda/camunda-composite-components": "0.23.3",
 		"@tanstack/react-query": "5.100.14",
 		"@tanstack/react-query-devtools": "5.100.14",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -22,7 +22,7 @@
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.71",
+				"@camunda/camunda-api-zod-schemas": "0.0.72",
 				"@camunda/camunda-composite-components": "0.23.3",
 				"@tanstack/react-query": "5.100.14",
 				"@tanstack/react-query-devtools": "5.100.14",
@@ -9567,13 +9567,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.71",
+				"@camunda/camunda-api-zod-schemas": "0.0.72",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.71",
+			"version": "0.0.72",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.9.1",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.71",
+		"@camunda/camunda-api-zod-schemas": "0.0.72",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.0.72
+
+### 🚀 Enhancements
+
+- Add agent instance history API schemas and endpoints for 8.10 ([#52123](https://github.com/camunda/camunda/issues/52123))
+  - `agentInstanceHistoryRoleSchema` enum (`USER`, `ASSISTANT`, `TOOL_RESULT`) and `agentInstanceHistoryCommitStatusSchema` enum (`COMMITTED`, `PENDING`, `DISCARDED`)
+  - `agentInstanceMessageContentSchema` — discriminated union of `agentInstanceTextContentSchema`, `agentInstanceDocumentContentSchema`, and `agentInstanceObjectContentSchema` on `contentType`
+  - `agentInstanceToolCallSchema` and `agentInstanceHistoryItemMetricsSchema` for tool calls and per-item LLM metrics
+  - `agentInstanceHistoryItemSchema` — full history item with key, role, content, toolCalls, metrics, commitStatus, and producedAt
+  - `POST /v2/agent-instances/{agentInstanceKey}/history` endpoint for creating a history item
+  - `POST /v2/agent-instances/{agentInstanceKey}/history/search` endpoint for querying history items
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.71
 
 ### 🩹 Fixes

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
@@ -10,12 +10,14 @@ import {z} from 'zod';
 import {
 	API_VERSION,
 	advancedDateTimeFilterSchema,
+	advancedIntegerFilterSchema,
 	basicStringFilterSchema,
 	getEnumFilterSchema,
 	getQueryRequestBodySchema,
 	getQueryResponseBodySchema,
 	type Endpoint,
 } from './common';
+import {documentReferenceSchema} from './document';
 
 const agentInstanceStatusSchema = z.enum([
 	'COMPLETED',
@@ -94,6 +96,108 @@ type QueryAgentInstancesResponseBody = z.infer<typeof queryAgentInstancesRespons
 const getAgentInstanceResponseBodySchema = agentInstanceSchema;
 type GetAgentInstanceResponseBody = z.infer<typeof getAgentInstanceResponseBodySchema>;
 
+const agentInstanceHistoryRoleSchema = z.enum(['USER', 'ASSISTANT', 'TOOL_RESULT']);
+type AgentInstanceHistoryRole = z.infer<typeof agentInstanceHistoryRoleSchema>;
+
+const agentInstanceHistoryCommitStatusSchema = z.enum(['COMMITTED', 'PENDING', 'DISCARDED']);
+type AgentInstanceHistoryCommitStatus = z.infer<typeof agentInstanceHistoryCommitStatusSchema>;
+
+const agentInstanceTextContentSchema = z.object({
+	contentType: z.literal('TEXT'),
+	text: z.string(),
+});
+type AgentInstanceTextContent = z.infer<typeof agentInstanceTextContentSchema>;
+
+const agentInstanceDocumentContentSchema = z.object({
+	contentType: z.literal('DOCUMENT'),
+	documentReference: documentReferenceSchema,
+});
+type AgentInstanceDocumentContent = z.infer<typeof agentInstanceDocumentContentSchema>;
+
+const agentInstanceObjectContentSchema = z.object({
+	contentType: z.literal('OBJECT'),
+	object: z.record(z.string(), z.unknown()),
+});
+type AgentInstanceObjectContent = z.infer<typeof agentInstanceObjectContentSchema>;
+
+const agentInstanceMessageContentSchema = z.discriminatedUnion('contentType', [
+	agentInstanceTextContentSchema,
+	agentInstanceDocumentContentSchema,
+	agentInstanceObjectContentSchema,
+]);
+type AgentInstanceMessageContent = z.infer<typeof agentInstanceMessageContentSchema>;
+
+const agentInstanceToolCallSchema = z.object({
+	toolCallId: z.string(),
+	toolName: z.string(),
+	elementId: z.string().nullable(),
+	arguments: z.record(z.string(), z.unknown()).nullable(),
+});
+type AgentInstanceToolCall = z.infer<typeof agentInstanceToolCallSchema>;
+
+const agentInstanceHistoryItemMetricsSchema = z.object({
+	inputTokens: z.number(),
+	outputTokens: z.number(),
+	durationMs: z.number(),
+});
+type AgentInstanceHistoryItemMetrics = z.infer<typeof agentInstanceHistoryItemMetricsSchema>;
+
+const agentInstanceHistoryItemSchema = z.object({
+	historyItemKey: z.string(),
+	agentInstanceKey: z.string(),
+	elementInstanceKey: z.string(),
+	jobKey: z.string(),
+	jobLease: z.string(),
+	iteration: z.number().int().nullable(),
+	role: agentInstanceHistoryRoleSchema,
+	content: z.array(agentInstanceMessageContentSchema),
+	toolCalls: z.array(agentInstanceToolCallSchema),
+	metrics: agentInstanceHistoryItemMetricsSchema.nullable(),
+	commitStatus: agentInstanceHistoryCommitStatusSchema,
+	producedAt: z.string(),
+});
+type AgentInstanceHistoryItem = z.infer<typeof agentInstanceHistoryItemSchema>;
+
+const agentInstanceHistoryFilterSchema = z
+	.object({
+		historyItemKey: basicStringFilterSchema,
+		role: getEnumFilterSchema(agentInstanceHistoryRoleSchema),
+		elementInstanceKey: basicStringFilterSchema,
+		jobKey: basicStringFilterSchema,
+		iteration: advancedIntegerFilterSchema,
+		commitStatus: getEnumFilterSchema(agentInstanceHistoryCommitStatusSchema),
+		producedAt: advancedDateTimeFilterSchema,
+	})
+	.partial();
+type AgentInstanceHistoryFilter = z.infer<typeof agentInstanceHistoryFilterSchema>;
+
+const createAgentInstanceHistoryItemRequestBodySchema = z.object({
+	elementInstanceKey: z.string(),
+	jobKey: z.string(),
+	jobLease: z.string(),
+	iteration: z.number().int().nullable().optional(),
+	role: agentInstanceHistoryRoleSchema,
+	content: z.array(agentInstanceMessageContentSchema),
+	toolCalls: z.array(agentInstanceToolCallSchema).nullable().optional(),
+	metrics: agentInstanceHistoryItemMetricsSchema.nullable().optional(),
+	producedAt: z.string(),
+});
+type CreateAgentInstanceHistoryItemRequestBody = z.infer<typeof createAgentInstanceHistoryItemRequestBodySchema>;
+
+const createAgentInstanceHistoryItemResponseBodySchema = z.object({
+	historyItemKey: z.string(),
+});
+type CreateAgentInstanceHistoryItemResponseBody = z.infer<typeof createAgentInstanceHistoryItemResponseBodySchema>;
+
+const searchAgentInstanceHistoryRequestBodySchema = getQueryRequestBodySchema({
+	sortFields: ['producedAt', 'historyItemKey', 'iteration'] as const,
+	filter: agentInstanceHistoryFilterSchema,
+});
+type SearchAgentInstanceHistoryRequestBody = z.infer<typeof searchAgentInstanceHistoryRequestBodySchema>;
+
+const searchAgentInstanceHistoryResponseBodySchema = getQueryResponseBodySchema(agentInstanceHistoryItemSchema);
+type SearchAgentInstanceHistoryResponseBody = z.infer<typeof searchAgentInstanceHistoryResponseBodySchema>;
+
 const getAgentInstance: Endpoint<{agentInstanceKey: string}> = {
 	method: 'GET',
 	getUrl: ({agentInstanceKey}) => `/${API_VERSION}/agent-instances/${agentInstanceKey}`,
@@ -102,6 +206,16 @@ const getAgentInstance: Endpoint<{agentInstanceKey: string}> = {
 const searchAgentInstances: Endpoint = {
 	method: 'POST',
 	getUrl: () => `/${API_VERSION}/agent-instances/search`,
+};
+
+const createAgentInstanceHistoryItem: Endpoint<{agentInstanceKey: string}> = {
+	method: 'POST',
+	getUrl: ({agentInstanceKey}) => `/${API_VERSION}/agent-instances/${agentInstanceKey}/history`,
+};
+
+const searchAgentInstanceHistory: Endpoint<{agentInstanceKey: string}> = {
+	method: 'POST',
+	getUrl: ({agentInstanceKey}) => `/${API_VERSION}/agent-instances/${agentInstanceKey}/history/search`,
 };
 
 export {
@@ -114,8 +228,24 @@ export {
 	queryAgentInstancesRequestBodySchema,
 	queryAgentInstancesResponseBodySchema,
 	getAgentInstanceResponseBodySchema,
+	agentInstanceHistoryRoleSchema,
+	agentInstanceHistoryCommitStatusSchema,
+	agentInstanceTextContentSchema,
+	agentInstanceDocumentContentSchema,
+	agentInstanceObjectContentSchema,
+	agentInstanceMessageContentSchema,
+	agentInstanceToolCallSchema,
+	agentInstanceHistoryItemMetricsSchema,
+	agentInstanceHistoryItemSchema,
+	agentInstanceHistoryFilterSchema,
+	createAgentInstanceHistoryItemRequestBodySchema,
+	createAgentInstanceHistoryItemResponseBodySchema,
+	searchAgentInstanceHistoryRequestBodySchema,
+	searchAgentInstanceHistoryResponseBodySchema,
 	getAgentInstance,
 	searchAgentInstances,
+	createAgentInstanceHistoryItem,
+	searchAgentInstanceHistory,
 };
 export type {
 	AgentInstanceStatus,
@@ -127,4 +257,18 @@ export type {
 	QueryAgentInstancesRequestBody,
 	QueryAgentInstancesResponseBody,
 	GetAgentInstanceResponseBody,
+	AgentInstanceHistoryRole,
+	AgentInstanceHistoryCommitStatus,
+	AgentInstanceTextContent,
+	AgentInstanceDocumentContent,
+	AgentInstanceObjectContent,
+	AgentInstanceMessageContent,
+	AgentInstanceToolCall,
+	AgentInstanceHistoryItemMetrics,
+	AgentInstanceHistoryItem,
+	AgentInstanceHistoryFilter,
+	CreateAgentInstanceHistoryItemRequestBody,
+	CreateAgentInstanceHistoryItemResponseBody,
+	SearchAgentInstanceHistoryRequestBody,
+	SearchAgentInstanceHistoryResponseBody,
 };

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
@@ -8,7 +8,12 @@
 
 import {getCurrentUser} from './authentication';
 import {activateAdHocSubProcessActivities} from './ad-hoc-sub-process';
-import {getAgentInstance, searchAgentInstances} from './agent-instance';
+import {
+	getAgentInstance,
+	searchAgentInstances,
+	createAgentInstanceHistoryItem,
+	searchAgentInstanceHistory,
+} from './agent-instance';
 import {
 	createAuthorization,
 	updateAuthorization,
@@ -193,6 +198,8 @@ const endpoints = {
 	activateAdHocSubProcessActivities,
 	getAgentInstance,
 	searchAgentInstances,
+	createAgentInstanceHistoryItem,
+	searchAgentInstanceHistory,
 	createAuthorization,
 	updateAuthorization,
 	getAuthorization,
@@ -427,6 +434,20 @@ export {
 	queryAgentInstancesRequestBodySchema,
 	queryAgentInstancesResponseBodySchema,
 	getAgentInstanceResponseBodySchema,
+	agentInstanceHistoryRoleSchema,
+	agentInstanceHistoryCommitStatusSchema,
+	agentInstanceTextContentSchema,
+	agentInstanceDocumentContentSchema,
+	agentInstanceObjectContentSchema,
+	agentInstanceMessageContentSchema,
+	agentInstanceToolCallSchema,
+	agentInstanceHistoryItemMetricsSchema,
+	agentInstanceHistoryItemSchema,
+	agentInstanceHistoryFilterSchema,
+	createAgentInstanceHistoryItemRequestBodySchema,
+	createAgentInstanceHistoryItemResponseBodySchema,
+	searchAgentInstanceHistoryRequestBodySchema,
+	searchAgentInstanceHistoryResponseBodySchema,
 	type AgentInstanceStatus,
 	type AgentInstanceDefinition,
 	type AgentInstanceMetrics,
@@ -436,6 +457,20 @@ export {
 	type QueryAgentInstancesRequestBody,
 	type QueryAgentInstancesResponseBody,
 	type GetAgentInstanceResponseBody,
+	type AgentInstanceHistoryRole,
+	type AgentInstanceHistoryCommitStatus,
+	type AgentInstanceTextContent,
+	type AgentInstanceDocumentContent,
+	type AgentInstanceObjectContent,
+	type AgentInstanceMessageContent,
+	type AgentInstanceToolCall,
+	type AgentInstanceHistoryItemMetrics,
+	type AgentInstanceHistoryItem,
+	type AgentInstanceHistoryFilter,
+	type CreateAgentInstanceHistoryItemRequestBody,
+	type CreateAgentInstanceHistoryItemResponseBody,
+	type SearchAgentInstanceHistoryRequestBody,
+	type SearchAgentInstanceHistoryResponseBody,
 } from './agent-instance';
 export {
 	activityTypeSchema,

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.71",
+	"version": "0.0.72",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

This PR syncs the new agent-instance history APIs introduced in https://github.com/camunda/camunda/pull/54698 into `camunda-api-zod-schema`.

## Checklist

- [ ] **Release new package version.**
- [ ] Update client apps to use new package version.

## Related issues

relates #51928
