### PR TITLE
feat: add partitionId to message subscriptions across the full E2E stack

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/MessageSubscriptionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/MessageSubscriptionFilter.java
@@ -290,4 +290,20 @@ public interface MessageSubscriptionFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   MessageSubscriptionFilter inboundConnectorType(Consumer<StringProperty> fn);
+
+  /**
+   * Filter by partition ID.
+   *
+   * @param partitionId the partition ID
+   * @return the updated filter
+   */
+  MessageSubscriptionFilter partitionId(Integer partitionId);
+
+  /**
+   * Filter by partition ID using an {@link IntegerProperty} consumer.
+   *
+   * @param fn the partition ID {@link IntegerProperty} consumer
+   * @return the updated filter
+   */
+  MessageSubscriptionFilter partitionId(Consumer<IntegerProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
@@ -66,4 +66,6 @@ public interface MessageSubscription {
   String getToolName();
 
   String getInboundConnectorType();
+
+  Integer getPartitionId();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/MessageSubscriptionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/MessageSubscriptionFilterImpl.java
@@ -259,6 +259,19 @@ public class MessageSubscriptionFilterImpl
   }
 
   @Override
+  public MessageSubscriptionFilter partitionId(final Integer partitionId) {
+    return partitionId(f -> f.eq(partitionId));
+  }
+
+  @Override
+  public MessageSubscriptionFilter partitionId(final Consumer<IntegerProperty> fn) {
+    final IntegerProperty property = new IntegerPropertyImpl();
+    fn.accept(property);
+    filter.setPartitionId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   protected io.camunda.client.protocol.rest.MessageSubscriptionFilter getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
@@ -45,6 +45,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   private final Map<String, String> toolProperties;
   private final String toolName;
   private final String inboundConnectorType;
+  private final Integer partitionId;
 
   public MessageSubscriptionImpl(final MessageSubscriptionResult item) {
     messageSubscriptionKey = ParseUtil.parseLongOrNull(item.getMessageSubscriptionKey());
@@ -67,6 +68,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
     toolProperties = item.getToolProperties();
     toolName = item.getToolName();
     inboundConnectorType = item.getInboundConnectorType();
+    partitionId = item.getPartitionId();
   }
 
   @Override
@@ -160,6 +162,11 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   }
 
   @Override
+  public Integer getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(
         messageSubscriptionKey,
@@ -179,7 +186,8 @@ public class MessageSubscriptionImpl implements MessageSubscription {
         processDefinitionVersion,
         toolProperties,
         toolName,
-        inboundConnectorType);
+        inboundConnectorType,
+        partitionId);
   }
 
   @Override
@@ -208,6 +216,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
         && Objects.equals(processDefinitionVersion, subscription.processDefinitionVersion)
         && Objects.equals(toolProperties, subscription.toolProperties)
         && Objects.equals(toolName, subscription.toolName)
-        && Objects.equals(inboundConnectorType, subscription.inboundConnectorType);
+        && Objects.equals(inboundConnectorType, subscription.inboundConnectorType)
+        && Objects.equals(partitionId, subscription.partitionId);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MessageSubscriptionColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MessageSubscriptionColumn.java
@@ -25,7 +25,8 @@ public enum MessageSubscriptionColumn implements SearchColumn<MessageSubscriptio
   PROCESS_DEFINITION_NAME("processDefinitionName"),
   PROCESS_DEFINITION_VERSION("processDefinitionVersion"),
   TOOL_NAME("toolName"),
-  INBOUND_CONNECTOR_TYPE("inboundConnectorType");
+  INBOUND_CONNECTOR_TYPE("inboundConnectorType"),
+  PARTITION_ID("partitionId");
 
   private final String property;
 

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -173,6 +173,12 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
+    <if test="filter.partitionIdOperations != null and !filter.partitionIdOperations.isEmpty()">
+      <foreach collection="filter.partitionIdOperations" item="operation">
+        AND PARTITION_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel">

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -1147,6 +1147,9 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getInboundConnectorType())
           .map(mapToStringOperations())
           .ifPresent(builder::inboundConnectorTypeOperations);
