### PR TITLE
feat: add chaos-killer option to load tests

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -74,6 +74,11 @@ on:
         type: boolean
         required: false
         default: true
+      enable-chaos:
+        description: 'Enable chaos-killer to randomly kill pods'
+        type: boolean
+        required: false
+        default: false
       enable-optimize-report-metrics:
         description: 'Enable the load-tester Optimize report-evaluation meter (requires Optimize backend)'
         type: boolean
@@ -174,6 +179,11 @@ on:
         type: boolean
         required: false
         default: true
+      enable-chaos:
+        description: 'Enable chaos-killer to randomly kill pods'
+        type: boolean
+        required: false
+        default: false
       enable-optimize-report-metrics:
         description: 'Enable the load-tester Optimize report-evaluation meter (requires Optimize backend)'
         type: boolean
@@ -257,6 +267,7 @@ jobs:
           | TTL (days) | `${{ inputs.ttl }}` |
           | Stable VMs | `${{ inputs.stable-vms }}` |
           | Enable Optimize | `${{ inputs.enable-optimize }}` |
+          | Enable chaos | `${{ inputs.enable-chaos }}` |
           | Enable Optimize report metrics | `${{ inputs.enable-optimize-report-metrics }}` |
           | Build frontend | `${{ inputs.build-frontend }}` |
           | Perform read benchmarks | `${{ inputs.perform-read-benchmarks }}` |
@@ -661,6 +672,7 @@ jobs:
             scenario=${{ inputs.scenario }} \
             secondary_storage=${{ inputs.secondary-storage-type }} \
             enable_optimize=${{ inputs.enable-optimize }} \
+            chaos=${{ inputs.enable-chaos }} \
             additional_platform_configuration="$additional_platform_config" \
             additional_load_test_configuration="$load_test_config" \
             additional_load_test_setup_configuration="$additional_load_test_setup_configuration"

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -152,6 +152,7 @@ The load-test-setup chart owns all the resources deployed for a single load test
 * the namespace (labels, AZ pinning, TTL annotation)
 * the `camunda-credentials` secret
 * the leader-balancer cronjob
+* the chaos-killer cronjob (optional, disabled by default)
 
 It is parameterized by a values file baked at scaffold time:
 
