### PR TITLE
ci: fix shell injection in stale-backport-tracker via env var

### DIFF
--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -212,9 +212,10 @@ jobs:
           NOTIFY_ORIGINAL: "false"
           TARGET_BACKPORT_PR: ${{ inputs.target_backport_pr || '' }}
           WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STALE_DATA: ${{ needs.collect-stale-backports.outputs.stale_data }}
         run: |
           chmod +x .ci/scripts/stale-backport-scripts/notify-stale-backports.sh
-          stale_data='${{ needs.collect-stale-backports.outputs.stale_data }}'
+          stale_data="$STALE_DATA"
           if [[ -n "$TARGET_BACKPORT_PR" ]]; then
             echo "🎯 Filtering to backport PR #${TARGET_BACKPORT_PR} only"
             stale_data=$(printf '%s' "$stale_data" | jq --arg pr "$TARGET_BACKPORT_PR" '
@@ -302,9 +303,10 @@ jobs:
           REPOSITORIES: "camunda/camunda,camunda/zeebe-process-test"
           SLACK_USER_MAP_FILE: /tmp/slack-user-map.json
           SLACK_USER_MAP_FALLBACK: ${{ env.SLACK_USER_MAP_FALLBACK }}
+          STALE_DATA: ${{ needs.collect-stale-backports.outputs.stale_data }}
         run: |
           chmod +x .ci/scripts/stale-backport-scripts/format-slack-report.sh
-          payload=$(echo '${{ needs.collect-stale-backports.outputs.stale_data }}' | \
+          payload=$(printf '%s' "$STALE_DATA" | \
             .ci/scripts/stale-backport-scripts/format-slack-report.sh)
 
           {


### PR DESCRIPTION
## Summary

- PR #54953 title `[Backport stable/8.9] fix: don't corrupt variable map...` contains a single quote (`'`) that breaks `stale_data='${{ ... }}'` shell assignment, terminating the string early and causing bash to execute `corrupt` as a command (exit 127)
- Same data causes `jq: parse error: Invalid string: control characters` in the Slack report step
- Fix: move `stale_data` into an env var in both affected steps; GHA handles quoting safely

## Test plan

- [x] Trigger `Stale Backport Tracker` workflow manually via `workflow_dispatch` to verify both jobs complete green
- [x] Confirm PR #54953 appears in output without breaking the run

Closes: n/a — operational fix for scheduled workflow failure