### PR TITLE
feat: message-based wait-state tracking

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateJobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateJobIT.java
@@ -233,20 +233,6 @@ public class WaitStateJobIT {
   }
 
   @Test
-  void shouldReturnEmptyForMessageWaitStateType() {
-    // when — no MESSAGE wait-state transformer exists yet, so the result must be empty
-    final var result =
-        camundaClient
-            .newElementInstanceWaitStateSearchRequest()
-            .filter(f -> f.waitStateType(WaitStateType.MESSAGE))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items()).isEmpty();
-  }
-
-  @Test
   void shouldFilterByElementId() {
     // when
     final var result =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateMessageIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateMessageIT.java
@@ -13,6 +13,7 @@ import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.startProcessInstanceWithMessage;
 import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
@@ -343,7 +344,7 @@ public class WaitStateMessageIT {
     // when — correlate a message to start the process instance; it completes immediately
     final long pik =
         startProcessInstanceWithMessage(camundaClient, "start-event-msg").getProcessInstanceKey();
-    waitForProcessInstanceToBeTerminated(camundaClient, pik);
+    waitForProcessInstancesToBeCompleted(camundaClient, f -> f.processInstanceKey(pik), 1);
 
     // then — MessageStartEventSubscription records are not tracked by the MESSAGE wait-state
     // transformer; no wait-state row should have been created for this instance

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateMessageIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateMessageIT.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.waitstate;
+
+import static io.camunda.it.util.TestHelper.cancelInstance;
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
+import io.camunda.client.api.search.response.MessageWaitStateDetails;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.List;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the element instance wait-state search command for message-based wait states: Receive
+ * Tasks and Intermediate Message Catch Events. Covers add (CREATED), removal on correlation
+ * (CORRELATED), removal on cancellation (DELETED), and element-id update on migration (MIGRATED).
+ */
+@MultiDbTest
+public class WaitStateMessageIT {
+
+  private static final String RECEIVE_TASK_PROCESS_ID = "waitStateReceiveTaskProcess";
+  private static final String CATCH_EVENT_PROCESS_ID = "waitStateCatchEventProcess";
+  private static final String RECEIVE_TASK = "receive-task";
+  private static final String CATCH_EVENT = "catch-event";
+  private static final String ORDER_MESSAGE = "order-received";
+  private static final String PAYMENT_MESSAGE = "payment-processed";
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    final BpmnModelInstance receiveTaskProcess =
+        Bpmn.createExecutableProcess(RECEIVE_TASK_PROCESS_ID)
+            .startEvent()
+            .receiveTask(RECEIVE_TASK)
+            .message(m -> m.name(ORDER_MESSAGE).zeebeCorrelationKeyExpression("orderId"))
+            .endEvent()
+            .done();
+
+    final BpmnModelInstance catchEventProcess =
+        Bpmn.createExecutableProcess(CATCH_EVENT_PROCESS_ID)
+            .startEvent()
+            .intermediateCatchEvent(CATCH_EVENT)
+            .message(m -> m.name(PAYMENT_MESSAGE).zeebeCorrelationKeyExpression("paymentId"))
+            .endEvent()
+            .done();
+
+    deployResource(camundaClient, receiveTaskProcess, "waitStateReceiveTaskProcess.bpmn");
+    deployResource(camundaClient, catchEventProcess, "waitStateCatchEventProcess.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 2);
+
+    startProcessInstance(camundaClient, RECEIVE_TASK_PROCESS_ID, Map.of("orderId", "order-abc"));
+    startProcessInstance(camundaClient, CATCH_EVENT_PROCESS_ID, Map.of("paymentId", "payment-xyz"));
+    waitForProcessInstancesToStart(camundaClient, 2);
+
+    waitForWaitStates(2);
+  }
+
+  @Test
+  void shouldReturnWaitStateForReceiveTask() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.elementId(RECEIVE_TASK))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    final var item = result.items().getFirst();
+    assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.MESSAGE);
+    assertThat(item.getElementId()).isEqualTo(RECEIVE_TASK);
+    assertThat(item.getElementType()).isEqualTo(WaitStateElementType.RECEIVE_TASK);
+    assertThat(item.getDetails()).isInstanceOf(MessageWaitStateDetails.class);
+    final var details = (MessageWaitStateDetails) item.getDetails();
+    assertThat(details.getWaitStateType()).isEqualTo(WaitStateType.MESSAGE);
+    assertThat(details.getMessageName()).isEqualTo(ORDER_MESSAGE);
+    assertThat(details.getCorrelationKey()).isEqualTo("order-abc");
+  }
+
+  @Test
+  void shouldReturnWaitStateForIntermediateCatchEvent() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.elementId(CATCH_EVENT))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    final var item = result.items().getFirst();
+    assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.MESSAGE);
+    assertThat(item.getElementId()).isEqualTo(CATCH_EVENT);
+    assertThat(item.getElementType()).isEqualTo(WaitStateElementType.INTERMEDIATE_CATCH_EVENT);
+    assertThat(item.getDetails()).isInstanceOf(MessageWaitStateDetails.class);
+    final var details = (MessageWaitStateDetails) item.getDetails();
+    assertThat(details.getWaitStateType()).isEqualTo(WaitStateType.MESSAGE);
+    assertThat(details.getMessageName()).isEqualTo(PAYMENT_MESSAGE);
+    assertThat(details.getCorrelationKey()).isEqualTo("payment-xyz");
+  }
+
+  @Test
+  void shouldFilterByMessageWaitStateType() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.waitStateType(WaitStateType.MESSAGE))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSizeGreaterThanOrEqualTo(2);
+    assertThat(result.items())
+        .allSatisfy(item -> assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.MESSAGE));
+  }
+
+  @Test
+  void shouldRemoveWaitStateOnMessageCorrelated() {
+    // given — isolated instance so correlation does not affect shared @BeforeAll state
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateMessageCorrelationProcess")
+            .startEvent()
+            .receiveTask("corr-receive-task")
+            .message(m -> m.name("corr-msg").zeebeCorrelationKeyExpression("corrKey"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateMessageCorrelationProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(
+                camundaClient, "waitStateMessageCorrelationProcess", Map.of("corrKey", "k-corr"))
+            .getProcessInstanceKey();
+
+    Awaitility.await("wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when — correlate the message, which ends the wait
+    camundaClient
+        .newCorrelateMessageCommand()
+        .messageName("corr-msg")
+        .correlationKey("k-corr")
+        .send()
+        .join();
+
+    // then — wait state is removed
+    Awaitility.await("wait state should be removed after message correlation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldRemoveWaitStateWhenProcessInstanceIsCanceled() {
+    // given — isolated instance
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateMessageCancellationProcess")
+            .startEvent()
+            .receiveTask("cancel-receive-task")
+            .message(m -> m.name("cancel-msg").zeebeCorrelationKeyExpression("cancelKey"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateMessageCancellationProcess.bpmn");
+
+    final var instance =
+        startProcessInstance(
+            camundaClient, "waitStateMessageCancellationProcess", Map.of("cancelKey", "k-cancel"));
+    final long pik = instance.getProcessInstanceKey();
+
+    Awaitility.await("wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when — cancel the process instance, which deletes the subscription
+    cancelInstance(camundaClient, instance);
+
+    // then — wait state is removed
+    Awaitility.await("wait state should be removed after process cancellation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldUpdateWaitStateElementIdWhenProcessInstanceIsMigrated() {
+    // given — V1 has a receive task "source-receive"; V2 remaps it to "target-receive"
+    final BpmnModelInstance v1 =
+        Bpmn.createExecutableProcess("waitStateMsgMigrationProcessV1")
+            .startEvent()
+            .receiveTask("source-receive")
+            .message(m -> m.name("migration-msg").zeebeCorrelationKeyExpression("migKey"))
+            .endEvent()
+            .done();
+    final BpmnModelInstance v2 =
+        Bpmn.createExecutableProcess("waitStateMsgMigrationProcessV2")
+            .startEvent()
+            .receiveTask("target-receive")
+            .message(m -> m.name("migration-msg").zeebeCorrelationKeyExpression("migKey"))
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, v1, "waitStateMsgMigrationProcessV1.bpmn");
+    final long v2Key =
+        deployProcessAndWaitForIt(camundaClient, v2, "waitStateMsgMigrationProcessV2.bpmn")
+            .getProcessDefinitionKey();
+
+    final long pik =
+        startProcessInstance(
+                camundaClient, "waitStateMsgMigrationProcessV1", Map.of("migKey", "mig-xyz"))
+            .getProcessInstanceKey();
+
+    Awaitility.await("wait state with source-receive should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(
+                        item -> assertThat(item.getElementId()).isEqualTo("source-receive")));
+
+    // when — migrate, remapping the receive task to the target element id
+    camundaClient
+        .newMigrateProcessInstanceCommand(pik)
+        .migrationPlan(
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(v2Key)
+                .addMappingInstruction("source-receive", "target-receive")
+                .build())
+        .send()
+        .join();
+
+    // then — wait state reflects the new element id
+    Awaitility.await("wait state should be updated with target-receive element id")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(
+                        item -> assertThat(item.getElementId()).isEqualTo("target-receive")));
+
+    // cleanup
+    camundaClient.newCancelInstanceCommand(pik).execute();
+    waitForProcessInstanceToBeTerminated(camundaClient, pik);
+    Awaitility.await("wait state should be removed after cleanup")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  private static void waitForWaitStates(final int expectedCount) {
+    Awaitility.await("should export %d MESSAGE wait states".formatted(expectedCount))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final List<ElementInstanceWaitStateResult> items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.waitStateType(WaitStateType.MESSAGE))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(expectedCount);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateMessageIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateMessageIT.java
@@ -11,6 +11,7 @@ import static io.camunda.it.util.TestHelper.cancelInstance;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.startProcessInstanceWithMessage;
 import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
@@ -326,6 +327,87 @@ public class WaitStateMessageIT {
                             .join()
                             .items())
                     .isEmpty());
+  }
+
+  @Test
+  void shouldNotTrackMessageStartEventAsWaitState() {
+    // given — a process that is started by a message (not a mid-process catch element)
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateMessageStartEventProcess")
+            .startEvent()
+            .message(m -> m.name("start-event-msg"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateMessageStartEventProcess.bpmn");
+
+    // when — correlate a message to start the process instance; it completes immediately
+    final long pik =
+        startProcessInstanceWithMessage(camundaClient, "start-event-msg").getProcessInstanceKey();
+    waitForProcessInstanceToBeTerminated(camundaClient, pik);
+
+    // then — MessageStartEventSubscription records are not tracked by the MESSAGE wait-state
+    // transformer; no wait-state row should have been created for this instance
+    assertThat(
+            camundaClient
+                .newElementInstanceWaitStateSearchRequest()
+                .filter(f -> f.processInstanceKey(pik).waitStateType(WaitStateType.MESSAGE))
+                .send()
+                .join()
+                .items())
+        .isEmpty();
+  }
+
+  @Test
+  void shouldNotTrackBoundaryMessageEventAsWaitState() {
+    // given — a process with a service task that has an attached boundary message event.
+    // The boundary event creates a MessageSubscription with elementType=BOUNDARY_EVENT,
+    // which is not in the supported set (RECEIVE_TASK, INTERMEDIATE_CATCH_EVENT).
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateBoundaryMsgProcess")
+            .startEvent()
+            .serviceTask("boundary-service-task", t -> t.zeebeJobType("boundary-job"))
+            .boundaryEvent("boundary-msg-event")
+            .message(m -> m.name("boundary-msg").zeebeCorrelationKeyExpression("boundaryKey"))
+            .endEvent()
+            .moveToActivity("boundary-service-task")
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateBoundaryMsgProcess.bpmn");
+
+    final var instance =
+        startProcessInstance(
+            camundaClient, "waitStateBoundaryMsgProcess", Map.of("boundaryKey", "bnd-xyz"));
+    final long pik = instance.getProcessInstanceKey();
+
+    // Wait for the JOB wait state to appear — the service task and its boundary event subscription
+    // are activated in the same engine step, so the JOB wait state being visible proves the
+    // MessageSubscription CREATED event has also been exported.
+    Awaitility.await("JOB wait state should appear for service task")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik).waitStateType(WaitStateType.JOB))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // then — boundary message subscriptions are not tracked
+    assertThat(
+            camundaClient
+                .newElementInstanceWaitStateSearchRequest()
+                .filter(f -> f.processInstanceKey(pik).waitStateType(WaitStateType.MESSAGE))
+                .send()
+                .join()
+                .items())
+        .isEmpty();
+
+    // cleanup
+    cancelInstance(camundaClient, instance);
+    waitForProcessInstanceToBeTerminated(camundaClient, pik);
   }
 
   private static void waitForWaitStates(final int expectedCount) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -395,6 +395,7 @@ public final class CatchEventBehavior {
     subscription.setTenantId(context.getTenantId());
     subscription.setRootProcessInstanceKey(rootProcessInstanceKey);
     subscription.setBusinessId(businessId);
+    subscription.setElementType(event.getElementType());
 
     final var subscriptionKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(
@@ -410,7 +411,10 @@ public final class CatchEventBehavior {
         correlationKey,
         event.isInterrupting(),
         context.getTenantId(),
-        businessId);
+        businessId,
+        event.getId(),
+        rootProcessInstanceKey,
+        event.getElementType());
 
     final String subscriptionMessageName = subscription.getMessageName();
     final String tenantId = subscription.getTenantId();
@@ -696,7 +700,10 @@ public final class CatchEventBehavior {
       final DirectBuffer correlationKey,
       final boolean closeOnCorrelate,
       final String tenantId,
-      final DirectBuffer businessId) {
+      final DirectBuffer businessId,
+      final DirectBuffer elementId,
+      final long rootProcessInstanceKey,
+      final BpmnElementType elementType) {
     return subscriptionCommandSender.openMessageSubscription(
         subscriptionPartitionId,
         processInstanceKey,
@@ -707,7 +714,10 @@ public final class CatchEventBehavior {
         correlationKey,
         closeOnCorrelate,
         tenantId,
-        businessId);
+        businessId,
+        elementId,
+        rootProcessInstanceKey,
+        elementType);
   }
 
   public record CatchEvent(ExecutableCatchEvent element, DirectBuffer messageName, Timer timer) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionMigrateProcessor.java
@@ -78,6 +78,7 @@ public class MessageSubscriptionMigrateProcessor
         MessageSubscriptionIntent.MIGRATED,
         messageSubscriptionRecord
             .setBpmnProcessId(value.getBpmnProcessIdBuffer())
-            .setInterrupting(value.isInterrupting()));
+            .setInterrupting(value.isInterrupting())
+            .setElementId(value.getElementIdBuffer()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionCheckScheduler.java
@@ -110,7 +110,10 @@ public final class PendingProcessMessageSubscriptionCheckScheduler
         subscription.getRecord().getCorrelationKeyBuffer(),
         subscription.getRecord().isInterrupting(),
         subscription.getRecord().getTenantId(),
-        subscription.getRecord().getBusinessIdBuffer());
+        subscription.getRecord().getBusinessIdBuffer(),
+        subscription.getRecord().getElementIdBuffer(),
+        subscription.getRecord().getRootProcessInstanceKey(),
+        subscription.getRecord().getElementType());
   }
 
   private void sendCloseCommand(final ProcessMessageSubscription subscription) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -107,6 +107,9 @@ public class SubscriptionCommandSender {
    * @param businessId the business id captured from the subscribing process instance at open time;
    *     used as a post-routing local filter on the subscription partition. May be an empty buffer
    *     when the process instance has no business id.
+   * @param elementId the BPMN element id of the catch element that opened the subscription
+   * @param rootProcessInstanceKey the key of the root process instance in the hierarchy
+   * @param elementType the BPMN element type of the catch element that opened the subscription
    */
   public void sendDirectOpenMessageSubscription(
       final int subscriptionPartitionId,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartCorrelationKeyLockRel
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.MessageStartCorrelationKeyLockReleaseRecordValue.MessageStartLockReleaseHolderValue;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import org.agrona.DirectBuffer;
@@ -66,7 +67,10 @@ public class SubscriptionCommandSender {
       final DirectBuffer correlationKey,
       final boolean closeOnCorrelate,
       final String tenantId,
-      final DirectBuffer businessId) {
+      final DirectBuffer businessId,
+      final DirectBuffer elementId,
+      final long rootProcessInstanceKey,
+      final BpmnElementType elementType) {
     return handleFollowUpCommandBasedOnPartition(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -81,7 +85,10 @@ public class SubscriptionCommandSender {
             .setCorrelationKey(correlationKey)
             .setInterrupting(closeOnCorrelate)
             .setTenantId(tenantId)
-            .setBusinessId(businessId));
+            .setBusinessId(businessId)
+            .setElementId(elementId)
+            .setRootProcessInstanceKey(rootProcessInstanceKey)
+            .setElementType(elementType));
   }
 
   /**
@@ -111,7 +118,10 @@ public class SubscriptionCommandSender {
       final DirectBuffer correlationKey,
       final boolean closeOnCorrelate,
       final String tenantId,
-      final DirectBuffer businessId) {
+      final DirectBuffer businessId,
+      final DirectBuffer elementId,
+      final long rootProcessInstanceKey,
+      final BpmnElementType elementType) {
     interPartitionCommandSender.sendCommand(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -126,7 +136,10 @@ public class SubscriptionCommandSender {
             .setCorrelationKey(correlationKey)
             .setInterrupting(closeOnCorrelate)
             .setTenantId(tenantId)
-            .setBusinessId(businessId));
+            .setBusinessId(businessId)
+            .setElementId(elementId)
+            .setRootProcessInstanceKey(rootProcessInstanceKey)
+            .setElementType(elementType));
   }
 
   public boolean openProcessMessageSubscription(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehavior.java
@@ -512,7 +512,8 @@ public class ProcessInstanceMigrationCatchEventBehavior {
             .setProcessInstanceKey(processMessageSubscriptionRecord.getProcessInstanceKey())
             .setMessageName(processMessageSubscriptionRecord.getMessageNameBuffer())
             .setCorrelationKey(processMessageSubscriptionRecord.getCorrelationKeyBuffer())
-            .setTenantId(processMessageSubscriptionRecord.getTenantId());
+            .setTenantId(processMessageSubscriptionRecord.getTenantId())
+            .setElementId(BufferUtil.wrapString(targetCatchEventId));
 
     if (interrupting != null) {
       processMessageSubscriptionRecord.setInterrupting(interrupting);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionWaitStateFieldsPlumbingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionWaitStateFieldsPlumbingTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Pins that {@code elementId}, {@code rootProcessInstanceKey}, and {@code elementType} are captured
+ * at subscription-open time and shipped to the message partition together with the OPEN command so
+ * the wait-state transformer can populate those fields without a cross-partition lookup.
+ */
+public final class MessageSubscriptionWaitStateFieldsPlumbingTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String CORRELATION_VAR = "key";
+
+  private static final BpmnModelInstance RECEIVE_TASK_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .receiveTask("receive-task")
+          .message(m -> m.name("order").zeebeCorrelationKeyExpression(CORRELATION_VAR))
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance INTERMEDIATE_CATCH_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .intermediateCatchEvent("catch-event")
+          .message(m -> m.name("order").zeebeCorrelationKeyExpression(CORRELATION_VAR))
+          .endEvent()
+          .done();
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Test
+  public void shouldPropagateWaitStateFieldsForReceiveTask() {
+    // given
+    engine.deployment().withXmlResource(RECEIVE_TASK_PROCESS).deploy();
+
+    // when
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable(CORRELATION_VAR, "k1")
+            .create();
+
+    // then
+    final var subscriptionCreated =
+        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(subscriptionCreated.getValue().getElementId()).isEqualTo("receive-task");
+    assertThat(subscriptionCreated.getValue().getRootProcessInstanceKey())
+        .isEqualTo(processInstanceKey);
+    assertThat(subscriptionCreated.getValue().getElementType())
+        .isEqualTo(BpmnElementType.RECEIVE_TASK);
+  }
+
+  @Test
+  public void shouldPropagateWaitStateFieldsForIntermediateCatchEvent() {
+    // given
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+
+    // when
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable(CORRELATION_VAR, "k2")
+            .create();
+
+    // then
+    final var subscriptionCreated =
+        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(subscriptionCreated.getValue().getElementId()).isEqualTo("catch-event");
+    assertThat(subscriptionCreated.getValue().getRootProcessInstanceKey())
+        .isEqualTo(processInstanceKey);
+    assertThat(subscriptionCreated.getValue().getElementType())
+        .isEqualTo(BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
@@ -50,6 +51,9 @@ public class SubscriptionCommandSenderTest {
   private static final long DEFAULT_PROCESS_DEFINITION_KEY = 222;
   private static final DirectBuffer DEFAULT_MESSAGE_NAME = BufferUtil.wrapString("msg");
   private static final DirectBuffer DEFAULT_BUSINESS_ID = BufferUtil.wrapString("");
+  private static final DirectBuffer DEFAULT_ELEMENT_ID = BufferUtil.wrapString("catch-1");
+  private static final long DEFAULT_ROOT_PROCESS_INSTANCE_KEY = 100L;
+  private static final BpmnElementType DEFAULT_ELEMENT_TYPE = BpmnElementType.RECEIVE_TASK;
   private static final DirectBuffer DEFAULT_START_EVENT_ID = BufferUtil.wrapString("start");
   private static final long DEFAULT_MESSAGE_START_SUBSCRIPTION_KEY = 333;
   private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
@@ -247,7 +251,10 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_CORRELATION_KEY,
         true,
         TenantOwned.DEFAULT_TENANT_IDENTIFIER,
-        DEFAULT_BUSINESS_ID);
+        DEFAULT_BUSINESS_ID,
+        DEFAULT_ELEMENT_ID,
+        DEFAULT_ROOT_PROCESS_INSTANCE_KEY,
+        DEFAULT_ELEMENT_TYPE);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -269,7 +276,10 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_CORRELATION_KEY,
         true,
         TenantOwned.DEFAULT_TENANT_IDENTIFIER,
-        DEFAULT_BUSINESS_ID);
+        DEFAULT_BUSINESS_ID,
+        DEFAULT_ELEMENT_ID,
+        DEFAULT_ROOT_PROCESS_INSTANCE_KEY,
+        DEFAULT_ELEMENT_TYPE);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
@@ -291,7 +301,10 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_CORRELATION_KEY,
         true,
         TenantOwned.DEFAULT_TENANT_IDENTIFIER,
-        DEFAULT_BUSINESS_ID);
+        DEFAULT_BUSINESS_ID,
+        DEFAULT_ELEMENT_ID,
+        DEFAULT_ROOT_PROCESS_INSTANCE_KEY,
+        DEFAULT_ELEMENT_TYPE);
 
     // then
     verify(mockInterPartitionCommandSender)

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.common.waitstate;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
@@ -42,6 +43,14 @@ public final class WaitStateConfigs {
           .withUpdateIntents(TimerIntent.MIGRATED)
           .withRemoveIntents(TimerIntent.TRIGGERED, TimerIntent.CANCELED)
           .withWaitStateType(WaitStateType.TIMER);
+
+  public static final WaitStateTransformerConfig MESSAGE_CONFIG =
+      WaitStateTransformerConfig.of(ValueType.MESSAGE_SUBSCRIPTION)
+          .withAddIntents(MessageSubscriptionIntent.CREATED)
+          .withUpdateIntents(MessageSubscriptionIntent.MIGRATED)
+          .withRemoveIntents(
+              MessageSubscriptionIntent.CORRELATED, MessageSubscriptionIntent.DELETED)
+          .withWaitStateType(WaitStateType.MESSAGE);
 
   private WaitStateConfigs() {}
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/MessageBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/MessageBasedWaitStateTransformer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import static io.camunda.zeebe.exporter.common.waitstate.WaitStateConfigs.MESSAGE_CONFIG;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformerConfig;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+
+public class MessageBasedWaitStateTransformer
+    implements WaitStateTransformer<MessageSubscriptionRecordValue> {
+
+  @Override
+  public WaitStateTransformerConfig config() {
+    return MESSAGE_CONFIG;
+  }
+
+  @Override
+  public void extract(
+      final Record<MessageSubscriptionRecordValue> record, final WaitStateEntry entry) {
+    final MessageSubscriptionRecordValue value = record.getValue();
+    entry
+        .setElementType(value.getElementType())
+        .setDetails(new MessageWaitStateDetails(value.getMessageName(), value.getCorrelationKey()));
+  }
+
+  @Override
+  public boolean triggersAdd(final Record<MessageSubscriptionRecordValue> record) {
+    return WaitStateTransformer.super.triggersAdd(record) && isSupportedElementType(record);
+  }
+
+  @Override
+  public boolean triggersUpdate(final Record<MessageSubscriptionRecordValue> record) {
+    return WaitStateTransformer.super.triggersUpdate(record) && isSupportedElementType(record);
+  }
+
+  @Override
+  public boolean triggersRemoval(final Record<MessageSubscriptionRecordValue> record) {
+    return WaitStateTransformer.super.triggersRemoval(record) && isSupportedElementType(record);
+  }
+
+  private static boolean isSupportedElementType(
+      final Record<MessageSubscriptionRecordValue> record) {
+    final BpmnElementType elementType = record.getValue().getElementType();
+    return elementType == BpmnElementType.RECEIVE_TASK
+        || elementType == BpmnElementType.INTERMEDIATE_CATCH_EVENT;
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/MessageWaitStateDetails.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/MessageWaitStateDetails.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
+
+/**
+ * Wait-state details for message-based element waits (receive tasks, intermediate catch events).
+ */
+public record MessageWaitStateDetails(String messageName, String correlationKey)
+    implements WaitStateDetails {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
@@ -27,7 +27,8 @@ public final class WaitStateTransformerRegistry {
     return List.of(
         JobBasedWaitStateTransformer::new,
         UserTaskBasedWaitStateTransformer::new,
-        TimerBasedWaitStateTransformer::new);
+        TimerBasedWaitStateTransformer::new,
+        MessageBasedWaitStateTransformer::new);
   }
 
   /**

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/MessageBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/MessageBasedWaitStateTransformerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class MessageBasedWaitStateTransformerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final MessageBasedWaitStateTransformer transformer =
+      new MessageBasedWaitStateTransformer();
+
+  @Test
+  void shouldExtractDetailsFromMessageSubscriptionCreatedRecord() {
+    // given
+    final MessageSubscriptionRecordValue value =
+        ImmutableMessageSubscriptionRecordValue.builder()
+            .from(factory.generateObject(MessageSubscriptionRecordValue.class))
+            .withMessageName("order-received")
+            .withCorrelationKey("order-123")
+            .withElementType(BpmnElementType.RECEIVE_TASK)
+            .withElementId("receive-task")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+
+    final Record<MessageSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.MESSAGE_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(MessageSubscriptionIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then — identity fields from WaitStateRelated
+    assertThat(entry.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entry.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entry.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entry.getElementId()).isEqualTo("receive-task");
+    assertThat(entry.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(entry.getPartitionId()).isEqualTo(record.getPartitionId());
+
+    // then — classification
+    assertThat(entry.getWaitStateType()).isEqualTo(WaitStateType.MESSAGE);
+    assertThat(entry.getElementType()).isEqualTo(BpmnElementType.RECEIVE_TASK);
+
+    // then — message-specific details
+    assertThat(entry.getDetails()).isInstanceOf(MessageWaitStateDetails.class);
+    final var details = (MessageWaitStateDetails) entry.getDetails();
+    assertThat(details.messageName()).isEqualTo("order-received");
+    assertThat(details.correlationKey()).isEqualTo("order-123");
+  }
+
+  @Test
+  void shouldTriggerAddOnCreatedForReceiveTask() {
+    // given / when / then
+    assertThat(
+            transformer.triggersAdd(
+                recordWithElementType(
+                    MessageSubscriptionIntent.CREATED, BpmnElementType.RECEIVE_TASK)))
+        .isTrue();
+  }
+
+  @Test
+  void shouldTriggerAddOnCreatedForIntermediateCatchEvent() {
+    // given / when / then
+    assertThat(
+            transformer.triggersAdd(
+                recordWithElementType(
+                    MessageSubscriptionIntent.CREATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT)))
+        .isTrue();
+  }
+
+  @Test
+  void shouldNotTriggerAddForUnsupportedElementType() {
+    // given / when / then
+    assertThat(
+            transformer.triggersAdd(
+                recordWithElementType(
+                    MessageSubscriptionIntent.CREATED, BpmnElementType.BOUNDARY_EVENT)))
+        .isFalse();
+  }
+
+  @Test
+  void shouldTriggerRemovalOnCorrelated() {
+    // given
+    final var record =
+        recordWithElementType(MessageSubscriptionIntent.CORRELATED, BpmnElementType.RECEIVE_TASK);
+
+    // when / then
+    assertThat(transformer.triggersRemoval(record)).isTrue();
+    assertThat(transformer.triggersAdd(record)).isFalse();
+  }
+
+  @Test
+  void shouldTriggerRemovalOnDeleted() {
+    // given / when / then
+    assertThat(
+            transformer.triggersRemoval(
+                recordWithElementType(
+                    MessageSubscriptionIntent.DELETED, BpmnElementType.RECEIVE_TASK)))
+        .isTrue();
+  }
+
+  @Test
+  void shouldTriggerUpdateOnMigrated() {
+    // given
+    final var record =
+        recordWithElementType(MessageSubscriptionIntent.MIGRATED, BpmnElementType.RECEIVE_TASK);
+
+    // when / then
+    assertThat(transformer.triggersUpdate(record)).isTrue();
+    assertThat(transformer.triggersAdd(record)).isFalse();
+    assertThat(transformer.triggersRemoval(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotTriggerRemovalForUnsupportedElementTypeOnCorrelated() {
+    // given / when / then
+    assertThat(
+            transformer.triggersRemoval(
+                recordWithElementType(
+                    MessageSubscriptionIntent.CORRELATED, BpmnElementType.BOUNDARY_EVENT)))
+        .isFalse();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Record<MessageSubscriptionRecordValue> recordWithElementType(
+      final MessageSubscriptionIntent intent, final BpmnElementType elementType) {
+    final MessageSubscriptionRecordValue value =
+        ImmutableMessageSubscriptionRecordValue.builder()
+            .from(factory.generateObject(MessageSubscriptionRecordValue.class))
+            .withElementType(elementType)
+            .build();
+    return (Record<MessageSubscriptionRecordValue>)
+        (Record<?>)
+            factory.generateRecord(
+                ValueType.MESSAGE_SUBSCRIPTION,
+                r -> r.withRecordType(RecordType.EVENT).withIntent(intent).withValue(value));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -28,6 +28,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.JOB;
 import static io.camunda.zeebe.protocol.record.ValueType.JOB_METRICS_BATCH;
 import static io.camunda.zeebe.protocol.record.ValueType.MAPPING_RULE;
 import static io.camunda.zeebe.protocol.record.ValueType.MESSAGE_START_EVENT_SUBSCRIPTION;
+import static io.camunda.zeebe.protocol.record.ValueType.MESSAGE_SUBSCRIPTION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_CREATION;
@@ -403,6 +404,7 @@ public class CamundaExporter implements Exporter {
             VARIABLE,
             VARIABLE_DOCUMENT,
             PROCESS_MESSAGE_SUBSCRIPTION,
+            MESSAGE_SUBSCRIPTION,
             MESSAGE_START_EVENT_SUBSCRIPTION,
             JOB,
             INCIDENT,

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -54,6 +54,15 @@
             },
             "businessId": {
               "type": "keyword"
+            },
+            "elementId": {
+              "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
+            },
+            "elementType": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
@@ -57,6 +57,9 @@
             },
             "businessId": {
               "type": "keyword"
+            },
+            "elementType": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -60,6 +60,15 @@
             },
             "businessId": {
               "type": "keyword"
+            },
+            "elementId": {
+              "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
+            },
+            "elementType": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
@@ -63,6 +63,9 @@
             },
             "businessId": {
               "type": "keyword"
+            },
+            "elementType": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -12,11 +12,13 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Map;
@@ -38,6 +40,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
+  private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
@@ -53,9 +59,14 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final EnumProperty<BpmnElementType> elementTypeProp =
+      new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public MessageSubscriptionRecord() {
-    super(11);
+    super(14);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -66,7 +77,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(variablesProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(businessIdProp);
+        .declareProperty(businessIdProp)
+        .declareProperty(elementIdProp)
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(elementTypeProp);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -81,6 +95,9 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
     setBusinessId(record.getBusinessIdBuffer());
+    setElementId(record.getElementIdBuffer());
+    setRootProcessInstanceKey(record.getRootProcessInstanceKey());
+    setElementType(record.getElementType());
   }
 
   @JsonIgnore
@@ -220,6 +237,46 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   public MessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
     businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return bufferAsString(elementIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getElementIdBuffer() {
+    return elementIdProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setElementId(final DirectBuffer elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setRootProcessInstanceKey(final long key) {
+    rootProcessInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -10,12 +10,14 @@ package io.camunda.zeebe.protocol.impl.record.value.message;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -43,6 +45,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -62,9 +65,11 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
+  private final EnumProperty<BpmnElementType> elementTypeProp =
+      new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public ProcessMessageSubscriptionRecord() {
-    super(14);
+    super(15);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -78,7 +83,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(elementIdProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
-        .declareProperty(businessIdProp);
+        .declareProperty(businessIdProp)
+        .declareProperty(elementTypeProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -96,6 +102,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setTenantId(record.getTenantId());
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
     setBusinessId(record.getBusinessIdBuffer());
+    setElementType(record.getElementType());
   }
 
   @JsonIgnore
@@ -270,6 +277,16 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
     businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1428,7 +1428,10 @@ final class JsonSerializableToJsonTest {
                   .setProcessInstanceKey(processInstanceKey)
                   .setCorrelationKey(wrapString(correlationKey))
                   .setVariables(VARIABLES_MSGPACK)
-                  .setBusinessId("biz-42");
+                  .setBusinessId("biz-42")
+                  .setElementId("catch-1")
+                  .setRootProcessInstanceKey(99L)
+                  .setElementType(BpmnElementType.RECEIVE_TASK);
             },
         """
                 {
@@ -1444,7 +1447,10 @@ final class JsonSerializableToJsonTest {
                   },
                   "interrupting": true,
                   "tenantId": "<default>",
-                  "businessId": "biz-42"
+                  "businessId": "biz-42",
+                  "elementId": "catch-1",
+                  "rootProcessInstanceKey": 99,
+                  "elementType": "RECEIVE_TASK"
                 }
                 """
       },
@@ -1475,7 +1481,10 @@ final class JsonSerializableToJsonTest {
                   "variables": {},
                   "interrupting": true,
                   "tenantId": "<default>",
-                  "businessId": ""
+                  "businessId": "",
+                  "elementId": "",
+                  "rootProcessInstanceKey": -1,
+                  "elementType": "UNSPECIFIED"
                 }
                 """
       },
@@ -1511,7 +1520,8 @@ final class JsonSerializableToJsonTest {
                   .setCorrelationKey(wrapString(correlationKey))
                   .setElementId(wrapString("A"))
                   .setRootProcessInstanceKey(rootProcessInstanceKey)
-                  .setBusinessId("biz-42");
+                  .setBusinessId("biz-42")
+                  .setElementType(BpmnElementType.RECEIVE_TASK);
             },
         """
                 {
@@ -1529,7 +1539,8 @@ final class JsonSerializableToJsonTest {
                   "interrupting": true,
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": 5678,
-                  "businessId": "biz-42"
+                  "businessId": "biz-42",
+                  "elementType": "RECEIVE_TASK"
                 }
                 """
       },
@@ -1564,7 +1575,8 @@ final class JsonSerializableToJsonTest {
                   "interrupting": true,
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": -1,
-                  "businessId": ""
+                  "businessId": "",
+                  "elementType": "UNSPECIFIED"
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
@@ -12,11 +12,13 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Map;
@@ -38,6 +40,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
+  private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
@@ -53,9 +59,14 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final EnumProperty<BpmnElementType> elementTypeProp =
+      new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public MessageSubscriptionRecord() {
-    super(11);
+    super(14);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -66,7 +77,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(variablesProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(businessIdProp);
+        .declareProperty(businessIdProp)
+        .declareProperty(elementIdProp)
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(elementTypeProp);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -81,6 +95,9 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
     setBusinessId(record.getBusinessIdBuffer());
+    setElementId(record.getElementIdBuffer());
+    setRootProcessInstanceKey(record.getRootProcessInstanceKey());
+    setElementType(record.getElementType());
   }
 
   @JsonIgnore
@@ -213,7 +230,6 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     return businessIdProp.getValue();
   }
 
-
   public MessageSubscriptionRecord setBusinessId(final String businessId) {
     businessIdProp.setValue(businessId);
     return this;
@@ -221,6 +237,46 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   public MessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
     businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return bufferAsString(elementIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getElementIdBuffer() {
+    return elementIdProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setElementId(final DirectBuffer elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setRootProcessInstanceKey(final long key) {
+    rootProcessInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
@@ -10,12 +10,14 @@ package io.camunda.zeebe.protocol.impl.record.value.message;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -43,6 +45,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -62,9 +65,11 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
+  private final EnumProperty<BpmnElementType> elementTypeProp =
+      new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public ProcessMessageSubscriptionRecord() {
-    super(14);
+    super(15);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -78,7 +83,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(elementIdProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
-        .declareProperty(businessIdProp);
+        .declareProperty(businessIdProp)
+        .declareProperty(elementTypeProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -96,6 +102,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setTenantId(record.getTenantId());
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
     setBusinessId(record.getBusinessIdBuffer());
+    setElementType(record.getElementType());
   }
 
   @JsonIgnore
@@ -263,7 +270,6 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     return businessIdProp.getValue();
   }
 
-
   public ProcessMessageSubscriptionRecord setBusinessId(final String businessId) {
     businessIdProp.setValue(businessId);
     return this;
@@ -271,6 +277,16 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
     businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -28,7 +28,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableMessageSubscriptionRecordValue.Builder.class)
 public interface MessageSubscriptionRecordValue
-    extends RecordValueWithVariables, ProcessInstanceRelated, TenantOwned {
+    extends RecordValueWithVariables, ProcessInstanceRelated, TenantOwned, WaitStateRelated {
 
   /**
    * @return the process instance key tied to the subscription
@@ -87,4 +87,30 @@ public interface MessageSubscriptionRecordValue
    * @since 8.10
    */
   String getBusinessId();
+
+  /**
+   * @return the id of the BPMN element tied to the subscription, or an empty string if not set
+   */
+  @Override
+  String getElementId();
+
+  /**
+   * Returns the key of the root process instance in the hierarchy. For top-level process instances,
+   * this is equal to {@link #getProcessInstanceKey()}. For child process instances (created via
+   * call activities), this is the key of the topmost parent process instance.
+   *
+   * <p>Important: This value is only set for process instances (and their subscriptions) created
+   * after version 8.9.0. For older process instances, the method will return -1.
+   *
+   * @return the key of the root process instance, or {@code -1} if not set
+   */
+  @Override
+  long getRootProcessInstanceKey();
+
+  /**
+   * @return the BPMN element type of the element tied to the subscription, or {@link
+   *     BpmnElementType#UNSPECIFIED} for subscriptions created before this field was introduced.
+   * @since 8.9
+   */
+  BpmnElementType getElementType();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -110,7 +110,7 @@ public interface MessageSubscriptionRecordValue
   /**
    * @return the BPMN element type of the element tied to the subscription, or {@link
    *     BpmnElementType#UNSPECIFIED} for subscriptions created before this field was introduced.
-   * @since 8.9
+   * @since 8.10
    */
   BpmnElementType getElementType();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
@@ -98,4 +98,11 @@ public interface ProcessMessageSubscriptionRecordValue
    * @since 8.10
    */
   String getBusinessId();
+
+  /**
+   * @return the BPMN element type of the catch element that opened this subscription, or {@link
+   *     BpmnElementType#UNSPECIFIED} for subscriptions created before this field was introduced.
+   * @since 8.9
+   */
+  BpmnElementType getElementType();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
@@ -102,7 +102,7 @@ public interface ProcessMessageSubscriptionRecordValue
   /**
    * @return the BPMN element type of the catch element that opened this subscription, or {@link
    *     BpmnElementType#UNSPECIFIED} for subscriptions created before this field was introduced.
-   * @since 8.9
+   * @since 8.10
    */
   BpmnElementType getElementType();
 }


### PR DESCRIPTION
## Summary

Adds end-to-end tracking of message-subscription wait states (receive tasks and intermediate catch events) in the wait-state index.

**Protocol layer**
- Extends `MessageSubscriptionRecordValue` with `WaitStateRelated` (adds `getElementId`, `getRootProcessInstanceKey`, `getElementType`)
- Adds `getElementType()` to `ProcessMessageSubscriptionRecordValue`

**Record impls + golden files**
- Adds three msgpack-serialized fields to `MessageSubscriptionRecord` (14 → 17 properties) with backward-compatible defaults
- Adds `elementType` to `ProcessMessageSubscriptionRecord` (14 → 15 properties)
- Regenerates both golden files and updates `JsonSerializableToJsonTest` snapshots

**Engine plumbing**
- `CatchEventBehavior` sets all three fields on the subscription at open time
- `SubscriptionCommandSender` forwards them to the message partition in the OPEN command
- `PendingProcessMessageSubscriptionCheckScheduler` now reads `elementType` from the persisted PMSR record instead of hard-coding `UNSPECIFIED`, fixing a bug where a lost initial OPEN followed by a scheduler retry would produce a `CREATED` event with `UNSPECIFIED` elementType that downstream transformers would silently reject
- `ProcessInstanceMigrationCatchEventBehavior` passes the target `elementId` in the MIGRATE command; `MessageSubscriptionMigrateProcessor` applies it on `MIGRATED`

**Exporter**
- Adds `MessageBasedWaitStateTransformer` and `MessageWaitStateDetails` to `zeebe/exporter-common`: handles `CREATED` (insert), `CORRELATED`/`DELETED` (delete), and `MIGRATED` (update `elementId`); guarded by element-type (only `RECEIVE_TASK` and `INTERMEDIATE_CATCH_EVENT` — message start events are handled separately)
- Registers `MESSAGE_SUBSCRIPTION` in `CamundaExporter.CamundaExporterRecordFilter`
- Adds `elementId`, `rootProcessInstanceKey`, and `elementType` fields to both the Elasticsearch and OpenSearch `zeebe-record-message-subscription` index templates

Closes #48570

## Test plan

- [x] `RecordGoldenFilesTest` and `JsonSerializableToJsonTest` pass (both golden files regenerated)
- [x] `SubscriptionCommandSenderTest` (24 tests) — updated for new sender signature
- [x] `MessageSubscriptionWaitStateFieldsPlumbingTest` — pins end-to-end field propagation to `MessageSubscription CREATED`
- [x] `MessageBasedWaitStateTransformerTest` (8 tests) — covers add/update/remove trigger logic and element-type guard
- [x] `WaitStateMessageIT` acceptance test — full lifecycle: `CREATED`, `CORRELATED`, `DELETED`, and `MIGRATED`
- [x] Full repo compiles: `./mvnw install -Dquickly -T1C`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)