### PR TITLE
ci: showcase shared operators on camunda-benchmark

### DIFF
--- a/.github/config/shared-operators-benchmark/cnpg.yaml
+++ b/.github/config/shared-operators-benchmark/cnpg.yaml
@@ -1,0 +1,16 @@
+# CloudNativePG Cluster CR for the shared-operators showcase on camunda-benchmark.
+# Proves the cluster-wide CNPG operator reconciles a team-owned Postgres cluster
+# in a c8-* namespace. The image is pulled through the benchmark GAR cache for
+# ghcr.io. See infra-core docs/shared-operators.md.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: c8-shared-operators-test
+  namespace: c8-shared-operators-test
+  annotations:
+    janitor/ttl: 1h # backstop: the workflow trap-deletes on exit; this catches leaked runs
+spec:
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:17
+  storage:
+    size: 1Gi

--- a/.github/config/shared-operators-benchmark/elasticsearch.yaml
+++ b/.github/config/shared-operators-benchmark/elasticsearch.yaml
@@ -1,0 +1,37 @@
+# Elasticsearch CR for the shared-operators showcase on camunda-benchmark.
+# Proves the cluster-wide ECK operator reconciles a team-owned Elasticsearch in
+# a c8-* namespace. No image pin is needed: the benchmark ECK operator runs with
+# --container-registry=europe-west1-docker.pkg.dev/camunda-benchmark/docker-elastic-co,
+# so it rewrites the node image to the GAR pull-through cache automatically.
+# Only spec.version is set. See infra-core docs/shared-operators.md.
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: c8-shared-operators-test
+  namespace: c8-shared-operators-test
+  annotations:
+    janitor/ttl: 1h # backstop: the workflow trap-deletes on exit; this catches leaked runs
+spec:
+  version: 8.17.3
+  nodeSets:
+    - name: default
+      count: 1
+      config:
+        node.store.allow_mmap: false
+      podTemplate:
+        spec:
+          containers:
+            - name: elasticsearch
+              resources:
+                requests:
+                  cpu: 500m
+                  memory: 2Gi
+      volumeClaimTemplates:
+        - metadata:
+            name: elasticsearch-data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi

--- a/.github/config/shared-operators-benchmark/keycloak.yaml
+++ b/.github/config/shared-operators-benchmark/keycloak.yaml
@@ -1,0 +1,33 @@
+# Keycloak CR for the shared-operators showcase on camunda-benchmark.
+# Unlike Elasticsearch and CNPG (which teams self-serve in their own c8-* namespaces),
+# the Keycloak operator only watches the shared `keycloak-operator` namespace, so this
+# CR is created there with a unique, namespace-prefixed name to avoid collisions.
+# The database below is a throwaway placeholder -- the showcase only verifies that the
+# operator reconciles this CR into a StatefulSet, it never serves traffic.
+# The image is pulled through the benchmark GAR cache for quay.io.
+# See infra-core docs/shared-operators.md.
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: c8-shared-operators-test-kc
+  namespace: keycloak-operator
+  annotations:
+    janitor/ttl: 1h # backstop: the workflow trap-deletes on exit; this catches leaked runs
+spec:
+  instances: 1
+  image: europe-west1-docker.pkg.dev/camunda-benchmark/quayio/keycloak/keycloak:26.2.5
+  http:
+    httpEnabled: true
+  hostname:
+    strict: false
+    hostname: c8-shared-operators-test-kc.benchmark.camunda.cloud
+  db:
+    vendor: postgres
+    host: c8-shared-operators-test-kc-db
+    database: keycloak
+    usernameSecret:
+      name: c8-shared-operators-test-kc-db-credentials
+      key: username
+    passwordSecret:
+      name: c8-shared-operators-test-kc-db-credentials
+      key: password

