### PR TITLE
ci: run forward compatibility tests on every PR instead of nightly

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -231,6 +231,15 @@ outputs:
         steps.ci-github-actions.outputs.ci-relevant == 'true' ||
         steps.filter-c8-e2e-test-suite.outputs.c8-e2e-test-suite-change == 'true'
       }}
+  forward-compat-tests-changes:
+    description: Output whether the C8 REST API forward compatibility tests should be run based on GitHub event and files changed
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        steps.ci-github-actions.outputs.ci-relevant == 'true' ||
+        steps.filter-c8-e2e-test-suite.outputs.c8-e2e-test-suite-change == 'true'
+      }}
 
 runs:
   using: composite

--- a/.github/workflows/ci-c8-forward-compatibility-tests.yml
+++ b/.github/workflows/ci-c8-forward-compatibility-tests.yml
@@ -82,10 +82,7 @@ jobs:
             echo "Base branch: $BASE_REF"
             echo "Test ref: $TEST_REF"
 
-            if [[ "$BASE_REF" == "main" ]]; then
-              SERVER_BRANCH="main"
-              SERVER_IMAGE="camunda/camunda:SNAPSHOT"
-            elif [[ "$BASE_REF" =~ ^stable/([0-9]+)\.([0-9]+)$ ]]; then
+            if [[ "$BASE_REF" =~ ^stable/([0-9]+)\.([0-9]+)$ ]]; then
               MAJOR="${BASH_REMATCH[1]}"
               MINOR="${BASH_REMATCH[2]}"
               NEXT_MINOR=$((MINOR + 1))
@@ -108,9 +105,11 @@ jobs:
             echo "Resolved: base=$BASE_REF → server=$SERVER_BRANCH ($SERVER_IMAGE), tests=$TEST_BRANCH"
           fi
 
-          echo "server_branch=$SERVER_BRANCH" >> "$GITHUB_OUTPUT"
-          echo "server_image=$SERVER_IMAGE" >> "$GITHUB_OUTPUT"
-          echo "test_branch=$TEST_BRANCH" >> "$GITHUB_OUTPUT"
+          {
+            echo "server_branch=$SERVER_BRANCH"
+            echo "server_image=$SERVER_IMAGE"
+            echo "test_branch=$TEST_BRANCH"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Print test configuration
         run: |

--- a/.github/workflows/ci-c8-forward-compatibility-tests.yml
+++ b/.github/workflows/ci-c8-forward-compatibility-tests.yml
@@ -1,28 +1,26 @@
 # description: Runs forward compatibility tests for C8 REST API endpoints.
 # Tests a server built from one branch against API tests from another branch
 # to ensure forward compatibility of REST endpoints across versions.
-# Scheduled nightly and supports manual dispatch for custom branch combinations.
+# Called from ci.yml (Unified CI) and supports manual dispatch.
 # type: CI
 # owner: @camunda/camunda-ex
 ---
 name: C8 REST API Forward Compatibility Tests
 
 on:
-  schedule:
-    - cron: "0 2 * * *" # Daily at 2 AM UTC
+  workflow_call: {}
   workflow_dispatch:
     inputs:
       server_branch:
-        description: "Branch to build the server from (e.g., main, stable/8.9). Leave empty for default matrix."
-        required: false
+        description: "Branch to build the server from (e.g., main, stable/8.9)."
+        required: true
         type: string
       test_branch:
-        description: "Branch to run the API tests from (e.g., stable/8.8, stable/8.9). Leave empty for default matrix."
-        required: false
+        description: "Branch to run the API tests from (e.g., stable/8.8, stable/8.9)."
+        required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 defaults:
   run:
@@ -33,8 +31,7 @@ jobs:
     name: Prepare Version Matrix
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: read
+    permissions: {}
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
@@ -42,6 +39,14 @@ jobs:
 
       - name: Generate matrix
         id: matrix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_SERVER_BRANCH: ${{ inputs.server_branch }}
+          INPUT_TEST_BRANCH: ${{ inputs.test_branch }}
+          GH_BASE_REF: ${{ github.base_ref }}
+          GH_HEAD_REF: ${{ github.head_ref }}
+          GH_REF: ${{ github.ref }}
+          MG_BASE_REF: ${{ github.event.merge_group.base_ref }}
         run: |
           # Resolve the public Docker image for a branch.
           # - stable/X.Y → camunda/camunda:X.Y-SNAPSHOT
@@ -55,15 +60,10 @@ jobs:
             fi
           }
 
