### PR TITLE
docs: add runbooks and process docs for green base branches

### DIFF
--- a/docs/monorepo-docs/ci-runbooks.md
+++ b/docs/monorepo-docs/ci-runbooks.md
@@ -102,26 +102,63 @@ Depends on the kind of failure.
 
 ---
 
-### Push `main` High Failure Rate
+### Base Branch Unsuccessful Job
 
-Unsuccessful [Unified CI](./ci.md#unified-ci) GHA jobs on push to `main` branch mean that artifacts
-might not get built nor uploaded. Those same jobs being green is a precondition for the
-[merge queue](./ci.md#github-merge-queue) — thus a high failure rate over the last hours can indicate
-a general CI instability e.g. with infrastructure or remote network services.
+Any unsuccessful GHA job on `push` or `schedule` to `main` or `stable/8.x` base branches means that
+artifacts might not get built or uploaded to artifact repositories, and indicates CI instability
+since we expect only green builds. Unlike merge-queue failures which block PRs, base-branch failures
+affect artifact availability and release readiness.
 
-This can prevent artifact uploads and needs to be investigated.
+Each alert instance is grouped by workflow job name and base branch, and includes:
+
+- Number of unsuccessful runs in the evaluation window
+- Links to failed workflow runs in the evaluation window (useful for root cause analysis)
+- Owner of the job (assigned by default)
+- Link to the Job Trends dashboard for the job (useful to verify recovery)
+- Associated failed test cases (if any)
 
 #### Troubleshooting
 
-Verify the high rate of unsuccessful GHA jobs (for push to `main`) over the last hours in the CI
-Health dashboard. Drill down into the list of recent unsuccessful jobs and check their GHA logs for
-common symptoms and correlate [known issues](./ci.md#issue-tracking).
+You can leverage [incident.io MCP](https://docs.incident.io/ai/remote-mcp) together with Claude for some steps:
 
-Check for [GitHub Actions outages](https://www.githubstatus.com/).
+0. **Ensure correct ownership information:** If this particular CI job is NOT owned by your team, do the following:
+   - Identify the owning team.
+   - Update the [.codeowners file](https://github.com/camunda/camunda/blob/main/.codeowners) to reflect right GitHub team handle for the GHA workflow YAML file path.
+   - Adjust the job-level `TEST_OWNER` environment variable in the GHA workflow YAML.
+   - Ask the medic of the owning team to take over incident command.
+
+1. **Verify the pattern**: Check the [Job Trends dashboard](https://dashboard.int.camunda.com/d/ch6qgkj/ci-job-trends-camunda-camunda) for the specific job and branch to understand whether this is a new regression or ongoing instability.
+
+2. **Identify the root cause**: Use the `/ci-fix-failure` skill or click the workflow run links in the alert to inspect job logs. Common causes include:
+   - Timeout (increase runner size or optimize the job)
+   - Flaky test failures (see [Flaky Test Gate](./flaky-test-gate.md) for test diagnostics)
+   - External service unavailability (Docker Hub, Maven Central, Nexus, etc. — check status pages)
+   - Infrastructure issues (self-hosted runner problems, disk space, etc.)
+   - For `check-licenses.yml` see [find specific FOSSA instructions](#check-licenses-workflow-high-failure-rate)
+
+3. **Check for related alerts**: If multiple jobs or workflows are failing simultaneously, there may be a common root cause (e.g., external service outage, infrastructure problem). Cross-reference recent incident reports.
+
+4. **Examine test failures**: If the alert includes unsuccessful test cases, use the test case names to determine whether:
+   - The test is new and unstable
+   - The test is a known flaky test (check [Flaky Test Gate baseline](./flaky-test-gate.md))
+   - The failure is environment-specific
 
 #### Solutions
 
-Depends on the kind of failure.
+**Immediate mitigation** ("stop the bleeding"):
+- If a test is blocking artifact builds, consider temporarily disabling it with a `@Disabled` annotation and a link to an incident ticket.
+- If a job is timing out, try increasing the runner size or optimizing the job logic.
+- If an external service is unavailable, wait for its recovery or find an alternative.
+
+**Root cause fix**:
+- Investigate the job logs and failing tests to understand the underlying issue.
+- For flaky tests, refer to the [Flaky Test Gate documentation](./flaky-test-gate.md) on how to fix or mark them.
+- For timeouts or performance issues, optimize the job (parallelization, caching, reducing scope).
+- For infrastructure issues, coordinate with the Infra team.
+
+**Validation**:
+- Monitor the [Job Trends dashboard](https://dashboard.int.camunda.com/d/ch6qgkj/ci-job-trends-camunda-camunda) to confirm the fix reduces the failure rate.
+- Ensure the job remains stable across multiple successful runs before closing the incident.
 
 ---
 
@@ -203,7 +240,7 @@ down development in the monorepo and should be addressed promptly.
 #### Troubleshooting
 
 Verify the [CI Health dashboard](https://dashboard.int.camunda.com/d/bdmo5l8puugaoc/ci-health-camunda-camunda-monorepo)
-for a high eviction rate over the last few hours. Identify affected PRs and check their GHA logs
+for a high eviction rate over the last few hours. Use the `/ci-fix-failure` skill. Identify affected PRs and check their GHA logs
 for common symptoms and correlate [known issues](./ci.md#issue-tracking).
 
 Check for [GitHub Actions outages](https://www.githubstatus.com/).

--- a/docs/monorepo-docs/processes.md
+++ b/docs/monorepo-docs/processes.md
@@ -172,11 +172,19 @@ Once an incident is identified, the [Monorepo CI Medic](#monorepo-ci-medic) beco
 Incidents are resolved according to the [Engineering Incident Management Process](https://confluence.camunda.com/display/HAN/Incident+Management) by the [Incident Response Team](https://confluence.camunda.com/display/HAN/IM+-+Roles+and+Responsibilities#IMRolesandResponsibilities-TheIncidentResponseTeam). Helpful resources:
 
 - [Runbooks](./ci-runbooks.md) for CI-related problems
+- `/ci-incident` and `/ci-fix-failure` skills for LLM assistance
 - generically applicable [Incident Checklist](https://confluence.camunda.com/display/SRE/Incident+Checklist) of the Infra team
+
+##### SLA
+
+The Incident Commander needs to ensure that mitigations are in place with timelines depending on the severity of the incident:
+
+- L1: Within 1 day after opening
+- L2: Within 2 days after opening
 
 The Communications Lead should send out periodic updates depending on the severity of the incident:
 
-- L1: Once per hour until resolved
+- L1: Once per hour until mitigated, afterwards once per day until resolved
 - L2: Once per day until resolved
 
 #### 3. Follow-Up

--- a/docs/monorepo-docs/processes.md
+++ b/docs/monorepo-docs/processes.md
@@ -2,6 +2,49 @@
 
 This page collects processes we follow in the `camunda/camunda` monorepo.
 
+## Green Checks on `main` and `stable/*` Branches
+
+### Purpose
+
+This process ensures that `main` and `stable/*` base branches stay green continuously. Every build failure is unexpected and will be handled as a L1 incident.
+
+We use this process because:
+
+- These branches are our release and integration baseline, so red checks indicate reduced stability and threaten release-readiness.
+- For base branches, we expect no failing checks after CI stabilization work; every red check matters.
+- Some important scheduled workflows are not part of Unified CI, so Unified CI thresholds alone are not sufficient.
+
+### Approach
+
+We want a fast feedback loop for any failed check on base branches that leads to short-term fixes and mid-term improvement work to prevent recurrence and increase reliability.
+
+High-level steps:
+
+- Detect GHA job failures across `on: push` and `on: schedule` workflows on `main` and `stable/*`.
+- Alert immediately via Grafana on any unsuccessful job.
+- Create and route incidents to the right owners/medics based on `.codeowners`.
+- Drive mitigation (SLA: within 1 day) and resolution via the established incident process.
+- Keep base branches green over time instead of reacting ad hoc.
+
+### Implementation
+
+1. **Coverage enforcement:** [CI policy checks](https://github.com/camunda/camunda/blob/main/.github/conftest-unified-ci-rules.rego) ensure that all relevant GHA workflows/jobs submit CI Analytics data.
+2. **Detection:** CI Analytics data is [queried regularly by Grafana](https://github.com/camunda/infra-core/blob/stage/camunda-int/kustomize/prod/monitoring/dashboard.int.camunda.com/config/alerts-monorepo-ci.yml) for unsuccessful jobs on `main` and `stable/*` for push/schedule triggers.
+3. **Alerting:** Grafana raises `base-branch-unsuccessful-job` [alerts](https://github.com/camunda/infra-core/blob/stage/camunda-int/kustomize/prod/monitoring/dashboard.int.camunda.com/config/alerts-monorepo-ci.yml) for any detected red check. Alerts are enriched with context about failed GHA job links, unsuccessful test cases, and ownership information.
+4. **Incident propagation:** Alerts are propagated into incident.io, which groups them by base branch and GHA workflow job name and raises `C8 Monorepo CI` type incidents, severity L1.
+5. **Ownership routing:** Incidents are assigned to the responsible medic/owner based on ownership information from [.codeowners file](https://github.com/camunda/camunda/blob/main/.codeowners). If the attribution is incorrect, the assignee is responsible for updating the ownership information.
+6. **Response and resolution:** Medics can use `/ci-incident` guidance skill to follow [runbooks](./ci-runbooks.md#base-branch-unsuccessful-job) and the [CI incident management process](#ci-incident-management) to mitigate the problem and fix root causes. Those measures include stopping the bleeding, preventing the problem from happening again and increasing reliability constantly.
+7. **Verification:** Job trends and alert behavior are monitored by medic via Grafana until checks are consistently green again.
+
+### Operating Notes
+
+- Complements Unified CI SLOs monitoring by being stricter for base branches: alerts on every failure.
+- Focuses on reliability of release-critical (base) branches: covers push and scheduled triggers.
+- Remind ICs to prioritize quick mitigation ([with 1 day SLA](#sla)) via incident.io nudges.
+- Monitoring via daily Slack overview of open CI incidents with "mitigation overdue" warning.
+- If recurring test instability found, evaluate quarantine or other mitigations with clear ownership and follow-up.
+
+
 ## Renovate PR Handling
 
 We use [Renovate to automate dependency updates](./ci.md#renovate) in the `camunda/camunda` monorepo. However, not all updates can be automatically merged as-is due to breaking changes or adjustments needed to the code base.


### PR DESCRIPTION
## Description

Adds runbook and process documentation supporting the new `base-branch-unsuccessful-job` Grafana alert (from camunda/infra-core#12999), which raises an incident for every unsuccessful GHA job on `push`/`schedule` to `main` or `stable/*`. This is goal 2 of #52873 — the docs side that complements the alert/incident wiring.

**`docs/monorepo-docs/ci-runbooks.md`:**

- Replace the threshold-based `Push main High Failure Rate` runbook with a per-failure `Base Branch Unsuccessful Job` runbook covering `push` and `schedule` on `main` and `stable/8.x`.
- Document the alert payload (failed run links, owner, Job Trends dashboard link, failed test cases) so medics know what they get.
- Expand troubleshooting into ordered steps: ownership re-routing via `.codeowners` and `TEST_OWNER`, pattern check on the Job Trends dashboard, root-cause categories (timeout, flaky test, external service, infra, FOSSA), cross-referencing related alerts, and triaging failed test cases.
- Split solutions into immediate mitigation (`@Disabled` with ticket link, runner resize, wait out external outage), root-cause fix, and validation on the Job Trends dashboard.
- Reference the `/ci-fix-failure` and `/ci-incident` skills where they apply from https://github.com/camunda/camunda/pull/55420

**`docs/monorepo-docs/processes.md`:**

- Add a `Green Checks on main and stable/* Branches` section explaining the why (release/integration baseline, scheduled workflows outside Unified CI, stricter than threshold-based monitoring) and the end-to-end implementation: conftest coverage enforcement → CI Analytics → Grafana alert → incident.io grouping/routing → medic response via runbook → verification on Job Trends.
- Add mitigation SLAs to the CI incident management process (L1: 1 day, L2: 2 days) and adjust the L1 comms cadence to hourly until mitigated, then daily until resolved.
- Link `/ci-incident` and `/ci-fix-failure` from the incident process.

Depends on #55420 for the CI skills referenced from the runbook and process docs.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to #52873 (goal 2)
Companion to camunda/infra-core#12999
Depends on #55420