### PR TITLE
fix: await decision instance indexing before deletion in AuditLogResourceOperationsIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogResourceOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogResourceOperationsIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.auditlog;
 
 import static io.camunda.it.auditlog.AuditLogUtils.DEFAULT_USERNAME;
 import static io.camunda.it.auditlog.AuditLogUtils.TENANT_A;
+import static io.camunda.it.util.TestHelper.waitForDecisionInstanceCount;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
@@ -533,6 +534,10 @@ public class AuditLogResourceOperationsIT {
             .join();
 
     final var decisionEvaluationKey = decisionEvaluation.getDecisionEvaluationKey();
+
+    // wait for the decision instance to be indexed in secondary storage before deleting;
+    // the delete API requires the instance to exist in secondary storage (eventual consistency)
+    waitForDecisionInstanceCount(client, f -> f.decisionInstanceKey(decisionEvaluationKey), 1);
 
     // when - delete the decision instance history
     client.newDeleteDecisionInstanceCommand(decisionEvaluationKey).send().join();


### PR DESCRIPTION
## Summary
- `shouldTrackDecisionInstanceHistoryDeletion` called `newDeleteDecisionInstanceCommand` immediately after evaluating a decision, without waiting for eventual consistency in secondary storage (ES/OS)
- Added an `Awaitility.await` on `newDecisionInstanceSearchRequest` by key before the delete, matching the pattern already used in `shouldTrackProcessInstanceHistoryDeletion` and `DeleteDecisionInstanceHistoryIT`
- If the delete races ahead of indexing, the command either throws a 404 or produces no audit log entry, causing a non-deterministic test failure

## Test plan
- [ ] Run `AuditLogResourceOperationsIT#shouldTrackDecisionInstanceHistoryDeletion` repeatedly to confirm it no longer flakes

Closes #54984

🤖 Generated with [Claude Code](https://claude.com/claude-code)