-          SERVER_BRANCH="${{ inputs.server_branch }}"
-          TEST_BRANCH="${{ inputs.test_branch }}"
-
-          if [[ -n "$SERVER_BRANCH" || -n "$TEST_BRANCH" ]]; then
-            # Manual trigger: require both inputs to avoid surprising fallback behavior
-            if [[ -z "$SERVER_BRANCH" || -z "$TEST_BRANCH" ]]; then
-              echo "::error::Both 'server_branch' and 'test_branch' must be provided for manual dispatch. Got server_branch='$SERVER_BRANCH', test_branch='$TEST_BRANCH'."
-              exit 1
-            fi
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            # Manual trigger: both inputs are required by the workflow definition.
+            SERVER_BRANCH="$INPUT_SERVER_BRANCH"
+            TEST_BRANCH="$INPUT_TEST_BRANCH"
             echo "Manual trigger: Testing Server=$SERVER_BRANCH with Tests=$TEST_BRANCH"
             SERVER_IMAGE=$(resolve_image "$SERVER_BRANCH")
             echo "Resolved server image: $SERVER_IMAGE"
@@ -73,50 +73,49 @@ jobs:
               --arg image "$SERVER_IMAGE" \
               '{"include": [{"server_branch": $server, "test_branch": $test, "server_image": $image}]}')
           else
-            echo "Discovering stable branches from remote..."
-            # List remote stable/X.Y branches, extract version, sort ascending by version
-            # Only include branches >= 8.8 (forward compatibility tests start from 8.8)
-            STABLE_BRANCHES=$(git ls-remote --heads origin 'refs/heads/stable/*' \
-              | sed -n 's|.*refs/heads/\(stable/[0-9]\+\.[0-9]\+\)$|\1|p' \
-              | sort -t/ -k2 -V \
-              | awk -F/ '{ split($2, v, "."); if (v[1] > 8 || (v[1] == 8 && v[2] >= 8)) print }')
+            # PR / merge queue: test the PR branch against the next server version.
+            # The base branch determines which server image to use:
+            #   PR → main          → server = SNAPSHOT (main)
+            #   PR → stable/8.8    → server = 8.9-SNAPSHOT (next minor)
+            #   PR → stable/8.9    → server = 8.10-SNAPSHOT if stable/8.10 exists, else SNAPSHOT (main)
+            if [[ "$EVENT_NAME" == "pull_request" || "$EVENT_NAME" == "workflow_call" ]]; then
+              BASE_REF="$GH_BASE_REF"
+              TEST_REF="$GH_HEAD_REF"
+            else
+              BASE_REF="${MG_BASE_REF#refs/heads/}"
+              TEST_REF="$GH_REF"
+            fi
+            echo "Base branch: $BASE_REF"
+            echo "Test ref: $TEST_REF"
 
-            mapfile -t BRANCHES <<< "$STABLE_BRANCHES"
-            echo "Discovered stable branches (ascending): ${BRANCHES[*]}"
+            if [[ "$BASE_REF" == "main" ]]; then
+              SERVER_LABEL="main"
+              SERVER_IMAGE="camunda/camunda:SNAPSHOT"
+            elif [[ "$BASE_REF" =~ ^stable/([0-9]+)\.([0-9]+)$ ]]; then
+              MAJOR="${BASH_REMATCH[1]}"
+              MINOR="${BASH_REMATCH[2]}"
+              NEXT_MINOR=$((MINOR + 1))
+              NEXT_BRANCH="stable/${MAJOR}.${NEXT_MINOR}"
 
