### PR TITLE
feat: support dynamic version tag expressions for business rule task decisions

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -137,7 +137,8 @@ public final class BpmnDecisionBehavior {
       case deployment -> getDecisionVersionInSameDeployment(decisionId, context);
       case latest -> getLatestDecisionVersion(decisionId, context.getTenantId());
       case versionTag ->
-          getLatestDecisionVersionWithVersionTag(decisionId, versionTag, context.getTenantId());
+          getLatestDecisionVersionWithVersionTag(
+              decisionId, versionTag, context.getElementInstanceKey(), context.getTenantId());
     };
   }
 
@@ -157,22 +158,16 @@ public final class BpmnDecisionBehavior {
   }
 
   private Either<Failure, PersistedDecision> getLatestDecisionVersionWithVersionTag(
-      final String decisionId, final Expression versionTag, final String tenantId) {
-    if (versionTag == null) {
-      return Either.left(
-          new Failure(
-              "Expected a version tag expression but none was provided for decision '%s'."
-                  .formatted(decisionId)));
-    }
-    if (!versionTag.isStatic()) {
-      // TODO(#52910): evaluate versionTag expression against process instance variables
-      return Either.left(
-          new Failure(
-              "Dynamic version tag expressions are not yet supported for decision '%s'."
-                  .formatted(decisionId)));
-    }
-    return decisionBehavior.findDecisionByIdAndVersionTagAndTenant(
-        decisionId, versionTag.getExpression(), tenantId);
+      final String decisionId,
+      final Expression versionTag,
+      final long scopeKey,
+      final String tenantId) {
+    return expressionBehavior
+        .evaluateStringExpression(versionTag, scopeKey, tenantId)
+        .flatMap(
+            evaluatedVersionTag ->
+                decisionBehavior.findDecisionByIdAndVersionTagAndTenant(
+                    decisionId, evaluatedVersionTag, tenantId));
   }
 
   private Either<Failure, String> evalDecisionIdExpression(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -921,4 +921,82 @@ public final class BusinessRuleTaskTest {
                 .getValue())
         .hasValue("\"EXPRESS\"");
   }
+
+  @Test
+  public void shouldCallLatestDecisionVersion() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlClasspathResource(DMN_DECISION_TABLE_V2)
+            .withXmlResource(
+                processWithBusinessRuleTask(
+                    t ->
+                        t.zeebeCalledDecisionId("jedi_or_sith")
+                            .zeebeBindingType(ZeebeBindingType.latest)
+                            .zeebeResultVariable(RESULT_VARIABLE)))
+            .deploy();
+    final var latestDecision = deployment.getValue().getDecisionsMetadata().getFirst();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    // then
+    final var decisionEvaluationRecord =
+        RecordingExporter.decisionEvaluationRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(decisionEvaluationRecord.getValue())
+        .hasDecisionId("jedi_or_sith")
+        .hasDecisionKey(latestDecision.getDecisionKey())
+        .hasDecisionVersion(latestDecision.getVersion());
+  }
+
+  @Test
+  public void shouldCallDecisionWithDynamicVersionTagExpression() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource(DMN_DECISION_TABLE_WITH_VERSION_TAG_V1)
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                t ->
+                    t.zeebeCalledDecisionId("jedi_or_sith")
+                        .zeebeBindingType(ZeebeBindingType.versionTag)
+                        .zeebeVersionTagExpression("versionTagVariable")
+                        .zeebeResultVariable(RESULT_VARIABLE)))
+        .deploy();
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlClasspathResource(DMN_DECISION_TABLE_WITH_VERSION_TAG_V1_NEW)
+            .deploy();
+    ENGINE.deployment().withXmlClasspathResource(DMN_DECISION_TABLE_WITH_VERSION_TAG_V2).deploy();
+    final var deployedDecisionV1New = deployment.getValue().getDecisionsMetadata().getFirst();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(
+                Map.ofEntries(
+                    Map.entry("versionTagVariable", "v1.0"), Map.entry("lightsaberColor", "blue")))
+            .create();
+
+    // then
+    final var decisionEvaluationRecord =
+        RecordingExporter.decisionEvaluationRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(decisionEvaluationRecord.getValue())
+        .hasDecisionId("jedi_or_sith")
+        .hasDecisionKey(deployedDecisionV1New.getDecisionKey())
+        .hasDecisionVersion(deployedDecisionV1New.getVersion());
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
@@ -528,4 +528,40 @@ public class BusinessRuleTaskIncidentTest {
         .isTrue();
     assertIncidentCreated(processInstanceKey, taskActivating.getKey(), tenantId);
   }
+
+  @Test
+  public void shouldCreateIncidentIfVersionTagExpressionEvaluationFailed() {
+    // given
+    engine
+        .deployment()
+        .withXmlClasspathResource(DMN_RESOURCE)
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                b ->
+                    b.zeebeCalledDecisionId(DECISION_ID)
+                        .zeebeBindingType(ZeebeBindingType.versionTag)
+                        .zeebeVersionTagExpression("versionTagVariable")
+                        .zeebeResultVariable(RESULT_VARIABLE)))
+        .deploy();
+
+    // when — no versionTagVariable set, expression evaluation fails
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var taskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, taskActivating.getKey())
+        .hasErrorType(ErrorType.CALLED_DECISION_ERROR)
+        .hasErrorMessage(
+            """
+            Expected result of the expression 'versionTagVariable' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'versionTagVariable'\
+            """);
+  }
 }


### PR DESCRIPTION
## Summary

- Version tag on business rule tasks can now be a dynamic FEEL expression evaluated against process instance variables at runtime
- Adds regression test confirming `latest` binding types are unaffected, and a new test for dynamic version tag resolution from a process variable
- Removed the null-guard as suggested in a previous review because `ZeebeBindingTypeValidator#checkValidBindingTypeAndVersionTag` already rejects this case (and we will add more validation with the next issue implementation)

Closes #52910