### PR TITLE
test: remove #54238 workarounds and add regression assertions in MI EL test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-start-end-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-start-end-tests.spec.ts
@@ -168,9 +168,7 @@ test.describe
         await assertStatusCode(failRes, 204);
 
         // Regression check #1 (#54238 fixed): /jobs/search must return HTTP 200
-        // even when an EL job is in FAILED state. Before the fix, null elementId
-        // (flowNodeId) caused HTTP 500. Assert state=FAILED, elementId='miTask'
-        // (not null/empty), confirming the fix and making the check precise.
+        // even when an EL job is in FAILED state.
         await expect(async () => {
           const res = await request.post(buildUrl('/jobs/search'), {
             headers: jsonHeaders(),
@@ -229,8 +227,7 @@ test.describe
         await assertStatusCode(updateRes, 204);
 
         // Regression check #2 (#54238 fixed): /jobs/search must return HTTP 200
-        // even when the EL job is in RETRIES_UPDATED state. Assert state on the
-        // specific job to confirm it is in RETRIES_UPDATED and the search works.
+        // even when the EL job is in RETRIES_UPDATED state.
         await expect(async () => {
           const res = await request.post(buildUrl('/jobs/search'), {
             headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-start-end-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-start-end-tests.spec.ts
@@ -167,6 +167,24 @@ test.describe
         );
         await assertStatusCode(failRes, 204);
 
+        // Regression check #1 (#54238 fixed): /jobs/search must return HTTP 200
+        // even when an EL job is in FAILED state.
+        await expect(async () => {
+          const res = await request.post(buildUrl('/jobs/search'), {
+            headers: jsonHeaders(),
+            data: {filter: {processInstanceKey: piKey, type: startElJobType}},
+          });
+          await assertStatusCode(res, 200);
+          const items = (await res.json()).items as Array<{
+            jobKey: string;
+            elementId: string;
+          }>;
+          const failedJob = items.find((j) => j.jobKey === String(jobKey));
+          expect(failedJob).toBeDefined();
+          // elementId must be "miTask" (not null/empty); null caused HTTP 500 before fix
+          expect(failedJob?.elementId).toBe('miTask');
+        }).toPass(extendedAssertionOptions);
+
         const incidents = await searchIncidentByPIK(request, {
           processInstanceKey: piKey,
         });
@@ -201,37 +219,14 @@ test.describe
           extendedAssertionOptions,
         );
 
-        // TODO: #54238: https://github.com/camunda/camunda/issues/54238
-        // /jobs/search returns HTTP 500 in FAILED/RETRIES_UPDATED state (ES-only,
-        // null flowNodeId). Workaround: activate before searching to avoid those states.
         const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
           headers: jsonHeaders(),
           data: {changeset: {retries: 1}},
         });
         await assertStatusCode(updateRes, 204);
 
-        const resolveRes = await request.post(
-          buildUrl(`/incidents/${incidents[0].incidentKey}/resolution`),
-          {headers: jsonHeaders()},
-        );
-        await assertStatusCode(resolveRes, 204);
-
-        // TODO: #54238 workaround — activate before searching.
-        // After incident resolution all 3 start EL jobs are activatable:
-        // 1 retried + 2 fresh (never-activated) instances. Activating first
-        // moves them all out of FAILED/RETRIES_UPDATED state so that the
-        // subsequent /jobs/search call returns 200 instead of 500.
-        let allStartJobs: Awaited<ReturnType<typeof activateJobsByType>> = [];
-        await expect(async () => {
-          allStartJobs = await activateJobsByType(
-            request,
-            startElJobType,
-            piKey,
-          );
-          expect(allStartJobs).toHaveLength(3);
-        }).toPass(extendedAssertionOptions);
-
-        // Search after activation: no jobs in FAILED/RETRIES_UPDATED state.
+        // Regression check #2 (#54238 fixed): /jobs/search must return HTTP 200
+        // even when the EL job is in RETRIES_UPDATED state.
         await expectJobsByType(
           request,
           piKey,
@@ -240,6 +235,28 @@ test.describe
           extendedAssertionOptions,
         );
 
+        const resolveRes = await request.post(
+          buildUrl(`/incidents/${incidents[0].incidentKey}/resolution`),
+          {headers: jsonHeaders()},
+        );
+        await assertStatusCode(resolveRes, 204);
+
+        // All 3 start EL jobs (1 retried + 2 fresh) are activatable after resolution.
+        await expectJobsByType(
+          request,
+          piKey,
+          startElJobType,
+          3,
+          extendedAssertionOptions,
+        );
+        const allStartJobs = await activateJobsByType(
+          request,
+          startElJobType,
+          piKey,
+          [],
+          3,
+        );
+        expect(allStartJobs).toHaveLength(3);
         for (const j of allStartJobs) {
           await completeJob(request, j.jobKey);
         }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-start-end-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-start-end-tests.spec.ts
@@ -168,7 +168,9 @@ test.describe
         await assertStatusCode(failRes, 204);
 
         // Regression check #1 (#54238 fixed): /jobs/search must return HTTP 200
-        // even when an EL job is in FAILED state.
+        // even when an EL job is in FAILED state. Before the fix, null elementId
+        // (flowNodeId) caused HTTP 500. Assert state=FAILED, elementId='miTask'
+        // (not null/empty), confirming the fix and making the check precise.
         await expect(async () => {
           const res = await request.post(buildUrl('/jobs/search'), {
             headers: jsonHeaders(),
@@ -178,10 +180,11 @@ test.describe
           const items = (await res.json()).items as Array<{
             jobKey: string;
             elementId: string;
+            state: string;
           }>;
           const failedJob = items.find((j) => j.jobKey === String(jobKey));
           expect(failedJob).toBeDefined();
-          // elementId must be "miTask" (not null/empty); null caused HTTP 500 before fix
+          expect(failedJob?.state).toBe('FAILED');
           expect(failedJob?.elementId).toBe('miTask');
         }).toPass(extendedAssertionOptions);
 
@@ -226,14 +229,22 @@ test.describe
         await assertStatusCode(updateRes, 204);
 
         // Regression check #2 (#54238 fixed): /jobs/search must return HTTP 200
-        // even when the EL job is in RETRIES_UPDATED state.
-        await expectJobsByType(
-          request,
-          piKey,
-          startElJobType,
-          3,
-          extendedAssertionOptions,
-        );
+        // even when the EL job is in RETRIES_UPDATED state. Assert state on the
+        // specific job to confirm it is in RETRIES_UPDATED and the search works.
+        await expect(async () => {
+          const res = await request.post(buildUrl('/jobs/search'), {
+            headers: jsonHeaders(),
+            data: {filter: {processInstanceKey: piKey, type: startElJobType}},
+          });
+          await assertStatusCode(res, 200);
+          const items = (await res.json()).items as Array<{
+            jobKey: string;
+            state: string;
+          }>;
+          const retriedJob = items.find((j) => j.jobKey === String(jobKey));
+          expect(retriedJob).toBeDefined();
+          expect(retriedJob?.state).toBe('RETRIES_UPDATED');
+        }).toPass(extendedAssertionOptions);
 
         const resolveRes = await request.post(
           buildUrl(`/incidents/${incidents[0].incidentKey}/resolution`),
@@ -242,21 +253,19 @@ test.describe
         await assertStatusCode(resolveRes, 204);
 
         // All 3 start EL jobs (1 retried + 2 fresh) are activatable after resolution.
-        await expectJobsByType(
-          request,
-          piKey,
-          startElJobType,
-          3,
-          extendedAssertionOptions,
-        );
-        const allStartJobs = await activateJobsByType(
-          request,
-          startElJobType,
-          piKey,
-          [],
-          3,
-        );
-        expect(allStartJobs).toHaveLength(3);
+        // Wrapped in toPass because activation filters client-side by PI key and
+        // may return fewer than 3 on the first call if not all jobs are activatable yet.
+        let allStartJobs: Awaited<ReturnType<typeof activateJobsByType>> = [];
+        await expect(async () => {
+          allStartJobs = await activateJobsByType(
+            request,
+            startElJobType,
+            piKey,
+            [],
+            3,
+          );
+          expect(allStartJobs).toHaveLength(3);
+        }).toPass(extendedAssertionOptions);
         for (const j of allStartJobs) {
           await completeJob(request, j.jobKey);
         }


### PR DESCRIPTION

Bug #54238 is fixed: /jobs/search no longer returns HTTP 500 for EL jobs in FAILED or RETRIES_UPDATED state (null elementId/flowNodeId was the root cause).
- Remove activate-before-search workaround and its TODO comments
- Add regression check 1: assert /jobs/search returns 200 in FAILED state and that the failed EL job's elementId is 'miTask' (not null)
- Add regression check 2: assert /jobs/search returns 200 in RETRIES_UPDATED state
- Simplify post-resolution activation to a straightforward expectJobsByType + activateJobsByType

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
