### PR TITLE
docs: add on-demand all-OS E2E trigger guide for c8run packaging changes

### DIFF
--- a/c8run/AGENTS.md
+++ b/c8run/AGENTS.md
@@ -121,7 +121,7 @@ go version
 | `docs/local-development.md`      | Prerequisites, quick start, and testing code changes against a local Camunda build                           |
 | `docs/package-layout.md`         | Key package areas, runtime artifact list, packaging a distribution                                           |
 | `docs/runtime-rules.md`          | Config precedence, H2 rules, Connectors compatibility, ports, health check timeout, quickstart marker        |
-| `docs/testing-guide.md`          | Platform coverage, process lifecycle, packaging, E2E layers, on-demand all-OS trigger guide                 |
+| `docs/testing-guide.md`          | Platform coverage, process lifecycle, packaging, E2E layers, on-demand all-OS trigger guide                  |
 | `docs/process-lifecycle.md`      | PID locking semantics, 4-state restart machine, signal handling, graceful shutdown, detached mode stub       |
 | `docs/configuration.md`          | JAVA_HOME fallback chain, config directory handling, H2 cleanup decision tree, RDBMS driver detection        |
 | `docs/platform-differences.md`   | Unix vs Windows: process groups, kill implementation, path/classpath conventions, archive formats, test tags |

--- a/c8run/AGENTS.md
+++ b/c8run/AGENTS.md
@@ -121,7 +121,7 @@ go version
 | `docs/local-development.md`      | Prerequisites, quick start, and testing code changes against a local Camunda build                           |
 | `docs/package-layout.md`         | Key package areas, runtime artifact list, packaging a distribution                                           |
 | `docs/runtime-rules.md`          | Config precedence, H2 rules, Connectors compatibility, ports, health check timeout, quickstart marker        |
-| `docs/testing-guide.md`          | Platform coverage, process lifecycle, packaging, startup test expectations                                   |
+| `docs/testing-guide.md`          | Platform coverage, process lifecycle, packaging, E2E layers, on-demand all-OS trigger guide                 |
 | `docs/process-lifecycle.md`      | PID locking semantics, 4-state restart machine, signal handling, graceful shutdown, detached mode stub       |
 | `docs/configuration.md`          | JAVA_HOME fallback chain, config directory handling, H2 cleanup decision tree, RDBMS driver detection        |
 | `docs/platform-differences.md`   | Unix vs Windows: process groups, kill implementation, path/classpath conventions, archive formats, test tags |
@@ -140,4 +140,5 @@ go version
 6. Build the changed binary to confirm it compiles: `go build -o c8run ./cmd/c8run`.
 7. For packaging changes, also build and verify `packager`.
 8. Commit with Conventional Commits format, no scope.
