### PR TITLE
ci: submit job-level owner to CI Analytics for push and schedule workflows

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -121,6 +121,7 @@ mwnw*                       @camunda/monorepo-devops-team
 /.github/workflows/camunda8-getting-started-bundle.yaml @camunda/camundaex
 /.github/workflows/camunda-client-compatibility-test* @camunda/camundaex
 /.github/workflows/camunda-process-test-compatibility* @camunda/camundaex
+/.github/workflows/camunda-spring-boot-starter-compatibility-test* @camunda/camundaex
 
 
 ################################
@@ -305,6 +306,7 @@ optimize.Dockerfile         @camunda/core-features
 /.github/workflows/c8-orchestration-cluster-*.yml @camunda/core-features
 /.github/workflows/gh-inherit-core-fields.yml @camunda/core-features
 /.github/workflows/publish-zod-schemas.yml @camunda/core-features
+/.github/workflows/verify-x-added-in-version-annotations.yml @camunda/core-features
 
 ################################
 ## @camunda/reliability-testing
@@ -373,6 +375,7 @@ optimize.Dockerfile         @camunda/core-features
 /.github/actions/rdbms/* @camunda/data-layer
 /.github/actions/setup-aws-opensearch-env/* @camunda/data-layer
 /.github/workflows/ci-database-integration-tests-reusable.yml @camunda/data-layer
+/.github/workflows/data-layer-nightly-tests.yml @camunda/data-layer
 /.github/workflows/operate-test-backup-restore.yml @camunda/data-layer
 /.github/workflows/operate-test-importer.yml @camunda/data-layer
 
@@ -389,3 +392,12 @@ optimize.Dockerfile         @camunda/core-features
 /.github/workflows/c8run*            @camunda/distribution
 /.github/workflows/docker-build-helm-integration.yml @camunda/distribution
 /.github/workflows/trigger-c8run-e2e-tests.yml @camunda/distribution
+
+################################
+## Late overrides
+################################
+
+# Codeowners is last-match-wins. Add specific overrides here when a broader
+# earlier rule (e.g. `/.github/workflows/zeebe*`) needs to be reverted to a
+# different team for a particular file.
+/.github/workflows/zeebe-release-stable-dry-run.yml @camunda/monorepo-devops-team

--- a/.codeowners
+++ b/.codeowners
@@ -400,4 +400,7 @@ optimize.Dockerfile         @camunda/core-features
 # Codeowners is last-match-wins. Add specific overrides here when a broader
 # earlier rule (e.g. `/.github/workflows/zeebe*`) needs to be reverted to a
 # different team for a particular file.
+/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml @camunda/qa-engineering
+/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml @camunda/camundaex
+/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml @camunda/qa-engineering
 /.github/workflows/zeebe-release-stable-dry-run.yml @camunda/monorepo-devops-team

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status.'
     required: false
   user_description:
-    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status.'
+    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status. When empty, falls back to the TEST_OWNER environment variable.'
     required: false
   job_name:
     description: 'Optional string, the job whose status is being observed; defaults to $GITHUB_JOB when omitted'
@@ -102,5 +102,5 @@ runs:
         build_status: "${{ inputs.build_status }}"
         build_duration_millis: "${{ steps.get-build-duration-millis.outputs.result }}"
         user_reason: "${{ inputs.user_reason }}"
-        user_description: "${{ inputs.user_description }}"
+        user_description: "${{ inputs.user_description != '' && inputs.user_description || env.TEST_OWNER }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"

--- a/.github/workflows/add-release-comments-to-issues.yml
+++ b/.github/workflows/add-release-comments-to-issues.yml
@@ -42,6 +42,7 @@ on:
         default: false
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 permissions: {}
@@ -57,7 +58,6 @@ jobs:
       run:
         shell: bash
     env:
-      TEST_OWNER: Engineering Operations
       TEST_PRODUCT: Orchestration Cluster
       TEST_TYPE: CI Helper
     steps:

--- a/.github/workflows/assign-urgency-to-issues-cron.yml
+++ b/.github/workflows/assign-urgency-to-issues-cron.yml
@@ -13,6 +13,9 @@ on:
     - cron: '0 * * * *' # every hour
   workflow_dispatch: {}
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   assign-urgency-batch:
     runs-on: ubuntu-latest

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -49,6 +49,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -50,7 +50,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/core-features'
+  TEST_OWNER: '@camunda/qa-engineering'
 
 jobs:
   triage:

--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -3,7 +3,7 @@
 # to ensure forward compatibility of REST endpoints across versions.
 # Scheduled nightly and supports manual dispatch for custom branch combinations.
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/camundaex
 ---
 name: C8 REST API Forward Compatibility Tests
 

--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -28,6 +28,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   prepare-matrix:
     name: Prepare Version Matrix

--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -29,7 +29,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/core-features'
+  TEST_OWNER: '@camunda/camundaex'
 
 jobs:
   prepare-matrix:

--- a/.github/workflows/c8-orchestration-cluster-nightly-metrics-report.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-metrics-report.yml
@@ -19,6 +19,9 @@ permissions:
   actions: read
   contents: read
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   nightly-metrics-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  TEST_OWNER: '@camunda/core-features'
+  TEST_OWNER: '@camunda/qa-engineering'
 
 jobs:
   request-validation-tests:
@@ -66,7 +66,7 @@ jobs:
             tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo "Failed")
             operate_status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
             identity_status=$(curl -s -m 5 http://localhost:8080/identity || echo "Failed")
-            
+
             if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" && "$identity_status" != "Failed" ]]; then
               echo "Services are ready!"
               ready=true

--- a/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   request-validation-tests:
     name: V2 Stateless Tests (${{ matrix.branch }})

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -23,6 +23,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   regenerate:
     name: Regenerate responses (${{ matrix.ref }})

--- a/.github/workflows/camunda-client-compatibility-test-trigger.yml
+++ b/.github/workflows/camunda-client-compatibility-test-trigger.yml
@@ -8,6 +8,9 @@ on:
     # Run daily at 02:00 UTC
     - cron: "0 2 * * *"
 
+env:
+  TEST_OWNER: '@camunda/camundaex'
+
 jobs:
   trigger-stable-8-8:
     runs-on: ubuntu-latest

--- a/.github/workflows/camunda-client-compatibility-test-trigger.yml
+++ b/.github/workflows/camunda-client-compatibility-test-trigger.yml
@@ -1,6 +1,6 @@
 # description: trigger workflow to run the camunda-client-compatibility-test.yml workflow on a schedule
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/camundaex
 name: Camunda Compatibility Tests - Trigger
 
 on:

--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -1,6 +1,6 @@
 # description: Daily compatibility tests for Camunda components across versions
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/camundaex
 name: Camunda Compatibility Tests
 
 on:

--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -31,6 +31,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/camundaex'
   FLAKY_TEST_RERUN_COUNT: '3'
 
 jobs:

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -27,6 +27,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
 jobs:
   benchmark-data:
     name: Collect benchmark data

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/camunda-load-test-ttl-cleanup.yml
+++ b/.github/workflows/camunda-load-test-ttl-cleanup.yml
@@ -15,6 +15,7 @@ on:
         required: false
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -19,6 +19,9 @@ on:
     # Runs at 01:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
     - cron: '0 1 * * 1-5'
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   setup:
     name: Resolve release branch

--- a/.github/workflows/camunda-process-test-compatibility-trigger.yml
+++ b/.github/workflows/camunda-process-test-compatibility-trigger.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
   actions: write
 
+env:
+  TEST_OWNER: '@camunda/camundaex'
+
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/camunda-scheduled-release-load-tests.yml
+++ b/.github/workflows/camunda-scheduled-release-load-tests.yml
@@ -19,6 +19,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test-trigger.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test-trigger.yml
@@ -8,6 +8,9 @@ on:
     # Run daily at 02:00 UTC
     - cron: "0 2 * * *"
 
+env:
+  TEST_OWNER: '@camunda/camundaex'
+
 jobs:
   trigger-stable-8-8:
     runs-on: ubuntu-latest

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test-trigger.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test-trigger.yml
@@ -1,6 +1,6 @@
 # description: trigger workflow to run the camunda-spring-boot-starter-compatibility-test.yml workflow on a schedule
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/camundaex
 name: Camunda Spring Boot Starter Compatibility Tests - Trigger
 
 on:

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -1,6 +1,6 @@
 # description: Daily compatibility tests for Camunda Spring Boot Starter across server versions
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/camundaex
 name: Camunda Spring Boot Starter Compatibility Tests
 
 on:

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -31,6 +31,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/camundaex'
   FLAKY_TEST_RERUN_COUNT: '3'
 
 jobs:

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -29,6 +29,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
 
 jobs:

--- a/.github/workflows/check-licenses-active-issues.yml
+++ b/.github/workflows/check-licenses-active-issues.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -20,6 +20,7 @@ on:
     - synchronize
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/check-outdated-prs.yml
+++ b/.github/workflows/check-outdated-prs.yml
@@ -26,6 +26,9 @@ permissions:
   pull-requests: write
   contents: read
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   get-prs:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   check-all-pr-conflicts:
     if: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -62,6 +62,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
 
@@ -157,7 +158,6 @@ jobs:
           job_name: "${{ inputs.test-type }}/${{ inputs.database-type }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -34,6 +34,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Operate
 
@@ -51,12 +52,15 @@ jobs:
         include:
           - suite: DataLayer
             suiteName: Data Layer
+            owner: '@camunda/data-layer'
           - suite: CoreFeatures
             suiteName: Core Features
+            owner: '@camunda/core-features'
     with:
       componentName: "Operate"
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
+      owner: ${{ matrix.owner }}
 
   # Checks to see if Operate can properly build itself and a docker image
   build-operate-backend:
@@ -67,7 +71,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-      TEST_OWNER: Core Features
       TEST_TYPE: Build
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -103,7 +106,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-unit-tests:
     if: inputs.runFeTests
@@ -118,7 +120,6 @@ jobs:
         shardTotal: [4]
     env:
       TEST_TYPE: Unit
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: operate/client
@@ -165,7 +166,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Unit
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: operate/client
@@ -196,7 +196,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Operate
     defaults:
       run:
@@ -222,7 +221,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   # Front End Code linting
   operate-fe-eslint:
@@ -233,7 +231,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Operate
     defaults:
       run:
@@ -259,7 +256,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-fe-prettier:
     if: inputs.runFeTests
@@ -269,7 +265,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Operate
     defaults:
       run:
@@ -295,7 +290,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-fe-sbom-snyk:
     if: inputs.runFeTests
@@ -305,7 +299,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: operate/client
@@ -341,7 +334,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   # description: This workflow runs a11y accessibility tests on Operate
   operate-fe-a11y-tests:
@@ -352,7 +344,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.60.0
       options: --user 1001:1000
@@ -390,7 +381,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-fe-visual-regression-tests:
     if: inputs.runFeTests
@@ -405,7 +395,6 @@ jobs:
         shardTotal: [4]
     env:
       TEST_TYPE: visual-regression
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.60.0
       options: --user 1001:1000
@@ -445,7 +434,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-fe-visual-regression-merge:
     if: ${{ !cancelled() && inputs.runFeTests }}
@@ -456,7 +444,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: operate/client
@@ -495,7 +482,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: screenshot-update
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.60.0
       options: --user 1001:1000
@@ -532,7 +518,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
 # As part of the V1 API cleanup, the backup restore tests have been disabled
 # and need to be reinstated before 8.10 releases.
@@ -544,7 +529,7 @@ jobs:
 #    permissions: {} # GITHUB_TOKEN unused in this job
 #    env:
 #      DOCKER_IMAGE_TAG: current-test
-#      TEST_OWNER: Data Layer
+#      TEST_OWNER: '@camunda/data-layer'
 #      TEST_TYPE: Integration
 #    services:
 #      registry:
@@ -599,7 +584,7 @@ jobs:
 #          job_name: "operate-ci/backup-restore"
 #          build_status: ${{ job.status }}
 #          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-#          user_description: "team-data-layer"
+#          user_description: "@camunda/data-layer"
 #          detailed_junit_tests: true
 #          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 #          secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -34,6 +34,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Optimize
 
@@ -51,12 +52,15 @@ jobs:
         include:
           - suite: DataLayer
             suiteName: Data Layer
+            owner: '@camunda/data-layer'
           - suite: CoreFeatures
             suiteName: Core Features
+            owner: '@camunda/core-features'
     with:
       componentName: "Optimize"
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
+      owner: ${{ matrix.owner }}
 
   optimize-it-elasticsearch:
     name: "Integration / Elasticsearch ITs"
@@ -65,7 +69,6 @@ jobs:
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: IT
     strategy:
       fail-fast: false
@@ -149,7 +152,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   optimize-it-opensearch:
     name: "Integration / OpenSearch ITs"
@@ -158,7 +160,6 @@ jobs:
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: IT
     strategy:
       fail-fast: false
@@ -242,7 +243,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   optimize-frontend-unit-tests:
     name: "Unit - Front End"
@@ -255,7 +255,6 @@ jobs:
         working-directory: optimize/client
     env:
       LIMITS_CPU: 4
-      TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -296,7 +295,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   optimize-frontend-sbom-snyk:
     name: "Tool / Front End - Snyk SBOM"
@@ -308,7 +306,6 @@ jobs:
       run:
         working-directory: optimize/client
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Tool
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -353,7 +350,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   hadolint:
     if: inputs.runBeTests
@@ -362,7 +358,6 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     timeout-minutes: 4
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Tool
     strategy:
       fail-fast: false
@@ -390,7 +385,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
   optimize-e2e-smoke:
     name: "E2E / Self-Managed (Smoke)"
     if: inputs.runFeTests
@@ -399,7 +393,6 @@ jobs:
     permissions: { }
     env:
       TEST_TYPE: E2E
-      TEST_OWNER: Core Features
 
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -550,7 +543,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   e2e-cloud-test:
     name: "E2E Cloud"
@@ -559,7 +551,6 @@ jobs:
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: E2E
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -665,4 +656,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -34,6 +34,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Tasklist
 
@@ -51,12 +52,15 @@ jobs:
         include:
           - suite: DataLayer
             suiteName: Data Layer
+            owner: '@camunda/data-layer'
           - suite: CoreFeatures
             suiteName: Core Features
+            owner: '@camunda/core-features'
     with:
       componentName: "Tasklist"
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
+      owner: ${{ matrix.owner }}
 
   fe-type-check:
     if: inputs.runFeTests
@@ -66,7 +70,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Tasklist
     defaults:
       run:
@@ -92,7 +95,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-eslint:
     if: inputs.runFeTests
@@ -102,7 +104,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Tasklist
     defaults:
       run:
@@ -128,7 +129,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-stylelint:
     if: inputs.runFeTests
@@ -138,7 +138,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: tasklist/client
@@ -163,7 +162,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-prettier:
     if: inputs.runFeTests
@@ -173,7 +171,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Tasklist
     defaults:
       run:
@@ -199,7 +196,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-tests:
     if: inputs.runFeTests
@@ -209,7 +205,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Unit
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: tasklist/client
@@ -234,7 +229,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-sbom-snyk:
     if: inputs.runFeTests
@@ -244,7 +238,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: tasklist/client
@@ -280,7 +273,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-visual-regression-tests:
     if: inputs.runFeTests
@@ -290,7 +282,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.60.0
       options: --user 1001:1000
@@ -328,7 +319,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-a11y-tests:
     if: inputs.runFeTests
@@ -338,7 +328,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.60.0
       options: --user 1001:1000
@@ -376,7 +365,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
 # As part of the V1 API cleanup, the backup restore tests have been disabled
 # and need to be reinstated before 8.10 releases.
@@ -390,7 +378,7 @@ jobs:
 #      TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
 #      TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
 #      TEST_TYPE: Integration
-#      TEST_OWNER: Data Layer
+#      TEST_OWNER: '@camunda/data-layer'
 #    strategy:
 #      fail-fast: false
 #      matrix:
@@ -458,7 +446,7 @@ jobs:
 #          job_name: "tasklist-ci/backup-restore-${{ matrix.database }}"
 #          build_status: ${{ job.status }}
 #          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-#          user_description: "team-data-layer"
+#          user_description: "@camunda/data-layer"
 #          detailed_junit_tests: true
 #          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 #          secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -473,7 +461,6 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Integration
-      TEST_OWNER: Core Features
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
       TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
     services:
@@ -534,4 +521,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -11,7 +11,7 @@ on:
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Orchestration Cluster Webapp
-  TEST_OWNER: Orchestration Cluster
+  TEST_OWNER: '@camunda/orchestration-cluster'
 
 jobs:
   typecheck:

--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -11,7 +11,7 @@ on:
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Orchestration Cluster Webapp
-  TEST_OWNER: '@camunda/orchestration-cluster'
+  TEST_OWNER: '@camunda/core-features'
 
 jobs:
   typecheck:

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -20,10 +20,14 @@ on:
         description: "Well formatted name of the suite under test. ie, 'Data Layer' or 'Core Features'"
         required: true
         type: string
+      owner:
+        description: "Canonical GitHub team handle owning the suite under test, e.g. '@camunda/data-layer'"
+        required: true
+        type: string
 
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
-  TEST_OWNER: Core Features
+  TEST_OWNER: ${{ inputs.owner }}
   TEST_TYPE: Unit
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
 
@@ -89,7 +93,6 @@ jobs:
           job_name: "${{inputs.componentName}}-unit-tests/${{inputs.suite}}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "${{inputs.suiteName}}"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -26,6 +26,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/zeebe-distributed-platform'
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Zeebe
@@ -38,7 +39,6 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runner }}
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Smoke
     strategy:
       fail-fast: false
@@ -121,7 +121,6 @@ jobs:
           job_name: "smoke-tests/${{ matrix.os }}-${{ matrix.arch }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-distributed-systems"
           detailed_junit_tests: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}  # feature only supported on Linux for now
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -133,7 +132,6 @@ jobs:
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -180,7 +178,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-distributed-systems"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -193,7 +190,7 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"
-      TEST_OWNER: Core Features
+      TEST_OWNER: '@camunda/core-features'
       TEST_TYPE: Performance
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -251,7 +248,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-core-features"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -264,7 +260,6 @@ jobs:
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -315,7 +310,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-distributed-systems"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -335,7 +329,6 @@ jobs:
           - 5000:5000
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/zeebe
-      TEST_OWNER: Core Features
       TEST_TYPE: Build
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -395,7 +388,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-distributed-systems"
 
   test-summary:
     # Used by the merge queue to check all tests, including the unit test matrix.
@@ -477,7 +469,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "team-distributed-systems"
 
   # Dynamically generate the concurrency group for load test image deployment
   utils-get-concurrency-group-for-load-test:
@@ -501,6 +492,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     env:
+      TEST_OWNER: '@camunda/reliability-testing'
       IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
       IMAGE_TAG: ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
     steps:
@@ -527,7 +519,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-reliability-testing"
 
   deploy-snyk-projects:
     name: Deploy Snyk development projects
@@ -564,6 +555,8 @@ jobs:
     permissions:
       checks: read
       pull-requests: write
+    env:
+      TEST_OWNER: '@camunda/monorepo-devops-team'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Generate GitHub token
@@ -596,4 +589,3 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "General"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,7 +532,7 @@ jobs:
               "runs-on": "gcp-perf-core-8-default",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "QA",
+              "owner": "@camunda/qa-engineering",
               "module": "QA",
               "stressRun": 1
             },
@@ -545,7 +545,7 @@ jobs:
               "runs-on": "gcp-perf-core-8-default",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "Distributed Platform",
+              "owner": "@camunda/zeebe-distributed-platform",
               "module": "Zeebe",
               "stressRun": 1
             },
@@ -558,7 +558,7 @@ jobs:
               "runs-on": "gcp-perf-core-16-longrunning",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "Distributed Platform",
+              "owner": "@camunda/zeebe-distributed-platform",
               "module": "Zeebe",
               "stressRun": 1
             },
@@ -571,7 +571,7 @@ jobs:
               "runs-on": "gcp-perf-core-16-longrunning",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "Core Features",
+              "owner": "@camunda/core-features",
               "module": "Zeebe",
               "stressRun": 1
             },
@@ -584,7 +584,7 @@ jobs:
               "runs-on": "gcp-perf-core-16-longrunning",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "DataLayer",
+              "owner": "@camunda/data-layer",
               "module": "Zeebe",
               "stressRun": 1
             },
@@ -597,7 +597,7 @@ jobs:
               "runs-on": "gcp-perf-core-8-default",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "Data Layer",
+              "owner": "@camunda/data-layer",
               "module": "Schema Manager",
               "stressRun": 1
             },
@@ -608,7 +608,7 @@ jobs:
               "maven-build-threads": 1,
               "maven-test-fork-count": 10,
               "runs-on": "gcp-perf-core-16-default",
-              "owner": "Core Features",
+              "owner": "@camunda/core-features",
               "module": "Zeebe",
               "test-filter": "io.camunda.zeebe.it.engine.**,!**/*${DOLLAR}*.java",
               "allow-stress": true,
