### PR TITLE
feat: recover from wrong exporter position

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/exception/ExporterPositionMismatchException.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/exception/ExporterPositionMismatchException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.exception;
+
+/**
+ * Thrown during an in-transaction flush when the exporter position stored in the database is
+ * <em>more advanced</em> than the local {@code lastFlushedPosition}.
+ *
+ * <p>This typically indicates that a concurrent exporter instance for the same partition has
+ * already written records beyond the current instance's last acknowledged position.
+ */
+public final class ExporterPositionMismatchException extends RuntimeException {
+
+  private final long expectedPosition;
+  private final long actualPosition;
+
+  public ExporterPositionMismatchException(
+      final int partitionId, final long expectedPosition, final long actualPosition) {
+    super(
+        String.format(
+            "Exporter position for partition %d is ahead of the local position:"
+                + " expected %d but found %d in the database."
+                + " Another exporter instance may have already exported to this partition.",
+            partitionId, expectedPosition, actualPosition));
+
+    this.expectedPosition = expectedPosition;
+    this.actualPosition = actualPosition;
+  }
+
+  public boolean isBehind() {
+    return expectedPosition < actualPosition;
+  }
+
+  public boolean isAhead() {
+    return expectedPosition > actualPosition;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/exception/ExporterPositionMismatchException.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/exception/ExporterPositionMismatchException.java
@@ -8,11 +8,11 @@
 package io.camunda.db.rdbms.exception;
 
 /**
- * Thrown during an in-transaction flush when the exporter position stored in the database is
- * <em>more advanced</em> than the local {@code lastFlushedPosition}.
+ * Thrown during an in-transaction flush when the exporter position stored in the database differs
+ * from the local expected position.
  *
- * <p>This typically indicates that a concurrent exporter instance for the same partition has
- * already written records beyond the current instance's last acknowledged position.
+ * <p>This can indicate either a concurrent exporter instance writing ahead (DB position > expected)
+ * or an operator/DB rollback which moved the position backwards (DB position < expected).
  */
 public final class ExporterPositionMismatchException extends RuntimeException {
 
@@ -23,9 +23,7 @@ public final class ExporterPositionMismatchException extends RuntimeException {
       final int partitionId, final long expectedPosition, final long actualPosition) {
     super(
         String.format(
-            "Exporter position for partition %d is ahead of the local position:"
-                + " expected %d but found %d in the database."
-                + " Another exporter instance may have already exported to this partition.",
+            "Exporter position mismatch for partition %d: expected %d but found %d in the database.",
             partitionId, expectedPosition, actualPosition));
 
     this.expectedPosition = expectedPosition;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/exception/ExporterPositionMismatchException.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/exception/ExporterPositionMismatchException.java
@@ -16,25 +16,11 @@ package io.camunda.db.rdbms.exception;
  */
 public final class ExporterPositionMismatchException extends RuntimeException {
 
-  private final long expectedPosition;
-  private final long actualPosition;
-
   public ExporterPositionMismatchException(
       final int partitionId, final long expectedPosition, final long actualPosition) {
     super(
         String.format(
             "Exporter position mismatch for partition %d: expected %d but found %d in the database.",
             partitionId, expectedPosition, actualPosition));
-
-    this.expectedPosition = expectedPosition;
-    this.actualPosition = actualPosition;
-  }
-
-  public boolean isBehind() {
-    return expectedPosition < actualPosition;
-  }
-
-  public boolean isAhead() {
-    return expectedPosition > actualPosition;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -137,7 +137,7 @@ public class DefaultExecutionQueue implements ExecutionQueue {
       try (final var ignored = metrics.measureFlushDuration()) {
         // Record memory usage before flush
         metrics.recordQueueMemoryUsage(currentQueueMemoryBytes);
-        final int numFlushedElements = doFLush();
+        final int numFlushedElements = doFlush();
         metrics.stopFlushLatencyMeasurement();
         metrics.recordBulkSize(numFlushedElements);
         // Reset memory tracking after flush
@@ -233,13 +233,13 @@ public class DefaultExecutionQueue implements ExecutionQueue {
     synchronized (queue) {
       queue.clear();
       currentQueueMemoryBytes = 0;
+      preFlushListeners.clear();
+      postFlushListeners.clear();
+      inTransactionHooks.clear();
     }
-    preFlushListeners.clear();
-    postFlushListeners.clear();
-    inTransactionHooks.clear();
   }
 
-  private int doFLush() {
+  private int doFlush() {
     LOG.debug(
         "[RDBMS ExecutionQueue, Partition {}] Flushing execution queue with {} items",
         partitionId,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -228,6 +228,17 @@ public class DefaultExecutionQueue implements ExecutionQueue {
     return false;
   }
 
+  @Override
+  public void reset() {
+    synchronized (queue) {
+      queue.clear();
+      currentQueueMemoryBytes = 0;
+    }
+    preFlushListeners.clear();
+    postFlushListeners.clear();
+    inTransactionHooks.clear();
+  }
+
   private int doFLush() {
     LOG.debug(
         "[RDBMS ExecutionQueue, Partition {}] Flushing execution queue with {} items",

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ExecutionQueue.java
@@ -74,4 +74,15 @@ public interface ExecutionQueue {
    * @return true if the queue was flushed, false otherwise
    */
   boolean checkQueueForFlush();
+
+  /**
+   * Resets the queue to a clean state: discards all pending queue items and removes all registered
+   * pre-flush listeners, post-flush listeners, and in-transaction hooks.
+   *
+   * <p>Call this at the start of {@code open()} before registering new listeners to prevent
+   * duplicate registrations when an exporter is reopened after a recoverable failure. Also call it
+   * after catching a {@link PositionMismatchException} to discard stale writes before the next
+   * flush.
+   */
+  void reset();
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ExecutionQueue.java
@@ -80,9 +80,7 @@ public interface ExecutionQueue {
    * pre-flush listeners, post-flush listeners, and in-transaction hooks.
    *
    * <p>Call this at the start of {@code open()} before registering new listeners to prevent
-   * duplicate registrations when an exporter is reopened after a recoverable failure. Also call it
-   * after catching a {@link PositionMismatchException} to discard stale writes before the next
-   * flush.
+   * duplicate registrations when an exporter is reopened after a recoverable failure.
    */
   void reset();
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ExporterPositionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ExporterPositionService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import io.camunda.db.rdbms.exception.ExporterPositionMismatchException;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
@@ -76,12 +77,10 @@ public class ExporterPositionService {
           final ExporterPositionModel lockedPosition = mapper.findOneForUpdate(partitionId);
           if (lockedPosition != null) {
             final long expectedPosition = expectedPositionSupplier.getAsLong();
-            if (lockedPosition.lastExportedPosition() != expectedPosition) {
-              throw new IllegalStateException(
-                  String.format(
-                      "Exporter position mismatch for partition %d: expected %d but found %d. "
-                          + "Another exporter instance may have already exported to this partition.",
-                      partitionId, expectedPosition, lockedPosition.lastExportedPosition()));
+            final long dbPosition = lockedPosition.lastExportedPosition();
+            if (dbPosition != expectedPosition) {
+              throw new ExporterPositionMismatchException(
+                  partitionId, expectedPosition, dbPosition);
             }
           }
         });

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsExporterPositionRecoveryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsExporterPositionRecoveryIT.java
@@ -16,6 +16,7 @@ import com.google.common.collect.Iterables;
 import io.camunda.client.CamundaClient;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.zeebe.broker.exporter.metrics.MetricsExporter;
 import io.camunda.zeebe.broker.exporter.stream.ExporterMetricsDoc;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -87,6 +88,7 @@ class RdbmsExporterPositionRecoveryIT {
     testInstance =
         new TestCamundaApplication()
             .withSecondaryStorageType(SecondaryStorageType.rdbms)
+            .withProperty("camunda.monitoring.metrics.enable-exporter-execution-metrics", true)
             .withProperty("camunda.data.secondary-storage.rdbms.url", postgres.getJdbcUrl())
             .withProperty("camunda.data.secondary-storage.rdbms.username", postgres.getUsername())
             .withProperty("camunda.data.secondary-storage.rdbms.password", postgres.getPassword())
@@ -116,9 +118,14 @@ class RdbmsExporterPositionRecoveryIT {
   @Test
   @Order(1)
   void shouldRecoverAfterPositionMismatchAndContinueExporting() throws Exception {
-    // given — note the current DB position before tamper
+    // given — note current positions before tamper
     final long positionBeforeTamper = getCurrentDbExporterPosition();
     assertThat(positionBeforeTamper).isGreaterThan(0);
+
+    // Capture the MetricsExporter baseline so we can prove it keeps advancing independently.
+    // It is auto-registered by BrokerCfg once execution metrics exporting is enabled in the test
+    // setup.
+    final long metricsPositionBeforeTamper = getCurrentMetricsExporterPosition();
 
     // Advance the DB position ahead to simulate another exporter instance writing ahead.
     // A small offset (+50) is used so that the 30 new process instances (~300 records) push
@@ -133,8 +140,8 @@ class RdbmsExporterPositionRecoveryIT {
       startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"foo\"}");
     }
 
-    // then — the exporter reopens, re-syncs from DB position, and eventually the DB position
-    // advances past the tampered value as new records (with positions > tamperedPosition) arrive
+    // then — the RDBMS exporter reopens, re-syncs from DB position, and eventually the DB
+    // position advances past the tampered value as new records arrive
     Awaitility.await("exporter recovers and advances position past tampered value")
         .atMost(Duration.ofMinutes(3))
         .untilAsserted(
@@ -144,6 +151,18 @@ class RdbmsExporterPositionRecoveryIT {
                         "DB exporter position must eventually exceed the tampered value, "
                             + "proving the exporter recovered and continued exporting")
                     .isGreaterThan(tamperedPosition));
+
+    // and — the MetricsExporter must keep advancing despite the RDBMS reopen; it shares the same
+    // actor loop but has its own ExporterContainer and is never closed or reopened as a side-effect
+    Awaitility.await("MetricsExporter continues to export after RDBMS reopen")
+        .atMost(Duration.ofMinutes(1))
+        .untilAsserted(
+            () ->
+                assertThat(getCurrentMetricsExporterPosition())
+                    .as(
+                        "MetricsExporter last-updated position must advance past its pre-tamper "
+                            + "baseline, proving it was not disrupted by the RDBMS exporter reopen")
+                    .isGreaterThan(metricsPositionBeforeTamper));
   }
 
   /**
@@ -151,9 +170,9 @@ class RdbmsExporterPositionRecoveryIT {
    *
    * <p>The in-transaction row-lock hook detects the divergence (DB &lt; {@code
    * lastFlushedPosition}) and raises a {@link
-   * io.camunda.db.rdbms.write.queue.PositionMismatchException}. On reopen the exporter finds DB
-   * &lt; broker and attempts a replay; but in this test environment the exporter is already in the
-   * exporting phase and replay is rejected. The exporter then fails hard with an {@link
+   * io.camunda.db.rdbms.exception.ExporterPositionMismatchException}. On reopen the exporter finds
+   * DB &lt; broker and attempts a replay; but in this test environment the exporter is already in
+   * the exporting phase and replay is rejected. The exporter then fails hard with an {@link
    * io.camunda.zeebe.exporter.api.ExporterException} rather than silently accepting a stale
    * baseline (which would risk data loss). This scenario requires log segments to be available in
    * production for automatic recovery.
@@ -222,13 +241,24 @@ class RdbmsExporterPositionRecoveryIT {
   }
 
   private long getCurrentAcknowledgedExporterPosition() {
-    return getMeterLong(ExporterMetricsDoc.LAST_UPDATED_EXPORTED_POSITION.getName());
+    return getMeterLong(ExporterMetricsDoc.LAST_UPDATED_EXPORTED_POSITION.getName(), "rdbms");
   }
 
-  private long getMeterLong(final String name) {
+  private long getCurrentMetricsExporterPosition() {
+    return getMeterLong(
+        ExporterMetricsDoc.LAST_UPDATED_EXPORTED_POSITION.getName(),
+        MetricsExporter.defaultExporterId());
+  }
+
+  private long getMeterLong(final String name, final String exporterId) {
     try {
       final var meters =
-          meterRegistry.get(name).tag("exporter", "rdbms").tag("partition", "1").meter().measure();
+          meterRegistry
+              .get(name)
+              .tag("exporter", exporterId)
+              .tag("partition", "1")
+              .meter()
+              .measure();
       final Measurement first = Iterables.getFirst(meters, null);
       return first == null ? 0L : (long) first.getValue();
     } catch (final Exception e) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsExporterPositionRecoveryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsExporterPositionRecoveryIT.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Iterables;
+import io.camunda.client.CamundaClient;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.zeebe.broker.exporter.stream.ExporterMetricsDoc;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Integration test verifying that the RDBMS exporter recovers automatically when the
+ * EXPORTER_POSITION table is tampered to simulate a diverged position.
+ *
+ * <p>Two scenarios are covered (run in order against a shared Camunda instance):
+ *
+ * <ol>
+ *   <li><b>DB position ahead of broker</b> – simulates another exporter instance writing ahead (the
+ *       original bug in issue #52460). The mismatch causes a reopen; the exporter re-syncs to the
+ *       DB position and continues.
+ *   <li><b>DB position behind broker</b> – simulates a DB rollback or manual admin tamper that left
+ *       the position counter lower than expected. The mismatch triggers the same reopen path; on
+ *       reopen the exporter requests a replay from the DB position. If log segments are available
+ *       the replay succeeds; if not, the exporter fails hard. This test is disabled because the
+ *       acceptance-test setup rejects the replay request.
+ * </ol>
+ */
+@Tag("rdbms")
+@TestInstance(Lifecycle.PER_CLASS)
+@TestMethodOrder(OrderAnnotation.class)
+class RdbmsExporterPositionRecoveryIT {
+
+  private static final String POSTGRES_IMAGE = "postgres:16-alpine";
+  private static final String DATABASE_NAME = "camunda";
+  private static final String DATABASE_USER = "camunda";
+  private static final String DATABASE_PASSWORD = "camunda";
+
+  @AutoClose
+  private final PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>(POSTGRES_IMAGE)
+          .withDatabaseName(DATABASE_NAME)
+          .withUsername(DATABASE_USER)
+          .withPassword(DATABASE_PASSWORD)
+          .withStartupTimeout(Duration.ofMinutes(5));
+
+  @AutoClose private TestCamundaApplication testInstance;
+  @AutoClose private CamundaClient camundaClient;
+
+  private MeterRegistry meterRegistry;
+
+  @BeforeAll
+  void beforeAll() {
+    postgres.start();
+
+    testInstance =
+        new TestCamundaApplication()
+            .withSecondaryStorageType(SecondaryStorageType.rdbms)
+            .withProperty("camunda.data.secondary-storage.rdbms.url", postgres.getJdbcUrl())
+            .withProperty("camunda.data.secondary-storage.rdbms.username", postgres.getUsername())
+            .withProperty("camunda.data.secondary-storage.rdbms.password", postgres.getPassword())
+            .withExporter(
+                "rdbms",
+                cfg -> {
+                  cfg.setClassName("io.camunda.db.rdbms.exporter.RdbmsExporter");
+                  cfg.setArgs(Map.of("flushInterval", "PT0S"));
+                })
+            .withBasicAuth();
+
+    testInstance.start();
+
+    camundaClient = testInstance.newClientBuilder().build();
+    meterRegistry = testInstance.bean(MeterRegistry.class);
+
+    Objects.requireNonNull(meterRegistry);
+    Objects.requireNonNull(camundaClient);
+
+    deployResource(camundaClient, "process/service_tasks_v1.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    // Let the exporter fully catch up before we tamper
+    awaitExporterPositionStabilises();
+  }
+
+  @Test
+  @Order(1)
+  void shouldRecoverAfterPositionMismatchAndContinueExporting() throws Exception {
+    // given — note the current DB position before tamper
+    final long positionBeforeTamper = getCurrentDbExporterPosition();
+    assertThat(positionBeforeTamper).isGreaterThan(0);
+
+    // Advance the DB position ahead to simulate another exporter instance writing ahead.
+    // A small offset (+50) is used so that the 30 new process instances (~300 records) push
+    // the broker position past the tampered baseline after recovery.
+    final long tamperedPosition = positionBeforeTamper + 50L;
+    setDbExporterPosition(tamperedPosition);
+
+    assertThat(getCurrentDbExporterPosition()).isEqualTo(tamperedPosition);
+
+    // when — generate traffic so the exporter tries to flush and detects the mismatch
+    for (int i = 0; i < 30; i++) {
+      startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"foo\"}");
+    }
+
+    // then — the exporter reopens, re-syncs from DB position, and eventually the DB position
+    // advances past the tampered value as new records (with positions > tamperedPosition) arrive
+    Awaitility.await("exporter recovers and advances position past tampered value")
+        .atMost(Duration.ofMinutes(3))
+        .untilAsserted(
+            () ->
+                assertThat(getCurrentDbExporterPosition())
+                    .as(
+                        "DB exporter position must eventually exceed the tampered value, "
+                            + "proving the exporter recovered and continued exporting")
+                    .isGreaterThan(tamperedPosition));
+  }
+
+  /**
+   * Scenario 2: RDBMS position is set to a value smaller than the broker's acknowledged position.
+   *
+   * <p>The in-transaction row-lock hook detects the divergence (DB &lt; {@code
+   * lastFlushedPosition}) and raises a {@link
+   * io.camunda.db.rdbms.write.queue.PositionMismatchException}. On reopen the exporter finds DB
+   * &lt; broker and attempts a replay; but in this test environment the exporter is already in the
+   * exporting phase and replay is rejected. The exporter then fails hard with an {@link
+   * io.camunda.zeebe.exporter.api.ExporterException} rather than silently accepting a stale
+   * baseline (which would risk data loss). This scenario requires log segments to be available in
+   * production for automatic recovery.
+   *
+   * <p>Disabled: replay is not available while the exporter is in the exporting phase; the
+   * hard-fail path cannot be fully verified in the acceptance-test setup. A manual integration test
+   * with log-segment availability is required to cover the replay-succeeds path.
+   */
+  @Test
+  @Order(2)
+  @Disabled(
+      "Replay is not available while the exporter is in the exporting phase; "
+          + "this scenario requires log segments that are not present in this test setup")
+  void shouldRecoverWhenRdbmsPositionIsLowerThanBrokerPosition() throws Exception {
+    // given — wait until the position has stabilised after the previous test
+    Awaitility.await("position stabilises after previous test")
+        .atMost(Duration.ofMinutes(2))
+        .until(
+            () -> {
+              final long acknowledged = getCurrentAcknowledgedExporterPosition();
+              final long db = getCurrentDbExporterPosition();
+              // both sides agree and are advancing (non-trivially ahead of 0)
+              return acknowledged > 0 && Math.abs(acknowledged - db) <= 10;
+            });
+
+    final long positionBeforeTamper = getCurrentDbExporterPosition();
+    assertThat(positionBeforeTamper).isGreaterThan(0);
+
+    // Set the DB position below the broker's acknowledged position to simulate a DB rollback or
+    // an admin mistake that left the position counter behind the actual data state.
+    final long tamperedPosition = positionBeforeTamper - 5;
+    setDbExporterPosition(tamperedPosition);
+
+    assertThat(getCurrentDbExporterPosition()).isEqualTo(tamperedPosition);
+
+    // when — generate traffic so the exporter flushes and detects the mismatch
+    for (int i = 0; i < 20; i++) {
+      startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"foo\"}");
+    }
+
+    // then — the exporter reopens, accepts the DB position as the new baseline, and eventually
+    // advances the DB position past the pre-tamper value (proving it did not get stuck)
+    Awaitility.await("exporter recovers from lower-than-expected DB position")
+        .atMost(Duration.ofMinutes(3))
+        .untilAsserted(
+            () ->
+                assertThat(getCurrentDbExporterPosition())
+                    .as(
+                        "DB exporter position must eventually exceed the pre-tamper value, "
+                            + "proving the exporter recovered and continued exporting after the gap")
+                    .isGreaterThan(positionBeforeTamper));
+  }
+
+  // -----------------------------------------------------------------------
+  // helpers
+  // -----------------------------------------------------------------------
+
+  private void awaitExporterPositionStabilises() {
+    Awaitility.await("initial export stabilises")
+        .atMost(Duration.ofMinutes(1))
+        .until(
+            () -> {
+              final long pos = getCurrentAcknowledgedExporterPosition();
+              return pos > 0;
+            });
+  }
+
+  private long getCurrentAcknowledgedExporterPosition() {
+    return getMeterLong(ExporterMetricsDoc.LAST_UPDATED_EXPORTED_POSITION.getName());
+  }
+
+  private long getMeterLong(final String name) {
+    try {
+      final var meters =
+          meterRegistry.get(name).tag("exporter", "rdbms").tag("partition", "1").meter().measure();
+      final Measurement first = Iterables.getFirst(meters, null);
+      return first == null ? 0L : (long) first.getValue();
+    } catch (final Exception e) {
+      return 0L;
+    }
+  }
+
+  /**
+   * Opens a direct, auto-commit JDBC connection to the Postgres container. Using DriverManager
+   * bypasses the HikariCP pool (which is configured with {@code autoCommit=false}), so every
+   * statement is immediately visible to the exporter without an explicit {@code commit()} call.
+   */
+  private Connection directPostgresConnection() throws SQLException {
+    return DriverManager.getConnection(
+        postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+  }
+
+  private long getCurrentDbExporterPosition() throws Exception {
+    try (final Connection conn = directPostgresConnection();
+        final PreparedStatement ps =
+            conn.prepareStatement(
+                "SELECT LAST_EXPORTED_POSITION FROM EXPORTER_POSITION WHERE PARTITION_ID = 1")) {
+      try (final ResultSet rs = ps.executeQuery()) {
+        return rs.next() ? rs.getLong(1) : 0L;
+      }
+    }
+  }
+
+  private void setDbExporterPosition(final long position) throws Exception {
+    try (final Connection conn = directPostgresConnection();
+        final PreparedStatement ps =
+            conn.prepareStatement(
+                "UPDATE EXPORTER_POSITION SET LAST_EXPORTED_POSITION = ? WHERE PARTITION_ID = 1")) {
+      ps.setLong(1, position);
+      final int rows = ps.executeUpdate();
+      if (rows == 0) {
+        throw new IllegalStateException(
+            "setDbExporterPosition updated 0 rows — EXPORTER_POSITION row not found for PARTITION_ID=1");
+      }
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsExporterPositionRecoveryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsExporterPositionRecoveryIT.java
@@ -9,7 +9,10 @@ package io.camunda.it.rdbms.db;
 
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitForUser;
+import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Iterables;
@@ -26,12 +29,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -51,11 +55,11 @@ import org.testcontainers.containers.PostgreSQLContainer;
  *   <li><b>DB position ahead of broker</b> – simulates another exporter instance writing ahead (the
  *       original bug in issue #52460). The mismatch causes a reopen; the exporter re-syncs to the
  *       DB position and continues.
- *   <li><b>DB position behind broker</b> – simulates a DB rollback or manual admin tamper that left
- *       the position counter lower than expected. The mismatch triggers the same reopen path; on
- *       reopen the exporter requests a replay from the DB position. If log segments are available
- *       the replay succeeds; if not, the exporter fails hard. This test is disabled because the
- *       acceptance-test setup rejects the replay request.
+ *   <li><b>DB position behind broker</b> – simulates a DB rollback, or an automated failover to a
+ *       lagging async replica, that left the position counter lower than expected. The mismatch
+ *       triggers the same reopen path; on reopen the exporter requests a replay from the DB
+ *       position, which rewinds the shared log reader and redelivers the missing records so the
+ *       exporter re-syncs and continues.
  * </ol>
  */
 @Tag("rdbms")
@@ -171,59 +175,73 @@ class RdbmsExporterPositionRecoveryIT {
    * <p>The in-transaction row-lock hook detects the divergence (DB &lt; {@code
    * lastFlushedPosition}) and raises a {@link
    * io.camunda.db.rdbms.exception.ExporterPositionMismatchException}. On reopen the exporter finds
-   * DB &lt; broker and attempts a replay; but in this test environment the exporter is already in
-   * the exporting phase and replay is rejected. The exporter then fails hard with an {@link
-   * io.camunda.zeebe.exporter.api.ExporterException} rather than silently accepting a stale
-   * baseline (which would risk data loss). This scenario requires log segments to be available in
-   * production for automatic recovery.
+   * DB &lt; broker and requests a replay from the DB position; the exporter director rewinds the
+   * shared log reader to that position and redelivers the missing records, allowing the exporter to
+   * re-sync and continue without any manual intervention or data loss.
    *
-   * <p>Disabled: replay is not available while the exporter is in the exporting phase; the
-   * hard-fail path cannot be fully verified in the acceptance-test setup. A manual integration test
-   * with log-segment availability is required to cover the replay-succeeds path.
+   * <p>A few users are created and then deleted directly from the database before rewinding the
+   * position, so replaying their creation records re-inserts them rather than hitting a primary
+   * key/unique constraint violation (which would occur if the rows were still present when the
+   * exporter replays their INSERTs).
    */
   @Test
   @Order(2)
-  @Disabled(
-      "Replay is not available while the exporter is in the exporting phase; "
-          + "this scenario requires log segments that are not present in this test setup")
   void shouldRecoverWhenRdbmsPositionIsLowerThanBrokerPosition() throws Exception {
     // given — wait until the position has stabilised after the previous test
-    Awaitility.await("position stabilises after previous test")
-        .atMost(Duration.ofMinutes(2))
-        .until(
-            () -> {
-              final long acknowledged = getCurrentAcknowledgedExporterPosition();
-              final long db = getCurrentDbExporterPosition();
-              // both sides agree and are advancing (non-trivially ahead of 0)
-              return acknowledged > 0 && Math.abs(acknowledged - db) <= 10;
-            });
+    awaitExporterPositionStabilises();
 
-    final long positionBeforeTamper = getCurrentDbExporterPosition();
-    assertThat(positionBeforeTamper).isGreaterThan(0);
+    final long positionBeforeUsers = getCurrentDbExporterPosition();
+    assertThat(positionBeforeUsers).isGreaterThan(0);
 
-    // Set the DB position below the broker's acknowledged position to simulate a DB rollback or
-    // an admin mistake that left the position counter behind the actual data state.
-    final long tamperedPosition = positionBeforeTamper - 5;
-    setDbExporterPosition(tamperedPosition);
-
-    assertThat(getCurrentDbExporterPosition()).isEqualTo(tamperedPosition);
-
-    // when — generate traffic so the exporter flushes and detects the mismatch
-    for (int i = 0; i < 20; i++) {
-      startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"foo\"}");
+    // create a few users; their creation records are exactly what the replay below must
+    // redeliver once the exporter position is rewound to before they existed
+    final var usernames =
+        List.of(
+            "recovery-user-1-" + UUID.randomUUID(),
+            "recovery-user-2-" + UUID.randomUUID(),
+            "recovery-user-3-" + UUID.randomUUID());
+    for (final var username : usernames) {
+      camundaClient
+          .newCreateUserCommand()
+          .username(username)
+          .name(username)
+          .password("password")
+          .email(username + "@example.com")
+          .send()
+          .join();
+    }
+    for (final var username : usernames) {
+      waitForUser(camundaClient, username);
     }
 
-    // then — the exporter reopens, accepts the DB position as the new baseline, and eventually
-    // advances the DB position past the pre-tamper value (proving it did not get stuck)
-    Awaitility.await("exporter recovers from lower-than-expected DB position")
-        .atMost(Duration.ofMinutes(3))
-        .untilAsserted(
-            () ->
-                assertThat(getCurrentDbExporterPosition())
-                    .as(
-                        "DB exporter position must eventually exceed the pre-tamper value, "
-                            + "proving the exporter recovered and continued exporting after the gap")
-                    .isGreaterThan(positionBeforeTamper));
+    // Delete the users directly from the database, simulating that their INSERTs were never
+    // durably persisted downstream (consistent with rewinding the position past their records
+    // below). Without this, replaying their creation would fail with a PK/unique constraint
+    // violation instead of exercising the recovery path.
+    for (final var username : usernames) {
+      deleteUserFromDb(username);
+    }
+
+    // Rewind the DB position to before the users were created, simulating a DB rollback or an
+    // automated failover to a lagging async replica that left the position counter behind the
+    // actual data state.
+    setDbExporterPosition(positionBeforeUsers);
+    assertThat(getCurrentDbExporterPosition()).isEqualTo(positionBeforeUsers);
+
+    // when — generate traffic so the exporter flushes and detects the mismatch
+    final var processInstance =
+        startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"foo\"}");
+
+    // then — the exporter reopens, replays from the rewound position (re-inserting the users it
+    // missed), and continues on to export the new process instance; all of it must become visible
+    // again through the client, proving no records were lost or permanently skipped
+    for (final var username : usernames) {
+      waitForUser(camundaClient, username);
+    }
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(processInstance.getProcessInstanceKey()),
+        instances -> assertThat(instances).isNotEmpty());
   }
 
   // -----------------------------------------------------------------------
@@ -231,13 +249,10 @@ class RdbmsExporterPositionRecoveryIT {
   // -----------------------------------------------------------------------
 
   private void awaitExporterPositionStabilises() {
-    Awaitility.await("initial export stabilises")
+    Awaitility.await("RDBMS exporter position stabilises")
         .atMost(Duration.ofMinutes(1))
-        .until(
-            () -> {
-              final long pos = getCurrentAcknowledgedExporterPosition();
-              return pos > 0;
-            });
+        .during(Duration.ofSeconds(5))
+        .until(this::getCurrentAcknowledgedExporterPosition, hasStableValue());
   }
 
   private long getCurrentAcknowledgedExporterPosition() {
@@ -298,6 +313,15 @@ class RdbmsExporterPositionRecoveryIT {
         throw new IllegalStateException(
             "setDbExporterPosition updated 0 rows — EXPORTER_POSITION row not found for PARTITION_ID=1");
       }
+    }
+  }
+
+  private void deleteUserFromDb(final String username) throws Exception {
+    try (final Connection conn = directPostgresConnection();
+        final PreparedStatement ps =
+            conn.prepareStatement("DELETE FROM USER_ WHERE USERNAME = ?")) {
+      ps.setString(1, username);
+      ps.executeUpdate();
     }
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -19,6 +19,7 @@ import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.RdbmsServiceFactory;
+import io.camunda.db.rdbms.exception.ExporterPositionMismatchException;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
@@ -57,6 +58,7 @@ import io.camunda.security.core.authz.TenantCheck;
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.broker.exporter.context.ExporterContext;
+import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
@@ -1530,10 +1532,16 @@ class RdbmsExporterIT {
     tamperExporterPosition(tamperedPosition);
     final var processInstanceRecord = FIXTURES.getProcessInstanceStartedRecord();
     assertThatThrownBy(() -> exporter.export(processInstanceRecord))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Exporter position mismatch for partition 1")
+        .isInstanceOf(ExporterException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ExporterException) ex).getCompensation())
+                    .isEqualTo(ExporterException.Compensation.REOPEN))
+        .hasCauseInstanceOf(ExporterPositionMismatchException.class)
+        .rootCause()
+        .hasMessageContaining("partition 1")
         .hasMessageContaining("expected " + currentPosition)
-        .hasMessageContaining("but found " + tamperedPosition);
+        .hasMessageContaining(String.valueOf(tamperedPosition));
 
     // cleanup because the H2 is shared
     FIXTURES.resetPosition(currentPosition);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportOutcome.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportOutcome.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.stream;
+
+/** The outcome of {@link ExporterContainer#exportRecord} for a single record. */
+enum ExportOutcome {
+  /** The record was exported (or skipped as already up to date) successfully. */
+  EXPORTED,
+
+  /** The export failed and should be retried against the same record. */
+  RETRY,
+
+  /**
+   * The exporter reopened and had a mid-run replay request accepted, rewinding the shared log
+   * reader. The current record is abandoned rather than retried immediately, so it - and everything
+   * the exporter missed before it - is redelivered strictly in order once reading resumes from the
+   * rewound position.
+   */
+  ABORT_REPLAY,
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.exporter.context.ExporterContext;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
 import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.exporter.api.context.ScheduledTask;
@@ -255,10 +256,40 @@ final class ExporterContainer implements Controller {
         }
       }
       return true;
+    } catch (final ExporterException ex) {
+      if (ex.getCompensation() == ExporterException.Compensation.REOPEN) {
+        context
+            .getLogger()
+            .warn(
+                "Export error for exporter '{}' requires reopen to re-sync position", getId(), ex);
+        try {
+          reopenExporter();
+        } catch (final Exception reopenEx) {
+          context
+              .getLogger()
+              .error(
+                  "Failed to reopen exporter '{}'; manual intervention may be required",
+                  getId(),
+                  reopenEx);
+        }
+      } else {
+        context.getLogger().warn("Error on exporting record with key {}", typedEvent.getKey(), ex);
+      }
+      return false;
     } catch (final Exception ex) {
       context.getLogger().warn("Error on exporting record with key {}", typedEvent.getKey(), ex);
       return false;
     }
+  }
+
+  void reopenExporter() {
+    try {
+      ThreadContextUtil.runCheckedWithClassLoader(
+          exporter::close, exporter.getClass().getClassLoader());
+    } catch (final Exception e) {
+      context.getLogger().error("Error closing exporter '{}' during reopen", getId(), e);
+    }
+    openExporter();
   }
 
   void softPauseExporter() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -50,6 +50,7 @@ final class ExporterContainer implements Controller {
   private ActorControl actor;
   private final ExporterInitializationInfo initializationInfo;
   private final ExporterReplayControl replayControl;
+  private boolean replayAcceptedOnReopen;
 
   ExporterContainer(
       final ExporterDescriptor descriptor,
@@ -124,6 +125,7 @@ final class ExporterContainer implements Controller {
 
   void openExporter() {
     LOG.debug("Open exporter with id '{}'", getId());
+    replayAcceptedOnReopen = false;
     ThreadContextUtil.runWithClassLoader(
         () -> exporter.open(this), exporter.getClass().getClassLoader());
   }
@@ -224,6 +226,7 @@ final class ExporterContainer implements Controller {
       lastAcknowledgedPosition = lastExportedPosition;
       lastExportedMetadata = null;
       exportersState.setPosition(getId(), lastExportedPosition);
+      replayAcceptedOnReopen = true;
     }
     return replayResult;
   }
@@ -246,7 +249,7 @@ final class ExporterContainer implements Controller {
         () -> exporter.configure(context), exporter.getClass().getClassLoader());
   }
 
-  boolean exportRecord(final RecordMetadata rawMetadata, final TypedRecord<?> typedEvent) {
+  ExportOutcome exportRecord(final RecordMetadata rawMetadata, final TypedRecord<?> typedEvent) {
     try {
       if (position < typedEvent.getPosition()) {
         if (acceptRecord(rawMetadata, typedEvent)) {
@@ -255,7 +258,7 @@ final class ExporterContainer implements Controller {
           updatePositionOnSkipIfUpToDate(typedEvent.getPosition());
         }
       }
-      return true;
+      return ExportOutcome.EXPORTED;
     } catch (final ExporterException ex) {
       if (ex.getCompensation() == ExporterException.Compensation.REOPEN) {
         context
@@ -264,16 +267,25 @@ final class ExporterContainer implements Controller {
                 "Export error for exporter '{}' requires reopen to re-sync position", getId(), ex);
         try {
           reopenExporter();
+          if (replayAcceptedOnReopen) {
+            context
+                .getLogger()
+                .info(
+                    "Exporter '{}' accepted a replay during reopen; abandoning the current record"
+                        + " so it is redelivered in order from the rewound position",
+                    getId());
+            return ExportOutcome.ABORT_REPLAY;
+          }
         } catch (final Exception reopenEx) {
           context.getLogger().error("Failed to reopen exporter '{}'", getId(), reopenEx);
         }
       } else {
         context.getLogger().warn("Error on exporting record with key {}", typedEvent.getKey(), ex);
       }
-      return false;
+      return ExportOutcome.RETRY;
     } catch (final Exception ex) {
       context.getLogger().warn("Error on exporting record with key {}", typedEvent.getKey(), ex);
-      return false;
+      return ExportOutcome.RETRY;
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -265,12 +265,7 @@ final class ExporterContainer implements Controller {
         try {
           reopenExporter();
         } catch (final Exception reopenEx) {
-          context
-              .getLogger()
-              .error(
-                  "Failed to reopen exporter '{}'; manual intervention may be required",
-                  getId(),
-                  reopenEx);
+          context.getLogger().error("Failed to reopen exporter '{}'", getId(), reopenEx);
         }
       } else {
         context.getLogger().warn("Error on exporting record with key {}", typedEvent.getKey(), ex);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.agrona.LangUtil;
@@ -753,8 +754,15 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       return;
     }
 
+    final AtomicReference<ExportOutcome> lastOutcome = new AtomicReference<>();
     final ActorFuture<Boolean> retryFuture =
-        exportingRetryStrategy.runWithRetry(recordExporter::export, this::isClosed);
+        exportingRetryStrategy.runWithRetry(
+            () -> {
+              final ExportOutcome outcome = recordExporter.export();
+              lastOutcome.set(outcome);
+              return outcome != ExportOutcome.RETRY;
+            },
+            this::isClosed);
 
     actor.runOnCompletion(
         retryFuture,
@@ -762,7 +770,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
           if (throwable != null) {
             LOG.error(ERROR_MESSAGE_EXPORTING_ABORTED, event, throwable);
             onFailure();
-          } else if (recordExporter.consumeAbortedForReplay()) {
+          } else if (lastOutcome.get() == ExportOutcome.ABORT_REPLAY) {
             // the record was abandoned because a reopened exporter's replay request rewound the
             // log reader; it will be redelivered, in order, once reading resumes below
             inExportingPhase = false;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -632,10 +632,14 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
    * Handles a replay request from an exporter container. Seeks the log reader to {@code
    * lastExportedPosition} so that records from that position onward will be re-exported.
    *
-   * <p>Replay is only valid during startup, i.e. while exporters are still being opened. If all
-   * exporters have already been opened ({@code allExportersOpened == true}) or the director is
-   * currently mid-export ({@code inExportingPhase == true}), the request is rejected with a warning
-   * and {@code false} is returned.
+   * <p>Replay may be requested at any time once the log stream reader has been created, both during
+   * the initial startup handshake and while exporting is already under way, e.g. when an exporter
+   * reopens after detecting that its secondary storage has fallen behind (an automatic failover to
+   * a lagging async replica). If a request is accepted while a record is currently mid-export
+   * ({@code inExportingPhase == true}), the container's {@link ExporterContainer#exportRecord}
+   * caller abandons that record instead of retrying it in place, so the rewound reader redelivers
+   * it - and everything the requesting exporter missed before it - strictly in order on the next
+   * read.
    *
    * @param lastExportedPosition the position to seek the log reader to for replay
    * @return {@code true} if the seek succeeded, {@code false} if the request was rejected or the
@@ -645,13 +649,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     if (logStreamReader == null) {
       LOG.warn(
           "Cannot process replay request at position {}: log stream reader is not available.",
-          lastExportedPosition);
-      return false;
-    }
-
-    if (allExportersOpened || inExportingPhase) {
-      LOG.warn(
-          "Replay requested at position {}, but all exporters are already opened and exporting started. Request should only be triggered during exporter opening. Ignoring replay request.",
           lastExportedPosition);
       return false;
     }
@@ -765,6 +762,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
           if (throwable != null) {
             LOG.error(ERROR_MESSAGE_EXPORTING_ABORTED, event, throwable);
             onFailure();
+          } else if (recordExporter.consumeAbortedForReplay()) {
+            // the record was abandoned because a reopened exporter's replay request rewound the
+            // log reader; it will be redelivered, in order, once reading resumes below
+            inExportingPhase = false;
+            actor.submit(this::readNextEvent);
           } else {
             logStream.getFlowControl().onExported(recordExporter.getTypedEvent().getPosition());
             metrics.eventExported(recordExporter.getTypedEvent().getValueType());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
@@ -26,6 +26,7 @@ class RecordExporter {
 
   private boolean shouldExport;
   private int exporterIndex;
+  private boolean abortedForReplay;
   private final InstantSource clock;
 
   RecordExporter(
@@ -50,6 +51,7 @@ class RecordExporter {
       typedEvent.wrap(rawEvent, rawMetadata, recordValue);
       exporterIndex = 0;
     }
+    abortedForReplay = false;
   }
 
   boolean export() {
@@ -75,11 +77,19 @@ class RecordExporter {
 
       try (final var timer =
           exporterMetrics.startExporterExportingTimer(valueType, container.getId())) {
-        if (container.exportRecord(rawMetadata, typedEvent)) {
-          exporterIndex++;
-          exporterMetrics.setLastExportedPosition(container.getId(), typedEvent.getPosition());
-        } else {
-          return false;
+        final ExportOutcome outcome = container.exportRecord(rawMetadata, typedEvent);
+        switch (outcome) {
+          case EXPORTED -> {
+            exporterIndex++;
+            exporterMetrics.setLastExportedPosition(container.getId(), typedEvent.getPosition());
+          }
+          case ABORT_REPLAY -> {
+            abortedForReplay = true;
+            return true;
+          }
+          case RETRY -> {
+            return false;
+          }
         }
       }
     }
@@ -93,5 +103,16 @@ class RecordExporter {
 
   public void resetExporterIndex() {
     exporterIndex = 0;
+  }
+
+  /**
+   * Returns whether the current record's export was abandoned because a container's reopen accepted
+   * a mid-run replay request, and clears the flag. The abandoned record is redelivered once reading
+   * resumes from the rewound log position.
+   */
+  boolean consumeAbortedForReplay() {
+    final boolean result = abortedForReplay;
+    abortedForReplay = false;
+    return result;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
@@ -26,7 +26,6 @@ class RecordExporter {
 
   private boolean shouldExport;
   private int exporterIndex;
-  private boolean abortedForReplay;
   private final InstantSource clock;
 
   RecordExporter(
@@ -51,12 +50,11 @@ class RecordExporter {
       typedEvent.wrap(rawEvent, rawMetadata, recordValue);
       exporterIndex = 0;
     }
-    abortedForReplay = false;
   }
 
-  boolean export() {
+  ExportOutcome export() {
     if (!shouldExport) {
-      return true;
+      return ExportOutcome.EXPORTED;
     }
 
     final ValueType valueType = typedEvent.getValueType();
@@ -78,23 +76,16 @@ class RecordExporter {
       try (final var timer =
           exporterMetrics.startExporterExportingTimer(valueType, container.getId())) {
         final ExportOutcome outcome = container.exportRecord(rawMetadata, typedEvent);
-        switch (outcome) {
-          case EXPORTED -> {
-            exporterIndex++;
-            exporterMetrics.setLastExportedPosition(container.getId(), typedEvent.getPosition());
-          }
-          case ABORT_REPLAY -> {
-            abortedForReplay = true;
-            return true;
-          }
-          case RETRY -> {
-            return false;
-          }
+        if (outcome == ExportOutcome.EXPORTED) {
+          exporterIndex++;
+          exporterMetrics.setLastExportedPosition(container.getId(), typedEvent.getPosition());
+        } else {
+          return outcome;
         }
       }
     }
 
-    return true;
+    return ExportOutcome.EXPORTED;
   }
 
   TypedRecordImpl getTypedEvent() {
@@ -103,16 +94,5 @@ class RecordExporter {
 
   public void resetExporterIndex() {
     exporterIndex = 0;
-  }
-
-  /**
-   * Returns whether the current record's export was abandoned because a container's reopen accepted
-   * a mid-run replay request, and clears the flag. The abandoned record is redelivered once reading
-   * resumes from the rewound log position.
-   */
-  boolean consumeAbortedForReplay() {
-    final boolean result = abortedForReplay;
-    abortedForReplay = false;
-    return result;
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
 import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
@@ -198,6 +199,55 @@ final class ExporterContainerTest {
         return new ConfigurableFilter(
             acceptTypeResult, acceptValueResult, acceptIntentResult, acceptRecordResult);
       }
+    }
+  }
+
+  /**
+   * Exporter that always throws {@link ExporterException} with {@link
+   * ExporterException.Compensation#REOPEN} and tracks how many times {@link #open} was called.
+   */
+  public static final class ReopenThrowingExporter extends FakeExporter {
+
+    private int openCount;
+
+    @Override
+    public void open(final Controller controller) {
+      super.open(controller);
+      openCount++;
+    }
+
+    public int getOpenCount() {
+      return openCount;
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      throw new ExporterException(
+          "position mismatch detected", ExporterException.Compensation.REOPEN);
+    }
+  }
+
+  /**
+   * Exporter that always throws a plain {@link ExporterException} (defaulting to {@link
+   * ExporterException.Compensation#RETRY}) and tracks how many times {@link #open} was called.
+   */
+  public static final class RetryThrowingExporter extends FakeExporter {
+
+    private int openCount;
+
+    @Override
+    public void open(final Controller controller) {
+      super.open(controller);
+      openCount++;
+    }
+
+    public int getOpenCount() {
+      return openCount;
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      throw new ExporterException("export failed");
     }
   }
 
@@ -1082,6 +1132,80 @@ final class ExporterContainerTest {
       assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
       // committed position is still previous value until record is acknowledged
       assertThat(exporterContainer.getPosition()).isEqualTo(-1L);
+    }
+  }
+
+  @Nested
+  class ExporterExceptionHandling {
+
+    @BeforeEach
+    void beforeEach(final @TempDir Path storagePath) {
+      runtime = new ExporterContainerRuntime(storagePath);
+    }
+
+    @Test
+    void shouldReopenExporterWhenExporterExceptionWithReopenCompensationIsThrown()
+        throws Exception {
+      // given
+      final var descriptor =
+          runtime
+              .getRepository()
+              .validateAndAddExporterDescriptor(
+                  EXPORTER_ID, ReopenThrowingExporter.class, Map.of());
+      exporterContainer = runtime.newContainer(descriptor, PARTITION_ID);
+      final var throwingExporter = (ReopenThrowingExporter) exporterContainer.getExporter();
+
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+      exporterContainer.openExporter(); // first open: openCount = 1
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+
+      // when
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // then — the REOPEN compensation triggers close() + openExporter() inside exportRecord()
+      assertThat(throwingExporter.isClosed())
+          .describedAs("exporter was closed as part of reopen")
+          .isTrue();
+      assertThat(throwingExporter.getOpenCount())
+          .describedAs("exporter was opened twice: once on startup, once on reopen")
+          .isEqualTo(2);
+    }
+
+    @Test
+    void shouldNotReopenExporterWhenExporterExceptionWithRetryCompensationIsThrown()
+        throws Exception {
+      // given
+      final var descriptor =
+          runtime
+              .getRepository()
+              .validateAndAddExporterDescriptor(EXPORTER_ID, RetryThrowingExporter.class, Map.of());
+      exporterContainer = runtime.newContainer(descriptor, PARTITION_ID);
+      final var throwingExporter = (RetryThrowingExporter) exporterContainer.getExporter();
+
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+      exporterContainer.openExporter(); // first open: openCount = 1
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+
+      // when
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // then — the RETRY compensation only logs the error; no close/reopen occurs
+      assertThat(throwingExporter.isClosed())
+          .describedAs("exporter was not closed for a RETRY compensation")
+          .isFalse();
+      assertThat(throwingExporter.getOpenCount())
+          .describedAs("exporter was opened exactly once (no reopen)")
+          .isEqualTo(1);
     }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -228,6 +228,35 @@ final class ExporterContainerTest {
   }
 
   /**
+   * Exporter that throws a {@link ExporterException.Compensation#REOPEN} exception on export, and
+   * requests a replay on the reopen's {@link #open}, simulating a real position-mismatch recovery
+   * (e.g. the RDBMS exporter re-syncing after an async DB failover).
+   */
+  public static final class ReplayRequestingReopenExporter extends FakeExporter {
+
+    private int openCount;
+
+    @Override
+    public void open(final Controller controller) {
+      super.open(controller);
+      openCount++;
+      if (openCount > 1) {
+        controller.requestReplay(0L);
+      }
+    }
+
+    public int getOpenCount() {
+      return openCount;
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      throw new ExporterException(
+          "position mismatch detected", ExporterException.Compensation.REOPEN);
+    }
+  }
+
+  /**
    * Exporter that always throws a plain {@link ExporterException} (defaulting to {@link
    * ExporterException.Compensation#RETRY}) and tracks how many times {@link #open} was called.
    */
@@ -1165,12 +1194,51 @@ final class ExporterContainerTest {
       final var recordMetadata = new RecordMetadata();
 
       // when
-      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+      final ExportOutcome outcome = exporterContainer.exportRecord(recordMetadata, mockedRecord);
 
-      // then — the REOPEN compensation triggers close() + openExporter() inside exportRecord()
+      // then — the REOPEN compensation triggers close() + openExporter() inside exportRecord();
+      // since the reopen did not request a replay, the record is retried, not abandoned
+      assertThat(outcome).isEqualTo(ExportOutcome.RETRY);
       assertThat(throwingExporter.isClosed())
           .describedAs("exporter was closed as part of reopen")
           .isTrue();
+      assertThat(throwingExporter.getOpenCount())
+          .describedAs("exporter was opened twice: once on startup, once on reopen")
+          .isEqualTo(2);
+    }
+
+    @Test
+    void shouldAbortRecordWhenReopenAcceptsMidRunReplayRequest() throws Exception {
+      // given
+      final var descriptor =
+          runtime
+              .getRepository()
+              .validateAndAddExporterDescriptor(
+                  EXPORTER_ID, ReplayRequestingReopenExporter.class, Map.of());
+      exporterContainer =
+          runtime.newContainer(
+              descriptor,
+              PARTITION_ID,
+              new ExporterInitializationInfo(0, null),
+              new SimpleMeterRegistry(),
+              pos -> true);
+      final var throwingExporter = (ReplayRequestingReopenExporter) exporterContainer.getExporter();
+
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+      exporterContainer.openExporter(); // first open: openCount = 1
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+
+      // when
+      final ExportOutcome outcome = exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // then — reopen accepted a replay, so the current record is abandoned rather than retried,
+      // letting the rewound log reader redeliver it (and anything missed before it) in order
+      assertThat(outcome).isEqualTo(ExportOutcome.ABORT_REPLAY);
       assertThat(throwingExporter.getOpenCount())
           .describedAs("exporter was opened twice: once on startup, once on reopen")
           .isEqualTo(2);
@@ -1197,9 +1265,10 @@ final class ExporterContainerTest {
       final var recordMetadata = new RecordMetadata();
 
       // when
-      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+      final ExportOutcome outcome = exporterContainer.exportRecord(recordMetadata, mockedRecord);
 
       // then — the RETRY compensation only logs the error; no close/reopen occurs
+      assertThat(outcome).isEqualTo(ExportOutcome.RETRY);
       assertThat(throwingExporter.isClosed())
           .describedAs("exporter was not closed for a RETRY compensation")
           .isFalse();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.broker.exporter.util.ControlledTestExporter;
 import io.camunda.zeebe.broker.exporter.util.PojoConfigurationExporter;
 import io.camunda.zeebe.broker.exporter.util.PojoConfigurationExporter.PojoExporterConfiguration;
 import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
@@ -53,6 +54,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -956,6 +958,57 @@ public final class ExporterDirectorTest {
               assertThat(exporters.get(0).getExportedRecords()).isEmpty();
               assertThat(exporters.get(1).getExportedRecords()).isEmpty();
             });
+  }
+
+  @Test
+  public void shouldReopenExporterAndContinueExportingAfterReopenCompensation() {
+    // given
+    final ControlledTestExporter exporter0 = exporters.get(0);
+
+    final AtomicInteger openCount = new AtomicInteger(0);
+    final AtomicBoolean wasClosed = new AtomicBoolean(false);
+    final AtomicBoolean shouldThrow = new AtomicBoolean(false);
+
+    exporter0
+        .onOpen(controller -> openCount.incrementAndGet())
+        .onClose(() -> wasClosed.set(true))
+        .onExport(
+            record -> {
+              if (shouldThrow.compareAndSet(true, false)) {
+                throw new ExporterException(
+                    "position mismatch", ExporterException.Compensation.REOPEN);
+              }
+            })
+        .shouldAutoUpdatePosition(true);
+    exporters.get(1).shouldAutoUpdatePosition(true);
+
+    startExporterDirector(exporterDescriptors);
+
+    // when — export one record successfully, then trigger a REOPEN exception on the next
+    final long eventPosition1 = writeEvent();
+    waitUntil(() -> exporter0.getExportedRecords().size() >= 1);
+
+    shouldThrow.set(true);
+    final long eventPosition2 = writeEvent();
+    final long eventPosition3 = writeEvent();
+
+    // then — advance the clock to drive back-off retries and wait for all records to appear
+    doRepeatedly(() -> rule.getClock().addTime(Duration.ofSeconds(1)))
+        .until(
+            r ->
+                exporter0.getExportedRecords().stream()
+                    .map(Record::getPosition)
+                    .anyMatch(pos -> pos == eventPosition3));
+
+    assertThat(wasClosed.get())
+        .describedAs("exporter was closed as part of REOPEN compensation")
+        .isTrue();
+    assertThat(openCount.get())
+        .describedAs("exporter was opened twice: once on startup, once on reopen")
+        .isEqualTo(2);
+    assertThat(exporter0.getExportedRecords())
+        .extracting(Record::getPosition)
+        .containsExactly(eventPosition1, eventPosition2, eventPosition3);
   }
 
   private long writeEvent() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -30,7 +30,6 @@ import io.camunda.zeebe.broker.exporter.util.PojoConfigurationExporter.PojoExpor
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
-import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -890,31 +889,70 @@ public final class ExporterDirectorTest {
   }
 
   @Test
-  public void shouldNotReplayRecordsWhenExporting() throws Exception {
-    // given - write 4 events
+  public void shouldReplayAndRedeliverGapRecordsWhenReopenedDuringExporting() throws Exception {
+    // given - write and export 4 events; both exporters auto-acknowledge their position after
+    // each export, exactly like a real exporter that updates its position per record
     final long eventPosition1 = writeEvent();
     final long eventPosition2 = writeEvent();
     final long eventPosition3 = writeEvent();
     final long eventPosition4 = writeEvent();
 
-    final AtomicReference<Controller> controllerRef = new AtomicReference<>();
+    final var openCount = new AtomicInteger(0);
     final var replayAccepted = new AtomicBoolean(false);
+    final var shouldThrow = new AtomicBoolean(false);
+
     exporters
         .getFirst()
-        .onOpen(controllerRef::set)
+        .onOpen(
+            controller -> {
+              if (openCount.incrementAndGet() > 1) {
+                // Simulate: exporter 0 detected a position mismatch and is re-syncing from
+                // eventPosition2, i.e. records 3 and 4 were never durably persisted downstream.
+                replayAccepted.set(controller.requestReplay(eventPosition2));
+              }
+            })
         .onExport(
             r -> {
-              if (r.getPosition() == eventPosition4) {
-                replayAccepted.set(controllerRef.get().requestReplay(eventPosition2));
+              if (shouldThrow.compareAndSet(true, false)) {
+                throw new ExporterException(
+                    "position mismatch", ExporterException.Compensation.REOPEN);
               }
-            });
+            })
+        .shouldAutoUpdatePosition(true);
+    exporters.get(1).shouldAutoUpdatePosition(true);
 
-    // when
     rule.startExporterDirector(exporterDescriptors);
     waitUntil(() -> exporters.getFirst().getExportedRecords().size() == 4);
 
-    // then
-    assertThat(replayAccepted.get()).isFalse();
+    // when - simulate the downstream storage falling behind: records 3 and 4 were never really
+    // persisted (clear them here), then trigger a REOPEN on the next record
+    exporters.getFirst().getExportedRecords().clear();
+    shouldThrow.set(true);
+    final long eventPosition5 = writeEvent();
+
+    // then - reopen is triggered, replay from eventPosition2 is accepted, and the record that
+    // triggered the REOPEN is abandoned (not retried immediately) so the rewound log redelivers
+    // records 3, 4 and 5 in order - proving no record is leapfrogged/skipped by an immediate retry
+    Awaitility.await("gap records are redelivered in order after a mid-run replay")
+        .atMost(Duration.ofSeconds(10))
+        .until(() -> exporters.getFirst().getExportedRecords().size() >= 3);
+
+    assertThat(replayAccepted.get()).isTrue();
+    assertThat(openCount.get())
+        .describedAs("exporter was opened twice: once on startup, once on reopen")
+        .isEqualTo(2);
+    assertThat(exporters.getFirst().getExportedRecords())
+        .extracting(Record::getPosition)
+        .containsExactly(eventPosition3, eventPosition4, eventPosition5);
+
+    // exporter 1 never requested replay; its own progress is unaffected by exporter 0's rewind
+    Awaitility.await("exporter 1 exports the new record")
+        .atMost(Duration.ofSeconds(10))
+        .until(() -> exporters.get(1).getExportedRecords().size() == 5);
+    assertThat(exporters.get(1).getExportedRecords())
+        .extracting(Record::getPosition)
+        .containsExactly(
+            eventPosition1, eventPosition2, eventPosition3, eventPosition4, eventPosition5);
   }
 
   @Test

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/ExporterException.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/ExporterException.java
@@ -15,14 +15,69 @@
  */
 package io.camunda.zeebe.exporter.api;
 
-public final class ExporterException extends RuntimeException {
+import org.jspecify.annotations.NonNull;
+
+public class ExporterException extends RuntimeException {
   private static final long serialVersionUID = 9144017472787012481L;
+  private final Compensation compensation;
 
   public ExporterException(final String message) {
     super(message);
+    compensation = Compensation.RETRY;
   }
 
   public ExporterException(final String message, final Throwable cause) {
     super(message, cause);
+    compensation = Compensation.RETRY;
+  }
+
+  /**
+   * Creates an exporter exception with an explicit compensation hint. When {@code compensation} is
+   * {@link Compensation#REOPEN}, the {@link
+   * io.camunda.zeebe.broker.exporter.stream.ExporterContainer} will close and reopen the exporter
+   * instead of simply logging the failure and skipping the record.
+   */
+  public ExporterException(
+      final String message, final Throwable cause, @NonNull final Compensation compensation) {
+    super(message, cause);
+    this.compensation = compensation;
+  }
+
+  /**
+   * Creates an exporter exception with an explicit compensation hint and no cause. When {@code
+   * compensation} is {@link Compensation#REOPEN}, the {@link
+   * io.camunda.zeebe.broker.exporter.stream.ExporterContainer} will close and reopen the exporter
+   * instead of simply logging the failure and skipping the record.
+   */
+  public ExporterException(final String message, @NonNull final Compensation compensation) {
+    super(message);
+    this.compensation = compensation;
+  }
+
+  /**
+   * Returns the compensation action the caller should take, or {@code null} if no specific action
+   * is requested (the exception will be logged and the record skipped).
+   */
+  public Compensation getCompensation() {
+    return compensation;
+  }
+
+  /**
+   * Describes the compensation action the {@link
+   * io.camunda.zeebe.broker.exporter.stream.ExporterContainer} should take when this exception is
+   * caught.
+   */
+  public enum Compensation {
+    /**
+     * Close and reopen the exporter to re-synchronise its state (e.g. re-read the authoritative DB
+     * position after a detected divergence).
+     */
+    REOPEN,
+
+    /**
+     * Retry the failed operation without reopening the exporter (e.g. transient network
+     * connectivity issues).
+     */
+    RETRY,
   }
 }

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/ExporterException.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/ExporterException.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.exporter.api;
 
-public class ExporterException extends RuntimeException {
+public final class ExporterException extends RuntimeException {
   private static final long serialVersionUID = 9144017472787012481L;
   private final Compensation compensation;
 

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/ExporterException.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/ExporterException.java
@@ -15,8 +15,6 @@
  */
 package io.camunda.zeebe.exporter.api;
 
-import org.jspecify.annotations.NonNull;
-
 public class ExporterException extends RuntimeException {
   private static final long serialVersionUID = 9144017472787012481L;
   private final Compensation compensation;
@@ -38,7 +36,7 @@ public class ExporterException extends RuntimeException {
    * instead of simply logging the failure and skipping the record.
    */
   public ExporterException(
-      final String message, final Throwable cause, @NonNull final Compensation compensation) {
+      final String message, final Throwable cause, final Compensation compensation) {
     super(message, cause);
     this.compensation = compensation;
   }
@@ -49,14 +47,14 @@ public class ExporterException extends RuntimeException {
    * io.camunda.zeebe.broker.exporter.stream.ExporterContainer} will close and reopen the exporter
    * instead of simply logging the failure and skipping the record.
    */
-  public ExporterException(final String message, @NonNull final Compensation compensation) {
+  public ExporterException(final String message, final Compensation compensation) {
     super(message);
     this.compensation = compensation;
   }
 
   /**
-   * Returns the compensation action the caller should take, or {@code null} if no specific action
-   * is requested (the exception will be logged and the record skipped).
+   * Returns the compensation action the caller should take. Defaults to {@link Compensation#RETRY}
+   * when not explicitly set.
    */
   public Compensation getCompensation() {
     return compensation;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -89,27 +89,18 @@ public final class RdbmsExporter {
     this.historyDeletionService = historyDeletionService;
     this.replicationControllerFactory = replicationControllerFactory;
 
-    LOG.info(
-        "[RDBMS Exporter P{} T-{}] RdbmsExporter created with Configuration: flushInterval={}, queueSize={}",
-        partitionId,
-        physicalTenantId,
+    logInfo(
+        "RdbmsExporter created with Configuration: flushInterval={}, queueSize={}",
         flushInterval,
         queueSize);
   }
 
   public void open(final Controller controller) {
     this.controller = controller;
-    LOG.info(
-        "[RDBMS Exporter P{} T-{}] Opening exporter with broker position {}",
-        partitionId,
-        physicalTenantId,
-        controller.getLastExportedRecordPosition());
+    logInfo("Opening exporter with broker position {}", controller.getLastExportedRecordPosition());
 
     if (!rdbmsSchemaManagerRegistry.isInitialized(physicalTenantId)) {
-      LOG.warn(
-          "[RDBMS Exporter P{} T-{}] Schema is not yet ready for use",
-          partitionId,
-          physicalTenantId);
+      logWarn("Schema is not yet ready for use");
       throw new ExporterException("Schema is not ready for use");
     }
 
@@ -119,19 +110,15 @@ public final class RdbmsExporter {
       if (lastPosition < exporterRdbmsPosition.lastExportedPosition()) {
         // This is needed since the brokers last exported position is from its last snapshot and can
         // be different from ours.
-        LOG.info(
-            "[RDBMS Exporter P{} T-{}] Updating broker position {} to last exported position in rdbms {}",
-            partitionId,
-            physicalTenantId,
+        logInfo(
+            "Updating broker position {} to last exported position in rdbms {}",
             lastPosition,
             exporterRdbmsPosition.lastExportedPosition());
         lastPosition = exporterRdbmsPosition.lastExportedPosition();
         updatePositionInBroker();
       } else if (lastPosition > exporterRdbmsPosition.lastExportedPosition()) {
-        LOG.info(
-            "[RDBMS Exporter P{} T-{}] Broker position {} is more advanced than rdbms position {}. Requesting replay from {}",
-            partitionId,
-            physicalTenantId,
+        logInfo(
+            "Broker position {} is more advanced than rdbms position {}. Requesting replay from {}",
             lastPosition,
             exporterRdbmsPosition.lastExportedPosition(),
             exporterRdbmsPosition.lastExportedPosition());
@@ -175,11 +162,7 @@ public final class RdbmsExporter {
             partitionId, historyCleanupService, historyDeletionService, LOG);
     backgroundTaskManager.start();
 
-    LOG.info(
-        "[RDBMS Exporter P{} T-{}] Exporter opened with last exported position {}",
-        partitionId,
-        physicalTenantId,
-        lastPosition);
+    logInfo("Exporter opened with last exported position {}", lastPosition);
   }
 
   public void close() {
@@ -195,11 +178,7 @@ public final class RdbmsExporter {
       try {
         rdbmsWriters.flush(true);
       } catch (final Exception e) {
-        LOG.warn(
-            "[RDBMS Exporter P{} T-{}] Failed to execute final flush on close for partition {}",
-            partitionId,
-            physicalTenantId,
-            partitionId);
+        logWarn("Failed to execute final flush on close for partition {}", partitionId);
         throw e;
       }
 
@@ -208,17 +187,11 @@ public final class RdbmsExporter {
         replicationController = null;
       }
     } catch (final Exception e) {
-      LOG.warn(
-          "[RDBMS Exporter P{} T-{}] Failed to flush records before closing exporter.",
-          partitionId,
-          physicalTenantId,
-          e);
+      logWarn("Failed to flush records before closing exporter.", e);
     }
 
-    LOG.info(
-        "[RDBMS Exporter P{} T-{}] Exporter closed at positions Broker {}, RDBMS {}",
-        partitionId,
-        physicalTenantId,
+    logInfo(
+        "Exporter closed at positions Broker {}, RDBMS {}",
         lastPosition,
         exporterRdbmsPosition == null ? null : exporterRdbmsPosition.lastExportedPosition());
   }
@@ -231,10 +204,8 @@ public final class RdbmsExporter {
               partitionId));
     }
 
-    LOG.trace(
-        "[RDBMS Exporter P{} T-{}] Process record {}-{} - {}:{}",
-        partitionId,
-        physicalTenantId,
+    logTrace(
+        "Process record {}-{} - {}:{}",
         record.getPartitionId(),
         record.getPosition(),
         record.getValueType(),
@@ -250,30 +221,17 @@ public final class RdbmsExporter {
     if (!alreadyProcessed && registeredHandlers.containsKey(record.getValueType())) {
       for (final var handler : registeredHandlers.get(record.getValueType())) {
         if (handler.canExport(record)) {
-          LOG.trace(
-              "[RDBMS Exporter P{} T-{}] Exporting record {} with handler {}",
-              partitionId,
-              physicalTenantId,
-              record.getValue(),
-              handler.getClass());
+          logTrace("Exporting record {} with handler {}", record.getValue(), handler.getClass());
           handler.export(record);
           exported = true;
           shouldFlushAfterRecordProcessed |= handler.shouldFlushAfterRecordProcessed();
         } else {
-          LOG.trace(
-              "[RDBMS Exporter P{} T-{}] Handler {} can not export record {}",
-              partitionId,
-              physicalTenantId,
-              handler.getClass(),
-              record.getValueType());
+          logTrace(
+              "Handler {} can not export record {}", handler.getClass(), record.getValueType());
         }
       }
     } else if (!alreadyProcessed) {
-      LOG.trace(
-          "[RDBMS Exporter P{} T-{}] No registered handler found for {}",
-          partitionId,
-          physicalTenantId,
-          record.getValueType());
+      logTrace("No registered handler found for {}", record.getValueType());
     }
 
     if (!alreadyProcessed) {
@@ -300,19 +258,15 @@ public final class RdbmsExporter {
           resetIntervalFlush();
         }
       } catch (final Exception e) {
-        LOG.warn(
-            "[RDBMS Exporter P{} T-{}] Failed to flush record for positions {} to {} to the database.",
-            partitionId,
-            physicalTenantId,
+        logWarn(
+            "Failed to flush record for positions {} to {} to the database.",
             lastFlushedPosition + 1,
             lastPosition);
         throw e;
       }
     } else {
-      LOG.trace(
-          "[RDBMS Exporter P{} T-{}] Record with key {} and original partitionId {} could not be exported {}.",
-          partitionId,
-          physicalTenantId,
+      logTrace(
+          "Record with key {} and original partitionId {} could not be exported {}.",
           record.getKey(),
           Protocol.decodePartitionId(record.getKey()),
           record);
@@ -344,21 +298,13 @@ public final class RdbmsExporter {
   }
 
   private void updatePositionInBroker() {
-    LOG.trace(
-        "[RDBMS Exporter P{} T-{}] Updating position to {} in broker",
-        partitionId,
-        physicalTenantId,
-        lastPosition);
+    logTrace("Updating position to {} in broker", lastPosition);
     controller.updateLastExportedRecordPosition(lastPosition);
   }
 
   private void updatePositionInRdbms() {
     if (lastPosition > exporterRdbmsPosition.lastExportedPosition()) {
-      LOG.trace(
-          "[RDBMS Exporter P{} T-{}] Updating position to {} in rdbms",
-          partitionId,
-          physicalTenantId,
-          lastPosition);
+      logTrace("Updating position to {} in rdbms", lastPosition);
       exporterRdbmsPosition =
           new ExporterPositionModel(
               exporterRdbmsPosition.partitionId(),
@@ -383,10 +329,8 @@ public final class RdbmsExporter {
     try {
       exporterRdbmsPosition = rdbmsWriters.getExporterPositionService().findOne(partitionId);
     } catch (final Exception e) {
-      LOG.warn(
-          "[RDBMS Exporter P{} T-{}] Failed to initialize exporter position because Database is not ready, retrying ... {}",
-          partitionId,
-          physicalTenantId,
+      logWarn(
+          "Failed to initialize exporter position because Database is not ready, retrying ... {}",
           e.getMessage());
       throw e;
     }
@@ -400,14 +344,9 @@ public final class RdbmsExporter {
               LocalDateTime.now(),
               LocalDateTime.now());
       rdbmsWriters.getExporterPositionService().createWithoutQueue(exporterRdbmsPosition);
-      LOG.debug(
-          "[RDBMS Exporter P{} T-{}] Initialize position in rdbms", partitionId, physicalTenantId);
+      logDebug("Initialize position in rdbms");
     } else {
-      LOG.debug(
-          "[RDBMS Exporter P{} T-{}] Found position in rdbms for this exporter: {}",
-          partitionId,
-          physicalTenantId,
-          exporterRdbmsPosition);
+      logDebug("Found position in rdbms for this exporter: {}", exporterRdbmsPosition);
     }
   }
 
@@ -420,10 +359,8 @@ public final class RdbmsExporter {
     try {
       flushExecutionQueue();
     } catch (final Exception e) {
-      LOG.warn(
-          "[RDBMS Exporter P{} T-{}] Failed to flush records for positions {} to {} to the database",
-          partitionId,
-          physicalTenantId,
+      logWarn(
+          "Failed to flush records for positions {} to {} to the database",
           lastFlushedPosition + 1,
           lastPosition);
     } finally {
@@ -436,11 +373,39 @@ public final class RdbmsExporter {
       "Each exporter creates it's own executionQueue, so we need an accessible flush method for tests")
   public void flushExecutionQueue() {
     if (flushAfterEachRecord()) {
-      LOG.warn("Unnecessary flush called, since flush interval is zero or max queue size is zero");
+      logWarn("Unnecessary flush called, since flush interval is zero or max queue size is zero");
       return;
     }
     rdbmsWriters.getMetrics().recordQueueFlush(FlushTrigger.FLUSH_INTERVAL);
     rdbmsWriters.flush(true);
+  }
+
+  private void logTrace(final String message, final Object... args) {
+    LOG.trace(withLogContext(message), withLogContextArgs(args));
+  }
+
+  private void logDebug(final String message, final Object... args) {
+    LOG.debug(withLogContext(message), withLogContextArgs(args));
+  }
+
+  private void logInfo(final String message, final Object... args) {
+    LOG.info(withLogContext(message), withLogContextArgs(args));
+  }
+
+  private void logWarn(final String message, final Object... args) {
+    LOG.warn(withLogContext(message), withLogContextArgs(args));
+  }
+
+  private String withLogContext(final String message) {
+    return "[RDBMS Exporter P{} T-{}] " + message;
+  }
+
+  private Object[] withLogContextArgs(final Object... args) {
+    final Object[] contextualArgs = new Object[args.length + 2];
+    contextualArgs[0] = partitionId;
+    contextualArgs[1] = physicalTenantId;
+    System.arraycopy(args, 0, contextualArgs, 2, args.length);
+    return contextualArgs;
   }
 
   @VisibleForTesting("Allows verification of registered handlers in tests")

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -99,7 +99,10 @@ public final class RdbmsExporter {
   public void open(final Controller controller) {
     this.controller = controller;
     rdbmsWriters.getExecutionQueue().reset();
-    logInfo("Opening exporter with broker position {}", controller.getLastExportedRecordPosition());
+    logInfo(
+        "Opening exporter with broker position {}, last flushed position {}",
+        controller.getLastExportedRecordPosition(),
+        lastFlushedPosition);
 
     if (!rdbmsSchemaManagerRegistry.isInitialized(physicalTenantId)) {
       logWarn("Schema is not yet ready for use");
@@ -107,7 +110,13 @@ public final class RdbmsExporter {
     }
 
     initializeRdbmsPosition();
-    lastPosition = controller.getLastExportedRecordPosition();
+    // Use whichever of the broker-acked position and this instance's own last-flushed position
+    // (preserved across a close+reopen on the same instance) is more advanced. On a cold start
+    // lastFlushedPosition is still -1, so this is exactly the broker position, matching what a
+    // fresh restart would use. On an in-process reopen, this instance may have already flushed
+    // further than what's been acknowledged - e.g. under async LSN-based replication
+    // (LsnReplicationController), acking is intentionally delayed until replication is confirmed.
+    lastPosition = Math.max(controller.getLastExportedRecordPosition(), lastFlushedPosition);
     if (exporterRdbmsPosition.lastExportedPosition() > -1) {
       if (lastPosition < exporterRdbmsPosition.lastExportedPosition()) {
         // This is needed since the brokers last exported position is from its last snapshot and can

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.rdbms;
 
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
+import io.camunda.db.rdbms.exception.ExporterPositionMismatchException;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics.FlushTrigger;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
@@ -97,6 +98,7 @@ public final class RdbmsExporter {
 
   public void open(final Controller controller) {
     this.controller = controller;
+    rdbmsWriters.getExecutionQueue().reset();
     logInfo("Opening exporter with broker position {}", controller.getLastExportedRecordPosition());
 
     if (!rdbmsSchemaManagerRegistry.isInitialized(physicalTenantId)) {
@@ -182,6 +184,8 @@ public final class RdbmsExporter {
         throw e;
       }
 
+      rdbmsWriters.getExecutionQueue().reset();
+
       if (replicationController != null) {
         replicationController.close();
         replicationController = null;
@@ -257,6 +261,16 @@ public final class RdbmsExporter {
         if (flushed) {
           resetIntervalFlush();
         }
+      } catch (final ExporterPositionMismatchException e) {
+        logWarn(
+            "Exporter position conflict detected during flush — requesting reopen to re-sync from DB position.");
+        throw new ExporterException(
+            String.format(
+                "[RDBMS Exporter P%d T-%s] Flush failed due to exporter position conflict;"
+                    + " exporter will reopen to re-sync.",
+                partitionId, physicalTenantId),
+            e,
+            ExporterException.Compensation.REOPEN);
       } catch (final Exception e) {
         logWarn(
             "Failed to flush record for positions {} to {} to the database.",

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
+import io.camunda.db.rdbms.exception.ExporterPositionMismatchException;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
@@ -300,6 +301,7 @@ class RdbmsExporterTest {
     // then
     verify(replicationController).close();
     verify(flushTask).cancel();
+    verify(rdbmsWriters.getExecutionQueue()).reset();
 
     // set null to avoid tear down flush
     exporter = null;
@@ -533,17 +535,21 @@ class RdbmsExporterTest {
   }
 
   @Test
-  void shouldThrowWhenReplayFailsBecauseLogSegmentsAreGone() {
-    // given - broker position is 1000, RDBMS position is 900, but log segments are gone
+  void shouldThrowWhenReplayIsUnavailable() {
+    // given - broker position is 1000, RDBMS position is 900, but replay is unavailable
+    // (segments deleted or already in exporting phase)
     final long brokerPosition = 1000L;
     final long rdbmsPosition = 900L;
     createExporterWithRdbmsPosition(brokerPosition, rdbmsPosition);
     when(controller.requestReplay(anyLong())).thenReturn(false);
 
-    // when + then - exporter should fail to open because replay is not possible
+    // when + then - exporter must throw when replay cannot be initiated; accepting a stale DB
+    // position as baseline risks data loss, so we fail hard and require manual intervention
     assertThatThrownBy(() -> exporter.open(controller))
         .isInstanceOf(ExporterException.class)
-        .hasMessageContaining("log segments are no longer available");
+        .hasMessageContaining("Cannot replay records");
+
+    verify(controller).requestReplay(rdbmsPosition);
   }
 
   @Test
@@ -557,6 +563,51 @@ class RdbmsExporterTest {
 
     // then - no replay should be requested
     verify(controller, never()).requestReplay(Mockito.anyLong());
+  }
+
+  @Test
+  void shouldThrowReopenExceptionWhenPositionIsAhead() {
+    // given
+    final var jobHandler = mockHandler(ValueType.JOB);
+    final var record = mockRecord(ValueType.JOB, 5);
+    createExporter(b -> b.withHandler(ValueType.JOB, jobHandler));
+
+    // Make the flush throw ExporterPositionAheadException to simulate DB ahead of broker
+    doAnswer(
+            invocation -> {
+              throw new ExporterPositionMismatchException(1, 4, 5); // expected 4 but found 5 in DB
+            })
+        .when(rdbmsWriters)
+        .flush(anyBoolean());
+
+    // when - export wraps the conflict in an ExporterException(REOPEN) so ExporterContainer
+    // closes and reopens the exporter to re-sync the position
+    final var thrown =
+        assertThatThrownBy(() -> exporter.export(record))
+            .isInstanceOf(ExporterException.class)
+            .hasMessageContaining("exporter position conflict")
+            .hasCauseInstanceOf(ExporterPositionMismatchException.class);
+
+    // then - compensation must be REOPEN so ExporterContainer calls reopenExporter()
+    thrown.satisfies(
+        ex ->
+            assertThat(((ExporterException) ex).getCompensation())
+                .isEqualTo(ExporterException.Compensation.REOPEN));
+  }
+
+  @Test
+  void shouldNotRegisterDuplicateListenersOnReopen() {
+    // given - exporter already opened (listeners registered once)
+    createExporter(b -> b.withHandler(ValueType.JOB, mockHandler(ValueType.JOB)));
+
+    final int listenersAfterFirstOpen = executionQueue.preFlushListeners.size();
+    assertThat(listenersAfterFirstOpen).isGreaterThan(0);
+
+    // when - exporter is reopened (simulating ExporterContainer.reopenExporter)
+    exporter.open(controller);
+
+    // then - listener count must not double; reset() in open() clears before re-registering
+    assertThat(executionQueue.preFlushListeners).hasSize(listenersAfterFirstOpen);
   }
 
   @Test
@@ -677,7 +728,7 @@ class RdbmsExporterTest {
     when(controller.scheduleCancellableTask(any(), any())).thenReturn(flushTask);
 
     rdbmsWriters = mock(RdbmsWriters.class);
-    executionQueue = new StubExecutionQueue();
+    executionQueue = Mockito.spy(new StubExecutionQueue());
     positionService = mock(ExporterPositionService.class);
     when(positionService.findOne(anyInt())).thenReturn(exporterPositionModel);
     rdbmsPurger = mock(RdbmsPurger.class);
@@ -735,6 +786,7 @@ class RdbmsExporterTest {
     exporter = builderFunction.apply(builder).build();
     if (openExporter) {
       exporter.open(controller);
+      Mockito.reset(executionQueue);
     }
   }
 
@@ -779,6 +831,13 @@ class RdbmsExporterTest {
     @Override
     public boolean checkQueueForFlush() {
       return false;
+    }
+
+    @Override
+    public void reset() {
+      preFlushListeners.clear();
+      postFlushListeners.clear();
+      inTransactionHooks.clear();
     }
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -566,6 +566,51 @@ class RdbmsExporterTest {
   }
 
   @Test
+  void shouldRequestReplayWhenInstanceFlushedFurtherThanBrokerAcked() {
+    // given - exporter opens with broker and DB both at position 500 (a normal, in-sync start)
+    final long initialPosition = 500L;
+    final var initialRdbmsPosition =
+        new ExporterPositionModel(
+            0,
+            RdbmsExporter.class.getSimpleName(),
+            initialPosition,
+            LocalDateTime.now(),
+            LocalDateTime.now());
+    final var jobHandler = mockHandler(ValueType.JOB);
+    createExporter(b -> b.withHandler(ValueType.JOB, jobHandler), true, true, initialRdbmsPosition);
+
+    // this instance flushes further than what gets acked to the broker - e.g. under async
+    // LSN-based replication (LsnReplicationController), acking is intentionally delayed until
+    // replication is confirmed, so the broker position lags this instance's real progress
+    final long instanceFlushedPosition = 1000L;
+    exporter.export(mockRecord(ValueType.JOB, instanceFlushedPosition));
+    executionQueue.flush(); // trigger the postFlushListener that sets lastFlushedPosition
+
+    // simulate a failover: the broker only ever got acked up to 900 (replication-confirmed floor)
+    // and the new (promoted) DB position is 950 - between the broker's ack and what this instance
+    // had actually flushed
+    final long brokerAckedPosition = 900L;
+    final long dbPositionAfterFailover = 950L;
+    when(controller.getLastExportedRecordPosition()).thenReturn(brokerAckedPosition);
+    when(positionService.findOne(anyInt()))
+        .thenReturn(
+            new ExporterPositionModel(
+                0,
+                RdbmsExporter.class.getSimpleName(),
+                dbPositionAfterFailover,
+                LocalDateTime.now(),
+                LocalDateTime.now()));
+    when(controller.requestReplay(anyLong())).thenReturn(true);
+
+    // when - exporter is reopened (simulating ExporterContainer.reopenExporter)
+    exporter.open(controller);
+
+    // then - replay is requested from the DB position; the broker position (900) alone would not
+    // have looked "ahead" of the DB (950), but this instance's own last-flushed position (1000) is
+    verify(controller).requestReplay(dbPositionAfterFailover);
+  }
+
+  @Test
   void shouldThrowReopenExceptionWhenPositionIsAhead() {
     // given
     final var jobHandler = mockHandler(ValueType.JOB);


### PR DESCRIPTION
## Description

Solves some problems for when the `RdbmsExporter` gets out of sync with the database.

Situations where this can occur:
- **Phantom-commit:** There can be rare situations where the DB connection is lost exactly in the moment we commit the transaction. The DB then executes the commit but because of the IO error the application never receives the ACK for this. We fail with an IOException and retry the flush later. But then we run into an `ExporterPositionMismatchException` because the DB is more advanced than the `RdbmsExporter`. 
  - Simply skipping the flush here is too dangerous because we maybe already have consumed other records and modified the `executionQueue` with more inserts which would have been skipped then
- **Async failover:** transparent failover to a async replica node of the DB cluster which might not be completely in sync with the primary. Here the DB position is behind the `RdbmsExporter` position and the DB is not aware of some commits

In both cases we need to resync the `RdbmsExporter` with the database because otherwise it would not recover from this position mismatch.
**Solution:**
- re-initialize the `RdbmsExporter`. Clear the `executionQueue` and start new from the last acknowledged position
- during re-open the `RdbmsExporter` syncs with the database and either replays or forwards the broker position and starts fresh
- introduce an `ExporterException.Compensation` enum to signal the `ExporterContainer` how to compensate the exception:
  - RETRY => default
  - REOPEN => close and re-open the exporter (currently only used by `RdbmsExporter`)

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52460 
