### PR TITLE
docs: add ADRs for Business ID message correlation and rejection retry

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -44,6 +44,7 @@ camunda.Dockerfile          @camunda/orchestration-cluster
 zeebe/README.md             @camunda/orchestration-cluster
 zeebe/docker/utils/         @camunda/orchestration-cluster
 zeebe/docs/.htaccess        @camunda/orchestration-cluster
+zeebe/docs/adr/             @camunda/orchestration-cluster
 zeebe/pom.xml               @camunda/orchestration-cluster
 zeebe/qa/pom.xml            @camunda/orchestration-cluster
 buf.yaml                    @camunda/orchestration-cluster

--- a/zeebe/docs/adr/0001-810-message-correlation-business-id-cross-partition.md
+++ b/zeebe/docs/adr/0001-810-message-correlation-business-id-cross-partition.md
@@ -1,0 +1,91 @@
+# Business ID message correlation: P_K owns messages, P_B enforces uniqueness, P_K pulls for release
+
+**DRI**: Mustafa Dagher
+
+**Status**: Accepted (8.10)
+
+**Purpose**: Defines how Business ID interacts with cross-partition message routing for message
+events, so the existing message and uniqueness routing contracts are both preserved.
+
+**Audience**: Zeebe engine engineers and AI agents working on message correlation or partitioning.
+
+## Context
+
+A message is routed to `P_K = hash(correlationKey)`, where all of its lifecycle state lives
+(subscriptions, TTL, deduplication, buffering, the process-correlation-key lock). A process instance
+with a `businessId` is owned by `P_B = hash(businessId)`, where Business ID uniqueness is a local
+lookup. When Business ID is used as an additional filter on message events, a single publish can
+carry a `correlationKey` and a `businessId` whose hashes resolve to different partitions, so the
+message and the instance it would create no longer co-locate.
+
+The outcome: message routing is unchanged; `P_K` remains the single owner of message state and
+`P_B` remains the single owner of Business ID uniqueness. Message-start events bridge the two
+partitions with a cross-partition ask; other message events filter locally; and the resulting
+cross-partition lock is released by `P_K` polling `P_B`.
+
+## Decision
+
+**D1. `P_K` owns message state; `P_B` owns Business ID uniqueness.** Messages keep routing by
+`hash(correlationKey)`. Subscriptions, TTL, dedup, buffering, and the correlation-key lock stay on
+`P_K`; the uniqueness check stays a local lookup on `P_B`. Neither concern is relocated or
+duplicated.
+
+**D2. Message-start events reconcile the two partitions with a cross-partition ask.** When a
+businessId-bearing start would create its instance on a different `P_B`, `P_K` sends a `REQUEST` to
+`P_B`, which creates the instance locally and replies `STARTED`, or declines with `REJECT_UNIQUENESS`
+(an active instance already holds the businessId) or `REJECT_NO_SUBSCRIPTION` (the start-event
+subscription has not yet been distributed to `P_B`). On a rejection the message stays buffered on
+`P_K`.
+
+**D3. The cross-partition correlation-key lock is released by pull, not push.** For a remotely
+created start, `P_K` records the holder instance and polls `P_B` (with back-off and batching) for
+that specific instance's completion, then releases the lock and picks up the next buffered message —
+keeping lock semantics identical to a single-partition start. Locally created starts use the
+existing local release path unchanged.
+
+**D4. Cross-partition creates are idempotent via a dedup row on `P_B`.** `P_B` records
+`(processDefinitionKey, messageKey) → processInstanceKey` with a deletion deadline equal to the
+message deadline. At-least-once ask retries either hit this row (re-reply the same instance, no
+second create) or arrive after it and the buffered message have expired together. The contract
+`retryDeadline <= messageDeadline` is what prevents duplicate instances.
+
+**D5. Catch, boundary, and intermediate message events filter Business ID locally, not via the ask.**
+A subscription stores its instance's `businessId` at open time. Correlation applies an asymmetric
+local match: a message without a `businessId` correlates regardless; a message with one correlates
+only to a subscription whose stored `businessId` matches exactly. Only start events need a uniqueness
+check, and only `P_B` can answer it — hence the asymmetry with D2.
+
+## Alternatives considered
+
+- **Combined-hash routing `hash(correlationKey + businessId)`.** Co-locates the lock and the
+  uniqueness check on one partition, but breaks both existing routing contracts and cannot satisfy
+  the requirement that a message without a `businessId` still correlates to an instance that has one
+  (it would route to a different partition than the subscription).
+- **`P_B` owns blocked starts; `P_K` forwards-and-forgets.** Moves the message itself to `P_B` on
+  forward. Relocates cross-partition state rather than removing it, and breaks `messageId`
+  deduplication and correlation to processes that listen for the same message without a Business ID.
+- **Push-based release notification from `P_B`.** `P_B` would track which partitions hold dependent
+  work and notify them on each completion. Rejected: it requires per-waiter bookkeeping and reliable
+  delivery on `P_B`, is not self-healing across restarts/leadership changes, and has no decisive
+  efficiency advantage over the pull (D3).
+
+## Consequences
+
+- Existing routing contracts for `correlationKey` and `businessId` are preserved; message lifecycle
+  stays observable from one partition per correlation key.
+- New cross-partition machinery is confined to the message-start path: an ask with three reply
+  outcomes, a per-`P_K` record of remotely held locks, and the dedup row on `P_B`.
+- The pull keeps all reaction-to-completion logic on the partition that owns the work and is
+  self-healing, at the cost of added latency on the release path (bounded by the poll interval and
+  back-off).
+- A start rejected purely on Business ID uniqueness stays buffered and relies on its TTL and existing
+  buffered-message triggers, matching single-partition behaviour. Proactively retrying it when the
+  Business ID frees is decided separately in
+  [ADR 0002](0002-810-message-start-rejection-retry.md).
+
+## Source
+
+- [Business ID + message correlation — design thread 1](https://camunda.slack.com/archives/C0AF71HUQ5V/p1776937625439169) (internal)
+- [Business ID + message correlation — design thread 2](https://camunda.slack.com/archives/C0AF71HUQ5V/p1777043511569139) (internal)
+- [Process Instance Creation: Message event](https://docs.camunda.io/docs/next/components/concepts/process-instance-creation/#message-event)
+

--- a/zeebe/docs/adr/0001-810-message-correlation-business-id-cross-partition.md
+++ b/zeebe/docs/adr/0001-810-message-correlation-business-id-cross-partition.md
@@ -30,12 +30,43 @@ cross-partition lock is released by `P_K` polling `P_B`.
 `P_K`; the uniqueness check stays a local lookup on `P_B`. Neither concern is relocated or
 duplicated.
 
+The partition split — a single publish can land its message and its instance on different partitions:
+
+```mermaid
+flowchart LR
+    Client["publish(name, correlationKey, businessId)"]
+    PK["P_K = hash(correlationKey)<br/>owns message state:<br/>subscriptions, TTL, dedup, buffer, correlation-key lock"]
+    PB["P_B = hash(businessId)<br/>owns the instance + Business ID uniqueness"]
+    Client -->|"routes by correlationKey"| PK
+    PK -.->|"businessId-bearing start: cross-partition ask (D2)"| PB
+```
+
 **D2. Message-start events reconcile the two partitions with a cross-partition ask.** When a
 businessId-bearing start would create its instance on a different `P_B`, `P_K` sends a `REQUEST` to
 `P_B`, which creates the instance locally and replies `STARTED`, or declines with `REJECT_UNIQUENESS`
 (an active instance already holds the businessId) or `REJECT_NO_SUBSCRIPTION` (the start-event
 subscription has not yet been distributed to `P_B`). On a rejection the message stays buffered on
 `P_K`.
+
+The pull-based release (D3), continuing from the `STARTED` reply above:
+
+```mermaid
+sequenceDiagram
+    participant P_K as P_K = hash(correlationKey)
+    participant P_B as P_B = hash(businessId)
+
+    Note over P_K: STARTED applied:<br/>correlation-key lock records holder on P_B
+
+    loop poll with back-off and batching, until holder completes (D3)
+        P_K->>P_B: is holder instance still active?
+        alt holder still active
+            P_B-->>P_K: yes
+        else holder completed or terminated
+            P_B-->>P_K: no
+            Note over P_K: release correlation-key lock,<br/>pick up next buffered message
+        end
+    end
+```
 
 **D3. The cross-partition correlation-key lock is released by pull, not push.** For a remotely
 created start, `P_K` records the holder instance and polls `P_B` (with back-off and batching) for

--- a/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
+++ b/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
@@ -1,0 +1,82 @@
+# A way out for rejected cross-partition message-starts: retry the ask with back-off
+
+**DRI**: Mustafa Dagher
+
+**Status**: Accepted (8.10)
+
+**Purpose**: Defines how a message-start that is rejected on Business ID uniqueness (or a not-yet-
+distributed subscription) is eventually started, instead of silently expiring.
+
+**Audience**: Zeebe engine engineers and AI agents working on message correlation or partitioning.
+
+## Context
+
+Under [ADR 0001](0001-810-message-correlation-business-id-cross-partition.md), a message-start whose
+Business ID is held elsewhere is rejected (`REJECT_UNIQUENESS`), and one whose subscription has not
+yet reached `P_B` is rejected (`REJECT_NO_SUBSCRIPTION`). Today the rejected message stays buffered
+and is only re-attempted if its own correlation key sees another completion — otherwise it expires
+unstarted at its TTL, even if the blocker cleared seconds earlier. The correlation-key buffer is the
+wrong thing to wait on: the unblocking event is a Business ID freeing, which may come from an
+instance with a different correlation key or none at all.
+
+The outcome: a rejected start is retried until it starts or its TTL expires, reusing the existing
+cross-partition ask; a dedicated registry owns that retry; and the same behaviour applies whether
+the Business ID is local or remote.
+
+## Decision
+
+**D1. A rejected message-start is retried until it starts or its TTL expires.** `UNIQUENESS_REJECTED`
+and `NO_SUBSCRIPTION_REJECTED` are treated as retriable, not terminal. The message remains buffered
+(its TTL is the bound); when the blocker clears, the retry starts it.
+
+**D2. Retry reuses the existing cross-partition ask, not a new query.** On rejection the pending ask
+is kept rather than removed; the scheduler re-sends the `REQUEST`, `P_B` re-evaluates live state, and
+the attempt flips to `STARTED` once the blocker clears. The existing `(processDefinitionKey,
+messageKey)` dedup row on `P_B` makes the retried ask idempotent — no duplicate instance.
+
+**D3. Retries use capped exponential back-off, advanced by the event applier.** Back-off prevents a
+long-blocked message from storming `P_B`. Because schedulers may not mutate persisted state, the
+back-off is event-sourced: the rejection applier advances it on each rejection reply (using the
+deterministic event timestamp); the scheduler only reads the resulting next-retry deadline and keeps
+its transient send-tracking.
+
+**D4. The rejection registry is the single owner of this retry.** The pending-ask state owns retrying
+rejected starts; the correlation-key buffer no longer re-attempts them. The buffer keys on
+correlation key, but the unblocking event is Business-ID-scoped, so the buffer cannot trigger these
+retries correctly — a buffered message with a live pending ask is skipped by the buffer scan.
+
+**D5. Same-partition parity: unify the retry, keep the local success path.** When the Business ID
+hashes to the local partition (`P_K = P_B`, always so on single-partition clusters), the success
+path stays local and synchronous, but a rejection enrolls in the same registry and retries via a
+self-addressed `REQUEST`. One retry implementation serves both topologies; the handshake cost is
+paid only by the rare blocked message.
+
+## Alternatives considered
+
+- **A dedicated poll mirroring the lock-release query.** A separate read-only "is the Business ID
+  free?" query plus its own registry. Rejected: the poll is non-authoritative (it still needs the
+  ask to start), so it is two mechanisms where one suffices, and it re-derives the ask path's
+  existing re-evaluation and idempotency for a traffic saving that back-off already bounds.
+- **Full same-partition unification — handshake even for the same-partition success path.** One code
+  path, but it taxes the common and single-partition case with extra records and a dedup write per
+  start and makes a synchronous start asynchronous, to pay for at-least-once machinery that
+  exactly-once same-log delivery does not need.
+
+## Consequences
+
+- Closes the liveness gap: a start blocked purely on Business ID now runs once the blocker clears,
+  bounded by the message TTL; no duplicates and no leaked state.
+- One retry mechanism for both topologies; the correlation-key buffer is relieved of a
+  responsibility it could not fulfil correctly.
+- Back-off is event-sourced, keeping schedulers free of persisted-state writes and surviving leader
+  changes without a reset storm.
+- A start still expires unstarted if its Business ID stays held for the entire TTL — the legitimate
+  "blocked the whole window" outcome.
+- The same-partition success path is unchanged; only the rare blocked case pays the ask handshake.
+
+## Source
+
+- [Business ID + message correlation — design thread 1](https://camunda.slack.com/archives/C0AF71HUQ5V/p1776937625439169) (internal)
+- [Business ID + message correlation — design thread 2](https://camunda.slack.com/archives/C0AF71HUQ5V/p1777043511569139) (internal)
+- [ADR 0001 — Business ID message correlation cross-partition routing](0001-810-message-correlation-business-id-cross-partition.md)
+

--- a/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
+++ b/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
@@ -1,4 +1,4 @@
-# A way out for rejected cross-partition message-starts: retry the ask with back-off
+# Retry rejected message-starts until they start or their TTL expires
 
 **DRI**: Mustafa Dagher
 
@@ -19,11 +19,10 @@ unstarted at its TTL, even if the blocker cleared seconds earlier. The correlati
 wrong thing to wait on: the unblocking event is a Business ID freeing, which may come from an
 instance with a different correlation key or none at all.
 
-The outcome: a rejected start is retried until it starts or its TTL expires; a remote Business ID
-reuses the existing cross-partition ask, while a local Business ID is retried by re-driving the local
-start when its holder frees the ID — discovered through a Business-ID index on the buffered message.
-The same observable guarantee applies whether the Business ID is local or remote, even though the
-mechanism differs.
+The outcome: a rejected start is retried until it starts or its TTL expires — a remote Business ID
+reuses the existing cross-partition ask, a local one re-drives the local start when its holder frees
+the ID. The same observable guarantee holds whether the Business ID is local or remote, even though
+the mechanism differs.
 
 ## Decision
 
@@ -36,19 +35,12 @@ is kept rather than removed; the scheduler re-sends the `REQUEST`, `P_B` re-eval
 the attempt flips to `STARTED` once the blocker clears. The existing `(processDefinitionKey,
 messageKey)` dedup row on `P_B` makes the retried ask idempotent — no duplicate instance.
 
-**D3. The cross-partition ask retries use capped exponential back-off, advanced by the event
-applier.** Back-off prevents a long-blocked message from storming `P_B`. Because schedulers may not
-mutate persisted state, the back-off is event-sourced as a per-ask **magnitude**: the rejection
-applier doubles a persisted back-off magnitude (capped) on each rejection reply. This advance is a
-pure function of the prior persisted value and the configured bounds — it needs no clock and no event
-timestamp, so it is trivially deterministic on replay. The scheduler derives the next-retry time from
-that magnitude plus its transient last-sent tracking, re-sending an ask once `lastSent +
-max(baseInterval, magnitude)` has passed; the transient also serves as the in-flight guard between a
-send and its reply. On recovery the magnitude survives in persisted state while the transient
-last-sent is rebuilt, so a long-blocked ask resumes at its backed-off cadence rather than resetting to
-a base-interval storm (at the cost of a bounded one-interval phase imprecision after a leader change).
-The same-partition retry (D5) needs no back-off: it is event-driven — re-driven once when a holder
-frees the Business ID — not polled, so there is nothing to storm.
+**D3. Cross-partition ask retries use capped exponential back-off, event-sourced by the rejection
+applier.** Each rejection doubles a persisted, capped back-off magnitude — a clock-free, pure function
+of the prior value, so it stays deterministic on replay and survives leader changes without resetting
+to a base-interval storm. The scheduler only derives the next-retry time from that magnitude, since
+schedulers may not mutate persisted state. The same-partition retry (D5) needs no back-off: it is
+event-driven, not polled, so there is nothing to storm.
 
 **D4. The correlation-key buffer is never relied on to retry a Business-ID rejection — it keys on the
 wrong thing.** The unblocking event is a Business ID freeing, which may come from a holder with a
@@ -60,31 +52,23 @@ drives the retry; should the correlation-key scan happen to revisit the same mes
 free, the ordinary correlation guards (`existMessageCorrelation`, the deadline check) make the overlap
 a harmless no-op rather than a double start.
 
-**D5. Same-partition rejections are retried by re-driving the local start when the Business ID frees,
-discovered through a Business-ID index on the buffered message — no scheduler, no cross-partition
-machinery.** When the Business ID hashes to the local partition (`P_K = P_B`, always so on
-single-partition clusters), both success and retry stay local. A successful start uses the normal
-local message-start flow (synchronous, no handshake). On rejection the message simply stays buffered;
-it is made discoverable by Business ID through a secondary index on the buffered-message store, keyed
-by `(tenantId, businessId, messageKey)` and maintained on the **same publish/expiry lifecycle as the
-message itself** (written when the message is buffered, removed when it expires) — so it needs no
-separate registry, enrollment event, or cleanup path. When a holder instance completes or terminates,
-the post-transition action that already re-drives the correlation-key buffer additionally looks up
-buffered messages by the freed Business ID and re-drives the ordinary local start for each (routing
-still honours D6). The existing correlation guards make a redundant re-drive a no-op. This path uses
-**no** `MessageStartProcessInstanceRequest` records, dedup row, cross-partition lock, scheduler, or
-back-off.
+**D5. Same-partition rejections are retried locally — re-driving the start when the Business ID frees
+— with no scheduler or cross-partition machinery.** When the Business ID is local (`P_K = P_B`, always
+so on single-partition clusters), success uses the normal synchronous local message-start flow; on
+rejection the message stays buffered and is indexed by Business ID so the existing holder-completion
+hook re-drives the ordinary local start when the ID frees (routing still honours D6). The hook fires
+whenever a completing instance held the Business ID, independent of that instance's own start type,
+because uniqueness is scoped per `(businessId, bpmnProcessId)` across versions — the holder may be a
+none-start instance or an older version that has no message start event, while the latest version that
+owns the buffered start does. This path uses **no** cross-partition records, dedup row, lock,
+scheduler, or back-off.
 
-This deliberately mirrors the existing correlation-key buffer, which is likewise only re-driven on a
-holder's completion/termination. It therefore inherits the same boundary: a Business ID also frees on
-**banning** (banned holders are treated as free) and on migration, neither of which fires a
-completion/termination event, so a start blocked behind a banned or migrated holder waits until its
-TTL rather than restarting immediately. This is **accepted** because it is exactly the existing
-behaviour of the correlation-key buffer — a message buffered behind a banned holder is already
-stranded until TTL today — so the Business-ID buffer is made a faithful twin of it rather than being
-granted a new, stronger liveness guarantee on only one arm. The cross-partition ask (D2/D3) is engaged
-**only** when the Business ID is remote; the two topologies share the goal (a blocked start eventually
-runs, bounded by its TTL) but deliberately **not** the mechanism.
+This mirrors the correlation-key buffer and inherits its boundary: a holder that frees the Business ID
+*without* a completion/termination event — a **banned** holder (treated as free) or a **migrated** one
+— leaves the start blocked until its TTL rather than restarting immediately. This is **accepted** so
+the Business-ID buffer stays a faithful twin of the correlation-key buffer (already stranded behind a
+banned holder until TTL today) rather than gaining a stronger one-arm guarantee. The cross-partition
+ask (D2/D3) is engaged **only** when the Business ID is remote.
 
 **D6. The uniqueness flag gates the rejection, not the routing/placement.** `businessIdUniquenessEnabled`
 controls only whether a uniqueness conflict is *rejected*, never whether a Business-ID-carrying
@@ -145,13 +129,11 @@ flag-independent — the instance is already local — so this matters for the c
   same-partition retry needs no scheduler or back-off — it is event-driven off holder completion.
 - A start still expires unstarted if its Business ID stays held for the entire TTL — the legitimate
   "blocked the whole window" outcome.
-- Accepted limitation (same-partition): a start blocked behind a holder that frees its Business ID
-  *without* a completion/termination event — a **banned** holder (banned holders are treated as free)
-  or a **migrated** one — waits until its TTL rather than restarting immediately. This is identical to
-  the existing correlation-key buffer, which is also only re-driven on completion/termination, so the
-  Business-ID buffer is a faithful twin of it rather than a new, stronger guarantee on one arm.
+- Accepted limitation (D5): a start blocked behind a holder that frees its Business ID *without* a
+  completion/termination event — a **banned** or **migrated** holder — waits until its TTL, matching
+  the correlation-key buffer rather than gaining a stronger guarantee.
 - The same-partition path stays fully local: success is synchronous and a blocked start is re-driven
-  locally on holder completion — no cross-partition records, no scheduler, on either path.
+  locally on holder completion — no cross-partition records, no scheduler.
 - Routing to `P_B` is independent of the uniqueness flag (D6), so the placement invariant holds even
   while the feature is switched off, and toggling the flag never strands instances on the wrong
   partition.

--- a/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
+++ b/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
@@ -30,6 +30,35 @@ the mechanism differs.
 and `NO_SUBSCRIPTION_REJECTED` are treated as retriable, not terminal. The message remains buffered
 (its TTL is the bound); when the blocker clears, the retry starts it.
 
+The cross-partition arm (D2–D3) runs this ask/retry handshake for a remote Business ID; the
+same-partition arm (D5) instead re-drives a local start with no handshake:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant P_K as P_K = hash(correlationKey)
+    participant P_B as P_B = hash(businessId)
+
+    Client->>P_K: publish(name, correlationKey, businessId, ttl)
+    Note over P_K: buffer message,<br/>register pending ask
+
+    loop retry with capped back-off, until STARTED or TTL (D1–D3)
+        P_K->>P_B: REQUEST(name, businessId, messageDeadline)
+        Note over P_B: re-evaluate live state
+        alt Business ID free and subscription present
+            Note over P_B: create instance once<br/>(dedup by processDefinitionKey, messageKey)
+            P_B-->>P_K: STARTED(processInstanceKey)
+            Note over P_K: clear ask, consume message,<br/>write correlation-key lock (released later per ADR 0001)
+        else Business ID already held
+            P_B-->>P_K: REJECT_UNIQUENESS
+            Note over P_K: keep buffered, back off, retry
+        else subscription not yet distributed
+            P_B-->>P_K: REJECT_NO_SUBSCRIPTION
+            Note over P_K: keep buffered, back off, retry
+        end
+    end
+```
+
 **D2. Retry reuses the existing cross-partition ask, not a new query.** On rejection the pending ask
 is kept rather than removed; the scheduler re-sends the `REQUEST`, `P_B` re-evaluates live state, and
 the attempt flips to `STARTED` once the blocker clears. The existing `(processDefinitionKey,

--- a/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
+++ b/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
@@ -19,9 +19,10 @@ unstarted at its TTL, even if the blocker cleared seconds earlier. The correlati
 wrong thing to wait on: the unblocking event is a Business ID freeing, which may come from an
 instance with a different correlation key or none at all.
 
-The outcome: a rejected start is retried until it starts or its TTL expires, reusing the existing
-cross-partition ask; a dedicated registry owns that retry; and the same behaviour applies whether
-the Business ID is local or remote.
+The outcome: a rejected start is retried until it starts or its TTL expires; a remote Business ID
+reuses the existing cross-partition ask, while a local Business ID is retried natively on this
+partition. The same observable guarantee applies whether the Business ID is local or remote, even
+though the mechanism differs.
 
 ## Decision
 
@@ -46,16 +47,38 @@ reply. On recovery the magnitude survives in persisted state while the transient
 rebuilt, so a long-blocked ask resumes at its backed-off cadence rather than resetting to a
 base-interval storm (at the cost of a bounded one-interval phase imprecision after a leader change).
 
-**D4. The rejection registry is the single owner of this retry.** The pending-ask state owns retrying
-rejected starts; the correlation-key buffer no longer re-attempts them. The buffer keys on
-correlation key, but the unblocking event is Business-ID-scoped, so the buffer cannot trigger these
-retries correctly — a buffered message with a live pending ask is skipped by the buffer scan.
+**D4. The retry has a single owner per topology — never the correlation-key buffer.** For
+cross-partition rejections the pending-ask registry owns the retry: a buffered message with a live
+pending ask is skipped by the buffer scan. For same-partition rejections the native Business-ID-keyed
+retry (D5) owns it. In neither case does the correlation-key buffer re-attempt these starts — it keys
+on correlation key, while the unblocking event is Business-ID-scoped (the holder may carry a different
+correlation key, or none at all).
 
-**D5. Same-partition parity: unify the retry, keep the local success path.** When the Business ID
-hashes to the local partition (`P_K = P_B`, always so on single-partition clusters), the success
-path stays local and synchronous, but a rejection enrolls in the same registry and retries via a
-self-addressed `REQUEST`. One retry implementation serves both topologies; the handshake cost is
-paid only by the rare blocked message.
+**D5. Same-partition rejections are retried natively-local by a dedicated registry + scheduler, not
+via the cross-partition ask.** When the Business ID hashes to the local partition (`P_K = P_B`,
+always so on single-partition clusters), both the success and the retry stay local. A successful
+start uses the normal local message-start flow (synchronous, no handshake). A rejection keeps the
+message buffered and enrolls it in a **local blocked-start registry** keyed by `(messageKey,
+processDefinitionKey)` (a local twin of the cross-partition pending-ask entry, but **never sent over
+the wire**). A scheduler periodically re-drives the **local** start for enrolled entries under the
+same capped exponential back-off as D3; once the Business ID frees, the re-attempt starts the
+instance through the ordinary local flow and the entry is removed (it is also removed when the
+buffered message expires). This path uses **no** `MessageStartProcessInstanceRequest` records, dedup
+row, or cross-partition lock. A scheduler — rather than a one-shot hook on holder completion — is
+chosen deliberately: a Business ID frees not only on completion but also on termination and on
+**banning** (banned holders are treated as free), so periodic re-evaluation catches every unblock
+cause without hooking each one. The cross-partition ask (D2/D3) is engaged **only** when the Business
+ID is remote; the two topologies share the goal (a blocked start eventually runs, bounded by its TTL)
+but deliberately **not** the mechanism.
+
+**D6. The uniqueness flag gates the rejection, not the routing/placement.** `businessIdUniquenessEnabled`
+controls only whether a uniqueness conflict is *rejected*, never whether a Business-ID-carrying
+message-start is *routed* to `P_B`. A remote Business ID is always delegated to `P_B` — preserving the
+ADR 0001 invariant that every root PI carrying a Business ID lives on `hash(businessId)` — and `P_B`
+creates the instance, replying `REJECT_UNIQUENESS` only while the flag is on. Decoupling placement
+from the flag keeps it consistent across flag flips, so enabling the feature later never finds
+Business-ID-carrying instances stranded on the wrong partition. (Same-partition placement is trivially
+flag-independent — the instance is already local — so this matters for the cross-partition arm.)
 
 ## Alternatives considered
 
@@ -63,22 +86,49 @@ paid only by the rare blocked message.
   free?" query plus its own registry. Rejected: the poll is non-authoritative (it still needs the
   ask to start), so it is two mechanisms where one suffices, and it re-derives the ask path's
   existing re-evaluation and idempotency for a traffic saving that back-off already bounds.
-- **Full same-partition unification — handshake even for the same-partition success path.** One code
-  path, but it taxes the common and single-partition case with extra records and a dedup write per
-  start and makes a synchronous start asynchronous, to pay for at-least-once machinery that
-  exactly-once same-log delivery does not need.
+- **Same-partition retry via a self-addressed cross-partition ask** (the original D5). A
+  same-partition rejection would enroll in the pending-ask registry and re-send a `REQUEST` addressed
+  to its own partition, reusing one retry implementation for both topologies. Rejected on closer
+  analysis: it imports the entire cross-partition apparatus onto a single partition — a dedup row, a
+  cross-partition lock plus its self-poll release, and the multi-record `REQUEST`/`STARTED`
+  handshake — so a same-partition start that succeeds *after a retry* diverges from one that succeeds
+  *immediately* (different record shape, and the retried instance ends up tracked by two release
+  mechanisms at once). The loopback also reset the persisted back-off magnitude on every retry and
+  leaked the pending ask for fire-and-forget (`TTL <= 0`) publishes. The native-local retry (D5)
+  avoids all of this.
+- **Event-driven same-partition retry (one-shot on holder completion).** Instead of a scheduler,
+  re-attempt the blocked start exactly once, hooked off the holder instance's completion. Rejected:
+  a Business ID frees on completion, termination *and* banning, and a banned holder never "completes",
+  so a completion hook would leave a start blocked behind a banned holder stuck until its TTL. A
+  scheduler re-evaluating live state catches every unblock cause, at the cost of bounded polling that
+  back-off already limits.
+- **Full same-partition unification — run the ask handshake for both topologies (deferred,
+  possible follow-up).** Instead of a local flow for same-partition and a separate ask flow for
+  cross-partition, route *every* message-start (both topologies) through one uniform `REQUEST`
+  handshake. This removes the two-flow divergence by construction (a single code path, a single
+  retry mechanism). It is **not chosen now** because it taxes the common and single-partition case
+  with extra records and a dedup write per start and makes a synchronous start asynchronous, to pay
+  for at-least-once machinery that exactly-once same-log delivery does not need. Given the divergence
+  between the two flows, however, it remains a legitimate candidate to revisit — as a separately
+  analysed, benchmarked decision in a follow-up ADR — once the native retry has shipped.
 
 ## Consequences
 
 - Closes the liveness gap: a start blocked purely on Business ID now runs once the blocker clears,
   bounded by the message TTL; no duplicates and no leaked state.
-- One retry mechanism for both topologies; the correlation-key buffer is relieved of a
-  responsibility it could not fulfil correctly.
-- Back-off is event-sourced, keeping schedulers free of persisted-state writes and surviving leader
-  changes without a reset storm.
+- Two topology-specific retry mechanisms — the cross-partition ask (remote Business ID) and a
+  native-local registry + scheduler (local Business ID) — and the correlation-key buffer is relieved
+  of a responsibility it could not fulfil correctly. The two flows diverge by design; unifying them
+  is a deferred follow-up (see Alternatives).
+- Both retries use capped exponential back-off advanced by an event applier, keeping schedulers free
+  of persisted-state writes and surviving leader changes without a reset storm.
 - A start still expires unstarted if its Business ID stays held for the entire TTL — the legitimate
   "blocked the whole window" outcome.
-- The same-partition success path is unchanged; only the rare blocked case pays the ask handshake.
+- The same-partition path stays fully local: success is synchronous and a blocked start is retried
+  locally under back-off — no cross-partition records on either path.
+- Routing to `P_B` is independent of the uniqueness flag (D6), so the placement invariant holds even
+  while the feature is switched off, and toggling the flag never strands instances on the wrong
+  partition.
 
 ## Source
 

--- a/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
+++ b/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
@@ -36,9 +36,15 @@ messageKey)` dedup row on `P_B` makes the retried ask idempotent — no duplicat
 
 **D3. Retries use capped exponential back-off, advanced by the event applier.** Back-off prevents a
 long-blocked message from storming `P_B`. Because schedulers may not mutate persisted state, the
-back-off is event-sourced: the rejection applier advances it on each rejection reply (using the
-deterministic event timestamp); the scheduler only reads the resulting next-retry deadline and keeps
-its transient send-tracking.
+back-off is event-sourced as a per-ask **magnitude**: the rejection applier doubles a persisted
+back-off magnitude (capped) on each rejection reply. This advance is a pure function of the prior
+persisted value and the configured bounds — it needs no clock and no event timestamp, so it is
+trivially deterministic on replay. The scheduler derives the next-retry time from that magnitude
+plus its transient last-sent tracking, re-sending an ask once `lastSent + max(baseInterval,
+magnitude)` has passed; the transient also serves as the in-flight guard between a send and its
+reply. On recovery the magnitude survives in persisted state while the transient last-sent is
+rebuilt, so a long-blocked ask resumes at its backed-off cadence rather than resetting to a
+base-interval storm (at the cost of a bounded one-interval phase imprecision after a leader change).
 
 **D4. The rejection registry is the single owner of this retry.** The pending-ask state owns retrying
 rejected starts; the correlation-key buffer no longer re-attempts them. The buffer keys on

--- a/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
+++ b/zeebe/docs/adr/0002-810-message-start-rejection-retry.md
@@ -20,9 +20,10 @@ wrong thing to wait on: the unblocking event is a Business ID freeing, which may
 instance with a different correlation key or none at all.
 
 The outcome: a rejected start is retried until it starts or its TTL expires; a remote Business ID
-reuses the existing cross-partition ask, while a local Business ID is retried natively on this
-partition. The same observable guarantee applies whether the Business ID is local or remote, even
-though the mechanism differs.
+reuses the existing cross-partition ask, while a local Business ID is retried by re-driving the local
+start when its holder frees the ID — discovered through a Business-ID index on the buffered message.
+The same observable guarantee applies whether the Business ID is local or remote, even though the
+mechanism differs.
 
 ## Decision
 
@@ -35,41 +36,55 @@ is kept rather than removed; the scheduler re-sends the `REQUEST`, `P_B` re-eval
 the attempt flips to `STARTED` once the blocker clears. The existing `(processDefinitionKey,
 messageKey)` dedup row on `P_B` makes the retried ask idempotent — no duplicate instance.
 
-**D3. Retries use capped exponential back-off, advanced by the event applier.** Back-off prevents a
-long-blocked message from storming `P_B`. Because schedulers may not mutate persisted state, the
-back-off is event-sourced as a per-ask **magnitude**: the rejection applier doubles a persisted
-back-off magnitude (capped) on each rejection reply. This advance is a pure function of the prior
-persisted value and the configured bounds — it needs no clock and no event timestamp, so it is
-trivially deterministic on replay. The scheduler derives the next-retry time from that magnitude
-plus its transient last-sent tracking, re-sending an ask once `lastSent + max(baseInterval,
-magnitude)` has passed; the transient also serves as the in-flight guard between a send and its
-reply. On recovery the magnitude survives in persisted state while the transient last-sent is
-rebuilt, so a long-blocked ask resumes at its backed-off cadence rather than resetting to a
-base-interval storm (at the cost of a bounded one-interval phase imprecision after a leader change).
+**D3. The cross-partition ask retries use capped exponential back-off, advanced by the event
+applier.** Back-off prevents a long-blocked message from storming `P_B`. Because schedulers may not
+mutate persisted state, the back-off is event-sourced as a per-ask **magnitude**: the rejection
+applier doubles a persisted back-off magnitude (capped) on each rejection reply. This advance is a
+pure function of the prior persisted value and the configured bounds — it needs no clock and no event
+timestamp, so it is trivially deterministic on replay. The scheduler derives the next-retry time from
+that magnitude plus its transient last-sent tracking, re-sending an ask once `lastSent +
+max(baseInterval, magnitude)` has passed; the transient also serves as the in-flight guard between a
+send and its reply. On recovery the magnitude survives in persisted state while the transient
+last-sent is rebuilt, so a long-blocked ask resumes at its backed-off cadence rather than resetting to
+a base-interval storm (at the cost of a bounded one-interval phase imprecision after a leader change).
+The same-partition retry (D5) needs no back-off: it is event-driven — re-driven once when a holder
+frees the Business ID — not polled, so there is nothing to storm.
 
-**D4. The retry has a single owner per topology — never the correlation-key buffer.** For
-cross-partition rejections the pending-ask registry owns the retry: a buffered message with a live
-pending ask is skipped by the buffer scan. For same-partition rejections the native Business-ID-keyed
-retry (D5) owns it. In neither case does the correlation-key buffer re-attempt these starts — it keys
-on correlation key, while the unblocking event is Business-ID-scoped (the holder may carry a different
-correlation key, or none at all).
+**D4. The correlation-key buffer is never relied on to retry a Business-ID rejection — it keys on the
+wrong thing.** The unblocking event is a Business ID freeing, which may come from a holder with a
+different correlation key, or none at all, so the correlation-key buffer scan cannot be trusted to
+re-attempt these starts. For cross-partition rejections the pending-ask registry is the single retry
+owner: a buffered message with a live pending ask is skipped by the buffer scan, so it does not emit a
+redundant second ask. For same-partition rejections the Business-ID index + completion hook (D5)
+drives the retry; should the correlation-key scan happen to revisit the same message once the ID is
+free, the ordinary correlation guards (`existMessageCorrelation`, the deadline check) make the overlap
+a harmless no-op rather than a double start.
 
-**D5. Same-partition rejections are retried natively-local by a dedicated registry + scheduler, not
-via the cross-partition ask.** When the Business ID hashes to the local partition (`P_K = P_B`,
-always so on single-partition clusters), both the success and the retry stay local. A successful
-start uses the normal local message-start flow (synchronous, no handshake). A rejection keeps the
-message buffered and enrolls it in a **local blocked-start registry** keyed by `(messageKey,
-processDefinitionKey)` (a local twin of the cross-partition pending-ask entry, but **never sent over
-the wire**). A scheduler periodically re-drives the **local** start for enrolled entries under the
-same capped exponential back-off as D3; once the Business ID frees, the re-attempt starts the
-instance through the ordinary local flow and the entry is removed (it is also removed when the
-buffered message expires). This path uses **no** `MessageStartProcessInstanceRequest` records, dedup
-row, or cross-partition lock. A scheduler — rather than a one-shot hook on holder completion — is
-chosen deliberately: a Business ID frees not only on completion but also on termination and on
-**banning** (banned holders are treated as free), so periodic re-evaluation catches every unblock
-cause without hooking each one. The cross-partition ask (D2/D3) is engaged **only** when the Business
-ID is remote; the two topologies share the goal (a blocked start eventually runs, bounded by its TTL)
-but deliberately **not** the mechanism.
+**D5. Same-partition rejections are retried by re-driving the local start when the Business ID frees,
+discovered through a Business-ID index on the buffered message — no scheduler, no cross-partition
+machinery.** When the Business ID hashes to the local partition (`P_K = P_B`, always so on
+single-partition clusters), both success and retry stay local. A successful start uses the normal
+local message-start flow (synchronous, no handshake). On rejection the message simply stays buffered;
+it is made discoverable by Business ID through a secondary index on the buffered-message store, keyed
+by `(tenantId, businessId, messageKey)` and maintained on the **same publish/expiry lifecycle as the
+message itself** (written when the message is buffered, removed when it expires) — so it needs no
+separate registry, enrollment event, or cleanup path. When a holder instance completes or terminates,
+the post-transition action that already re-drives the correlation-key buffer additionally looks up
+buffered messages by the freed Business ID and re-drives the ordinary local start for each (routing
+still honours D6). The existing correlation guards make a redundant re-drive a no-op. This path uses
+**no** `MessageStartProcessInstanceRequest` records, dedup row, cross-partition lock, scheduler, or
+back-off.
+
+This deliberately mirrors the existing correlation-key buffer, which is likewise only re-driven on a
+holder's completion/termination. It therefore inherits the same boundary: a Business ID also frees on
+**banning** (banned holders are treated as free) and on migration, neither of which fires a
+completion/termination event, so a start blocked behind a banned or migrated holder waits until its
+TTL rather than restarting immediately. This is **accepted** because it is exactly the existing
+behaviour of the correlation-key buffer — a message buffered behind a banned holder is already
+stranded until TTL today — so the Business-ID buffer is made a faithful twin of it rather than being
+granted a new, stronger liveness guarantee on only one arm. The cross-partition ask (D2/D3) is engaged
+**only** when the Business ID is remote; the two topologies share the goal (a blocked start eventually
+runs, bounded by its TTL) but deliberately **not** the mechanism.
 
 **D6. The uniqueness flag gates the rejection, not the routing/placement.** `businessIdUniquenessEnabled`
 controls only whether a uniqueness conflict is *rejected*, never whether a Business-ID-carrying
@@ -96,12 +111,17 @@ flag-independent — the instance is already local — so this matters for the c
   mechanisms at once). The loopback also reset the persisted back-off magnitude on every retry and
   leaked the pending ask for fire-and-forget (`TTL <= 0`) publishes. The native-local retry (D5)
   avoids all of this.
-- **Event-driven same-partition retry (one-shot on holder completion).** Instead of a scheduler,
-  re-attempt the blocked start exactly once, hooked off the holder instance's completion. Rejected:
-  a Business ID frees on completion, termination *and* banning, and a banned holder never "completes",
-  so a completion hook would leave a start blocked behind a banned holder stuck until its TTL. A
-  scheduler re-evaluating live state catches every unblock cause, at the cost of bounded polling that
-  back-off already limits.
+- **Same-partition retry via a dedicated blocked-start registry + scheduler** (an earlier D5). A
+  rejection would enroll the message in its own persisted registry keyed by `(messageKey,
+  processDefinitionKey)` with an event-sourced back-off magnitude, and a poller would re-drive the
+  local start on a back-off cadence. Rejected: it builds a parallel registry, a second back-off
+  mechanism, and a poller purely to restart *promptly* in the cases a completion hook misses — a
+  banned or migrated holder, which frees the Business ID without a completion/termination event. Those
+  cases are rare and already bounded by the message TTL, and giving the Business-ID buffer a *stronger*
+  liveness guarantee than the correlation-key buffer sitting next to it (which is itself only re-driven
+  on completion/termination, and so also strands a message behind a banned holder until TTL) is an
+  inconsistency, not an improvement. The completion-hook design (D5) reuses the existing post-transition
+  re-drive and keeps the two buffers behaviourally identical.
 - **Full same-partition unification — run the ask handshake for both topologies (deferred,
   possible follow-up).** Instead of a local flow for same-partition and a separate ask flow for
   cross-partition, route *every* message-start (both topologies) through one uniform `REQUEST`
@@ -116,16 +136,22 @@ flag-independent — the instance is already local — so this matters for the c
 
 - Closes the liveness gap: a start blocked purely on Business ID now runs once the blocker clears,
   bounded by the message TTL; no duplicates and no leaked state.
-- Two topology-specific retry mechanisms — the cross-partition ask (remote Business ID) and a
-  native-local registry + scheduler (local Business ID) — and the correlation-key buffer is relieved
-  of a responsibility it could not fulfil correctly. The two flows diverge by design; unifying them
-  is a deferred follow-up (see Alternatives).
-- Both retries use capped exponential back-off advanced by an event applier, keeping schedulers free
-  of persisted-state writes and surviving leader changes without a reset storm.
+- Two topology-specific retry mechanisms — the cross-partition ask (remote Business ID) and re-driving
+  the local start on holder completion via a Business-ID index (local Business ID) — and the
+  correlation-key buffer is relieved of a responsibility it could not fulfil correctly. The two flows
+  diverge by design; unifying them is a deferred follow-up (see Alternatives).
+- The cross-partition ask uses capped exponential back-off advanced by an event applier, keeping the
+  scheduler free of persisted-state writes and surviving leader changes without a reset storm. The
+  same-partition retry needs no scheduler or back-off — it is event-driven off holder completion.
 - A start still expires unstarted if its Business ID stays held for the entire TTL — the legitimate
   "blocked the whole window" outcome.
-- The same-partition path stays fully local: success is synchronous and a blocked start is retried
-  locally under back-off — no cross-partition records on either path.
+- Accepted limitation (same-partition): a start blocked behind a holder that frees its Business ID
+  *without* a completion/termination event — a **banned** holder (banned holders are treated as free)
+  or a **migrated** one — waits until its TTL rather than restarting immediately. This is identical to
+  the existing correlation-key buffer, which is also only re-driven on completion/termination, so the
+  Business-ID buffer is a faithful twin of it rather than a new, stronger guarantee on one arm.
+- The same-partition path stays fully local: success is synchronous and a blocked start is re-driven
+  locally on holder completion — no cross-partition records, no scheduler, on either path.
 - Routing to `P_B` is independent of the uniqueness flag (D6), so the placement invariant holds even
   while the feature is switched off, and toggling the flag never strands instances on the wrong
   partition.

--- a/zeebe/docs/adr/README.md
+++ b/zeebe/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Zeebe ADRs
+
+Architecture Decision Records scoped to the Zeebe module (engine, protocol, exporters, and the
+process-execution data path). These are module-scoped decisions; see the
+[top-level ADR README](../../../docs/adr/README.md) for the tier structure and cross-cutting ADRs.
+
+## Index
+
+### 8.10
+
+|                                 ADR                                 |                                                   Decision                                                    |
+|---------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| [0001](0001-810-message-correlation-business-id-cross-partition.md) | Business ID message correlation: `P_K` owns messages, `P_B` enforces uniqueness, `P_K` pulls for lock release |
+| [0002](0002-810-message-start-rejection-retry.md)                   | A way out for rejected cross-partition message-starts: retry the ask with back-off                            |
+

--- a/zeebe/docs/adr/README.md
+++ b/zeebe/docs/adr/README.md
@@ -11,5 +11,5 @@ process-execution data path). These are module-scoped decisions; see the
 |                                 ADR                                 |                                                   Decision                                                    |
 |---------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | [0001](0001-810-message-correlation-business-id-cross-partition.md) | Business ID message correlation: `P_K` owns messages, `P_B` enforces uniqueness, `P_K` pulls for lock release |
-| [0002](0002-810-message-start-rejection-retry.md)                   | A way out for rejected cross-partition message-starts: retry the ask with back-off                            |
+| [0002](0002-810-message-start-rejection-retry.md)                   | Retry rejected message-starts until they start or their TTL expires                                           |
 


### PR DESCRIPTION
## Description

Records two (8.10) decisions under `zeebe/docs/adr`:

- 0001: P_K owns message state, P_B enforces Business ID uniqueness via a cross-partition ask, and P_K pulls P_B for correlation-key lock release.
- 0002: a message-start rejected on uniqueness or a not-yet-distributed subscription is retried via the existing ask with event-sourced back-off instead of expiring unstarted.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54915
