### PR TITLE
Resolve nested target refs in subsequent input mappings

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -102,7 +102,8 @@ public final class VariableMappingTransformer {
 
   private Expression buildLocalInputMappingExpression(
       final List<Mapping> mappings, final ExpressionLanguage expressionLanguage) {
-    return buildIncrementalMappingExpression(mappings, expressionLanguage, INPUT_RESULT_CONTEXT);
+    return buildIncrementalMappingExpressionWithNestedVariableSupport(
+        mappings, expressionLanguage, INPUT_RESULT_CONTEXT);
   }
 
   private Expression buildLocalOutputMappingExpression(
@@ -172,6 +173,85 @@ public final class VariableMappingTransformer {
     sb.append(String.format("}.%s", resultContextName));
 
     return parseExpression(sb.toString(), expressionLanguage);
+  }
+
+  /**
+   * Builds an incremental mapping expression using {@code context put()}.
+   *
+   * <p>Each mapping first assigns the source expression to a local variable (so that subsequent
+   * mappings can reference it), then adds that variable to the accumulating result context.
+   *
+   * <p>This approach ensures:
+   *
+   * <ul>
+   *   <li>Mappings are evaluated in definition order
+   *   <li>Subsequent mappings can reference variables from previous mappings
+   *   <li>Nested target paths are handled correctly without premature evaluation
+   * </ul>
+   *
+   * Compared to {@link #buildIncrementalMappingExpression}, this method adds support for
+   * nested variable references in source expressions of subsequent mappings.
+   *
+   * @param mappings the list of mappings to process
+   * @param expressionLanguage the expression language to parse the result
+   * @param resultContextName the name of the accumulator context variable
+   * @return the parsed expression
+   */
+  private Expression buildIncrementalMappingExpressionWithNestedVariableSupport(
+      final List<Mapping> mappings,
+      final ExpressionLanguage expressionLanguage,
+      final String resultContextName) {
+
+    if (mappings.isEmpty()) {
+      return parseExpression("{}", expressionLanguage);
+    }
+
+    final var sb = new StringBuilder("{");
+
+    for (int i = 0; i < mappings.size(); i++) {
+      final var mapping = mappings.get(i);
+      final var parts = splitPathExpression(mapping.target());
+      final var sourceExpr = formatSourceExpression(mapping.source());
+      final var base = (i == 0) ? "{}" : resultContextName;
+
+      if (i > 0) {
+        sb.append(",");
+      }
+
+      // First, assign the variable so it's available in context for subsequent expressions
+      if (parts.size() == 1) {
+        sb.append(String.format("%s:%s,", mapping.target(), sourceExpr));
+      } else {
+        // If it is a nested variable, it is necessary to ensure that the root variable is available
+        // and then it should be updated with `context put` (assigning to the nested variable
+        // directly will create a new flat variable with "." in its name)
+        final var root = parts.getFirst();
+        sb.append(String.format("%s:get or else(%s,{}),", root, root));
+        final var subPath = parts.stream().skip(1).toList();
+        sb.append(buildContextUpdate(root, root, subPath, sourceExpr)).append(",");
+      }
+
+      // Then, add it to the result context referencing the just-assigned variable
+      sb.append(buildContextUpdate(resultContextName, base, parts, mapping.target()));
+    }
+
+    sb.append(String.format("}.%s", resultContextName));
+
+    return parseExpression(sb.toString(), expressionLanguage);
+  }
+
+  private String buildContextUpdate(
+      final String targetContext,
+      final String sourceContext,
+      final List<String> path,
+      final String value) {
+    final String pathList;
+    if (path.size() == 1) {
+      pathList = String.format("\"%s\"", path.getFirst());
+    } else {
+      pathList = path.stream().collect(Collectors.joining("\",\"", "[\"", "\"]"));
+    }
+    return String.format("%s:context put(%s,%s,%s)", targetContext, sourceContext, pathList, value);
   }
 
   private List<Mapping> toMappings(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -189,8 +189,8 @@ public final class VariableMappingTransformer {
    *   <li>Nested target paths are handled correctly without premature evaluation
    * </ul>
    *
-   * Compared to {@link #buildIncrementalMappingExpression}, this method adds support for
-   * nested variable references in source expressions of subsequent mappings.
+   * Compared to {@link #buildIncrementalMappingExpression}, this method adds support for nested
+   * variable references in source expressions of subsequent mappings.
    *
    * @param mappings the list of mappings to process
    * @param expressionLanguage the expression language to parse the result
@@ -226,7 +226,20 @@ public final class VariableMappingTransformer {
         // and then it should be updated with `context put` (assigning to the nested variable
         // directly will create a new flat variable with "." in its name)
         final var root = parts.getFirst();
-        sb.append(String.format("%s:get or else(%s,{}),", root, root));
+        // Note: the following expression is necessary to handle three cases:
+        // - root variable does not exist yet
+        //   - `get entries` will return null (as the variable is not found)
+        //   - `get or else` will return an empty list
+        //   - `context` will convert it to an empty context object
+        // - root variable exists but contains a scalar
+        //   - `get entries` will return null (as the variable is not a context)
+        //   - `get or else` will return an empty list
+        //   - `context` will convert it to an empty context object
+        // - root variable exists and it is an object
+        //   - `get entries` will return the contained entries (as it is in fact a context)
+        //   - `get or else` will return the contained entries
+        //   - `context` will rebuild the context object exactly as it was
+        sb.append(String.format("%s:context(get or else(get entries(%s),[])),", root, root));
         final var subPath = parts.stream().skip(1).toList();
         sb.append(buildContextUpdate(root, root, subPath, sourceExpr)).append(",");
       }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTest.java
@@ -218,6 +218,50 @@ public final class VariableInputMappingTest {
     assertThat(zJson.path("b").path("c").isNull()).isTrue();
   }
 
+  @Test
+  public void shouldReferencePreviousMappingWithNestedTarget() {
+    // given
+    final String processId = "proc" + COUNTER.incrementAndGet();
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .subProcess(
+                "sub",
+                sub ->
+                    sub.zeebeInputExpression("\"value\"", "nested.variable")
+                        .zeebeInputExpression("nested.variable", "x")
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .endEvent())
+            .endEvent()
+            .done();
+
+    ENGINE_RULE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE_RULE.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(processId)
+        .await();
+
+    assertVariableValue(processInstanceKey, "x", "\"value\"");
+
+    final String nestedValue =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("nested")
+            .getFirst()
+            .getValue()
+            .getValue();
+
+    final JsonNode nestedJson = parseJson(nestedValue);
+    assertThat(nestedJson.path("variable").asText()).isEqualTo("value");
+  }
+
   private void assertVariableValue(
       final long processInstanceKey, final String variableName, final String expectedValue) {
     final String actualValue =
@@ -234,7 +278,7 @@ public final class VariableInputMappingTest {
   private JsonNode parseJson(final String json) {
     try {
       return OBJECT_MAPPER.readTree(json);
-    } catch (JsonProcessingException e) {
+    } catch (final JsonProcessingException e) {
       throw new RuntimeException("Failed to parse JSON: " + json, e);
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
+import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.Either;
 import java.time.InstantSource;
 import java.util.List;
@@ -142,6 +143,29 @@ public final class VariableMappingTransformerTest {
     assertThat(result.getExpression())
         .isEqualTo(
             "{a:null,_camunda_input_context:context put({},\"a\",a)}._camunda_input_context");
+  }
+
+  @Test
+  public void shouldResolveNestedTargetPathInSubsequentInputSourceExpression() {
+    // given — "a" is mapped first, then nested "a.b" is set, then "c" uses "a.b" as source
+    final var mappings =
+        List.of(
+            mapping("=\"placeholder\"", "a"),
+            mapping("={\"key\":\"value\"}", "a.b"),
+            mapping("=1", "a.c"),
+            mapping("=a.b", "c"));
+    final var expression = transformer.transformInputMappings(mappings, expressionLanguage);
+
+    // when
+    final var result = expressionLanguage.evaluateExpression(expression, name -> Either.left(null));
+
+    // then
+    assertThat(result.isFailure())
+        .describedAs("Expected valid result: %s", result.getFailureMessage())
+        .isFalse();
+    assertThat(result.getType()).isEqualTo(ResultType.OBJECT);
+    MsgPackUtil.assertEquality(
+        result.toBuffer(), "{'a':{'b':{'key':'value'},'c':1},'c':{'key':'value'}}");
   }
 
   private static ZeebeMapping mapping(final String source, final String target) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.engine.processing.variable.mapping;
 import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
+import io.camunda.zeebe.el.EvaluationContext;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.el.ResultType;
@@ -21,6 +23,8 @@ import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.Either;
 import java.time.InstantSource;
 import java.util.List;
+import java.util.Map;
+import org.agrona.DirectBuffer;
 import org.junit.Test;
 
 public final class VariableMappingTransformerTest {
@@ -146,6 +150,29 @@ public final class VariableMappingTransformerTest {
   }
 
   @Test
+  public void shouldUseLocallyReconstructedValueForNestedPathExpressionInResultContextUpdate() {
+    // given — external a.b = "external"; mapping overrides a.b = "overridden"
+    final var mappings =
+        List.of(
+            mapping("=a.b", "preRef"),
+            mapping("=\"overridden\"", "a.b"),
+            mapping("=a.b", "postRef")); // proves which a.b was used for the result context update
+    final var expression = transformer.transformInputMappings(mappings, expressionLanguage);
+
+    final var context = Map.of("a", Map.of("b", "external"));
+
+    // when
+    final var result = expressionLanguage.evaluateExpression(expression, buildContext(context));
+
+    // then — both a.b and ref must be "overridden", not "external"
+    assertThat(result.isFailure())
+        .describedAs("Expected valid result: %s", result.getFailureMessage())
+        .isFalse();
+    MsgPackUtil.assertEquality(
+        result.toBuffer(), "{'preRef':'external','a':{'b':'overridden'},'postRef':'overridden'}");
+  }
+
+  @Test
   public void shouldResolveNestedTargetPathInSubsequentInputSourceExpression() {
     // given — "a" is mapped first, then nested "a.b" is set, then "c" uses "a.b" as source
     final var mappings =
@@ -168,6 +195,52 @@ public final class VariableMappingTransformerTest {
         result.toBuffer(), "{'a':{'b':{'key':'value'},'c':1},'c':{'key':'value'}}");
   }
 
+  @Test
+  public void shouldOverrideVariablesWithSameFullNameButNotPartialMatches() {
+    // given
+    final var mappings =
+        List.of(
+            mapping("=\"non-nested\"", "var2"),
+            mapping("=\"overridden\"", "global.var2"), // should override global nested var
+            mapping("=\"new-value\"", "global.var3"), // should add nested value to global var
+            mapping(
+                "=global.var1", "refGlobal1"), // should reference global var from external context
+            mapping("=global.var2", "refGlobal2"), // backref to nested var
+            mapping("=global.var3", "refGlobal3"), // backref to nested var
+            mapping("=var2", "refNonNested")); // backref to non-nested var
+    final var expression = transformer.transformInputMappings(mappings, expressionLanguage);
+
+    final var context =
+        Map.of(
+            "global",
+            Map.of(
+                "var1", "value1",
+                "var2", "value2"));
+
+    // when
+    final var result = expressionLanguage.evaluateExpression(expression, buildContext(context));
+
+    // then
+    assertThat(result.isFailure())
+        .describedAs("Expected valid result: %s", result.getFailureMessage())
+        .isFalse();
+    assertThat(result.getType()).isEqualTo(ResultType.OBJECT);
+    MsgPackUtil.assertEquality(
+        result.toBuffer(),
+        """
+  {
+    'global': {
+      'var2': 'overridden',
+      'var3': 'new-value'
+    },
+    'var2': 'non-nested',
+    'refGlobal1': 'value1',
+    'refGlobal2': 'overridden',
+    'refGlobal3': 'new-value',
+    'refNonNested': 'non-nested'
+  }""");
+  }
+
   private static ZeebeMapping mapping(final String source, final String target) {
     return new ZeebeMapping() {
       @Override
@@ -184,6 +257,24 @@ public final class VariableMappingTransformerTest {
       public String toString() {
         return source + " -> " + target;
       }
+    };
+  }
+
+  private EvaluationContext buildContext(final Map<?, ?> context) {
+    return name -> {
+      final Object value = context.get(name);
+      final DirectBuffer encodedValue;
+      if (value instanceof final Map nestedContext) {
+        encodedValue = asMsgPack((Map<String, Object>) nestedContext);
+      } else if (value == null) {
+        encodedValue = null;
+      } else if (value instanceof final String str) {
+        encodedValue = asMsgPack(str);
+      } else {
+        fail("Unsupported value type in context: " + value.getClass());
+        encodedValue = null;
+      }
+      return Either.left(encodedValue);
     };
   }
 }


### PR DESCRIPTION
## Description

Input mappings with nested targets (e.g. `objects.foo`) were not usable as FEEL variables by subsequent mappings. The existing expression builder stored nested targets only inside `_camunda_input_context` via `context put`, but never bound the root variable (e.g. `objects`) in the FEEL expression scope. A later mapping with source `=objects.foo` therefore could not resolve it.

The fix introduces `buildIncrementalMappingExpressionWithNestedVariableSupport` for input mappings. For each nested target, it:

1. **Initialises the root variable** before writing to it:
   `root: context(get or else(get entries(root), []))`
   This handles three cases uniformly:
   - root not yet defined → `get entries` returns `null` → `get or else` returns `[]` → `context([])` produces `{}`
   - root is a scalar → same path as above (scalars have no entries) → produces `{}`
   - root is already an object → `get entries` returns its entries → `context(...)` reconstructs it unchanged

   `get or else(root, {})` alone is not sufficient because it preserves scalar values unchanged, which would then cause `context put` to fail.

2. **Writes the nested key** via `context put(root, ["sub","path"], value)` rather than a direct dotted assignment. A direct `objects.foo: <value>` in a FEEL context literal would create a flat variable whose name literally contains `.`, not a nested variable.

3. **Propagates the updated root** into `_camunda_input_context` so the result context is correct.

A new method was added rather than modifying `buildIncrementalMappingExpression` to avoid changing output mapping behaviour, which customers may rely on.

## Related

- Fixes #54946
- Regression introduced by #52737

## Test plan

- [ ] `VariableMappingTransformerTest#shouldResolveNestedTargetPathInSubsequentInputSourceExpression`
- [ ] `VariableInputMappingTest#shouldReferencePreviousMappingWithNestedTarged`
- [ ] `VariableInputMappingTest` — test for input mappings not overwriting unrelated variables