### PR TITLE
test: add azure-sql to the test matrix

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -52,6 +52,10 @@ mssql:
   - "2022-latest"
   - "2025-latest"
 
+azure-sql:
+  - "1.0.7"
+  - "2.0.0"
+
 oracle:
   - "21-slim-faststart"
   - "23.26.1-slim-faststart"

--- a/.github/actions/read-db-versions/action.yml
+++ b/.github/actions/read-db-versions/action.yml
@@ -27,7 +27,7 @@ outputs:
 
   # ── Matrix outputs ────────────────────────────────────────────────────────────
   # Each is a JSON object ({ include: [...] }) ready for strategy.matrix via fromJSON().
-  # rdbms-matrix:   one entry per version of PostgreSQL, MySQL, MariaDB, MSSQL, Oracle.
+  # rdbms-matrix:   one entry per version of PostgreSQL, MySQL, MariaDB, MSSQL, Azure SQL, Oracle.
   #                 Fields: database-name, database-type, database-image-version, it-database-type.
   #                 Used by zeebe-rdbms-integration-tests.yml.
   # es-os-matrix:   min and max entries per supported major series of ES8, ES9, OS2, OS3.

--- a/.github/actions/read-db-versions/generate-db-versions.py
+++ b/.github/actions/read-db-versions/generate-db-versions.py
@@ -177,6 +177,14 @@ for v in versions["mssql"]:
         "it-database-type":       "rdbms_mssql",
     })
 
+for v in versions["azure-sql"]:
+    rdbms_matrix["include"].append({
+        "database-name":          f"Azure SQL {v}",
+        "database-type":          "azure-sql",
+        "database-image-version": v,
+        "it-database-type":       "rdbms_mssql",
+    })
+
 for v in versions["oracle"]:
     major = v.split(".")[0].split("-")[0]  # "23.26.1-slim-faststart" -> "23"; "21-slim-faststart" -> "21"
     meta  = oracle_meta.get(major, {"name": f"Oracle {major}", "type": "oracle"})

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -28,6 +28,15 @@ services:
     ports:
       - "1433:1433"
 
+  azure-sql:
+    image: mcr.microsoft.com/azure-sql-edge:${IMAGE_VERSION:-latest}
+    restart: always
+    environment:
+      ACCEPT_EULA: y
+      MSSQL_SA_PASSWORD: Camunda#8_demo
+    ports:
+      - "1433:1433"
+
   mariadb:
     image: mariadb:${IMAGE_VERSION:-12.0}
     restart: always


### PR DESCRIPTION
## Description

- add azure-sql-edge to the test matrix

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
