### PR TITLE
feat: hide waiting state when an agent instance exists for an element

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -32,6 +32,7 @@ import type {
   UserTask,
   MessageSubscription,
 } from '@camunda/camunda-api-zod-schemas/8.10';
+import {mockSearchAgentInstances} from 'modules/mocks/api/v2/agentInstances/searchAgentInstances';
 
 const PROCESS_INSTANCE_ID = '111222333';
 const PROCESS_DEFINITION_KEY = '444555666';
@@ -291,6 +292,9 @@ describe('<DetailsTab />', () => {
     mockSearchProcessInstances().withSuccess(searchResult([]));
     mockSearchDecisionInstances().withSuccess(searchResult([]));
     mockSearchMessageSubscriptions().withSuccess(searchResult([]));
+    mockSearchAgentInstances().withSuccess(searchResult([]));
+    mockSearchAgentInstances().withSuccess(searchResult([]));
+    mockSearchElementInstanceInspection().withSuccess(searchResult([]));
   });
 
   it('should show multi-instance message when multiple instances exist', async () => {
@@ -906,14 +910,14 @@ describe('<DetailsTab />', () => {
     expect(screen.queryByTestId('waiting-status')).not.toBeInTheDocument();
   });
 
-  it('should render WaitingStatus with wait states when waitStatesEnabled is true and element is ACTIVE', async () => {
+  it('should not render WaitingStatus when an agent instance exists', async () => {
     mockFetchElementInstance('123456789').withSuccess({
       ...mockElementInstance,
       state: 'ACTIVE',
       endDate: null,
     });
-    mockSearchElementInstanceInspection().withSuccess({
-      items: [
+    mockSearchElementInstanceInspection().withSuccess(
+      searchResult([
         {
           rootProcessInstanceKey: PROCESS_INSTANCE_ID,
           processInstanceKey: PROCESS_INSTANCE_ID,
@@ -923,14 +927,68 @@ describe('<DetailsTab />', () => {
           waitStateType: 'JOB',
           details: {jobType: 'customJob'},
         },
-      ],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
+      ]),
+    );
+    mockSearchAgentInstances().withSuccess(
+      searchResult([
+        {
+          agentInstanceKey: '2251799813851828',
+          status: 'TOOL_CALLING',
+          definition: {
+            model: 'gpt-4',
+            provider: 'openai',
+            systemPrompt: 'You are a helpful assistant.',
+          },
+          metrics: {
+            inputTokens: 100,
+            outputTokens: 50,
+            modelCalls: 3,
+            toolCalls: 2,
+          },
+          limits: {
+            maxModelCalls: 10,
+            maxToolCalls: 5,
+            maxTokens: 1000,
+          },
+          elementId: 'Task_1',
+          processInstanceKey: '123456789',
+          processDefinitionKey: '444555666',
+          tenantId: '<default>',
+          creationDate: '2025-01-15T10:00:00.000Z',
+          lastUpdatedDate: '2025-01-15T10:05:00.000Z',
+          completionDate: null,
+          elementInstanceKeys: ['123456789'],
+        },
+      ]),
+    );
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
     });
+
+    expect(await screen.findByText('Element Instance Key')).toBeInTheDocument();
+    expect(screen.queryByTestId('waiting-status')).not.toBeInTheDocument();
+  });
+
+  it('should render WaitingStatus with wait states when waitStatesEnabled is true and element is ACTIVE', async () => {
+    mockFetchElementInstance('123456789').withSuccess({
+      ...mockElementInstance,
+      state: 'ACTIVE',
+      endDate: null,
+    });
+    mockSearchElementInstanceInspection().withSuccess(
+      searchResult([
+        {
+          rootProcessInstanceKey: PROCESS_INSTANCE_ID,
+          processInstanceKey: PROCESS_INSTANCE_ID,
+          elementInstanceKey: '123456789',
+          elementId: 'Task_1',
+          elementType: 'SERVICE_TASK',
+          waitStateType: 'JOB',
+          details: {jobType: 'customJob'},
+        },
+      ]),
+    );
 
     render(<DetailsTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -500,6 +500,9 @@ const DetailsTab: React.FC = () => {
     );
   }
 
+  const showAgentInstance =
+    agentInstance !== undefined || isAgentLoading || isAgentError;
+
   return (
     <Container data-testid="details-tab">
       {resolvedElementType === 'USER_TASK' &&
@@ -520,14 +523,14 @@ const DetailsTab: React.FC = () => {
         ]}
         rows={rows}
       />
-      {(agentInstance !== undefined || isAgentLoading || isAgentError) && (
+      {showAgentInstance && (
         <AgentDetails
           agentInstance={agentInstance}
           isLoading={isAgentLoading}
           isError={isAgentError}
         />
       )}
-      {clientConfig.waitStatesEnabled && (
+      {!showAgentInstance && clientConfig.waitStatesEnabled && (
         <WaitingStatus waitStates={elementWaitStates} />
       )}
     </Container>

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -193,7 +193,7 @@ const TopPanel: React.FC = observer(() => {
       : notCompletedElementStateOverlays;
   }, [statistics, businessObjects, isExecutionCountVisible]);
 
-  const waitingStateOverlays = useMemo(() => {
+  const allWaitingStateOverlays = useMemo(() => {
     if (!inspectionData?.items?.length) {
       return [];
     }
@@ -228,42 +228,51 @@ const TopPanel: React.FC = observer(() => {
     return overlays;
   }, [inspectionData]);
 
-  const agentOverlays = useMemo(() => {
+  const {agentOverlays, elementsWithAgent} = useMemo(() => {
     if (!agentInstancesData?.items?.length) {
-      return [];
+      return {agentOverlays: [], elementsWithAgent: new Set<string>()};
     }
 
-    const mappedElementIds = new Set<string>();
+    const elementsWithAgent = new Set<string>();
 
-    return agentInstancesData.items.flatMap<OverlayData>((agentInstance) => {
-      // We expect only one active agent instance per element. But there *can* be multiple.
-      // For now, only add an overlay to an element for first matching agent instance.
-      if (mappedElementIds.has(agentInstance.elementId)) {
-        return [];
-      }
+    const agentOverlays = agentInstancesData.items.flatMap<OverlayData>(
+      (agentInstance) => {
+        // We expect only one active agent instance per element. But there *can* be multiple.
+        // For now, only add an overlay to an element for first matching agent instance.
+        if (elementsWithAgent.has(agentInstance.elementId)) {
+          return [];
+        }
 
-      mappedElementIds.add(agentInstance.elementId);
-      return [
-        {
-          type: OVERLAY_TYPE_AGENT_STATUS,
-          elementId: agentInstance.elementId,
-          position: AGENT_STATUS_TAG,
-          payload: {
-            status: agentInstance.status,
-            agentInstanceKey: agentInstance.agentInstanceKey,
-          } satisfies AgentStatusPayload,
-        },
-        {
-          type: OVERLAY_TYPE_AGENT_SHINE,
-          elementId: agentInstance.elementId,
-          position: AGENT_SHINE,
-          payload: {
-            agentInstanceKey: agentInstance.agentInstanceKey,
-          } satisfies AgentShinePayload,
-        },
-      ];
-    });
+        elementsWithAgent.add(agentInstance.elementId);
+        return [
+          {
+            type: OVERLAY_TYPE_AGENT_STATUS,
+            elementId: agentInstance.elementId,
+            position: AGENT_STATUS_TAG,
+            payload: {
+              status: agentInstance.status,
+              agentInstanceKey: agentInstance.agentInstanceKey,
+            } satisfies AgentStatusPayload,
+          },
+          {
+            type: OVERLAY_TYPE_AGENT_SHINE,
+            elementId: agentInstance.elementId,
+            position: AGENT_SHINE,
+            payload: {
+              agentInstanceKey: agentInstance.agentInstanceKey,
+            } satisfies AgentShinePayload,
+          },
+        ];
+      },
+    );
+    return {agentOverlays, elementsWithAgent};
   }, [agentInstancesData]);
+
+  const waitingStateOverlays = useMemo(() => {
+    return allWaitingStateOverlays.filter(
+      (overlay) => !elementsWithAgent.has(overlay.elementId),
+    );
+  }, [allWaitingStateOverlays, elementsWithAgent]);
 
   const selectedElementIds = useMemo(() => {
     return selectedAnchorElementId


### PR DESCRIPTION
## Description

This PR hides waiting states in the frontend if an agent instance exists as well. This resolves a conflict with both showing overlapping overlays.