-            if [[ ${#BRANCHES[@]} -lt 2 ]]; then
-              echo "::error::Need at least 2 stable branches for forward compatibility testing, found ${#BRANCHES[@]}"
+              if git ls-remote --exit-code --heads origin "refs/heads/${NEXT_BRANCH}" > /dev/null 2>&1; then
+                SERVER_LABEL="${NEXT_BRANCH}"
+                SERVER_IMAGE="camunda/camunda:${MAJOR}.${NEXT_MINOR}-SNAPSHOT"
+              else
+                # Next minor has no stable branch yet — main is the next version
+                SERVER_LABEL="main"
+                SERVER_IMAGE="camunda/camunda:SNAPSHOT"
+              fi
+            else
+              echo "::error::Unsupported base branch for forward compatibility: $BASE_REF"
               exit 1
             fi
 
-            NEWEST="${BRANCHES[-1]}"
-            echo "Newest stable: $NEWEST"
-
-            # Build matrix:
-            #   1. main → newest stable
-            #   2. Consecutive stable pairs only (e.g. 8.8→8.9, 8.9→8.10, NOT 8.8→8.10)
-            MATRIX_ITEMS="[]"
-
-            # main tested against newest stable only
-            MATRIX_ITEMS=$(echo "$MATRIX_ITEMS" | jq -c \
-              --arg server "main" \
-              --arg test "$NEWEST" \
-              --arg image "$(resolve_image "main")" \
-              '. += [{"server_branch": $server, "test_branch": $test, "server_image": $image}]')
-
-            # Consecutive stable pairs: each branch tested against its next minor
-            for (( i=0; i < ${#BRANCHES[@]} - 1; i++ )); do
-              OLDER="${BRANCHES[$i]}"
-              NEWER="${BRANCHES[$((i + 1))]}"
-              echo "Adding consecutive pair: server=$NEWER, tests=$OLDER"
-              MATRIX_ITEMS=$(echo "$MATRIX_ITEMS" | jq -c \
-                --arg server "$NEWER" \
-                --arg test "$OLDER" \
-                --arg image "$(resolve_image "$NEWER")" \
-                '. += [{"server_branch": $server, "test_branch": $test, "server_image": $image}]')
-            done
-
-            MATRIX_JSON=$(jq -nc --argjson items "$MATRIX_ITEMS" '{"include": $items}')
+            echo "Resolved: base=$BASE_REF → server=$SERVER_LABEL ($SERVER_IMAGE), tests=$TEST_REF"
+            MATRIX_JSON=$(jq -nc \
+              --arg server "$SERVER_LABEL" \
+              --arg test "$TEST_REF" \
+              --arg image "$SERVER_IMAGE" \
+              '{"include": [{"server_branch": $server, "test_branch": $test, "server_image": $image}]}')
           fi
 
           echo "Matrix: $MATRIX_JSON"
@@ -134,11 +133,9 @@ jobs:
   forward-compatibility-api-tests:
     name: "Server: ${{ matrix.server_branch }} / Tests: ${{ matrix.test_branch }}"
     needs: prepare-matrix
-    if: needs.prepare-matrix.outputs.matrix != ''
     runs-on: ubuntu-latest
-    timeout-minutes: 90
-    permissions:
-      contents: read
+    timeout-minutes: 30
+    permissions: {}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
@@ -151,11 +148,12 @@ jobs:
           echo "Test branch:   ${{ matrix.test_branch }}"
           echo "===================================================="
 
-      # Checkout test branch at root — provides composite actions, docker-compose config, and tests
-      - name: Checkout test branch
+      # For PRs/merge queue: default checkout gets the PR code (what we want to test).
+      # For workflow_dispatch: checkout the explicitly specified test branch.
+      - name: Checkout test code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ matrix.test_branch }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && matrix.test_branch || '' }}
 
       - name: Pull server Docker image
         run: |
@@ -225,22 +223,8 @@ jobs:
           cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
 
       - name: Clean install dependencies
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install
+        run: npm ci
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
-
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
@@ -303,65 +287,6 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           job_name: "forward-compatibility-api-tests/server-${{ matrix.server_branch }}/tests-${{ matrix.test_branch }}"
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
-  notify-failure:
-    name: Notify on failure
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [prepare-matrix, forward-compatibility-api-tests]
-    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
-
-      - name: Notify failure
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-        with:
-          webhook: ${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-               "blocks": [
-                 {
-                   "type": "section",
-                   "text": {
-                     "type": "mrkdwn",
-                     "text": ":alarm: *REST API Forward Compatibility Tests Failed*"
-                   }
-                 },
-                 {
-                   "type": "section",
-                   "text": {
-                     "type": "mrkdwn",
-                     "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-                   }
-                 }
-               ]
-             }
-
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
           build_status: ${{ job.status }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/ci-c8-forward-compatibility-tests.yml
+++ b/.github/workflows/ci-c8-forward-compatibility-tests.yml
@@ -27,18 +27,16 @@ defaults:
     shell: bash
 
 jobs:
-  prepare-matrix:
-    name: Prepare Version Matrix
+  forward-compatibility-api-tests:
+    name: Forward Compatibility API Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 30
     permissions: {}
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Generate matrix
-        id: matrix
+      - name: Resolve server image
+        id: resolve
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_SERVER_BRANCH: ${{ inputs.server_branch }}
@@ -67,13 +65,9 @@ jobs:
             echo "Manual trigger: Testing Server=$SERVER_BRANCH with Tests=$TEST_BRANCH"
             SERVER_IMAGE=$(resolve_image "$SERVER_BRANCH")
             echo "Resolved server image: $SERVER_IMAGE"
-            MATRIX_JSON=$(jq -nc \
-              --arg server "$SERVER_BRANCH" \
-              --arg test "$TEST_BRANCH" \
-              --arg image "$SERVER_IMAGE" \
-              '{"include": [{"server_branch": $server, "test_branch": $test, "server_image": $image}]}')
           else
-            # PR / merge queue: test the PR branch against the next server version.
+            # PR / merge queue (via workflow_call from ci.yml):
+            # Test the PR branch against the next server version.
             # The base branch determines which server image to use:
             #   PR → main          → server = SNAPSHOT (main)
             #   PR → stable/8.8    → server = 8.9-SNAPSHOT (next minor)
@@ -89,7 +83,7 @@ jobs:
             echo "Test ref: $TEST_REF"
 
             if [[ "$BASE_REF" == "main" ]]; then
-              SERVER_LABEL="main"
+              SERVER_BRANCH="main"
               SERVER_IMAGE="camunda/camunda:SNAPSHOT"
             elif [[ "$BASE_REF" =~ ^stable/([0-9]+)\.([0-9]+)$ ]]; then
               MAJOR="${BASH_REMATCH[1]}"
@@ -98,11 +92,11 @@ jobs:
               NEXT_BRANCH="stable/${MAJOR}.${NEXT_MINOR}"
 
               if git ls-remote --exit-code --heads origin "refs/heads/${NEXT_BRANCH}" > /dev/null 2>&1; then
-                SERVER_LABEL="${NEXT_BRANCH}"
+                SERVER_BRANCH="${NEXT_BRANCH}"
                 SERVER_IMAGE="camunda/camunda:${MAJOR}.${NEXT_MINOR}-SNAPSHOT"
               else
                 # Next minor has no stable branch yet — main is the next version
-                SERVER_LABEL="main"
+                SERVER_BRANCH="main"
                 SERVER_IMAGE="camunda/camunda:SNAPSHOT"
               fi
             else
@@ -110,59 +104,30 @@ jobs:
               exit 1
             fi
 
-            echo "Resolved: base=$BASE_REF → server=$SERVER_LABEL ($SERVER_IMAGE), tests=$TEST_REF"
-            MATRIX_JSON=$(jq -nc \
-              --arg server "$SERVER_LABEL" \
-              --arg test "$TEST_REF" \
-              --arg image "$SERVER_IMAGE" \
-              '{"include": [{"server_branch": $server, "test_branch": $test, "server_image": $image}]}')
+            TEST_BRANCH="$TEST_REF"
+            echo "Resolved: base=$BASE_REF → server=$SERVER_BRANCH ($SERVER_IMAGE), tests=$TEST_BRANCH"
           fi
 
-          echo "Matrix: $MATRIX_JSON"
-          echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          echo "server_branch=$SERVER_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "server_image=$SERVER_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "test_branch=$TEST_BRANCH" >> "$GITHUB_OUTPUT"
 
-  forward-compatibility-api-tests:
-    name: "Server: ${{ matrix.server_branch }} / Tests: ${{ matrix.test_branch }}"
-    needs: prepare-matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions: {}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
-    steps:
       - name: Print test configuration
         run: |
           echo "===== Forward Compatibility Test Configuration ====="
-          echo "Server branch: ${{ matrix.server_branch }}"
-          echo "Server image:  ${{ matrix.server_image }}"
-          echo "Test branch:   ${{ matrix.test_branch }}"
+          echo "Server branch: ${{ steps.resolve.outputs.server_branch }}"
+          echo "Server image:  ${{ steps.resolve.outputs.server_image }}"
+          echo "Test branch:   ${{ steps.resolve.outputs.test_branch }}"
           echo "===================================================="
-
-      # For PRs/merge queue: default checkout gets the PR code (what we want to test).
-      # For workflow_dispatch: checkout the explicitly specified test branch.
-      - name: Checkout test code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && matrix.test_branch || '' }}
 
       - name: Pull server Docker image
         run: |
-          echo "Pulling image: ${{ matrix.server_image }}"
+          echo "Pulling image: ${{ steps.resolve.outputs.server_image }}"
           # Retry to absorb transient Docker Hub registry timeouts
           # (e.g. "Get https://registry-1.docker.io/v2/: context deadline exceeded").
           attempts=3
           for attempt in $(seq 1 "$attempts"); do
-            if docker pull "${{ matrix.server_image }}"; then
+            if docker pull "${{ steps.resolve.outputs.server_image }}"; then
               echo "Image pulled on attempt ${attempt}."
               exit 0
             fi
@@ -176,7 +141,7 @@ jobs:
           exit 1
 
       - name: Start Camunda
-        run: CAMUNDA_DOCKER_IMAGE=${{ matrix.server_image }} DATABASE=elasticsearch docker compose up -d camunda
+        run: CAMUNDA_DOCKER_IMAGE=${{ steps.resolve.outputs.server_image }} DATABASE=elasticsearch docker compose up -d camunda
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers
@@ -239,7 +204,7 @@ jobs:
           CAMUNDA_BASIC_AUTH_USERNAME: "demo"
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           INCLUDE_SLACK_REPORTER: "false"
-          VERSION: "Forward Compat - Server: ${{ matrix.server_branch }} / Tests: ${{ matrix.test_branch }}"
+          VERSION: "Forward Compat - Server: ${{ steps.resolve.outputs.server_branch }} / Tests: ${{ steps.resolve.outputs.test_branch }}"
           API_TESTS_ONLY: "true"
           DATABASE: "Elasticsearch"
           AJB_ALLOW_EXTRA_FIELDS: "true"
@@ -247,19 +212,20 @@ jobs:
           FORWARD_COMPAT_MODE: "true"
         run: |
           echo "Running forward compatibility API tests"
-          echo "Server built from: ${{ matrix.server_branch }}"
-          echo "Tests checked out from: ${{ matrix.test_branch }}"
+          echo "Server built from: ${{ steps.resolve.outputs.server_branch }}"
+          echo "Tests checked out from: ${{ steps.resolve.outputs.test_branch }}"
           npm run test -- --project=api-tests --retries=4 tests/api/v2/
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
       - name: Sanitize branch names for artifact names
         id: sanitize
         if: always()
+        env:
+          SERVER_BRANCH: ${{ steps.resolve.outputs.server_branch }}
+          TEST_BRANCH: ${{ steps.resolve.outputs.test_branch }}
         run: |
-          server="${{ matrix.server_branch }}"
-          test="${{ matrix.test_branch }}"
-          safe_server="${server//\//-}"
-          safe_test="${test//\//-}"
+          safe_server="${SERVER_BRANCH//\//-}"
+          safe_test="${TEST_BRANCH//\//-}"
           echo "safe_server=$safe_server" >> "$GITHUB_OUTPUT"
           echo "safe_test=$safe_test" >> "$GITHUB_OUTPUT"
 
@@ -286,7 +252,6 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "forward-compatibility-api-tests/server-${{ matrix.server_branch }}/tests-${{ matrix.test_branch }}"
           build_status: ${{ job.status }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
       webapp-client-changes: ${{ steps.filter.outputs.webapp-client-changes }}
       docs-changes: ${{ steps.filter.outputs.docs-changes }}
       c8-e2e-test-suite-changes: ${{ steps.filter.outputs.c8-e2e-test-suite-changes }}
+      forward-compat-tests-changes: ${{ steps.filter.outputs.forward-compat-tests-changes }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -1771,6 +1772,14 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  forward-compat-tests:
+    if: needs.detect-changes.outputs.forward-compat-tests-changes == 'true'
+    name: "C8 Forward Compatibility"
+    needs: [ detect-changes ]
+    uses: ./.github/workflows/ci-c8-forward-compatibility-tests.yml
+    secrets: inherit
+    permissions: { }
+
   protobuf-checks:
     name: "Protobuf Backwards Compatibility"
     needs: [ detect-changes ]
@@ -2036,6 +2045,7 @@ jobs:
       - detect-changes
       - detect-new-flaky-tests
       - docker-checks
+      - forward-compat-tests
       - general-unit-tests
       - generate-db-versions
       - history-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1773,7 +1773,9 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   forward-compat-tests:
-    if: needs.detect-changes.outputs.forward-compat-tests-changes == 'true'
+    if: |
+      needs.detect-changes.outputs.forward-compat-tests-changes == 'true'
+      && startsWith(github.base_ref, 'stable/')
     name: "C8 Forward Compatibility"
     needs: [ detect-changes ]
     uses: ./.github/workflows/ci-c8-forward-compatibility-tests.yml


### PR DESCRIPTION
## Description

Integrates the REST API forward compatibility tests into the Unified CI so they run on every PR and merge queue entry via `ci.yml`, providing earlier feedback on forward compatibility regressions.

## What changed

### Unified CI integration
- **Renamed** the workflow to `ci-c8-forward-compatibility-tests.yml` (prefixed with `ci-` per convention).
- **Converted** the workflow to a reusable workflow (`workflow_call`) called from `ci.yml`, while keeping `workflow_dispatch` for manual use.
- **Removed** direct `pull_request` / `merge_group` / `schedule` triggers — the Unified CI handles triggering.
- **Removed** the standalone `concurrency` group — `ci.yml` manages concurrency.
- **Set** `permissions: {}` at the workflow and job level to match the Unified CI convention (the caller controls permissions).
- **Added** a `forward-compat-tests-changes` output to the paths-filter action (reuses the existing `c8-e2e-test-suite` filter since the tests live in the same directory).
- **Added** the `forward-compat-tests` job to `ci.yml` with change detection gating, `secrets: inherit`, and to the `check-results` needs list.

### Matrix generation
- **PR / merge queue** (called via `ci.yml`): the workflow resolves the next server version from the PR's base branch automatically:
  - PR → `main` → tests against `camunda/camunda:SNAPSHOT`
  - PR → `stable/8.8` → tests against `camunda/camunda:8.9-SNAPSHOT`
  - PR → `stable/8.9` → tests against `8.10-SNAPSHOT` if `stable/8.10` exists, otherwise `SNAPSHOT` (main)
- **`workflow_dispatch`**: both `server_branch` and `test_branch` inputs are now **required**.
- The `test_branch` in the matrix reflects the actual ref being checked out (PR head ref / merge-queue ref) so job names, logs, and artifact names are accurate.

### Security
- All `github.*` context values (`head_ref`, `base_ref`, etc.) are passed through `env:` variables instead of direct `${{ }}` interpolation in `run:` scripts, preventing script injection (satisfies actionlint).

### Dependencies & timeout
- Replaced `rm -rf node_modules package-lock.json && npm install` with `npm ci` to leverage npm cache.
- Reduced `timeout-minutes` from 90 → 30 to align with Unified CI criteria.

### Removed
- **Slack notification job** (`notify-failure`): PR failures are visible via GitHub check status.
- **Vault secret import** for `SLACK_CORE_DOMAIN_BOT_TOKEN`: no longer needed.