@@ -623,7 +623,7 @@ jobs:
               "runs-on": "gcp-perf-core-16-default",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "Distributed Platform",
+              "owner": "@camunda/zeebe-distributed-platform",
               "module": "Zeebe",
               "test-filter": "io.camunda.zeebe.it.cluster.**,!io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest,!**/*${DOLLAR}*.java",
               "allow-stress": true,
@@ -636,7 +636,7 @@ jobs:
               "maven-build-threads": 1,
               "maven-test-fork-count": 1,
               "runs-on": "gcp-perf-core-8-default",
-              "owner": "Distributed Platform",
+              "owner": "@camunda/zeebe-distributed-platform",
               "module": "Zeebe",
               "test-filter": "io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest",
               "stressRun": 1
@@ -650,7 +650,7 @@ jobs:
               "runs-on": "gcp-perf-core-16-default",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "General",
+              "owner": "@camunda/monorepo-devops-team",
               "module": "Zeebe",
               "test-filter": "!io.camunda.zeebe.it.engine.**,!io.camunda.zeebe.it.cluster.**,!**/*${DOLLAR}*.java",
               "stressRun": 1
@@ -664,7 +664,7 @@ jobs:
               "runs-on": "gcp-perf-core-8-default",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "CamundaEx",
+              "owner": "@camunda/camundaex",
               "module": "Testing",
               "stressRun": 1
             },
