### PR TITLE
build: Use Connectors 8.8.14 for CPT

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -16,12 +16,12 @@
   <properties>
     <version.java>8</version.java>
     <maven-commit-id-plugin-version>9.0.2</maven-commit-id-plugin-version>
-    <!-- Camunda Docker image properties. CI overrides the properties to use the current image. -->
+    <!-- Camunda/Connectors Docker image properties. CI overrides the properties to use the current image. -->
     <io.camunda.process.test.camundaDockerImageName>camunda/camunda</io.camunda.process.test.camundaDockerImageName>
     <io.camunda.process.test.camundaDockerImageVersion>${project.version}</io.camunda.process.test.camundaDockerImageVersion>
-    <!-- Connectors Docker image properties. CI overrides the properties to use the current image. -->
     <io.camunda.process.test.connectorsDockerImageName>camunda/connectors-bundle</io.camunda.process.test.connectorsDockerImageName>
-    <io.camunda.process.test.connectorsDockerImageVersion>${project.version}</io.camunda.process.test.connectorsDockerImageVersion>
+    <!-- Use a fixed Connectors Docker image version as it follows a different release cycle. Update to the latest available version. -->
+    <io.camunda.process.test.connectorsDockerImageVersion>8.8.14</io.camunda.process.test.connectorsDockerImageVersion>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Description

This PR sets the version of the Connectors bundle to 8.8.14 as the latest available version.

Connectors have a different release cycle than CPT. As a result, we can't use the project version.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to https://github.com/camunda/camunda/issues/50779
