### PR TITLE
fix: input mapping sync local keys

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -102,37 +102,28 @@ public final class VariableMappingTransformer {
 
   private Expression buildLocalInputMappingExpression(
       final List<Mapping> mappings, final ExpressionLanguage expressionLanguage) {
-    return buildIncrementalMappingExpression(mappings, expressionLanguage, INPUT_RESULT_CONTEXT);
+    return buildIncrementalMappingExpression(
+        mappings, expressionLanguage, INPUT_RESULT_CONTEXT, true);
   }
 
   private Expression buildLocalOutputMappingExpression(
       final List<Mapping> mappings, final ExpressionLanguage expressionLanguage) {
-    return buildIncrementalMappingExpression(mappings, expressionLanguage, OUTPUT_RESULT_CONTEXT);
+    return buildIncrementalMappingExpression(
+        mappings, expressionLanguage, OUTPUT_RESULT_CONTEXT, false);
   }
 
   /**
-   * Builds an incremental mapping expression using {@code context put()}.
-   *
-   * <p>Each mapping first assigns the source expression to a local variable (so that subsequent
-   * mappings can reference it), then adds that variable to the accumulating result context.
-   *
-   * <p>This approach ensures:
-   *
-   * <ul>
-   *   <li>Mappings are evaluated in definition order
-   *   <li>Subsequent mappings can reference variables from previous mappings
-   *   <li>Nested target paths are handled correctly without premature evaluation
-   * </ul>
-   *
-   * @param mappings the list of mappings to process
-   * @param expressionLanguage the expression language to parse the result
-   * @param resultContextName the name of the accumulator context variable
-   * @return the parsed expression
+   * Builds a FEEL context expression that evaluates all mappings in order and returns the
+   * accumulated result. Each mapping is assigned to a local variable first, then added to the
+   * result via {@code context put()}. When {@code syncLocalKeys} is {@code true}, the top-level
+   * parent local variable is also updated after each nested-path assignment so that later mappings
+   * can reference it by path (e.g. {@code =a.b}).
    */
   private Expression buildIncrementalMappingExpression(
       final List<Mapping> mappings,
       final ExpressionLanguage expressionLanguage,
-      final String resultContextName) {
+      final String resultContextName,
+      final boolean syncLocalKeys) {
 
     if (mappings.isEmpty()) {
       return parseExpression("{}", expressionLanguage);
@@ -166,6 +157,12 @@ public final class VariableMappingTransformer {
         sb.append(
             String.format(
                 "%s:context put(%s,[%s],%s)", resultContextName, base, pathList, targetName));
+        // Re-sync the top-level parent so subsequent source expressions can traverse the
+        // nested path without hitting the stale scalar local variable.
+        if (syncLocalKeys) {
+          final var parentName = parts.getFirst();
+          sb.append(String.format(",%s:%s.%s", parentName, resultContextName, parentName));
+        }
       }
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
+import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.Either;
 import java.time.InstantSource;
 import java.util.List;
@@ -142,6 +143,28 @@ public final class VariableMappingTransformerTest {
     assertThat(result.getExpression())
         .isEqualTo(
             "{a:null,_camunda_input_context:context put({},\"a\",a)}._camunda_input_context");
+  }
+
+  @Test
+  public void shouldResolveNestedTargetPathInSubsequentInputSourceExpression() {
+    // given — "a" is mapped first, then nested "a.b" is set, then "c" uses "a.b" as source
+    final var mappings =
+        List.of(
+            mapping("=\"placeholder\"", "a"),
+            mapping("={\"key\":\"value\"}", "a.b"),
+            mapping("=a.b", "c"));
+    final var expression = transformer.transformInputMappings(mappings, expressionLanguage);
+
+    // when
+    final var result = expressionLanguage.evaluateExpression(expression, name -> Either.left(null));
+
+    // then
+    assertThat(result.isFailure())
+        .describedAs("Expected valid result: %s", result.getFailureMessage())
+        .isFalse();
+    assertThat(result.getType()).isEqualTo(ResultType.OBJECT);
+    MsgPackUtil.assertEquality(
+        result.toBuffer(), "{'a':{'b':{'key':'value'}},'c':{'key':'value'}}");
   }
 
   private static ZeebeMapping mapping(final String source, final String target) {


### PR DESCRIPTION
## Description

Implement a synchronization mechanism in `VariableMappingTransformer` behind a `syncLocalKeys` boolean flag (enabled for input mappings only, since output mapping semantics differ).

### Validation

Covered by:

- `VariableMappingTransformerTest#shouldResolveNestedTargetPathInSubsequentInputSourceExpression`

Verified against the full parameterized:

- `VariableInputMappingTransformerTest` suite

### Tested Scenarios

All 22 existing test cases pass, including:

- `a.b` followed by `a.c` sibling mappings
- Deep nesting such as `a.b.c`
- Subsequent source expressions referencing previously mapped nested paths

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54945
