### PR TITLE
fix: deduplicate fetchVariables in StreamActivatedJobs requests

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +29,7 @@ final class JobStreamServiceStepTest {
       final var properties =
           new JobActivationPropertiesImpl()
               .setTimeout(250)
-              .setFetchVariables(List.of(new StringValue("foo"), new StringValue("bar")))
+              .setFetchVariables(Set.of(new StringValue("foo"), new StringValue("bar")))
               .setWorker(worker, 0, worker.capacity())
               .setTenantIds(List.of("tenant1", "tenant2"))
               .setTenantFilter(TenantFilter.ASSIGNED);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
@@ -89,7 +89,7 @@ public class ActivatableJobsPushTest {
             .setTimeout(timeout)
             .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
             .setFetchVariables(
-                List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")));
+                Set.of(new StringValue("a"), new StringValue("b"), new StringValue("c")));
     jobStream = JOB_STREAMER.addJobStream(BufferUtil.wrapString(jobType), jobActivationProperties);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenancyActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenancyActivatableJobsPushTest.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -92,7 +93,7 @@ public class MultiTenancyActivatableJobsPushTest {
             .setWorker(worker, 0, worker.capacity())
             .setTimeout(timeout)
             .setFetchVariables(
-                List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
+                Set.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
             .setClaims(authorizationClaims)
             .setTenantIds(List.of(tenantIdA));
 
@@ -101,7 +102,7 @@ public class MultiTenancyActivatableJobsPushTest {
             .setWorker(worker, 0, worker.capacity())
             .setTimeout(timeout)
             .setFetchVariables(
-                List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
+                Set.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
             .setClaims(authorizationClaims)
             .setTenantIds(List.of(tenantIdB));
 
@@ -163,7 +164,7 @@ public class MultiTenancyActivatableJobsPushTest {
             .setWorker(worker, 0, worker.capacity())
             .setTimeout(timeout)
             .setFetchVariables(
-                List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
+                Set.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
             .setClaims(authorizationClaims)
             .setTenantFilter(TenantFilter.ASSIGNED);
 
@@ -173,7 +174,7 @@ public class MultiTenancyActivatableJobsPushTest {
             .setWorker(worker, 0, worker.capacity())
             .setTimeout(timeout)
             .setFetchVariables(
-                List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
+                Set.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
             .setClaims(authorizationClaims)
             .setTenantIds(List.of(tenantIdB));
 
@@ -236,7 +237,7 @@ public class MultiTenancyActivatableJobsPushTest {
             .setWorker(worker, 0, worker.capacity())
             .setTimeout(timeout)
             .setFetchVariables(
-                List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
+                Set.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
             .setClaims(authorizationClaims)
             .setTenantIds(List.of(tenantIdA))
             .setTenantFilter(TenantFilter.ASSIGNED);
@@ -247,7 +248,7 @@ public class MultiTenancyActivatableJobsPushTest {
             .setWorker(worker, 0, worker.capacity())
             .setTimeout(timeout)
             .setFetchVariables(
-                List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
+                Set.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
             .setClaims(authorizationClaims)
             .setTenantIds(List.of(tenantIdB));
 
@@ -309,7 +310,7 @@ public class MultiTenancyActivatableJobsPushTest {
         new JobActivationPropertiesImpl()
             .setWorker(worker, 0, worker.capacity())
             .setTimeout(timeout)
-            .setFetchVariables(List.of(new StringValue("a")))
+            .setFetchVariables(Set.of(new StringValue("a")))
             .setClaims(authorizationClaims)
             .setTenantIds(List.of(tenantIdA));
 
@@ -318,7 +319,7 @@ public class MultiTenancyActivatableJobsPushTest {
         new JobActivationPropertiesImpl()
             .setWorker(worker, 0, worker.capacity())
             .setTimeout(timeout)
-            .setFetchVariables(List.of(new StringValue("a")))
+            .setFetchVariables(Set.of(new StringValue("a")))
             .setClaims(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true))
             .setTenantFilter(TenantFilter.ASSIGNED);
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -71,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.apache.commons.lang3.StringUtils;
@@ -475,7 +476,10 @@ public final class RequestMapper extends RequestUtil {
     jobActivationProperties
         .setWorker(worker, 0, worker.capacity())
         .setTimeout(request.getTimeout())
-        .setFetchVariables(request.getFetchVariableList().stream().map(StringValue::new).toList())
+        .setFetchVariables(
+            request.getFetchVariableList().stream()
+                .map(StringValue::new)
+                .collect(Collectors.toUnmodifiableSet()))
         .setTenantIds(tenantIds)
         .setTenantFilter(tenantFilter)
         .setClaims(claims);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -544,7 +544,29 @@ public class RequestMapperTest {
       // then
       assertThat(properties.fetchVariables())
           .extracting(BufferUtil::bufferAsString)
-          .containsExactly("var1", "var2");
+          .containsExactlyInAnyOrder("var1", "var2");
+    }
+
+    @Test
+    public void shouldDeduplicateFetchVariables() {
+      // given — the same variable name appears twice in the gRPC request
+      final var request =
+          StreamActivatedJobsRequest.newBuilder()
+              .setType("test-job")
+              .setWorker("test-worker")
+              .addTenantIds("tenant-a")
+              .addFetchVariable("var1")
+              .addFetchVariable("var2")
+              .addFetchVariable("var1")
+              .build();
+
+      // when
+      final var properties = RequestMapper.toJobActivationProperties(request, EMPTY_CLAIMS);
+
+      // then — only two unique names, not three; prevents off-by-one in DbVariableState map header
+      assertThat(properties.fetchVariables())
+          .extracting(BufferUtil::bufferAsString)
+          .containsExactlyInAnyOrder("var1", "var2");
     }
 
     @Test

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -57,7 +58,7 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
     return this;
   }
 
-  public JobActivationPropertiesImpl setFetchVariables(final Collection<StringValue> variables) {
+  public JobActivationPropertiesImpl setFetchVariables(final Set<StringValue> variables) {
     fetchVariablesProp.reset();
     variables.forEach(variable -> fetchVariablesProp.add().wrap(variable));
     return this;


### PR DESCRIPTION
## Description

Deduplicate requested variable names at the gRPC boundary in `RequestMapper.toJobActivationProperties` by collecting `StringValue` objects into an unmodifiable `Set` instead of a `List`. Narrow `setFetchVariables` to `Set<StringValue>` to make the invariant explicit at the API level.

closes #54929