@@ -677,7 +677,7 @@ jobs:
               "runs-on": "gcp-perf-core-16-default",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "Core Features",
+              "owner": "@camunda/core-features",
               "module": "Zeebe",
               "stressRun": 1
             }
@@ -770,7 +770,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
+          user_description: "@camunda/monorepo-devops-team"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -793,25 +793,25 @@ jobs:
       matrix:
         include:
           - component: General
-            suite: CoreFeatures
+            suite: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_CORE_FEATURES_MODULES }}
           - component: Protocol
-            suite: CoreFeatures
+            suite: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_PROTOCOL_MODULES }}
           - component: Gateway
-            suite: CoreFeatures
+            suite: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_GATEWAY_MODULES }}
           - component: Exporter
-            suite: DataLayer
+            suite: '@camunda/data-layer'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_EXPORTER_MODULES }}
           - component: Backup
-            suite: DistributedPlatform
+            suite: '@camunda/zeebe-distributed-platform'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_BACKUP_MODULES }}
           - component:  Distributed
-            suite: DistributedPlatform
+            suite: '@camunda/zeebe-distributed-platform'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_DISTRIBUTED_MODULES }}
           - component: Client
-            suite: CamundaEx
+            suite: '@camunda/camundaex'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_CLIENT_MODULES }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -1021,7 +1021,7 @@ jobs:
           job_name: ${{ format('rdbms-integration-tests{0}', matrix.stressRun != 1 && format('/{0}', matrix.stressRun) || '') }}
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
+          user_description: "@camunda/monorepo-devops-team"
           detailed_junit_tests: true
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -1181,7 +1181,7 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     env:
-      TEST_OWNER: General
+      TEST_OWNER: '@camunda/monorepo-devops-team'
       TEST_PRODUCT: Camunda
       TEST_TYPE: Unit
     outputs:
