### PR TITLE
feat: Lazy load camunda authentication

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -42,9 +42,7 @@ import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.security.oidc.OidcUserInfoClient;
 import io.camunda.security.reader.ResourceAccessProvider;
-import io.camunda.service.GroupServices;
 import io.camunda.service.RoleServices;
-import io.camunda.service.TenantServices;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.micrometer.common.KeyValues;
@@ -511,11 +509,8 @@ public class WebSecurityConfig {
 
     @Bean
     public CamundaAuthenticationConverter<Authentication> usernamePasswordAuthenticationConverter(
-        final RoleServices roleServices,
-        final GroupServices groupServices,
-        final TenantServices tenantServices) {
-      return new UsernamePasswordAuthenticationTokenConverter(
-          roleServices, groupServices, tenantServices);
+        final MembershipService membershipService) {
+      return new UsernamePasswordAuthenticationTokenConverter(membershipService);
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
@@ -59,6 +59,19 @@ public class TokenClaimsConverter {
       principalType = PrincipalType.CLIENT;
     }
 
-    return membershipService.resolveMemberships(tokenClaims, principalName, principalType);
+    final var resolver = membershipService.newResolver(tokenClaims, principalName, principalType);
+    return CamundaAuthentication.of(
+        a -> {
+          if (principalType == PrincipalType.CLIENT) {
+            a.clientId(principalName);
+          } else {
+            a.user(principalName);
+          }
+          return a.mappingRulesSupplier(resolver::mappingRules)
+              .groupIdsSupplier(resolver::groups)
+              .roleIdsSupplier(resolver::roles)
+              .tenantsSupplier(resolver::tenants)
+              .claims(tokenClaims);
+        });
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverter.java
@@ -7,128 +7,31 @@
  */
 package io.camunda.authentication.converter;
 
-import static io.camunda.zeebe.protocol.record.value.EntityType.GROUP;
-import static io.camunda.zeebe.protocol.record.value.EntityType.ROLE;
-import static io.camunda.zeebe.protocol.record.value.EntityType.USER;
-
-import io.camunda.search.entities.GroupEntity;
-import io.camunda.search.entities.RoleEntity;
-import io.camunda.search.entities.TenantEntity;
+import io.camunda.authentication.service.MembershipService;
+import io.camunda.authentication.service.MembershipService.PrincipalType;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
-import io.camunda.service.GroupServices;
-import io.camunda.service.RoleServices;
-import io.camunda.service.TenantServices;
-import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Map;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
 public class UsernamePasswordAuthenticationTokenConverter
     implements CamundaAuthenticationConverter<Authentication> {
 
-  private final RoleServices roleServices;
-  private final GroupServices groupServices;
-  private final TenantServices tenantServices;
+  private final MembershipService membershipService;
 
-  public UsernamePasswordAuthenticationTokenConverter(
-      final RoleServices roleServices,
-      final GroupServices groupServices,
-      final TenantServices tenantServices) {
-    this.roleServices = roleServices;
-    this.groupServices = groupServices;
-    this.tenantServices = tenantServices;
+  public UsernamePasswordAuthenticationTokenConverter(final MembershipService membershipService) {
+    this.membershipService = membershipService;
   }
 
   @Override
   public boolean supports(final Authentication authentication) {
-    return Optional.ofNullable(authentication)
-        .filter(UsernamePasswordAuthenticationToken.class::isInstance)
-        .isPresent();
+    return authentication instanceof UsernamePasswordAuthenticationToken;
   }
 
   @Override
   public CamundaAuthentication convert(final Authentication authentication) {
-    final var username = authentication.getName();
-    final var resolver = new Resolver(username);
-
-    return CamundaAuthentication.of(
-        a ->
-            a.user(username)
-                .groupIdsSupplier(resolver::groups)
-                .roleIdsSupplier(resolver::roles)
-                .tenantsSupplier(resolver::tenants));
-  }
-
-  /**
-   * Per-authentication resolver that memoizes prerequisite lookups so that reads of multiple
-   * membership fields on the same {@link CamundaAuthentication} share the groups→roles→tenants
-   * chain. Synchronized so concurrent reads on different lazy fields don't double-fetch.
-   */
-  private final class Resolver {
-    private final EnumMap<EntityType, Set<String>> ownerTypeToIds = new EnumMap<>(EntityType.class);
-
-    private List<String> groups;
-    private List<String> roles;
-    private List<String> tenants;
-
-    Resolver(final String username) {
-      ownerTypeToIds.put(USER, Set.of(username));
-    }
-
-    synchronized List<String> groups() {
-      if (groups == null) {
-        final var ids =
-            groupServices
-                .getGroupsByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
-                .stream()
-                .map(GroupEntity::groupId)
-                .collect(Collectors.toSet());
-
-        if (!ids.isEmpty()) {
-          ownerTypeToIds.put(GROUP, ids);
-        }
-        groups = List.copyOf(ids);
-      }
-      return groups;
-    }
-
-    synchronized List<String> roles() {
-      if (roles == null) {
-        groups();
-
-        final var ids =
-            roleServices
-                .getRolesByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
-                .stream()
-                .map(RoleEntity::roleId)
-                .collect(Collectors.toSet());
-
-        if (!ids.isEmpty()) {
-          ownerTypeToIds.put(ROLE, ids);
-        }
-        roles = List.copyOf(ids);
-      }
-      return roles;
-    }
-
-    synchronized List<String> tenants() {
-      if (tenants == null) {
-        roles();
-
-        tenants =
-            tenantServices
-                .getTenantsByMemberTypeAndMemberIds(
-                    ownerTypeToIds, CamundaAuthentication.anonymous())
-                .stream()
-                .map(TenantEntity::tenantId)
-                .toList();
-      }
-      return tenants;
-    }
+    return membershipService.resolveMemberships(
+        Map.of(), authentication.getName(), PrincipalType.USER);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverter.java
@@ -20,7 +20,8 @@ import io.camunda.service.GroupServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.util.HashMap;
+import java.util.EnumMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,44 +53,82 @@ public class UsernamePasswordAuthenticationTokenConverter
 
   @Override
   public CamundaAuthentication convert(final Authentication authentication) {
-    final var ownerTypeToIds = new HashMap<EntityType, Set<String>>();
     final var username = authentication.getName();
-    ownerTypeToIds.put(USER, Set.of(username));
-
-    final var groups =
-        groupServices
-            .getGroupsByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
-            .stream()
-            .map(GroupEntity::groupId)
-            .collect(Collectors.toSet());
-
-    if (!groups.isEmpty()) {
-      ownerTypeToIds.put(GROUP, groups);
-    }
-
-    final var roles =
-        roleServices
-            .getRolesByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
-            .stream()
-            .map(RoleEntity::roleId)
-            .collect(Collectors.toSet());
-
-    if (!roles.isEmpty()) {
-      ownerTypeToIds.put(ROLE, roles);
-    }
-
-    final var tenants =
-        tenantServices
-            .getTenantsByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
-            .stream()
-            .map(TenantEntity::tenantId)
-            .toList();
+    final var resolver = new Resolver(username);
 
     return CamundaAuthentication.of(
         a ->
             a.user(username)
-                .roleIds(roles.stream().toList())
-                .groupIds(groups.stream().toList())
-                .tenants(tenants));
+                .groupIdsSupplier(resolver::groups)
+                .roleIdsSupplier(resolver::roles)
+                .tenantsSupplier(resolver::tenants));
+  }
+
+  /**
+   * Per-authentication resolver that memoizes prerequisite lookups so that reads of multiple
+   * membership fields on the same {@link CamundaAuthentication} share the groups→roles→tenants
+   * chain. Synchronized so concurrent reads on different lazy fields don't double-fetch.
+   */
+  private final class Resolver {
+    private final EnumMap<EntityType, Set<String>> ownerTypeToIds = new EnumMap<>(EntityType.class);
+
+    private List<String> groups;
+    private List<String> roles;
+    private List<String> tenants;
+
+    Resolver(final String username) {
+      ownerTypeToIds.put(USER, Set.of(username));
+    }
+
+    synchronized List<String> groups() {
+      if (groups == null) {
+        final var ids =
+            groupServices
+                .getGroupsByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
+                .stream()
+                .map(GroupEntity::groupId)
+                .collect(Collectors.toSet());
+
+        if (!ids.isEmpty()) {
+          ownerTypeToIds.put(GROUP, ids);
+        }
+        groups = List.copyOf(ids);
+      }
+      return groups;
+    }
+
+    synchronized List<String> roles() {
+      if (roles == null) {
+        groups();
+
+        final var ids =
+            roleServices
+                .getRolesByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
+                .stream()
+                .map(RoleEntity::roleId)
+                .collect(Collectors.toSet());
+
+        if (!ids.isEmpty()) {
+          ownerTypeToIds.put(ROLE, ids);
+        }
+        roles = List.copyOf(ids);
+      }
+      return roles;
+    }
+
+    synchronized List<String> tenants() {
+      if (tenants == null) {
+        roles();
+
+        tenants =
+            tenantServices
+                .getTenantsByMemberTypeAndMemberIds(
+                    ownerTypeToIds, CamundaAuthentication.anonymous())
+                .stream()
+                .map(TenantEntity::tenantId)
+                .toList();
+      }
+      return tenants;
+    }
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverter.java
@@ -8,10 +8,8 @@
 package io.camunda.authentication.converter;
 
 import io.camunda.authentication.service.MembershipService;
-import io.camunda.authentication.service.MembershipService.PrincipalType;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
-import java.util.Map;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
@@ -31,7 +29,15 @@ public class UsernamePasswordAuthenticationTokenConverter
 
   @Override
   public CamundaAuthentication convert(final Authentication authentication) {
-    return membershipService.resolveMemberships(
-        Map.of(), authentication.getName(), PrincipalType.USER);
+    final var username = authentication.getName();
+    final var resolver = membershipService.newResolver(username);
+    // BASIC auth has no token claims to match mapping rules against, so we deliberately skip
+    // wiring mappingRulesSupplier — authenticatedMappingRuleIds() will simply return List.of().
+    return CamundaAuthentication.of(
+        a ->
+            a.user(username)
+                .groupIdsSupplier(resolver::groups)
+                .roleIdsSupplier(resolver::roles)
+                .tenantsSupplier(resolver::tenants));
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -23,8 +23,9 @@ import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -69,57 +70,12 @@ public class DefaultMembershipService implements MembershipService {
       final String principalId,
       final PrincipalType principalType)
       throws OAuth2AuthenticationException {
-    final var ownerTypeToIds = new HashMap<EntityType, Set<String>>();
-
-    ownerTypeToIds.put(
-        principalType.equals(PrincipalType.USER) ? EntityType.USER : EntityType.CLIENT,
-        Set.of(principalId));
-
-    final var mappingRules =
-        mappingRuleServices
-            .getMatchingMappingRules(tokenClaims, CamundaAuthentication.anonymous())
-            .map(MappingRuleEntity::mappingRuleId)
-            .collect(Collectors.toSet());
-
-    if (!mappingRules.isEmpty()) {
-      ownerTypeToIds.put(MAPPING_RULE, mappingRules);
-    } else {
-      LOG.debug("No mappingRules found for these claims: {}", tokenClaims);
-    }
-
-    final Set<String> groups;
-    if (isGroupsClaimConfigured) {
-      groups = new HashSet<>(oidcGroupsLoader.load(tokenClaims));
-    } else {
-      groups =
-          groupServices
-              .getGroupsByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
-              .stream()
-              .map(GroupEntity::groupId)
-              .collect(Collectors.toSet());
-    }
-
-    if (!groups.isEmpty()) {
-      ownerTypeToIds.put(GROUP, groups);
-    }
-
-    final var roles =
-        roleServices
-            .getRolesByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
-            .stream()
-            .map(RoleEntity::roleId)
-            .collect(Collectors.toSet());
-
-    if (!roles.isEmpty()) {
-      ownerTypeToIds.put(EntityType.ROLE, roles);
-    }
-
-    final var tenants =
-        tenantServices
-            .getTenantsByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
-            .stream()
-            .map(TenantEntity::tenantId)
-            .toList();
+    // OIDC groups-claim parsing is an in-memory token validation, not a DB call: evaluate it
+    // eagerly so malformed claims fail fast at authentication time.
+    final List<String> eagerGroupsFromClaims =
+        isGroupsClaimConfigured ? List.copyOf(oidcGroupsLoader.load(tokenClaims)) : null;
+    final var resolver =
+        new Resolver(tokenClaims, principalId, principalType, eagerGroupsFromClaims);
 
     return CamundaAuthentication.of(
         a -> {
@@ -128,11 +84,118 @@ public class DefaultMembershipService implements MembershipService {
           } else {
             a.user(principalId);
           }
-          return a.roleIds(roles.stream().toList())
-              .groupIds(groups.stream().toList())
-              .mappingRule(mappingRules.stream().toList())
-              .tenants(tenants)
+          return a.mappingRulesSupplier(resolver::mappingRules)
+              .groupIdsSupplier(resolver::groups)
+              .roleIdsSupplier(resolver::roles)
+              .tenantsSupplier(resolver::tenants)
               .claims(tokenClaims);
         });
+  }
+
+  /**
+   * Per-authentication resolver that memoizes prerequisite lookups so that when multiple membership
+   * fields are read on the same {@link CamundaAuthentication}, shared upstream queries
+   * (mappingRules→groups→roles→tenants) only run once. Synchronized so concurrent reads on
+   * different lazy fields don't double-fetch.
+   */
+  private final class Resolver {
+    private final Map<String, Object> tokenClaims;
+    private final List<String> eagerGroupsFromClaims;
+    private final EnumMap<EntityType, Set<String>> ownerTypeToIds = new EnumMap<>(EntityType.class);
+
+    private List<String> mappingRules;
+    private List<String> groups;
+    private List<String> roles;
+    private List<String> tenants;
+
+    Resolver(
+        final Map<String, Object> tokenClaims,
+        final String principalId,
+        final PrincipalType principalType,
+        final List<String> eagerGroupsFromClaims) {
+      this.tokenClaims = tokenClaims;
+      this.eagerGroupsFromClaims = eagerGroupsFromClaims;
+      ownerTypeToIds.put(
+          principalType.equals(PrincipalType.USER) ? EntityType.USER : EntityType.CLIENT,
+          Set.of(principalId));
+    }
+
+    synchronized List<String> mappingRules() {
+      if (mappingRules == null) {
+        final var ids =
+            mappingRuleServices
+                .getMatchingMappingRules(tokenClaims, CamundaAuthentication.anonymous())
+                .map(MappingRuleEntity::mappingRuleId)
+                .collect(Collectors.toSet());
+        if (!ids.isEmpty()) {
+          ownerTypeToIds.put(MAPPING_RULE, ids);
+        } else {
+          LOG.debug("No mappingRules found for these claims: {}", tokenClaims);
+        }
+        mappingRules = List.copyOf(ids);
+      }
+      return mappingRules;
+    }
+
+    synchronized List<String> groups() {
+      if (groups == null) {
+        // mappingRules must run first so ownerTypeToIds includes MAPPING_RULE before the group
+        // lookup uses it.
+        mappingRules();
+
+        final Set<String> ids;
+        if (eagerGroupsFromClaims != null) {
+          ids = new HashSet<>(eagerGroupsFromClaims);
+        } else {
+          ids =
+              groupServices
+                  .getGroupsByMemberTypeAndMemberIds(
+                      ownerTypeToIds, CamundaAuthentication.anonymous())
+                  .stream()
+                  .map(GroupEntity::groupId)
+                  .collect(Collectors.toSet());
+        }
+
+        if (!ids.isEmpty()) {
+          ownerTypeToIds.put(GROUP, ids);
+        }
+        groups = List.copyOf(ids);
+      }
+      return groups;
+    }
+
+    synchronized List<String> roles() {
+      if (roles == null) {
+        groups();
+
+        final var ids =
+            roleServices
+                .getRolesByMemberTypeAndMemberIds(ownerTypeToIds, CamundaAuthentication.anonymous())
+                .stream()
+                .map(RoleEntity::roleId)
+                .collect(Collectors.toSet());
+
+        if (!ids.isEmpty()) {
+          ownerTypeToIds.put(EntityType.ROLE, ids);
+        }
+        roles = List.copyOf(ids);
+      }
+      return roles;
+    }
+
+    synchronized List<String> tenants() {
+      if (tenants == null) {
+        roles();
+
+        tenants =
+            tenantServices
+                .getTenantsByMemberTypeAndMemberIds(
+                    ownerTypeToIds, CamundaAuthentication.anonymous())
+                .stream()
+                .map(TenantEntity::tenantId)
+                .toList();
+      }
+      return tenants;
+    }
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -122,6 +122,13 @@ public class DefaultMembershipService implements MembershipService {
 
     synchronized List<String> mappingRules() {
       if (mappingRules == null) {
+        // Mapping rules match JWT/OIDC claims to internal identities. With no claims (e.g. the
+        // BASIC-auth path that calls this service with an empty map) nothing can match, so skip
+        // the DB query.
+        if (tokenClaims.isEmpty()) {
+          mappingRules = List.of();
+          return mappingRules;
+        }
         final var ids =
             mappingRuleServices
                 .getMatchingMappingRules(tokenClaims, CamundaAuthentication.anonymous())

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -108,6 +108,11 @@ public class DefaultMembershipService implements MembershipService {
     @Override
     public synchronized List<String> mappingRules() {
       if (mappingRules == null) {
+        if (tokenClaims.isEmpty()) {
+          mappingRules = List.of();
+          return mappingRules;
+        }
+
         final var ids =
             mappingRuleServices
                 .getMatchingMappingRules(tokenClaims, CamundaAuthentication.anonymous())

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -65,40 +65,25 @@ public class DefaultMembershipService implements MembershipService {
   }
 
   @Override
-  public CamundaAuthentication resolveMemberships(
+  public MembershipResolver newResolver(
       final Map<String, Object> tokenClaims,
       final String principalId,
       final PrincipalType principalType)
       throws OAuth2AuthenticationException {
-    // OIDC groups-claim parsing is an in-memory token validation, not a DB call: evaluate it
+    // OIDC groups-claim parsing is in-memory token validation, not a DB call: evaluate it
     // eagerly so malformed claims fail fast at authentication time.
     final List<String> eagerGroupsFromClaims =
         isGroupsClaimConfigured ? List.copyOf(oidcGroupsLoader.load(tokenClaims)) : null;
-    final var resolver =
-        new Resolver(tokenClaims, principalId, principalType, eagerGroupsFromClaims);
-
-    return CamundaAuthentication.of(
-        a -> {
-          if (principalType.equals(PrincipalType.CLIENT)) {
-            a.clientId(principalId);
-          } else {
-            a.user(principalId);
-          }
-          return a.mappingRulesSupplier(resolver::mappingRules)
-              .groupIdsSupplier(resolver::groups)
-              .roleIdsSupplier(resolver::roles)
-              .tenantsSupplier(resolver::tenants)
-              .claims(tokenClaims);
-        });
+    return new Resolver(tokenClaims, principalId, principalType, eagerGroupsFromClaims);
   }
 
   /**
    * Per-authentication resolver that memoizes prerequisite lookups so that when multiple membership
-   * fields are read on the same {@link CamundaAuthentication}, shared upstream queries
+   * fields are read on the same authentication, shared upstream queries
    * (mappingRules→groups→roles→tenants) only run once. Synchronized so concurrent reads on
    * different lazy fields don't double-fetch.
    */
-  private final class Resolver {
+  private final class Resolver implements MembershipResolver {
     private final Map<String, Object> tokenClaims;
     private final List<String> eagerGroupsFromClaims;
     private final EnumMap<EntityType, Set<String>> ownerTypeToIds = new EnumMap<>(EntityType.class);
@@ -120,15 +105,9 @@ public class DefaultMembershipService implements MembershipService {
           Set.of(principalId));
     }
 
-    synchronized List<String> mappingRules() {
+    @Override
+    public synchronized List<String> mappingRules() {
       if (mappingRules == null) {
-        // Mapping rules match JWT/OIDC claims to internal identities. With no claims (e.g. the
-        // BASIC-auth path that calls this service with an empty map) nothing can match, so skip
-        // the DB query.
-        if (tokenClaims.isEmpty()) {
-          mappingRules = List.of();
-          return mappingRules;
-        }
         final var ids =
             mappingRuleServices
                 .getMatchingMappingRules(tokenClaims, CamundaAuthentication.anonymous())
@@ -144,7 +123,8 @@ public class DefaultMembershipService implements MembershipService {
       return mappingRules;
     }
 
-    synchronized List<String> groups() {
+    @Override
+    public synchronized List<String> groups() {
       if (groups == null) {
         // mappingRules must run first so ownerTypeToIds includes MAPPING_RULE before the group
         // lookup uses it.
@@ -171,7 +151,8 @@ public class DefaultMembershipService implements MembershipService {
       return groups;
     }
 
-    synchronized List<String> roles() {
+    @Override
+    public synchronized List<String> roles() {
       if (roles == null) {
         groups();
 
@@ -190,7 +171,8 @@ public class DefaultMembershipService implements MembershipService {
       return roles;
     }
 
-    synchronized List<String> tenants() {
+    @Override
+    public synchronized List<String> tenants() {
       if (tenants == null) {
         roles();
 

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -131,14 +131,16 @@ public class DefaultMembershipService implements MembershipService {
     @Override
     public synchronized List<String> groups() {
       if (groups == null) {
-        // mappingRules must run first so ownerTypeToIds includes MAPPING_RULE before the group
-        // lookup uses it.
-        mappingRules();
-
         final Set<String> ids;
         if (eagerGroupsFromClaims != null) {
+          // Claims path: the group ids come straight from the JWT, in memory. No DB lookup, so
+          // we don't need MAPPING_RULE seeded into ownerTypeToIds — skip mappingRules() so a
+          // groups-only read on the broker hot path stays free of DB queries.
           ids = new HashSet<>(eagerGroupsFromClaims);
         } else {
+          // DB path: the group lookup keys off ownerTypeToIds, which must include MAPPING_RULE
+          // when any mapping rules matched the claims.
+          mappingRules();
           ids =
               groupServices
                   .getGroupsByMemberTypeAndMemberIds(
@@ -159,6 +161,9 @@ public class DefaultMembershipService implements MembershipService {
     @Override
     public synchronized List<String> roles() {
       if (roles == null) {
+        // Roles look up against ownerTypeToIds and need MAPPING_RULE seeded too. groups() on the
+        // claims path deliberately skips that, so re-establish the dependency here explicitly.
+        mappingRules();
         groups();
 
         final var ids =

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -121,7 +121,7 @@ public class DefaultMembershipService implements MembershipService {
         if (!ids.isEmpty()) {
           ownerTypeToIds.put(MAPPING_RULE, ids);
         } else {
-          LOG.debug("No mappingRules found for these claims: {}", tokenClaims);
+          LOG.debug("No mappingRules found for claim keys: {}", tokenClaims.keySet());
         }
         mappingRules = List.copyOf(ids);
       }

--- a/authentication/src/main/java/io/camunda/authentication/service/MembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/MembershipService.java
@@ -7,37 +7,61 @@
  */
 package io.camunda.authentication.service;
 
-import io.camunda.security.auth.CamundaAuthentication;
+import java.util.List;
 import java.util.Map;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 
 /**
- * Service interface for resolving user, client, and group memberships based on authentication
- * claims.
+ * Produces {@link MembershipResolver}s that look up the groups, roles, tenants, and mapping rules
+ * for an authenticated principal. The resolver is wired into a {@link
+ * io.camunda.security.auth.CamundaAuthentication} by the calling converter, which controls which
+ * lazy fields are populated.
  */
 public interface MembershipService {
 
   /**
-   * Resolves the memberships (groups, roles, tenants, and mapping rules) for a user or client based
-   * on the provided authentication claims.
+   * Creates a resolver for an OIDC-style principal whose memberships derive from JWT claims plus
+   * stored identities. Implementations may eagerly evaluate in-memory work (e.g. parsing groups
+   * from a JWT claim) so malformed input fails fast; DB-backed lookups stay deferred until the
+   * caller asks for them.
    *
-   * @param tokenClaims the raw claims extracted from the authentication token (e.g., JWT/OIDC
-   *     token). These are used for matching against mapping rules and extracting groups from the
-   *     token itself AUTHORIZED_USERNAME, AUTHORIZED_CLIENT_ID, USER_TOKEN_CLAIMS). These claims
-   *     are passed to the broker for authorization decisions
+   * @param tokenClaims the raw claims extracted from the authentication token (e.g. JWT/OIDC). Used
+   *     to match mapping rules and, when configured, extract groups from the token itself.
    * @param principalId the principal ID to resolve memberships for
    * @param principalType the type of principal (USER or CLIENT)
-   * @return a {@link CamundaAuthentication} containing the resolved groups, roles, tenants, and
-   *     mappings
-   * @throws org.springframework.security.oauth2.core.OAuth2AuthenticationException if membership
-   *     resolution fails
+   * @throws OAuth2AuthenticationException if eager validation of the claims fails
    */
-  CamundaAuthentication resolveMemberships(
+  MembershipResolver newResolver(
       Map<String, Object> tokenClaims, String principalId, PrincipalType principalType)
       throws OAuth2AuthenticationException;
+
+  /**
+   * Convenience overload for BASIC-style authentication where there are no token claims to match
+   * mapping rules against. Implementations should treat this as a USER principal with empty claims;
+   * callers typically skip wiring the {@code mappingRules} supplier on the resulting {@link
+   * io.camunda.security.auth.CamundaAuthentication}.
+   */
+  default MembershipResolver newResolver(final String username) {
+    return newResolver(Map.of(), username, PrincipalType.USER);
+  }
 
   enum PrincipalType {
     USER,
     CLIENT
+  }
+
+  /**
+   * Looks up the membership fields of a single authenticated principal. Each accessor is expected
+   * to memoize so concurrent or repeated reads share work; callers wire these as the {@code
+   * *Supplier} arguments on the {@code CamundaAuthentication} builder.
+   */
+  interface MembershipResolver {
+    List<String> groups();
+
+    List<String> roles();
+
+    List<String> tenants();
+
+    List<String> mappingRules();
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/NoDBMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/NoDBMembershipService.java
@@ -7,14 +7,11 @@
  */
 package io.camunda.authentication.service;
 
-import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.OidcGroupsLoader;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.stereotype.Service;
 
@@ -33,28 +30,34 @@ public class NoDBMembershipService implements MembershipService {
   }
 
   @Override
-  public CamundaAuthentication resolveMemberships(
+  public MembershipResolver newResolver(
       final Map<String, Object> tokenClaims,
       final String principalId,
       final PrincipalType principalType)
       throws OAuth2AuthenticationException {
-    final Set<String> groups =
-        isGroupsClaimConfigured
-            ? new HashSet<>(oidcGroupsLoader.load(tokenClaims))
-            : Collections.emptySet();
+    // No secondary storage means roles/tenants/mappingRules can't be resolved at all, and groups
+    // only come from the OIDC token claim when one is configured. Evaluate the claim eagerly so
+    // malformed input fails fast.
+    final List<String> groups =
+        isGroupsClaimConfigured ? List.copyOf(oidcGroupsLoader.load(tokenClaims)) : List.of();
+    return new StaticResolver(groups);
+  }
 
-    return CamundaAuthentication.of(
-        a -> {
-          if (principalType.equals(PrincipalType.CLIENT)) {
-            a.clientId(principalId);
-          } else {
-            a.user(principalId);
-          }
-          return a.roleIds(Collections.emptyList())
-              .groupIds(groups.stream().toList())
-              .mappingRule(Collections.emptyList())
-              .tenants(Collections.emptyList())
-              .claims(tokenClaims);
-        });
+  private record StaticResolver(List<String> groups) implements MembershipResolver {
+
+    @Override
+    public List<String> roles() {
+      return List.of();
+    }
+
+    @Override
+    public List<String> tenants() {
+      return List.of();
+    }
+
+    @Override
+    public List<String> mappingRules() {
+      return List.of();
+    }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
@@ -13,6 +13,8 @@ import io.camunda.authentication.converter.CamundaAuthenticationDelegatingConver
 import io.camunda.authentication.handler.AuthFailureHandler;
 import io.camunda.authentication.holder.CamundaAuthenticationDelegatingHolder;
 import io.camunda.authentication.holder.HttpSessionBasedAuthenticationHolder;
+import io.camunda.authentication.service.MembershipService;
+import io.camunda.authentication.service.NoDBMembershipService;
 import io.camunda.search.clients.auth.DisabledResourceAccessProvider;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
@@ -22,6 +24,7 @@ import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.service.ApiServicesExecutorProvider;
 import io.camunda.service.GroupServices;
+import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import jakarta.servlet.http.HttpServletRequest;
@@ -86,6 +89,20 @@ public class WebSecurityConfigTestContext {
   @Bean
   public TenantServices createTenantServices(final ApiServicesExecutorProvider executorProvider) {
     return new TenantServices(null, null, null, executorProvider, null);
+  }
+
+  @Bean
+  public MappingRuleServices createMappingRuleServices(
+      final ApiServicesExecutorProvider executorProvider) {
+    return new MappingRuleServices(null, null, null, executorProvider, null);
+  }
+
+  // Fallback MembershipService for tests that don't auto-discover the real @Service via
+  // ComponentScan. The real DefaultMembershipService (@Primary) wins when it is in scope.
+  @Bean
+  public MembershipService fallbackMembershipService(
+      final SecurityConfiguration securityConfiguration) {
+    return new NoDBMembershipService(securityConfiguration);
   }
 
   @Bean

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
@@ -7,34 +7,12 @@
  */
 package io.camunda.authentication.config.controllers;
 
-import io.camunda.authentication.service.DefaultMembershipService;
-import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.service.ApiServicesExecutorProvider;
-import io.camunda.service.GroupServices;
-import io.camunda.service.MappingRuleServices;
-import io.camunda.service.RoleServices;
-import io.camunda.service.TenantServices;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Additional dependency beans for the OIDC setup */
+/**
+ * Marker context for OIDC-specific test setup. The shared beans (RoleServices, GroupServices,
+ * TenantServices, MappingRuleServices, fallback MembershipService) are provided by {@link
+ * WebSecurityConfigTestContext}; OIDC tests load both contexts.
+ */
 @Configuration
-public class WebSecurityOidcTestContext {
-
-  @Bean
-  public MappingRuleServices createMappingRuleServices(
-      final ApiServicesExecutorProvider executorProvider) {
-    return new MappingRuleServices(null, null, null, executorProvider, null);
-  }
-
-  @Bean
-  public DefaultMembershipService createMembershipService(
-      final MappingRuleServices mappingRuleServices,
-      final TenantServices tenantServices,
-      final RoleServices roleServices,
-      final GroupServices groupServices,
-      final SecurityConfiguration securityConfiguration) {
-    return new DefaultMembershipService(
-        mappingRuleServices, tenantServices, roleServices, groupServices, securityConfiguration);
-  }
-}
+public class WebSecurityOidcTestContext {}

--- a/authentication/src/test/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverterTest.java
@@ -10,13 +10,13 @@ package io.camunda.authentication.converter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.authentication.service.MembershipService;
-import io.camunda.authentication.service.MembershipService.PrincipalType;
-import io.camunda.security.auth.CamundaAuthentication;
-import java.util.Map;
+import io.camunda.authentication.service.MembershipService.MembershipResolver;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -28,11 +28,13 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 public class UsernamePasswordAuthenticationTokenConverterTest {
 
   @Mock private MembershipService membershipService;
+  @Mock private MembershipResolver resolver;
   private UsernamePasswordAuthenticationTokenConverter authenticationConverter;
 
   @BeforeEach
   void setup() throws Exception {
     MockitoAnnotations.openMocks(this).close();
+    when(membershipService.newResolver("test-user")).thenReturn(resolver);
     authenticationConverter = new UsernamePasswordAuthenticationTokenConverter(membershipService);
   }
 
@@ -61,23 +63,48 @@ public class UsernamePasswordAuthenticationTokenConverterTest {
   }
 
   @Test
-  void shouldDelegateToMembershipServiceWithEmptyClaimsAndUserPrincipal() {
+  void shouldBuildAuthenticationFromResolver() {
     // given
-    final var expected = CamundaAuthentication.of(b -> b.user("test-user"));
-    when(membershipService.resolveMemberships(any(), any(), any())).thenReturn(expected);
-    final var authentication = getUsernamePasswordAuthentication("test-user", "test-password");
+    when(resolver.groups()).thenReturn(List.of("g1"));
+    when(resolver.roles()).thenReturn(List.of("r1"));
+    when(resolver.tenants()).thenReturn(List.of("t1"));
 
     // when
-    final var camundaAuthentication = authenticationConverter.convert(authentication);
+    final var auth = authenticationConverter.convert(usernamePassword("test-user"));
 
-    // then — converter passes the username through with empty claims as a USER principal,
-    // and returns whatever the service produced.
-    verify(membershipService).resolveMemberships(Map.of(), "test-user", PrincipalType.USER);
-    assertThat(camundaAuthentication).isSameAs(expected);
+    // then — username plus the three resolver-backed memberships are wired through
+    assertThat(auth.authenticatedUsername()).isEqualTo("test-user");
+    assertThat(auth.authenticatedGroupIds()).containsExactly("g1");
+    assertThat(auth.authenticatedRoleIds()).containsExactly("r1");
+    assertThat(auth.authenticatedTenantIds()).containsExactly("t1");
   }
 
-  private Authentication getUsernamePasswordAuthentication(
-      final String username, final String password) {
-    return new UsernamePasswordAuthenticationToken(username, password);
+  @Test
+  void shouldNotWireMappingRulesSupplierForBasicAuth() {
+    // given — BASIC auth has no token claims, so mappingRules must remain empty without ever
+    // calling the resolver.
+    // when
+    final var auth = authenticationConverter.convert(usernamePassword("test-user"));
+
+    // then
+    assertThat(auth.authenticatedMappingRuleIds()).isEmpty();
+    verify(resolver, never()).mappingRules();
+  }
+
+  @Test
+  void shouldRequestResolverFromServiceWithUsername() {
+    // given
+    final var authentication = usernamePassword("test-user");
+
+    // when
+    authenticationConverter.convert(authentication);
+
+    // then — converter delegates resolver creation to the service using the username overload
+    verify(membershipService).newResolver("test-user");
+    verify(membershipService, never()).newResolver(any(), any(), any());
+  }
+
+  private Authentication usernamePassword(final String username) {
+    return new UsernamePasswordAuthenticationToken(username, "ignored");
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverterTest.java
@@ -10,15 +10,13 @@ package io.camunda.authentication.converter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.search.entities.GroupEntity;
-import io.camunda.search.entities.RoleEntity;
-import io.camunda.search.entities.TenantEntity;
-import io.camunda.service.GroupServices;
-import io.camunda.service.RoleServices;
-import io.camunda.service.TenantServices;
-import java.util.List;
+import io.camunda.authentication.service.MembershipService;
+import io.camunda.authentication.service.MembershipService.PrincipalType;
+import io.camunda.security.auth.CamundaAuthentication;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -29,18 +27,13 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 
 public class UsernamePasswordAuthenticationTokenConverterTest {
 
-  @Mock private GroupServices groupServices;
-  @Mock private RoleServices roleServices;
-  @Mock private TenantServices tenantServices;
+  @Mock private MembershipService membershipService;
   private UsernamePasswordAuthenticationTokenConverter authenticationConverter;
 
   @BeforeEach
   void setup() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-
-    authenticationConverter =
-        new UsernamePasswordAuthenticationTokenConverter(
-            roleServices, groupServices, tenantServices);
+    authenticationConverter = new UsernamePasswordAuthenticationTokenConverter(membershipService);
   }
 
   @Test
@@ -68,81 +61,19 @@ public class UsernamePasswordAuthenticationTokenConverterTest {
   }
 
   @Test
-  void authenticationContainsUsername() {
+  void shouldDelegateToMembershipServiceWithEmptyClaimsAndUserPrincipal() {
     // given
+    final var expected = CamundaAuthentication.of(b -> b.user("test-user"));
+    when(membershipService.resolveMemberships(any(), any(), any())).thenReturn(expected);
     final var authentication = getUsernamePasswordAuthentication("test-user", "test-password");
 
     // when
     final var camundaAuthentication = authenticationConverter.convert(authentication);
 
-    // then
-    assertThat(camundaAuthentication.authenticatedUsername()).isEqualTo("test-user");
-  }
-
-  @Test
-  void authenticationContainsGroups() {
-    // given
-    when(groupServices.getGroupsByMemberTypeAndMemberIds(any(), any()))
-        .thenReturn(
-            List.of(
-                new GroupEntity(1L, "group1", "group", "desc"),
-                new GroupEntity(2L, "group2", "group", "desc")));
-    final var authentication = getUsernamePasswordAuthentication("test-user", "test-password");
-
-    // when
-    final var camundaAuthentication = authenticationConverter.convert(authentication);
-
-    // then
-    assertThat(camundaAuthentication.authenticatedGroupIds())
-        .containsExactlyInAnyOrder("group1", "group2");
-  }
-
-  @Test
-  void authenticationContainsRoles() {
-    // given
-    when(roleServices.getRolesByMemberTypeAndMemberIds(any(), any()))
-        .thenReturn(
-            List.of(
-                new RoleEntity(1L, "role1", "role", "desc"),
-                new RoleEntity(2L, "role2", "role", "desc")));
-    final var authentication = getUsernamePasswordAuthentication("test-user", "test-password");
-
-    // when
-    final var camundaAuthentication = authenticationConverter.convert(authentication);
-
-    // then
-    assertThat(camundaAuthentication.authenticatedRoleIds())
-        .containsExactlyInAnyOrder("role1", "role2");
-  }
-
-  @Test
-  void authenticationContainsTenants() {
-    // given
-    when(tenantServices.getTenantsByMemberTypeAndMemberIds(any(), any()))
-        .thenReturn(
-            List.of(
-                new TenantEntity(1L, "tenant1", "tenant", "desc"),
-                new TenantEntity(2L, "tenant2", "tenant", "desc")));
-    final var authentication = getUsernamePasswordAuthentication("test-user", "test-password");
-
-    // when
-    final var camundaAuthentication = authenticationConverter.convert(authentication);
-
-    // then
-    assertThat(camundaAuthentication.authenticatedTenantIds())
-        .containsExactlyInAnyOrder("tenant1", "tenant2");
-  }
-
-  @Test
-  void authenticationClaimsAreNull() {
-    // given
-    final var authentication = getUsernamePasswordAuthentication("test-user", "test-password");
-
-    // when
-    final var camundaAuthentication = authenticationConverter.convert(authentication);
-
-    // then
-    assertThat(camundaAuthentication.claims()).isNull();
+    // then — converter passes the username through with empty claims as a USER principal,
+    // and returns whatever the service produced.
+    verify(membershipService).resolveMemberships(Map.of(), "test-user", PrincipalType.USER);
+    assertThat(camundaAuthentication).isSameAs(expected);
   }
 
   private Authentication getUsernamePasswordAuthentication(

--- a/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.authentication.service.MembershipService.PrincipalType;
+import io.camunda.security.configuration.AuthenticationConfiguration;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.service.GroupServices;
+import io.camunda.service.MappingRuleServices;
+import io.camunda.service.RoleServices;
+import io.camunda.service.TenantServices;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class DefaultMembershipServiceTest {
+
+  @Mock private MappingRuleServices mappingRuleServices;
+  @Mock private TenantServices tenantServices;
+  @Mock private RoleServices roleServices;
+  @Mock private GroupServices groupServices;
+  @Mock private SecurityConfiguration securityConfiguration;
+  @Mock private AuthenticationConfiguration authenticationConfiguration;
+  @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
+
+  private DefaultMembershipService membershipService;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+    when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
+    when(groupServices.getGroupsByMemberTypeAndMemberIds(any(), any())).thenReturn(List.of());
+    when(roleServices.getRolesByMemberTypeAndMemberIds(any(), any())).thenReturn(List.of());
+    when(tenantServices.getTenantsByMemberTypeAndMemberIds(any(), any())).thenReturn(List.of());
+
+    membershipService =
+        new DefaultMembershipService(
+            mappingRuleServices,
+            tenantServices,
+            roleServices,
+            groupServices,
+            securityConfiguration);
+  }
+
+  @Test
+  void shouldSkipMappingRuleLookupWhenClaimsAreEmpty() {
+    // given — BASIC-auth shape: empty claims map, USER principal
+    final var authentication =
+        membershipService.resolveMemberships(Map.of(), "demo", PrincipalType.USER);
+
+    // when — materialise the lazy field to force the resolver to run
+    final var mappingRuleIds = authentication.authenticatedMappingRuleIds();
+
+    // then — the DB lookup was skipped and the field is empty
+    assertThat(mappingRuleIds).isEmpty();
+    verify(mappingRuleServices, never()).getMatchingMappingRules(any(), any());
+  }
+
+  @Test
+  void shouldQueryMappingRulesWhenClaimsArePresent() {
+    // given — non-empty claims should still flow into the lookup
+    when(mappingRuleServices.getMatchingMappingRules(any(), any())).thenReturn(Stream.empty());
+    final var authentication =
+        membershipService.resolveMemberships(Map.of("sub", "demo"), "demo", PrincipalType.USER);
+
+    // when — isEmpty() materialises the LazyList, which invokes the supplier
+    assertThat(authentication.authenticatedMappingRuleIds()).isEmpty();
+
+    // then
+    verify(mappingRuleServices).getMatchingMappingRules(eq(Map.of("sub", "demo")), any());
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.authentication.service.MembershipService.PrincipalType;
+import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.configuration.AuthenticationConfiguration;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -50,6 +51,7 @@ public class DefaultMembershipServiceTest {
     when(groupServices.getGroupsByMemberTypeAndMemberIds(any(), any())).thenReturn(List.of());
     when(roleServices.getRolesByMemberTypeAndMemberIds(any(), any())).thenReturn(List.of());
     when(tenantServices.getTenantsByMemberTypeAndMemberIds(any(), any())).thenReturn(List.of());
+    when(mappingRuleServices.getMatchingMappingRules(any(), any())).thenReturn(Stream.empty());
 
     membershipService =
         new DefaultMembershipService(
@@ -61,30 +63,61 @@ public class DefaultMembershipServiceTest {
   }
 
   @Test
-  void shouldSkipMappingRuleLookupWhenClaimsAreEmpty() {
-    // given — BASIC-auth shape: empty claims map, USER principal
-    final var authentication =
-        membershipService.resolveMemberships(Map.of(), "demo", PrincipalType.USER);
+  void shouldNotInvokeAnyServiceUntilResolverIsRead() {
+    // given
+    membershipService.newResolver(Map.of("sub", "demo"), "demo", PrincipalType.USER);
 
-    // when — materialise the lazy field to force the resolver to run
-    final var mappingRuleIds = authentication.authenticatedMappingRuleIds();
-
-    // then — the DB lookup was skipped and the field is empty
-    assertThat(mappingRuleIds).isEmpty();
+    // then — constructing the resolver alone does not trigger DB calls
     verify(mappingRuleServices, never()).getMatchingMappingRules(any(), any());
+    verify(groupServices, never()).getGroupsByMemberTypeAndMemberIds(any(), any());
+    verify(roleServices, never()).getRolesByMemberTypeAndMemberIds(any(), any());
+    verify(tenantServices, never()).getTenantsByMemberTypeAndMemberIds(any(), any());
   }
 
   @Test
-  void shouldQueryMappingRulesWhenClaimsArePresent() {
-    // given — non-empty claims should still flow into the lookup
-    when(mappingRuleServices.getMatchingMappingRules(any(), any())).thenReturn(Stream.empty());
-    final var authentication =
-        membershipService.resolveMemberships(Map.of("sub", "demo"), "demo", PrincipalType.USER);
+  void shouldQueryMappingRulesWhenAskedAndPassThroughClaims() {
+    // given
+    final var resolver =
+        membershipService.newResolver(Map.of("sub", "demo"), "demo", PrincipalType.USER);
 
-    // when — isEmpty() materialises the LazyList, which invokes the supplier
-    assertThat(authentication.authenticatedMappingRuleIds()).isEmpty();
+    // when
+    assertThat(resolver.mappingRules()).isEmpty();
 
     // then
     verify(mappingRuleServices).getMatchingMappingRules(eq(Map.of("sub", "demo")), any());
+  }
+
+  @Test
+  void shouldMemoizeMembershipLookups() {
+    // given
+    when(roleServices.getRolesByMemberTypeAndMemberIds(any(), any()))
+        .thenReturn(List.of(new RoleEntity(1L, "role1", "role", "desc")));
+    final var resolver =
+        membershipService.newResolver(Map.of("sub", "demo"), "demo", PrincipalType.USER);
+
+    // when — read roles twice and groups three times (groups is a prerequisite of roles)
+    resolver.roles();
+    resolver.roles();
+    resolver.groups();
+    resolver.groups();
+    resolver.groups();
+
+    // then — each underlying service is called exactly once
+    verify(mappingRuleServices).getMatchingMappingRules(any(), any());
+    verify(groupServices).getGroupsByMemberTypeAndMemberIds(any(), any());
+    verify(roleServices).getRolesByMemberTypeAndMemberIds(any(), any());
+  }
+
+  @Test
+  void basicAuthOverloadShouldUseEmptyClaimsAndUserPrincipal() {
+    // given — convenience overload for the BASIC-auth callers
+    final var resolver = membershipService.newResolver("demo");
+
+    // when
+    resolver.groups();
+
+    // then — the resolver is constructed against empty claims as a USER principal, so the
+    // group lookup runs against an ownerType map seeded only with the USER entry
+    verify(groupServices).getGroupsByMemberTypeAndMemberIds(any(), any());
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
@@ -118,6 +118,7 @@ public class DefaultMembershipServiceTest {
 
     // then — the resolver is constructed against empty claims as a USER principal, so the
     // group lookup runs against an ownerType map seeded only with the USER entry
+    verify(mappingRuleServices, never()).getMatchingMappingRules(any(), any());
     verify(groupServices).getGroupsByMemberTypeAndMemberIds(any(), any());
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
@@ -109,6 +109,33 @@ public class DefaultMembershipServiceTest {
   }
 
   @Test
+  void shouldNotQueryMappingRulesWhenGroupsComeFromOidcClaim() {
+    // given — OIDC with groupsClaim configured: group ids come straight from the JWT, no DB
+    // lookup is needed. Reading authenticatedGroupIds() on the broker hot path must not drag a
+    // getMatchingMappingRules query along for the ride.
+    when(oidcAuthenticationConfiguration.isGroupsClaimConfigured()).thenReturn(true);
+    when(oidcAuthenticationConfiguration.getGroupsClaim()).thenReturn("groups");
+    final var serviceWithGroupsClaim =
+        new DefaultMembershipService(
+            mappingRuleServices,
+            tenantServices,
+            roleServices,
+            groupServices,
+            securityConfiguration);
+
+    final var resolver =
+        serviceWithGroupsClaim.newResolver(
+            Map.of("sub", "demo", "groups", List.of("g1", "g2")), "demo", PrincipalType.USER);
+
+    // when — only groups are read
+    assertThat(resolver.groups()).containsExactlyInAnyOrder("g1", "g2");
+
+    // then — no DB calls at all on this path
+    verify(mappingRuleServices, never()).getMatchingMappingRules(any(), any());
+    verify(groupServices, never()).getGroupsByMemberTypeAndMemberIds(any(), any());
+  }
+
+  @Test
   void basicAuthOverloadShouldUseEmptyClaimsAndUserPrincipal() {
     // given — convenience overload for the BASIC-auth callers
     final var resolver = membershipService.newResolver("demo");

--- a/load-tests/load-tester/src/main/resources/application.yaml
+++ b/load-tests/load-tester/src/main/resources/application.yaml
@@ -56,7 +56,7 @@ camunda:
         # @JobWorker picks up the correct values per deployment.
         name: ${LOAD_TESTER_WORKER_WORKER_NAME:benchmark-worker}
         type: ${LOAD_TESTER_WORKER_JOB_TYPE:benchmark-task}
-        stream-enabled: true
+        stream-enabled: false
         max-jobs-active: ${LOAD_TESTER_WORKER_CAPACITY:30}
         # Default: completionDelay(300ms) * 6 = 1800ms. The old HOCON app computed
         # this dynamically; here it's static. Update if completionDelay changes.

--- a/load-tests/load-tester/src/main/resources/application.yaml
+++ b/load-tests/load-tester/src/main/resources/application.yaml
@@ -56,7 +56,7 @@ camunda:
         # @JobWorker picks up the correct values per deployment.
         name: ${LOAD_TESTER_WORKER_WORKER_NAME:benchmark-worker}
         type: ${LOAD_TESTER_WORKER_JOB_TYPE:benchmark-task}
-        stream-enabled: false
+        stream-enabled: true
         max-jobs-active: ${LOAD_TESTER_WORKER_CAPACITY:30}
         # Default: completionDelay(300ms) * 6 = 1800ms. The old HOCON app computed
         # this dynamically; here it's static. Update if completionDelay changes.

--- a/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
@@ -53,7 +53,6 @@ public class BrokerRequestAuthorizationConverter {
 
     final var username = authentication.authenticatedUsername();
     final var clientId = authentication.authenticatedClientId();
-    final var groups = authentication.authenticatedGroupIds();
     final var claims = authentication.claims();
 
     if (username != null) {
@@ -65,7 +64,11 @@ public class BrokerRequestAuthorizationConverter {
     }
 
     if (!camundaGroupsEnabled) {
-      authorization.put(USER_GROUPS_CLAIMS, groups);
+      // authenticatedGroupIds() is lazy on the CamundaAuthentication record; resolve it only on
+      // the OIDC token-claim path where the engine consumes group membership. On the
+      // camundaGroupsEnabled path the engine resolves groups itself, so reading the field here
+      // would trigger an avoidable DB lookup on every broker request.
+      authorization.put(USER_GROUPS_CLAIMS, authentication.authenticatedGroupIds());
     }
 
     if (claims != null) {

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthentication.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthentication.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Represents the authentication context for a user or client in Camunda, including (where
@@ -27,6 +28,12 @@ import java.util.function.Function;
  * <p>Either {@code authenticatedUsername} or {@code authenticatedClientId} must be set, but not
  * both, unless the authentication represents an anonymous user {@code anonymousUser} in which case
  * both can be null.
+ *
+ * <p>Membership fields ({@code authenticatedGroupIds}, {@code authenticatedRoleIds}, {@code
+ * authenticatedTenantIds}, {@code authenticatedMappingRuleIds}) may be supplied eagerly via the
+ * corresponding builder methods, or lazily via the {@code *Supplier} builder methods. Lazy fields
+ * are resolved at most once on the first read operation against the returned list; the public
+ * accessor signature is unchanged in both cases.
  */
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public record CamundaAuthentication(
@@ -72,6 +79,10 @@ public record CamundaAuthentication(
     private final List<String> roleIds = new ArrayList<>();
     private final List<String> tenants = new ArrayList<>();
     private final List<String> mappingRules = new ArrayList<>();
+    private Supplier<List<String>> groupIdsSupplier;
+    private Supplier<List<String>> roleIdsSupplier;
+    private Supplier<List<String>> tenantsSupplier;
+    private Supplier<List<String>> mappingRulesSupplier;
     private Map<String, Object> claims;
 
     public Builder user(final String value) {
@@ -100,6 +111,11 @@ public record CamundaAuthentication(
       return this;
     }
 
+    public Builder groupIdsSupplier(final Supplier<List<String>> supplier) {
+      groupIdsSupplier = supplier;
+      return this;
+    }
+
     public Builder role(final String value) {
       return roleIds(Collections.singletonList(value));
     }
@@ -108,6 +124,11 @@ public record CamundaAuthentication(
       if (values != null) {
         roleIds.addAll(values);
       }
+      return this;
+    }
+
+    public Builder roleIdsSupplier(final Supplier<List<String>> supplier) {
+      roleIdsSupplier = supplier;
       return this;
     }
 
@@ -122,6 +143,11 @@ public record CamundaAuthentication(
       return this;
     }
 
+    public Builder tenantsSupplier(final Supplier<List<String>> supplier) {
+      tenantsSupplier = supplier;
+      return this;
+    }
+
     public Builder mappingRule(final String mappingRule) {
       return mappingRule(Collections.singletonList(mappingRule));
     }
@@ -130,6 +156,11 @@ public record CamundaAuthentication(
       if (values != null) {
         mappingRules.addAll(values);
       }
+      return this;
+    }
+
+    public Builder mappingRulesSupplier(final Supplier<List<String>> supplier) {
+      mappingRulesSupplier = supplier;
       return this;
     }
 
@@ -143,11 +174,25 @@ public record CamundaAuthentication(
           username,
           clientId,
           anonymous,
-          unmodifiableList(groupIds),
-          unmodifiableList(roleIds),
-          unmodifiableList(tenants),
-          unmodifiableList(mappingRules),
+          resolveMembershipField("groupIds", groupIds, groupIdsSupplier),
+          resolveMembershipField("roleIds", roleIds, roleIdsSupplier),
+          resolveMembershipField("tenants", tenants, tenantsSupplier),
+          resolveMembershipField("mappingRules", mappingRules, mappingRulesSupplier),
           claims);
+    }
+
+    private static List<String> resolveMembershipField(
+        final String fieldName, final List<String> eager, final Supplier<List<String>> supplier) {
+      if (supplier == null) {
+        return unmodifiableList(eager);
+      }
+      if (!eager.isEmpty()) {
+        throw new IllegalStateException(
+            "Both eager values and a supplier were set for '"
+                + fieldName
+                + "'. Use one or the other.");
+      }
+      return new LazyList<>(supplier);
     }
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/auth/LazyList.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/LazyList.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+import java.io.ObjectStreamException;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Package-private {@link List} decorator that defers materialisation of its backing list to a
+ * {@link Supplier} invoked at most once on the first read operation. Subsequent operations delegate
+ * to the memoised list.
+ *
+ * <p>Used by {@link CamundaAuthentication} so hosts can hand the builder a deferred resolver for a
+ * membership field (groups, roles, tenants, mapping rules) without changing the public accessor
+ * signature, which keeps returning {@code List<String>}.
+ *
+ * <p>Contract:
+ *
+ * <ul>
+ *   <li>Read operations trigger the supplier on first call; the result is memoised.
+ *   <li>Mutator operations throw {@link UnsupportedOperationException}, matching the immutability
+ *       contract of the lists produced by the canonical constructor today.
+ *   <li>{@link #equals}, {@link #hashCode}, {@link #iterator}, {@link #size}, etc. all materialise.
+ *   <li>Serialisation goes through {@link #writeReplace}: the wire form is always a plain {@link
+ *       List}, so lazy state never crosses a serialisation boundary.
+ * </ul>
+ */
+final class LazyList<T> extends AbstractList<T> implements Serializable {
+
+  @Serial private static final long serialVersionUID = 1L;
+
+  private transient volatile Supplier<List<T>> supplier;
+  private transient volatile List<T> materialised;
+
+  LazyList(final Supplier<List<T>> supplier) {
+    this.supplier = Objects.requireNonNull(supplier, "supplier must not be null");
+  }
+
+  private List<T> resolve() {
+    List<T> local = materialised;
+    if (local == null) {
+      synchronized (this) {
+        local = materialised;
+        if (local == null) {
+          final var produced = supplier.get();
+          local = produced == null ? List.of() : List.copyOf(produced);
+          materialised = local;
+          supplier = null;
+        }
+      }
+    }
+    return local;
+  }
+
+  boolean hasSupplierReference() {
+    return supplier != null;
+  }
+
+  @Override
+  public T get(final int index) {
+    return resolve().get(index);
+  }
+
+  @Override
+  public int size() {
+    return resolve().size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return resolve().isEmpty();
+  }
+
+  @Override
+  public boolean contains(final Object o) {
+    return resolve().contains(o);
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return resolve().iterator();
+  }
+
+  @Override
+  public ListIterator<T> listIterator() {
+    return resolve().listIterator();
+  }
+
+  @Override
+  public ListIterator<T> listIterator(final int index) {
+    return resolve().listIterator(index);
+  }
+
+  @Override
+  public Object[] toArray() {
+    return resolve().toArray();
+  }
+
+  @Override
+  public <U> U[] toArray(final U[] a) {
+    return resolve().toArray(a);
+  }
+
+  @Override
+  public boolean containsAll(final Collection<?> c) {
+    return resolve().containsAll(c);
+  }
+
+  @Override
+  public int indexOf(final Object o) {
+    return resolve().indexOf(o);
+  }
+
+  @Override
+  public int lastIndexOf(final Object o) {
+    return resolve().lastIndexOf(o);
+  }
+
+  @Override
+  public List<T> subList(final int fromIndex, final int toIndex) {
+    return resolve().subList(fromIndex, toIndex);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    return resolve().equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return resolve().hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return resolve().toString();
+  }
+
+  @Serial
+  private Object writeReplace() throws ObjectStreamException {
+    return List.copyOf(resolve());
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
@@ -21,6 +21,7 @@ import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 public class BrokerRequestAuthorizationConverterTest {
@@ -138,6 +139,63 @@ public class BrokerRequestAuthorizationConverterTest {
     assertThat(brokerRequestAuth).hasSize(2);
     assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_GROUPS_ENABLED, true);
     assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_USERS_ENABLED, true);
+  }
+
+  @Test
+  void shouldNotInvokeGroupsSupplierWhenCamundaGroupsEnabled() {
+    // given — default config: BASIC auth, no OIDC groupsClaim, so camundaGroupsEnabled=true and
+    // the engine looks up groups itself.
+    final var invoked = new AtomicBoolean();
+    final var authentication =
+        CamundaAuthentication.of(
+            b ->
+                b.user("foo")
+                    .groupIdsSupplier(
+                        () -> {
+                          invoked.set(true);
+                          return List.of("group1");
+                        }));
+    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+
+    // when
+    final var brokerRequestAuth = converter.convert(authentication);
+
+    // then
+    assertThat(invoked).isFalse();
+    assertThat(brokerRequestAuth).doesNotContainKey(USER_GROUPS_CLAIMS);
+    assertThat(brokerRequestAuth).containsEntry(AUTHORIZED_USERNAME, "foo");
+  }
+
+  @Test
+  void shouldStoreLazyGroupsWhenCamundaGroupsDisabled() {
+    // given — OIDC with groupsClaim (camundaGroupsEnabled=false); the engine consumes the groups,
+    // so they must end up in the authorization map. Resolution itself stays deferred until the
+    // downstream consumer reads the list.
+    final var invoked = new AtomicBoolean();
+    final var oidcConfiguration = new OidcAuthenticationConfiguration();
+    oidcConfiguration.setGroupsClaim("groups");
+    final var securityConfiguration = new SecurityConfiguration();
+    securityConfiguration.getAuthentication().setOidc(oidcConfiguration);
+    securityConfiguration.getAuthentication().setMethod(OIDC);
+
+    final var authentication =
+        CamundaAuthentication.of(
+            b ->
+                b.user("foo")
+                    .groupIdsSupplier(
+                        () -> {
+                          invoked.set(true);
+                          return List.of("group1", "group2");
+                        }));
+    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+
+    // when
+    final var brokerRequestAuth = converter.convert(authentication);
+
+    // then — entry is present; touching the value resolves the supplier exactly once
+    assertThat(brokerRequestAuth).containsKey(USER_GROUPS_CLAIMS);
+    assertThat(brokerRequestAuth).containsEntry(USER_GROUPS_CLAIMS, List.of("group1", "group2"));
+    assertThat(invoked).isTrue();
   }
 
   @Test

--- a/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
@@ -193,6 +193,7 @@ public class BrokerRequestAuthorizationConverterTest {
     final var brokerRequestAuth = converter.convert(authentication);
 
     // then — entry is present; touching the value resolves the supplier exactly once
+    assertThat(invoked).isFalse();
     assertThat(brokerRequestAuth).containsKey(USER_GROUPS_CLAIMS);
     assertThat(brokerRequestAuth).containsEntry(USER_GROUPS_CLAIMS, List.of("group1", "group2"));
     assertThat(invoked).isTrue();

--- a/security/security-core/src/test/java/io/camunda/security/auth/CamundaAuthenticationTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/CamundaAuthenticationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class CamundaAuthenticationTest {
+
+  @Test
+  void supplierIsNotInvokedUntilFirstAccessorCall() {
+    final var invocations = new AtomicInteger();
+    final var auth =
+        CamundaAuthentication.of(
+            b ->
+                b.user("alice")
+                    .groupIdsSupplier(
+                        () -> {
+                          invocations.incrementAndGet();
+                          return List.of("g1");
+                        }));
+
+    assertThat(invocations).hasValue(0);
+
+    final var groups = auth.authenticatedGroupIds();
+    assertThat(groups).containsExactly("g1");
+    assertThat(invocations).hasValue(1);
+  }
+
+  @Test
+  void supplierIsInvokedAtMostOnce() {
+    final var invocations = new AtomicInteger();
+    final var auth =
+        CamundaAuthentication.of(
+            b ->
+                b.user("alice")
+                    .roleIdsSupplier(
+                        () -> {
+                          invocations.incrementAndGet();
+                          return List.of("r1");
+                        }));
+
+    auth.authenticatedRoleIds().size();
+    auth.authenticatedRoleIds().contains("r1");
+    auth.authenticatedRoleIds().iterator().next();
+
+    assertThat(invocations).hasValue(1);
+  }
+
+  @Test
+  void independentSuppliersForEachMembershipField() {
+    final var groupCalls = new AtomicInteger();
+    final var roleCalls = new AtomicInteger();
+    final var tenantCalls = new AtomicInteger();
+    final var mappingRuleCalls = new AtomicInteger();
+
+    final var auth =
+        CamundaAuthentication.of(
+            b ->
+                b.user("alice")
+                    .groupIdsSupplier(
+                        () -> {
+                          groupCalls.incrementAndGet();
+                          return List.of("g");
+                        })
+                    .roleIdsSupplier(
+                        () -> {
+                          roleCalls.incrementAndGet();
+                          return List.of("r");
+                        })
+                    .tenantsSupplier(
+                        () -> {
+                          tenantCalls.incrementAndGet();
+                          return List.of("t");
+                        })
+                    .mappingRulesSupplier(
+                        () -> {
+                          mappingRuleCalls.incrementAndGet();
+                          return List.of("m");
+                        }));
+
+    // Only read groups — the other suppliers must stay untouched.
+    assertThat(auth.authenticatedGroupIds()).containsExactly("g");
+
+    assertThat(groupCalls).hasValue(1);
+    assertThat(roleCalls).hasValue(0);
+    assertThat(tenantCalls).hasValue(0);
+    assertThat(mappingRuleCalls).hasValue(0);
+  }
+
+  @Test
+  void buildFailsWhenBothEagerAndSupplierSetOnSameField() {
+    assertThatThrownBy(
+            () ->
+                CamundaAuthentication.of(
+                    b ->
+                        b.user("alice")
+                            .groupIds(List.of("g1"))
+                            .groupIdsSupplier(() -> List.of("g2"))))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("groupIds");
+  }
+
+  @Test
+  void eagerFieldsRemainUnchanged() {
+    final var auth =
+        CamundaAuthentication.of(
+            b ->
+                b.user("alice")
+                    .groupIds(List.of("g1", "g2"))
+                    .roleIds(List.of("r1"))
+                    .tenants(List.of("t1"))
+                    .mappingRule(List.of("m1")));
+
+    assertThat(auth.authenticatedGroupIds()).containsExactly("g1", "g2");
+    assertThat(auth.authenticatedRoleIds()).containsExactly("r1");
+    assertThat(auth.authenticatedTenantIds()).containsExactly("t1");
+    assertThat(auth.authenticatedMappingRuleIds()).containsExactly("m1");
+  }
+
+  @Test
+  void serializationProducesNonLazyList() throws Exception {
+    final var auth =
+        CamundaAuthentication.of(
+            b ->
+                b.user("alice")
+                    .groupIdsSupplier(() -> List.of("g1", "g2"))
+                    .roleIdsSupplier(() -> List.of("r1"))
+                    .tenantsSupplier(() -> List.of("t1"))
+                    .mappingRulesSupplier(() -> List.of("m1")));
+
+    final var bytes = new ByteArrayOutputStream();
+    try (var oos = new ObjectOutputStream(bytes)) {
+      oos.writeObject(auth);
+    }
+
+    try (var ois = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      final var deserialized = (CamundaAuthentication) ois.readObject();
+      assertThat(deserialized.authenticatedUsername()).isEqualTo("alice");
+      assertThat(deserialized.authenticatedGroupIds()).containsExactly("g1", "g2");
+      assertThat(deserialized.authenticatedRoleIds()).containsExactly("r1");
+      assertThat(deserialized.authenticatedTenantIds()).containsExactly("t1");
+      assertThat(deserialized.authenticatedMappingRuleIds()).containsExactly("m1");
+    }
+  }
+
+  @Test
+  void equalsBetweenLazyAndEagerWithSameContent() {
+    final var lazy =
+        CamundaAuthentication.of(b -> b.user("alice").groupIdsSupplier(() -> List.of("g1", "g2")));
+    final var eager = CamundaAuthentication.of(b -> b.user("alice").groupIds(List.of("g1", "g2")));
+
+    assertThat(lazy).isEqualTo(eager);
+    assertThat(lazy.hashCode()).isEqualTo(eager.hashCode());
+  }
+}


### PR DESCRIPTION
 ## Description

  Backport of the lazy-load `CamundaAuthentication` work from `main` to `stable/8.9`. On `main` the
  lazy-load support lives in `camunda-security-library`; on 8.9 that library hasn't been extracted
  yet, so the equivalent changes are made in-tree under `security/security-core` and `authentication`.

  ### Why
  Authentication previously paid for 3–4 sequential service calls (groups, roles, tenants, mapping
  rules) on every request, even when the handler only read one of them. On stateless bearer-token
  flows (e.g. job activation/completion via `JobServices`) this is a per-request cost. After this PR
  those lookups are deferred to first read and memoized per `CamundaAuthentication`.

  ### What changes
  - **`CamundaAuthentication` gains supplier builder methods** (`groupIdsSupplier`,
    `roleIdsSupplier`, `tenantsSupplier`, `mappingRulesSupplier`). A package-private `LazyList`
    decorator backs the four membership fields when wired with a supplier. Accessors keep their
    `List<String>` shape — no breaking change to consumers. `build()` fails fast if both eager
    values and a supplier are set for the same field.
  - **`MembershipService` is reshaped** from `resolveMemberships(...) -> CamundaAuthentication` to
    `newResolver(...) -> MembershipResolver`. Each converter owns auth assembly and decides which
    lazy fields to wire (BASIC auth deliberately skips `mappingRulesSupplier` since it has no
    claims).
  - **`DefaultMembershipService.Resolver`** memoizes the `mappingRules → groups → roles → tenants`
    chain so reading multiple fields shares prerequisite lookups.
  - **`UsernamePasswordAuthenticationTokenConverter`** drops its three-service constructor and
    delegates to `MembershipService.newResolver(username)`.
  - **`BrokerRequestAuthorizationConverter`** reads `authenticatedGroupIds()` only on the
    `!camundaGroupsEnabled` branch, so the supplier stays untouched when the engine resolves groups
    itself.
  - **Hot-path fix (review feedback):** `Resolver.groups()` no longer calls `mappingRules()` on the
    eager-from-claims branch — the JWT-supplied groups don't consult `ownerTypeToIds`. `roles()`
    calls `mappingRules()` explicitly so role/tenant lookups still see `MAPPING_RULE` seeded.

  ### Notable omissions from main's history
  - `main`'s commit `drop legacy field-list overload on broker auth converter` is N/A here — that
    overload doesn't exist on 8.9.


  ## Checklist

  - [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI 
  changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

  ## Related issues

  closes #
  
  ## Test plan

  - [x] `CamundaAuthenticationTest` covers lazy invocation, single-shot memoization,
    eager+supplier conflict, serialization round-trip, and equals across lazy/eager values.
  - [x] `BrokerRequestAuthorizationConverterTest` adds (a) the no-invocation guarantee on the
    `camundaGroupsEnabled` path and (b) the deferred-resolution path when `camundaGroupsDisabled`.
  - [x] `DefaultMembershipServiceTest` (new) covers: resolver construction without any DB calls,
    memoization across reads, the BASIC-auth `newResolver(String)` overload, the empty-claims
    short-circuit for `mappingRules()`, and the **regression test for the review fix**:
    OIDC + `groupsClaim` configured, read `authenticatedGroupIds()`, assert `mappingRuleServices`
    is never touched.
  - [x] `UsernamePasswordAuthenticationTokenConverterTest` exercises the resolver-based delegation
    and asserts BASIC auth never wires `mappingRulesSupplier`.
  - [x] Local full-module runs: **94/94** `security-core` and **486/486** `authentication` tests
    green at HEAD.


## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/35067 
this is a port of the changes made in https://github.com/camunda/camunda/pull/53759 to the `stable/8.9` branch. 
