### PR TITLE
build: add zeebe.version to allowed property changes

### DIFF
--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -120,12 +120,14 @@ jobs:
           # - <version>: Main project version (X.Y.Z-SNAPSHOT)
           # - <backwards.compat.version>: Java API compatibility version
           # - <version.identity>: Identity component version (updated by automation)
+          # - <zeebe.version>: Used in Optimize (updated by automation)
           ALLOWED_PATTERNS=(
             '^\+\+\+'                              # Diff header
             '^---'                                 # Diff header
             '^[+-]\s*<version>'                    # Main version tag
             '^[+-]\s*<backwards\.compat\.version>' # Backwards compatibility version
             '^[+-]\s*<version\.identity>'          # Identity version
+            '^[+-]\s*<zeebe\.version>'             # Zeebe component version
           )
           
           # Build regex from allowed patterns (join with |)


### PR DESCRIPTION


## Description

Fix the following case

```
✅ Validated 156 pom.xml files
❌ Non-version changes in pom.xml:
-    <zeebe.version>8.8.26-SNAPSHOT</zeebe.version>
+    <zeebe.version>8.8.27-SNAPSHOT</zeebe.version>
```
Failure: https://github.com/camunda/camunda/actions/runs/27202458402/job/80309614683

`zeebe.version` is not used in other places among pom.xml files: https://github.com/search?q=repo%3Acamunda%2Fcamunda%20zeebe.version&type=code

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