@@ -1238,7 +1238,7 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
+          user_description: "@camunda/monorepo-devops-team"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -1364,7 +1364,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
+          user_description: "@camunda/monorepo-devops-team"
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
 
   detect-new-flaky-tests:
@@ -1641,7 +1641,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "Identity"
+          user_description: "@camunda/identity"
 
   identity-frontend-sbom-snyk:
     if: needs.detect-changes.outputs.identity-frontend-tests == 'true'
@@ -1651,7 +1651,7 @@ jobs:
     timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Identity
+      TEST_OWNER: '@camunda/identity'
       TEST_PRODUCT: Identity
       TEST_TYPE: Tool
     defaults:
@@ -1689,7 +1689,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "Identity"
+          user_description: "@camunda/identity"
 
   pr-maven-snapshot:
     name: "Security / Submit Maven Dependency Snapshot"
@@ -1900,7 +1900,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
+          user_description: "@camunda/monorepo-devops-team"
 
   openapi-lint:
     name: "Lint / C8 REST OpenAPI"
@@ -1958,7 +1958,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
+          user_description: "@camunda/monorepo-devops-team"
 
   openapi-x-added-in-version-check:
     name: "Lint / C8 REST OpenAPI x-added-in-version"
@@ -2037,7 +2037,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
+          user_description: "@camunda/monorepo-devops-team"
 
   renovatelint:
     if: needs.detect-changes.outputs.renovate-config-changes == 'true'
