### PR TITLE
fix: don't corrupt variable map when duplicate variables are requested

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -250,6 +250,7 @@ public class DbVariableState implements MutableVariableState {
 
     writer.reserveMapHeader();
 
+    final MutableInteger written = new MutableInteger(0);
     visitVariables(
         scopeKey,
         name -> variablesToCollect.contains(name.getBuffer()),
@@ -258,10 +259,11 @@ public class DbVariableState implements MutableVariableState {
           writer.writeRaw(value.getValue());
 
           variablesToCollect.remove(name.getBuffer());
+          written.increment();
         },
         variablesToCollect::isEmpty);
 
-    writer.writeReservedMapHeader(0, names.size() - variablesToCollect.size());
+    writer.writeReservedMapHeader(0, written.get());
 
     resultView.wrap(documentResultBuffer, 0, writer.getOffset());
     return resultView;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
@@ -242,6 +242,23 @@ public final class VariableStateTest {
   }
 
   @Test
+  public void shouldCollectVariablesByNameWithDuplicateNamesInRequest() {
+    // given
+    declareScope(parent);
+
+    setVariableLocal(parent, wrapString("a"), asMsgPack("1"));
+    setVariableLocal(parent, wrapString("b"), asMsgPack("2"));
+
+    // when — "a" appears twice, as would happen if a client sends a duplicate fetchVariable name
+    final DirectBuffer variablesDocument =
+        variableState.getVariablesAsDocument(
+            parent, Arrays.asList(wrapString("a"), wrapString("b"), wrapString("a")));
+
+    // then — map32 header count must equal the number of entries written, not names.size()
+    assertEquality(variablesDocument, "{'a': 1, 'b': 2}");
+  }
+
+  @Test
   public void shouldSetLocalVariable() {
     // given
     declareScope(parent);


### PR DESCRIPTION
## Description

`DbVariableState.getVariablesAsDocument(scopeKey, names)` computed the `map32` header count as `names.size() - variablesToCollect.size()`. When `names` contained duplicate variable names, `names.size()` counted every element while `ObjectHashSet.addAll()` silently deduplicated by content — making the declared count `N+D` while only `N` entries were written. Any consumer that fully deserialised the resulting MsgPack document received a `JsonEOFException`.

The fix replaces the formula with an explicit `MutableInteger` counter incremented per entry written, matching the pattern already used in `getVariablesLocalAsDocument`.

closes #54917