### PR TITLE
refactor: exporter director doesn't need to send to legacy subject

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -149,14 +149,12 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
     final var exporterPositionsLegacySubject =
         String.format(LEGACY_EXPORTER_STATE_TOPIC_FORMAT, partitionId);
-    final var exporterPositionsSubject =
-        String.format(EXPORTER_STATE_TOPIC_FORMAT, physicalTenantId, partitionId);
     exporterPositionsSendingSubject =
-        context.isSendOnLegacySubject() ? exporterPositionsLegacySubject : exporterPositionsSubject;
+        String.format(EXPORTER_STATE_TOPIC_FORMAT, physicalTenantId, partitionId);
     exporterPositionsReceivingSubjects =
         context.isReceiveOnLegacySubject()
-            ? List.of(exporterPositionsLegacySubject, exporterPositionsSubject)
-            : List.of(exporterPositionsSubject);
+            ? List.of(exporterPositionsLegacySubject, exporterPositionsSendingSubject)
+            : List.of(exporterPositionsSendingSubject);
 
     exporterMode = context.getExporterMode();
     distributionInterval = context.getDistributionInterval();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -37,7 +37,6 @@ public final class ExporterDirectorContext {
   private String clusterId = "";
   private @Nullable String licenseKey;
   private String tenantName;
-  private boolean sendOnLegacySubject = true;
   private boolean receiveOnLegacySubject = true;
 
   public int getId() {
@@ -94,10 +93,6 @@ public final class ExporterDirectorContext {
 
   public String getTenantName() {
     return tenantName;
-  }
-
-  public boolean isSendOnLegacySubject() {
-    return sendOnLegacySubject;
   }
 
   public boolean isReceiveOnLegacySubject() {
@@ -173,11 +168,6 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext tenantName(final String tenantName) {
     this.tenantName = tenantName;
-    return this;
-  }
-
-  public ExporterDirectorContext sendOnLegacySubject(final boolean sendOnLegacySubject) {
-    this.sendOnLegacySubject = sendOnLegacySubject;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -118,6 +119,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
     final var exporterFilter = SkipPositionsFilter.of(skipRecords);
     final ExporterMode exporterMode =
         targetRole == Role.LEADER ? ExporterMode.ACTIVE : ExporterMode.PASSIVE;
+    final var tenantName = context.getRaftPartition().getPartitionConfig().getTenantName();
     final ExporterDirectorContext exporterCtx =
         new ExporterDirectorContext()
             .id(EXPORTER_PROCESSOR_ID)
@@ -133,9 +135,8 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .meterRegistry(context.getPartitionTransitionMeterRegistry())
             .clusterId(requireNonNullElse(brokerCfg.getCluster().getClusterId(), ""))
             .licenseKey(brokerCfg.getLicenseKey())
-            .tenantName(context.getRaftPartition().getPartitionConfig().getTenantName())
-            .sendOnLegacySubject(brokerCfg.getExperimental().isSendOnLegacySubject())
-            .receiveOnLegacySubject(brokerCfg.getExperimental().isReceiveOnLegacySubject());
+            .tenantName(tenantName)
+            .receiveOnLegacySubject(Protocol.DEFAULT_PARTITION_GROUP_NAME.equals(tenantName));
 
     final ExporterDirector director =
         exporterDirectorBuilder.apply(exporterCtx, context.getExporterPhase());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
@@ -192,110 +192,33 @@ public final class ExporterDirectorDistributionTest {
   @Parameters
   public static Object[][] activeExporters() {
     return new Object[][] {
-      create89ExporterMode(),
-      create89To810ExporterMode(),
-      create89To810ExporterModeReverse(),
-      create810ExporterMode(),
-      create810To811ExporterMode(),
-      create810To811ExporterModeReverse(),
-      create811ExporterMode(),
-      create811ExporterModeWithAnotherEngineName()
+      createDefaultTenantExporterMode(), createCustomTenantExporterMode(),
     };
   }
 
-  static Object[] create89ExporterMode() {
-    return new Object[] {
-      ExporterRule.activeExporter()
-          .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withDistributionInterval(DISTRIBUTION_INTERVAL),
-      ExporterRule.passiveExporter().withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-    };
-  }
-
-  static Object[] create89To810ExporterMode() {
+  static Object[] createDefaultTenantExporterMode() {
     return new Object[] {
       ExporterRule.activeExporter()
           .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
           .withDistributionInterval(DISTRIBUTION_INTERVAL)
-          .withExporterDirectorContextConfigurator(c -> c.sendOnLegacySubject(false)),
-      ExporterRule.passiveExporter().withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-    };
-  }
-
-  static Object[] create89To810ExporterModeReverse() {
-    return new Object[] {
-      ExporterRule.activeExporter()
-          .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withDistributionInterval(DISTRIBUTION_INTERVAL),
+          .withExporterDirectorContextConfigurator(c -> c.receiveOnLegacySubject(true)),
       ExporterRule.passiveExporter()
           .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withExporterDirectorContextConfigurator(c -> c.sendOnLegacySubject(false))
+          .withExporterDirectorContextConfigurator(c -> c.receiveOnLegacySubject(true))
     };
   }
 
-  static Object[] create810ExporterMode() {
-    return new Object[] {
-      ExporterRule.activeExporter()
-          .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withDistributionInterval(DISTRIBUTION_INTERVAL)
-          .withExporterDirectorContextConfigurator(c -> c.sendOnLegacySubject(false)),
-      ExporterRule.passiveExporter()
-          .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withExporterDirectorContextConfigurator(c -> c.sendOnLegacySubject(false))
-    };
-  }
-
-  static Object[] create810To811ExporterMode() {
+  static Object[] createCustomTenantExporterMode() {
     return new Object[] {
       ExporterRule.activeExporter()
           .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
           .withDistributionInterval(DISTRIBUTION_INTERVAL)
           .withExporterDirectorContextConfigurator(
-              c -> c.sendOnLegacySubject(false).receiveOnLegacySubject(false)),
-      ExporterRule.passiveExporter()
-          .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withExporterDirectorContextConfigurator(c -> c.sendOnLegacySubject(false))
-    };
-  }
-
-  static Object[] create810To811ExporterModeReverse() {
-    return new Object[] {
-      ExporterRule.activeExporter()
-          .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withDistributionInterval(DISTRIBUTION_INTERVAL)
-          .withExporterDirectorContextConfigurator(c -> c.sendOnLegacySubject(false)),
+              c -> c.tenantName("foo").receiveOnLegacySubject(false)),
       ExporterRule.passiveExporter()
           .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
           .withExporterDirectorContextConfigurator(
-              c -> c.sendOnLegacySubject(false).receiveOnLegacySubject(false))
-    };
-  }
-
-  static Object[] create811ExporterMode() {
-    return new Object[] {
-      ExporterRule.activeExporter()
-          .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withDistributionInterval(DISTRIBUTION_INTERVAL)
-          .withExporterDirectorContextConfigurator(
-              c -> c.sendOnLegacySubject(false).receiveOnLegacySubject(false)),
-      ExporterRule.passiveExporter()
-          .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withExporterDirectorContextConfigurator(
-              c -> c.sendOnLegacySubject(false).receiveOnLegacySubject(false))
-    };
-  }
-
-  static Object[] create811ExporterModeWithAnotherEngineName() {
-    return new Object[] {
-      ExporterRule.activeExporter()
-          .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withDistributionInterval(DISTRIBUTION_INTERVAL)
-          .withExporterDirectorContextConfigurator(
-              c -> c.sendOnLegacySubject(false).receiveOnLegacySubject(false).tenantName("foo")),
-      ExporterRule.passiveExporter()
-          .withPartitionMessageService(SIMPLE_PARTITION_MESSAGE_SERVICE)
-          .withExporterDirectorContextConfigurator(
-              c -> c.sendOnLegacySubject(false).receiveOnLegacySubject(false).tenantName("foo"))
+              c -> c.tenantName("foo").receiveOnLegacySubject(false))
     };
   }
 


### PR DESCRIPTION
Brokers on 8.9 already listen to the new format so brokers on 8.10 don't need to send to the legacy subject. For the default tenant, they still need to receive on the legacy subject to ensure rolling upgrades work.

closes #54830