@@ -2222,7 +2222,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
+          user_description: "@camunda/monorepo-devops-team"
 
   # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
   utils-get-snapshot-docker-tag:
@@ -2304,7 +2304,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
+          user_description: "@camunda/monorepo-devops-team"
 
   utils-get-concurrency-group-for-optimize-docker-snapshot:
     needs: [ check-results ]
@@ -2369,4 +2369,4 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
+          user_description: "@camunda/core-features"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
@@ -770,7 +771,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "@camunda/monorepo-devops-team"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -786,6 +786,7 @@ jobs:
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     env:
+      TEST_OWNER: ${{ matrix.owner }}
       TEST_TYPE: "Unit"
       TEST_PRODUCT: "Zeebe"
     strategy:
@@ -793,25 +794,32 @@ jobs:
       matrix:
         include:
           - component: General
-            suite: '@camunda/core-features'
+            suite: CoreFeatures
+            owner: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_CORE_FEATURES_MODULES }}
           - component: Protocol
-            suite: '@camunda/core-features'
+            suite: CoreFeatures
+            owner: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_PROTOCOL_MODULES }}
           - component: Gateway
-            suite: '@camunda/core-features'
+            suite: CoreFeatures
+            owner: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_GATEWAY_MODULES }}
           - component: Exporter
-            suite: '@camunda/data-layer'
+            suite: DataLayer
+            owner: '@camunda/data-layer'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_EXPORTER_MODULES }}
           - component: Backup
-            suite: '@camunda/zeebe-distributed-platform'
+            suite: DistributedPlatform
+            owner: '@camunda/zeebe-distributed-platform'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_BACKUP_MODULES }}
           - component:  Distributed