--- a/.github/workflows/validate-shared-operators-benchmark.yml
+++ b/.github/workflows/validate-shared-operators-benchmark.yml
@@ -1,0 +1,135 @@
+# description: Showcase / validation that the cluster-wide shared operators (ECK,
+#              CloudNativePG, Keycloak) on camunda-benchmark-prod reconcile team-owned
+#              CRs created via the GitHub Actions Teleport bot. Spins up an Elasticsearch
+#              and a Postgres cluster in a throwaway c8-* namespace plus a Keycloak in the
+#              shared keycloak-operator namespace, waits for them to become healthy, then
+#              cleans everything up.
+# test location: .github/config/shared-operators-benchmark/
+# type: CI
+# owner: camunda/infrastructure
+name: validate-shared-operators-benchmark.yml
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
+  NAMESPACE: c8-shared-operators-test
+  KEYCLOAK_NAME: c8-shared-operators-test-kc
+  KEYCLOAK_NS: keycloak-operator
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+permissions: {}
+
+jobs:
+  validate-shared-operators:
+    name: Validate shared operators (benchmark)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Teleport
+        uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
+        with:
+          proxy: camunda.teleport.sh:443
+          version: auto
+
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@0f46164469ae4fcd4d359d40e06bab17d4be17c9 # v2.0.6
+        with:
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
+
+      - name: Create test namespace
+        run: |
+          kubectl create namespace "${NAMESPACE}"
+          # janitor TTL is best-effort on benchmark (annotation-only); the cleanup
+          # step below is the real backstop.
+          kubectl annotate namespace "${NAMESPACE}" janitor/ttl=1h --overwrite
+
+      - name: Wait for replicated editor RoleBinding
+        run: |
+          # The replicator-tool copies the base kube-editor-binding into every c8-* namespace
+          # as `zeebe-kube-editor-binding`. Without it the bot cannot create CRs here.
+          for i in $(seq 1 24); do
+            if kubectl get rolebinding zeebe-kube-editor-binding -n "${NAMESPACE}" >/dev/null 2>&1; then
+              echo "RoleBinding replicated."
+              exit 0
+            fi
+            echo "Waiting for zeebe-kube-editor-binding in ${NAMESPACE} (attempt ${i}/24)..."
+            sleep 5
+          done
+          echo "::error::zeebe-kube-editor-binding was not replicated into ${NAMESPACE} in time."
+          exit 1
+
+      - name: Apply Elasticsearch and CNPG CRs
+        run: |
+          kubectl apply -f .github/config/shared-operators-benchmark/elasticsearch.yaml
+          kubectl apply -f .github/config/shared-operators-benchmark/cnpg.yaml
+
+      - name: Create placeholder Keycloak DB secret
+        run: |
+          # The Keycloak CR references a DB that never actually serves traffic; the
+          # showcase only checks that the operator reconciles the CR into a StatefulSet.
+          kubectl create secret generic "${KEYCLOAK_NAME}-db-credentials" \
+            -n "${KEYCLOAK_NS}" \
+            --from-literal=username=placeholder \
+            --from-literal=password=placeholder
+
+      - name: Apply Keycloak CR
+        run: kubectl apply -f .github/config/shared-operators-benchmark/keycloak.yaml
+
+      - name: Wait for Elasticsearch to be green
+        run: |
+          kubectl wait --for=jsonpath='{.status.health}'=green \
+            elasticsearch/c8-shared-operators-test \
+            -n "${NAMESPACE}" --timeout=600s
+
+      - name: Wait for CNPG cluster to be ready
+        run: |
+          kubectl wait --for=condition=Ready \
+            cluster.postgresql.cnpg.io/c8-shared-operators-test \
+            -n "${NAMESPACE}" --timeout=600s
+
+      - name: Wait for Keycloak StatefulSet to be created
+        run: |
+          for i in $(seq 1 60); do
+            if kubectl get statefulset "${KEYCLOAK_NAME}" -n "${KEYCLOAK_NS}" >/dev/null 2>&1; then
+              echo "Keycloak StatefulSet created."
+              exit 0
+            fi
+            echo "Waiting for Keycloak StatefulSet ${KEYCLOAK_NAME} (attempt ${i}/60)..."
+            sleep 5
+          done
+          echo "::error::Keycloak StatefulSet ${KEYCLOAK_NAME} was not created in time."
+          exit 1
+
+      - name: Clean up
+        if: always()
+        run: |
+          kubectl delete namespace "${NAMESPACE}" --ignore-not-found --wait=false
+          kubectl delete keycloak "${KEYCLOAK_NAME}" -n "${KEYCLOAK_NS}" --ignore-not-found
+          kubectl delete secret "${KEYCLOAK_NAME}-db-credentials" -n "${KEYCLOAK_NS}" --ignore-not-found
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

**One-off showcase — do not merge.** This draft validates that the cluster-wide shared operators on `camunda-benchmark-prod` reconcile team-owned CRs created via the GitHub Actions Teleport bot. Once the workflow run is green, the PR will be closed and the branch deleted.

It mirrors the EKS showcase from [`c8-cross-component-sm-testing#769`](https://github.com/camunda/c8-cross-component-sm-testing/pull/769), targeting benchmark (GKE/GAR) instead of ci-eks (ECR).

The workflow (`validate-shared-operators-benchmark.yml`) runs on `pull_request` + `workflow_dispatch` so it executes immediately, and:

1. Authenticates to `camunda-benchmark-prod` via Teleport as the `infra-benchmark-prod-github-action-zeebe` bot.
2. Creates a throwaway `c8-shared-operators-test` namespace and waits for the replicated `zeebe-kube-editor-binding`.
3. Applies an **Elasticsearch** (ECK) and a **Postgres** (CloudNativePG) CR in that namespace, plus a **Keycloak** CR in the shared `keycloak-operator` namespace.
4. Waits for ES `health=green`, the CNPG cluster `Ready`, and the Keycloak StatefulSet to be created.
5. Cleans everything up in an `if: always()` step.

### Benchmark-specific details

- **ECK:** no per-CR image pin — the benchmark ECK operator runs with `--container-registry=…/camunda-benchmark/docker-elastic-co`, so only `spec.version` is set; node images are rewritten to the GAR cache automatically.
- **CNPG:** `imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:17`
- **Keycloak:** `image: europe-west1-docker.pkg.dev/camunda-benchmark/quayio/keycloak/keycloak:26.2.5`
- **kube-janitor** on benchmark is annotation-only (no default-TTL rules), so the explicit cleanup step is the real backstop; `janitor/ttl: 1h` is a best-effort safety net.

### Dependency

The Keycloak portion relies on the benchmark zeebe CI bot being allow-listed for the shared `keycloak-operator` namespace in Teleport (on par with human editor access). That was added in [infra-core#13115](https://github.com/camunda/infra-core/pull/13115), which is merged and synced on benchmark-prod.

## Related issues

Showcase for the benchmark shared-operators rollout.
* camunda/team-infrastructure#1007
