### PR TITLE
feat: extend Security with CamundaSecutiryLibraryProperties

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -207,6 +207,17 @@
       <groupId>io.camunda</groupId>
       <artifactId>dynamic-node-id-provider</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-library-spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-library-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/configuration/src/main/java/io/camunda/configuration/Security.java
+++ b/configuration/src/main/java/io/camunda/configuration/Security.java
@@ -7,9 +7,10 @@
  */
 package io.camunda.configuration;
 
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-public class Security {
+public class Security extends CamundaSecurityLibraryProperties {
 
   /** TLS configuration. */
   @NestedConfigurationProperty private Tls transportLayerSecurity = new Tls();

--- a/configuration/src/test/java/io/camunda/configuration/SecurityPropertiesBindingTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecurityPropertiesBindingTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/** Verifies that CSL security properties bind through {@link Camunda#getSecurity()}. */
+@SpringJUnitConfig(UnifiedConfiguration.class)
+public class SecurityPropertiesBindingTest {
+
+  @Autowired private Camunda camunda;
+
+  @Test
+  void shouldExposeSecurityAsInstanceOfCamundaSecurityLibraryProperties() {
+    // given / when
+    final Security security = camunda.getSecurity();
+
+    // then
+    assertThat(security).isInstanceOf(CamundaSecurityLibraryProperties.class);
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.security.authentication.method=oidc",
+        "camunda.security.authentication.unprotected-api=true",
+        "camunda.security.authorizations.enabled=false",
+        "camunda.security.multi-tenancy.checks-enabled=true",
+        "camunda.security.transport-layer-security.cluster.enabled=true",
+      })
+  class WithCslPropertiesSet {
+
+    @Test
+    void shouldBindCslPropertiesThroughUnifiedTree(@Autowired final Camunda camunda) {
+      // given / when
+      final Security security = camunda.getSecurity();
+
+      // then
+      assertThat(security.getAuthentication().getMethod()).isEqualTo(AuthenticationMethod.OIDC);
+      assertThat(security.getAuthentication().isUnprotectedApi()).isTrue();
+      assertThat(security.getAuthorizations().isEnabled()).isFalse();
+      assertThat(security.getMultiTenancy().isChecksEnabled()).isTrue();
+      assertThat(security.getTransportLayerSecurity().getCluster().isEnabled()).isTrue();
+    }
+  }
+}

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -303,6 +303,15 @@ processing.max-commands-in-batch
 processing.max-recoverable-retries
 processing.scheduled-tasks-check-interval
 processing.skip-positions
+security.authentication
+security.authorizations
+security.csrf
+security.http-headers
+security.id-validation-pattern
+security.initialization
+security.multi-tenancy
+security.saas
+security.session
 security.transport-layer-security.cluster.certificate-chain-path
 security.transport-layer-security.cluster.certificate-private-key-path
 security.transport-layer-security.cluster.enabled


### PR DESCRIPTION
## Description

Make OC's security configuration class extend CSL's SecurityProperties so the CSL-owned security properties are pulled into OC's unified configuration tree.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54908
