### PR TITLE
fix: make Document UC storeId lowercase as legacy did

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -55,12 +55,14 @@ public class Document {
   @NestedConfigurationProperty private Map<String, InMemoryStore> inMemory = new LinkedHashMap<>();
 
   public String getDefaultStoreId() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
-        "camunda.document.default-store-id",
-        defaultStoreId,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED,
-        Set.of("DOCUMENT_DEFAULT_STORE_ID"));
+    final String value =
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+            "camunda.document.default-store-id",
+            defaultStoreId,
+            String.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            Set.of("DOCUMENT_DEFAULT_STORE_ID"));
+    return value != null ? value.toLowerCase() : null;
   }
 
   public void setDefaultStoreId(final String defaultStoreId) {

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 
 /**
  * Loads document store configuration from unified properties under {@code camunda.document.*}.
@@ -57,11 +58,11 @@ public final class CamundaDocumentStoreConfigurationLoader
     final Map<String, DocumentStoreConfigurationRecord> storesById = new LinkedHashMap<>();
 
     legacyConfiguration.documentStores().forEach(store -> storesById.put(store.id(), store));
-    document.getAws().forEach((id, store) -> storesById.put(id, toAwsStore(id, store)));
-    document.getGcp().forEach((id, store) -> storesById.put(id, toGcpStore(id, store)));
-    document.getAzure().forEach((id, store) -> storesById.put(id, toAzureStore(id, store)));
-    document.getLocal().forEach((id, store) -> storesById.put(id, toLocalStore(id, store)));
-    document.getInMemory().forEach((id, store) -> storesById.put(id, toInMemoryStore(id, store)));
+    registerStores(document.getAws(), storesById, this::toAwsStore);
+    registerStores(document.getGcp(), storesById, this::toGcpStore);
+    registerStores(document.getAzure(), storesById, this::toAzureStore);
+    registerStores(document.getLocal(), storesById, this::toLocalStore);
+    registerStores(document.getInMemory(), storesById, this::toInMemoryStore);
 
     return new DocumentStoreConfiguration(
         document.getDefaultStoreId(),
@@ -69,7 +70,15 @@ public final class CamundaDocumentStoreConfigurationLoader
         List.copyOf(storesById.values()));
   }
 
-  private static DocumentStoreConfigurationRecord toAwsStore(
+  private <T> void registerStores(
+      final Map<String, T> storeConfigs,
+      final Map<String, DocumentStoreConfigurationRecord> storesById,
+      final BiFunction<String, T, DocumentStoreConfigurationRecord> factory) {
+    storeConfigs.forEach(
+        (id, store) -> storesById.put(id.toLowerCase(), factory.apply(id.toLowerCase(), store)));
+  }
+
+  private DocumentStoreConfigurationRecord toAwsStore(
       final String storeId, final Document.AwsStore store) {
     final Map<String, String> properties = new LinkedHashMap<>();
     putResolved(properties, AWS, storeId, "bucket-name", "BUCKET", store.getBucketName());
@@ -79,7 +88,7 @@ public final class CamundaDocumentStoreConfigurationLoader
     return toRecord(storeId, AwsDocumentStoreProvider.class, properties);
   }
 
-  private static DocumentStoreConfigurationRecord toGcpStore(
+  private DocumentStoreConfigurationRecord toGcpStore(
       final String storeId, final Document.GcpStore store) {
     final Map<String, String> properties = new LinkedHashMap<>();
     putResolved(properties, GCP, storeId, "bucket-name", "BUCKET", store.getBucketName());
@@ -87,7 +96,7 @@ public final class CamundaDocumentStoreConfigurationLoader
     return toRecord(storeId, GcpDocumentStoreProvider.class, properties);
   }
 
-  private static DocumentStoreConfigurationRecord toAzureStore(
+  private DocumentStoreConfigurationRecord toAzureStore(
       final String storeId, final Document.AzureStore store) {
     final Map<String, String> properties = new LinkedHashMap<>();
     putResolved(
@@ -105,14 +114,14 @@ public final class CamundaDocumentStoreConfigurationLoader
     return toRecord(storeId, AzureBlobDocumentStoreProvider.class, properties);
   }
 
-  private static DocumentStoreConfigurationRecord toLocalStore(
+  private DocumentStoreConfigurationRecord toLocalStore(
       final String storeId, final Document.LocalStore store) {
     final Map<String, String> properties = new LinkedHashMap<>();
     putResolved(properties, LOCAL, storeId, "path", "PATH", store.getPath());
     return toRecord(storeId, LocalStorageDocumentStoreProvider.class, properties);
   }
 
-  private static DocumentStoreConfigurationRecord toInMemoryStore(
+  private DocumentStoreConfigurationRecord toInMemoryStore(
       final String storeId, final Document.InMemoryStore store) {
     return toRecord(storeId, InMemoryDocumentStoreProvider.class, Map.of());
   }

--- a/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Document;
+import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.store.aws.AwsDocumentStoreProvider;
 import io.camunda.document.store.azure.AzureBlobDocumentStoreProvider;
@@ -18,6 +19,7 @@ import io.camunda.document.store.gcp.GcpDocumentStoreProvider;
 import io.camunda.document.store.localstorage.LocalStorageDocumentStoreProvider;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
 
 class CamundaDocumentStoreConfigurationLoaderTest {
 
@@ -86,34 +88,33 @@ class CamundaDocumentStoreConfigurationLoaderTest {
   }
 
   @Test
-  void shouldLoadLegacyOnlyStoreDefinitions() {
+  void shouldLoadOnlyLegacyStoreDefinitions() {
     // given
-    final Camunda camunda = new Camunda();
-    final var loader = new CamundaDocumentStoreConfigurationLoader(camunda);
-    System.setProperty("DOCUMENT_DEFAULT_STORE_ID", "LEGACY");
+    final var mockEnv = new MockEnvironment();
+    mockEnv.setProperty("DOCUMENT_DEFAULT_STORE_ID", "GCP");
+    UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
+
     System.setProperty(
-        "DOCUMENT_STORE_LEGACY_CLASS", "io.camunda.document.store.gcp.GcpDocumentStoreProvider");
-    System.setProperty("DOCUMENT_STORE_LEGACY_BUCKET", "legacy-bucket");
+        "DOCUMENT_STORE_GCP_CLASS", "io.camunda.document.store.gcp.GcpDocumentStoreProvider");
+    System.setProperty("DOCUMENT_STORE_GCP_BUCKET", "legacy-bucket");
 
     try {
       // when
-      final var configuration = loader.loadConfiguration();
+      final var configuration =
+          new CamundaDocumentStoreConfigurationLoader(new Camunda()).loadConfiguration();
 
       // then
-      // Root-level legacy fallback (defaultDocumentStoreId, threadPoolSize) is handled by
-      // Document.getDefaultStoreId() / getThreadPoolSize() via UnifiedConfigurationHelper, which
-      // requires a Spring environment — in this non-Spring unit test the helper returns null.
-      assertThat(configuration.defaultDocumentStoreId()).isNull();
+      assertThat(configuration.defaultDocumentStoreId()).isEqualTo("gcp");
       assertThat(configuration.threadPoolSize()).isNull();
       assertThat(configuration.documentStores())
           .extracting(DocumentStoreConfigurationRecord::id)
-          .containsExactly("legacy");
-      assertThat(store("legacy", configuration.documentStores()).properties())
+          .containsExactly("gcp");
+      assertThat(store("gcp", configuration.documentStores()).properties())
           .containsEntry("BUCKET", "legacy-bucket");
     } finally {
-      System.clearProperty("DOCUMENT_DEFAULT_STORE_ID");
-      System.clearProperty("DOCUMENT_STORE_LEGACY_CLASS");
-      System.clearProperty("DOCUMENT_STORE_LEGACY_BUCKET");
+      UnifiedConfigurationHelper.setCustomEnvironment(null);
+      System.clearProperty("DOCUMENT_STORE_GCP_CLASS");
+      System.clearProperty("DOCUMENT_STORE_GCP_BUCKET");
     }
   }
 


### PR DESCRIPTION
## Description

Create `DocumentStoreConfigurationRecord` with lowerCase storeId in new `CamundaDocumentStoreConfigurationLoader`, just like `EnvironmentConfigurationLoader` does (legacy loader). So that `SimpleDocumentStoreRegistry` following LOC does not fail:

``` java 
    if (!stores.containsKey(defaultDocumentStoreId)) {
      throw new IllegalArgumentException(
          "Default document store ID does not match any configured document store: "
              + defaultDocumentStoreId);
    }
```

## Related issues

closes #54999
