### PR TITLE
feat: strip unused RocksDB native libs from packaged c8run archive

### DIFF
--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -172,24 +172,31 @@ func rocksdbNativeLibName(osType, arch string) (string, error) {
 	case "linux":
 		switch arch {
 		case "x86_64":
-			return "librocksdb-jni-linux64.so", nil
+			return "librocksdbjni-linux64.so", nil
 		case "aarch64":
-			return "librocksdb-jni-linux-aarch64.so", nil
+			return "librocksdbjni-linux-aarch64.so", nil
 		}
 	case "darwin":
 		switch arch {
 		case "x86_64":
-			return "librocksdb-jni-osx-x86_64.jnilib", nil
+			return "librocksdbjni-osx-x86_64.jnilib", nil
 		case "aarch64":
-			return "librocksdb-jni-osx-arm64.jnilib", nil
+			return "librocksdbjni-osx-arm64.jnilib", nil
 		}
 	case "windows":
 		switch arch {
 		case "x86_64":
-			return "librocksdb-jni-win64.dll", nil
+			return "librocksdbjni-win64.dll", nil
 		}
 	}
 	return "", fmt.Errorf("no RocksDB native lib mapping for os=%s arch=%s", osType, arch)
+}
+
+func isRootNativeLib(name string) bool {
+	if strings.ContainsRune(name, '/') {
+		return false
+	}
+	return strings.HasSuffix(name, ".so") || strings.HasSuffix(name, ".jnilib") || strings.HasSuffix(name, ".dll")
 }
 
 func copyZipEntry(w *zip.Writer, f *zip.File) error {
@@ -237,9 +244,9 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	var copyErr error
 
 	for _, f := range r.File {
-		isNativeEntry := strings.HasPrefix(f.Name, "META-INF/native/") && !strings.HasSuffix(f.Name, "/")
+		isNativeEntry := isRootNativeLib(f.Name)
 		if isNativeEntry {
-			if filepath.Base(f.Name) != libName {
+			if f.Name != libName {
 				continue
 			}
 			nativeLibCount++

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -276,6 +276,25 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	return nil
 }
 
+func stripRocksDbNativeLibs(camundaVersion, osType, arch string) error {
+	libName, err := rocksdbNativeLibName(osType, arch)
+	if err != nil {
+		return fmt.Errorf("stripRocksDbNativeLibs: %w", err)
+	}
+
+	pattern := filepath.Join("camunda-zeebe-"+camundaVersion, "lib", "rocksdbjni-*.jar")
+	jars, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("stripRocksDbNativeLibs: failed to glob %s: %w", pattern, err)
+	}
+	if len(jars) == 0 {
+		return fmt.Errorf("stripRocksDbNativeLibs: no rocksdbjni jar found matching %s", pattern)
+	}
+
+	log.Info().Str("jar", jars[0]).Str("keeping", libName).Msg("stripping unused RocksDB native libs")
+	return rewriteZipKeepingNativeLib(jars[0], libName)
+}
+
 func getJavaArtifactsToken() (string, error) {
 	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
 	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")
@@ -591,6 +610,10 @@ func New(camundaVersion, connectorsVersion string) error {
 	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, ".", javaArtifactsToken, extractFunc)
 	if err != nil {
 		return fmt.Errorf("Package "+osType+": failed to download camunda %w\n%s", err, debug.Stack())
+	}
+
+	if err := stripRocksDbNativeLibs(camundaVersion, osType, architecture); err != nil {
+		return fmt.Errorf("Package %s: failed to strip RocksDB native libs: %w", osType, err)
 	}
 
 	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, ".", javaArtifactsToken, func(_, _ string) error { return nil })

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -165,6 +165,30 @@ func setOsSpecificValues() (string, string, string, string, func(string, string)
 	}
 }
 
+func rocksdbNativeLibName(osType, arch string) (string, error) {
+	switch osType {
+	case "linux":
+		switch arch {
+		case "x86_64":
+			return "librocksdb-jni-linux64.so", nil
+		case "aarch64":
+			return "librocksdb-jni-linux-aarch64.so", nil
+		}
+	case "darwin":
+		switch arch {
+		case "x86_64":
+			return "librocksdb-jni-osx-x86_64.jnilib", nil
+		case "aarch64":
+			return "librocksdb-jni-osx-arm64.jnilib", nil
+		}
+	case "windows":
+		if arch == "x86_64" {
+			return "librocksdb-jni-win64.dll", nil
+		}
+	}
+	return "", fmt.Errorf("no RocksDB native lib mapping for os=%s arch=%s", osType, arch)
+}
+
 func getJavaArtifactsToken() (string, error) {
 	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
 	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -192,7 +192,10 @@ func rocksdbNativeLibName(osType, arch string) (string, error) {
 	return "", fmt.Errorf("no RocksDB native lib mapping for os=%s arch=%s", osType, arch)
 }
 
-func isRootNativeLib(name string) bool {
+// isRocksdbNativeLib reports whether name is a RocksDB JNI native library entry.
+// rocksdbjni JARs pack native libs at the JAR root (no directory prefix).
+// Only call this on rocksdbjni-*.jar entries — other JARs may contain unrelated root-level natives.
+func isRocksdbNativeLib(name string) bool {
 	if strings.ContainsRune(name, '/') {
 		return false
 	}
@@ -245,7 +248,7 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	var copyErr error
 
 	for _, f := range r.File {
-		isNativeEntry := isRootNativeLib(f.Name)
+		isNativeEntry := isRocksdbNativeLib(f.Name)
 		if isNativeEntry {
 			if f.Name != libName {
 				continue
@@ -292,6 +295,8 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	return nil
 }
 
+// stripRocksDbNativeLibs must be called from the c8run working directory:
+// it globs camunda-zeebe-<version>/lib/rocksdbjni-*.jar relative to CWD.
 func stripRocksDbNativeLibs(camundaVersion, osType, arch string) error {
 	libName, err := rocksdbNativeLibName(osType, arch)
 	if err != nil {

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -233,7 +233,7 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	tmpPath := jarPath + ".tmp"
 	tmpFile, err := os.Create(tmpPath)
 	if err != nil {
-		r.Close()
+		_ = r.Close()
 		return fmt.Errorf("failed to create temp file %s: %w", tmpPath, err)
 	}
 
@@ -262,25 +262,25 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	}
 
 	if copyErr != nil {
-		w.Close()
-		tmpFile.Close()
-		r.Close()
+		_ = w.Close()
+		_ = tmpFile.Close()
+		_ = r.Close()
 		removeTmp()
 		return copyErr
 	}
 	if err := w.Close(); err != nil {
-		tmpFile.Close()
-		r.Close()
+		_ = tmpFile.Close()
+		_ = r.Close()
 		removeTmp()
 		return fmt.Errorf("failed to finalize temp jar: %w", err)
 	}
 	if err := tmpFile.Close(); err != nil {
-		r.Close()
+		_ = r.Close()
 		removeTmp()
 		return fmt.Errorf("failed to close temp file: %w", err)
 	}
 	if nativeLibCount != 1 {
-		r.Close()
+		_ = r.Close()
 		removeTmp()
 		return fmt.Errorf("expected exactly 1 native lib %q in jar, got %d: verify rocksdbNativeLibName mapping", libName, nativeLibCount)
 	}
@@ -637,7 +637,7 @@ func New(camundaVersion, connectorsVersion string) error {
 	}
 
 	if err := stripRocksDbNativeLibs(camundaVersion, osType, architecture); err != nil {
-		return fmt.Errorf("Package %s: failed to strip RocksDB native libs: %w", osType, err)
+		return fmt.Errorf("package %s: failed to strip RocksDB native libs: %w", osType, err)
 	}
 
 	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, ".", javaArtifactsToken, func(_, _ string) error { return nil })

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -290,6 +290,9 @@ func stripRocksDbNativeLibs(camundaVersion, osType, arch string) error {
 	if len(jars) == 0 {
 		return fmt.Errorf("stripRocksDbNativeLibs: no rocksdbjni jar found matching %s", pattern)
 	}
+	if len(jars) > 1 {
+		log.Warn().Strs("jars", jars).Msg("multiple rocksdbjni jars found; stripping only the first")
+	}
 
 	log.Info().Str("jar", jars[0]).Str("keeping", libName).Msg("stripping unused RocksDB native libs")
 	return rewriteZipKeepingNativeLib(jars[0], libName)

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -225,11 +225,12 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open jar %s: %w", jarPath, err)
 	}
-	defer r.Close()
+	// r is closed explicitly before os.Rename — Windows cannot rename over an open file.
 
 	tmpPath := jarPath + ".tmp"
 	tmpFile, err := os.Create(tmpPath)
 	if err != nil {
+		r.Close()
 		return fmt.Errorf("failed to create temp file %s: %w", tmpPath, err)
 	}
 
@@ -260,21 +261,29 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	if copyErr != nil {
 		w.Close()
 		tmpFile.Close()
+		r.Close()
 		removeTmp()
 		return copyErr
 	}
 	if err := w.Close(); err != nil {
 		tmpFile.Close()
+		r.Close()
 		removeTmp()
 		return fmt.Errorf("failed to finalize temp jar: %w", err)
 	}
 	if err := tmpFile.Close(); err != nil {
+		r.Close()
 		removeTmp()
 		return fmt.Errorf("failed to close temp file: %w", err)
 	}
 	if nativeLibCount != 1 {
+		r.Close()
 		removeTmp()
 		return fmt.Errorf("expected exactly 1 native lib %q in jar, got %d: verify rocksdbNativeLibName mapping", libName, nativeLibCount)
+	}
+	if err := r.Close(); err != nil {
+		removeTmp()
+		return fmt.Errorf("failed to close source jar before rename: %w", err)
 	}
 	if err := os.Rename(tmpPath, jarPath); err != nil {
 		removeTmp()

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -182,7 +182,8 @@ func rocksdbNativeLibName(osType, arch string) (string, error) {
 			return "librocksdb-jni-osx-arm64.jnilib", nil
 		}
 	case "windows":
-		if arch == "x86_64" {
+		switch arch {
+		case "x86_64":
 			return "librocksdb-jni-win64.dll", nil
 		}
 	}

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -8,9 +8,11 @@
 package packages
 
 import (
+	"archive/zip"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -188,6 +190,77 @@ func rocksdbNativeLibName(osType, arch string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no RocksDB native lib mapping for os=%s arch=%s", osType, arch)
+}
+
+func rewriteZipKeepingNativeLib(jarPath, libName string) error {
+	r, err := zip.OpenReader(jarPath)
+	if err != nil {
+		return fmt.Errorf("failed to open jar %s: %w", jarPath, err)
+	}
+
+	tmpPath := jarPath + ".tmp"
+	tmpFile, err := os.Create(tmpPath)
+	if err != nil {
+		r.Close()
+		return fmt.Errorf("failed to create temp file %s: %w", tmpPath, err)
+	}
+
+	w := zip.NewWriter(tmpFile)
+	var nativeLibCount int
+	var copyErr error
+
+	for _, f := range r.File {
+		isNativeEntry := strings.HasPrefix(f.Name, "META-INF/native/") && !strings.HasSuffix(f.Name, "/")
+		if isNativeEntry {
+			if filepath.Base(f.Name) != libName {
+				continue
+			}
+			nativeLibCount++
+		}
+
+		fw, err := w.CreateHeader(&f.FileHeader)
+		if err != nil {
+			copyErr = fmt.Errorf("failed to create entry %s in temp jar: %w", f.Name, err)
+			break
+		}
+		rc, err := f.Open()
+		if err != nil {
+			copyErr = fmt.Errorf("failed to read entry %s from jar: %w", f.Name, err)
+			break
+		}
+		_, err = io.Copy(fw, rc)
+		rc.Close()
+		if err != nil {
+			copyErr = fmt.Errorf("failed to copy entry %s: %w", f.Name, err)
+			break
+		}
+	}
+	r.Close()
+
+	if copyErr != nil {
+		w.Close()
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return copyErr
+	}
+	if err := w.Close(); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to finalize temp jar: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	if nativeLibCount != 1 {
+		os.Remove(tmpPath)
+		return fmt.Errorf("expected exactly 1 native lib %q in jar, got %d: verify rocksdbNativeLibName mapping", libName, nativeLibCount)
+	}
+	if err := os.Rename(tmpPath, jarPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to replace jar with slimmed version: %w", err)
+	}
+	return nil
 }
 
 func getJavaArtifactsToken() (string, error) {

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -193,7 +193,8 @@ func rocksdbNativeLibName(osType, arch string) (string, error) {
 }
 
 func copyZipEntry(w *zip.Writer, f *zip.File) error {
-	fw, err := w.CreateHeader(&f.FileHeader)
+	hdr := f.FileHeader
+	fw, err := w.CreateHeader(&hdr)
 	if err != nil {
 		return fmt.Errorf("failed to create entry %s in temp jar: %w", f.Name, err)
 	}
@@ -217,11 +218,11 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open jar %s: %w", jarPath, err)
 	}
+	defer r.Close()
 
 	tmpPath := jarPath + ".tmp"
 	tmpFile, err := os.Create(tmpPath)
 	if err != nil {
-		r.Close()
 		return fmt.Errorf("failed to create temp file %s: %w", tmpPath, err)
 	}
 
@@ -248,7 +249,6 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 			break
 		}
 	}
-	r.Close()
 
 	if copyErr != nil {
 		w.Close()

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -192,6 +192,26 @@ func rocksdbNativeLibName(osType, arch string) (string, error) {
 	return "", fmt.Errorf("no RocksDB native lib mapping for os=%s arch=%s", osType, arch)
 }
 
+func copyZipEntry(w *zip.Writer, f *zip.File) error {
+	fw, err := w.CreateHeader(&f.FileHeader)
+	if err != nil {
+		return fmt.Errorf("failed to create entry %s in temp jar: %w", f.Name, err)
+	}
+	rc, err := f.Open()
+	if err != nil {
+		return fmt.Errorf("failed to read entry %s from jar: %w", f.Name, err)
+	}
+	defer func() {
+		if err := rc.Close(); err != nil {
+			log.Warn().Err(err).Str("entry", f.Name).Msg("failed to close zip entry reader")
+		}
+	}()
+	if _, err := io.Copy(fw, rc); err != nil {
+		return fmt.Errorf("failed to copy entry %s: %w", f.Name, err)
+	}
+	return nil
+}
+
 func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	r, err := zip.OpenReader(jarPath)
 	if err != nil {
@@ -203,6 +223,12 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	if err != nil {
 		r.Close()
 		return fmt.Errorf("failed to create temp file %s: %w", tmpPath, err)
+	}
+
+	removeTmp := func() {
+		if err := os.Remove(tmpPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Warn().Err(err).Str("path", tmpPath).Msg("failed to remove temp jar")
+		}
 	}
 
 	w := zip.NewWriter(tmpFile)
@@ -217,21 +243,8 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 			}
 			nativeLibCount++
 		}
-
-		fw, err := w.CreateHeader(&f.FileHeader)
-		if err != nil {
-			copyErr = fmt.Errorf("failed to create entry %s in temp jar: %w", f.Name, err)
-			break
-		}
-		rc, err := f.Open()
-		if err != nil {
-			copyErr = fmt.Errorf("failed to read entry %s from jar: %w", f.Name, err)
-			break
-		}
-		_, err = io.Copy(fw, rc)
-		rc.Close()
-		if err != nil {
-			copyErr = fmt.Errorf("failed to copy entry %s: %w", f.Name, err)
+		if err := copyZipEntry(w, f); err != nil {
+			copyErr = err
 			break
 		}
 	}
@@ -240,24 +253,24 @@ func rewriteZipKeepingNativeLib(jarPath, libName string) error {
 	if copyErr != nil {
 		w.Close()
 		tmpFile.Close()
-		os.Remove(tmpPath)
+		removeTmp()
 		return copyErr
 	}
 	if err := w.Close(); err != nil {
 		tmpFile.Close()
-		os.Remove(tmpPath)
+		removeTmp()
 		return fmt.Errorf("failed to finalize temp jar: %w", err)
 	}
 	if err := tmpFile.Close(); err != nil {
-		os.Remove(tmpPath)
+		removeTmp()
 		return fmt.Errorf("failed to close temp file: %w", err)
 	}
 	if nativeLibCount != 1 {
-		os.Remove(tmpPath)
+		removeTmp()
 		return fmt.Errorf("expected exactly 1 native lib %q in jar, got %d: verify rocksdbNativeLibName mapping", libName, nativeLibCount)
 	}
 	if err := os.Rename(tmpPath, jarPath); err != nil {
-		os.Remove(tmpPath)
+		removeTmp()
 		return fmt.Errorf("failed to replace jar with slimmed version: %w", err)
 	}
 	return nil

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -273,7 +273,11 @@ func TestRewriteZipKeepingNativeLibStripsOtherPlatforms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open rewritten jar: %v", err)
 	}
-	defer r.Close()
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("failed to close rewritten jar: %v", err)
+		}
+	}()
 
 	var keptNative []string
 	allKept := make(map[string]bool)
@@ -388,7 +392,11 @@ func TestStripRocksDbNativeLibsStripsJar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open stripped jar: %v", err)
 	}
-	defer r.Close()
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("failed to close stripped jar: %v", err)
+		}
+	}()
 
 	var nativeLibs []string
 	for _, entry := range r.File {

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -279,7 +279,7 @@ func TestRewriteZipKeepingNativeLibStripsOtherPlatforms(t *testing.T) {
 	allKept := make(map[string]bool)
 	for _, entry := range r.File {
 		allKept[entry.Name] = true
-		if isRootNativeLib(entry.Name) {
+		if isRocksdbNativeLib(entry.Name) {
 			keptNative = append(keptNative, entry.Name)
 		}
 	}
@@ -392,7 +392,7 @@ func TestStripRocksDbNativeLibsStripsJar(t *testing.T) {
 
 	var nativeLibs []string
 	for _, entry := range r.File {
-		if isRootNativeLib(entry.Name) {
+		if isRocksdbNativeLib(entry.Name) {
 			nativeLibs = append(nativeLibs, entry.Name)
 		}
 	}

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -206,9 +206,22 @@ func TestRocksdbNativeLibName(t *testing.T) {
 }
 
 func TestRocksdbNativeLibNameUnknownPlatformErrors(t *testing.T) {
-	_, err := rocksdbNativeLibName("freebsd", "x86_64")
-	if err == nil {
-		t.Fatal("expected error for unknown os/arch, got nil")
+	tests := []struct {
+		osType string
+		arch   string
+	}{
+		{"freebsd", "x86_64"},
+		{"windows", "arm64"},
+		{"linux", "i386"},
+		{"darwin", "i386"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.osType+"/"+tt.arch, func(t *testing.T) {
+			_, err := rocksdbNativeLibName(tt.osType, tt.arch)
+			if err == nil {
+				t.Fatalf("expected error for unsupported os/arch %s/%s, got nil", tt.osType, tt.arch)
+			}
+		})
 	}
 }
 

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -327,6 +327,105 @@ func TestRewriteZipKeepingNativeLibErrorsWhenLibNotFound(t *testing.T) {
 	}
 }
 
+func TestStripRocksDbNativeLibsStripsJar(t *testing.T) {
+	// given
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "rocksdbjni-9.0.0.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	for _, name := range []string{
+		"META-INF/native/librocksdb-jni-linux64.so",
+		"META-INF/native/librocksdb-jni-linux-aarch64.so",
+		"META-INF/native/librocksdb-jni-osx-arm64.jnilib",
+		"META-INF/native/librocksdb-jni-osx-x86_64.jnilib",
+		"META-INF/native/librocksdb-jni-win64.dll",
+	} {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", name, err)
+		}
+		if _, err := fw.Write([]byte("binary")); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when
+	err = stripRocksDbNativeLibs(version, "linux", "x86_64")
+
+	// then
+	if err != nil {
+		t.Fatalf("stripRocksDbNativeLibs returned error: %v", err)
+	}
+
+	r, err := zip.OpenReader(jarPath)
+	if err != nil {
+		t.Fatalf("failed to open stripped jar: %v", err)
+	}
+	defer r.Close()
+
+	var nativeLibs []string
+	for _, entry := range r.File {
+		if strings.HasPrefix(entry.Name, "META-INF/native/") {
+			nativeLibs = append(nativeLibs, entry.Name)
+		}
+	}
+	if len(nativeLibs) != 1 || nativeLibs[0] != "META-INF/native/librocksdb-jni-linux64.so" {
+		t.Fatalf("expected only linux64 native lib after strip, got %v", nativeLibs)
+	}
+}
+
+func TestStripRocksDbNativeLibsErrorsWhenJarMissing(t *testing.T) {
+	// given: empty temp dir — no camunda-zeebe dir, no jar
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	// when
+	err = stripRocksDbNativeLibs("8.10.0-test", "linux", "x86_64")
+
+	// then
+	if err == nil {
+		t.Fatal("expected error when rocksdbjni jar not found, got nil")
+	}
+}
+
 func TestMaterializeSymlinksReplacesSymlinkWithRegularFile(t *testing.T) {
 	// given
 	root := t.TempDir()

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -180,6 +180,38 @@ func TestMergeModulesAddsRuntimeJREModules(t *testing.T) {
 	}
 }
 
+func TestRocksdbNativeLibName(t *testing.T) {
+	tests := []struct {
+		osType   string
+		arch     string
+		expected string
+	}{
+		{"linux", "x86_64", "librocksdb-jni-linux64.so"},
+		{"linux", "aarch64", "librocksdb-jni-linux-aarch64.so"},
+		{"darwin", "x86_64", "librocksdb-jni-osx-x86_64.jnilib"},
+		{"darwin", "aarch64", "librocksdb-jni-osx-arm64.jnilib"},
+		{"windows", "x86_64", "librocksdb-jni-win64.dll"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.osType+"/"+tt.arch, func(t *testing.T) {
+			got, err := rocksdbNativeLibName(tt.osType, tt.arch)
+			if err != nil {
+				t.Fatalf("rocksdbNativeLibName(%q, %q) error: %v", tt.osType, tt.arch, err)
+			}
+			if got != tt.expected {
+				t.Fatalf("rocksdbNativeLibName(%q, %q) = %q, want %q", tt.osType, tt.arch, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRocksdbNativeLibNameUnknownPlatformErrors(t *testing.T) {
+	_, err := rocksdbNativeLibName("freebsd", "x86_64")
+	if err == nil {
+		t.Fatal("expected error for unknown os/arch, got nil")
+	}
+}
+
 func TestMaterializeSymlinksReplacesSymlinkWithRegularFile(t *testing.T) {
 	// given
 	root := t.TempDir()

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"archive/zip"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -222,6 +223,107 @@ func TestRocksdbNativeLibNameUnknownPlatformErrors(t *testing.T) {
 				t.Fatalf("expected error for unsupported os/arch %s/%s, got nil", tt.osType, tt.arch)
 			}
 		})
+	}
+}
+
+func TestRewriteZipKeepingNativeLibStripsOtherPlatforms(t *testing.T) {
+	// given: fake JAR with all 5 native libs plus non-native entries
+	root := t.TempDir()
+	jarPath := filepath.Join(root, "rocksdbjni-9.0.0.jar")
+
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create temp jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	entries := []struct{ name, content string }{
+		{"META-INF/MANIFEST.MF", "Manifest-Version: 1.0\n"},
+		{"META-INF/native/librocksdb-jni-linux64.so", "linux64-binary"},
+		{"META-INF/native/librocksdb-jni-linux-aarch64.so", "linux-aarch64-binary"},
+		{"META-INF/native/librocksdb-jni-osx-arm64.jnilib", "osx-arm64-binary"},
+		{"META-INF/native/librocksdb-jni-osx-x86_64.jnilib", "osx-x86_64-binary"},
+		{"META-INF/native/librocksdb-jni-win64.dll", "win64-binary"},
+		{"org/rocksdb/RocksDB.class", "class-bytes"},
+	}
+	for _, e := range entries {
+		fw, err := w.Create(e.name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", e.name, err)
+		}
+		if _, err := fw.Write([]byte(e.content)); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", e.name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when
+	err = rewriteZipKeepingNativeLib(jarPath, "librocksdb-jni-linux64.so")
+
+	// then
+	if err != nil {
+		t.Fatalf("rewriteZipKeepingNativeLib returned error: %v", err)
+	}
+
+	r, err := zip.OpenReader(jarPath)
+	if err != nil {
+		t.Fatalf("failed to open rewritten jar: %v", err)
+	}
+	defer r.Close()
+
+	var keptNative []string
+	allKept := make(map[string]bool)
+	for _, entry := range r.File {
+		allKept[entry.Name] = true
+		if strings.HasPrefix(entry.Name, "META-INF/native/") {
+			keptNative = append(keptNative, entry.Name)
+		}
+	}
+
+	if len(keptNative) != 1 || keptNative[0] != "META-INF/native/librocksdb-jni-linux64.so" {
+		t.Fatalf("expected only linux64 native lib, got %v", keptNative)
+	}
+	for _, mustKeep := range []string{"META-INF/MANIFEST.MF", "org/rocksdb/RocksDB.class"} {
+		if !allKept[mustKeep] {
+			t.Fatalf("expected non-native entry %q to be preserved, got entries: %v", mustKeep, allKept)
+		}
+	}
+}
+
+func TestRewriteZipKeepingNativeLibErrorsWhenLibNotFound(t *testing.T) {
+	// given: JAR with only a different native lib (target is absent)
+	root := t.TempDir()
+	jarPath := filepath.Join(root, "rocksdbjni-9.0.0.jar")
+
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create temp jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	fw, err := w.Create("META-INF/native/librocksdb-jni-linux64.so")
+	if err != nil {
+		t.Fatalf("failed to create zip entry: %v", err)
+	}
+	if _, err := fw.Write([]byte("binary")); err != nil {
+		t.Fatalf("failed to write zip entry: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: ask for a lib name that isn't in the jar
+	err = rewriteZipKeepingNativeLib(jarPath, "librocksdb-jni-nonexistent.so")
+
+	// then
+	if err == nil {
+		t.Fatal("expected error when target native lib not found in jar, got nil")
 	}
 }
 

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -187,11 +187,11 @@ func TestRocksdbNativeLibName(t *testing.T) {
 		arch     string
 		expected string
 	}{
-		{"linux", "x86_64", "librocksdb-jni-linux64.so"},
-		{"linux", "aarch64", "librocksdb-jni-linux-aarch64.so"},
-		{"darwin", "x86_64", "librocksdb-jni-osx-x86_64.jnilib"},
-		{"darwin", "aarch64", "librocksdb-jni-osx-arm64.jnilib"},
-		{"windows", "x86_64", "librocksdb-jni-win64.dll"},
+		{"linux", "x86_64", "librocksdbjni-linux64.so"},
+		{"linux", "aarch64", "librocksdbjni-linux-aarch64.so"},
+		{"darwin", "x86_64", "librocksdbjni-osx-x86_64.jnilib"},
+		{"darwin", "aarch64", "librocksdbjni-osx-arm64.jnilib"},
+		{"windows", "x86_64", "librocksdbjni-win64.dll"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.osType+"/"+tt.arch, func(t *testing.T) {
@@ -238,11 +238,11 @@ func TestRewriteZipKeepingNativeLibStripsOtherPlatforms(t *testing.T) {
 	w := zip.NewWriter(f)
 	entries := []struct{ name, content string }{
 		{"META-INF/MANIFEST.MF", "Manifest-Version: 1.0\n"},
-		{"META-INF/native/librocksdb-jni-linux64.so", "linux64-binary"},
-		{"META-INF/native/librocksdb-jni-linux-aarch64.so", "linux-aarch64-binary"},
-		{"META-INF/native/librocksdb-jni-osx-arm64.jnilib", "osx-arm64-binary"},
-		{"META-INF/native/librocksdb-jni-osx-x86_64.jnilib", "osx-x86_64-binary"},
-		{"META-INF/native/librocksdb-jni-win64.dll", "win64-binary"},
+		{"librocksdbjni-linux64.so", "linux64-binary"},
+		{"librocksdbjni-linux-aarch64.so", "linux-aarch64-binary"},
+		{"librocksdbjni-osx-arm64.jnilib", "osx-arm64-binary"},
+		{"librocksdbjni-osx-x86_64.jnilib", "osx-x86_64-binary"},
+		{"librocksdbjni-win64.dll", "win64-binary"},
 		{"org/rocksdb/RocksDB.class", "class-bytes"},
 	}
 	for _, e := range entries {
@@ -262,7 +262,7 @@ func TestRewriteZipKeepingNativeLibStripsOtherPlatforms(t *testing.T) {
 	}
 
 	// when
-	err = rewriteZipKeepingNativeLib(jarPath, "librocksdb-jni-linux64.so")
+	err = rewriteZipKeepingNativeLib(jarPath, "librocksdbjni-linux64.so")
 
 	// then
 	if err != nil {
@@ -279,12 +279,12 @@ func TestRewriteZipKeepingNativeLibStripsOtherPlatforms(t *testing.T) {
 	allKept := make(map[string]bool)
 	for _, entry := range r.File {
 		allKept[entry.Name] = true
-		if strings.HasPrefix(entry.Name, "META-INF/native/") {
+		if isRootNativeLib(entry.Name) {
 			keptNative = append(keptNative, entry.Name)
 		}
 	}
 
-	if len(keptNative) != 1 || keptNative[0] != "META-INF/native/librocksdb-jni-linux64.so" {
+	if len(keptNative) != 1 || keptNative[0] != "librocksdbjni-linux64.so" {
 		t.Fatalf("expected only linux64 native lib, got %v", keptNative)
 	}
 	for _, mustKeep := range []string{"META-INF/MANIFEST.MF", "org/rocksdb/RocksDB.class"} {
@@ -304,7 +304,7 @@ func TestRewriteZipKeepingNativeLibErrorsWhenLibNotFound(t *testing.T) {
 		t.Fatalf("failed to create temp jar: %v", err)
 	}
 	w := zip.NewWriter(f)
-	fw, err := w.Create("META-INF/native/librocksdb-jni-linux64.so")
+	fw, err := w.Create("librocksdbjni-linux64.so")
 	if err != nil {
 		t.Fatalf("failed to create zip entry: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestRewriteZipKeepingNativeLibErrorsWhenLibNotFound(t *testing.T) {
 	}
 
 	// when: ask for a lib name that isn't in the jar
-	err = rewriteZipKeepingNativeLib(jarPath, "librocksdb-jni-nonexistent.so")
+	err = rewriteZipKeepingNativeLib(jarPath, "librocksdbjni-nonexistent.so")
 
 	// then
 	if err == nil {
@@ -355,11 +355,11 @@ func TestStripRocksDbNativeLibsStripsJar(t *testing.T) {
 	}
 	w := zip.NewWriter(f)
 	for _, name := range []string{
-		"META-INF/native/librocksdb-jni-linux64.so",
-		"META-INF/native/librocksdb-jni-linux-aarch64.so",
-		"META-INF/native/librocksdb-jni-osx-arm64.jnilib",
-		"META-INF/native/librocksdb-jni-osx-x86_64.jnilib",
-		"META-INF/native/librocksdb-jni-win64.dll",
+		"librocksdbjni-linux64.so",
+		"librocksdbjni-linux-aarch64.so",
+		"librocksdbjni-osx-arm64.jnilib",
+		"librocksdbjni-osx-x86_64.jnilib",
+		"librocksdbjni-win64.dll",
 	} {
 		fw, err := w.Create(name)
 		if err != nil {
@@ -392,11 +392,11 @@ func TestStripRocksDbNativeLibsStripsJar(t *testing.T) {
 
 	var nativeLibs []string
 	for _, entry := range r.File {
-		if strings.HasPrefix(entry.Name, "META-INF/native/") {
+		if isRootNativeLib(entry.Name) {
 			nativeLibs = append(nativeLibs, entry.Name)
 		}
 	}
-	if len(nativeLibs) != 1 || nativeLibs[0] != "META-INF/native/librocksdb-jni-linux64.so" {
+	if len(nativeLibs) != 1 || nativeLibs[0] != "librocksdbjni-linux64.so" {
 		t.Fatalf("expected only linux64 native lib after strip, got %v", nativeLibs)
 	}
 }


### PR DESCRIPTION
## Summary

- Reduces each platform archive by ~70 MB by keeping only the native lib for the build target OS/arch
- Pure Go implementation using `archive/zip` — no shell-out, cross-platform
- Consistent with the Docker image fix in #52185

## Changes

New functions in `c8run/internal/packages/package.go`:
- `rocksdbNativeLibName(osType, arch)` — maps OS/arch to the native lib filename to keep
- `copyZipEntry(w, f)` — helper to copy a single zip entry (copies `FileHeader` by value to avoid mutation)
- `rewriteZipKeepingNativeLib(jarPath, libName)` — rewrites a JAR in-place, keeping only the target native lib, atomically replacing via `os.Rename`
- `stripRocksDbNativeLibs(camundaVersion, osType, arch)` — orchestrator; globs the jar, calls rewrite; called from `New()` after Camunda distribution extraction

## Platform mapping

| OS / arch | Native lib kept |
|---|---|
| linux / x86_64 | `librocksdbjni-linux64.so` |
| linux / aarch64 | `librocksdbjni-linux-aarch64.so` |
| darwin / x86_64 | `librocksdbjni-osx-x86_64.jnilib` |
| darwin / aarch64 | `librocksdbjni-osx-arm64.jnilib` |
| windows / x86_64 | `librocksdbjni-win64.dll` |

## Test plan

- [ ] `go test ./...` passes (99 tests, 15 packages)
- [ ] Package a c8run archive locally and verify size reduction (~70 MB)
- [ ] Verify the kept native lib matches the build host platform

Closes #54948