### PR TITLE
feat: add bpmnProcessId for wait states and complete authorization checks

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ElementInstanceWaitStateResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ElementInstanceWaitStateResult.java
@@ -34,6 +34,8 @@ public interface ElementInstanceWaitStateResult {
 
   String getTenantId();
 
+  String getBpmnProcessId();
+
   /**
    * Returns the wait-state-specific details, or {@code null} if absent. Resolves to {@link
    * JobWaitStateDetails} or {@link MessageWaitStateDetails}.

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
@@ -32,6 +32,7 @@ public class ElementInstanceWaitStateResultImpl implements ElementInstanceWaitSt
   private final String elementId;
   private final WaitStateElementType elementType;
   private final String tenantId;
+  private final String bpmnProcessId;
   private final WaitStateDetails details;
 
   public ElementInstanceWaitStateResultImpl(
@@ -42,6 +43,7 @@ public class ElementInstanceWaitStateResultImpl implements ElementInstanceWaitSt
     elementId = item.getElementId();
     elementType = EnumUtil.convert(item.getElementType(), WaitStateElementType.class);
     tenantId = item.getTenantId();
+    bpmnProcessId = item.getBpmnProcessId();
     details = extractDetails(item.getDetails());
   }
 
@@ -97,6 +99,11 @@ public class ElementInstanceWaitStateResultImpl implements ElementInstanceWaitSt
   @Override
   public String getTenantId() {
     return tenantId;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/elementinstancewaitstate/SearchElementInstanceWaitStatesTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstancewaitstate/SearchElementInstanceWaitStatesTest.java
@@ -180,6 +180,7 @@ public class SearchElementInstanceWaitStatesTest extends ClientRestTest {
     item.setElementInstanceKey("300");
     item.setElementId("task-1");
     item.setTenantId("<default>");
+    item.setBpmnProcessId("payment-process");
     item.setDetails(jobDetails);
 
     final ElementInstanceWaitStateQueryResult response = buildEmptyResponse();
@@ -199,6 +200,7 @@ public class SearchElementInstanceWaitStatesTest extends ClientRestTest {
     assertThat(mapped.getElementInstanceKey()).isEqualTo("300");
     assertThat(mapped.getElementId()).isEqualTo("task-1");
     assertThat(mapped.getTenantId()).isEqualTo("<default>");
+    assertThat(mapped.getBpmnProcessId()).isEqualTo("payment-process");
     assertThat(mapped.getDetails()).isInstanceOf(JobWaitStateDetails.class);
     final JobWaitStateDetails details = (JobWaitStateDetails) mapped.getDetails();
     assertThat(details.getWaitStateType()).isEqualTo(WaitStateType.JOB);

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -305,6 +305,19 @@
     </createTable>
   </changeSet>
 
+  <changeSet id="create_wait_state_process_definition_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_WAIT_STATE_PROCESS_DEFINITION_ID"
+          tableName="${prefix}WAIT_STATE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}WAIT_STATE"
+      indexName="${prefix}IDX_WAIT_STATE_PROCESS_DEFINITION_ID">
+      <column name="PROCESS_DEFINITION_ID"/>
+    </createIndex>
+  </changeSet>
+
   <changeSet id="create_wait_state_process_instance_key_index" author="camunda">
     <preConditions onFail="MARK_RAN">
       <not>

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -298,6 +298,7 @@
       <column name="ELEMENT_ID" type="NVARCHAR(${userCharColumnSize})"/>
       <column name="ELEMENT_TYPE" type="VARCHAR(50)"/>
       <column name="WAIT_STATE_TYPE" type="VARCHAR(50)"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
       <column name="DETAILS" type="CLOB"/>
       <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
       <column name="PARTITION_ID" type="NUMBER"/>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/WaitStateDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/WaitStateDbQuery.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 
 public record WaitStateDbQuery(
     ElementInstanceWaitStateFilter filter,
+    List<String> authorizedResourceIds,
     List<String> authorizedTenantIds,
     DbQuerySorting<WaitStateEntity> sort,
     DbQueryPage page) {
@@ -32,6 +33,7 @@ public record WaitStateDbQuery(
         FilterBuilders.elementInstanceWaitState().build();
 
     private ElementInstanceWaitStateFilter filter;
+    private List<String> authorizedResourceIds;
     private List<String> authorizedTenantIds;
     private DbQuerySorting<WaitStateEntity> sort;
     private DbQueryPage page;
@@ -51,6 +53,11 @@ public record WaitStateDbQuery(
       return this;
     }
 
+    public Builder authorizedResourceIds(final List<String> value) {
+      authorizedResourceIds = value;
+      return this;
+    }
+
     public Builder authorizedTenantIds(final List<String> value) {
       authorizedTenantIds = value;
       return this;
@@ -60,8 +67,9 @@ public record WaitStateDbQuery(
     public WaitStateDbQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
       sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      authorizedResourceIds = Objects.requireNonNullElse(authorizedResourceIds, List.of());
       authorizedTenantIds = Objects.requireNonNullElse(authorizedTenantIds, List.of());
-      return new WaitStateDbQuery(filter, authorizedTenantIds, sort, page);
+      return new WaitStateDbQuery(filter, authorizedResourceIds, authorizedTenantIds, sort, page);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
@@ -30,6 +30,7 @@ public class WaitStateEntityMapper {
         dbModel.elementId(),
         toFlowNodeType(dbModel.elementType()),
         dbModel.rootProcessInstanceKey(),
+        dbModel.processDefinitionId(),
         parseDetails(dbModel.waitStateType(), dbModel.details()),
         dbModel.tenantId());
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/WaitStateDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/WaitStateDbReader.java
@@ -17,6 +17,7 @@ import io.camunda.search.clients.reader.WaitStateReader;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.query.ElementInstanceWaitStateQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
@@ -45,11 +46,16 @@ public class WaitStateDbReader extends AbstractEntityReader<WaitStateEntity>
       return buildSearchQueryResult(0, List.of(), dbSort);
     }
 
+    final var authorizedResourceIds =
+        resourceAccessChecks
+            .getAuthorizedResourceIdsByType()
+            .getOrDefault(AuthorizationResourceType.PROCESS_DEFINITION.name(), List.of());
     final var dbPage = convertPaging(dbSort, query.page());
     final var dbQuery =
         WaitStateDbQuery.of(
             b ->
                 b.filter(query.filter())
+                    .authorizedResourceIds(authorizedResourceIds)
                     .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
                     .sort(dbSort)
                     .page(dbPage));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/WaitStateDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/WaitStateDbModel.java
@@ -24,6 +24,7 @@ public record WaitStateDbModel(
     String elementId,
     String elementType,
     String waitStateType,
+    String processDefinitionId,
     String details,
     String tenantId,
     Integer partitionId) {
@@ -37,6 +38,7 @@ public record WaitStateDbModel(
     private String elementId;
     private String elementType;
     private String waitStateType;
+    private String processDefinitionId;
     private String details;
     private String tenantId;
     private Integer partitionId;
@@ -76,6 +78,11 @@ public record WaitStateDbModel(
       return this;
     }
 
+    public Builder processDefinitionId(final String bpmnProcessId) {
+      processDefinitionId = bpmnProcessId;
+      return this;
+    }
+
     public Builder details(final String details) {
       this.details = details;
       return this;
@@ -101,6 +108,7 @@ public record WaitStateDbModel(
           elementId,
           elementType,
           waitStateType,
+          processDefinitionId,
           details,
           tenantId,
           partitionId);

--- a/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
@@ -19,6 +19,7 @@
       <arg column="ELEMENT_ID" javaType="java.lang.String"/>
       <arg column="ELEMENT_TYPE" javaType="java.lang.String"/>
       <arg column="WAIT_STATE_TYPE" javaType="java.lang.String"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
       <arg column="DETAILS" javaType="java.lang.String"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
       <arg column="PARTITION_ID" javaType="java.lang.Integer"/>
@@ -28,7 +29,7 @@
   <select id="findOne" parameterType="java.lang.Long"
     resultMap="io.camunda.db.rdbms.sql.WaitStateMapper.waitStateResultMap">
     SELECT WAIT_STATE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESS_INSTANCE_KEY, ELEMENT_INSTANCE_KEY,
-           ELEMENT_ID, ELEMENT_TYPE, WAIT_STATE_TYPE, DETAILS, TENANT_ID, PARTITION_ID
+           ELEMENT_ID, ELEMENT_TYPE, WAIT_STATE_TYPE, PROCESS_DEFINITION_ID, DETAILS, TENANT_ID, PARTITION_ID
     FROM ${prefix}WAIT_STATE
     WHERE WAIT_STATE_KEY = #{waitStateKey}
   </select>
@@ -54,6 +55,7 @@
       ELEMENT_ID,
       ELEMENT_TYPE,
       WAIT_STATE_TYPE,
+      PROCESS_DEFINITION_ID,
       DETAILS,
       TENANT_ID,
       PARTITION_ID
@@ -67,6 +69,12 @@
 
   <sql id="searchFilter">
     <where>
+      <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
+        AND PROCESS_DEFINITION_ID IN
+        <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator="," close=")">
+          #{resourceId}
+        </foreach>
+      </if>
       <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
         AND TENANT_ID IN
         <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
@@ -115,18 +123,19 @@
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.WaitStateDbModel">
     INSERT INTO ${prefix}WAIT_STATE (WAIT_STATE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESS_INSTANCE_KEY,
                                      ELEMENT_INSTANCE_KEY, ELEMENT_ID, ELEMENT_TYPE, WAIT_STATE_TYPE,
-                                     DETAILS, TENANT_ID, PARTITION_ID)
+                                     PROCESS_DEFINITION_ID, DETAILS, TENANT_ID, PARTITION_ID)
     VALUES (#{waitStateKey}, #{rootProcessInstanceKey}, #{processInstanceKey},
             #{elementInstanceKey}, #{elementId}, #{elementType}, #{waitStateType},
-            #{details, jdbcType=CLOB}, #{tenantId}, #{partitionId})
+            #{processDefinitionId}, #{details, jdbcType=CLOB}, #{tenantId}, #{partitionId})
   </insert>
 
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.WaitStateDbModel">
     UPDATE ${prefix}WAIT_STATE
-    SET ELEMENT_INSTANCE_KEY = #{elementInstanceKey},
-        ELEMENT_ID           = #{elementId},
-        ELEMENT_TYPE         = #{elementType},
-        DETAILS              = #{details, jdbcType=CLOB}
+    SET ELEMENT_INSTANCE_KEY  = #{elementInstanceKey},
+        ELEMENT_ID            = #{elementId},
+        ELEMENT_TYPE          = #{elementType},
+        PROCESS_DEFINITION_ID = #{processDefinitionId},
+        DETAILS               = #{details, jdbcType=CLOB}
     WHERE WAIT_STATE_KEY = #{waitStateKey}
   </update>
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -675,7 +675,8 @@ public final class SearchQueryResponseMapper {
             .elementId(item.elementId())
             .elementType(elementType)
             .tenantId(item.tenantId())
-            .rootProcessInstanceKey(rootKey);
+            .rootProcessInstanceKey(rootKey)
+            .bpmnProcessId(item.bpmnProcessId());
     return switch (item.details()) {
       case WaitStateJobDetails(
               final var jobKey,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/WaitStateAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/WaitStateAuthorizationsIT.java
@@ -31,7 +31,6 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -137,8 +136,6 @@ public class WaitStateAuthorizationsIT {
     assertThat(result.items().getFirst().getElementId()).isEqualTo("task");
   }
 
-  @Disabled(
-      "Wait-state search authorization not yet enforced — see https://github.com/camunda/camunda/issues/54604")
   @Test
   void shouldDenyUserAuthorizedForOtherProcess(
       @Authenticated(OTHER_PROCESS_USER) final CamundaClient client) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
@@ -34,6 +34,7 @@ public class WaitStateEntityTransformer
         value.getElementId(),
         toFlowNodeType(value.getElementType()),
         value.getRootProcessInstanceKey(),
+        value.getBpmnProcessId(),
         parseDetails(value.getWaitStateType(), value.getDetails()),
         value.getTenantId());
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/WaitStateFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/WaitStateFilterTransformer.java
@@ -9,8 +9,9 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
-import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.webapps.schema.descriptors.template.WaitStateTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.WaitStateTemplate.ELEMENT_ID;
 import static io.camunda.webapps.schema.descriptors.template.WaitStateTemplate.ELEMENT_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.template.WaitStateTemplate.ELEMENT_TYPE;
@@ -35,7 +36,7 @@ public class WaitStateFilterTransformer
   @Override
   protected SearchQuery toAuthorizationCheckSearchQuery(
       final RequiredAuthorization<?> authorization) {
-    return matchAll();
+    return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateEntity.java
@@ -20,6 +20,7 @@ public record WaitStateEntity(
     String elementId,
     FlowNodeType elementType,
     @Nullable Long rootProcessInstanceKey,
+    String bpmnProcessId,
     WaitStateDetails details,
     String tenantId) {
 
@@ -28,6 +29,7 @@ public record WaitStateEntity(
     Objects.requireNonNull(elementInstanceKey, "elementInstanceKey");
     Objects.requireNonNull(elementId, "elementId");
     Objects.requireNonNull(elementType, "elementType");
+    Objects.requireNonNull(bpmnProcessId, "bpmnProcessId");
     Objects.requireNonNull(tenantId, "tenantId");
     Objects.requireNonNull(details, "details");
   }
@@ -38,6 +40,7 @@ public record WaitStateEntity(
     private @Nullable String elementId;
     private @Nullable FlowNodeType elementType;
     private @Nullable Long rootProcessInstanceKey;
+    private @Nullable String bpmnProcessId;
     private @Nullable WaitStateDetails details;
     private @Nullable String tenantId;
 
@@ -66,6 +69,11 @@ public record WaitStateEntity(
       return this;
     }
 
+    public Builder bpmnProcessId(final String bpmnProcessId) {
+      this.bpmnProcessId = bpmnProcessId;
+      return this;
+    }
+
     public Builder details(final WaitStateDetails details) {
       this.details = details;
       return this;
@@ -83,7 +91,8 @@ public record WaitStateEntity(
           Objects.requireNonNull(elementInstanceKey, "elementInstanceKey"),
           Objects.requireNonNull(elementId, "elementId"),
           Objects.requireNonNull(elementType, "elementType"),
-          Objects.requireNonNull(rootProcessInstanceKey, "rootProcessInstanceKey"),
+          rootProcessInstanceKey,
+          Objects.requireNonNull(bpmnProcessId, "bpmnProcessId"),
           Objects.requireNonNull(details, "details"),
           Objects.requireNonNull(tenantId, "tenantId"));
     }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/WaitStateTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/WaitStateTemplate.java
@@ -25,6 +25,7 @@ public class WaitStateTemplate extends AbstractTemplateDescriptor
   public static final String ELEMENT_INSTANCE_KEY = "elementInstanceKey";
   public static final String ELEMENT_ID = "elementId";
   public static final String ELEMENT_TYPE = "elementType";
+  public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String WAIT_STATE_TYPE = "waitStateType";
   public static final String DETAILS = "details";
   public static final String TENANT_ID = "tenantId";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/waitstate/WaitStateEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/waitstate/WaitStateEntity.java
@@ -29,6 +29,9 @@ public class WaitStateEntity extends AbstractExporterEntity<WaitStateEntity> {
   private String elementType;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String bpmnProcessId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
   private String waitStateType;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
@@ -82,6 +85,15 @@ public class WaitStateEntity extends AbstractExporterEntity<WaitStateEntity> {
 
   public WaitStateEntity setElementType(final String elementType) {
     this.elementType = elementType;
+    return this;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public WaitStateEntity setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-wait-state.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-wait-state.json
@@ -20,6 +20,9 @@
       "elementType": {
         "type": "keyword"
       },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
       "waitStateType": {
         "type": "keyword"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-wait-state.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-wait-state.json
@@ -20,6 +20,9 @@
       "elementType": {
         "type": "keyword"
       },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
       "waitStateType": {
         "type": "keyword"
       },

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntry.java
@@ -32,6 +32,7 @@ public class WaitStateEntry {
   private String elementId;
   private BpmnElementType elementType;
   private WaitStateType waitStateType;
+  private String bpmnProcessId;
   private WaitStateDetails details;
   private String tenantId;
   private long partitionId;
@@ -90,6 +91,15 @@ public class WaitStateEntry {
     return this;
   }
 
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public WaitStateEntry setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+    return this;
+  }
+
   public WaitStateDetails getDetails() {
     return details;
   }
@@ -134,6 +144,7 @@ public class WaitStateEntry {
         .setProcessInstanceKey(value.getProcessInstanceKey())
         .setElementInstanceKey(value.getElementInstanceKey())
         .setElementId(value.getElementId())
+        .setBpmnProcessId(value.getBpmnProcessId())
         .setTenantId(value.getTenantId())
         .setPartitionId(record.getPartitionId());
   }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntryTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntryTest.java
@@ -40,6 +40,7 @@ class WaitStateEntryTest {
             .setElementId("task-1")
             .setElementType(BpmnElementType.SERVICE_TASK)
             .setWaitStateType(WaitStateType.JOB)
+            .setBpmnProcessId("myProcess")
             .setDetails(details)
             .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             .setPartitionId(1L);
@@ -51,6 +52,7 @@ class WaitStateEntryTest {
     assertThat(entry.getElementId()).isEqualTo("task-1");
     assertThat(entry.getElementType()).isEqualTo(BpmnElementType.SERVICE_TASK);
     assertThat(entry.getWaitStateType()).isEqualTo(WaitStateType.JOB);
+    assertThat(entry.getBpmnProcessId()).isEqualTo("myProcess");
     assertThat(entry.getDetails()).isEqualTo(details);
     assertThat(entry.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     assertThat(entry.getPartitionId()).isEqualTo(1L);
@@ -103,6 +105,7 @@ class WaitStateEntryTest {
     assertThat(entry.getProcessInstanceKey()).isEqualTo(200L);
     assertThat(entry.getElementInstanceKey()).isEqualTo(300L);
     assertThat(entry.getElementId()).isEqualTo("task-1");
+    assertThat(entry.getBpmnProcessId()).isEqualTo(value.getBpmnProcessId());
     assertThat(entry.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     assertThat(entry.getPartitionId()).isEqualTo(record.getPartitionId());
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateAddHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateAddHandler.java
@@ -85,6 +85,7 @@ public class WaitStateAddHandler<R extends RecordValue & WaitStateRelated>
         .setElementId(entry.getElementId())
         .setElementType(entry.getElementType() != null ? entry.getElementType().name() : null)
         .setWaitStateType(entry.getWaitStateType() != null ? entry.getWaitStateType().name() : null)
+        .setBpmnProcessId(entry.getBpmnProcessId())
         .setDetails(serializeDetails(entry.getDetails()))
         .setTenantId(entry.getTenantId())
         .setPartitionId(entry.getPartitionId());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
@@ -117,6 +117,7 @@ class JobWaitStateHandlerTest {
             .withElementInstanceKey(300L)
             .withProcessInstanceKey(200L)
             .withRootProcessInstanceKey(100L)
+            .withBpmnProcessId("payment-process")
             .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             .build();
     final var record =
@@ -140,6 +141,7 @@ class JobWaitStateHandlerTest {
     assertThat(entity.getElementId()).isEqualTo("task-payment");
     assertThat(entity.getElementType()).isEqualTo(BpmnElementType.SERVICE_TASK.name());
     assertThat(entity.getWaitStateType()).isEqualTo(WaitStateType.JOB.name());
+    assertThat(entity.getBpmnProcessId()).isEqualTo("payment-process");
     assertThat(entity.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then — details serialised as JSON with all fields

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandler.java
@@ -76,6 +76,7 @@ public class WaitStateAddHandler<R extends RecordValue & WaitStateRelated>
         .elementId(entry.getElementId())
         .elementType(entry.getElementType() != null ? entry.getElementType().name() : null)
         .waitStateType(entry.getWaitStateType() != null ? entry.getWaitStateType().name() : null)
+        .processDefinitionId(entry.getBpmnProcessId())
         .details(serializeDetails(entry.getDetails()))
         .tenantId(entry.getTenantId())
         .partitionId(record.getPartitionId())

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandlerTest.java
@@ -137,6 +137,7 @@ class WaitStateAddHandlerTest {
             .withElementInstanceKey(300L)
             .withProcessInstanceKey(200L)
             .withRootProcessInstanceKey(100L)
+            .withBpmnProcessId("payment-process")
             .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             .build();
     final Record<JobRecordValue> record =
@@ -161,6 +162,7 @@ class WaitStateAddHandlerTest {
     assertThat(model.elementId()).isEqualTo("task-payment");
     assertThat(model.elementType()).isEqualTo(BpmnElementType.SERVICE_TASK.name());
     assertThat(model.waitStateType()).isEqualTo(WaitStateType.JOB.name());
+    assertThat(model.processDefinitionId()).isEqualTo("payment-process");
     assertThat(model.tenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     assertThat(model.partitionId()).isEqualTo(record.getPartitionId());
     assertThat(model.details())

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -802,6 +802,7 @@ components:
         - elementType
         - tenantId
         - rootProcessInstanceKey
+        - bpmnProcessId
         - details
       properties:
         rootProcessInstanceKey:
@@ -829,6 +830,9 @@ components:
           description: The tenant ID of the element instance.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+        bpmnProcessId:
+          description: The BPMN process ID of the process definition associated to this element instance.
+          type: string
         details:
           description: Wait-state-specific details, resolved by waitStateType.
           allOf:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
@@ -98,6 +98,7 @@ public class ElementInstanceControllerTest extends RestControllerTest {
   private static final SearchQueryResult<WaitStateEntity> DUMMY_WAIT_STATE_ITEMS =
       SearchQueryResult.of(
           new WaitStateEntity.Builder()
+              .bpmnProcessId("order-process")
               .processInstanceKey(2251799813685249L)
               .elementInstanceKey(2251799813685251L)
               .elementId("payment-task")
@@ -113,6 +114,7 @@ public class ElementInstanceControllerTest extends RestControllerTest {
                       .build())
               .build(),
           new WaitStateEntity.Builder()
+              .bpmnProcessId("order-process")
               .processInstanceKey(2251799813685249L)
               .elementInstanceKey(2251799813685253L)
               .elementId("order-received")
@@ -126,6 +128,7 @@ public class ElementInstanceControllerTest extends RestControllerTest {
                       .build())
               .build(),
           new WaitStateEntity.Builder()
+              .bpmnProcessId("order-process")
               .processInstanceKey(2251799813685249L)
               .elementInstanceKey(2251799813685261L)
               .elementId("notify-task")

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/WaitStateRelated.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/WaitStateRelated.java
@@ -39,6 +39,11 @@ public interface WaitStateRelated {
   String getElementId();
 
   /**
+   * @return the BPMN process id of the process that contains this waiting element
+   */
+  String getBpmnProcessId();
+
+  /**
    * @return the tenant id that owns this waiting-state element
    */
   String getTenantId();


### PR DESCRIPTION
## Description

- Store bpmnProcessId in the RDBMS WAIT_STATE table (new column in the 8.10.0 changeset) and in the ES/OS index mapping, propagated from WaitStateRelated → WaitStateEntry → both exporters
- Add getBpmnProcessId() to the WaitStateRelated protocol interface so all future wait-state record types carry the field
- Enforce process-definition-scoped authorization on wait-state search: ES/OS filters by bpmnProcessId IN (resourceIds), RDBMS applies the same BPMN_PROCESS_ID IN (...) SQL filter — previously both backends returned all results regardless of authorization
- Enable WaitStateAuthorizationsIT.shouldDenyUserAuthorizedForOtherProcess, which was @Disabled pending this fix
- Expose bpmnProcessId in the REST response (ElementInstanceWaitStateResult schema) and Java client API (ElementInstanceWaitStateResult.getBpmnProcessId())

## Related issues

closes #54604