-            suite: '@camunda/zeebe-distributed-platform'
+            suite: DistributedPlatform
+            owner: '@camunda/zeebe-distributed-platform'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_DISTRIBUTED_MODULES }}
           - component: Client
-            suite: '@camunda/camundaex'
+            suite: CamundaEx
+            owner: '@camunda/camundaex'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_CLIENT_MODULES }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -820,7 +828,7 @@ jobs:
       - name: Print metadata
         uses: ./.github/actions/print-metadata
         with:
-          test_owner: "${{ matrix.suite }}"
+          test_owner: "${{ matrix.owner }}"
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: ut-zeebe
@@ -880,7 +888,6 @@ jobs:
           job_name: "zeebe-unit-tests/${{ matrix.component }}-${{matrix.suite}}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "${{matrix.suite}}"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -1021,7 +1028,6 @@ jobs:
           job_name: ${{ format('rdbms-integration-tests{0}', matrix.stressRun != 1 && format('/{0}', matrix.stressRun) || '') }}
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "@camunda/monorepo-devops-team"
           detailed_junit_tests: true
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -1043,6 +1049,7 @@ jobs:
         # Opt-in to stress testing this job via the PR label "ci:stress-test".
         include: ${{ fromJson(needs.setup-tests.outputs.INTEGRATION_TESTS_MATRIX) }}
     env:
+      TEST_OWNER: ${{ matrix.owner }}
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist:current-test
@@ -1167,7 +1174,6 @@ jobs:
           job_name: ${{ format('integration-tests/{0}{1}', matrix.group, matrix.stressRun != 1 && format('/{0}', matrix.stressRun) || '') }}
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ matrix.owner }}
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -1181,7 +1187,6 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     env:
-      TEST_OWNER: '@camunda/monorepo-devops-team'
       TEST_PRODUCT: Camunda
       TEST_TYPE: Unit
     outputs:
@@ -1238,7 +1243,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "@camunda/monorepo-devops-team"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -1364,7 +1368,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "@camunda/monorepo-devops-team"
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
 
   detect-new-flaky-tests:
@@ -1608,6 +1611,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
+    env:
+      TEST_OWNER: '@camunda/identity'
     defaults:
       run:
         working-directory: identity/client
@@ -1641,7 +1646,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "@camunda/identity"
 
   identity-frontend-sbom-snyk:
     if: needs.detect-changes.outputs.identity-frontend-tests == 'true'
@@ -1689,7 +1693,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "@camunda/identity"
 
   pr-maven-snapshot:
     name: "Security / Submit Maven Dependency Snapshot"
@@ -1900,7 +1903,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "@camunda/monorepo-devops-team"
 
   openapi-lint:
     name: "Lint / C8 REST OpenAPI"
@@ -1958,7 +1960,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "@camunda/monorepo-devops-team"
 
   openapi-x-added-in-version-check:
     name: "Lint / C8 REST OpenAPI x-added-in-version"
@@ -2037,7 +2038,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "@camunda/monorepo-devops-team"
 
   renovatelint:
     if: needs.detect-changes.outputs.renovate-config-changes == 'true'
@@ -2222,7 +2222,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "@camunda/monorepo-devops-team"
 
   # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
   utils-get-snapshot-docker-tag:
@@ -2304,7 +2303,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "@camunda/monorepo-devops-team"
 
   utils-get-concurrency-group-for-optimize-docker-snapshot:
     needs: [ check-results ]
@@ -2326,6 +2324,8 @@ jobs:
     concurrency:
       group: ${{ needs.utils-get-concurrency-group-for-optimize-docker-snapshot.outputs.concurrency_group_name }}
       cancel-in-progress: false
+    env:
+      TEST_OWNER: '@camunda/core-features'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -2369,4 +2369,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "@camunda/core-features"

--- a/.github/workflows/codeowners-file-owner.yml
+++ b/.github/workflows/codeowners-file-owner.yml
@@ -19,6 +19,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
@@ -29,7 +30,6 @@ jobs:
     permissions:
       contents: read
     env:
-      TEST_OWNER: Orchestration Cluster
       TEST_PRODUCT: Orchestration Cluster
       TEST_TYPE: CI Helper
     steps:

--- a/.github/workflows/data-layer-nightly-tests.yml
+++ b/.github/workflows/data-layer-nightly-tests.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  TEST_OWNER: '@camunda/data-layer'
+
 jobs:
   nightly-tests:
     name: "Data Layer Nightly Tests (${{ matrix.branch }})"

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -45,6 +45,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  TEST_OWNER: '@camunda/distribution'
   GHA_BEST_PRACTICES_LINTER: enabled
   HARBOR_REGISTRY: registry.camunda.cloud
   HARBOR_REPOSITORY: registry.camunda.cloud/team-camunda/camunda

--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -22,6 +22,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   # renovate: datasource=node-version depName=node
   NODE_VERSION: '24.16.0'
 

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -21,6 +21,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   cleanup-orphaned-previews:
     name: Cleanup Orphaned Documentation Previews

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   submit-maven-snapshot:
     name: "Security / Submit Maven Dependency Snapshot"

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -1,5 +1,5 @@
 # type: Project Management
-# owner: Engineering Ops
+# owner: @camunda/monorepo-devops-team
 name: "Opened Issue Labeler"
 on:
   issues:

--- a/.github/workflows/optimize-ci-data-upgrade-nightly.yml
+++ b/.github/workflows/optimize-ci-data-upgrade-nightly.yml
@@ -21,6 +21,9 @@ permissions:
   checks: write
   pull-requests: write
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   detect-changes:
     name: Get changed directories

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -18,6 +18,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 permissions:
@@ -34,7 +35,6 @@ jobs:
     timeout-minutes: 120
     env:
       TEST_TYPE: E2E
