### PR TITLE
fix: clear stale list-view incident flag on same-batch create+resolve

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -319,6 +319,12 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final AdditionalData data, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
     final var bulkUpdate = new IncidentBulkUpdate();
     return mapActiveIncidentsToAffectedInstances(data)
+        .thenApplyAsync(
+            ignored -> {
+              seedResolvedIncidentsAsActive(data, batch);
+              return null;
+            },
+            executor)
         .thenComposeAsync(
             ignored ->
                 // processIncident one at a time, stopping if an error is raised
@@ -332,6 +338,29 @@ public final class IncidentUpdateTask implements BackgroundTask {
             updatedIds ->
                 notifyIncidents(updatedIds, bulkUpdate.incidentRequests(), data.incidents()))
         .join();
+  }
+
+  private void seedResolvedIncidentsAsActive(
+      final AdditionalData data, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
+    for (final var incident : data.incidents().values()) {
+      final var newState = batch.newIncidentStates().get(incident.incident().getKey());
+      if (newState != IncidentState.RESOLVED) {
+        continue;
+      }
+
+      final var treePath = data.incidentTreePaths().get(incident.id());
+      if (treePath == null) {
+        continue;
+      }
+
+      final var parsedTreePath = new TreePath(treePath);
+      parsedTreePath
+          .extractProcessInstanceIds()
+          .forEach(id -> data.addPiIdsWithIncidentIds(id, incident.id()));
+      parsedTreePath
+          .extractFlowNodeInstanceIds()
+          .forEach(id -> data.addFniIdsWithIncidentIds(id, incident.id()));
+    }
   }
 
   private CompletableFuture<Void> processIncidentInBatch(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
@@ -623,7 +623,6 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
         });
   }
 
-  @TestTemplate
   void shouldResolveIncidentButNotUnsetFlagsWhenOtherIncidentsStillActive(
       final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
     withTask(
@@ -751,6 +750,95 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           assertThat(updatedActiveIncident.getState()).isEqualTo(IncidentState.ACTIVE);
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
+        });
+  }
+
+  // regression test for https://github.com/camunda/camunda/issues/54279
+  @TestTemplate
+  void shouldClearStaleIncidentFlagWhenCreatedAndResolvedInSameBatch(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withTask(
+        config,
+        (job, resources) -> {
+          final var listViewTemplate = resources.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final var incidentTemplate = resources.getIndexTemplateDescriptor(IncidentTemplate.class);
+          final var postImporterTemplate =
+              resources.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+
+          // the incident document is still PENDING: the CREATED update will be dropped because
+          // RESOLVED is present in the same batch, so it never transitions to ACTIVE
+          final var key = ID_GENERATOR.getAndIncrement();
+          final IncidentEntity incidentEntity =
+              new IncidentEntity()
+                  .setId(String.valueOf(key))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(key)
+                  .setState(IncidentState.PENDING)
+                  .setErrorMessage("An error happened")
+                  .setProcessInstanceKey(key)
+                  .setFlowNodeInstanceKey(key)
+                  .setFlowNodeId(String.valueOf(key));
+          store(incidentTemplate, client, incidentEntity);
+          client.refresh(incidentTemplate.getFullQualifiedName());
+
+          // the process instance is already displaying an incident (incident=true) in the list
+          // view
+          final ProcessInstanceForListViewEntity processInstance =
+              new ProcessInstanceForListViewEntity()
+                  .setId(String.valueOf(key))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(key)
+                  .setProcessDefinitionKey(9999L)
+                  .setBpmnProcessId("process-1")
+                  .setTreePath("PI_" + key)
+                  .setIncident(true);
+          store(listViewTemplate, client, processInstance);
+          client.refresh(listViewTemplate.getFullQualifiedName());
+
+          // a CREATED + RESOLVED pair for the same incident in the same post-importer-queue batch
+          store(
+              postImporterTemplate,
+              client,
+              new PostImporterQueueEntity()
+                  .setId("queue-1")
+                  .setPartitionId(PARTITION_ID)
+                  .setActionType(PostImporterActionType.INCIDENT)
+                  .setIntent("CREATED")
+                  .setKey(key)
+                  .setProcessInstanceKey(key)
+                  .setPosition(1L));
+          store(
+              postImporterTemplate,
+              client,
+              new PostImporterQueueEntity()
+                  .setId("queue-2")
+                  .setPartitionId(PARTITION_ID)
+                  .setActionType(PostImporterActionType.INCIDENT)
+                  .setIntent("RESOLVED")
+                  .setKey(key)
+                  .setProcessInstanceKey(key)
+                  .setPosition(2L));
+          client.refresh(postImporterTemplate.getFullQualifiedName());
+
+          // when
+          final var updated = job.execute();
+
+          // then - the task advances the position unconditionally past the whole batch
+          assertThat(updated).succeedsWithin(EXECUTE_TIMEOUT);
+          assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(2L);
+
+          client.refresh(testPrefix);
+
+          // the incident document is updated to RESOLVED
+          final var updatedIncident = getFromIndex(incidentTemplate, client, incidentEntity);
+          assertThat(updatedIncident.getState()).isEqualTo(IncidentState.RESOLVED);
+
+          // the list-view process instance must no longer be marked as having an incident,
+          // otherwise operate-list-view-* stays permanently inconsistent with the now-RESOLVED
+          // incident document
+          final var updatedProcessInstance =
+              getFromIndex(listViewTemplate, client, processInstance);
+          assertThat(updatedProcessInstance.isIncident()).isFalse();
         });
   }
 


### PR DESCRIPTION
## Summary

`IncidentUpdateTask` could leave a process instance flagged `incident=true` in `operate-list-view-*` after its incident was already resolved in `operate-incident-*`, leaving the two indices permanently inconsistent (e.g. canceled instances still shown as having incidents).

Closes #54279

## Root cause

The list-view `incident` flag is derived from a per-run reference-count set that is seeded only from incidents in state `ACTIVE`. When a `CREATED` and `RESOLVED` for the same incident land in the same post-importer-queue batch, `createPendingIncidentBatch` collapses them to just `RESOLVED`, so the incident document jumps `PENDING → RESOLVED` and never becomes `ACTIVE`. The seed then misses it, the `RESOLVED` removal is a no-op (`changedState=false`), no list-view update is queued, and the cursor advances past the batch — leaving `incident=true` stale forever.

## Fix

Seed every incident **resolved within the current batch** into the active-incident set before applying the resolution, reconstructing the `ACTIVE` state the collapse dropped. The engine guarantees a `CREATED` always precedes a `RESOLVED` (`IncidentResolveProcessor` rejects resolves for unknown incidents), so a resolved incident was active at some point. The subsequent removal then performs a real 1→0 transition and clears the flag.

Seeding an already-active incident is a harmless no-op, so the multi-incident invariant is preserved: if another incident on the same instance is still active, the set stays non-empty and `incident=true` is correctly kept.
