### PR TITLE
fix: prevent overflow menu button from being pushed off-screen with long entity names

### DIFF
--- a/identity/client/src/components/layout/PageHeadline.tsx
+++ b/identity/client/src/components/layout/PageHeadline.tsx
@@ -9,8 +9,10 @@
 import styled from "styled-components";
 
 const PageHeadline = styled.h1`
-  display: flex;
-  gap: var(--cds-spacing-04);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export default PageHeadline;


### PR DESCRIPTION
## Summary

- `PageHeadline` lacked `min-width: 0`, so as a flex item it never shrank below its text content's intrinsic width
- On the tenants, groups, roles, and users detail pages this caused the Edit/Delete overflow menu button to be pushed outside the viewport when the entity name was very long
- Replaces the unused `display: flex` / `gap` with `min-width: 0` + `text-overflow: ellipsis` so long names truncate in-place and the action button stays visible

Closes #54365

## Test plan

- [ ] Navigate to any entity detail page (tenants, groups, roles, or users)
- [ ] Edit the entity to give it a very long name (50+ characters)
- [ ] Verify the name truncates with `…` and the overflow menu button remains visible next to it
- [ ] Click the overflow menu button and confirm the dropdown renders fully within the viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)