-      TEST_OWNER: Core Features
 
     steps:
       - name: Checkout code
@@ -140,4 +140,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -35,6 +35,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GH_TOKEN: ${{ github.token }} # needs to be available for the gh CLI tool
 
 jobs:

--- a/.github/workflows/preview-env-clean.yml
+++ b/.github/workflows/preview-env-clean.yml
@@ -23,6 +23,9 @@ on:
         required: true
   workflow_dispatch:
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   preview-env-clean:
     concurrency:

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -26,6 +26,9 @@ on:
         type: boolean
         default: false
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   deploy-8-8:
     name: Deploy 8.8 Preview Environment

--- a/.github/workflows/publish-zod-schemas.yml
+++ b/.github/workflows/publish-zod-schemas.yml
@@ -21,6 +21,7 @@ on:
       - 'webapp/client/packages/camunda-api-zod-schemas/**'
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
@@ -36,7 +37,6 @@ jobs:
         working-directory: webapp/client
         shell: bash
     env:
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Camunda
       TEST_TYPE: Build
     steps:

--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - release-*
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   validate-event:
     name: Validate GitHub event for release branch activity

--- a/.github/workflows/renovate-daily.yml
+++ b/.github/workflows/renovate-daily.yml
@@ -15,6 +15,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/renovate-weekly.yml
+++ b/.github/workflows/renovate-weekly.yml
@@ -14,6 +14,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -81,6 +81,9 @@ defaults:
 
 permissions: {}
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   collect-stale-backports:
     name: Collect stale backport PRs

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -16,6 +16,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/verify-x-added-in-version-annotations.yml
+++ b/.github/workflows/verify-x-added-in-version-annotations.yml
@@ -17,6 +17,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
@@ -13,6 +13,7 @@ on:
     - cron: "0 4 * * Mon-Fri"
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 defaults:
@@ -121,7 +122,6 @@ jobs:
           job_name: "integration-tests/camunda-qa-acceptance-tests"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: General
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -26,6 +26,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   cleanup-opensearch-indices:
     name: "[PRE] Cleanup old AWS OpenSearch indices. OS ver.${{ matrix.os_version }}"
@@ -66,7 +69,6 @@ jobs:
         with:
           job_name: "cleanup-opensearch-indices/${{ matrix.os_version }}"
           build_status: ${{ job.status }}
-          user_description: "General"
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -20,6 +20,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   # This URL is used as the business key for the various QA workflows
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/zeebe-rdbms-integration-tests.yml
+++ b/.github/workflows/zeebe-rdbms-integration-tests.yml
@@ -22,6 +22,7 @@ on:
     - cron: "0 5 * * Mon-Fri"
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 defaults:

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -10,6 +10,9 @@ on:
     # Runs at 02:00 every week day; see this link for more: https://crontab.guru/#0_2_*_*_1-5
     - cron: '0 2 * * 1-5'
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   # Create short-lived branches from each stable branch so that dry-run pushes
   # don't conflict with concurrent merges landing on the shared stable/* branches.

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -15,6 +15,9 @@ concurrency:
 permissions:
   actions: read # Required to get the previous report
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   released-versions:
     name: Released Versions

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -10,6 +10,9 @@ on:
     # Run at 7:00 on every monday
     - cron: "0 7 * * 1"
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   # This job will figure out the last supported versions based on the latest tags.
   #

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -202,15 +202,27 @@ Related resources:
 
 ### Ownership
 
-Each CI test file has an owning team. The owning team can be found either through the `CODEOWNERS` file or on the metadata in the file itself. The `CODEOWNERS` file is organized and broken down by team, any additions to the file should follow that convention. The metadata on a GHA workflow file is used by a scraping tool so that it is easy to gather information about the current state of CI. You can look at the metadata for a quick overview of the owning team, where the tests live, how the test is called, and a description of what the file is actually testing
+Each CI test file has an owning team. The owning team can be found in `.codeowners` (lookup via `codeowners-cli owner <path>`) with the same value also in the metadata in the GHA workflow YAML file itself. `.codeowners` is the source-of-truth, the metadata is for human overview only:
+
+You can look at the metadata for a quick overview of the owning team, where the tests live, how the test is called, and a description of what the file is actually testing
+
+The owning team is the general point of contact for any questions or problems with the GHA workflow. Unless overwritten on the GHA job-level, the owning team will also own all job failures and their medic can be contacted to resolve those.
 
 Metadata follows this structure and is placed at the beginning of a GHA workflow file
 
 ```
 # <Description of what the GHA is running and what is being tested>
 # test location: <The filepath of the tests being run>
-# owner: <The name of the owning team>
+# owner: <The GitHub handle of the owning team>
 ```
