### PR TITLE
fix rescheduling process instance count job

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTask.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTask.java
@@ -45,7 +45,8 @@ public final class ReschedulingTask implements RunnableTask {
 
     periodicLogger = new ReschedulingTaskLogger(logger, true);
     idleStrategy = new ExponentialBackoff(maxDelayBetweenRunsMs, delayBetweenRunsMs, 1.2, 0);
-    errorStrategy = new ExponentialBackoff(10_000, delayBetweenRunsMs, 1.2, 0);
+    errorStrategy =
+        new ExponentialBackoff(Math.max(10_000, delayBetweenRunsMs), delayBetweenRunsMs, 1.2, 0);
   }
 
   @Override

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTask.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTask.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 
 public final class ReschedulingTask implements RunnableTask {
+  private static final long ERROR_DELAY_MS = 10_000L;
   private final BackgroundTask task;
   private final int minimumWorkCount;
   private final ScheduledExecutorService executor;
@@ -45,8 +46,14 @@ public final class ReschedulingTask implements RunnableTask {
 
     periodicLogger = new ReschedulingTaskLogger(logger, true);
     idleStrategy = new ExponentialBackoff(maxDelayBetweenRunsMs, delayBetweenRunsMs, 1.2, 0);
+    // some tasks have a really long delayBetweenRunsMs, so we need to tweak
+    // those delays for the error backoff.
     errorStrategy =
-        new ExponentialBackoff(Math.max(10_000, delayBetweenRunsMs), delayBetweenRunsMs, 1.2, 0);
+        new ExponentialBackoff(
+            Math.max(ERROR_DELAY_MS, delayBetweenRunsMs),
+            Math.min(ERROR_DELAY_MS, delayBetweenRunsMs),
+            1.2,
+            0);
   }
 
   @Override

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTask.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTask.java
@@ -71,7 +71,16 @@ public final class ReschedulingTask implements RunnableTask {
         .thenApplyAsync(this::onWorkPerformed, executor)
         .exceptionallyAsync(this::onError, executor)
         .thenAcceptAsync(this::reschedule, executor)
-        .thenAccept(unused -> executionCounter.incrementAndGet());
+        .thenAccept(unused -> executionCounter.incrementAndGet())
+        .exceptionally(
+            error -> {
+              logger.error(
+                  "Unexpected error occurred while rescheduling task {} (bug in error handling code?);"
+                      + " task will NOT be retried",
+                  task,
+                  error);
+              return null;
+            });
   }
 
   @Override

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/ExponentialBackoff.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/ExponentialBackoff.java
@@ -78,6 +78,10 @@ public final class ExponentialBackoff implements LongUnaryOperator {
     this.backoffFactor = backoffFactor;
     this.jitterFactor = jitterFactor;
     this.random = random;
+    if (minDelay > maxDelay) {
+      throw new IllegalArgumentException(
+          "minDelay (" + minDelay + "ms) must be <= maxDelay (" + maxDelay + "ms)");
+    }
   }
 
   @Override

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/ExponentialBackoffTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/ExponentialBackoffTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ExponentialBackoffTest {
+
+  @Test
+  void shouldThrowExceptionIfMinDelayIsGreaterThanMaxDelay() {
+    assertThatThrownBy(() -> new ExponentialBackoff(100L, 200L, 1.2, 0))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldBackoffUntilMaxDelay() {
+    final var backoff = new ExponentialBackoff(200L, 100L, 1.4, 0);
+    assertThat(backoff.applyAsLong(0L)).isEqualTo(100L);
+    assertThat(backoff.applyAsLong(100L)).isEqualTo(140L);
+    assertThat(backoff.applyAsLong(140L)).isEqualTo(196L);
+    assertThat(backoff.applyAsLong(196L)).isEqualTo(200L);
+  }
+}


### PR DESCRIPTION
When there was an error running the `ProcessInstanceToBeArchivedCountJob` task it was failing silently with an exception:

```
java.lang.IllegalArgumentException: 60000.0 > 10000.0
	at java.base/java.lang.Math.clamp(Math.java:2274)
	at io.camunda.zeebe.util.ExponentialBackoff.supplyRetryDelay(ExponentialBackoff.java:89)
	at io.camunda.zeebe.util.ExponentialBackoff.applyAsLong(ExponentialBackoff.java:85)
	at io.camunda.zeebe.exporter.common.tasks.ReschedulingTask.onError(ReschedulingTask.java:104)
	at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:990)
	at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:974)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

This adds logging so would see that error in the logs in the future, but also ensures we don't try to call `Math.clamp` with invalid values.  Instead now we check the min/max delay values much earlier (when we are creating the backoff objects inside `ReschedulingTask` (so things would fail at start up).  Plus we now ensure that we don't pass invalid values to the constructor.