@@ -254,6 +255,40 @@ make install-load-test-setup
 ```
 
 The load-test-setup chart deploys a leader balancing cronjob that runs every 10 minutes to rebalance cluster leaders.
+
+#### Optional chaos-killer
+
+The load-test-setup chart can optionally deploy a chaos-killer CronJob. When enabled, it lists all
+pods in the namespace, expands a space-separated list of shell glob patterns, and deletes **one
+random matching pod per run**.
+
+- Default schedule: hourly (`0 * * * *`)
+- Default target patterns: `camunda-* elastic-* postgresql-*`
+- Default state: disabled
+
+Enable via the `chaos` variable or the convenience shortcuts:
+
+```sh
+make install chaos=true     # enable chaos with any install target
+make install-chaos          # shorthand for the above
+make install-stable-chaos   # stable VMs + chaos
+```
+
+To override the default schedule or target patterns, pass them via `additional_load_test_setup_configuration`:
+
+```sh
+make install chaos=true \
+  additional_load_test_setup_configuration="--set chaosKiller.schedule='*/15 * * * *' \
+  --set chaosKiller.targetPatterns='camunda-* elastic-* postgresql-* keycloak-*'"
+```
+
+To preview the rendered manifests before installing:
+
+```sh
+make template-load-test-setup-chaos
+```
+
+In the GitHub workflow, set the `enable-chaos` input to `true`.
 
 This will deploy the full Camunda Platform (including `orchestration cluster`, `elasticsearch`, `optimize`, `connectors`, `identity` and `keycloak`) and load test applications (e.g. `starter` and `worker`).
 

--- a/load-tests/setup/charts/load-test-setup/templates/chaos-killer.yaml
+++ b/load-tests/setup/charts/load-test-setup/templates/chaos-killer.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.chaosKiller.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chaos-killer
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chaos-killer
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chaos-killer
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: chaos-killer
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chaos-killer
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chaos-killer
+  namespace: {{ .Release.Namespace }}
+spec:
+  schedule: {{ .Values.chaosKiller.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: chaos-killer
+          restartPolicy: OnFailure
+          containers:
+            - name: chaos-killer
+              image: bitnami/kubectl:latest
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: CHAOS_TARGET_PATTERNS
+                  value: {{ .Values.chaosKiller.targetPatterns | quote }}
+              command:
+                - /bin/sh
+                - -ceu
+                - |-
+                  if [ -z "$CHAOS_TARGET_PATTERNS" ]; then
+                    echo "No chaos target patterns configured."
+                    exit 1
+                  fi
+
+                  all_pods="$(kubectl get pods --namespace {{ .Release.Namespace }} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"
+                  if [ -z "$all_pods" ]; then
+                    echo "No pods found in namespace {{ .Release.Namespace }}."
+                    exit 1
+                  fi
+
+                  matched_pods="$({
+                    for pattern in $CHAOS_TARGET_PATTERNS; do
+                      for pod in $all_pods; do
+                        case "$pod" in
+                          $pattern) printf '%s\n' "$pod" ;;
+                        esac
+                      done
+                    done
+                  } | awk 'NF && !seen[$0]++')"
+
+                  if [ -z "$matched_pods" ]; then
+                    echo "No pods matched patterns: $CHAOS_TARGET_PATTERNS"
+                    exit 1
+                  fi
+
+                  selected_pod="$(printf '%s\n' "$matched_pods" | awk 'BEGIN { srand(); } { pods[NR] = $0 } END { if (NR > 0) print pods[int(rand() * NR) + 1] }')"
+                  if [ -z "$selected_pod" ]; then
+                    echo "Failed to choose a pod from the matched set."
+                    exit 1
+                  fi
+
+                  echo "Matched pods:"
+                  printf ' - %s\n' $matched_pods
+                  echo "Deleting pod $selected_pod in namespace {{ .Release.Namespace }}"
+                  kubectl delete pod "$selected_pod" --namespace {{ .Release.Namespace }} --ignore-not-found=true --wait=false
+{{- end }}

--- a/load-tests/setup/charts/load-test-setup/values.yaml
+++ b/load-tests/setup/charts/load-test-setup/values.yaml
@@ -29,3 +29,14 @@ metricsExporter:
   database:
     # -- The URL to the database (Elasticsearch or OpenSearch) endpoint to fetch metrics from.
     url: http://elastic:9200
+
+# -- Configuration for the optional chaos-killer CronJob.
+# When enabled, one randomly-selected matching pod is deleted per run to simulate
+# unscheduled restarts (e.g. PostgreSQL, Zeebe broker, Elasticsearch).
+chaosKiller:
+  # -- Set to true to deploy the chaos-killer CronJob.
+  enabled: false
+  # -- Cron schedule for the chaos-killer (default: once per hour).
+  schedule: "0 * * * *"
+  # -- Space-separated shell glob patterns. One pod matching any pattern is deleted per run.
+  targetPatterns: "camunda-* elastic-* postgresql-*"

--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -3,6 +3,9 @@ secondary_storage ?= __STORAGE_TYPE__
 template_output_dir ?= .
 helm_chart ?= camunda-platform-8.10
 enable_optimize ?= __ENABLE_OPTIMIZE__
+# Enable the chaos-killer CronJob (randomly deletes one matching pod per run).
+# Use named targets (make install-chaos) or pass directly: make install chaos=true
+chaos ?= false
 prometheus_elasticsearch_exporter_chart_version ?= 7.2.1
 # Optional: additional Helm configuration for the Camunda Platform release.
 # Use this to pass extra `--set`/`-f` flags, for example:
@@ -99,6 +102,10 @@ else ifeq ($(enable_optimize),true)
 	additional_load_test_setup_configuration += --set metricsExporter.database.url=http://elastic:9200
 else
 	install_es_prom_exporter := false
+endif
+
+ifeq ($(chaos),true)
+	additional_load_test_setup_configuration += --set chaosKiller.enabled=true
 endif
 
 .PHONY: all
@@ -278,6 +285,12 @@ template-load-test-setup:
 		$(additional_load_test_setup_configuration) \
 		--output-dir $(template_output_dir)
 
+# Renders the load-test-setup chart with the chaos-killer enabled.
+# Equivalent to: make template-load-test-setup chaos=true
+.PHONY: template-load-test-setup-chaos
+template-load-test-setup-chaos:
+	$(MAKE) template-load-test-setup chaos=true
+
 # Generates templates from the load test helm chart
 .PHONY: template-load-test
 template-load-test:
@@ -295,6 +308,13 @@ print-scenario:
 	@echo "Scenario:         $(if $(scenario),$(scenario),(none — chart defaults apply))"
 	@echo "Load test flags:  $(if $(_scenario_load_test_flags),$(_scenario_load_test_flags),(none))"
 	@echo "Platform flags:   $(if $(_scenario_platform_flags),$(_scenario_platform_flags),(none))"
+
+# Chaos shortcuts — install (or render) with the chaos-killer CronJob enabled.
+.PHONY: install-chaos install-stable-chaos
+install-chaos:
+	$(MAKE) install chaos=true
+install-stable-chaos:
+	$(MAKE) install-stable chaos=true
 
 # Workload scenario shortcuts — each runs 'make install' with the corresponding scenario profile.
 # For stable VMs, use: make install-stable scenario=<name>

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Mecf3^TeprMaqo"
+  identity-admin-client-token: "PibxFuvoXavo7#"
+  identity-firstuser-password: "SosqMiti1!Vamu"
+  identity-keycloak-admin-password: "TapkDoyiRuny0-"
+  identity-keycloak-postgresql-admin-password: "NipiRowgGart4["
+  identity-keycloak-postgresql-user-password: "KuneGazp5/Bivr"
+  identity-optimize-client-token: "PachCuwu3/Yera"
+  identity-optimize-loadtest-client-secret: "TiqaQezrYunx6]"
+  identity-postgresql-admin-password: "DaciPiso1&Wiye"
+  identity-postgresql-user-password: "Muri6_TofyCogi"
+  orchestration-security-authentication-oidc-secret: "PubmGibe9~Veku"

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/chaos-killer.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/chaos-killer.yaml
@@ -1,0 +1,98 @@
+---
+# Source: load-test-setup/templates/chaos-killer.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chaos-killer
+  namespace: c8-golden-main-chaos-killer
+---
+# Source: load-test-setup/templates/chaos-killer.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chaos-killer
+  namespace: c8-golden-main-chaos-killer
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+# Source: load-test-setup/templates/chaos-killer.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chaos-killer
+  namespace: c8-golden-main-chaos-killer
+subjects:
+  - kind: ServiceAccount
+    name: chaos-killer
+    namespace: c8-golden-main-chaos-killer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chaos-killer
+---
+# Source: load-test-setup/templates/chaos-killer.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chaos-killer
+  namespace: c8-golden-main-chaos-killer
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: chaos-killer
+          restartPolicy: OnFailure
+          containers:
+            - name: chaos-killer
+              image: bitnami/kubectl:TEST
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: CHAOS_TARGET_PATTERNS
+                  value: "camunda-* elastic-* postgresql-*"
+              command:
+                - /bin/sh
+                - -ceu
+                - |-
+                  if [ -z "$CHAOS_TARGET_PATTERNS" ]; then
+                    echo "No chaos target patterns configured."
+                    exit 1
+                  fi
+
+                  all_pods="$(kubectl get pods --namespace c8-golden-main-chaos-killer -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"
+                  if [ -z "$all_pods" ]; then
+                    echo "No pods found in namespace c8-golden-main-chaos-killer."
+                    exit 1
+                  fi
+
+                  matched_pods="$({
+                    for pattern in $CHAOS_TARGET_PATTERNS; do
+                      for pod in $all_pods; do
+                        case "$pod" in
+                          $pattern) printf '%s\n' "$pod" ;;
+                        esac
+                      done
+                    done
+                  } | awk 'NF && !seen[$0]++')"
+
+                  if [ -z "$matched_pods" ]; then
+                    echo "No pods matched patterns: $CHAOS_TARGET_PATTERNS"
+                    exit 1
+                  fi
+
+                  selected_pod="$(printf '%s\n' "$matched_pods" | awk 'BEGIN { srand(); } { pods[NR] = $0 } END { if (NR > 0) print pods[int(rand() * NR) + 1] }')"
+                  if [ -z "$selected_pod" ]; then
+                    echo "Failed to choose a pod from the matched set."
+                    exit 1
+                  fi
+
+                  echo "Matched pods:"
+                  printf ' - %s\n' $matched_pods
+                  echo "Deleting pod $selected_pod in namespace c8-golden-main-chaos-killer"
+                  kubectl delete pod "$selected_pod" --namespace c8-golden-main-chaos-killer --ignore-not-found=true --wait=false

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:TEST
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,15 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: orchestration
+  clientSecret: "PubmGibe9~Veku"
+  zeebeRestAddress: http://camunda:8080
+  authServer: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token
+  authType: OAUTH
+  zeebeGrpcAddress: http://camunda:26500
+  authorizationAudience: orchestration-api

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        args:
+          - --es.addresses=http://elastic:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-c"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-main-chaos-killer"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -20,12 +20,18 @@ var update = flag.Bool("update-golden", false,
 // Workload, when set, selects a Makefile workload profile (scenario=<workload>).
 // Workload scenarios render only the load-tester chart — that is where the
 // workload flags apply — so they don't duplicate the storage-matrix renders.
+//
+// SetupTarget, when set, names an alternative Makefile target for rendering the
+// load-test-setup chart only — used to test opt-in chart features that have a
+// dedicated make target (e.g. template-load-test-setup-chaos). This avoids
+// duplicating the full storage matrix for features that are orthogonal to storage.
 type scenario struct {
-	Name     string
-	Storage  string // elasticsearch | opensearch | postgresql | none
-	Optimize bool
-	Stable   bool
-	Workload string // "" = default profile; e.g. "max", "realistic"
+	Name        string
+	Storage     string // elasticsearch | opensearch | postgresql | none
+	Optimize    bool
+	Stable      bool
+	Workload    string // "" = default profile; e.g. "max", "realistic"
+	SetupTarget string // named make target for template-load-test-setup variants
 }
 
 // scenarios covers every unique rendering path produced by the Makefile.
@@ -49,6 +55,10 @@ var scenarios = []scenario{
 	{Name: "rdbms-stable", Storage: "postgresql", Optimize: false, Stable: true},
 	{Name: "max", Storage: "elasticsearch", Optimize: true, Stable: false, Workload: "max"},
 	{Name: "realistic", Storage: "elasticsearch", Optimize: true, Stable: false, Workload: "realistic"},
+	// SetupTarget scenarios render only the load-test-setup chart via a named
+	// Makefile target, verifying opt-in chart features without duplicating the
+	// full storage matrix.
+	{Name: "chaos-killer", Storage: "elasticsearch", Optimize: false, SetupTarget: "template-load-test-setup-chaos"},
 }
 
 // versions lists the setup directories under test, each the name of a directory
@@ -90,6 +100,14 @@ func TestGoldenFiles(t *testing.T) {
 					// render just that one with the workload profile applied.
 					if s.Workload != "" {
 						renderAndAssert(t, version, s.Name, "load-tester", ns, "template-load-test", s.Workload)
+						return
+					}
+
+					// SetupTarget scenarios verify opt-in load-test-setup features
+					// via their dedicated Makefile target. They render only that
+					// chart to avoid duplicating the full platform/load-tester matrix.
+					if s.SetupTarget != "" {
+						renderAndAssert(t, version, s.Name, "load-test-setup", ns, s.SetupTarget, "")
 						return
 					}
 


### PR DESCRIPTION
## Description

Adds an optional chaos-killer CronJob to the load-test-setup chart. Motivated by a recurring
problem with RDBMS load tests: PostgreSQL restarts happen randomly when Kubernetes reschedules
pods, and we want to *enforce* those restarts on a predictable schedule so we can verify that
Camunda survives unscheduled restarts of any pod (cluster nodes, secondary storage, ...).

When enabled, the chaos-killer lists all pods in the namespace, matches them against a set of
shell glob patterns, and deletes **one random matching pod per run**.

### What changed

- `charts/load-test-setup`: new `chaos-killer.yaml` Helm template (ServiceAccount, Role,
  RoleBinding, CronJob); disabled by default (`chaosKiller.enabled: false`)
- `Makefile`: `chaos ?= false` variable — composable with any install or template target:
  - `make install chaos=true`
  - `make install-chaos` / `make install-stable-chaos` (convenience shortcuts)
  - `make template-load-test-setup-chaos` (dry-run preview)
- `camunda-load-test.yml`: `enable-chaos` boolean workflow input; passed as `chaos=...` on the
  make command line (no bash if-block needed)
- `README`: documents all chaos-killer options

### Defaults

- Schedule: hourly (`0 * * * *`)
- Target patterns: `camunda-* elastic-* postgresql-*`
- Enabled: `false`

To override schedule or patterns:

```sh
make install chaos=true \
  additional_load_test_setup_configuration="--set chaosKiller.schedule='*/15 * * * *'"
```

### Tests

Golden file test added: `chaos-killer` scenario renders the load-test-setup chart with
`chaosKiller.enabled=true` via `make template-load-test-setup-chaos` and snapshots all four
resources (ServiceAccount, Role, RoleBinding, CronJob).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
