### PR TITLE
test: assert Complete Task button is hidden for non-assignee (nightly main)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/user-task-permission-management.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/user-task-permission-management.spec.ts
@@ -627,7 +627,11 @@ test.describe
 
     await taskPanelPage.goToTaskDetails(bobUserTaskKey);
 
-    await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
+    // Alice is not the assignee and has no permission to read the task's
+    // variables or process definition, so the task body — and with it the
+    // Complete Task button — is never rendered for her, preventing completion.
+    await expect(taskDetailsPage.detailsInfo).toBeVisible({timeout: 30000});
+    await expect(taskDetailsPage.completeTaskButton).toBeHidden();
   });
 });
 


### PR DESCRIPTION
## Root cause

The test `should prevent Alice from completing a task assigned to Bob` (tasklist v2) asserted that the **Complete Task** button is rendered in a **disabled** state. In the failing nightly run the button is **not rendered at all**, so `toBeDisabled()` times out with `element(s) not found`.

Trace analysis of the failure shows why this is the correct (not regressed) product behavior:

- Alice is granted `READ` + `COMPLETE` on `USER_TASK`, but **no `PROCESS_DEFINITION` read** authorization.
- She is **not the assignee** (Bob is), so she also cannot read the task's variables.
- Result (from the Playwright trace): `GET /v2/process-definitions/{key}/xml` → **403** (3 retries + abort), and the task-variables query never succeeds.
- `TaskDetailsLayout` keeps the body in a loading state until the process-XML query settles, and `Variables` renders `null` while its (403) variables query is loading. The **Complete Task button is therefore never rendered**, which correctly prevents Alice from completing Bob's task.

These 403s are legitimate authorization responses — there is no server-side regression. The assertion was simply too specific about *how* the UI denies completion.

## Fix

Assert that the Complete Task button is **hidden** for Alice instead of disabled, after confirming the task details panel has loaded. This matches the permission-denied pattern already used in the same spec for the *Assign to me* button (`await expect(taskDetailsPage.assignToMeButton).toBeHidden()`).

```ts
await expect(taskDetailsPage.detailsInfo).toBeVisible({timeout: 30000});
await expect(taskDetailsPage.completeTaskButton).toBeHidden();
```

## Tests fixed

- `tests/tasklist/user-task-permission-management.spec.ts` › `should prevent Alice from completing a task assigned to Bob` (e2e, tasklist v2)

## Links

- Failing nightly E2E run: https://github.com/camunda/camunda/actions/runs/27249477594
- Triage run: https://github.com/camunda/camunda/actions/runs/27255298973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/27255798175