+9. For packaging changes (archive layout, JRE bundling, lib stripping, new artifacts), trigger the all-OS on-demand E2E suite against the branch — see [Testing Guide — Triggering the all-OS on-demand suite](docs/testing-guide.md#triggering-the-all-os-on-demand-suite-against-a-feature-branch).
 

--- a/c8run/docs/testing-guide.md
+++ b/c8run/docs/testing-guide.md
@@ -114,12 +114,12 @@ Use `playwright_c8Run_release_test.yml` to validate a `camunda/camunda` feature 
 
 **Required inputs:**
 
-| Input               | Description                                      | Where to get it                                               |
-|---------------------|--------------------------------------------------|---------------------------------------------------------------|
-| `c8Version`         | Minor version, e.g. `8.10`                       | `major.minor` of `CAMUNDA_VERSION` in `c8run/.env`           |
-| `branchName`        | Branch in `camunda/camunda` to check out         | Your feature branch name                                      |
-| `camundaVersion`    | Full version, e.g. `8.10.0-alpha2`               | `CAMUNDA_VERSION` in `c8run/.env`                             |
-| `connectorsVersion` | Full connectors version, e.g. `8.10.0-alpha2`   | `CONNECTORS_VERSION` in `c8run/.env`                          |
+|        Input        |                  Description                  |                  Where to get it                   |
+|---------------------|-----------------------------------------------|----------------------------------------------------|
+| `c8Version`         | Minor version, e.g. `8.10`                    | `major.minor` of `CAMUNDA_VERSION` in `c8run/.env` |
+| `branchName`        | Branch in `camunda/camunda` to check out      | Your feature branch name                           |
+| `camundaVersion`    | Full version, e.g. `8.10.0-alpha2`            | `CAMUNDA_VERSION` in `c8run/.env`                  |
+| `connectorsVersion` | Full connectors version, e.g. `8.10.0-alpha2` | `CONNECTORS_VERSION` in `c8run/.env`               |
 
 **Trigger via `gh` CLI:**
 

--- a/c8run/docs/testing-guide.md
+++ b/c8run/docs/testing-guide.md
@@ -108,6 +108,48 @@ No config file is passed — H2 is the c8run default for 8.9+. The matrix sets `
 
 The release workflow publishes results to TestRail. Each action accepts `database`, `tasklist_version`, and `version` inputs.
 
+### Triggering the all-OS on-demand suite against a feature branch
+
+Use `playwright_c8Run_release_test.yml` to validate a `camunda/camunda` feature branch across all platforms before merge. The workflow checks out the branch, builds c8run from source, downloads the Camunda distribution from Nexus, packages it, and runs the full Playwright suite.
+
+**Required inputs:**
+
+| Input               | Description                                      | Where to get it                                               |
+|---------------------|--------------------------------------------------|---------------------------------------------------------------|
+| `c8Version`         | Minor version, e.g. `8.10`                       | `major.minor` of `CAMUNDA_VERSION` in `c8run/.env`           |
+| `branchName`        | Branch in `camunda/camunda` to check out         | Your feature branch name                                      |
+| `camundaVersion`    | Full version, e.g. `8.10.0-alpha2`               | `CAMUNDA_VERSION` in `c8run/.env`                             |
+| `connectorsVersion` | Full connectors version, e.g. `8.10.0-alpha2`   | `CONNECTORS_VERSION` in `c8run/.env`                          |
+
+**Trigger via `gh` CLI:**
+
+```bash
+# Read versions from .env
+CAMUNDA_VERSION=$(grep '^CAMUNDA_VERSION=' c8run/.env | cut -d= -f2)
+C8_MINOR=$(echo "$CAMUNDA_VERSION" | cut -d. -f1-2)   # e.g. 8.10
+CONNECTORS_VERSION=$(grep '^CONNECTORS_VERSION=' c8run/.env | cut -d= -f2)
+BRANCH=$(git branch --show-current)
+
+gh api repos/camunda/c8-cross-component-e2e-tests/actions/workflows/playwright_c8Run_release_test.yml/dispatches \
+  -X POST \
+  -f ref=main \
+  -F "inputs[c8Version]=$C8_MINOR" \
+  -F "inputs[branchName]=$BRANCH" \
+  -F "inputs[camundaVersion]=$CAMUNDA_VERSION" \
+  -F "inputs[connectorsVersion]=$CONNECTORS_VERSION"
+```
+
+**Verify it queued** (run within ~10 seconds of dispatch):
+
+```bash
+gh api "repos/camunda/c8-cross-component-e2e-tests/actions/workflows/playwright_c8Run_release_test.yml/runs?per_page=3" \
+  --jq '.workflow_runs[] | {id, status, created_at}'
+```
+
+Then open the run URL from the `id` field: `https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/<id>`
+
+**When to use:** For any packaging change (archive layout, JRE bundling, lib stripping, new artifacts). The PR trigger (Layer 2 above) only runs Linux; this covers macOS and Windows too.
+
 ### RDBMS configuration summary
 
 |             Layer              |      DB       |             How configured              |


### PR DESCRIPTION
## Summary

- Adds a new subsection to `docs/testing-guide.md` explaining how to manually trigger `playwright_c8Run_release_test.yml` (all-OS: Linux + macOS + Windows) against a feature branch in `camunda/camunda`
- Adds step 9 to the `AGENTS.md` recommended workflow pointing packaging-change authors to the guide
- Updates the `docs/testing-guide.md` description in the AGENTS.md context table

## Why

The existing testing guide documented that the on-demand all-OS workflow exists but not how to trigger it. For packaging changes (archive layout, JRE bundling, lib stripping), the automatic PR trigger only runs Linux — macOS and Windows require a manual dispatch. Without a written runbook, contributors either skip the cross-platform check or have to rediscover the inputs each time.

## Test plan

- [ ] Verify the `gh` command in the new section works end-to-end (was validated manually while triggering tests for #55046)
- [ ] Docs-only change, no Go code modified