### PR TITLE
feat: inspect intermediate conditional catch events (CONDITION wait state)

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/WaitStateType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/WaitStateType.java
@@ -16,11 +16,11 @@
 package io.camunda.client.api.search.enums;
 
 public enum WaitStateType {
+  CONDITION,
   JOB,
   MESSAGE,
+  SIGNAL,
   TIMER,
   USER_TASK,
-  SIGNAL,
-  CONDITION,
   UNKNOWN_ENUM_VALUE;
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/WaitStateType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/WaitStateType.java
@@ -21,5 +21,6 @@ public enum WaitStateType {
   TIMER,
   USER_TASK,
   SIGNAL,
+  CONDITION,
   UNKNOWN_ENUM_VALUE;
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ConditionWaitStateDetails.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ConditionWaitStateDetails.java
@@ -15,14 +15,12 @@
  */
 package io.camunda.client.api.search.response;
 
-import io.camunda.client.api.search.enums.WaitStateType;
+import java.util.List;
 
-/**
- * Wait-state-specific details of an element instance. Resolves to {@link JobWaitStateDetails},
- * {@link MessageWaitStateDetails}, or {@link ConditionWaitStateDetails} depending on {@link
- * #getWaitStateType()}.
- */
-public interface WaitStateDetails {
+/** Details of an element instance waiting on a condition. */
+public interface ConditionWaitStateDetails extends WaitStateDetails {
 
-  WaitStateType getWaitStateType();
+  String getExpression();
+
+  List<String> getEvents();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ConditionWaitStateDetailsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ConditionWaitStateDetailsImpl.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.enums.WaitStateType;
 import io.camunda.client.api.search.response.ConditionWaitStateDetails;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -30,10 +31,13 @@ public class ConditionWaitStateDetailsImpl implements ConditionWaitStateDetails 
     expression = details.getExpression();
     events =
         details.getEvents() == null
-            ? null
-            : details.getEvents().stream()
-                .map(io.camunda.client.protocol.rest.ConditionWaitStateDetails.EventsEnum::getValue)
-                .collect(Collectors.toList());
+            ? Collections.emptyList()
+            : Collections.unmodifiableList(
+                details.getEvents().stream()
+                    .map(
+                        io.camunda.client.protocol.rest.ConditionWaitStateDetails.EventsEnum
+                            ::getValue)
+                    .collect(Collectors.toList()));
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ConditionWaitStateDetailsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ConditionWaitStateDetailsImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.ConditionWaitStateDetails;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ConditionWaitStateDetailsImpl implements ConditionWaitStateDetails {
+
+  private final String expression;
+  private final List<String> events;
+
+  public ConditionWaitStateDetailsImpl(
+      final io.camunda.client.protocol.rest.ConditionWaitStateDetails details) {
+    expression = details.getExpression();
+    events =
+        details.getEvents() == null
+            ? null
+            : details.getEvents().stream()
+                .map(io.camunda.client.protocol.rest.ConditionWaitStateDetails.EventsEnum::getValue)
+                .collect(Collectors.toList());
+  }
+
+  @Override
+  public WaitStateType getWaitStateType() {
+    return WaitStateType.CONDITION;
+  }
+
+  @Override
+  public String getExpression() {
+    return expression;
+  }
+
+  @Override
+  public List<String> getEvents() {
+    return events;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
@@ -70,6 +70,9 @@ public class ElementInstanceWaitStateResultImpl implements ElementInstanceWaitSt
       case SIGNAL:
         return new SignalWaitStateDetailsImpl(
             (io.camunda.client.protocol.rest.SignalWaitStateDetails) item);
+      case CONDITION:
+        return new ConditionWaitStateDetailsImpl(
+            (io.camunda.client.protocol.rest.ConditionWaitStateDetails) item);
       default:
         return null;
     }

--- a/clients/java/src/test/java/io/camunda/client/impl/response/ConditionWaitStateDetailsImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/response/ConditionWaitStateDetailsImplTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.impl.search.response.ConditionWaitStateDetailsImpl;
+import io.camunda.client.protocol.rest.ConditionWaitStateDetails;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class ConditionWaitStateDetailsImplTest {
+
+  @Test
+  void shouldReturnEmptyListWhenEventsIsNull() {
+    // given
+    final ConditionWaitStateDetails proto = new ConditionWaitStateDetails();
+    proto.setExpression("x > 0");
+    proto.setEvents(null);
+
+    // when
+    final io.camunda.client.impl.search.response.ConditionWaitStateDetailsImpl impl =
+        new ConditionWaitStateDetailsImpl(proto);
+
+    // then
+    assertThat(impl.getEvents()).isNotNull().isEmpty();
+  }
+
+  @Test
+  void shouldReturnUnmodifiableListWhenEventsIsPresent() {
+    // given
+    final ConditionWaitStateDetails proto = new ConditionWaitStateDetails();
+    proto.setExpression("x > 0");
+    final List<ConditionWaitStateDetails.EventsEnum> eventsEnums = new ArrayList<>();
+    eventsEnums.add(ConditionWaitStateDetails.EventsEnum.CREATE);
+    proto.setEvents(eventsEnums);
+
+    // when
+    final ConditionWaitStateDetailsImpl impl = new ConditionWaitStateDetailsImpl(proto);
+
+    // then
+    assertThat(impl.getEvents()).containsExactly("create");
+    assertThatThrownBy(() -> impl.getEvents().add("x"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void shouldReturnConditionWaitStateType() {
+    // given
+    final ConditionWaitStateDetails proto = new ConditionWaitStateDetails();
+    proto.setExpression("x > 0");
+
+    // when
+    final ConditionWaitStateDetailsImpl impl = new ConditionWaitStateDetailsImpl(proto);
+
+    // then
+    assertThat(impl.getWaitStateType()).isEqualTo(WaitStateType.CONDITION);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.read.mapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
+import io.camunda.search.entities.WaitStateConditionDetails;
 import io.camunda.search.entities.WaitStateDetails;
 import io.camunda.search.entities.WaitStateDetails.WaitStateType;
 import io.camunda.search.entities.WaitStateEntity;
@@ -63,6 +64,7 @@ public class WaitStateEntityMapper {
         case USER_TASK -> OBJECT_MAPPER.readValue(detailsJson, WaitStateUserTaskDetails.class);
         case TIMER -> OBJECT_MAPPER.readValue(detailsJson, WaitStateTimerDetails.class);
         case SIGNAL -> OBJECT_MAPPER.readValue(detailsJson, WaitStateSignalDetails.class);
+        case CONDITION -> OBJECT_MAPPER.readValue(detailsJson, WaitStateConditionDetails.class);
       };
     } catch (final Exception e) {
       LOG.warn("Failed to parse wait state details for type {}: {}", waitStateType, e.getMessage());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -56,6 +56,7 @@ import io.camunda.gateway.protocol.model.ClusterVariableResult;
 import io.camunda.gateway.protocol.model.ClusterVariableScopeEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableSearchQueryResult;
 import io.camunda.gateway.protocol.model.ClusterVariableSearchResult;
+import io.camunda.gateway.protocol.model.ConditionWaitStateDetails;
 import io.camunda.gateway.protocol.model.CorrelatedMessageSubscriptionResult;
 import io.camunda.gateway.protocol.model.CorrelatedMessageSubscriptionSearchQueryResult;
 import io.camunda.gateway.protocol.model.DecisionDefinitionResult;
@@ -226,6 +227,7 @@ import io.camunda.search.entities.UsageMetricTUStatisticsEntity.UsageMetricTUSta
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.entities.WaitStateConditionDetails;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
@@ -725,6 +727,19 @@ public final class SearchQueryResponseMapper {
                       .waitStateType(WaitStateTypeEnum.MESSAGE.name())
                       .messageName(messageName)
                       .correlationKey(correlationKey)
+                      .build())
+              .build();
+      case WaitStateConditionDetails(final var expression, final var events) ->
+          base.details(
+                  ConditionWaitStateDetails.Builder.create()
+                      .waitStateType(WaitStateTypeEnum.CONDITION.name())
+                      .expression(expression)
+                      .events(
+                          events == null
+                              ? null
+                              : events.stream()
+                                  .map(ConditionWaitStateDetails.EventsEnum::fromValue)
+                                  .collect(Collectors.toList()))
                       .build())
               .build();
       case WaitStateUserTaskDetails(final var taskKey, final var dueDate) ->

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse.StateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
+import io.camunda.gateway.protocol.model.ConditionWaitStateDetails;
 import io.camunda.gateway.protocol.model.IncidentErrorTypeEnum;
 import io.camunda.gateway.protocol.model.IncidentStateEnum;
 import io.camunda.gateway.protocol.model.JobListenerEventTypeEnum;
@@ -59,6 +60,7 @@ import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.UserTaskEntity.UserTaskState;
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.entities.WaitStateConditionDetails;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.query.SearchQueryResult;
@@ -1079,6 +1081,37 @@ class SearchQueryResponseMapperTest {
     // then
     final var responseDetails = (JobWaitStateDetails) result.getItems().getFirst().getDetails();
     assertThat(responseDetails.getListenerEventType()).isNull();
+  }
+
+  @Test
+  void shouldMapConditionWaitStateDetails() {
+    // given
+    final var conditionDetails =
+        new WaitStateConditionDetails("= x > 5", List.of("create", "update"));
+    final var entity =
+        new WaitStateEntity.Builder()
+            .processInstanceKey(789L)
+            .elementInstanceKey(111L)
+            .elementId("cond-ice")
+            .elementType(FlowNodeType.INTERMEDIATE_CATCH_EVENT)
+            .rootProcessInstanceKey(999L)
+            .bpmnProcessId("process1")
+            .details(conditionDetails)
+            .tenantId("default")
+            .build();
+
+    // when
+    final var result =
+        SearchQueryResponseMapper.toElementInstanceWaitStateQueryResult(
+            new SearchQueryResult<>(1, false, List.of(entity), null, null));
+
+    // then
+    final var responseDetails =
+        (ConditionWaitStateDetails) result.getItems().getFirst().getDetails();
+    assertThat(responseDetails.getExpression()).isEqualTo("= x > 5");
+    assertThat(responseDetails.getEvents())
+        .extracting(ConditionWaitStateDetails.EventsEnum::getValue)
+        .containsExactly("create", "update");
   }
 
   @Nested

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateConditionalIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateConditionalIT.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.waitstate;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.ConditionWaitStateDetails;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.List;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies element-instance wait-state search for conditional-subscription wait states, covering
+ * intermediate catch events and the removal of wait states when the condition is satisfied.
+ */
+@MultiDbTest
+public class WaitStateConditionalIT {
+
+  private static final String CONDITION_EXPRESSION = "=x > 10";
+  private static final String VARIABLE_EVENTS = "create, update";
+  private static final String CATCH_EVENT_ID = "conditional-catch";
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldExportConditionWaitStateForIntermediateCatchEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("condWaitStateIceProcess")
+            .startEvent()
+            .intermediateCatchEvent(CATCH_EVENT_ID)
+            .condition(c -> c.condition(CONDITION_EXPRESSION).zeebeVariableEvents(VARIABLE_EVENTS))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "condWaitStateIceProcess.bpmn");
+
+    // when — start with x=1, condition not satisfied
+    final long pik =
+        startProcessInstance(camundaClient, "condWaitStateIceProcess", Map.of("x", 1))
+            .getProcessInstanceKey();
+
+    // then — a CONDITION wait state is exported for the catch event
+    Awaitility.await("condition wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.processInstanceKey(pik))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+
+              final var item = items.getFirst();
+              assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.CONDITION);
+              assertThat(item.getElementId()).isEqualTo(CATCH_EVENT_ID);
+              assertThat(item.getElementType())
+                  .isEqualTo(WaitStateElementType.INTERMEDIATE_CATCH_EVENT);
+              assertThat(item.getProcessInstanceKey()).isEqualTo(pik);
+              assertThat(item.getElementInstanceKey()).isNotNull();
+
+              assertThat(item.getDetails()).isInstanceOf(ConditionWaitStateDetails.class);
+              final var details = (ConditionWaitStateDetails) item.getDetails();
+              assertThat(details.getExpression()).isEqualTo(CONDITION_EXPRESSION);
+              assertThat(details.getEvents()).containsExactlyInAnyOrder("create", "update");
+            });
+  }
+
+  @Test
+  void shouldRemoveConditionWaitStateWhenTriggered() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("condWaitStateRemovalProcess")
+            .startEvent()
+            .intermediateCatchEvent("cond-removal-catch")
+            .condition(c -> c.condition(CONDITION_EXPRESSION).zeebeVariableEvents(VARIABLE_EVENTS))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "condWaitStateRemovalProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "condWaitStateRemovalProcess", Map.of("x", 1))
+            .getProcessInstanceKey();
+
+    Awaitility.await("condition wait state should appear before trigger")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when — update x to 42, satisfying the condition
+    camundaClient.newSetVariablesCommand(pik).variables(Map.of("x", 42)).send().join();
+
+    // then — wait state is removed once the condition fires
+    Awaitility.await("condition wait state should be removed after trigger")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldNotExportConditionWaitStateForRootStartEvent() {
+    // given — a process whose root start event has a conditional event definition.
+    // Root conditional start subscriptions use processInstanceKey == -1 (no active instance)
+    // and must not appear in the wait-state index.
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("condRootStartProcess")
+            .startEvent("root-start")
+            .condition(c -> c.condition("=y > 0"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "condRootStartProcess.bpmn");
+
+    // No instance is started — the subscription is process-scoped, not instance-scoped.
+    // Wait a short time and assert nothing appears for this element id.
+    Awaitility.await("no CONDITION wait state for root start event")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.elementId("root-start"))
+                      .send()
+                      .join()
+                      .items();
+              // Root-level conditional start subscriptions are excluded from the wait-state index
+              // because they have no real process-instance context (processInstanceKey == -1).
+              final List<ElementInstanceWaitStateResult> conditionItems =
+                  items.stream()
+                      .filter(i -> i.getWaitStateType() == WaitStateType.CONDITION)
+                      .toList();
+              assertThat(conditionItems).isEmpty();
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateConditionalIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateConditionalIT.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.it.waitstate;
 
+import static io.camunda.it.util.TestHelper.cancelInstance;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.search.enums.WaitStateElementType;
 import io.camunda.client.api.search.enums.WaitStateType;
 import io.camunda.client.api.search.response.ConditionWaitStateDetails;
@@ -26,8 +28,9 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies element-instance wait-state search for conditional-subscription wait states, covering
- * intermediate catch events and the removal of wait states when the condition is satisfied.
+ * Verifies element-instance wait-state search for conditional-subscription wait states. Only
+ * intermediate conditional catch events are tracked; boundary events, event-subprocess start
+ * events, and root conditional start events are excluded.
  */
 @MultiDbTest
 public class WaitStateConditionalIT {
@@ -165,5 +168,197 @@ public class WaitStateConditionalIT {
                       .toList();
               assertThat(conditionItems).isEmpty();
             });
+  }
+
+  @Test
+  void shouldUpdateConditionWaitStateElementIdWhenProcessInstanceIsMigrated() {
+    // given — V1 has ICE "cond-v1", V2 has ICE "cond-v2" at the same position
+    final BpmnModelInstance v1 =
+        Bpmn.createExecutableProcess("condMigrationV1")
+            .startEvent()
+            .intermediateCatchEvent("cond-v1")
+            .condition(c -> c.condition("=x > 10"))
+            .endEvent()
+            .done();
+    final BpmnModelInstance v2 =
+        Bpmn.createExecutableProcess("condMigrationV2")
+            .startEvent()
+            .intermediateCatchEvent("cond-v2")
+            .condition(c -> c.condition("=x > 10"))
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, v1, "condMigrationV1.bpmn");
+    final long v2Key =
+        deployProcessAndWaitForIt(camundaClient, v2, "condMigrationV2.bpmn")
+            .getProcessDefinitionKey();
+
+    final var instance = startProcessInstance(camundaClient, "condMigrationV1", Map.of("x", 1));
+    final long pik = instance.getProcessInstanceKey();
+
+    Awaitility.await("wait state with cond-v1 should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("cond-v1")));
+
+    // when — migrate the process instance, remapping cond-v1 → cond-v2
+    camundaClient
+        .newMigrateProcessInstanceCommand(pik)
+        .migrationPlan(
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(v2Key)
+                .addMappingInstruction("cond-v1", "cond-v2")
+                .build())
+        .send()
+        .join();
+
+    // then — wait state is updated to reflect the new element id
+    Awaitility.await("wait state should be updated to cond-v2")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("cond-v2")));
+
+    // cleanup
+    cancelInstance(camundaClient, instance);
+    Awaitility.await("wait state should be removed after cancellation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldNotTrackConditionWaitStateForBoundaryConditionalEvent() {
+    // given — a process with two concurrent branches:
+    //   branch 1: intermediate catch event condition (should be exported as a wait state)
+    //   branch 2: service task with a boundary conditional event (boundary should NOT be exported)
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("condBoundaryProcess")
+            .startEvent()
+            .parallelGateway("fork")
+            .intermediateCatchEvent("cond-ice")
+            .condition(c -> c.condition("=x > 10"))
+            .parallelGateway("join")
+            .moveToLastGateway()
+            .serviceTask("svc-task")
+            .zeebeJobType("svc")
+            .connectTo("join")
+            .endEvent()
+            .moveToActivity("svc-task")
+            .boundaryEvent("cond-boundary")
+            .condition(c -> c.condition("=y > 10"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "condBoundaryProcess.bpmn");
+
+    final var instance =
+        startProcessInstance(camundaClient, "condBoundaryProcess", Map.of("x", 1, "y", 1));
+    final long pik = instance.getProcessInstanceKey();
+
+    // when — wait for exactly one CONDITION wait state (the ICE, not the boundary)
+    final List<ElementInstanceWaitStateResult> items =
+        Awaitility.await("exactly one CONDITION wait state should appear — the ICE only")
+            .atMost(TIMEOUT_DATA_AVAILABILITY)
+            .until(
+                () ->
+                    camundaClient
+                        .newElementInstanceWaitStateSearchRequest()
+                        .filter(
+                            f -> f.processInstanceKey(pik).waitStateType(WaitStateType.CONDITION))
+                        .send()
+                        .join()
+                        .items(),
+                list -> list.size() == 1);
+
+    // then — only the ICE is tracked; boundary event is excluded
+    assertThat(items)
+        .singleElement()
+        .satisfies(item -> assertThat(item.getElementId()).isEqualTo("cond-ice"));
+
+    cancelInstance(camundaClient, instance);
+  }
+
+  @Test
+  void shouldNotTrackConditionWaitStateForEventSubProcessStartEvent() {
+    // given — a process with an ICE (to produce known exporter traffic) plus an event subprocess
+    //   whose conditional start event should NOT produce a CONDITION wait state
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("condEventSubProcess")
+            .eventSubProcess(
+                "cond-sub",
+                sp ->
+                    sp.startEvent("cond-sub-start")
+                        .interrupting(false)
+                        .condition("=z > 10")
+                        .endEvent())
+            .startEvent()
+            .intermediateCatchEvent("cond-ice-traffic")
+            .condition(c -> c.condition("=x > 10"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "condEventSubProcess.bpmn");
+
+    final var instance =
+        startProcessInstance(camundaClient, "condEventSubProcess", Map.of("x", 1, "z", 1));
+    final long pik = instance.getProcessInstanceKey();
+
+    // when — wait for the ICE wait state; this proves the exporter has processed all conditional
+    //   subscription records including the event-subprocess start event subscription
+    Awaitility.await("ICE CONDITION wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(pik)
+                                        .waitStateType(WaitStateType.CONDITION))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // then — exactly one CONDITION wait state (the ICE) — the event-subprocess start is excluded
+    final var allConditionWs =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.processInstanceKey(pik).waitStateType(WaitStateType.CONDITION))
+            .send()
+            .join()
+            .items();
+
+    assertThat(allConditionWs)
+        .hasSize(1)
+        .singleElement()
+        .satisfies(item -> assertThat(item.getElementId()).isEqualTo("cond-ice-traffic"));
+
+    cancelInstance(camundaClient, instance);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateConditionalIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateConditionalIT.java
@@ -135,6 +135,53 @@ public class WaitStateConditionalIT {
   }
 
   @Test
+  void shouldRemoveConditionWaitStateWhenProcessInstanceIsCancelled() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("condWaitStateCancelProcess")
+            .startEvent()
+            .intermediateCatchEvent("cond-cancel-catch")
+            .condition(c -> c.condition(CONDITION_EXPRESSION).zeebeVariableEvents(VARIABLE_EVENTS))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "condWaitStateCancelProcess.bpmn");
+
+    final var instance =
+        startProcessInstance(camundaClient, "condWaitStateCancelProcess", Map.of("x", 1));
+    final long pik = instance.getProcessInstanceKey();
+
+    Awaitility.await("condition wait state should appear before cancellation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when — cancel the process instance
+    cancelInstance(camundaClient, instance);
+
+    // then — wait state is removed after cancellation
+    Awaitility.await("condition wait state should be removed after cancellation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
   void shouldNotExportConditionWaitStateForRootStartEvent() {
     // given — a process whose root start event has a conditional event definition.
     // Root conditional start subscriptions use processInstanceKey == -1 (no active instance)
@@ -235,21 +282,6 @@ public class WaitStateConditionalIT {
                             .items())
                     .hasSize(1)
                     .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("cond-v2")));
-
-    // cleanup
-    cancelInstance(camundaClient, instance);
-    Awaitility.await("wait state should be removed after cancellation")
-        .atMost(TIMEOUT_DATA_AVAILABILITY)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        camundaClient
-                            .newElementInstanceWaitStateSearchRequest()
-                            .filter(f -> f.processInstanceKey(pik))
-                            .send()
-                            .join()
-                            .items())
-                    .isEmpty());
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateConditionalIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateConditionalIT.java
@@ -77,7 +77,7 @@ public class WaitStateConditionalIT {
               assertThat(item.getElementId()).isEqualTo(CATCH_EVENT_ID);
               assertThat(item.getElementType())
                   .isEqualTo(WaitStateElementType.INTERMEDIATE_CATCH_EVENT);
-              assertThat(item.getProcessInstanceKey()).isEqualTo(pik);
+              assertThat(item.getProcessInstanceKey()).isEqualTo(String.valueOf(pik));
               assertThat(item.getElementInstanceKey()).isNotNull();
 
               assertThat(item.getDetails()).isInstanceOf(ConditionWaitStateDetails.class);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers.entity;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
+import io.camunda.search.entities.WaitStateConditionDetails;
 import io.camunda.search.entities.WaitStateDetails;
 import io.camunda.search.entities.WaitStateDetails.WaitStateType;
 import io.camunda.search.entities.WaitStateEntity;
@@ -65,6 +66,7 @@ public class WaitStateEntityTransformer
         case USER_TASK -> OBJECT_MAPPER.readValue(detailsJson, WaitStateUserTaskDetails.class);
         case TIMER -> OBJECT_MAPPER.readValue(detailsJson, WaitStateTimerDetails.class);
         case SIGNAL -> OBJECT_MAPPER.readValue(detailsJson, WaitStateSignalDetails.class);
+        case CONDITION -> OBJECT_MAPPER.readValue(detailsJson, WaitStateConditionDetails.class);
       };
     } catch (final Exception e) {
       LOG.warn("Failed to parse wait state details for type {}: {}", waitStateType, e.getMessage());

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateConditionDetails.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateConditionDetails.java
@@ -9,7 +9,6 @@ package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.util.ObjectBuilder;
-import java.util.ArrayList;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
@@ -18,7 +17,7 @@ public record WaitStateConditionDetails(@Nullable String expression, @Nullable L
     implements WaitStateDetails {
 
   public WaitStateConditionDetails {
-    events = events != null ? events : new ArrayList<>();
+    events = events != null ? List.copyOf(events) : List.of();
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateConditionDetails.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateConditionDetails.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WaitStateConditionDetails(@Nullable String expression, @Nullable List<String> events)
+    implements WaitStateDetails {
+
+  public WaitStateConditionDetails {
+    events = events != null ? events : new ArrayList<>();
+  }
+
+  @Override
+  public WaitStateDetails.WaitStateType waitStateType() {
+    return WaitStateDetails.WaitStateType.CONDITION;
+  }
+
+  public static class Builder implements ObjectBuilder<WaitStateConditionDetails> {
+    private @Nullable String expression;
+    private @Nullable List<String> events;
+
+    public Builder expression(final @Nullable String expression) {
+      this.expression = expression;
+      return this;
+    }
+
+    public Builder events(final @Nullable List<String> events) {
+      this.events = events;
+      return this;
+    }
+
+    @Override
+    public WaitStateConditionDetails build() {
+      return new WaitStateConditionDetails(expression, events);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateConditionDetails.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateConditionDetails.java
@@ -9,6 +9,7 @@ package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
@@ -17,7 +18,7 @@ public record WaitStateConditionDetails(@Nullable String expression, @Nullable L
     implements WaitStateDetails {
 
   public WaitStateConditionDetails {
-    events = events != null ? List.copyOf(events) : List.of();
+    events = events != null ? new ArrayList<>(events) : new ArrayList<>();
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateDetails.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateDetails.java
@@ -12,7 +12,8 @@ public sealed interface WaitStateDetails
         WaitStateMessageDetails,
         WaitStateUserTaskDetails,
         WaitStateTimerDetails,
-        WaitStateSignalDetails {
+        WaitStateSignalDetails,
+        WaitStateConditionDetails {
 
   WaitStateType waitStateType();
 
@@ -21,6 +22,7 @@ public sealed interface WaitStateDetails
     MESSAGE,
     USER_TASK,
     TIMER,
-    SIGNAL
+    SIGNAL,
+    CONDITION
   }
 }

--- a/search/search-domain/src/test/java/io/camunda/search/entities/WaitStateConditionDetailsTest.java
+++ b/search/search-domain/src/test/java/io/camunda/search/entities/WaitStateConditionDetailsTest.java
@@ -8,7 +8,6 @@
 package io.camunda.search.entities;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,17 +25,19 @@ class WaitStateConditionDetailsTest {
   }
 
   @Test
-  void shouldReturnImmutableListWhenEventsIsNull() {
+  void shouldReturnMutableListWhenEventsIsNull() {
     // given
     final var details = new WaitStateConditionDetails(null, null);
 
-    // when / then
-    assertThatThrownBy(() -> details.events().add("event"))
-        .isInstanceOf(UnsupportedOperationException.class);
+    // when
+    details.events().add("event");
+
+    // then
+    assertThat(details.events()).containsExactly("event");
   }
 
   @Test
-  void shouldReturnImmutableCopyOfProvidedEvents() {
+  void shouldReturnCopyOfProvidedEvents() {
     // given
     final var mutableList = new ArrayList<>(List.of("event-a", "event-b"));
     final var details = new WaitStateConditionDetails(null, mutableList);
@@ -49,12 +50,14 @@ class WaitStateConditionDetailsTest {
   }
 
   @Test
-  void shouldReturnImmutableListWhenEventsIsNonNull() {
+  void shouldReturnMutableListWhenEventsIsNonNull() {
     // given
     final var details = new WaitStateConditionDetails(null, List.of("event-a"));
 
-    // when / then
-    assertThatThrownBy(() -> details.events().add("event-b"))
-        .isInstanceOf(UnsupportedOperationException.class);
+    // when
+    details.events().add("event-b");
+
+    // then
+    assertThat(details.events()).containsExactly("event-a", "event-b");
   }
 }

--- a/search/search-domain/src/test/java/io/camunda/search/entities/WaitStateConditionDetailsTest.java
+++ b/search/search-domain/src/test/java/io/camunda/search/entities/WaitStateConditionDetailsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class WaitStateConditionDetailsTest {
+
+  @Test
+  void shouldReturnEmptyListWhenEventsIsNull() {
+    // given / when
+    final var details = new WaitStateConditionDetails(null, null);
+
+    // then
+    assertThat(details.events()).isNotNull().isEmpty();
+  }
+
+  @Test
+  void shouldReturnImmutableListWhenEventsIsNull() {
+    // given
+    final var details = new WaitStateConditionDetails(null, null);
+
+    // when / then
+    assertThatThrownBy(() -> details.events().add("event"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void shouldReturnImmutableCopyOfProvidedEvents() {
+    // given
+    final var mutableList = new ArrayList<>(List.of("event-a", "event-b"));
+    final var details = new WaitStateConditionDetails(null, mutableList);
+
+    // when
+    mutableList.add("event-c");
+
+    // then
+    assertThat(details.events()).containsExactly("event-a", "event-b");
+  }
+
+  @Test
+  void shouldReturnImmutableListWhenEventsIsNonNull() {
+    // given
+    final var details = new WaitStateConditionDetails(null, List.of("event-a"));
+
+    // when / then
+    assertThatThrownBy(() -> details.events().add("event-b"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -22,7 +22,8 @@
 				"globals": "17.6.0",
 				"prettier": "3.8.4",
 				"typescript-eslint": "8.61.0"
-			}
+			},
+			"version": "8.10.0-SNAPSHOT"
 		},
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
@@ -11157,5 +11158,6 @@
 				}
 			}
 		}
-	}
+	},
+	"version": "8.10.0-SNAPSHOT"
 }

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -22,8 +22,7 @@
 				"globals": "17.6.0",
 				"prettier": "3.8.4",
 				"typescript-eslint": "8.61.0"
-			},
-			"version": "8.10.0-SNAPSHOT"
+			}
 		},
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
@@ -11158,6 +11157,5 @@
 				}
 			}
 		}
-	},
-	"version": "8.10.0-SNAPSHOT"
+	}
 }

--- a/webapp/client/package.json
+++ b/webapp/client/package.json
@@ -39,6 +39,5 @@
 		"globals": "17.6.0",
 		"prettier": "3.8.4",
 		"typescript-eslint": "8.61.0"
-	},
-	"version": "8.10.0-SNAPSHOT"
+	}
 }

--- a/webapp/client/package.json
+++ b/webapp/client/package.json
@@ -39,5 +39,6 @@
 		"globals": "17.6.0",
 		"prettier": "3.8.4",
 		"typescript-eslint": "8.61.0"
-	}
+	},
+	"version": "8.10.0-SNAPSHOT"
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -248,7 +248,7 @@ public final class CatchEventBehavior {
 
     // conditional events don't require expression evaluation for subscription
     // condition expressions are stored as-is and evaluated when a variable changes
-    subscribeToConditionalEvents(context, supplier);
+    subscribeToConditionalEvents(context, supplier, filterBeforeEvaluation);
 
     return evaluationResults.map(r -> null);
   }
@@ -516,9 +516,12 @@ public final class CatchEventBehavior {
   }
 
   private void subscribeToConditionalEvents(
-      final BpmnElementContext context, final ExecutableCatchEventSupplier supplier) {
+      final BpmnElementContext context,
+      final ExecutableCatchEventSupplier supplier,
+      final Predicate<ExecutableCatchEvent> filter) {
     supplier.getEvents().stream()
         .filter(ExecutableCatchEvent::isConditional)
+        .filter(filter)
         .forEach(event -> subscribeToConditionalEvent(context, event));
   }
 

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.common.waitstate;
 
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
@@ -59,6 +60,13 @@ public final class WaitStateConfigs {
           .withUpdateIntents(SignalSubscriptionIntent.MIGRATED)
           .withRemoveIntents(SignalSubscriptionIntent.DELETED)
           .withWaitStateType(WaitStateType.SIGNAL);
+
+  public static final WaitStateTransformerConfig CONDITION_CONFIG =
+      WaitStateTransformerConfig.of(ValueType.CONDITIONAL_SUBSCRIPTION)
+          .withAddIntents(ConditionalSubscriptionIntent.CREATED)
+          .withUpdateIntents(ConditionalSubscriptionIntent.MIGRATED)
+          .withRemoveIntents(ConditionalSubscriptionIntent.DELETED)
+          .withWaitStateType(WaitStateType.CONDITION);
 
   private WaitStateConfigs() {}
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntry.java
@@ -150,13 +150,13 @@ public class WaitStateEntry {
   }
 
   public enum WaitStateType {
+    CALL_ACTIVITY,
+    CONDITION,
+    INCIDENT,
     JOB,
     MESSAGE,
-    USER_TASK,
-    TIMER,
     SIGNAL,
-    INCIDENT,
-    CALL_ACTIVITY,
-    CONDITION
+    TIMER,
+    USER_TASK
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntry.java
@@ -156,6 +156,7 @@ public class WaitStateEntry {
     TIMER,
     SIGNAL,
     INCIDENT,
-    CALL_ACTIVITY
+    CALL_ACTIVITY,
+    CONDITION
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformer.java
@@ -14,9 +14,22 @@ import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformerConfig;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
 import java.util.List;
 
+/**
+ * Transforms conditional-subscription records into wait-state entries. Only intermediate catch
+ * event conditions are exported. Records are skipped when:
+ *
+ * <ul>
+ *   <li>processInstanceKey is -1 (root conditional start event — no process instance context)
+ *   <li>rootProcessInstanceKey is -1 or bpmnProcessId is empty (pre-8.10 V1 records without these
+ *       fields — exporting partial data would be misleading)
+ *   <li>elementType is not INTERMEDIATE_CATCH_EVENT (boundary events and event-subprocess start
+ *       events are not tracked as wait states)
+ * </ul>
+ */
 public class ConditionBasedWaitStateTransformer
     implements WaitStateTransformer<ConditionalSubscriptionRecordValue> {
 
@@ -41,23 +54,31 @@ public class ConditionBasedWaitStateTransformer
 
   @Override
   public boolean triggersAdd(final Record<ConditionalSubscriptionRecordValue> r) {
-    return WaitStateTransformer.super.triggersAdd(r) && r.getValue().getProcessInstanceKey() != -1;
+    return isIntermediateCatchEventCondition(r) && WaitStateTransformer.super.triggersAdd(r);
   }
 
   @Override
   public boolean triggersUpdate(final Record<ConditionalSubscriptionRecordValue> r) {
-    return WaitStateTransformer.super.triggersUpdate(r)
-        && r.getValue().getProcessInstanceKey() != -1;
+    return isIntermediateCatchEventCondition(r) && WaitStateTransformer.super.triggersUpdate(r);
   }
 
   @Override
   public boolean triggersRemoval(final Record<ConditionalSubscriptionRecordValue> r) {
-    if (r.getValue().getProcessInstanceKey() == -1) {
+    if (!isIntermediateCatchEventCondition(r)) {
       return false;
     }
     // DELETED always removes (covered by config); TRIGGERED removes only when interrupting
     return WaitStateTransformer.super.triggersRemoval(r)
         || (r.getIntent() == ConditionalSubscriptionIntent.TRIGGERED
             && r.getValue().isInterrupting());
+  }
+
+  private static boolean isIntermediateCatchEventCondition(
+      final Record<ConditionalSubscriptionRecordValue> record) {
+    final var value = record.getValue();
+    return value.getProcessInstanceKey() != -1L
+        && value.getRootProcessInstanceKey() != -1L
+        && !value.getBpmnProcessId().isEmpty()
+        && value.getElementType() == BpmnElementType.INTERMEDIATE_CATCH_EVENT;
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import static io.camunda.zeebe.exporter.common.waitstate.WaitStateConfigs.CONDITION_CONFIG;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformerConfig;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
+import java.util.List;
+
+public class ConditionBasedWaitStateTransformer
+    implements WaitStateTransformer<ConditionalSubscriptionRecordValue> {
+
+  @Override
+  public WaitStateTransformerConfig config() {
+    return CONDITION_CONFIG;
+  }
+
+  @Override
+  public void extract(
+      final Record<ConditionalSubscriptionRecordValue> record, final WaitStateEntry entry) {
+    final var value = record.getValue();
+    // empty variableEvents means "all events" in the engine — normalize to explicit list
+    final var events =
+        value.getVariableEvents().isEmpty()
+            ? List.of("create", "update")
+            : value.getVariableEvents();
+    entry
+        .setElementType(value.getElementType())
+        .setDetails(new ConditionWaitStateDetails(value.getCondition(), events));
+  }
+
+  @Override
+  public boolean triggersAdd(final Record<ConditionalSubscriptionRecordValue> r) {
+    return WaitStateTransformer.super.triggersAdd(r) && r.getValue().getProcessInstanceKey() != -1;
+  }
+
+  @Override
+  public boolean triggersUpdate(final Record<ConditionalSubscriptionRecordValue> r) {
+    return WaitStateTransformer.super.triggersUpdate(r)
+        && r.getValue().getProcessInstanceKey() != -1;
+  }
+
+  @Override
+  public boolean triggersRemoval(final Record<ConditionalSubscriptionRecordValue> r) {
+    if (r.getValue().getProcessInstanceKey() == -1) {
+      return false;
+    }
+    // DELETED always removes (covered by config); TRIGGERED removes only when interrupting
+    return WaitStateTransformer.super.triggersRemoval(r)
+        || (r.getIntent() == ConditionalSubscriptionIntent.TRIGGERED
+            && r.getValue().isInterrupting());
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionWaitStateDetails.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionWaitStateDetails.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
+import java.util.List;
+
+/**
+ * Wait-state details for condition-based element waits (conditional intermediate catch events,
+ * conditional boundary events, and conditional start events in event subprocesses).
+ */
+public record ConditionWaitStateDetails(String expression, List<String> events)
+    implements WaitStateDetails {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionWaitStateDetails.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionWaitStateDetails.java
@@ -11,8 +11,8 @@ import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
 import java.util.List;
 
 /**
- * Wait-state details for condition-based element waits (conditional intermediate catch events,
- * conditional boundary events, and conditional start events in event subprocesses).
+ * Wait-state details for condition-based element waits. Only intermediate conditional catch events
+ * are exported; boundary events and event-subprocess start events are excluded.
  */
 public record ConditionWaitStateDetails(String expression, List<String> events)
     implements WaitStateDetails {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
@@ -29,7 +29,8 @@ public final class WaitStateTransformerRegistry {
         UserTaskBasedWaitStateTransformer::new,
         TimerBasedWaitStateTransformer::new,
         SignalBasedWaitStateTransformer::new,
-        MessageBasedWaitStateTransformer::new);
+        MessageBasedWaitStateTransformer::new,
+        ConditionBasedWaitStateTransformer::new);
   }
 
   /**

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntryTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntryTest.java
@@ -117,13 +117,13 @@ class WaitStateEntryTest {
     // when / then
     assertThat(WaitStateType.values())
         .containsExactlyInAnyOrder(
+            WaitStateType.CALL_ACTIVITY,
+            WaitStateType.CONDITION,
+            WaitStateType.INCIDENT,
             WaitStateType.JOB,
             WaitStateType.MESSAGE,
-            WaitStateType.USER_TASK,
-            WaitStateType.TIMER,
             WaitStateType.SIGNAL,
-            WaitStateType.INCIDENT,
-            WaitStateType.CALL_ACTIVITY,
-            WaitStateType.CONDITION);
+            WaitStateType.TIMER,
+            WaitStateType.USER_TASK);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntryTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntryTest.java
@@ -123,6 +123,7 @@ class WaitStateEntryTest {
             WaitStateType.TIMER,
             WaitStateType.SIGNAL,
             WaitStateType.INCIDENT,
-            WaitStateType.CALL_ACTIVITY);
+            WaitStateType.CALL_ACTIVITY,
+            WaitStateType.CONDITION);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformerTest.java
@@ -21,12 +21,25 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 class ConditionBasedWaitStateTransformerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final ConditionBasedWaitStateTransformer transformer =
       new ConditionBasedWaitStateTransformer();
+
+  /** Builds a value that passes all four guards in {@code isIntermediateCatchEventCondition}. */
+  private ImmutableConditionalSubscriptionRecordValue.Builder validIceValue() {
+    return ImmutableConditionalSubscriptionRecordValue.builder()
+        .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+        .withProcessInstanceKey(200L)
+        .withRootProcessInstanceKey(100L)
+        .withBpmnProcessId("test-process")
+        .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+  }
 
   @Test
   void shouldExtractDetailsFromConditionalSubscriptionCreatedRecord() {
@@ -40,6 +53,7 @@ class ConditionBasedWaitStateTransformerTest {
             .withElementInstanceKey(300L)
             .withProcessInstanceKey(200L)
             .withRootProcessInstanceKey(100L)
+            .withBpmnProcessId("test-process")
             .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             .withInterrupting(true)
             .build();
@@ -75,13 +89,10 @@ class ConditionBasedWaitStateTransformerTest {
   }
 
   @Test
-  void shouldTriggerAddOnCreatedWithNonRootProcessInstance() {
-    // given
+  void shouldNormalizeEmptyVariableEventsToCreateAndUpdate() {
+    // given — no variableEvents set (empty list means "all events" in the engine)
     final ConditionalSubscriptionRecordValue value =
-        ImmutableConditionalSubscriptionRecordValue.builder()
-            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
-            .withProcessInstanceKey(200L)
-            .build();
+        validIceValue().withCondition("= x > 5").withVariableEvents(List.of()).build();
 
     final Record<ConditionalSubscriptionRecordValue> record =
         factory.generateRecord(
@@ -91,6 +102,25 @@ class ConditionBasedWaitStateTransformerTest {
                     .withIntent(ConditionalSubscriptionIntent.CREATED)
                     .withValue(value));
 
+    // when
+    final var entry = transformer.transform(record);
+
+    // then — empty list normalized to explicit ["create", "update"]
+    final var details = (ConditionWaitStateDetails) entry.getDetails();
+    assertThat(details.events()).containsExactlyInAnyOrder("create", "update");
+  }
+
+  @Test
+  void shouldTriggerAddOnCreatedForIntermediateCatchEvent() {
+    // given
+    final Record<ConditionalSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.CREATED)
+                    .withValue(validIceValue().build()));
+
     // when / then
     assertThat(transformer.triggersAdd(record)).isTrue();
     assertThat(transformer.triggersRemoval(record)).isFalse();
@@ -98,21 +128,15 @@ class ConditionBasedWaitStateTransformerTest {
   }
 
   @Test
-  void shouldTriggerUpdateOnMigrated() {
+  void shouldTriggerUpdateOnMigratedForIntermediateCatchEvent() {
     // given
-    final ConditionalSubscriptionRecordValue value =
-        ImmutableConditionalSubscriptionRecordValue.builder()
-            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
-            .withProcessInstanceKey(200L)
-            .build();
-
     final Record<ConditionalSubscriptionRecordValue> record =
         factory.generateRecord(
             ValueType.CONDITIONAL_SUBSCRIPTION,
             r ->
                 r.withRecordType(RecordType.EVENT)
                     .withIntent(ConditionalSubscriptionIntent.MIGRATED)
-                    .withValue(value));
+                    .withValue(validIceValue().build()));
 
     // when / then
     assertThat(transformer.triggersUpdate(record)).isTrue();
@@ -121,21 +145,15 @@ class ConditionBasedWaitStateTransformerTest {
   }
 
   @Test
-  void shouldTriggerRemovalOnDeleted() {
+  void shouldTriggerRemovalOnDeletedForIntermediateCatchEvent() {
     // given
-    final ConditionalSubscriptionRecordValue value =
-        ImmutableConditionalSubscriptionRecordValue.builder()
-            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
-            .withProcessInstanceKey(200L)
-            .build();
-
     final Record<ConditionalSubscriptionRecordValue> record =
         factory.generateRecord(
             ValueType.CONDITIONAL_SUBSCRIPTION,
             r ->
                 r.withRecordType(RecordType.EVENT)
                     .withIntent(ConditionalSubscriptionIntent.DELETED)
-                    .withValue(value));
+                    .withValue(validIceValue().build()));
 
     // when / then
     assertThat(transformer.triggersRemoval(record)).isTrue();
@@ -146,20 +164,13 @@ class ConditionBasedWaitStateTransformerTest {
   @Test
   void shouldTriggerRemovalOnTriggeredWhenInterrupting() {
     // given
-    final ConditionalSubscriptionRecordValue value =
-        ImmutableConditionalSubscriptionRecordValue.builder()
-            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
-            .withProcessInstanceKey(200L)
-            .withInterrupting(true)
-            .build();
-
     final Record<ConditionalSubscriptionRecordValue> record =
         factory.generateRecord(
             ValueType.CONDITIONAL_SUBSCRIPTION,
             r ->
                 r.withRecordType(RecordType.EVENT)
                     .withIntent(ConditionalSubscriptionIntent.TRIGGERED)
-                    .withValue(value));
+                    .withValue(validIceValue().withInterrupting(true).build()));
 
     // when / then
     assertThat(transformer.triggersRemoval(record)).isTrue();
@@ -170,20 +181,13 @@ class ConditionBasedWaitStateTransformerTest {
   @Test
   void shouldNotTriggerRemovalOnTriggeredWhenNonInterrupting() {
     // given
-    final ConditionalSubscriptionRecordValue value =
-        ImmutableConditionalSubscriptionRecordValue.builder()
-            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
-            .withProcessInstanceKey(200L)
-            .withInterrupting(false)
-            .build();
-
     final Record<ConditionalSubscriptionRecordValue> record =
         factory.generateRecord(
             ValueType.CONDITIONAL_SUBSCRIPTION,
             r ->
                 r.withRecordType(RecordType.EVENT)
                     .withIntent(ConditionalSubscriptionIntent.TRIGGERED)
-                    .withValue(value));
+                    .withValue(validIceValue().withInterrupting(false).build()));
 
     // when / then
     assertThat(transformer.triggersRemoval(record)).isFalse();
@@ -195,11 +199,7 @@ class ConditionBasedWaitStateTransformerTest {
   void shouldNotTriggerAnyActionForRootStartEvent() {
     // given — processInstanceKey == -1 marks a root-level start event
     final ConditionalSubscriptionRecordValue value =
-        ImmutableConditionalSubscriptionRecordValue.builder()
-            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
-            .withProcessInstanceKey(-1L)
-            .withInterrupting(true)
-            .build();
+        validIceValue().withProcessInstanceKey(-1L).withInterrupting(true).build();
 
     final Record<ConditionalSubscriptionRecordValue> createdRecord =
         factory.generateRecord(
@@ -233,6 +233,46 @@ class ConditionBasedWaitStateTransformerTest {
     // when / then — all intents should be suppressed for root start events
     assertThat(transformer.triggersAdd(createdRecord)).isFalse();
     assertThat(transformer.triggersUpdate(migratedRecord)).isFalse();
+    assertThat(transformer.triggersRemoval(deletedRecord)).isFalse();
+    assertThat(transformer.triggersRemoval(triggeredRecord)).isFalse();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = BpmnElementType.class,
+      names = "INTERMEDIATE_CATCH_EVENT",
+      mode = Mode.EXCLUDE)
+  void shouldNotTriggerAnyActionForNonIntermediateCatchEventElementTypes(
+      final BpmnElementType elementType) {
+    // given — only INTERMEDIATE_CATCH_EVENT conditions are exported as wait states;
+    //   boundary events and event-subprocess start events must be suppressed
+    final ConditionalSubscriptionRecordValue value =
+        validIceValue().withElementType(elementType).withInterrupting(true).build();
+
+    final Record<ConditionalSubscriptionRecordValue> createdRecord =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.CREATED)
+                    .withValue(value));
+    final Record<ConditionalSubscriptionRecordValue> deletedRecord =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.DELETED)
+                    .withValue(value));
+    final Record<ConditionalSubscriptionRecordValue> triggeredRecord =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.TRIGGERED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersAdd(createdRecord)).isFalse();
     assertThat(transformer.triggersRemoval(deletedRecord)).isFalse();
     assertThat(transformer.triggersRemoval(triggeredRecord)).isFalse();
   }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformerTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableConditionalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ConditionBasedWaitStateTransformerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ConditionBasedWaitStateTransformer transformer =
+      new ConditionBasedWaitStateTransformer();
+
+  @Test
+  void shouldExtractDetailsFromConditionalSubscriptionCreatedRecord() {
+    // given
+    final ConditionalSubscriptionRecordValue value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withCondition("= x > 5")
+            .withVariableEvents(List.of("create", "update"))
+            .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .withInterrupting(true)
+            .build();
+
+    final Record<ConditionalSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then — identity fields from WaitStateRelated
+    assertThat(entry.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entry.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entry.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entry.getElementId()).isEqualTo("catch-condition");
+    assertThat(entry.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(entry.getPartitionId()).isEqualTo(record.getPartitionId());
+
+    // then — classification set by config and extract
+    assertThat(entry.getWaitStateType()).isEqualTo(WaitStateType.CONDITION);
+    assertThat(entry.getElementType()).isEqualTo(BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // then — condition-specific details
+    assertThat(entry.getDetails()).isInstanceOf(ConditionWaitStateDetails.class);
+    final var details = (ConditionWaitStateDetails) entry.getDetails();
+    assertThat(details.expression()).isEqualTo("= x > 5");
+    assertThat(details.events()).containsExactly("create", "update");
+  }
+
+  @Test
+  void shouldTriggerAddOnCreatedWithNonRootProcessInstance() {
+    // given
+    final ConditionalSubscriptionRecordValue value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .build();
+
+    final Record<ConditionalSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.CREATED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersAdd(record)).isTrue();
+    assertThat(transformer.triggersRemoval(record)).isFalse();
+    assertThat(transformer.triggersUpdate(record)).isFalse();
+  }
+
+  @Test
+  void shouldTriggerUpdateOnMigrated() {
+    // given
+    final ConditionalSubscriptionRecordValue value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .build();
+
+    final Record<ConditionalSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.MIGRATED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersUpdate(record)).isTrue();
+    assertThat(transformer.triggersAdd(record)).isFalse();
+    assertThat(transformer.triggersRemoval(record)).isFalse();
+  }
+
+  @Test
+  void shouldTriggerRemovalOnDeleted() {
+    // given
+    final ConditionalSubscriptionRecordValue value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .build();
+
+    final Record<ConditionalSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.DELETED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersRemoval(record)).isTrue();
+    assertThat(transformer.triggersAdd(record)).isFalse();
+    assertThat(transformer.triggersUpdate(record)).isFalse();
+  }
+
+  @Test
+  void shouldTriggerRemovalOnTriggeredWhenInterrupting() {
+    // given
+    final ConditionalSubscriptionRecordValue value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .withInterrupting(true)
+            .build();
+
+    final Record<ConditionalSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.TRIGGERED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersRemoval(record)).isTrue();
+    assertThat(transformer.triggersAdd(record)).isFalse();
+    assertThat(transformer.triggersUpdate(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotTriggerRemovalOnTriggeredWhenNonInterrupting() {
+    // given
+    final ConditionalSubscriptionRecordValue value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .withInterrupting(false)
+            .build();
+
+    final Record<ConditionalSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.TRIGGERED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersRemoval(record)).isFalse();
+    assertThat(transformer.triggersAdd(record)).isFalse();
+    assertThat(transformer.triggersUpdate(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotTriggerAnyActionForRootStartEvent() {
+    // given — processInstanceKey == -1 marks a root-level start event
+    final ConditionalSubscriptionRecordValue value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withProcessInstanceKey(-1L)
+            .withInterrupting(true)
+            .build();
+
+    final Record<ConditionalSubscriptionRecordValue> createdRecord =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.CREATED)
+                    .withValue(value));
+    final Record<ConditionalSubscriptionRecordValue> migratedRecord =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.MIGRATED)
+                    .withValue(value));
+    final Record<ConditionalSubscriptionRecordValue> deletedRecord =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.DELETED)
+                    .withValue(value));
+    final Record<ConditionalSubscriptionRecordValue> triggeredRecord =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.TRIGGERED)
+                    .withValue(value));
+
+    // when / then — all intents should be suppressed for root start events
+    assertThat(transformer.triggersAdd(createdRecord)).isFalse();
+    assertThat(transformer.triggersUpdate(migratedRecord)).isFalse();
+    assertThat(transformer.triggersRemoval(deletedRecord)).isFalse();
+    assertThat(transformer.triggersRemoval(triggeredRecord)).isFalse();
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformerTest.java
@@ -50,6 +50,7 @@ class ConditionBasedWaitStateTransformerTest {
             .withCondition("= x > 5")
             .withVariableEvents(List.of("create", "update"))
             .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .withCatchEventId("catch-condition")
             .withElementInstanceKey(300L)
             .withProcessInstanceKey(200L)
             .withRootProcessInstanceKey(100L)

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/ConditionBasedWaitStateTransformerTest.java
@@ -257,6 +257,13 @@ class ConditionBasedWaitStateTransformerTest {
                 r.withRecordType(RecordType.EVENT)
                     .withIntent(ConditionalSubscriptionIntent.CREATED)
                     .withValue(value));
+    final Record<ConditionalSubscriptionRecordValue> migratedRecord =
+        factory.generateRecord(
+            ValueType.CONDITIONAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ConditionalSubscriptionIntent.MIGRATED)
+                    .withValue(value));
     final Record<ConditionalSubscriptionRecordValue> deletedRecord =
         factory.generateRecord(
             ValueType.CONDITIONAL_SUBSCRIPTION,
@@ -274,6 +281,7 @@ class ConditionBasedWaitStateTransformerTest {
 
     // when / then
     assertThat(transformer.triggersAdd(createdRecord)).isFalse();
+    assertThat(transformer.triggersUpdate(migratedRecord)).isFalse();
     assertThat(transformer.triggersRemoval(deletedRecord)).isFalse();
     assertThat(transformer.triggersRemoval(triggeredRecord)).isFalse();
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -16,6 +16,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_EXECUTI
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_INITIALIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT;
 import static io.camunda.zeebe.protocol.record.ValueType.CLUSTER_VARIABLE;
+import static io.camunda.zeebe.protocol.record.ValueType.CONDITIONAL_SUBSCRIPTION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_EVALUATION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_REQUIREMENTS;
@@ -427,7 +428,8 @@ public class CamundaExporter implements Exporter {
             AGENT_INSTANCE,
             AGENT_HISTORY,
             TIMER,
-            SIGNAL_SUBSCRIPTION);
+            SIGNAL_SUBSCRIPTION,
+            CONDITIONAL_SUBSCRIPTION);
 
     @Override
     public boolean acceptType(final RecordType recordType) {

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -849,12 +849,14 @@ components:
           USER_TASK: '#/components/schemas/UserTaskWaitStateDetails'
           TIMER: '#/components/schemas/TimerWaitStateDetails'
           SIGNAL: '#/components/schemas/SignalWaitStateDetails'
+          CONDITION: '#/components/schemas/ConditionWaitStateDetails'
       oneOf:
         - $ref: '#/components/schemas/JobWaitStateDetails'
         - $ref: '#/components/schemas/MessageWaitStateDetails'
         - $ref: '#/components/schemas/UserTaskWaitStateDetails'
         - $ref: '#/components/schemas/TimerWaitStateDetails'
         - $ref: '#/components/schemas/SignalWaitStateDetails'
+        - $ref: '#/components/schemas/ConditionWaitStateDetails'
 
     WaitStateTypeEnum:
       description: The type of waiting state an element instance is in.
@@ -865,6 +867,7 @@ components:
         - USER_TASK
         - TIMER
         - SIGNAL
+        - CONDITION
 
     BaseWaitStateDetails:
       description: Common fields shared by all wait-state details variants.
@@ -978,6 +981,27 @@ components:
           description: The name of the signal being awaited.
           type: string
       x-added-in-version: "8.10"
+
+    ConditionWaitStateDetails:
+      type: object
+      required:
+        - waitStateType
+        - expression
+        - events
+      allOf:
+        - $ref: '#/components/schemas/BaseWaitStateDetails'
+      properties:
+        expression:
+          description: The condition expression that must evaluate to true to proceed.
+          type: string
+        events:
+          description: The variable events that trigger condition re-evaluation. Empty means all events.
+          type: array
+          items:
+            type: string
+            enum:
+              - create
+              - update
 
     AdHocSubProcessActivateActivityReference:
       type: object

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
@@ -135,6 +135,17 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @JsonIgnore
+  @Override
+  public String getElementId() {
+    return getCatchEventId();
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
   @Override
   public long getProcessInstanceKey() {
     return processInstanceKeyProp.getValue();
@@ -213,13 +224,19 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  public ConditionalSubscriptionRecord setCatchEventId(final DirectBuffer catchEventId) {
-    catchEventIdProp.setValue(catchEventId);
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public ConditionalSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
     return this;
   }
 
-  public String getBpmnProcessId() {
-    return bufferAsString(bpmnProcessIdProp.getValue());
+  public ConditionalSubscriptionRecord setCatchEventId(final DirectBuffer catchEventId) {
+    catchEventIdProp.setValue(catchEventId);
+    return this;
   }
 
   public ConditionalSubscriptionRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
@@ -249,21 +266,6 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
 
   public ConditionalSubscriptionRecord setRootProcessInstanceKey(final long key) {
     rootProcessInstanceKeyProp.setValue(key);
-    return this;
-  }
-
-  @Override
-  public String getElementId() {
-    return getCatchEventId();
-  }
-
-  @Override
-  public BpmnElementType getElementType() {
-    return elementTypeProp.getValue();
-  }
-
-  public ConditionalSubscriptionRecord setElementType(final BpmnElementType elementType) {
-    elementTypeProp.setValue(elementType);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4348,8 +4348,7 @@ final class JsonSerializableToJsonTest {
                   "bpmnProcessId":"process-1",
                   "processDefinitionKey":456,
                   "rootProcessInstanceKey":999,
-                  "elementType":"INTERMEDIATE_CATCH_EVENT",
-                  "elementId":"catchEvent"
+                  "elementType":"INTERMEDIATE_CATCH_EVENT"
                 }
                 """
       },
@@ -4376,8 +4375,7 @@ final class JsonSerializableToJsonTest {
                   "bpmnProcessId":"",
                   "processDefinitionKey":-1,
                   "rootProcessInstanceKey":-1,
-                  "elementType":"UNSPECIFIED",
-                  "elementId":""
+                  "elementType":"UNSPECIFIED"
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalSubscriptionRecord.golden
@@ -135,6 +135,17 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @JsonIgnore
+  @Override
+  public String getElementId() {
+    return getCatchEventId();
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
   @Override
   public long getProcessInstanceKey() {
     return processInstanceKeyProp.getValue();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ConditionalSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ConditionalSubscriptionRecordValue.java
@@ -45,7 +45,27 @@ public interface ConditionalSubscriptionRecordValue
   /**
    * @return the key of the related element instance.
    */
+  @Override
   long getElementInstanceKey();
+
+  /**
+   * Bridges {@link WaitStateRelated#getElementId()} to {@link #getCatchEventId()}.
+   *
+   * <p>Implementations should annotate this override with {@code @JsonIgnore} to avoid duplicating
+   * {@code catchEventId} in serialised output.
+   *
+   * @since 8.10
+   */
+  @Override
+  default String getElementId() {
+    return getCatchEventId();
+  }
+
+  /**
+   * @return the bpmn process id of the corresponding process definition
+   */
+  @Override
+  String getBpmnProcessId();
 
   /**
    * @return the key of the related process instance
@@ -56,12 +76,8 @@ public interface ConditionalSubscriptionRecordValue
   /**
    * @return the process definition key
    */
+  @Override
   long getProcessDefinitionKey();
-
-  /**
-   * @return the bpmn process id of the corresponding process definition
-   */
-  String getBpmnProcessId();
 
   /**
    * @return the id of the catch event tied to the subscription


### PR DESCRIPTION
## Summary

Exports conditional subscriptions to secondary storage as a new `CONDITION` wait-state type and surfaces it through the element-inspection API and Java client, so the UI can show what condition an intermediate conditional catch event is waiting for.

Modeled on the existing **JOB** wait-state implementation (the only live transformer until now).

- **Export** (`zeebe/exporter-common`): `ConditionBasedWaitStateTransformer` — `CREATED` adds, `MIGRATED` updates, `DELETED` removes, and `TRIGGERED` removes only for interrupting subscriptions; root start-event subscriptions (`processInstanceKey == -1`) are excluded. Auto-wired into both the camunda and rdbms exporters via the transformer registry.
- **Search / read** (`search-domain`, `search-client-query-transformer`, `db/rdbms`): new `WaitStateConditionDetails` (`expression`, `events`) added to the sealed model and deserialized in the ES/OS and RDBMS read mappers.
- **REST / OpenAPI** (`gateway-mapping-http`, `element-instances.yaml`): new `CONDITION` enum value, `ConditionWaitStateDetails` schema, and `conditionDetails` response field.
- **Java client**: `ConditionWaitStateDetails` (`getExpression()`, `getEvents()`) exposed via the element-instance wait-state search response.
- **Acceptance test**: `WaitStateConditionalIT` (`@MultiDbTest`) covering export while waiting, removal on trigger, and exclusion of root conditional start events.

The intent → operation mapping was verified against the engine appliers (`TRIGGERED` deletes from state only when interrupting; non-interrupting subscriptions end via `DELETED`).

Closes #49693

> **Stacked PR:** based on the `claude/reverent-mayer-30f8fb` branch (PR #54918), which adds `elementType` to the conditional record. Review/merge that first; this PR's base should retarget to `main` once #54918 merges.

## Test plan

- [x] `ConditionBasedWaitStateTransformerTest` (7/7) — intent triggering incl. interrupting-`TRIGGERED` and `processInstanceKey == -1` exclusion
- [x] Full-repo compile green; both exporters auto-wire the transformer
- [ ] `WaitStateConditionalIT` via `-Pmulti-db-test` in CI (requires testcontainers; not run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)