### PR TITLE
fix: build zeebe-protocol from source before Optimize docker snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2263,6 +2263,10 @@ jobs:
         id: build-optimize-fe
         with:
           directory: ./optimize/client
+      - name: Build zeebe-protocol from source
+        uses: ./.github/actions/run-maven
+        with:
+          parameters: install -pl zeebe/protocol -Dquickly
       - name: Generate Optimize production .tar.gz
         uses: ./.github/actions/run-maven
         with:


### PR DESCRIPTION
## Problem

The `deploy-optimize-docker-snapshot` CI job was failing with a compilation error after PR #54592 ("support request source in record metadata") was merged:

```
Error: /home/runner/work/camunda/camunda/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java:[12,40] cannot find symbol
  symbol:   class ChannelType
  location: package io.camunda.zeebe.protocol.record
Error:  /home/runner/work/camunda/camunda/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java:[117,10] cannot find symbol
  symbol:   class ChannelType
  location: class io.camunda.optimize.dto.zeebe.ZeebeRecordDto<VALUE,INTENT>
Error:  /home/runner/work/camunda/camunda/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java:[116,3] method does not override or implement a method from a supertype
Error:  /home/runner/work/camunda/camunda/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java:[121,3] method does not override or implement a method from a supertype
```

## Root Cause

PR #54592 added `ChannelType` to the Zeebe SBE protocol (`protocol.xml`) and updated `Record.java` and `ZeebeRecordDto.java` to reference `io.camunda.zeebe.protocol.record.ChannelType`. This class is **SBE-generated** at build time from `zeebe/protocol/src/main/resources/protocol.xml` — it only exists in the `zeebe-protocol` JAR after the module is compiled.

The `deploy-optimize-docker-snapshot` CI job builds Optimize with:

```
./mvnw install -f optimize -DskipTests -Dskip.docker -PskipFrontendBuild,runAssembly -T1
```

Using `-f optimize` treats `optimize/pom.xml` as the Maven root. Maven resolves the `zeebe-protocol` dependency (declared as `${project.version}`, i.e. a SNAPSHOT) from its remote/cached SNAPSHOT repository — it does **not** rebuild `zeebe-protocol` from source.

Combined with the Maven caching strategy in this repo (`aether.enhancedLocalRepository.split=true`), the SNAPSHOT JAR downloaded by Maven was built **before** PR #54592 was merged and therefore does not contain the SBE-generated `ChannelType` class. The Optimize compilation then fails because `ChannelType` cannot be resolved.

## Fix

Add a Maven step before the Optimize build that installs `zeebe/protocol` from source:

```
./mvnw install -pl zeebe/protocol -Dquickly
```

This generates `ChannelType` via SBE and installs the fresh JAR into the local Maven repository. Maven's local repository takes precedence over remote SNAPSHOTs, so the subsequent Optimize build resolves the up-to-date `zeebe-protocol` JAR containing `ChannelType`.

## Alternatives Considered

- **Bust the Maven cache**: Changing the cache key would force a full re-download on every run — expensive and doesn't address the structural issue of `-f optimize` not rebuilding protocol from source.
- **Rebuild all dependencies with `-am`**: Using `-pl optimize -am` from the root POM would rebuild every transitive dependency, far exceeding what's needed and significantly increasing build time.
- **Hand-write `ChannelType.java`**: Duplicating the SBE enum as a hand-written Java class would conflict with the SBE-generated class at build time and create a maintenance burden.

https://claude.ai/code/session_011EH4TzJHheGmZ9NEtnPYCM

---
_Generated by [Claude Code](https://claude.ai/code/session_011EH4TzJHheGmZ9NEtnPYCM)_