### PR TITLE
feat: seed duration kpi reports

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -10,10 +10,10 @@ package io.camunda.optimize.service.dashboard;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_AVG_TOKENS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID;
-import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_P50_DURATION_REPORT_ID;
-import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_P95_DURATION_REPORT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
@@ -39,8 +39,12 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
@@ -98,12 +102,14 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   // ---------------------------------------------------------------------------
-  // P50 duration (median)
+  // Percentile durations
   // ---------------------------------------------------------------------------
 
-  @Test
-  void shouldComputeP50DurationOfCompletedAgenticInstances() {
-    // durations: 1h, 2h, 3h, 4h, 5h → P50 = 3h = 10_800_000 ms
+  @ParameterizedTest
+  @MethodSource("durationPercentileReportIds")
+  void shouldComputeDurationPercentileOfCompletedAgenticInstances(
+      final String reportId, final double expectedValue, final double tolerance) {
+    // durations: 1h, 2h, 3h, 4h, 5h
     final ProcessInstanceDto inst1 = agenticInstance(PROC_KEY, 0L, 0L).duration(3_600_000L).build();
     final ProcessInstanceDto inst2 = agenticInstance(PROC_KEY, 0L, 0L).duration(7_200_000L).build();
     final ProcessInstanceDto inst3 =
@@ -115,32 +121,9 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
     persistProcessInstances(List.of(inst1, inst2, inst3, inst4, inst5));
 
-    final Double result = evaluateNumber(KPI_P50_DURATION_REPORT_ID, noExtraFilters());
-    // ES percentile approximation — allow small delta
-    assertThat(result).isCloseTo(10_800_000.0, within(10_000.0));
-  }
-
-  // ---------------------------------------------------------------------------
-  // P95 duration
-  // ---------------------------------------------------------------------------
-
-  @Test
-  void shouldComputeP95DurationOfCompletedAgenticInstances() {
-    // durations: 1h, 2h, 3h, 4h, 5h → P95 ≈ 5h = 18_000_000 ms
-    final ProcessInstanceDto inst1 = agenticInstance(PROC_KEY, 0L, 0L).duration(3_600_000L).build();
-    final ProcessInstanceDto inst2 = agenticInstance(PROC_KEY, 0L, 0L).duration(7_200_000L).build();
-    final ProcessInstanceDto inst3 =
-        agenticInstance(PROC_KEY, 0L, 0L).duration(10_800_000L).build();
-    final ProcessInstanceDto inst4 =
-        agenticInstance(PROC_KEY, 0L, 0L).duration(14_400_000L).build();
-    final ProcessInstanceDto inst5 =
-        agenticInstance(PROC_KEY, 0L, 0L).duration(18_000_000L).build();
-
-    persistProcessInstances(List.of(inst1, inst2, inst3, inst4, inst5));
-
-    final Double result = evaluateNumber(KPI_P95_DURATION_REPORT_ID, noExtraFilters());
-    // ES percentile approximation — allow generous delta for P95 with small dataset
-    assertThat(result).isCloseTo(18_000_000.0, within(1_000_000.0));
+    final Double result = evaluateNumber(reportId, noExtraFilters());
+    // ES percentile approximation
+    assertThat(result).isCloseTo(expectedValue, within(tolerance));
   }
 
   // ---------------------------------------------------------------------------
@@ -408,7 +391,7 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
     persistProcessInstances(List.of(recent, old));
 
-    assertThat(evaluateNumber(KPI_P50_DURATION_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
+    assertThat(evaluateNumber(KPI_DURATION_P50_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
         .isCloseTo(3_600_000.0, within(1.0));
   }
 
@@ -431,7 +414,7 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
     persistProcessInstances(List.of(recent, old));
 
-    assertThat(evaluateNumber(KPI_P95_DURATION_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
+    assertThat(evaluateNumber(KPI_DURATION_P95_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
         .isCloseTo(3_600_000.0, within(1.0));
   }
 
@@ -619,7 +602,7 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
     assertThat(
             evaluateNumber(
-                KPI_P50_DURATION_REPORT_ID,
+                KPI_DURATION_P50_REPORT_ID,
                 withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
         .isCloseTo(7_200_000.0, within(10_000.0));
   }
@@ -639,7 +622,7 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
     assertThat(
             evaluateNumber(
-                KPI_P95_DURATION_REPORT_ID,
+                KPI_DURATION_P95_REPORT_ID,
                 withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
         .isCloseTo(10_800_000.0, within(1_000_000.0));
   }
@@ -805,5 +788,11 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
     final AdditionalProcessReportEvaluationFilterDto dto = withDefinitions(definitions);
     dto.setFilter(List.of((ProcessFilterDto<?>) filter));
     return dto;
+  }
+
+  private static Stream<Arguments> durationPercentileReportIds() {
+    return Stream.of(
+        Arguments.of(KPI_DURATION_P50_REPORT_ID, 10_800_000.0, 10_000.0),
+        Arguments.of(KPI_DURATION_P95_REPORT_ID, 18_000_000.0, 1_000_000.0));
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -12,6 +12,8 @@ import static io.camunda.optimize.service.dashboard.AgenticControlDashboardServi
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_P50_DURATION_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_P95_DURATION_REPORT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
@@ -93,6 +95,52 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
     final Double result = evaluateNumber(KPI_AVG_DURATION_REPORT_ID, noExtraFilters());
     assertThat(result).isCloseTo(7_200_000.0, within(1.0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // P50 duration (median)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldComputeP50DurationOfCompletedAgenticInstances() {
+    // durations: 1h, 2h, 3h, 4h, 5h → P50 = 3h = 10_800_000 ms
+    final ProcessInstanceDto inst1 = agenticInstance(PROC_KEY, 0L, 0L).duration(3_600_000L).build();
+    final ProcessInstanceDto inst2 = agenticInstance(PROC_KEY, 0L, 0L).duration(7_200_000L).build();
+    final ProcessInstanceDto inst3 =
+        agenticInstance(PROC_KEY, 0L, 0L).duration(10_800_000L).build();
+    final ProcessInstanceDto inst4 =
+        agenticInstance(PROC_KEY, 0L, 0L).duration(14_400_000L).build();
+    final ProcessInstanceDto inst5 =
+        agenticInstance(PROC_KEY, 0L, 0L).duration(18_000_000L).build();
+
+    persistProcessInstances(List.of(inst1, inst2, inst3, inst4, inst5));
+
+    final Double result = evaluateNumber(KPI_P50_DURATION_REPORT_ID, noExtraFilters());
+    // ES percentile approximation — allow small delta
+    assertThat(result).isCloseTo(10_800_000.0, within(10_000.0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // P95 duration
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldComputeP95DurationOfCompletedAgenticInstances() {
+    // durations: 1h, 2h, 3h, 4h, 5h → P95 ≈ 5h = 18_000_000 ms
+    final ProcessInstanceDto inst1 = agenticInstance(PROC_KEY, 0L, 0L).duration(3_600_000L).build();
+    final ProcessInstanceDto inst2 = agenticInstance(PROC_KEY, 0L, 0L).duration(7_200_000L).build();
+    final ProcessInstanceDto inst3 =
+        agenticInstance(PROC_KEY, 0L, 0L).duration(10_800_000L).build();
+    final ProcessInstanceDto inst4 =
+        agenticInstance(PROC_KEY, 0L, 0L).duration(14_400_000L).build();
+    final ProcessInstanceDto inst5 =
+        agenticInstance(PROC_KEY, 0L, 0L).duration(18_000_000L).build();
+
+    persistProcessInstances(List.of(inst1, inst2, inst3, inst4, inst5));
+
+    final Double result = evaluateNumber(KPI_P95_DURATION_REPORT_ID, noExtraFilters());
+    // ES percentile approximation — allow generous delta for P95 with small dataset
+    assertThat(result).isCloseTo(18_000_000.0, within(1_000_000.0));
   }
 
   // ---------------------------------------------------------------------------
@@ -342,6 +390,52 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   @Test
+  void shouldApplyDateFilterToP50Duration() {
+    // within window: duration 1h
+    final ProcessInstanceDto recent =
+        agenticInstance(PROC_KEY, 0L, 0L)
+            .startDate(OffsetDateTime.now().minusHours(3))
+            .endDate(OffsetDateTime.now().minusHours(2))
+            .duration(3_600_000L)
+            .build();
+    // outside window: duration 5h — should not affect P50
+    final ProcessInstanceDto old =
+        agenticInstance(PROC_KEY, 0L, 0L)
+            .startDate(OffsetDateTime.now().minusDays(10))
+            .endDate(OffsetDateTime.now().minusDays(9))
+            .duration(18_000_000L)
+            .build();
+
+    persistProcessInstances(List.of(recent, old));
+
+    assertThat(evaluateNumber(KPI_P50_DURATION_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
+        .isCloseTo(3_600_000.0, within(1.0));
+  }
+
+  @Test
+  void shouldApplyDateFilterToP95Duration() {
+    // within window: duration 1h
+    final ProcessInstanceDto recent =
+        agenticInstance(PROC_KEY, 0L, 0L)
+            .startDate(OffsetDateTime.now().minusHours(3))
+            .endDate(OffsetDateTime.now().minusHours(2))
+            .duration(3_600_000L)
+            .build();
+    // outside window: duration 5h — should not affect P95
+    final ProcessInstanceDto old =
+        agenticInstance(PROC_KEY, 0L, 0L)
+            .startDate(OffsetDateTime.now().minusDays(10))
+            .endDate(OffsetDateTime.now().minusDays(9))
+            .duration(18_000_000L)
+            .build();
+
+    persistProcessInstances(List.of(recent, old));
+
+    assertThat(evaluateNumber(KPI_P95_DURATION_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
+        .isCloseTo(3_600_000.0, within(1.0));
+  }
+
+  @Test
   void shouldApplyDateFilterToIncidentRate() {
     // within window: 1 resolved incident
     final String recentId = UUID.randomUUID().toString();
@@ -508,6 +602,46 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
                 KPI_AVG_DURATION_REPORT_ID,
                 withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
         .isCloseTo(7_200_000.0, within(1.0));
+  }
+
+  @Test
+  void shouldApplyDefinitionFilterToP50Duration() {
+    final String procKeyA = "proc-p50-dur-a";
+    final String procKeyB = "proc-p50-dur-b";
+
+    // procKeyA: durations 1h and 3h → P50 = 2h = 7_200_000 ms
+    // procKeyB: duration 10h — should be excluded
+    persistProcessInstances(
+        List.of(
+            agenticInstance(procKeyA, 0L, 0L).duration(3_600_000L).build(),
+            agenticInstance(procKeyA, 0L, 0L).duration(10_800_000L).build(),
+            agenticInstance(procKeyB, 0L, 0L).duration(36_000_000L).build()));
+
+    assertThat(
+            evaluateNumber(
+                KPI_P50_DURATION_REPORT_ID,
+                withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
+        .isCloseTo(7_200_000.0, within(10_000.0));
+  }
+
+  @Test
+  void shouldApplyDefinitionFilterToP95Duration() {
+    final String procKeyA = "proc-p95-dur-a";
+    final String procKeyB = "proc-p95-dur-b";
+
+    // procKeyA: durations 1h and 3h → P95 ≈ 3h = 10_800_000 ms
+    // procKeyB: duration 10h — should be excluded
+    persistProcessInstances(
+        List.of(
+            agenticInstance(procKeyA, 0L, 0L).duration(3_600_000L).build(),
+            agenticInstance(procKeyA, 0L, 0L).duration(10_800_000L).build(),
+            agenticInstance(procKeyB, 0L, 0L).duration(36_000_000L).build()));
+
+    assertThat(
+            evaluateNumber(
+                KPI_P95_DURATION_REPORT_ID,
+                withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
+        .isCloseTo(10_800_000.0, within(1_000_000.0));
   }
 
   @Test

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/ReportRestMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/mapper/ReportRestMapper.java
@@ -103,7 +103,7 @@ public class ReportRestMapper {
       final ReportDefinitionDto<?> reportDefinitionDto,
       final String locale,
       final LocalizationService localizationService) {
-    if (isManagementOrInstantPreviewOrAgenticReport(reportDefinitionDto)) {
+    if (isSystemGeneratedReport(reportDefinitionDto)) {
       final String validLocale = localizationService.validateAndReturnValidLocale(locale);
       final var data = ((SingleProcessReportDefinitionRequestDto) reportDefinitionDto).getData();
       if (data.isManagementReport()) {
@@ -222,8 +222,7 @@ public class ReportRestMapper {
         .ifPresent(reportDefinitionDto::setLastModifier);
   }
 
-  private static boolean isManagementOrInstantPreviewOrAgenticReport(
-      final ReportDefinitionDto<?> reportDefinitionDto) {
+  private static boolean isSystemGeneratedReport(final ReportDefinitionDto<?> reportDefinitionDto) {
     if (!(reportDefinitionDto instanceof SingleProcessReportDefinitionRequestDto)) {
       return false;
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -74,6 +74,10 @@ public class AgenticControlDashboardService {
       "agenticKpiExecutionMedianTokensName";
   public static final String KPI_EXECUTION_MEDIAN_TOKENS_DESCRIPTION =
       "agenticKpiExecutionMedianTokensDescription";
+  public static final String KPI_DURATION_P50_NAME = "agenticKpiDurationP50Name";
+  public static final String KPI_DURATION_P50_DESCRIPTION = "agenticKpiDurationP50Description";
+  public static final String KPI_DURATION_P95_NAME = "agenticKpiDurationP95Name";
+  public static final String KPI_DURATION_P95_DESCRIPTION = "agenticKpiDurationP95Description";
 
   // Deterministic report IDs — derived from fixed seed strings so IDs are stable across restarts
   // and DB reimports. Same seed always produces the same UUID (UUID v3 / name-based).
@@ -91,6 +95,10 @@ public class AgenticControlDashboardService {
   public static final String KPI_MEDIAN_TOKENS_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-kpi-median-tokens".getBytes(StandardCharsets.UTF_8))
           .toString();
+  public static final String KPI_P50_DURATION_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-duration-p50".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String KPI_P95_DURATION_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-duration-p95".getBytes(StandardCharsets.UTF_8)).toString();
 
   private static final long INSTANCE_END_DATE_ROLLING_DAYS = 30L;
 
@@ -123,7 +131,7 @@ public class AgenticControlDashboardService {
   }
 
   public void reconcile() {
-    // Always upsert the five KPI reports so config changes are applied on every restart.
+    // Always upsert all KPI reports so config changes are applied on every restart.
     // Report IDs are deterministic so upserts are safe and tile references never orphan.
     final List<DashboardReportTileDto> tiles = new ArrayList<>();
     tiles.add(buildCompletedInstancesReport());
@@ -131,6 +139,8 @@ public class AgenticControlDashboardService {
     tiles.add(buildIncidentRateReport());
     tiles.add(buildAvgTokensReport());
     tiles.add(buildMedianTokensReport());
+    tiles.add(buildP50DurationReport());
+    tiles.add(buildP95DurationReport());
 
     // Always upsert the dashboard too — tile list can grow across versions and the cold-start
     // guard would leave an existing deployment stuck on the old layout.
@@ -274,6 +284,66 @@ public class AgenticControlDashboardService {
     reportWriter.createOrUpdateSingleProcessReport(
         id, null, reportData, nameKey, descriptionKey, null);
     return buildTile(id, position, new DimensionDto(9, 2), Map.of("section", "token"));
+  }
+
+  private DashboardReportTileDto buildP50DurationReport() {
+    final SingleReportConfigurationDto config = new SingleReportConfigurationDto();
+    config.setAggregationTypes(new AggregationDto(AggregationType.PERCENTILE, 50.0));
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .configuration(config)
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.DURATION))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.NUMBER)
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .buildList())
+            .agenticControlReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        KPI_P50_DURATION_REPORT_ID,
+        null,
+        reportData,
+        KPI_DURATION_P50_NAME,
+        KPI_DURATION_P50_DESCRIPTION,
+        null);
+    return buildTile(KPI_P50_DURATION_REPORT_ID, new PositionDto(0, 4), new DimensionDto(6, 2));
+  }
+
+  private DashboardReportTileDto buildP95DurationReport() {
+    final SingleReportConfigurationDto config = new SingleReportConfigurationDto();
+    config.setAggregationTypes(new AggregationDto(AggregationType.PERCENTILE, 95.0));
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .configuration(config)
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.DURATION))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.NUMBER)
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .buildList())
+            .agenticControlReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        KPI_P95_DURATION_REPORT_ID,
+        null,
+        reportData,
+        KPI_DURATION_P95_NAME,
+        KPI_DURATION_P95_DESCRIPTION,
+        null);
+    return buildTile(KPI_P95_DURATION_REPORT_ID, new PositionDto(6, 4), new DimensionDto(6, 2));
   }
 
   private DashboardDefinitionRestDto buildAgentDashboard(final List<DashboardReportTileDto> tiles) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -95,9 +95,9 @@ public class AgenticControlDashboardService {
   public static final String KPI_MEDIAN_TOKENS_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-kpi-median-tokens".getBytes(StandardCharsets.UTF_8))
           .toString();
-  public static final String KPI_P50_DURATION_REPORT_ID =
+  public static final String KPI_DURATION_P50_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-duration-p50".getBytes(StandardCharsets.UTF_8)).toString();
-  public static final String KPI_P95_DURATION_REPORT_ID =
+  public static final String KPI_DURATION_P95_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-duration-p95".getBytes(StandardCharsets.UTF_8)).toString();
 
   private static final long INSTANCE_END_DATE_ROLLING_DAYS = 30L;
@@ -287,38 +287,31 @@ public class AgenticControlDashboardService {
   }
 
   private DashboardReportTileDto buildP50DurationReport() {
-    final SingleReportConfigurationDto config = new SingleReportConfigurationDto();
-    config.setAggregationTypes(new AggregationDto(AggregationType.PERCENTILE, 50.0));
-    final ProcessReportDataDto reportData =
-        ProcessReportDataDto.builder()
-            .definitions(Collections.emptyList())
-            .configuration(config)
-            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.DURATION))
-            .groupBy(new NoneGroupByDto())
-            .distributedBy(new NoneDistributedByDto())
-            .visualization(ProcessVisualization.NUMBER)
-            .filter(
-                ProcessFilterBuilder.filter()
-                    .completedInstancesOnly()
-                    .add()
-                    .hasAgentInstances()
-                    .add()
-                    .buildList())
-            .agenticControlReport(true)
-            .build();
-    reportWriter.createOrUpdateSingleProcessReport(
-        KPI_P50_DURATION_REPORT_ID,
-        null,
-        reportData,
+    return buildDurationPercentileReport(
+        50.0,
+        KPI_DURATION_P50_REPORT_ID,
         KPI_DURATION_P50_NAME,
         KPI_DURATION_P50_DESCRIPTION,
-        null);
-    return buildTile(KPI_P50_DURATION_REPORT_ID, new PositionDto(0, 4), new DimensionDto(6, 2));
+        new PositionDto(0, 4));
   }
 
   private DashboardReportTileDto buildP95DurationReport() {
+    return buildDurationPercentileReport(
+        95.0,
+        KPI_DURATION_P95_REPORT_ID,
+        KPI_DURATION_P95_NAME,
+        KPI_DURATION_P95_DESCRIPTION,
+        new PositionDto(6, 4));
+  }
+
+  private DashboardReportTileDto buildDurationPercentileReport(
+      final double percentile,
+      final String reportId,
+      final String nameKey,
+      final String descriptionKey,
+      final PositionDto position) {
     final SingleReportConfigurationDto config = new SingleReportConfigurationDto();
-    config.setAggregationTypes(new AggregationDto(AggregationType.PERCENTILE, 95.0));
+    config.setAggregationTypes(new AggregationDto(AggregationType.PERCENTILE, percentile));
     final ProcessReportDataDto reportData =
         ProcessReportDataDto.builder()
             .definitions(Collections.emptyList())
@@ -337,13 +330,8 @@ public class AgenticControlDashboardService {
             .agenticControlReport(true)
             .build();
     reportWriter.createOrUpdateSingleProcessReport(
-        KPI_P95_DURATION_REPORT_ID,
-        null,
-        reportData,
-        KPI_DURATION_P95_NAME,
-        KPI_DURATION_P95_DESCRIPTION,
-        null);
-    return buildTile(KPI_P95_DURATION_REPORT_ID, new PositionDto(6, 4), new DimensionDto(6, 2));
+        reportId, null, reportData, nameKey, descriptionKey, null);
+    return buildTile(reportId, position, new DimensionDto(9, 2), Map.of("section", "duration"));
   }
 
   private DashboardDefinitionRestDto buildAgentDashboard(final List<DashboardReportTileDto> tiles) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -301,7 +301,7 @@ public class AgenticControlDashboardService {
         KPI_DURATION_P95_REPORT_ID,
         KPI_DURATION_P95_NAME,
         KPI_DURATION_P95_DESCRIPTION,
-        new PositionDto(6, 4));
+        new PositionDto(9, 4));
   }
 
   private DashboardReportTileDto buildDurationPercentileReport(

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -1554,7 +1554,11 @@
       "agenticKpiExecutionAvgTokensName": "Durchschnittliche Tokens pro Ausführung",
       "agenticKpiExecutionAvgTokensDescription": "Durchschnittliche Gesamtanzahl der verbrauchten Tokens pro abgeschlossener agentischer Prozessinstanz im gewählten Zeitraum.",
       "agenticKpiExecutionMedianTokensName": "Mediane Tokens pro Ausführung",
-      "agenticKpiExecutionMedianTokensDescription": "Median der verbrauchten Tokens pro abgeschlossener agentischer Prozessinstanz im gewählten Zeitraum."
+      "agenticKpiExecutionMedianTokensDescription": "Median der verbrauchten Tokens pro abgeschlossener agentischer Prozessinstanz im gewählten Zeitraum.",
+      "agenticKpiDurationP50Name": "P50-Ausführungsdauer",
+      "agenticKpiDurationP50Description": "Median (P50) der Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum.",
+      "agenticKpiDurationP95Name": "P95-Ausführungsdauer",
+      "agenticKpiDurationP95Description": "95. Perzentil der Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum."
     }
   },
   "managementDashboard": {

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -6,6 +6,7 @@
     "description": "Überwachen Sie die Einführung, das Verhalten und die Zuverlässigkeit von KI-Agenten sowie den Token-Verbrauch prozessübergreifend.",
     "dateRange": "Zeitraum",
     "tokenUsage": "Token-Nutzung",
+    "duration": "Dauer",
     "presets": {
       "last7Days": "Letzte 7 Tage",
       "last30Days": "Letzte 30 Tage",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -6,6 +6,7 @@
     "description": "Monitor AI agent adoption, token spend, behavior, and reliability across your processes.",
     "dateRange": "Date range",
     "tokenUsage": "Token usage",
+    "duration": "Duration",
     "presets": {
       "last7Days": "Last 7 days",
       "last30Days": "Last 30 days",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -1554,7 +1554,11 @@
       "agenticKpiExecutionAvgTokensName": "Avg tokens per execution",
       "agenticKpiExecutionAvgTokensDescription": "Average total tokens consumed per completed agentic process instance in the selected period.",
       "agenticKpiExecutionMedianTokensName": "Median tokens per execution",
-      "agenticKpiExecutionMedianTokensDescription": "Median total tokens consumed per completed agentic process instance in the selected period."
+      "agenticKpiExecutionMedianTokensDescription": "Median total tokens consumed per completed agentic process instance in the selected period.",
+      "agenticKpiDurationP50Name": "P50 execution duration",
+      "agenticKpiDurationP50Description": "Median (P50) execution duration of completed agentic process instances in the selected period.",
+      "agenticKpiDurationP95Name": "P95 execution duration",
+      "agenticKpiDurationP95Description": "95th percentile execution duration of completed agentic process instances in the selected period."
     }
   },
   "managementDashboard": {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.service.dashboard.AgenticControlDashboardServi
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -27,9 +28,14 @@ import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardInstance
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardProcessScopeFilterDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.filter.data.DashboardDateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RollingDateFilterDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
 import io.camunda.optimize.service.db.reader.DashboardReader;
 import io.camunda.optimize.service.db.writer.DashboardWriter;
 import io.camunda.optimize.service.db.writer.ReportWriter;
@@ -78,7 +84,7 @@ public class AgenticControlDashboardServiceTest {
     assertThat(saved.isAgenticControlDashboard()).isTrue();
     assertThat(saved.isManagementDashboard()).isFalse();
     assertThat(saved.getCollectionId()).isNull();
-    assertThat(saved.getTiles()).hasSize(5);
+    assertThat(saved.getTiles()).hasSize(7);
   }
 
   @Test
@@ -165,7 +171,9 @@ public class AgenticControlDashboardServiceTest {
             AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID,
             AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID,
             AgenticControlDashboardService.KPI_AVG_TOKENS_REPORT_ID,
-            AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID);
+            AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID,
+            AgenticControlDashboardService.KPI_P50_DURATION_REPORT_ID,
+            AgenticControlDashboardService.KPI_P95_DURATION_REPORT_ID);
   }
 
   @Test
@@ -226,7 +234,7 @@ public class AgenticControlDashboardServiceTest {
     underTest.reconcile();
 
     // then reports are upserted and dashboard tiles are updated, but dashboard is not recreated
-    verify(reportWriter, org.mockito.Mockito.times(5))
+    verify(reportWriter, org.mockito.Mockito.times(7))
         .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
     verify(dashboardWriter, never()).saveDashboard(any());
     verify(dashboardWriter).updateDashboard(any(), any());
@@ -315,8 +323,97 @@ public class AgenticControlDashboardServiceTest {
               AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_NAME,
               AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_DESCRIPTION,
               AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_NAME,
-              AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION);
+              AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION,
+              AgenticControlDashboardService.KPI_DURATION_P50_NAME,
+              AgenticControlDashboardService.KPI_DURATION_P50_DESCRIPTION,
+              AgenticControlDashboardService.KPI_DURATION_P95_NAME,
+              AgenticControlDashboardService.KPI_DURATION_P95_DESCRIPTION);
     }
+  }
+
+  @Test
+  void shouldSeedP50DurationReportWithCorrectConfig() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+    final ArgumentCaptor<ProcessReportDataDto> dataCaptor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+
+    // when
+    underTest.reconcile();
+
+    // then the P50 report is upserted with the correct deterministic ID and localization keys
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.KPI_P50_DURATION_REPORT_ID),
+            isNull(),
+            dataCaptor.capture(),
+            eq(AgenticControlDashboardService.KPI_DURATION_P50_NAME),
+            eq(AgenticControlDashboardService.KPI_DURATION_P50_DESCRIPTION),
+            isNull());
+
+    final ProcessReportDataDto p50Data = dataCaptor.getValue();
+    assertThat(p50Data.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
+    assertThat(p50Data.getView().getProperties()).contains(ViewProperty.DURATION);
+    assertThat(p50Data.getConfiguration().getAggregationTypes())
+        .containsExactly(new AggregationDto(AggregationType.PERCENTILE, 50.0));
+    assertThat(p50Data.isAgenticControlReport()).isTrue();
+  }
+
+  @Test
+  void shouldSeedP95DurationReportWithCorrectConfig() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+    final ArgumentCaptor<ProcessReportDataDto> dataCaptor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+
+    // when
+    underTest.reconcile();
+
+    // then the P95 report is upserted with the correct deterministic ID and localization keys
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.KPI_P95_DURATION_REPORT_ID),
+            isNull(),
+            dataCaptor.capture(),
+            eq(AgenticControlDashboardService.KPI_DURATION_P95_NAME),
+            eq(AgenticControlDashboardService.KPI_DURATION_P95_DESCRIPTION),
+            isNull());
+
+    final ProcessReportDataDto p95Data = dataCaptor.getValue();
+    assertThat(p95Data.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
+    assertThat(p95Data.getView().getProperties()).contains(ViewProperty.DURATION);
+    assertThat(p95Data.getConfiguration().getAggregationTypes())
+        .containsExactly(new AggregationDto(AggregationType.PERCENTILE, 95.0));
+    assertThat(p95Data.isAgenticControlReport()).isTrue();
+  }
+
+  @Test
+  void shouldUpsertP50AndP95ReportsOnWarmRestart() {
+    // given — dashboard already exists (warm restart)
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID))
+        .thenReturn(Optional.of(new DashboardDefinitionRestDto()));
+
+    // when
+    underTest.reconcile();
+
+    // then both duration percentile reports are upserted even when the dashboard is not recreated
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.KPI_P50_DURATION_REPORT_ID),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.KPI_P95_DURATION_REPORT_ID),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+    verify(dashboardWriter, never()).saveDashboard(any());
   }
 
   @SuppressWarnings("unchecked")

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -172,8 +172,8 @@ public class AgenticControlDashboardServiceTest {
             AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID,
             AgenticControlDashboardService.KPI_AVG_TOKENS_REPORT_ID,
             AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID,
-            AgenticControlDashboardService.KPI_P50_DURATION_REPORT_ID,
-            AgenticControlDashboardService.KPI_P95_DURATION_REPORT_ID);
+            AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID,
+            AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID);
   }
 
   @Test
@@ -333,58 +333,20 @@ public class AgenticControlDashboardServiceTest {
 
   @Test
   void shouldSeedP50DurationReportWithCorrectConfig() {
-    // given
-    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
-    final ArgumentCaptor<ProcessReportDataDto> dataCaptor =
-        ArgumentCaptor.forClass(ProcessReportDataDto.class);
-
-    // when
-    underTest.reconcile();
-
-    // then the P50 report is upserted with the correct deterministic ID and localization keys
-    verify(reportWriter)
-        .createOrUpdateSingleProcessReport(
-            eq(AgenticControlDashboardService.KPI_P50_DURATION_REPORT_ID),
-            isNull(),
-            dataCaptor.capture(),
-            eq(AgenticControlDashboardService.KPI_DURATION_P50_NAME),
-            eq(AgenticControlDashboardService.KPI_DURATION_P50_DESCRIPTION),
-            isNull());
-
-    final ProcessReportDataDto p50Data = dataCaptor.getValue();
-    assertThat(p50Data.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
-    assertThat(p50Data.getView().getProperties()).contains(ViewProperty.DURATION);
-    assertThat(p50Data.getConfiguration().getAggregationTypes())
-        .containsExactly(new AggregationDto(AggregationType.PERCENTILE, 50.0));
-    assertThat(p50Data.isAgenticControlReport()).isTrue();
+    assertDurationReportSeeded(
+        AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID,
+        AgenticControlDashboardService.KPI_DURATION_P50_NAME,
+        AgenticControlDashboardService.KPI_DURATION_P50_DESCRIPTION,
+        50.0);
   }
 
   @Test
   void shouldSeedP95DurationReportWithCorrectConfig() {
-    // given
-    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
-    final ArgumentCaptor<ProcessReportDataDto> dataCaptor =
-        ArgumentCaptor.forClass(ProcessReportDataDto.class);
-
-    // when
-    underTest.reconcile();
-
-    // then the P95 report is upserted with the correct deterministic ID and localization keys
-    verify(reportWriter)
-        .createOrUpdateSingleProcessReport(
-            eq(AgenticControlDashboardService.KPI_P95_DURATION_REPORT_ID),
-            isNull(),
-            dataCaptor.capture(),
-            eq(AgenticControlDashboardService.KPI_DURATION_P95_NAME),
-            eq(AgenticControlDashboardService.KPI_DURATION_P95_DESCRIPTION),
-            isNull());
-
-    final ProcessReportDataDto p95Data = dataCaptor.getValue();
-    assertThat(p95Data.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
-    assertThat(p95Data.getView().getProperties()).contains(ViewProperty.DURATION);
-    assertThat(p95Data.getConfiguration().getAggregationTypes())
-        .containsExactly(new AggregationDto(AggregationType.PERCENTILE, 95.0));
-    assertThat(p95Data.isAgenticControlReport()).isTrue();
+    assertDurationReportSeeded(
+        AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID,
+        AgenticControlDashboardService.KPI_DURATION_P95_NAME,
+        AgenticControlDashboardService.KPI_DURATION_P95_DESCRIPTION,
+        95.0);
   }
 
   @Test
@@ -399,7 +361,7 @@ public class AgenticControlDashboardServiceTest {
     // then both duration percentile reports are upserted even when the dashboard is not recreated
     verify(reportWriter)
         .createOrUpdateSingleProcessReport(
-            eq(AgenticControlDashboardService.KPI_P50_DURATION_REPORT_ID),
+            eq(AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID),
             any(),
             any(),
             any(),
@@ -407,7 +369,7 @@ public class AgenticControlDashboardServiceTest {
             any());
     verify(reportWriter)
         .createOrUpdateSingleProcessReport(
-            eq(AgenticControlDashboardService.KPI_P95_DURATION_REPORT_ID),
+            eq(AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID),
             any(),
             any(),
             any(),
@@ -431,5 +393,31 @@ public class AgenticControlDashboardServiceTest {
         ArgumentCaptor.forClass(DashboardDefinitionRestDto.class);
     verify(dashboardWriter).saveDashboard(captor.capture());
     return captor.getValue();
+  }
+
+  private void assertDurationReportSeeded(
+      final String reportId,
+      final String nameKey,
+      final String descKey,
+      final double expectedPercentile) {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+    final ArgumentCaptor<ProcessReportDataDto> dataCaptor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+
+    // when
+    underTest.reconcile();
+
+    // then the report is upserted with the correct deterministic ID and localization keys
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(reportId), isNull(), dataCaptor.capture(), eq(nameKey), eq(descKey), isNull());
+
+    final ProcessReportDataDto reportData = dataCaptor.getValue();
+    assertThat(reportData.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
+    assertThat(reportData.getView().getProperties()).contains(ViewProperty.DURATION);
+    assertThat(reportData.getConfiguration().getAggregationTypes())
+        .containsExactly(new AggregationDto(AggregationType.PERCENTILE, expectedPercentile));
+    assertThat(reportData.isAgenticControlReport()).isTrue();
   }
 }

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
@@ -97,6 +97,7 @@ export function AgenticControlPlane() {
   const sections = [
     {key: 'kpi', loadTile: scopedEvaluateReport},
     {key: 'token', titleKey: 'agenticControlPlane.tokenUsage', loadTile: scopedEvaluateReport},
+    {key: 'duration', titleKey: 'agenticControlPlane.duration', loadTile: scopedEvaluateReport},
   ];
 
   return (


### PR DESCRIPTION
related to #54848

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54848