+      ofNullable(filter.getPartitionId())
+          .map(mapToIntegerOperations("partitionId", validationErrors))
+          .ifPresent(builder::partitionIdOperations);
     }
     return validationErrors.isEmpty()
         ? Either.right(builder.build())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -783,6 +783,19 @@ public final class SearchQueryRequestMapper {
   }
 
   public static Either<ProblemDetail, MessageSubscriptionQuery> toMessageSubscriptionQuery(
+      final io.camunda.gateway.protocol.model.simple.@Nullable MessageSubscriptionSearchQuery
+          query) {
+    return toMessageSubscriptionQuery(
+        query == null
+            ? null
+            : MessageSubscriptionSearchQuery.Builder.create()
+                .filter(SimpleSearchQueryMapper.toMessageSubscriptionFilter(query.getFilter()))
+                .page(SimpleSearchQueryMapper.toPageRequest(query.getPage()))
+                .sort(query.getSort() == null ? List.of() : query.getSort())
+                .build());
+  }
+
+  public static Either<ProblemDetail, MessageSubscriptionQuery> toMessageSubscriptionQuery(
       final @Nullable MessageSubscriptionSearchQuery request) {
     if (request == null) {
       return Either.right(SearchQueryBuilders.messageSubscriptionSearchQuery().build());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1234,6 +1234,7 @@ public final class SearchQueryResponseMapper {
         .processDefinitionName(messageSubscription.processDefinitionName())
         .processDefinitionVersion(messageSubscription.processDefinitionVersion())
         .processInstanceKey(keyToStringOrNull(messageSubscription.processInstanceKey()))
+        .partitionId(messageSubscription.partitionId())
         .tenantId(messageSubscription.tenantId())
         .toolName(messageSubscription.toolName())
         .build();

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
@@ -29,6 +29,7 @@ import io.camunda.gateway.protocol.model.ProcessInstanceFilterFields;
 import io.camunda.gateway.protocol.model.StringFilterProperty;
 import io.camunda.gateway.protocol.model.VariableValueFilterProperty;
 import io.camunda.gateway.protocol.model.simple.IncidentFilter;
+import io.camunda.gateway.protocol.model.simple.MessageSubscriptionFilter;
 import io.camunda.gateway.protocol.model.simple.SearchQueryPageRequest;
 import io.camunda.gateway.protocol.model.simple.SimpleDateTimeFilterProperty;
 import io.camunda.service.exception.ServiceError;
@@ -442,6 +443,66 @@ public class SimpleSearchQueryMapper {
                     .value(AdvancedStringFilter.Builder.create().$eq(simpleVar.getValue()).build())
                     .build())
         .toList();
+  }
+
+  public static io.camunda.gateway.protocol.model.MessageSubscriptionFilter toMessageSubscriptionFilter(
+      final @Nullable MessageSubscriptionFilter filter) {
+    final var filterModel =
+        io.camunda.gateway.protocol.model.MessageSubscriptionFilter.Builder.create().build();
+    if (filter != null) {
+      ofNullable(filter.getMessageSubscriptionKey())
+          .map(SimpleSearchQueryMapper::getBasicStringFilter)
+          .ifPresent(filterModel::messageSubscriptionKey);
+      ofNullable(filter.getProcessDefinitionKey())
+          .map(SimpleSearchQueryMapper::getBasicStringFilter)
+          .ifPresent(filterModel::processDefinitionKey);
+      ofNullable(filter.getProcessDefinitionId())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::processDefinitionId);
+      ofNullable(filter.getProcessInstanceKey())
+          .map(SimpleSearchQueryMapper::getBasicStringFilter)
+          .ifPresent(filterModel::processInstanceKey);
+      ofNullable(filter.getElementId())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::elementId);
+      ofNullable(filter.getElementInstanceKey())
+          .map(SimpleSearchQueryMapper::getBasicStringFilter)
+          .ifPresent(filterModel::elementInstanceKey);
+      ofNullable(filter.getMessageSubscriptionState())
+          .map(s -> io.camunda.gateway.protocol.model.AdvancedMessageSubscriptionStateFilter.Builder.create().$eq(s).build())
+          .ifPresent(filterModel::messageSubscriptionState);
+      ofNullable(filter.getLastUpdatedDate())
+          .map(SimpleSearchQueryMapper::getDateTimeFilter)
+          .ifPresent(filterModel::lastUpdatedDate);
+      ofNullable(filter.getMessageName())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::messageName);
+      ofNullable(filter.getCorrelationKey())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::correlationKey);
+      ofNullable(filter.getTenantId())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::tenantId);
+      ofNullable(filter.getMessageSubscriptionType())
+          .map(s -> io.camunda.gateway.protocol.model.AdvancedMessageSubscriptionTypeFilter.Builder.create().$eq(s).build())
+          .ifPresent(filterModel::messageSubscriptionType);
+      ofNullable(filter.getProcessDefinitionName())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::processDefinitionName);
+      ofNullable(filter.getProcessDefinitionVersion())
+          .map(SimpleSearchQueryMapper::getIntegerFilter)
+          .ifPresent(filterModel::processDefinitionVersion);
+      ofNullable(filter.getToolName())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::toolName);
+      ofNullable(filter.getInboundConnectorType())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::inboundConnectorType);
+      ofNullable(filter.getPartitionId())
+          .map(SimpleSearchQueryMapper::getIntegerFilter)
+          .ifPresent(filterModel::partitionId);
+    }
+    return filterModel;
   }
 
   private static StringFilterProperty getStringFilter(final @Nullable String value) {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpJackson3Module.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpJackson3Module.java
@@ -8,6 +8,7 @@
 package io.camunda.gateway.mcp.config;
 
 import io.camunda.gateway.mcp.model.McpIncidentFilter;
+import io.camunda.gateway.mcp.model.McpMessageSubscriptionFilter;
 import io.camunda.gateway.mcp.model.McpProcessDefinitionFilter;
 import io.camunda.gateway.mcp.model.McpProcessInstanceCreationInstruction;
 import io.camunda.gateway.mcp.model.McpProcessInstanceFilter;
@@ -15,6 +16,7 @@ import io.camunda.gateway.mcp.model.McpUserTaskAssignmentRequest;
 import io.camunda.gateway.mcp.model.McpUserTaskFilter;
 import io.camunda.gateway.mcp.model.McpVariableFilter;
 import io.camunda.gateway.protocol.model.simple.IncidentFilter;
+import io.camunda.gateway.protocol.model.simple.MessageSubscriptionFilter;
 import io.camunda.gateway.protocol.model.simple.ProcessDefinitionFilter;
 import io.camunda.gateway.protocol.model.simple.ProcessInstanceCreationInstruction;
 import io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter;
@@ -39,6 +41,7 @@ public class CamundaMcpJackson3Module extends SimpleModule {
   public CamundaMcpJackson3Module() {
     super(MODULE_NAME);
     setMixInAnnotation(IncidentFilter.class, McpIncidentFilter.class);
+    setMixInAnnotation(MessageSubscriptionFilter.class, McpMessageSubscriptionFilter.class);
     setMixInAnnotation(ProcessDefinitionFilter.class, McpProcessDefinitionFilter.class);
     setMixInAnnotation(
         ProcessInstanceCreationInstruction.class, McpProcessInstanceCreationInstruction.class);

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpMessageSubscriptionFilter.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpMessageSubscriptionFilter.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.gateway.protocol.model.simple.MessageSubscriptionFilter;
+
+/**
+ * MCP-specific MessageSubscription filter modifying the {@link MessageSubscriptionFilter} to hide
+ * fields from MCP clients that are not relevant in the MCP context.
+ *
+ * <p>{@code partitionId} is hidden because the MCP tool always restricts results to partition 1.
+ * {@code tenantId} is hidden to avoid unnecessary context bloat.
+ */
+@JsonIgnoreProperties({"partitionId", "tenantId"})
+public interface McpMessageSubscriptionFilter {}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/message/MessageSubscriptionTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/message/MessageSubscriptionTools.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.message;
+
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
+
+import io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext;
+import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
+import io.camunda.gateway.mcp.config.tool.McpToolParamsUnwrapped;
+import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
+import io.camunda.gateway.protocol.model.simple.MessageSubscriptionFilter;
+import io.camunda.gateway.protocol.model.simple.MessageSubscriptionSearchQuery;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.registry.ServiceRegistry;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import jakarta.validation.Valid;
+import org.springframework.ai.mcp.annotation.McpTool.McpAnnotations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@Validated
+public class MessageSubscriptionTools {
+
+  private static final int PARTITION_1 = 1;
+
+  private final ServiceRegistry serviceRegistry;
+  private final CamundaAuthenticationProvider authenticationProvider;
+
+  public MessageSubscriptionTools(
+      final ServiceRegistry serviceRegistry,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.serviceRegistry = serviceRegistry;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  @CamundaMcpTool(
+      description =
+          "Search for message subscriptions restricted to partition 1. "
+              + EVENTUAL_CONSISTENCY_NOTE,
+      annotations = @McpAnnotations(readOnlyHint = true))
+  public CallToolResult searchMessageSubscriptions(
+      @McpToolParamsUnwrapped @Valid final MessageSubscriptionSearchQuery query) {
+    try {
+      // Always restrict to partition 1 — MCP clients should only access single-partition data.
+      final var filter =
+          query.getFilter() != null ? query.getFilter() : new MessageSubscriptionFilter();
+      filter.setPartitionId(PARTITION_1);
+      query.setFilter(filter);
+
+      final var messageSubscriptionQuery =
+          SearchQueryRequestMapper.toMessageSubscriptionQuery(query);
+      if (messageSubscriptionQuery.isLeft()) {
+        return CallToolResultMapper.mapProblemToResult(messageSubscriptionQuery.getLeft());
+      }
+
+      return CallToolResultMapper.from(
+          SearchQueryResponseMapper.toMessageSubscriptionSearchQueryResponse(
+              serviceRegistry
+                  .messageSubscriptionServices(PhysicalTenantContext.current())
+                  .search(
+                      messageSubscriptionQuery.get(),
+                      authenticationProvider.getCamundaAuthentication())));
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+}

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Fail.fail;
 import io.camunda.gateway.mcp.config.CamundaMcpJackson3Module;
 import io.camunda.gateway.mcp.config.schema.CamundaJsonSchemaGenerator;
 import io.camunda.gateway.protocol.model.simple.IncidentFilter;
+import io.camunda.gateway.protocol.model.simple.MessageSubscriptionFilter;
 import io.camunda.gateway.protocol.model.simple.ProcessDefinitionFilter;
 import io.camunda.gateway.protocol.model.simple.ProcessInstanceCreationInstruction;
 import io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter;
@@ -53,6 +54,25 @@ public class CustomMcpModelPropertiesTest {
                 "processDefinitionKey",
                 "processInstanceKey",
                 "state")),
+        Arguments.argumentSet(
+            "MessageSubscriptionFilter",
+            MessageSubscriptionFilter.class,
+            Set.of(
+                "messageSubscriptionKey",
+                "processDefinitionKey",
+                "processDefinitionId",
+                "processInstanceKey",
+                "elementId",
+                "elementInstanceKey",
+                "messageSubscriptionState",
+                "lastUpdatedDate",
+                "messageName",
+                "correlationKey",
+                "messageSubscriptionType",
+                "processDefinitionName",
+                "processDefinitionVersion",
+                "toolName",
+                "inboundConnectorType")),
         Arguments.argumentSet(
             "ProcessDefinitionFilter",
             ProcessDefinitionFilter.class,

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/ToolsSchemaRegressionTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/ToolsSchemaRegressionTest.java
@@ -10,6 +10,7 @@ package io.camunda.gateway.mcp.tool;
 import io.camunda.gateway.mcp.OperationalToolsTest;
 import io.camunda.gateway.mcp.tool.cluster.ClusterTools;
 import io.camunda.gateway.mcp.tool.incident.IncidentTools;
+import io.camunda.gateway.mcp.tool.message.MessageSubscriptionTools;
 import io.camunda.gateway.mcp.tool.process.definition.ProcessDefinitionTools;
 import io.camunda.gateway.mcp.tool.process.instance.ProcessInstanceTools;
 import io.camunda.gateway.mcp.tool.usertask.UserTaskTools;
@@ -18,6 +19,7 @@ import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
+import io.camunda.service.MessageSubscriptionServices;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.TopologyServices;
@@ -62,6 +64,7 @@ import tools.jackson.databind.node.ObjectNode;
     classes = {
       ClusterTools.class,
       IncidentTools.class,
+      MessageSubscriptionTools.class,
       ProcessDefinitionTools.class,
       ProcessInstanceTools.class,
       UserTaskTools.class,
@@ -78,6 +81,7 @@ class ToolsSchemaRegressionTest extends OperationalToolsTest {
   @MockitoBean private TopologyServices topologyServices;
   @MockitoBean private IncidentServices incidentServices;
   @MockitoBean private JobServices<JobActivationResult> jobServices;
+  @MockitoBean private MessageSubscriptionServices messageSubscriptionServices;
   @MockitoBean private ProcessDefinitionServices processDefinitionServices;
   @MockitoBean private ProcessInstanceServices processInstanceServices;
   @MockitoBean private UserTaskServices userTaskServices;

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/message/MessageSubscriptionToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/message/MessageSubscriptionToolsTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.message;
+
+import static io.camunda.gateway.mcp.tool.CallToolResultAssertions.assertTextContentFallback;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.gateway.mcp.OperationalToolsTest;
+import io.camunda.gateway.protocol.model.MessageSubscriptionResult;
+import io.camunda.gateway.protocol.model.MessageSubscriptionSearchQueryResult;
+import io.camunda.gateway.protocol.model.MessageSubscriptionStateEnum;
+import io.camunda.gateway.protocol.model.MessageSubscriptionTypeEnum;
+import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
+import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
+import io.camunda.search.filter.MessageSubscriptionFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.Operator;
+import io.camunda.search.query.MessageSubscriptionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.SearchQueryResult.Builder;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.service.MessageSubscriptionServices;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import tools.jackson.databind.json.JsonMapper;
+
+@ExtendWith(MockitoExtension.class)
+@ContextConfiguration(classes = {MessageSubscriptionTools.class})
+class MessageSubscriptionToolsTest extends OperationalToolsTest {
+
+  static final MessageSubscriptionEntity MESSAGE_SUBSCRIPTION_ENTITY =
+      MessageSubscriptionEntity.builder()
+          .messageSubscriptionKey(5L)
+          .processDefinitionId("complexProcess")
+          .processDefinitionKey(23L)
+          .processInstanceKey(42L)
+          .rootProcessInstanceKey(42L)
+          .flowNodeId("elementId")
+          .flowNodeInstanceKey(17L)
+          .messageSubscriptionState(MessageSubscriptionState.CREATED)
+          .messageSubscriptionType(MessageSubscriptionType.PROCESS_EVENT)
+          .dateTime(OffsetDateTime.parse("2024-05-23T23:05:00.000Z"))
+          .messageName("myMessage")
+          .correlationKey("myKey")
+          .tenantId("<default>")
+          .processDefinitionName("Complex Process")
+          .processDefinitionVersion(2)
+          .toolName("myTool")
+          .inboundConnectorType("io.camunda:connector")
+          .partitionId(1)
+          .build();
+
+  static final SearchQueryResult<MessageSubscriptionEntity> SEARCH_QUERY_RESULT =
+      new Builder<MessageSubscriptionEntity>()
+          .total(1L)
+          .items(List.of(MESSAGE_SUBSCRIPTION_ENTITY))
+          .startCursor("f")
+          .endCursor("v")
+          .build();
+
+  @MockitoBean private MessageSubscriptionServices messageSubscriptionServices;
+
+  @Autowired private JsonMapper objectMapper;
+  @Captor private ArgumentCaptor<MessageSubscriptionQuery> queryCaptor;
+
+  @BeforeEach
+  void wireServiceRegistry() {
+    when(serviceRegistry.messageSubscriptionServices(any()))
+        .thenReturn(messageSubscriptionServices);
+  }
+
+  private void assertExampleMessageSubscription(final MessageSubscriptionResult item) {
+    assertThat(item.getMessageSubscriptionKey()).isEqualTo("5");
+    assertThat(item.getProcessDefinitionId()).isEqualTo("complexProcess");
+    assertThat(item.getProcessDefinitionKey()).isEqualTo("23");
+    assertThat(item.getProcessInstanceKey()).isEqualTo("42");
+    assertThat(item.getElementId()).isEqualTo("elementId");
+    assertThat(item.getElementInstanceKey()).isEqualTo("17");
+    assertThat(item.getMessageSubscriptionState()).isEqualTo(MessageSubscriptionStateEnum.CREATED);
+    assertThat(item.getMessageSubscriptionType())
+        .isEqualTo(MessageSubscriptionTypeEnum.PROCESS_EVENT);
+    assertThat(item.getMessageName()).isEqualTo("myMessage");
+    assertThat(item.getCorrelationKey()).isEqualTo("myKey");
+    assertThat(item.getProcessDefinitionName()).isEqualTo("Complex Process");
+    assertThat(item.getProcessDefinitionVersion()).isEqualTo(2);
+    assertThat(item.getToolName()).isEqualTo("myTool");
+    assertThat(item.getInboundConnectorType()).isEqualTo("io.camunda:connector");
+    assertThat(item.getPartitionId()).isEqualTo(1);
+  }
+
+  @Nested
+  class SearchMessageSubscriptions {
+
+    @Test
+    void shouldSearchMessageSubscriptionsWithNoFilter() {
+      // given
+      when(messageSubscriptionServices.search(any(MessageSubscriptionQuery.class), any()))
+          .thenReturn(SEARCH_QUERY_RESULT);
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder("searchMessageSubscriptions").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isFalse();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var searchResult =
+          objectMapper.convertValue(
+              result.structuredContent(), MessageSubscriptionSearchQueryResult.class);
+      assertThat(searchResult.getPage().getTotalItems()).isEqualTo(1L);
+      assertThat(searchResult.getPage().getHasMoreTotalItems()).isFalse();
+      assertThat(searchResult.getPage().getStartCursor()).isEqualTo("f");
+      assertThat(searchResult.getPage().getEndCursor()).isEqualTo("v");
+      assertThat(searchResult.getItems())
+          .hasSize(1)
+          .first()
+          .satisfies(MessageSubscriptionToolsTest.this::assertExampleMessageSubscription);
+
+      // partition 1 always injected
+      verify(messageSubscriptionServices).search(queryCaptor.capture(), any());
+      assertThat(queryCaptor.getValue().filter().partitionIdOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(tuple(Operator.EQUALS, 1));
+
+      assertTextContentFallback(result);
+    }
+
+    @Test
+    void shouldSearchMessageSubscriptionsWithFilterSortAndPaging() {
+      // given
+      when(messageSubscriptionServices.search(any(MessageSubscriptionQuery.class), any()))
+          .thenReturn(SEARCH_QUERY_RESULT);
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder("searchMessageSubscriptions")
+                  .arguments(
+                      Map.of(
+                          "filter",
+                          Map.of(
+                              "messageSubscriptionState", "CREATED",
+                              "messageName", "myMessage"),
+                          "sort",
+                          List.of(Map.of("field", "messageSubscriptionKey", "order", "DESC")),
+                          "page",
+                          Map.of("limit", 10, "after", "WzEwMjRd")))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isFalse();
+
+      verify(messageSubscriptionServices).search(queryCaptor.capture(), any());
+      final MessageSubscriptionQuery capturedQuery = queryCaptor.getValue();
+
+      final MessageSubscriptionFilter filter = capturedQuery.filter();
+      assertThat(filter.messageSubscriptionStateOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(tuple(Operator.EQUALS, "CREATED"));
+      assertThat(filter.messageNameOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(tuple(Operator.EQUALS, "myMessage"));
+
+      // partition 1 always injected
+      assertThat(filter.partitionIdOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(tuple(Operator.EQUALS, 1));
+
+      assertThat(capturedQuery.sort().orderings())
+          .extracting(FieldSorting::field, FieldSorting::order)
+          .containsExactly(tuple("messageSubscriptionKey", SortOrder.DESC));
+
+      assertThat(capturedQuery.page().size()).isEqualTo(10);
+      assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
+
+      assertTextContentFallback(result);
+    }
+
+    @Test
+    void shouldSearchMessageSubscriptionsWithLastUpdatedDateRangeFilter() {
+      // given
+      when(messageSubscriptionServices.search(any(MessageSubscriptionQuery.class), any()))
+          .thenReturn(SEARCH_QUERY_RESULT);
+
+      final var from = OffsetDateTime.of(2025, 5, 23, 9, 35, 12, 0, ZoneOffset.UTC);
+      final var to = OffsetDateTime.of(2025, 12, 18, 17, 22, 33, 0, ZoneOffset.UTC);
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder("searchMessageSubscriptions")
+                  .arguments(
+                      Map.of(
+                          "filter",
+                          Map.of(
+                              "lastUpdatedDate",
+                              Map.of(
+                                  "from", "2025-05-23T09:35:12Z", "to", "2025-12-18T17:22:33Z"))))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isFalse();
+
+      verify(messageSubscriptionServices).search(queryCaptor.capture(), any());
+      final MessageSubscriptionQuery capturedQuery = queryCaptor.getValue();
+
+      assertThat(capturedQuery.filter().dateTimeOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(
+              tuple(Operator.GREATER_THAN_EQUALS, from), tuple(Operator.LOWER_THAN, to));
+    }
+
+    @Test
+    void shouldFailSearchMessageSubscriptionsOnException() {
+      // given
+      when(messageSubscriptionServices.search(any(MessageSubscriptionQuery.class), any()))
+          .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder("searchMessageSubscriptions").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
+    }
+  }
+}

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -215,6 +215,172 @@
       }
     },
     {
+      "name": "searchMessageSubscriptions",
+      "title": "searchMessageSubscriptions",
+      "description": "Search for message subscriptions restricted to partition 1. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "object",
+            "properties": {
+              "correlationKey": {
+                "type": "string",
+                "description": "The correlation key of the message subscription."
+              },
+              "elementId": {
+                "type": "string",
+                "description": "The element ID associated with this message subscription."
+              },
+              "elementInstanceKey": {
+                "type": "string",
+                "description": "The element instance key associated with this message subscription."
+              },
+              "inboundConnectorType": {
+                "type": "string",
+                "description": "Filter by inbound connector type extracted from the `inbound.type` zeebe:property."
+              },
+              "lastUpdatedDate": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "description": "Filter from this time (inclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  },
+                  "to": {
+                    "type": "string",
+                    "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  }
+                },
+                "description": "The last updated date of the message subscription."
+              },
+              "messageName": {
+                "type": "string",
+                "description": "The name of the message associated with the message subscription."
+              },
+              "messageSubscriptionKey": {
+                "type": "string",
+                "description": "The message subscription key associated with this message subscription."
+              },
+              "messageSubscriptionState": {
+                "type": "string",
+                "enum": [
+                  "CORRELATED",
+                  "CREATED",
+                  "DELETED",
+                  "MIGRATED"
+                ],
+                "description": "The message subscription state."
+              },
+              "messageSubscriptionType": {
+                "type": "string",
+                "enum": [
+                  "START_EVENT",
+                  "PROCESS_EVENT"
+                ],
+                "description": "The type of message subscription to filter by. When omitted, both `START_EVENT` and `PROCESS_EVENT` are returned. Only available for data created with Camunda 8.10 or later. "
+              },
+              "processDefinitionId": {
+                "type": "string",
+                "description": "The process definition ID associated with this message subscription."
+              },
+              "processDefinitionKey": {
+                "type": "string",
+                "description": "The process definition key associated with this correlated message subscription. This only works for data created with 8.9 and later."
+              },
+              "processDefinitionName": {
+                "type": "string",
+                "description": "The name of the process definition associated with this message subscription."
+              },
+              "processDefinitionVersion": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The version of the process definition associated with this message subscription."
+              },
+              "processInstanceKey": {
+                "type": "string",
+                "description": "The process instance key associated with this message subscription."
+              },
+              "toolName": {
+                "type": "string",
+                "description": "Filter by tool name extracted from the `io.camunda.tool:name` zeebe:property."
+              }
+            },
+            "description": "The message subscription search filters."
+          },
+          "page": {
+            "type": "object",
+            "properties": {
+              "after": {
+                "type": "string",
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
+              },
+              "before": {
+                "type": "string",
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
+              },
+              "from": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The index of items to start searching from."
+              },
+              "limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The maximum number of items to return in one request."
+              }
+            },
+            "description": "Pagination criteria."
+          },
+          "sort": {
+            "description": "Sort field criteria.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "enum": [
+                    "messageSubscriptionKey",
+                    "processDefinitionId",
+                    "processDefinitionName",
+                    "processDefinitionVersion",
+                    "processInstanceKey",
+                    "elementId",
+                    "elementInstanceKey",
+                    "messageSubscriptionState",
+                    "messageSubscriptionType",
+                    "lastUpdatedDate",
+                    "messageName",
+                    "correlationKey",
+                    "tenantId",
+                    "toolName",
+                    "inboundConnectorType"
+                  ],
+                  "description": "The field to sort by."
+                },
+                "order": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ]
+                }
+              },
+              "required": [
+                "field"
+              ]
+            }
+          }
+        },
+        "required": []
+      },
+      "annotations": {
+        "readOnlyHint": true
+      }
+    },
+    {
       "name": "getProcessDefinition",
       "title": "getProcessDefinition",
       "description": "Get process definition by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
@@ -38,7 +38,8 @@ public class MessageSubscriptionEntityTransformer
         value.getProcessDefinitionVersion(),
         value.getToolProperties(),
         value.getToolName(),
-        value.getInboundConnectorType());
+        value.getInboundConnectorType(),
+        value.getPartitionId());
   }
 
   private io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionFilterTransformer.java
