### PR TITLE
ci: change created branch name

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -152,7 +152,7 @@ jobs:
         run: |
           set -euo pipefail
           stamp="$(date -u +%Y%m%d-%H%M%S)"
-          branch="test/regenerate-responses-${SAFE}-${stamp}-${GITHUB_RUN_ID}"
+          branch="regenerate-responses-${SAFE}-${stamp}-${GITHUB_RUN_ID}"
           echo "branch=${branch}" >> "$GITHUB_OUTPUT"
 
           git checkout -b "$branch"


### PR DESCRIPTION
## Description

This PR changes branch name that is created in the response schema regeneration workflow (example [fail run here](https://github.com/camunda/camunda/actions/runs/27282040851/job/80578919470))


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

