### PR TITLE
test: stabilize "Alice cannot complete Bob's task" by waiting for details to load

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/user-task-permission-management.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/user-task-permission-management.spec.ts
@@ -627,6 +627,12 @@ test.describe
 
     await taskPanelPage.goToTaskDetails(bobUserTaskKey);
 
+    // Alice is not the assignee, so the Complete Task button is rendered in a
+    // disabled state ("Task is not assigned"), which prevents her from
+    // completing Bob's task. Wait for the task details panel to finish loading
+    // before asserting — otherwise the button may not be rendered yet and the
+    // assertion times out with "element(s) not found".
+    await expect(taskDetailsPage.detailsInfo).toBeVisible({timeout: 30000});
     await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Root cause

The nightly test `should prevent Alice from completing a task assigned to Bob` (tasklist v2) failed with `toBeDisabled()` timing out: `element(s) not found`.

The earlier fix attempt in #54977 assumed the **Complete Task** button is never rendered for Alice and changed the assertion to `toBeHidden()`. The verification run ([27255798175](https://github.com/camunda/camunda/actions/runs/27255798175/job/80489904843)) disproves that — the button **is** rendered, just in a disabled state:

```
22 × locator resolved to <button disabled type="submit" title="Task is not assigned"
     class="...cds--btn--disabled">Complete Task</button>
   - unexpected value "visible"
```

So `toBeHidden()` is wrong — the button stays visible-but-disabled. The real problem is **timing**: the original assertion ran before the task details panel finished loading, so the button didn't exist yet and the assertion timed out.

## Fix

Wait for the task details panel (`detailsInfo`) to be visible, then assert the Complete Task button is **disabled** (its correct non-assignee state, `title="Task is not assigned"`). This makes the assertion robust against load timing without changing the asserted behavior.

```ts
await expect(taskDetailsPage.detailsInfo).toBeVisible({timeout: 30000});
await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
```

## Tests fixed

- `tests/tasklist/user-task-permission-management.spec.ts` › `should prevent Alice from completing a task assigned to Bob`

## Links

- Failing verification run: https://github.com/camunda/camunda/actions/runs/27255798175/job/80489904843
- Supersedes the incorrect `toBeHidden()` approach in #54977

## Validation
https://github.com/camunda/camunda/actions/runs/27270427741 -> e2e ✅ 
---
_Generated by [Claude Code](https://claude.ai/code/session_011Hfi9wYdkur7K614D5KVuL)_