### PR TITLE
fix: use gcp-core-4-default runner for idenity-e2e-tests

### DIFF
--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -60,7 +60,7 @@ jobs:
 
   test:
     needs: [ generate-db-versions ]
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-4-default
     timeout-minutes: 15
     services:
       elasticsearch:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
fix failing identity-e2e-tests

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to https://camunda.slack.com/archives/C071KP5BTHB/p1780479565912099
 