+
+#### Automatic Alert Attribution
+
+For programmatic alert routing and medic assignment on CI incidents, each workflow also propagates the canonical GitHub team handle to [CI Analytics](#ci-health-metrics) via a workflow-level `env: TEST_OWNER:` block.
+
+The [`observe-build-status` action](#metrics-collection) reads this env var as the default for the `user_description` field it submits to CI Analytics. This can be overwritten on the job-level with more specific `env: TEST_OWNER:` blocks.
+
+See [Metrics Collection](#metrics-collection) for the concrete `env:` snippet, including how to override per-job and how to wire matrix-driven values.
 
 ### Legacy CI
 
@@ -355,6 +367,32 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 ```
+
+To attribute CI Analytics rows to an owning team, set a canonical handle as a workflow-level env var. This is read by `observe-build-status` as the default for its `user_description` input, so no inline argument is needed at the call site:
+
+```yaml
+# owner: @camunda/core-features
+env:
+  TEST_OWNER: '@camunda/core-features'
+```
+
+The handle must match with `.codeowners` (verify with `codeowners-cli owner <path>`). Override per job for outliers if necessary, including matrix-driven values:
+
+```yaml
+jobs:
+  per-suite-tests:
+    strategy:
+      matrix:
+        include:
+          - suite: CoreFeatures
+            owner: '@camunda/core-features'
+          - suite: DataLayer
+            owner: '@camunda/data-layer'
+    env:
+      TEST_OWNER: ${{ matrix.owner }}
+    # ...
+```
+
 
 Related resources:
 

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -1508,7 +1508,7 @@ Failures are reported to Slack and visible in the [Actions tab](https://github.c
 **What this means for contributors:**
 
 - If you change an endpoint's response shape, remove a field, or alter error codes, the forward compatibility tests will detect it.
-- If your PR intentionally introduces a breaking change (see §2.7), coordinate with `@camunda/camunda-ex` to update the test expectations on the affected older branches _before_ merging.
+- If your PR intentionally introduces a breaking change (see §2.7), coordinate with `@camunda/camundaex` to update the test expectations on the affected older branches _before_ merging.
 
 There is also an **on-demand workflow** ([`c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml`](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml)) that builds the server _and_ runs the tests from the same branch. This is useful for verifying that a feature branch passes all API tests — both against Elasticsearch _and_ H2/RDBMS — before merging. It also detects differential behavior between storage engines.
 


### PR DESCRIPTION
## Description

This PR makes every `on: push` and `on: schedule` workflow submit a canonical owning team GitHub handle to CI Analytics, so failures can be routed to the responsible team's medic for https://github.com/camunda/camunda/issues/52873

**Before:** vocabulary across workflows was a mix of free-text labels (`Core Features`, `team-distributed-systems`, `General`, `Orchestration Cluster`, …) that didn't match the canonical `@camunda/...` handles in [`.codeowners`](.codeowners), and most `push`/`schedule` workflows didn't pass `user_description` at all (rows landed with `NULL`).

**After:** every affected workflow submits a `@camunda/...` handle sourced from `.codeowners`. This is tracked via the freetext `user_description` field which after this PR will now be a convention for this repo - we could persist it in the schema later. Verified end-to-end by querying `ci-30-162810.prod_ci_analytics.build_status_v2` for this branch's CI runs.

### Changes

- **Vocabulary alignment.** Inline `user_description` strings and `TEST_OWNER` env values are now all canonical `@camunda/...` handles. Each workflow's handle matches `codeowners-cli owner <path>` output.
- **Workflow-level defaults.** Added `env: TEST_OWNER: '@camunda/...'` to `ci.yml`, the six reusable workflows it calls directly, and 46 additional `on: push`/`on: schedule` workflows.
- **Per-job overrides.** Where a workflow has mixed ownership (`ci-zeebe.yml`, `zeebe-unit-tests`/`integration-tests` in `ci.yml`), per-job `env:` blocks override the default — including matrix-driven `TEST_OWNER: ${{ matrix.owner }}`.
- **New convention.** `observe-build-status` now defaults its `user_description` input from `env.TEST_OWNER` when empty, so callers can declare ownership once at the workflow/job level instead of repeating it at each call site.
- **Display vs ownership split.** Matrix fields that were doing double duty (display name + ownership) are split into a human-readable label and an explicit `owner` field, so job names like `zeebe-unit-tests/General-CoreFeatures` stay readable while `user_description` carries the canonical handle. Affects `ci.yml`, `ci-operate.yml`, `ci-optimize.yml`, `ci-tasklist.yml`, and `ci-webapp-run-ut-reuseable.yml` (new required `owner` input).
- **`.codeowners` fixes.** Added 4 specific rules where the file's intended owner diverged from what codeowners-cli returned: `camunda-spring-boot-starter-compatibility-test*` → `camundaex`, `data-layer-nightly-tests.yml` → `data-layer`, `verify-x-added-in-version-annotations.yml` → `core-features`, `zeebe-release-stable-dry-run.yml` → `monorepo-devops-team` (via a new "Late overrides" section, needed because last-match-wins).
- **Documentation.** [`docs/monorepo-docs/ci.md`](docs/monorepo-docs/ci.md) now describes the layered ownership model — `# owner:` YAML header for human overview vs. `env: TEST_OWNER:` for programmatic CI Analytics attribution, with `.codeowners` as the authoritative source for the GitHub team handle.
  * See https://camunda.github.io/camunda/pr-preview/pr-55040/ci/#ownership

**Mockup example of how this info would be used in alerts (using old vocabulary before merge):**

<img width="1138" height="631" alt="image" src="https://github.com/user-attachments/assets/d74bf6bb-d096-425b-a543-2a7af3e85e04" />

**Visual Change Overview:**

[ci-ownership-visualization.html](https://github.com/user-attachments/files/28832697/ci-ownership-visualization.html)

### Future

We extend the BigQuery schema to track the effective owner on the job-level (defaults from workflow) instead of using `user_description` if the current implementation proves as fit for purpose of https://github.com/camunda/camunda/issues/52873

We can even introduce a 3rd layer: workflow owner -> job owner (override) -> **test owner**

Since a job could run tests classes owned by different teams (see info in `.codeowners`), we could differentiate and improve the routing even more by tracking ownership on test class level in CI Analytics.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - no, will be done manually as automated backports will likely create many conflicts
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to #52873