@@ -26,6 +26,7 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_DEFINITION_NAME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_DEFINITION_VERSION;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_KEY;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PARTITION_ID;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_NAME;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -64,7 +65,8 @@ public class MessageSubscriptionFilterTransformer
         stringOperations(PROCESS_DEFINITION_NAME, filter.processDefinitionNameOperations()),
         intOperations(PROCESS_DEFINITION_VERSION, filter.processDefinitionVersionOperations()),
         stringOperations(TOOL_NAME, filter.toolNameOperations()),
-        stringOperations(INBOUND_CONNECTOR_TYPE, filter.inboundConnectorTypeOperations()));
+        stringOperations(INBOUND_CONNECTOR_TYPE, filter.inboundConnectorTypeOperations()),
+        intOperations(PARTITION_ID, filter.partitionIdOperations()));
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -34,7 +34,8 @@ public record MessageSubscriptionEntity(
     @Nullable Integer processDefinitionVersion,
     Map<String, String> toolProperties,
     @Nullable String toolName,
-    @Nullable String inboundConnectorType)
+    @Nullable String inboundConnectorType,
+    @Nullable Integer partitionId)
     implements TenantOwnedEntity {
 
   public MessageSubscriptionEntity {
@@ -78,6 +79,7 @@ public record MessageSubscriptionEntity(
     private @Nullable Map<String, String> toolProperties;
     private @Nullable String toolName;
     private @Nullable String inboundConnectorType;
+    private @Nullable Integer partitionId;
 
     public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
       this.messageSubscriptionKey = messageSubscriptionKey;
@@ -150,6 +152,11 @@ public record MessageSubscriptionEntity(
       return this;
     }
 
+    public Builder partitionId(final Integer partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
     public Builder dateTime(final OffsetDateTime dateTime) {
       this.dateTime = dateTime;
       return this;
@@ -190,7 +197,8 @@ public record MessageSubscriptionEntity(
           processDefinitionVersion,
           toolProperties,
           toolName,
-          inboundConnectorType);
+          inboundConnectorType,
+          partitionId);
     }
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MessageSubscriptionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MessageSubscriptionFilter.java
@@ -33,7 +33,8 @@ public record MessageSubscriptionFilter(
     List<Operation<String>> processDefinitionNameOperations,
     List<Operation<Integer>> processDefinitionVersionOperations,
     List<Operation<String>> toolNameOperations,
-    List<Operation<String>> inboundConnectorTypeOperations)
+    List<Operation<String>> inboundConnectorTypeOperations,
+    List<Operation<Integer>> partitionIdOperations)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<MessageSubscriptionFilter> {
@@ -54,6 +55,7 @@ public record MessageSubscriptionFilter(
     private List<Operation<Integer>> processDefinitionVersionOperations;
     private List<Operation<String>> toolNameOperations;
     private List<Operation<String>> inboundConnectorTypeOperations;
+    private List<Operation<Integer>> partitionIdOperations;
 
     public Builder messageSubscriptionKeys(final Long value, final Long... values) {
       return messageSubscriptionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
@@ -299,6 +301,21 @@ public record MessageSubscriptionFilter(
       return this;
     }
 
+    public Builder partitionIds(final Integer value, final Integer... values) {
+      return partitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder partitionIdOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return partitionIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder partitionIdOperations(final List<Operation<Integer>> operations) {
+      partitionIdOperations = addValuesToList(partitionIdOperations, operations);
+      return this;
+    }
+
     @Override
     public MessageSubscriptionFilter build() {
       return new MessageSubscriptionFilter(
@@ -317,7 +334,8 @@ public record MessageSubscriptionFilter(
           Objects.requireNonNullElse(processDefinitionNameOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionVersionOperations, Collections.emptyList()),
           Objects.requireNonNullElse(toolNameOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(inboundConnectorTypeOperations, Collections.emptyList()));
+          Objects.requireNonNullElse(inboundConnectorTypeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(partitionIdOperations, Collections.emptyList()));
     }
   }
 }

--- a/webapp/client/apps/orchestration-cluster-webapp/src/admin/pages/McpProcessesOverviewPage.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/admin/pages/McpProcessesOverviewPage.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useSuspenseQuery} from '@tanstack/react-query';
+import type {MessageSubscription} from '@camunda/camunda-api-zod-schemas/8.10';
+import {queries} from '#/shared/http/queries';
+
+type Props = {
+	messageSubscriptions: MessageSubscription[];
+};
+
+const McpProcessesOverviewPage: React.FC<Props> = ({messageSubscriptions}) => {
+	return (
+		<main>
+			<h1>MCP Processes Overview</h1>
+			<p>{messageSubscriptions.length} message subscription(s) on partition 1</p>
+		</main>
+	);
+};
+
+const McpProcessesOverview: React.FC = () => {
+	const {data} = useSuspenseQuery(queries.getMcpProcessMessageSubscriptions());
+
+	return <McpProcessesOverviewPage messageSubscriptions={data.items} />;
+};
+
+export {McpProcessesOverviewPage, McpProcessesOverview};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routeTree.gen.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as AuthAdminRouteRouteImport } from './routes/_auth/admin/route'
 import { Route as AuthTasklistIndexRouteImport } from './routes/_auth/tasklist/index'
 import { Route as AuthOperateIndexRouteImport } from './routes/_auth/operate/index'
 import { Route as AuthAdminIndexRouteImport } from './routes/_auth/admin/index'
+import { Route as AuthAdminMcpProcessesRouteImport } from './routes/_auth/admin/mcp-processes'
 
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
@@ -63,6 +64,11 @@ const AuthAdminIndexRoute = AuthAdminIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AuthAdminRouteRoute,
 } as any)
+const AuthAdminMcpProcessesRoute = AuthAdminMcpProcessesRouteImport.update({
+  id: '/mcp-processes',
+  path: '/mcp-processes',
+  getParentRoute: () => AuthAdminRouteRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof AuthIndexRoute
@@ -70,6 +76,7 @@ export interface FileRoutesByFullPath {
   '/admin': typeof AuthAdminRouteRouteWithChildren
   '/operate': typeof AuthOperateRouteRouteWithChildren
   '/tasklist': typeof AuthTasklistRouteRouteWithChildren
+  '/admin/mcp-processes': typeof AuthAdminMcpProcessesRoute
   '/admin/': typeof AuthAdminIndexRoute
   '/operate/': typeof AuthOperateIndexRoute
   '/tasklist/': typeof AuthTasklistIndexRoute
@@ -77,6 +84,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/': typeof AuthIndexRoute
+  '/admin/mcp-processes': typeof AuthAdminMcpProcessesRoute
   '/admin': typeof AuthAdminIndexRoute
   '/operate': typeof AuthOperateIndexRoute
   '/tasklist': typeof AuthTasklistIndexRoute
@@ -89,6 +97,7 @@ export interface FileRoutesById {
   '/_auth/operate': typeof AuthOperateRouteRouteWithChildren
   '/_auth/tasklist': typeof AuthTasklistRouteRouteWithChildren
   '/_auth/': typeof AuthIndexRoute
+  '/_auth/admin/mcp-processes': typeof AuthAdminMcpProcessesRoute
   '/_auth/admin/': typeof AuthAdminIndexRoute
   '/_auth/operate/': typeof AuthOperateIndexRoute
   '/_auth/tasklist/': typeof AuthTasklistIndexRoute
@@ -101,11 +110,18 @@ export interface FileRouteTypes {
     | '/admin'
     | '/operate'
     | '/tasklist'
+    | '/admin/mcp-processes'
     | '/admin/'
     | '/operate/'
     | '/tasklist/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/login' | '/' | '/admin' | '/operate' | '/tasklist'
+  to:
+    | '/login'
+    | '/'
+    | '/admin/mcp-processes'
+    | '/admin'
+    | '/operate'
+    | '/tasklist'
   id:
     | '__root__'
     | '/_auth'
@@ -114,6 +130,7 @@ export interface FileRouteTypes {
     | '/_auth/operate'
     | '/_auth/tasklist'
     | '/_auth/'
+    | '/_auth/admin/mcp-processes'
     | '/_auth/admin/'
     | '/_auth/operate/'
     | '/_auth/tasklist/'
@@ -189,14 +206,23 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthAdminIndexRouteImport
       parentRoute: typeof AuthAdminRouteRoute
     }
+    '/_auth/admin/mcp-processes': {
+      id: '/_auth/admin/mcp-processes'
+      path: '/mcp-processes'
+      fullPath: '/admin/mcp-processes'
+      preLoaderRoute: typeof AuthAdminMcpProcessesRouteImport
+      parentRoute: typeof AuthAdminRouteRoute
+    }
   }
 }
 
 interface AuthAdminRouteRouteChildren {
+  AuthAdminMcpProcessesRoute: typeof AuthAdminMcpProcessesRoute
   AuthAdminIndexRoute: typeof AuthAdminIndexRoute
 }
 
 const AuthAdminRouteRouteChildren: AuthAdminRouteRouteChildren = {
+  AuthAdminMcpProcessesRoute: AuthAdminMcpProcessesRoute,
   AuthAdminIndexRoute: AuthAdminIndexRoute,
 }
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/admin/mcp-processes.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/admin/mcp-processes.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createFileRoute} from '@tanstack/react-router';
+import {queries} from '#/shared/http/queries';
+import {McpProcessesOverview} from '#/admin/pages/McpProcessesOverviewPage';
+
+export const Route = createFileRoute('/_auth/admin/mcp-processes')({
+	loader: ({context: {queryClient}}) => {
+		return queryClient.ensureQueryData(queries.getMcpProcessMessageSubscriptions());
+	},
+	component: McpProcessesOverview,
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
@@ -6,7 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {endpoints as unifiedAPIEndpoints} from '@camunda/camunda-api-zod-schemas/8.10';
+import {
+	endpoints as unifiedAPIEndpoints,
+	type QueryMessageSubscriptionsRequestBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 import {getBootConfig} from '#/shared/config/getBootConfig';
 import {mergePathname} from './mergePathname';
 
@@ -52,6 +55,14 @@ const endpoints = {
 			...BASE_REQUEST_OPTIONS,
 			method: unifiedAPIEndpoints.getSystemConfiguration.method,
 			headers: {'Content-Type': 'application/json'},
+		}),
+
+	queryMessageSubscriptions: (body: QueryMessageSubscriptionsRequestBody) =>
+		new Request(getFullURL(unifiedAPIEndpoints.queryMessageSubscriptions.getUrl()), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.queryMessageSubscriptions.method,
+			headers: {'Content-Type': 'application/json'},
+			body: JSON.stringify(body),
 		}),
 };
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/queries.ts
@@ -7,13 +7,20 @@
  */
 
 import {queryOptions} from '@tanstack/react-query';
-import type {GetSystemConfigurationResponseBody, CurrentUser} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {
+	GetSystemConfigurationResponseBody,
+	CurrentUser,
+	QueryMessageSubscriptionsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 import {request} from './request';
 import {endpoints} from './endpoints';
+
+const MCP_PARTITION_ID = 1;
 
 const queryKeys = {
 	currentUser: () => ['getCurrentUser'] as const,
 	systemConfiguration: () => ['systemConfiguration'] as const,
+	mcpProcessMessageSubscriptions: () => ['mcpProcessMessageSubscriptions'] as const,
 };
 
 const queries = {
@@ -43,6 +50,21 @@ const queries = {
 			},
 			staleTime: Infinity,
 			gcTime: Infinity,
+		}),
+	getMcpProcessMessageSubscriptions: () =>
+		queryOptions({
+			queryKey: queryKeys.mcpProcessMessageSubscriptions(),
+			queryFn: async (): Promise<QueryMessageSubscriptionsResponseBody> => {
+				const {response, error} = await request(
+					endpoints.queryMessageSubscriptions({
+						filter: {partitionId: MCP_PARTITION_ID},
+					}),
+				);
+				if (error !== null) {
+					throw error;
+				}
+				return response.json();
+			},
 		}),
 } as const;
 

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/message-subscriptions.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/message-subscriptions.ts
@@ -37,6 +37,7 @@ const messageSubscriptionSchema = z.object({
 	messageName: z.string(),
 	correlationKey: z.string().nullable(),
 	tenantId: z.string(),
+	partitionId: z.number().int(),
 	rootProcessInstanceKey: z.string().nullable(),
 	toolProperties: z.record(z.string(), z.string()),
 	processDefinitionName: z.string().nullable(),
@@ -61,6 +62,7 @@ const queryMessageSubscriptionRequestBodySchema = getQueryRequestBodySchema({
 		'messageName',
 		'correlationKey',
 		'tenantId',
+		'partitionId',
 		'toolName',
 		'inboundConnectorType',
 	] as const,
@@ -80,6 +82,7 @@ const queryMessageSubscriptionRequestBodySchema = getQueryRequestBodySchema({
 			messageName: advancedStringFilterSchema,
 			correlationKey: advancedStringFilterSchema,
 			tenantId: advancedStringFilterSchema,
+			partitionId: advancedIntegerFilterSchema,
 			toolName: advancedStringFilterSchema,
 			inboundConnectorType: advancedStringFilterSchema,
 		})

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.8/message-subscriptions.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.8/message-subscriptions.ts
@@ -61,6 +61,7 @@ const queryMessageSubscriptionRequestBodySchema = getQueryRequestBodySchema({
 			messageName: advancedStringFilterSchema,
 			correlationKey: advancedStringFilterSchema,
 			tenantId: advancedStringFilterSchema,
+			partitionId: advancedIntegerFilterSchema,
 		})
 		.partial(),
 });

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.9/message-subscriptions.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.9/message-subscriptions.ts
@@ -62,6 +62,7 @@ const queryMessageSubscriptionRequestBodySchema = getQueryRequestBodySchema({
 			messageName: advancedStringFilterSchema,
 			correlationKey: advancedStringFilterSchema,
 			tenantId: advancedStringFilterSchema,
+			partitionId: advancedIntegerFilterSchema,
 		})
 		.partial(),
 });

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/CorrelatedMessageSubscriptionTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/CorrelatedMessageSubscriptionTemplate.java
@@ -29,7 +29,9 @@ public class CorrelatedMessageSubscriptionTemplate extends AbstractTemplateDescr
   public static final String MESSAGE_KEY = "messageKey";
   public static final String MESSAGE_NAME = "messageName";
   public static final String POSITION = "position";
+  public static final String PARTITION_ID = "partitionId";
   public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
+  public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
   public static final String SUBSCRIPTION_KEY = "subscriptionKey";
   public static final String TENANT_ID = "tenantId";
   public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
@@ -112,6 +112,7 @@ public class MessageSubscriptionTemplate extends AbstractTemplateDescriptor
   public static final String MESSAGE_SUBSCRIPTION_TYPE = "messageSubscriptionType";
   public static final String TOOL_NAME = "toolName";
   public static final String INBOUND_CONNECTOR_TYPE = "inboundConnectorType";
+  public static final String PARTITION_ID = "partitionId";
 
   public MessageSubscriptionTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -294,6 +294,7 @@ components:
         - messageSubscriptionKey
         - messageSubscriptionState
         - messageSubscriptionType
+        - partitionId
         - processDefinitionId
         - processDefinitionKey
         - processDefinitionName
@@ -356,6 +357,11 @@ components:
           description: The correlation key of the message subscription.
         messageSubscriptionType:
           $ref: '#/components/schemas/MessageSubscriptionTypeEnum'
+        partitionId:
+          description: The partition ID of the message subscription.
+          type: integer
+          format: int32
+          nullable: true
         toolProperties:
           type: object
           additionalProperties:
@@ -401,6 +407,8 @@ components:
         - propertyName: toolName
           addedInVersion: "8.10"
         - propertyName: inboundConnectorType
+          addedInVersion: "8.10"
+        - propertyName: partitionId
           addedInVersion: "8.10"
 
     MessageSubscriptionSearchQuerySortRequest:
@@ -517,6 +525,10 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: Filter by inbound connector type extracted from the `inbound.type` zeebe:property.
+        partitionId:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
+          description: The partition ID of the message subscription.
       x-properties-added-in-version:
         - propertyName: messageSubscriptionKey
           addedInVersion: "8.8"
@@ -549,6 +561,8 @@ components:
         - propertyName: toolName
           addedInVersion: "8.10"
         - propertyName: inboundConnectorType
+          addedInVersion: "8.10"
+        - propertyName: partitionId
           addedInVersion: "8.10"
 
     CorrelatedMessageSubscriptionSearchQueryResult:


### PR DESCRIPTION
## Summary

- Exposes `partitionId` in the `MessageSubscription` search domain entity, V2 REST API (filter + response field), and Java SDK (`MessageSubscription` interface and `MessageSubscriptionFilter`)
- Adds `PARTITION_ID` to the RDBMS column definition and updates the MyBatis mapper and entity transformer accordingly
- Introduces a new `searchMessageSubscriptions` MCP tool in `gateways/gateway-mcp/` that always restricts results to partition 1
- Updates OC Admin UI Zod schemas (8.8–8.10) to include `partitionId` in the message subscription response and filter shapes
- Adds the MCP Processes overview page and query in the OC Admin UI, with the search request hard-coded to `partitionId: 1`

## Test plan

- [ ] `./mvnw verify -pl search/search-domain -DskipTests=false -Dquickly`
- [ ] `./mvnw verify -pl search/search-client-query-transformer -DskipTests=false -Dquickly`
- [ ] `./mvnw verify -pl zeebe/gateway-rest -DskipTests=false -Dquickly`
- [ ] `./mvnw verify -pl clients/java -DskipTests=false -Dquickly`
- [ ] `./mvnw verify -pl gateways/gateway-mcp -DskipTests=false -Dquickly`
- [ ] Frontend: `npm run typecheck` and unit tests pass in `webapp/client/`
- [ ] V2 `POST /v2/message-subscriptions/search` returns `partitionId` in each result
- [ ] V2 search with `filter.partitionId` correctly filters results
- [ ] OC Admin UI MCP Processes overview page loads and shows only partition-1 subscriptions


---
_Generated by [Claude Code](https://claude.ai/code/session_01BUKxFs9h8MyUpHqvv24C7a)_