### PR TITLE
54766 implement avg and median tokens per execution number tiles 

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractBrokerlessZeebeCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractBrokerlessZeebeCCSMIT.java
@@ -8,10 +8,21 @@
 package io.camunda.optimize;
 
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.CCSM_PROFILE;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.ProcessInstanceConstants;
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
 import io.camunda.optimize.service.util.IdGenerator;
 import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -99,5 +110,63 @@ public abstract class AbstractBrokerlessZeebeCCSMIT extends AbstractIT {
   protected void importAllZeebeEntitiesFromLastIndex() {
     embeddedOptimizeExtension.importAllZeebeEntitiesFromLastIndex();
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+  }
+
+  /**
+   * Persists the given process instances directly into the Optimize process-instance index, then
+   * refreshes all indices so subsequent reads in the same test see the data immediately. Use this
+   * when you want to test report logic without going through the Zeebe import pipeline.
+   *
+   * <p>Also persists a minimal process definition for each unique definition key+version in the
+   * list, so report evaluation via allFullyImportedProcessDefinitions() can find them.
+   */
+  protected void persistProcessInstances(final List<ProcessInstanceDto> instances) {
+    final List<ProcessDefinitionOptimizeDto> definitions =
+        instances.stream()
+            .filter(i -> i.getProcessDefinitionKey() != null)
+            .map(
+                i ->
+                    ProcessDefinitionOptimizeDto.builder()
+                        .id(i.getProcessDefinitionId())
+                        .key(i.getProcessDefinitionKey())
+                        .version(i.getProcessDefinitionVersion())
+                        .name(i.getProcessDefinitionKey())
+                        .dataSource(i.getDataSource())
+                        .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+                        .bpmn20Xml("<definitions/>")
+                        .build())
+            .distinct()
+            .toList();
+    embeddedOptimizeExtension
+        .getBean(ProcessDefinitionWriter.class)
+        .importProcessDefinitions(definitions);
+
+    final ProcessInstanceWriter writer =
+        embeddedOptimizeExtension.getBean(ProcessInstanceWriter.class);
+    final DatabaseClient dbClient = embeddedOptimizeExtension.getBean(DatabaseClient.class);
+    final var requests = writer.generateProcessInstanceImports(instances, "test-source-index");
+    dbClient.executeImportRequestsAsBulk(
+        "test process instances",
+        requests,
+        embeddedOptimizeExtension
+            .getConfigurationService()
+            .getSkipDataAfterNestedDocLimitReached());
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+  }
+
+  /** Returns a builder for a minimal completed {@link ProcessInstanceDto}. */
+  protected static ProcessInstanceDto.ProcessInstanceDtoBuilder completedInstance(
+      final String processDefinitionKey) {
+    return ProcessInstanceDto.builder()
+        .processInstanceId(UUID.randomUUID().toString())
+        .processDefinitionKey(processDefinitionKey)
+        .processDefinitionVersion("1")
+        .processDefinitionId(processDefinitionKey + ":1:1")
+        .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+        .state(ProcessInstanceConstants.COMPLETED_STATE)
+        .dataSource(new ZeebeDataSourceDto("test-source", 1))
+        .startDate(OffsetDateTime.now().minusHours(2))
+        .endDate(OffsetDateTime.now().minusHours(1))
+        .duration(3_600_000L);
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -1,0 +1,675 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.dashboard;
+
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_AVG_TOKENS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessInstanceConstants;
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.persistence.incident.IncidentDto;
+import io.camunda.optimize.dto.optimize.persistence.incident.IncidentStatus;
+import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto;
+import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto.AgentMetricsDto;
+import io.camunda.optimize.dto.optimize.query.report.AdditionalProcessReportEvaluationFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
+import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RollingDateFilterDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FilterApplicationLevel;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceEndDateFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.result.MeasureDto;
+import io.camunda.optimize.service.db.report.result.NumberCommandResult;
+import io.camunda.optimize.service.report.ReportEvaluationService;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final String PROC_KEY = "my-agent-process";
+  private static final String USER_ID = "testUser";
+  private static final ZoneId UTC = ZoneId.of("UTC");
+
+  private ReportEvaluationService evaluationService;
+
+  @BeforeEach
+  void setUp() {
+    embeddedOptimizeExtension.getBean(AgenticControlDashboardService.class).reconcile();
+    evaluationService = embeddedOptimizeExtension.getBean(ReportEvaluationService.class);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Completed agent runs
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldCountOnlyCompletedAgenticInstances() {
+    final ProcessInstanceDto completed1 = agenticInstance(PROC_KEY, 100L, 50L).build();
+    final ProcessInstanceDto completed2 = agenticInstance(PROC_KEY, 200L, 100L).build();
+    // running instance — should not be counted
+    final ProcessInstanceDto running =
+        agenticInstance(PROC_KEY, 50L, 25L)
+            .state(ProcessInstanceConstants.ACTIVE_STATE)
+            .endDate(null)
+            .duration(null)
+            .build();
+    // completed but no agent instances — should not be counted
+    final ProcessInstanceDto nonAgentic = completedInstance(PROC_KEY).build();
+
+    persistProcessInstances(List.of(completed1, completed2, running, nonAgentic));
+
+    final Double result = evaluateNumber(KPI_COMPLETED_REPORT_ID, noExtraFilters());
+    assertThat(result).isEqualTo(2.0);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Average duration
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldComputeAverageDurationOfCompletedAgenticInstances() {
+    // durations: 1 h and 3 h → avg = 2 h = 7_200_000 ms
+    final ProcessInstanceDto inst1 = agenticInstance(PROC_KEY, 0L, 0L).duration(3_600_000L).build();
+    final ProcessInstanceDto inst2 =
+        agenticInstance(PROC_KEY, 0L, 0L).duration(10_800_000L).build();
+
+    persistProcessInstances(List.of(inst1, inst2));
+
+    final Double result = evaluateNumber(KPI_AVG_DURATION_REPORT_ID, noExtraFilters());
+    assertThat(result).isCloseTo(7_200_000.0, within(1.0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Incident rate (count of resolved incidents on completed agentic instances)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldCountResolvedIncidentsOnCompletedAgenticInstances() {
+    final String instanceId1 = UUID.randomUUID().toString();
+    final String instanceId2 = UUID.randomUUID().toString();
+
+    // one resolved incident
+    final IncidentDto resolved =
+        IncidentDto.builder()
+            .incidentStatus(IncidentStatus.RESOLVED)
+            .processInstanceId(instanceId1)
+            .build();
+    final ProcessInstanceDto withIncident =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .processInstanceId(instanceId1)
+            .incidents(List.of(resolved))
+            .build();
+
+    // no incidents
+    final ProcessInstanceDto clean =
+        agenticInstance(PROC_KEY, 100L, 50L).processInstanceId(instanceId2).build();
+
+    // running instance with a resolved incident — must not be counted
+    final String runningId = UUID.randomUUID().toString();
+    final ProcessInstanceDto running =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .processInstanceId(runningId)
+            .state(ProcessInstanceConstants.ACTIVE_STATE)
+            .endDate(null)
+            .duration(null)
+            .incidents(
+                List.of(
+                    IncidentDto.builder()
+                        .incidentStatus(IncidentStatus.RESOLVED)
+                        .processInstanceId(runningId)
+                        .build()))
+            .build();
+
+    persistProcessInstances(List.of(withIncident, clean, running));
+
+    final Double result = evaluateNumber(KPI_INCIDENT_RATE_REPORT_ID, noExtraFilters());
+    assertThat(result).isEqualTo(1.0);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Average tokens
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldComputeAverageTokensPerExecution() {
+    // totals: 150, 300, 450  → avg = 300
+    final ProcessInstanceDto inst1 = agenticInstance(PROC_KEY, 100L, 50L).build();
+    final ProcessInstanceDto inst2 = agenticInstance(PROC_KEY, 200L, 100L).build();
+    final ProcessInstanceDto inst3 = agenticInstance(PROC_KEY, 300L, 150L).build();
+
+    persistProcessInstances(List.of(inst1, inst2, inst3));
+
+    final Double result = evaluateNumber(KPI_AVG_TOKENS_REPORT_ID, noExtraFilters());
+    assertThat(result).isCloseTo(300.0, within(1.0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Median tokens
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldComputeMedianTokensPerExecution() {
+    // totals: 100, 200, 300, 400, 500 → median = 300
+    final ProcessInstanceDto inst1 = agenticInstance(PROC_KEY, 70L, 30L).build();
+    final ProcessInstanceDto inst2 = agenticInstance(PROC_KEY, 140L, 60L).build();
+    final ProcessInstanceDto inst3 = agenticInstance(PROC_KEY, 210L, 90L).build();
+    final ProcessInstanceDto inst4 = agenticInstance(PROC_KEY, 280L, 120L).build();
+    final ProcessInstanceDto inst5 = agenticInstance(PROC_KEY, 350L, 150L).build();
+
+    persistProcessInstances(List.of(inst1, inst2, inst3, inst4, inst5));
+
+    final Double result = evaluateNumber(KPI_MEDIAN_TOKENS_REPORT_ID, noExtraFilters());
+    // ES percentile approximation — allow small delta
+    assertThat(result).isCloseTo(300.0, within(10.0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Date range filters
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldCountAllInstancesWhenNoDateFilterApplied() {
+    // instances spread across a wide range — all should be counted without a date filter
+    final ProcessInstanceDto recent =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusHours(1))
+            .endDate(OffsetDateTime.now().minusMinutes(30))
+            .build();
+    final ProcessInstanceDto older =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusDays(30))
+            .endDate(OffsetDateTime.now().minusDays(29))
+            .build();
+    final ProcessInstanceDto oldest =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusDays(365))
+            .endDate(OffsetDateTime.now().minusDays(364))
+            .build();
+
+    persistProcessInstances(List.of(recent, older, oldest));
+
+    assertThat(evaluateNumber(KPI_COMPLETED_REPORT_ID, noExtraFilters())).isEqualTo(3.0);
+  }
+
+  @Test
+  void shouldApplyRollingHourDateFilter() {
+    // ended 30 min ago — within last-2-hours window
+    final ProcessInstanceDto withinWindow =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusHours(1))
+            .endDate(OffsetDateTime.now().minusMinutes(30))
+            .build();
+    // ended 6 hours ago — outside window
+    final ProcessInstanceDto outsideWindow =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusHours(7))
+            .endDate(OffsetDateTime.now().minusHours(6))
+            .build();
+
+    persistProcessInstances(List.of(withinWindow, outsideWindow));
+
+    assertThat(evaluateNumber(KPI_COMPLETED_REPORT_ID, rollingEndDateFilter(2L, DateUnit.HOURS)))
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldApplyRollingDayDateFilter() {
+    // ended 12 hours ago — within last-1-day window
+    final ProcessInstanceDto withinWindow =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusHours(13))
+            .endDate(OffsetDateTime.now().minusHours(12))
+            .build();
+    // ended 3 days ago — outside window
+    final ProcessInstanceDto outsideWindow =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusDays(4))
+            .endDate(OffsetDateTime.now().minusDays(3))
+            .build();
+
+    persistProcessInstances(List.of(withinWindow, outsideWindow));
+
+    assertThat(evaluateNumber(KPI_COMPLETED_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldApplyRollingWeekDateFilter() {
+    // ended 3 days ago — within last-1-week window
+    final ProcessInstanceDto withinWindow =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusDays(4))
+            .endDate(OffsetDateTime.now().minusDays(3))
+            .build();
+    // ended 10 days ago — outside window
+    final ProcessInstanceDto outsideWindow =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusDays(11))
+            .endDate(OffsetDateTime.now().minusDays(10))
+            .build();
+
+    persistProcessInstances(List.of(withinWindow, outsideWindow));
+
+    assertThat(evaluateNumber(KPI_COMPLETED_REPORT_ID, rollingEndDateFilter(1L, DateUnit.WEEKS)))
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldApplyRollingMonthDateFilter() {
+    // ended 15 days ago — within last-1-month window
+    final ProcessInstanceDto withinWindow =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusDays(16))
+            .endDate(OffsetDateTime.now().minusDays(15))
+            .build();
+    // ended 40 days ago — outside window
+    final ProcessInstanceDto outsideWindow =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusDays(41))
+            .endDate(OffsetDateTime.now().minusDays(40))
+            .build();
+
+    persistProcessInstances(List.of(withinWindow, outsideWindow));
+
+    assertThat(evaluateNumber(KPI_COMPLETED_REPORT_ID, rollingEndDateFilter(1L, DateUnit.MONTHS)))
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldAggregateMetricsWithinRollingDateFilter() {
+    // both within last-1-week: avg tokens should reflect only these two
+    final ProcessInstanceDto inst1 =
+        agenticInstance(PROC_KEY, 100L, 100L)
+            .startDate(OffsetDateTime.now().minusDays(3))
+            .endDate(OffsetDateTime.now().minusDays(2))
+            .build();
+    final ProcessInstanceDto inst2 =
+        agenticInstance(PROC_KEY, 200L, 200L)
+            .startDate(OffsetDateTime.now().minusDays(2))
+            .endDate(OffsetDateTime.now().minusDays(1))
+            .build();
+    // old instance with very different tokens — outside 1-week window
+    final ProcessInstanceDto oldInst =
+        agenticInstance(PROC_KEY, 10_000L, 10_000L)
+            .startDate(OffsetDateTime.now().minusDays(30))
+            .endDate(OffsetDateTime.now().minusDays(29))
+            .build();
+
+    persistProcessInstances(List.of(inst1, inst2, oldInst));
+
+    // avg of 200 and 400 = 300
+    assertThat(evaluateNumber(KPI_AVG_TOKENS_REPORT_ID, rollingEndDateFilter(1L, DateUnit.WEEKS)))
+        .isCloseTo(300.0, within(1.0));
+  }
+
+  @Test
+  void shouldApplyDateFilterToAvgDuration() {
+    // within window: duration 1h
+    final ProcessInstanceDto recent =
+        agenticInstance(PROC_KEY, 0L, 0L)
+            .startDate(OffsetDateTime.now().minusHours(3))
+            .endDate(OffsetDateTime.now().minusHours(2))
+            .duration(3_600_000L)
+            .build();
+    // outside window: duration 5h — should not skew the avg
+    final ProcessInstanceDto old =
+        agenticInstance(PROC_KEY, 0L, 0L)
+            .startDate(OffsetDateTime.now().minusDays(10))
+            .endDate(OffsetDateTime.now().minusDays(9))
+            .duration(18_000_000L)
+            .build();
+
+    persistProcessInstances(List.of(recent, old));
+
+    assertThat(evaluateNumber(KPI_AVG_DURATION_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
+        .isCloseTo(3_600_000.0, within(1.0));
+  }
+
+  @Test
+  void shouldApplyDateFilterToIncidentRate() {
+    // within window: 1 resolved incident
+    final String recentId = UUID.randomUUID().toString();
+    final ProcessInstanceDto recent =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .processInstanceId(recentId)
+            .startDate(OffsetDateTime.now().minusHours(3))
+            .endDate(OffsetDateTime.now().minusHours(2))
+            .incidents(
+                List.of(
+                    IncidentDto.builder()
+                        .incidentStatus(IncidentStatus.RESOLVED)
+                        .processInstanceId(recentId)
+                        .build()))
+            .build();
+    // outside window: 1 resolved incident — should be excluded
+    final String oldId = UUID.randomUUID().toString();
+    final ProcessInstanceDto old =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .processInstanceId(oldId)
+            .startDate(OffsetDateTime.now().minusDays(10))
+            .endDate(OffsetDateTime.now().minusDays(9))
+            .incidents(
+                List.of(
+                    IncidentDto.builder()
+                        .incidentStatus(IncidentStatus.RESOLVED)
+                        .processInstanceId(oldId)
+                        .build()))
+            .build();
+
+    persistProcessInstances(List.of(recent, old));
+
+    assertThat(evaluateNumber(KPI_INCIDENT_RATE_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldApplyDateFilterToMedianTokens() {
+    // within window: totals 100, 200, 300 → median 200
+    final ProcessInstanceDto inst1 =
+        agenticInstance(PROC_KEY, 50L, 50L)
+            .startDate(OffsetDateTime.now().minusDays(3))
+            .endDate(OffsetDateTime.now().minusDays(2))
+            .build();
+    final ProcessInstanceDto inst2 =
+        agenticInstance(PROC_KEY, 100L, 100L)
+            .startDate(OffsetDateTime.now().minusDays(2))
+            .endDate(OffsetDateTime.now().minusDays(1))
+            .build();
+    final ProcessInstanceDto inst3 =
+        agenticInstance(PROC_KEY, 150L, 150L)
+            .startDate(OffsetDateTime.now().minusDays(1))
+            .endDate(OffsetDateTime.now().minusHours(1))
+            .build();
+    // outside window — very high total, should not affect median
+    final ProcessInstanceDto old =
+        agenticInstance(PROC_KEY, 10_000L, 10_000L)
+            .startDate(OffsetDateTime.now().minusDays(30))
+            .endDate(OffsetDateTime.now().minusDays(29))
+            .build();
+
+    persistProcessInstances(List.of(inst1, inst2, inst3, old));
+
+    assertThat(
+            evaluateNumber(KPI_MEDIAN_TOKENS_REPORT_ID, rollingEndDateFilter(1L, DateUnit.WEEKS)))
+        .isCloseTo(200.0, within(10.0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Process definition filters
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldCountAllProcessesWhenNoDefinitionFilterApplied() {
+    final String procKeyA = "proc-all-a";
+    final String procKeyB = "proc-all-b";
+
+    persistProcessInstances(
+        List.of(
+            agenticInstance(procKeyA, 100L, 50L).build(),
+            agenticInstance(procKeyB, 200L, 100L).build(),
+            agenticInstance(procKeyB, 300L, 150L).build()));
+
+    // no definition filter → all 3 counted
+    assertThat(evaluateNumber(KPI_COMPLETED_REPORT_ID, noExtraFilters())).isEqualTo(3.0);
+  }
+
+  @Test
+  void shouldFilterToSingleProcessDefinition() {
+    final String procKeyA = "proc-single-a";
+    final String procKeyB = "proc-single-b";
+
+    persistProcessInstances(
+        List.of(
+            agenticInstance(procKeyA, 100L, 50L).build(),
+            agenticInstance(procKeyA, 200L, 100L).build(),
+            agenticInstance(procKeyB, 300L, 150L).build()));
+
+    assertThat(
+            evaluateNumber(
+                KPI_COMPLETED_REPORT_ID,
+                withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
+        .isEqualTo(2.0);
+  }
+
+  @Test
+  void shouldFilterToMultipleProcessDefinitions() {
+    final String procKeyA = "proc-multi-a";
+    final String procKeyB = "proc-multi-b";
+    final String procKeyC = "proc-multi-c";
+
+    persistProcessInstances(
+        List.of(
+            agenticInstance(procKeyA, 100L, 50L).build(),
+            agenticInstance(procKeyB, 200L, 100L).build(),
+            agenticInstance(procKeyC, 300L, 150L).build()));
+
+    // select A and B only — C excluded
+    assertThat(
+            evaluateNumber(
+                KPI_COMPLETED_REPORT_ID,
+                withDefinitions(
+                    List.of(
+                        new ReportDataDefinitionDto(procKeyA),
+                        new ReportDataDefinitionDto(procKeyB)))))
+        .isEqualTo(2.0);
+  }
+
+  @Test
+  void shouldAggregateMetricsForSelectedProcessDefinition() {
+    final String procKeyA = "proc-metrics-a";
+    final String procKeyB = "proc-metrics-b";
+
+    // procKeyA: input+output totals = 300 and 600 → avg = 450
+    // procKeyB: total = 900 — should be excluded
+    persistProcessInstances(
+        List.of(
+            agenticInstance(procKeyA, 100L, 200L).build(),
+            agenticInstance(procKeyA, 200L, 400L).build(),
+            agenticInstance(procKeyB, 300L, 600L).build()));
+
+    assertThat(
+            evaluateNumber(
+                KPI_AVG_TOKENS_REPORT_ID,
+                withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
+        .isCloseTo(450.0, within(1.0));
+  }
+
+  @Test
+  void shouldApplyDefinitionFilterToAvgDuration() {
+    final String procKeyA = "proc-dur-a";
+    final String procKeyB = "proc-dur-b";
+
+    // procKeyA: durations 1h and 3h → avg 2h
+    // procKeyB: duration 10h — should be excluded
+    persistProcessInstances(
+        List.of(
+            agenticInstance(procKeyA, 0L, 0L).duration(3_600_000L).build(),
+            agenticInstance(procKeyA, 0L, 0L).duration(10_800_000L).build(),
+            agenticInstance(procKeyB, 0L, 0L).duration(36_000_000L).build()));
+
+    assertThat(
+            evaluateNumber(
+                KPI_AVG_DURATION_REPORT_ID,
+                withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
+        .isCloseTo(7_200_000.0, within(1.0));
+  }
+
+  @Test
+  void shouldApplyDefinitionFilterToIncidentRate() {
+    final String procKeyA = "proc-inc-a";
+    final String procKeyB = "proc-inc-b";
+
+    final String idA = UUID.randomUUID().toString();
+    final String idB = UUID.randomUUID().toString();
+
+    persistProcessInstances(
+        List.of(
+            agenticInstance(procKeyA, 100L, 50L)
+                .processInstanceId(idA)
+                .incidents(
+                    List.of(
+                        IncidentDto.builder()
+                            .incidentStatus(IncidentStatus.RESOLVED)
+                            .processInstanceId(idA)
+                            .build()))
+                .build(),
+            agenticInstance(procKeyB, 100L, 50L)
+                .processInstanceId(idB)
+                .incidents(
+                    List.of(
+                        IncidentDto.builder()
+                            .incidentStatus(IncidentStatus.RESOLVED)
+                            .processInstanceId(idB)
+                            .build()))
+                .build()));
+
+    // only procKeyA selected → 1 incident
+    assertThat(
+            evaluateNumber(
+                KPI_INCIDENT_RATE_REPORT_ID,
+                withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldApplyDefinitionFilterToMedianTokens() {
+    final String procKeyA = "proc-med-a";
+    final String procKeyB = "proc-med-b";
+
+    // procKeyA: totals 100, 200, 300 → median 200
+    // procKeyB: total 50_000 — should be excluded
+    persistProcessInstances(
+        List.of(
+            agenticInstance(procKeyA, 50L, 50L).build(),
+            agenticInstance(procKeyA, 100L, 100L).build(),
+            agenticInstance(procKeyA, 150L, 150L).build(),
+            agenticInstance(procKeyB, 25_000L, 25_000L).build()));
+
+    assertThat(
+            evaluateNumber(
+                KPI_MEDIAN_TOKENS_REPORT_ID,
+                withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
+        .isCloseTo(200.0, within(10.0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Combined: process definition + date range
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldApplyDefinitionAndDateFilterTogether() {
+    final String procKeyA = "proc-combo-a";
+    final String procKeyB = "proc-combo-b";
+
+    // procKeyA recent — should be counted
+    final ProcessInstanceDto aRecent =
+        agenticInstance(procKeyA, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusHours(2))
+            .endDate(OffsetDateTime.now().minusHours(1))
+            .build();
+    // procKeyA old — excluded by date
+    final ProcessInstanceDto aOld =
+        agenticInstance(procKeyA, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusDays(10))
+            .endDate(OffsetDateTime.now().minusDays(9))
+            .build();
+    // procKeyB recent — excluded by definition
+    final ProcessInstanceDto bRecent =
+        agenticInstance(procKeyB, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusHours(2))
+            .endDate(OffsetDateTime.now().minusHours(1))
+            .build();
+
+    persistProcessInstances(List.of(aRecent, aOld, bRecent));
+
+    final AdditionalProcessReportEvaluationFilterDto combined =
+        withDefinitionsAndDateFilter(
+            List.of(new ReportDataDefinitionDto(procKeyA)), 1L, DateUnit.DAYS);
+    assertThat(evaluateNumber(KPI_COMPLETED_REPORT_ID, combined)).isEqualTo(1.0);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds a minimal completed agentic {@link ProcessInstanceDto} with one {@link AgentInstanceDto}
+   * and the given total token counts.
+   */
+  private ProcessInstanceDto.ProcessInstanceDtoBuilder agenticInstance(
+      final String processDefinitionKey, final long inputTokens, final long outputTokens) {
+    final AgentMetricsDto metrics = new AgentMetricsDto();
+    metrics.setInputTokens(inputTokens);
+    metrics.setOutputTokens(outputTokens);
+
+    final AgentInstanceDto agentInstance = new AgentInstanceDto();
+    agentInstance.setAgentInstanceId(UUID.randomUUID().toString());
+    agentInstance.setMetrics(metrics);
+
+    return completedInstance(processDefinitionKey)
+        .agentInstances(List.of(agentInstance))
+        .agentTotalInputTokens(inputTokens)
+        .agentTotalOutputTokens(outputTokens)
+        .agentTotalTokens(inputTokens + outputTokens);
+  }
+
+  private Double evaluateNumber(
+      final String reportId, final AdditionalProcessReportEvaluationFilterDto filterDto) {
+    final var result =
+        evaluationService.evaluateSavedReportWithAdditionalFilters(
+            USER_ID, UTC, reportId, filterDto, null);
+    final NumberCommandResult commandResult =
+        (NumberCommandResult)
+            ((io.camunda.optimize.dto.optimize.query.report.SingleReportEvaluationResult<?>)
+                    result.getEvaluationResult())
+                .getFirstCommandResult();
+    final List<MeasureDto<Double>> measures = commandResult.getMeasures();
+    return measures.isEmpty() ? null : measures.getFirst().getData();
+  }
+
+  private AdditionalProcessReportEvaluationFilterDto noExtraFilters() {
+    return new AdditionalProcessReportEvaluationFilterDto(List.of());
+  }
+
+  private AdditionalProcessReportEvaluationFilterDto rollingEndDateFilter(
+      final long value, final DateUnit unit) {
+    final InstanceEndDateFilterDto filter = new InstanceEndDateFilterDto();
+    filter.setData(new RollingDateFilterDataDto(new RollingDateFilterStartDto(value, unit)));
+    filter.setFilterLevel(FilterApplicationLevel.INSTANCE);
+    return new AdditionalProcessReportEvaluationFilterDto(List.of((ProcessFilterDto<?>) filter));
+  }
+
+  private AdditionalProcessReportEvaluationFilterDto withDefinitions(
+      final List<ReportDataDefinitionDto> definitions) {
+    final AdditionalProcessReportEvaluationFilterDto dto =
+        new AdditionalProcessReportEvaluationFilterDto(List.of());
+    dto.setDefinitions(definitions);
+    return dto;
+  }
+
+  private AdditionalProcessReportEvaluationFilterDto withDefinitionsAndDateFilter(
+      final List<ReportDataDefinitionDto> definitions, final long value, final DateUnit unit) {
+    final InstanceEndDateFilterDto filter = new InstanceEndDateFilterDto();
+    filter.setData(new RollingDateFilterDataDto(new RollingDateFilterStartDto(value, unit)));
+    filter.setFilterLevel(FilterApplicationLevel.INSTANCE);
+    final AdditionalProcessReportEvaluationFilterDto dto = withDefinitions(definitions);
+    dto.setFilter(List.of((ProcessFilterDto<?>) filter));
+    return dto;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.dashboard;
 
 import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
+import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionUpdateDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardFilterDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardInstanceEndDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardProcessScopeFilterDto;
@@ -18,6 +19,9 @@ import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardTileType;
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.DimensionDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.PositionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.SingleReportConfigurationDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RollingDateFilterDataDto;
@@ -35,7 +39,9 @@ import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -61,6 +67,13 @@ public class AgenticControlDashboardService {
       "agenticKpiExecutionIncidentRateName";
   public static final String KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION =
       "agenticKpiExecutionIncidentRateDescription";
+  public static final String KPI_EXECUTION_AVG_TOKENS_NAME = "agenticKpiExecutionAvgTokensName";
+  public static final String KPI_EXECUTION_AVG_TOKENS_DESCRIPTION =
+      "agenticKpiExecutionAvgTokensDescription";
+  public static final String KPI_EXECUTION_MEDIAN_TOKENS_NAME =
+      "agenticKpiExecutionMedianTokensName";
+  public static final String KPI_EXECUTION_MEDIAN_TOKENS_DESCRIPTION =
+      "agenticKpiExecutionMedianTokensDescription";
 
   // Deterministic report IDs — derived from fixed seed strings so IDs are stable across restarts
   // and DB reimports. Same seed always produces the same UUID (UUID v3 / name-based).
@@ -72,6 +85,11 @@ public class AgenticControlDashboardService {
           .toString();
   public static final String KPI_INCIDENT_RATE_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-kpi-incident-rate".getBytes(StandardCharsets.UTF_8))
+          .toString();
+  public static final String KPI_AVG_TOKENS_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-kpi-avg-tokens".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String KPI_MEDIAN_TOKENS_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-kpi-median-tokens".getBytes(StandardCharsets.UTF_8))
           .toString();
 
   private static final long INSTANCE_END_DATE_ROLLING_DAYS = 30L;
@@ -105,17 +123,22 @@ public class AgenticControlDashboardService {
   }
 
   public void reconcile() {
-    // Always upsert the three KPI reports so config changes are applied on every restart.
+    // Always upsert the five KPI reports so config changes are applied on every restart.
     // Report IDs are deterministic so upserts are safe and tile references never orphan.
     final List<DashboardReportTileDto> tiles = new ArrayList<>();
     tiles.add(buildCompletedInstancesReport());
     tiles.add(buildAvgDurationReport());
     tiles.add(buildIncidentRateReport());
+    tiles.add(buildAvgTokensReport());
+    tiles.add(buildMedianTokensReport());
 
-    // Only create the dashboard itself if it is absent — the stable tile IDs mean we never
-    // need to recreate it just to keep tile→report references consistent.
+    // Always upsert the dashboard too — tile list can grow across versions and the cold-start
+    // guard would leave an existing deployment stuck on the old layout.
+    final DashboardDefinitionRestDto dashboard = buildAgentDashboard(tiles);
     if (dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID).isEmpty()) {
-      dashboardWriter.saveDashboard(buildAgentDashboard(tiles));
+      dashboardWriter.saveDashboard(dashboard);
+    } else {
+      dashboardWriter.updateDashboard(toUpdateDto(dashboard), AGENTIC_DASHBOARD_ID);
     }
   }
 
@@ -177,7 +200,7 @@ public class AgenticControlDashboardService {
     final ProcessReportDataDto reportData =
         ProcessReportDataDto.builder()
             .definitions(Collections.emptyList())
-            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.PERCENTAGE))
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.FREQUENCY))
             .groupBy(new NoneGroupByDto())
             .distributedBy(new NoneDistributedByDto())
             .visualization(ProcessVisualization.NUMBER)
@@ -200,6 +223,57 @@ public class AgenticControlDashboardService {
         KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION,
         null);
     return buildTile(KPI_INCIDENT_RATE_REPORT_ID, new PositionDto(12, 0), new DimensionDto(6, 2));
+  }
+
+  private DashboardReportTileDto buildAvgTokensReport() {
+    return buildTokensReport(
+        KPI_AVG_TOKENS_REPORT_ID,
+        new AggregationDto(AggregationType.AVERAGE),
+        new PositionDto(0, 2),
+        KPI_EXECUTION_AVG_TOKENS_NAME,
+        KPI_EXECUTION_AVG_TOKENS_DESCRIPTION);
+  }
+
+  private DashboardReportTileDto buildMedianTokensReport() {
+    return buildTokensReport(
+        KPI_MEDIAN_TOKENS_REPORT_ID,
+        new AggregationDto(AggregationType.PERCENTILE, 50.0),
+        new PositionDto(9, 2),
+        KPI_EXECUTION_MEDIAN_TOKENS_NAME,
+        KPI_EXECUTION_MEDIAN_TOKENS_DESCRIPTION);
+  }
+
+  private DashboardReportTileDto buildTokensReport(
+      final String id,
+      final AggregationDto aggregation,
+      final PositionDto position,
+      final String nameKey,
+      final String descriptionKey) {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.AGENT_INSTANCE, ViewProperty.TOTAL_TOKENS))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.NUMBER)
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .aggregationTypes(new LinkedHashSet<>(Collections.singletonList(aggregation)))
+                    .precision(2)
+                    .valueFormat("compact")
+                    .build())
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .buildList())
+            .agenticControlReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        id, null, reportData, nameKey, descriptionKey, null);
+    return buildTile(id, position, new DimensionDto(9, 2), Map.of("section", "token"));
   }
 
   private DashboardDefinitionRestDto buildAgentDashboard(final List<DashboardReportTileDto> tiles) {
@@ -229,11 +303,28 @@ public class AgenticControlDashboardService {
 
   private DashboardReportTileDto buildTile(
       final String reportId, final PositionDto position, final DimensionDto dimensions) {
+    return buildTile(reportId, position, dimensions, null);
+  }
+
+  private DashboardReportTileDto buildTile(
+      final String reportId,
+      final PositionDto position,
+      final DimensionDto dimensions,
+      final Object configuration) {
     return DashboardReportTileDto.builder()
         .id(reportId)
         .type(DashboardTileType.OPTIMIZE_REPORT)
         .position(position)
         .dimensions(dimensions)
+        .configuration(configuration)
         .build();
+  }
+
+  private DashboardDefinitionUpdateDto toUpdateDto(final DashboardDefinitionRestDto source) {
+    final DashboardDefinitionUpdateDto updateDto = new DashboardDefinitionUpdateDto();
+    updateDto.setName(source.getName());
+    updateDto.setTiles(source.getTiles());
+    updateDto.setAvailableFilters(source.getAvailableFilters());
+    return updateDto;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/view/process/agent/AgentMetricScripts.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/view/process/agent/AgentMetricScripts.java
@@ -18,23 +18,24 @@ import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 public final class AgentMetricScripts {
 
   /**
-   * Total tokens is derived (not a raw Zeebe field): the sum of the input and output token fields.
-   * The {@code .empty} guard handles non-agent docs that lack the fields — the index mapping's
-   * {@code null_value(0L)} only substitutes explicit nulls, not missing fields, so without the
-   * guard the script would throw on such docs.
+   * Returns the pre-computed {@code agentTotalTokens} value, or {@code null} when the instance has
+   * no agent activity (null or empty {@code agentInstances} array).
+   *
+   * <p>The array is read from {@code _source} because nested fields are not accessible via doc
+   * values in aggregation scripts. Instances without agent activity are excluded from
+   * avg/percentile aggregations so they do not skew the median. Instances with agent activity but
+   * zero tokens legitimately contribute 0 and are included.
    */
   public static final String TOTAL_TOKENS =
-      "long inputTokens = doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
+      "def instances = params._source['"
+          + ProcessInstanceIndex.AGENT_INSTANCES
+          + "'];"
+          + "if (instances == null || instances.size() == 0) return null;"
+          + "return doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_TOKENS
           + "'].empty ? 0L : doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
-          + "'].value;"
-          + "long outputTokens = doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
-          + "'].empty ? 0L : doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
-          + "'].value;"
-          + "return inputTokens + outputTokens;";
+          + ProcessInstanceIndex.AGENT_TOTAL_TOKENS
+          + "'].value;";
 
   private AgentMetricScripts() {}
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/util/ValidationHelper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/util/ValidationHelper.java
@@ -108,9 +108,9 @@ public final class ValidationHelper {
     if (data instanceof SingleReportDataDto) {
       final SingleReportDataDto singleReportData = (SingleReportDataDto) data;
       if (data instanceof ProcessReportDataDto
-          && !((ProcessReportDataDto) data).isManagementReport()) {
-        // it is valid for management reports to not have a key if the user has no authorization for
-        // any processes
+          && !((ProcessReportDataDto) data).isSystemGeneratedReport()) {
+        // system-generated reports (management, instant preview, agentic control) have their
+        // definitions injected at query time, so an empty key is valid when no definitions exist
         ensureNotNull("definitionKey", singleReportData.getDefinitionKey());
       }
       ensureNotNull("definitionVersions", singleReportData.getDefinitionVersions());

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -5,6 +5,7 @@
     "title": "Agentic control plane",
     "description": "Überwachen Sie die Einführung, das Verhalten und die Zuverlässigkeit von KI-Agenten sowie den Token-Verbrauch prozessübergreifend.",
     "dateRange": "Zeitraum",
+    "tokenUsage": "Token-Nutzung",
     "presets": {
       "last7Days": "Letzte 7 Tage",
       "last30Days": "Letzte 30 Tage",
@@ -299,7 +300,9 @@
       "multi": "Anzahl und Dauer",
       "evaluationCount": "Evaluierungsanzahl",
       "variable": "Variable",
-      "process": "Prozessansicht"
+      "process": "Prozessansicht",
+      "agentInstance": "Agenteninstanz",
+      "totalTokens": "Tokens insgesamt"
     },
     "groupBy": {
       "label": "Gruppiere nach",
@@ -1547,7 +1550,11 @@
       "agenticKpiExecutionAvgDurationName": "Durchschnittliche Ausführungsdauer",
       "agenticKpiExecutionAvgDurationDescription": "Durchschnittliche Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum.",
       "agenticKpiExecutionIncidentRateName": "Vorfallsrate",
-      "agenticKpiExecutionIncidentRateDescription": "Anzahl der abgeschlossenen agentischen Prozessinstanzen mit einem gelösten Vorfall im gewählten Zeitraum."
+      "agenticKpiExecutionIncidentRateDescription": "Anzahl der abgeschlossenen agentischen Prozessinstanzen mit einem gelösten Vorfall im gewählten Zeitraum.",
+      "agenticKpiExecutionAvgTokensName": "Durchschnittliche Tokens pro Ausführung",
+      "agenticKpiExecutionAvgTokensDescription": "Durchschnittliche Gesamtanzahl der verbrauchten Tokens pro abgeschlossener agentischer Prozessinstanz im gewählten Zeitraum.",
+      "agenticKpiExecutionMedianTokensName": "Mediane Tokens pro Ausführung",
+      "agenticKpiExecutionMedianTokensDescription": "Median der verbrauchten Tokens pro abgeschlossener agentischer Prozessinstanz im gewählten Zeitraum."
     }
   },
   "managementDashboard": {

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -5,6 +5,7 @@
     "title": "Agentic control plane",
     "description": "Monitor AI agent adoption, token spend, behavior, and reliability across your processes.",
     "dateRange": "Date range",
+    "tokenUsage": "Token usage",
     "presets": {
       "last7Days": "Last 7 days",
       "last30Days": "Last 30 days",
@@ -299,7 +300,9 @@
       "multi": "Count and duration",
       "evaluationCount": "Evaluation count",
       "variable": "Variable",
-      "process": "Process view"
+      "process": "Process view",
+      "agentInstance": "Agent instance",
+      "totalTokens": "Total tokens"
     },
     "groupBy": {
       "label": "Group by",
@@ -1547,7 +1550,11 @@
       "agenticKpiExecutionAvgDurationName": "Avg execution duration",
       "agenticKpiExecutionAvgDurationDescription": "Average execution duration of completed agentic process instances in the selected period.",
       "agenticKpiExecutionIncidentRateName": "Incident rate",
-      "agenticKpiExecutionIncidentRateDescription": "Number of completed agentic process instances that encountered a resolved incident in the selected period."
+      "agenticKpiExecutionIncidentRateDescription": "Number of completed agentic process instances that encountered a resolved incident in the selected period.",
+      "agenticKpiExecutionAvgTokensName": "Avg tokens per execution",
+      "agenticKpiExecutionAvgTokensDescription": "Average total tokens consumed per completed agentic process instance in the selected period.",
+      "agenticKpiExecutionMedianTokensName": "Median tokens per execution",
+      "agenticKpiExecutionMedianTokensDescription": "Median total tokens consumed per completed agentic process instance in the selected period."
     }
   },
   "managementDashboard": {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -78,7 +78,7 @@ public class AgenticControlDashboardServiceTest {
     assertThat(saved.isAgenticControlDashboard()).isTrue();
     assertThat(saved.isManagementDashboard()).isFalse();
     assertThat(saved.getCollectionId()).isNull();
-    assertThat(saved.getTiles()).hasSize(3);
+    assertThat(saved.getTiles()).hasSize(5);
   }
 
   @Test
@@ -134,7 +134,7 @@ public class AgenticControlDashboardServiceTest {
     underTest.reconcile();
     underTest.reconcile();
 
-    // then — reports are upserted on every call, dashboard is never recreated
+    // then — reports are upserted on every call, dashboard is updated but never recreated
     verify(reportWriter, org.mockito.Mockito.times(2))
         .createOrUpdateSingleProcessReport(
             org.mockito.ArgumentMatchers.eq(AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID),
@@ -144,6 +144,7 @@ public class AgenticControlDashboardServiceTest {
             any(),
             any());
     verify(dashboardWriter, never()).saveDashboard(any());
+    verify(dashboardWriter, org.mockito.Mockito.times(2)).updateDashboard(any(), any());
   }
 
   @Test
@@ -162,7 +163,9 @@ public class AgenticControlDashboardServiceTest {
         .containsExactlyInAnyOrder(
             AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID,
             AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID,
-            AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID);
+            AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID,
+            AgenticControlDashboardService.KPI_AVG_TOKENS_REPORT_ID,
+            AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID);
   }
 
   @Test
@@ -222,11 +225,11 @@ public class AgenticControlDashboardServiceTest {
     // when
     underTest.reconcile();
 
-    // then reports are upserted (so config changes are applied) but dashboard is not touched
-    verify(reportWriter, org.mockito.Mockito.times(3))
+    // then reports are upserted and dashboard tiles are updated, but dashboard is not recreated
+    verify(reportWriter, org.mockito.Mockito.times(5))
         .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
     verify(dashboardWriter, never()).saveDashboard(any());
-    verify(dashboardWriter, never()).updateDashboard(any(), any());
+    verify(dashboardWriter).updateDashboard(any(), any());
     verify(dashboardWriter, never()).deleteDashboard(any());
   }
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterESTest.java
@@ -27,17 +27,10 @@ class ProcessViewAgentTotalTokensInterpreterESTest {
   }
 
   @Test
-  void getAggregationScriptReferencesInputTokensField() {
+  void getAggregationScriptReferencesTotalTokensField() {
     final var script = interpreter.getAggregationScript();
     assertThat(script).isNotNull();
-    assertThat(script.source()).contains(ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS);
-  }
-
-  @Test
-  void getAggregationScriptReferencesOutputTokensField() {
-    final var script = interpreter.getAggregationScript();
-    assertThat(script).isNotNull();
-    assertThat(script.source()).contains(ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS);
+    assertThat(script.source()).contains(ProcessInstanceIndex.AGENT_TOTAL_TOKENS);
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterOSTest.java
@@ -27,17 +27,10 @@ class ProcessViewAgentTotalTokensInterpreterOSTest {
   }
 
   @Test
-  void getAggregationScriptReferencesInputTokensField() {
+  void getAggregationScriptReferencesTotalTokensField() {
     final var script = interpreter.getAggregationScript();
     assertThat(script).isNotNull();
-    assertThat(script.inline().source()).contains(ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS);
-  }
-
-  @Test
-  void getAggregationScriptReferencesOutputTokensField() {
-    final var script = interpreter.getAggregationScript();
-    assertThat(script).isNotNull();
-    assertThat(script.inline().source()).contains(ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS);
+    assertThat(script.inline().source()).contains(ProcessInstanceIndex.AGENT_TOTAL_TOKENS);
   }
 
   @Test

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.js
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.js
@@ -19,6 +19,7 @@ import {loadAgenticDashboard} from './service';
 
 import './AgenticControlPlane.scss';
 
+
 function presetToFilter(preset) {
   return {
     type: 'instanceEndDate',
@@ -67,6 +68,11 @@ export function AgenticControlPlane() {
     return true;
   });
 
+  const sections = [
+    {key: 'kpi', loadTile: scopedEvaluateReport},
+    {key: 'token', titleKey: 'agenticControlPlane.tokenUsage', loadTile: scopedEvaluateReport},
+  ];
+
   return (
     <div className="AgenticControlPlane">
       <div className="AgenticControlPlane__header">
@@ -79,12 +85,29 @@ export function AgenticControlPlane() {
         processScope={processScope}
         onProcessScopeChange={setProcessScope}
       />
-      <DashboardRenderer
-        key={processScope ?? '__all__'}
-        loadTile={scopedEvaluateReport}
-        tiles={visibleTiles}
-        filter={filter}
-      />
+      {sections.map(({key, titleKey, loadTile}) => {
+        const tiles = visibleTiles?.filter(
+          (tile) => (tile.configuration?.section ?? 'kpi') === key
+        );
+        return (
+          <div key={key}>
+            {titleKey && (
+              <>
+                <h3 className="AgenticControlPlane__section-title">{t(titleKey)}</h3>
+                <hr className="AgenticControlPlane__section-divider" />
+              </>
+            )}
+            <div className={`AgenticControlPlane__${key}-section`}>
+              <DashboardRenderer
+                key={`${processScope ?? '__all__'}-${key}`}
+                loadTile={loadTile}
+                tiles={tiles}
+                filter={filter}
+              />
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.scss
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.scss
@@ -26,4 +26,17 @@
     color: var(--cds-text-secondary);
     margin: 0 0 0.5rem;
   }
+
+  &__section-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 1rem 0 0.25rem;
+    color: var(--cds-text-primary);
+  }
+
+  &__section-divider {
+    border: none;
+    border-top: 1px solid var(--cds-border-subtle-01, var(--silver-darken-80));
+    margin: 0;
+  }
 }

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.js
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.js
@@ -64,7 +64,7 @@ it('should pass the default Last 30 days filter to DashboardRenderer', async () 
 
   await runAllEffects();
 
-  expect(node.find('DashboardRenderer').prop('filter')).toEqual([
+  const expectedFilter = [
     {
       type: 'instanceEndDate',
       filterLevel: 'instance',
@@ -76,7 +76,9 @@ it('should pass the default Last 30 days filter to DashboardRenderer', async () 
         includeUndefined: false,
       },
     },
-  ]);
+  ];
+  expect(node.find('.AgenticControlPlane__kpi-section').find('DashboardRenderer').prop('filter')).toEqual(expectedFilter);
+  expect(node.find('.AgenticControlPlane__token-section').find('DashboardRenderer').prop('filter')).toEqual(expectedFilter);
 });
 
 it('should update the filter when the date preset changes', async () => {
@@ -86,7 +88,7 @@ it('should update the filter when the date preset changes', async () => {
 
   node.find('FilterBar').prop('onPresetChange')('7d');
 
-  expect(node.find('DashboardRenderer').prop('filter')).toEqual([
+  const expectedFilter = [
     {
       type: 'instanceEndDate',
       filterLevel: 'instance',
@@ -98,7 +100,9 @@ it('should update the filter when the date preset changes', async () => {
         includeUndefined: false,
       },
     },
-  ]);
+  ];
+  expect(node.find('.AgenticControlPlane__kpi-section').find('DashboardRenderer').prop('filter')).toEqual(expectedFilter);
+  expect(node.find('.AgenticControlPlane__token-section').find('DashboardRenderer').prop('filter')).toEqual(expectedFilter);
 });
 
 it('should render the page header with title and description', async () => {
@@ -118,14 +122,14 @@ it('should pass the loaded tiles to DashboardRenderer', async () => {
 
   await runAllEffects();
 
-  expect(node.find('DashboardRenderer').prop('tiles')).toEqual(tiles);
+  expect(node.find('.AgenticControlPlane__kpi-section').find('DashboardRenderer').prop('tiles')).toEqual(tiles);
 });
 
 it('should hide visibleInL0Only tiles when a process is selected', async () => {
   const tiles = [
-    {id: 'l0-tile', configuration: {visibleInL0Only: true}},
-    {id: 'l1-tile', configuration: {visibleInL1Only: true}},
-    {id: 'common-tile', configuration: {}},
+    {id: 'l0-tile', configuration: {visibleInL0Only: true}, position: {x: 0, y: 0}},
+    {id: 'l1-tile', configuration: {visibleInL1Only: true}, position: {x: 1, y: 0}},
+    {id: 'common-tile', configuration: {}, position: {x: 2, y: 0}},
   ];
   loadAgenticDashboard.mockReturnValueOnce({tiles, availableFilters: []});
 
@@ -134,22 +138,22 @@ it('should hide visibleInL0Only tiles when a process is selected', async () => {
 
   node.find('FilterBar').prop('onProcessScopeChange')('my-process');
 
-  const visibleTiles = node.find('DashboardRenderer').prop('tiles');
+  const visibleTiles = node.find('.AgenticControlPlane__kpi-section').find('DashboardRenderer').prop('tiles');
   expect(visibleTiles.map((t) => t.id)).toEqual(['l1-tile', 'common-tile']);
 });
 
 it('should hide visibleInL1Only tiles when no process is selected (L0)', async () => {
   const tiles = [
-    {id: 'l0-tile', configuration: {visibleInL0Only: true}},
-    {id: 'l1-tile', configuration: {visibleInL1Only: true}},
-    {id: 'common-tile', configuration: {}},
+    {id: 'l0-tile', configuration: {visibleInL0Only: true}, position: {x: 0, y: 0}},
+    {id: 'l1-tile', configuration: {visibleInL1Only: true}, position: {x: 1, y: 0}},
+    {id: 'common-tile', configuration: {}, position: {x: 2, y: 0}},
   ];
   loadAgenticDashboard.mockReturnValueOnce({tiles, availableFilters: []});
 
   const node = shallow(<AgenticControlPlane />);
   await runAllEffects();
 
-  const visibleTiles = node.find('DashboardRenderer').prop('tiles');
+  const visibleTiles = node.find('.AgenticControlPlane__kpi-section').find('DashboardRenderer').prop('tiles');
   expect(visibleTiles.map((t) => t.id)).toEqual(['l0-tile', 'common-tile']);
 });
 
@@ -159,7 +163,7 @@ it('should include definitions in evaluate calls when a process is selected', as
 
   node.find('FilterBar').prop('onProcessScopeChange')('my-process');
 
-  const loadTile = node.find('DashboardRenderer').prop('loadTile');
+  const loadTile = node.find('.AgenticControlPlane__kpi-section').find('DashboardRenderer').prop('loadTile');
   loadTile('report-id', [], {});
 
   expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, [
@@ -171,7 +175,7 @@ it('should pass empty definitions in evaluate calls when no process is selected'
   const node = shallow(<AgenticControlPlane />);
   await runAllEffects();
 
-  const loadTile = node.find('DashboardRenderer').prop('loadTile');
+  const loadTile = node.find('.AgenticControlPlane__kpi-section').find('DashboardRenderer').prop('loadTile');
   loadTile('report-id', [], {});
 
   expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, []);

--- a/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.js
+++ b/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.js
@@ -10,7 +10,7 @@ import React from 'react';
 import deepEqual from 'fast-deep-equal';
 
 import {ErrorBoundary} from 'components';
-import {formatters, getReportResult} from 'services';
+import {formatters, getReportResult, reportConfig} from 'services';
 import {t} from 'translation';
 
 import ProcessReportRenderer from './ProcessReportRenderer';
@@ -91,11 +91,14 @@ export default React.memo(ReportRenderer, (prevProps, nextProps) => {
 });
 
 function checkProcessReport(data) {
+  const viewEntry = reportConfig.view.find(({matcher}) => matcher(data));
+  const definitionsRequired = viewEntry?.requiresDefinition !== false;
   if (
-    isEmpty(data.definitions) ||
-    isEmpty(data.definitions?.[0].key) ||
-    isEmpty(data.definitions?.[0].versions) ||
-    isEmpty(data.definitions?.[0].tenantIds)
+    definitionsRequired &&
+    (isEmpty(data.definitions) ||
+      isEmpty(data.definitions?.[0].key) ||
+      isEmpty(data.definitions?.[0].versions) ||
+      isEmpty(data.definitions?.[0].tenantIds))
   ) {
     return <p>{t('report.noDefinitionMessage.process')}</p>;
   } else {

--- a/optimize/client/src/modules/components/ReportRenderer/service.js
+++ b/optimize/client/src/modules/components/ReportRenderer/service.js
@@ -25,6 +25,8 @@ export function getFormatter(measure) {
       return formatters.duration;
     case 'percentage':
       return formatters.percentage;
+    case 'compact':
+      return formatters.compact;
     default:
       return (v) => v;
   }

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.js
@@ -23,7 +23,7 @@ import './Number.scss';
 
 export function Number({report, formatter, mightFail}) {
   const {data, result} = report;
-  const {targetValue, precision} = data.configuration;
+  const {targetValue, precision, valueFormat} = data.configuration;
   const [processVariable, setProcessVariable] = useState();
   const processVariableReport = data.view.entity === 'variable';
   const isMultiMeasure = result?.measures.length > 1;
@@ -107,14 +107,17 @@ export function Number({report, formatter, mightFail}) {
           } else {
             const view = reportConfig.view.find(({matcher}) => matcher(data));
             let measureString = '';
-            measureString = t(
-              'report.view.' + (measure.property === 'frequency' ? 'count' : 'duration')
-            );
-            if (view.key === 'incident' && measure.property === 'duration') {
+            const propertyKey = measure.property === 'frequency' ? 'count' : measure.property;
+            try {
+              measureString = t(`report.view.${propertyKey}`);
+            } catch {
+              measureString = propertyKey;
+            }
+            if (view?.key === 'incident' && measure.property === 'duration') {
               measureString = t('report.view.resolutionDuration');
             }
 
-            viewString = `${view.label()} ${measureString}`;
+            viewString = view ? `${view.label()} ${measureString}` : measureString;
           }
 
           if (measure.property === 'duration' || data.view.entity === 'variable') {
@@ -124,7 +127,7 @@ export function Number({report, formatter, mightFail}) {
 
           return (
             <React.Fragment key={idx}>
-              <div className="data">{formatValue(measure.data, measure.property, precision)}</div>
+              <div className="data">{formatValue(measure.data, valueFormat ?? measure.property, precision)}</div>
               <div className="label">{viewString}</div>
             </React.Fragment>
           );

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.test.js
@@ -22,6 +22,7 @@ jest.mock('services', () => {
       convertDurationToSingleNumber: () => 12,
       frequency: (data) => data,
       duration: (data) => data,
+      compact: (v) => (v == null ? '--' : `${v}K`),
     },
     reportConfig: {
       view: [
@@ -188,4 +189,34 @@ it('should call loadVariables for process variable report', () => {
       {processDefinitionKey: 'aKey', processDefinitionVersions: ['1'], tenantIds: ['tenantId']},
     ],
   });
+});
+
+it('should apply valueFormat from configuration instead of measure property', () => {
+  const node = shallow(
+    <Number
+      report={{
+        ...report,
+        data: {
+          ...report.data,
+          configuration: {targetValue: {active: false}, valueFormat: 'compact'},
+        },
+        result: {measures: [{property: 'totalTokens', data: 150000}]},
+      }}
+    />
+  );
+
+  expect(node.find('.data')).toIncludeText('150000K');
+});
+
+it('should fall back to measure property formatter when valueFormat is not set', () => {
+  const node = shallow(
+    <Number
+      report={{
+        ...report,
+        result: {measures: [{property: 'frequency', data: 42}]},
+      }}
+    />
+  );
+
+  expect(node.find('.data')).toIncludeText('42');
 });

--- a/optimize/client/src/modules/services/formatters.test.ts
+++ b/optimize/client/src/modules/services/formatters.test.ts
@@ -24,6 +24,7 @@ import {
   getRelativeValue,
   frequency as frequencyFormatter,
   percentage as percentageFormatter,
+  compact as compactFormatter,
 } from './formatters';
 import {UNAUTHORIZED_TENANT_ID} from './tenantService';
 
@@ -561,5 +562,31 @@ describe('formatLabel', () => {
     const numberWithString = '02132' + new Array(55).join('a');
 
     expect(formatLabel(numberWithString, true)).toBe(numberWithString);
+  });
+});
+
+describe('compactFormatter', () => {
+  it('should return -- for null', () => {
+    expect(compactFormatter(null)).toBe('--');
+  });
+
+  it('should return -- for undefined', () => {
+    expect(compactFormatter(undefined)).toBe('--');
+  });
+
+  it('should return -- for NaN string', () => {
+    expect(compactFormatter('not-a-number')).toBe('--');
+  });
+
+  it('should format large numbers with compact notation', () => {
+    expect(compactFormatter(1500000)).toMatch(/1\.5M|1,5M/);
+  });
+
+  it('should format small numbers without suffix', () => {
+    expect(compactFormatter(42)).toBe('42');
+  });
+
+  it('should format zero', () => {
+    expect(compactFormatter(0)).toBe('0');
   });
 });

--- a/optimize/client/src/modules/services/formatters.tsx
+++ b/optimize/client/src/modules/services/formatters.tsx
@@ -483,6 +483,16 @@ export function createDurationFormattingOptions(
   };
 }
 
+export function compact(value?: number | string | null): string {
+  if ((!value && value !== 0) || Number.isNaN(Number(value))) {
+    return '--';
+  }
+  return new Intl.NumberFormat(undefined, {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(Number(value));
+}
+
 export function formatFileName(name: string) {
   return name.replace(/[^a-zA-Z0-9-_.]/gi, '_').toLowerCase();
 }

--- a/optimize/client/src/modules/services/reportConfig/process.js
+++ b/optimize/client/src/modules/services/reportConfig/process.js
@@ -81,6 +81,16 @@ export const view = [
       return {view: {entity: 'variable'}};
     },
   },
+  {
+    // System-generated entity not shown in the user-facing report builder.
+    key: 'agentInstance',
+    label: () => t('report.view.agentInstance'),
+    visible: ({view}) => view?.entity === 'agentInstance',
+    enabled: () => false,
+    requiresDefinition: false,
+    matcher: ({view}) => view?.entity === 'agentInstance',
+    payload: ({view}) => ({view: {entity: 'agentInstance', properties: view?.properties ?? []}}),
+  },
 ];
 
 export const group = [

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/SingleReportConfigurationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/SingleReportConfigurationDto.java
@@ -65,6 +65,7 @@ public class SingleReportConfigurationDto implements Combinable {
   private Boolean stackedBar = false;
   private Boolean horizontalBar = false;
   private Boolean logScale = false;
+  private String valueFormat = null;
 
   public SingleReportConfigurationDto(
       final String color,
@@ -93,7 +94,8 @@ public class SingleReportConfigurationDto implements Combinable {
       final MeasureVisualizationsDto measureVisualizations,
       final Boolean stackedBar,
       final Boolean horizontalBar,
-      final Boolean logScale) {
+      final Boolean logScale,
+      final String valueFormat) {
     if (groupByDateVariableUnit == null) {
       throw new IllegalArgumentException("groupByDateVariableUnit must not be null");
     }
@@ -129,6 +131,7 @@ public class SingleReportConfigurationDto implements Combinable {
     this.stackedBar = stackedBar;
     this.horizontalBar = horizontalBar;
     this.logScale = logScale;
+    this.valueFormat = valueFormat;
   }
 
   public SingleReportConfigurationDto() {}
@@ -381,6 +384,14 @@ public class SingleReportConfigurationDto implements Combinable {
     this.logScale = logScale;
   }
 
+  public String getValueFormat() {
+    return valueFormat;
+  }
+
+  public void setValueFormat(final String valueFormat) {
+    this.valueFormat = valueFormat;
+  }
+
   protected boolean canEqual(final Object other) {
     return other instanceof SingleReportConfigurationDto;
   }
@@ -417,7 +428,8 @@ public class SingleReportConfigurationDto implements Combinable {
         && Objects.equals(measureVisualizations, that.measureVisualizations)
         && Objects.equals(stackedBar, that.stackedBar)
         && Objects.equals(horizontalBar, that.horizontalBar)
-        && Objects.equals(logScale, that.logScale);
+        && Objects.equals(logScale, that.logScale)
+        && Objects.equals(valueFormat, that.valueFormat);
   }
 
   @Override
@@ -449,7 +461,8 @@ public class SingleReportConfigurationDto implements Combinable {
         measureVisualizations,
         stackedBar,
         horizontalBar,
-        logScale);
+        logScale,
+        valueFormat);
   }
 
   @Override
@@ -508,6 +521,8 @@ public class SingleReportConfigurationDto implements Combinable {
         + getHorizontalBar()
         + ", logScale="
         + getLogScale()
+        + ", valueFormat="
+        + getValueFormat()
         + ")";
   }
 
@@ -620,6 +635,10 @@ public class SingleReportConfigurationDto implements Combinable {
     return false;
   }
 
+  private static String defaultValueFormat() {
+    return null;
+  }
+
   public static SingleReportConfigurationDtoBuilder builder() {
     return new SingleReportConfigurationDtoBuilder();
   }
@@ -654,6 +673,7 @@ public class SingleReportConfigurationDto implements Combinable {
     public static final String stackedBar = "stackedBar";
     public static final String horizontalBar = "horizontalBar";
     public static final String logScale = "logScale";
+    public static final String valueFormat = "valueFormat";
   }
 
   public static class SingleReportConfigurationDtoBuilder {
@@ -712,6 +732,8 @@ public class SingleReportConfigurationDto implements Combinable {
     private boolean horizontalBarSet;
     private Boolean logScaleValue;
     private boolean logScaleSet;
+    private String valueFormatValue;
+    private boolean valueFormatSet;
 
     SingleReportConfigurationDtoBuilder() {}
 
@@ -897,6 +919,12 @@ public class SingleReportConfigurationDto implements Combinable {
       return this;
     }
 
+    public SingleReportConfigurationDtoBuilder valueFormat(final String valueFormat) {
+      valueFormatValue = valueFormat;
+      valueFormatSet = true;
+      return this;
+    }
+
     public SingleReportConfigurationDto build() {
       String colorValue = this.colorValue;
       if (!colorSet) {
@@ -1010,6 +1038,10 @@ public class SingleReportConfigurationDto implements Combinable {
       if (!logScaleSet) {
         logScaleValue = SingleReportConfigurationDto.defaultLogScale();
       }
+      String valueFormatValue = this.valueFormatValue;
+      if (!valueFormatSet) {
+        valueFormatValue = SingleReportConfigurationDto.defaultValueFormat();
+      }
       return new SingleReportConfigurationDto(
           colorValue,
           aggregationTypesValue,
@@ -1037,7 +1069,8 @@ public class SingleReportConfigurationDto implements Combinable {
           measureVisualizationsValue,
           stackedBarValue,
           horizontalBarValue,
-          logScaleValue);
+          logScaleValue,
+          valueFormatValue);
     }
 
     @Override
@@ -1096,6 +1129,8 @@ public class SingleReportConfigurationDto implements Combinable {
           + horizontalBarValue
           + ", logScaleValue="
           + logScaleValue
+          + ", valueFormatValue="
+          + valueFormatValue
           + ")";
     }
   }


### PR DESCRIPTION
## Description

 Implements avg and median tokens per execution KPI tiles on the Agentic Control Plane dashboard
  
  Backend — new reports seeded on startup

  AgenticControlDashboardService now reconciles two additional Number reports on every startup: Avg tokens per execution (KPI_AVG_TOKENS_REPORT_ID) and Median tokens per execution (KPI_MEDIAN_TOKENS_REPORT_ID). Both use deterministic UUIDs (UUID.nameUUIDFromBytes) so restarts upsert rather than duplicate. Reports scope to completed agent instances only (COMPLETED_STATE + agentInstances not-empty filter) and set valueFormat: compact for K/M notation display. Token tiles carry configuration.section = "token" so the frontend routes them to the correct section renderer.
  
  Backend — Painless aggregation script

  AgentMetricScripts.TOTAL_TOKENS returns null for instances with no agent activity (null or empty agentInstances array), read from _source since nested fields are not accessible via doc values in aggregation scripts. Instances with agent activity but zero tokens contribute 0 and are included. This excludes non-agent instances from avg/percentile computations without incorrectly discarding legitimate zero-token runs.
  
  Backend — validation fix

  ValidationHelper now uses isSystemGeneratedReport() (covers management, instant-preview, and agentic control reports) instead of isManagementReport() when exempting reports from the null definitionKey check. Agentic control reports have definitions injected at query time, so an empty key at creation time is valid.

  Frontend — generic valueFormat config for compact number display

  SingleReportConfigurationDto gains an optional valueFormat field. Number.js reads configuration.valueFormat and passes it to getFormatter instead of measure.property, so any report can declare its own display format without coupling the shared formatter to a specific view property. A compact() formatter is added to formatters.tsx and registered under the 'compact' key in getFormatter(). Token KPI reports set valueFormat: 'compact' on startup, removing the need for any pre-formatting intercept layer in AgenticControlPlane.
  
  Frontend — section-based tile routing

  Token tiles carry configuration.section = "token" (set by the backend). AgenticControlPlane uses a sections config array to route tiles to the correct DashboardRenderer and render section headings and dividers — no hardcoded y-coordinate thresholds or positional logic. Adding a new section in future requires one entry in the sections array on the frontend and a section key on the backend tile.
  
  Frontend — report config and view label support

  ReportRenderer.js and process.js add support for agentInstance as a report entity: the "no definition selected" guard is skipped (definitions are injected at query time), and unknown view.property values fall back to the raw key instead of throwing. The agentInstance entry in the View selector is only shown when the current report is already an agentInstance report, preventing a blank Select state when such a report is opened in the report editor. 'compact' key in getFormatter(). Token KPI reports set valueFormat: 'compact' on startup, removing the need for any pre-formatting intercept layer in AgenticControlPlane.

  Frontend — section-based tile routing

  Token tiles carry configuration.section = "token" (set by the backend). AgenticControlPlane uses a sections config array to route tiles to the correct DashboardRenderer and render section headings and dividers . Adding a new section in future requires one entry in the sections array on the frontend and a section key on the backend tile.

  Frontend — report config and view label support

  ReportRenderer.js and process.js add support for agentInstance as a report entity: the "no definition selected" guard is skipped (definitions are injected at query time), and unknown view.property values fall back to the raw key instead of throwing. The agentInstance entry in the View selector is only shown when the current report is already an agentInstance report, preventing a blank Select state when such a report is opened in the report editor.

  i18n

  Added en.json / de.json keys for tile names (agenticKpiExecutionAvgTokensName/Description, agenticKpiExecutionMedianTokensName/Description) and the Token Usage section heading (tokenUsage).

  Tests — AgenticKpiTilesIT

  AbstractBrokerlessZeebeCCSMIT provides shared helpers for seeding process instances and definitions directly into the Optimize index without a live Zeebe broker, including ZEEBE_DEFAULT_TENANT_ID on definitions and instances for CCSM tenant authorization to resolve correctly. AgenticKpiTilesIT covers all five KPI tiles with date-range and process-scope filters, zero-token runs, resolved incidents on active instances, and CCSM tenant authorization.

## Related issues

Closes #54766
