### PR TITLE
ci: harden macOS signing pipeline against JRE entitlement regressions

### DIFF
--- a/.github/actions/sign-and-notarize/sign_and_notarize.sh
+++ b/.github/actions/sign-and-notarize/sign_and_notarize.sh
@@ -52,13 +52,15 @@ C8RUN_BASENAME="$(basename "$C8RUN_DIR")"
 EXCLUDE_PREFIXES=("camunda-zeebe" "connector-runtime-bundle" "elasticsearch")
 
 ##############################################
-# Directory name patterns that contain JVM runtimes.
-# Any Mach-O binary whose path contains one of these as a path component
-# will be signed with JRE_ENTITLEMENTS (allow-jit + allow-unsigned-executable-memory
-# + disable-library-validation) instead of the default hardened-runtime flags.
-# Add a new entry here when bundling an additional JRE/JDK/runtime package.
+# Literal directory names that identify a bundled JVM runtime.
+# Each entry is matched as an exact path component (not a glob), so "jre"
+# matches .../jre/... but not .../jre-custom/... or .../myjre/...
+# Any Mach-O binary under one of these directories is signed with
+# JRE_ENTITLEMENTS (allow-jit + allow-unsigned-executable-memory +
+# disable-library-validation) instead of the default hardened-runtime flags.
+# Add a new entry here when bundling an additional JRE/JDK under a new name.
 ##############################################
-JRE_PATH_PATTERNS=("jre" "jdk" "runtime")
+JRE_DIR_NAMES=("jre" "jdk" "runtime")
 
 ##############################################
 # Temp dirs for exclude items + notarize steps
@@ -152,10 +154,10 @@ sign_macho_in_folder() {
         echo "    Signing Mach-O: $candidate"
         # Binaries inside a JVM runtime need JIT entitlements so the JVM can
         # call pthread_jit_write_protect_np under the hardened runtime on Apple Silicon.
-        # The set of recognized runtime directory names is in JRE_PATH_PATTERNS.
+        # The set of recognized runtime directory names is in JRE_DIR_NAMES.
         local entitlements_flag=()
-        for jre_pattern in "${JRE_PATH_PATTERNS[@]}"; do
-          if [[ "$candidate" == */"$jre_pattern"/* ]]; then
+        for jre_dir in "${JRE_DIR_NAMES[@]}"; do
+          if [[ "$candidate" == */"$jre_dir"/* ]]; then
             entitlements_flag=(--entitlements "$JRE_ENTITLEMENTS")
             break
           fi
@@ -222,7 +224,7 @@ sign_jars_in_folder "$C8RUN_DIR"
 #      Note: Mach-O inside .jar files are signed and immediately repackaged;
 #      codesign --verify cannot reach them post-repackaging — they are covered
 #      by the exit-on-error in sign_macho_in_folder.
-#   3. Every Mach-O under a JRE_PATH_PATTERNS directory → assert allow-jit
+#   3. Every Mach-O under a JRE_DIR_NAMES directory → assert allow-jit
 #      entitlement is present (missing it crashes libjvm.dylib on Apple Silicon
 #      under the hardened runtime via pthread_jit_write_protect_np).
 ##############################################
@@ -253,17 +255,23 @@ while IFS= read -r -d '' candidate; do
     verify_errors=$((verify_errors + 1))
   fi
 
-  # 3. JRE path → must carry allow-jit
-  for jre_pattern in "${JRE_PATH_PATTERNS[@]}"; do
-    if [[ "$candidate" == */"$jre_pattern"/* ]]; then
-      if codesign -d --entitlements - "$candidate" 2>/dev/null | grep -q "allow-jit"; then
-        echo "  -> allow-jit OK: $candidate"
-      else
-        echo "[Error] missing allow-jit on JVM runtime binary: $candidate"
-        echo "        Check JRE_PATH_PATTERNS includes '$jre_pattern' and sign_macho_in_folder"
-        echo "        applies JRE_ENTITLEMENTS to that pattern."
-        verify_errors=$((verify_errors + 1))
-      fi
+  # 3. JRE path → must carry all three JVM entitlements
+  for jre_dir in "${JRE_DIR_NAMES[@]}"; do
+    if [[ "$candidate" == */"$jre_dir"/* ]]; then
+      entitlements_out="$(codesign -d --entitlements - "$candidate" 2>/dev/null)"
+      for required_entitlement in \
+          "com.apple.security.cs.allow-jit" \
+          "com.apple.security.cs.allow-unsigned-executable-memory" \
+          "com.apple.security.cs.disable-library-validation"; do
+        if echo "$entitlements_out" | grep -q "$required_entitlement"; then
+          echo "  -> $required_entitlement OK: $candidate"
+        else
+          echo "[Error] missing $required_entitlement on JVM runtime binary: $candidate"
+          echo "        Check JRE_DIR_NAMES includes '$jre_dir' and sign_macho_in_folder"
+          echo "        applies JRE_ENTITLEMENTS to that directory."
+          verify_errors=$((verify_errors + 1))
+        fi
+      done
       break
     fi
   done
@@ -325,7 +333,7 @@ echo "All done. Final archive with excluded items is: $FINAL_ZIP"
 
 ##############################################
 # G) JVM smoke test — verify the signed JRE actually starts
-# Finds any java binary under JRE_PATH_PATTERNS in the notarized tree and
+# Finds any java binary under JRE_DIR_NAMES in the notarized tree and
 # runs -version. Catches signing regressions that only manifest at JVM init
 # time (e.g. a newly added binary that was missed by the entitlements loop).
 # Runs against the notarized, re-injected tree before any further packaging.
@@ -333,7 +341,7 @@ echo "All done. Final archive with excluded items is: $FINAL_ZIP"
 echo "=== Step G: JVM smoke test ==="
 NOTARIZED_ROOT="$TMP_NOTARIZE_DIR/notarized/$C8RUN_BASENAME"
 smoke_tested=0
-for jre_pattern in "${JRE_PATH_PATTERNS[@]}"; do
+for jre_dir in "${JRE_DIR_NAMES[@]}"; do
   while IFS= read -r -d '' java_bin; do
     echo "  -> Running: $java_bin -version"
     if "$java_bin" -version; then
@@ -343,10 +351,10 @@ for jre_pattern in "${JRE_PATH_PATTERNS[@]}"; do
       echo "[Error] JVM smoke test FAILED: $java_bin"
       exit 1
     fi
-  done < <(find "$NOTARIZED_ROOT" -path "*/${jre_pattern}/bin/java" -type f -print0)
+  done < <(find "$NOTARIZED_ROOT" -path "*/${jre_dir}/bin/java" \( -type f -o -type l \) -print0)
 done
 if [ "$smoke_tested" -eq 0 ]; then
-  echo "  -> No java binary found under JRE_PATH_PATTERNS in $NOTARIZED_ROOT; skipping smoke test."
+  echo "  -> No java binary found under JRE_DIR_NAMES in $NOTARIZED_ROOT; skipping smoke test."
 fi
 
 ##############################################

--- a/.github/actions/sign-and-notarize/sign_and_notarize.sh
+++ b/.github/actions/sign-and-notarize/sign_and_notarize.sh
@@ -52,6 +52,15 @@ C8RUN_BASENAME="$(basename "$C8RUN_DIR")"
 EXCLUDE_PREFIXES=("camunda-zeebe" "connector-runtime-bundle" "elasticsearch")
 
 ##############################################
+# Directory name patterns that contain JVM runtimes.
+# Any Mach-O binary whose path contains one of these as a path component
+# will be signed with JRE_ENTITLEMENTS (allow-jit + allow-unsigned-executable-memory
+# + disable-library-validation) instead of the default hardened-runtime flags.
+# Add a new entry here when bundling an additional JRE/JDK/runtime package.
+##############################################
+JRE_PATH_PATTERNS=("jre" "jdk" "runtime")
+
+##############################################
 # Temp dirs for exclude items + notarize steps
 ##############################################
 TMP_EXCLUDE_DIR="$(mktemp -d)"
@@ -141,12 +150,16 @@ sign_macho_in_folder() {
       fi
       if file -b "$candidate" | grep -q "Mach-O"; then
         echo "    Signing Mach-O: $candidate"
-        # Binaries inside the bundled JRE need JIT entitlements so the JVM can
+        # Binaries inside a JVM runtime need JIT entitlements so the JVM can
         # call pthread_jit_write_protect_np under the hardened runtime on Apple Silicon.
+        # The set of recognized runtime directory names is in JRE_PATH_PATTERNS.
         local entitlements_flag=()
-        if [[ "$candidate" == */jre/* ]]; then
-          entitlements_flag=(--entitlements "$JRE_ENTITLEMENTS")
-        fi
+        for jre_pattern in "${JRE_PATH_PATTERNS[@]}"; do
+          if [[ "$candidate" == */"$jre_pattern"/* ]]; then
+            entitlements_flag=(--entitlements "$JRE_ENTITLEMENTS")
+            break
+          fi
+        done
         if codesign --verbose=4 --force --options runtime --timestamp \
             "${entitlements_flag[@]}" --sign "$CERT_NAME" "$candidate"; then
           ((signed_count++))
@@ -199,6 +212,71 @@ sign_macho_in_folder "$C8RUN_DIR"
 sign_jars_in_folder "$C8RUN_DIR"
 
 ##############################################
+# C.5) Verify all signatures before notarizing
+#
+# Three checks on everything in $C8RUN_DIR (excluded items are already moved
+# out, so this only covers what was actually signed above):
+#
+#   1. Every .app bundle   → codesign --verify --deep --strict
+#   2. Every Mach-O file outside .app and .jar → codesign --verify --strict
+#      Note: Mach-O inside .jar files are signed and immediately repackaged;
+#      codesign --verify cannot reach them post-repackaging — they are covered
+#      by the exit-on-error in sign_macho_in_folder.
+#   3. Every Mach-O under a JRE_PATH_PATTERNS directory → assert allow-jit
+#      entitlement is present (missing it crashes libjvm.dylib on Apple Silicon
+#      under the hardened runtime via pthread_jit_write_protect_np).
+##############################################
+echo "=== Step C.5: Verifying all Mach-O signatures ==="
+verify_errors=0
+
+# Check 1: .app bundles
+while IFS= read -r -d '' app_bundle; do
+  if codesign --verify --deep --strict "$app_bundle" 2>/dev/null; then
+    echo "  -> signature OK (.app): $app_bundle"
+  else
+    echo "[Error] invalid/missing signature (.app): $app_bundle"
+    verify_errors=$((verify_errors + 1))
+  fi
+done < <(find "$C8RUN_DIR" -name "*.app" -type d -print0)
+
+# Check 2 + 3: individual Mach-O files
+while IFS= read -r -d '' candidate; do
+  # skip files inside .app bundles (covered by --deep above) and inside .jar files
+  [[ "$candidate" == *.app/* ]] && continue
+  [[ "$candidate" == *.jar/* ]] && continue
+  file -b "$candidate" | grep -q "Mach-O" || continue
+
+  # 2. Valid signature
+  if codesign --verify --strict "$candidate" 2>/dev/null; then
+    echo "  -> signature OK: $candidate"
+  else
+    echo "[Error] invalid/missing signature: $candidate"
+    verify_errors=$((verify_errors + 1))
+  fi
+
+  # 3. JRE path → must carry allow-jit
+  for jre_pattern in "${JRE_PATH_PATTERNS[@]}"; do
+    if [[ "$candidate" == */"$jre_pattern"/* ]]; then
+      if codesign -d --entitlements - "$candidate" 2>/dev/null | grep -q "allow-jit"; then
+        echo "  -> allow-jit OK: $candidate"
+      else
+        echo "[Error] missing allow-jit on JVM runtime binary: $candidate"
+        echo "        Check JRE_PATH_PATTERNS includes '$jre_pattern' and sign_macho_in_folder"
+        echo "        applies JRE_ENTITLEMENTS to that pattern."
+        verify_errors=$((verify_errors + 1))
+      fi
+      break
+    fi
+  done
+done < <(find "$C8RUN_DIR" -type f -print0)
+
+if [ "$verify_errors" -gt 0 ]; then
+  echo "[Error] $verify_errors verification failure(s). Aborting before notarization."
+  exit 1
+fi
+echo "  -> All signed binaries verified."
+
+##############################################
 # D) Create c8run_signed.zip with ditto
 ##############################################
 echo "=== Step C: Creating c8run_signed.zip with ditto (excluding removed items) ==="
@@ -245,6 +323,28 @@ FINAL_ZIP="$(dirname "$C8RUN_DIR")/c8run_complete.zip"
 mv "$TMP_NOTARIZE_DIR/notarized/c8run_complete.zip" "$FINAL_ZIP"
 
 echo "All done. Final archive with excluded items is: $FINAL_ZIP"
+
+##############################################
+# G) JVM smoke test — verify the signed JRE actually starts
+# Finds any java binary under JRE_PATH_PATTERNS in the notarized tree and
+# runs -version. Catches signing regressions that only manifest at JVM init
+# time (e.g. a newly added binary that was missed by the entitlements loop).
+# Runs against the notarized, re-injected tree before any further packaging.
+##############################################
+echo "=== Step F.5: JVM smoke test ==="
+NOTARIZED_ROOT="$TMP_NOTARIZE_DIR/notarized/$C8RUN_BASENAME"
+smoke_tested=0
+for jre_pattern in "${JRE_PATH_PATTERNS[@]}"; do
+  while IFS= read -r -d '' java_bin; do
+    echo "  -> Running: $java_bin -version"
+    "$java_bin" -version
+    echo "  -> JVM smoke test passed: $java_bin"
+    smoke_tested=$((smoke_tested + 1))
+  done < <(find "$NOTARIZED_ROOT" -path "*/${jre_pattern}/bin/java" -type f -print0)
+done
+if [ "$smoke_tested" -eq 0 ]; then
+  echo "  -> No java binary found under JRE_PATH_PATTERNS in $NOTARIZED_ROOT; skipping smoke test."
+fi
 
 ##############################################
 # Cleanup

--- a/.github/actions/sign-and-notarize/sign_and_notarize.sh
+++ b/.github/actions/sign-and-notarize/sign_and_notarize.sh
@@ -241,9 +241,8 @@ done < <(find "$C8RUN_DIR" -name "*.app" -type d -print0)
 
 # Check 2 + 3: individual Mach-O files
 while IFS= read -r -d '' candidate; do
-  # skip files inside .app bundles (covered by --deep above) and inside .jar files
+  # skip files inside .app bundles (covered by --deep above)
   [[ "$candidate" == *.app/* ]] && continue
-  [[ "$candidate" == *.jar/* ]] && continue
   file -b "$candidate" | grep -q "Mach-O" || continue
 
   # 2. Valid signature
@@ -331,15 +330,19 @@ echo "All done. Final archive with excluded items is: $FINAL_ZIP"
 # time (e.g. a newly added binary that was missed by the entitlements loop).
 # Runs against the notarized, re-injected tree before any further packaging.
 ##############################################
-echo "=== Step F.5: JVM smoke test ==="
+echo "=== Step G: JVM smoke test ==="
 NOTARIZED_ROOT="$TMP_NOTARIZE_DIR/notarized/$C8RUN_BASENAME"
 smoke_tested=0
 for jre_pattern in "${JRE_PATH_PATTERNS[@]}"; do
   while IFS= read -r -d '' java_bin; do
     echo "  -> Running: $java_bin -version"
-    "$java_bin" -version
-    echo "  -> JVM smoke test passed: $java_bin"
-    smoke_tested=$((smoke_tested + 1))
+    if "$java_bin" -version; then
+      echo "  -> JVM smoke test passed: $java_bin"
+      smoke_tested=$((smoke_tested + 1))
+    else
+      echo "[Error] JVM smoke test FAILED: $java_bin"
+      exit 1
+    fi
   done < <(find "$NOTARIZED_ROOT" -path "*/${jre_pattern}/bin/java" -type f -print0)
 done
 if [ "$smoke_tested" -eq 0 ]; then

--- a/c8run/docs/release.md
+++ b/c8run/docs/release.md
@@ -5,6 +5,60 @@ Releases are owned by `@camunda/distribution` and triggered manually via the
 
 ---
 
+## macOS Signing Requirements
+
+### What gets signed
+
+`sign_and_notarize.sh` signs everything in the c8run package directory except the items listed in
+`EXCLUDE_PREFIXES` (`camunda-zeebe`, `connector-runtime-bundle`, `elasticsearch`), which are
+moved out before signing and re-injected after notarization unsigned.
+
+| Content type | How it is signed |
+|---|---|
+| `.app` bundles | `codesign --deep --options runtime` (covers all contents recursively) |
+| Mach-O files outside `.app` | `codesign --options runtime` |
+| Mach-O inside `.jar` files | Extracted, signed individually, jar rebuilt |
+| Mach-O under a JVM runtime path | Same as above **plus** JIT entitlements plist (see below) |
+
+### JVM runtime entitlements
+
+Binaries inside a bundled JRE/JDK/runtime require three additional entitlements that the standard
+hardened runtime blocks:
+
+| Entitlement | Why required |
+|---|---|
+| `com.apple.security.cs.allow-jit` | JVM JIT compilation via `pthread_jit_write_protect_np` |
+| `com.apple.security.cs.allow-unsigned-executable-memory` | JIT code page allocation |
+| `com.apple.security.cs.disable-library-validation` | Native libraries loaded by the JVM |
+
+Without these, `libjvm.dylib` crashes with `EXC_BREAKPOINT` during `Threads::create_vm` on
+Apple Silicon (see [#54877](https://github.com/camunda/camunda/issues/54877)).
+
+The script applies these entitlements to any Mach-O binary whose path contains a directory name
+listed in `JRE_PATH_PATTERNS` (currently `jre`, `jdk`, `runtime`). **To bundle an additional JRE
+or JDK under a different directory name, add that name to `JRE_PATH_PATTERNS`** — signing,
+entitlement verification, and the JVM smoke test all derive their scope from that single array.
+
+### Post-signing verification (Step C.5)
+
+Before submitting to Apple Notary, the script verifies the entire signed tree:
+
+1. **Signature check** — `codesign --verify --strict` on every Mach-O file and
+   `codesign --verify --deep --strict` on every `.app` bundle. Any unsigned or
+   invalidly signed binary fails the release.
+2. **JIT entitlement check** — every Mach-O under a `JRE_PATH_PATTERNS` directory is
+   additionally checked for `allow-jit`. A missing entitlement fails the release before
+   Apple sees the artifact.
+
+### Post-notarization smoke test (Step G)
+
+After notarization and re-injection of excluded items, the script finds every `bin/java`
+executable under any `JRE_PATH_PATTERNS` directory in the re-packaged tree and runs
+`java -version`. A crash at this point (e.g. a newly added JRE binary missing entitlements)
+fails the release before upload.
+
+---
+
 ## Before You Start
 
 ### 1. Check Docker Compose is released

--- a/c8run/docs/release.md
+++ b/c8run/docs/release.md
@@ -35,8 +35,8 @@ Without these, `libjvm.dylib` crashes with `EXC_BREAKPOINT` during `Threads::cre
 Apple Silicon (see [#54877](https://github.com/camunda/camunda/issues/54877)).
 
 The script applies these entitlements to any Mach-O binary whose path contains a directory name
-listed in `JRE_PATH_PATTERNS` (currently `jre`, `jdk`, `runtime`). **To bundle an additional JRE
-or JDK under a different directory name, add that name to `JRE_PATH_PATTERNS`** — signing,
+listed in `JRE_DIR_NAMES` (currently `jre`, `jdk`, `runtime`). **To bundle an additional JRE
+or JDK under a different directory name, add that name to `JRE_DIR_NAMES`** — signing,
 entitlement verification, and the JVM smoke test all derive their scope from that single array.
 
 ### Post-signing verification (Step C.5)
@@ -46,14 +46,14 @@ Before submitting to Apple Notary, the script verifies the entire signed tree:
 1. **Signature check** — `codesign --verify --strict` on every Mach-O file and
    `codesign --verify --deep --strict` on every `.app` bundle. Any unsigned or
    invalidly signed binary fails the release.
-2. **JIT entitlement check** — every Mach-O under a `JRE_PATH_PATTERNS` directory is
+2. **JIT entitlement check** — every Mach-O under a `JRE_DIR_NAMES` directory is
    additionally checked for `allow-jit`. A missing entitlement fails the release before
    Apple sees the artifact.
 
 ### Post-notarization smoke test (Step G)
 
 After notarization and re-injection of excluded items, the script finds every `bin/java`
-executable under any `JRE_PATH_PATTERNS` directory in the re-packaged tree and runs
+executable under any `JRE_DIR_NAMES` directory in the re-packaged tree and runs
 `java -version`. A crash at this point (e.g. a newly added JRE binary missing entitlements)
 fails the release before upload.
 

--- a/c8run/docs/release.md
+++ b/c8run/docs/release.md
@@ -13,23 +13,23 @@ Releases are owned by `@camunda/distribution` and triggered manually via the
 `EXCLUDE_PREFIXES` (`camunda-zeebe`, `connector-runtime-bundle`, `elasticsearch`), which are
 moved out before signing and re-injected after notarization unsigned.
 
-| Content type | How it is signed |
-|---|---|
-| `.app` bundles | `codesign --deep --options runtime` (covers all contents recursively) |
-| Mach-O files outside `.app` | `codesign --options runtime` |
-| Mach-O inside `.jar` files | Extracted, signed individually, jar rebuilt |
-| Mach-O under a JVM runtime path | Same as above **plus** JIT entitlements plist (see below) |
+|          Content type           |                           How it is signed                            |
+|---------------------------------|-----------------------------------------------------------------------|
+| `.app` bundles                  | `codesign --deep --options runtime` (covers all contents recursively) |
+| Mach-O files outside `.app`     | `codesign --options runtime`                                          |
+| Mach-O inside `.jar` files      | Extracted, signed individually, jar rebuilt                           |
+| Mach-O under a JVM runtime path | Same as above **plus** JIT entitlements plist (see below)             |
 
 ### JVM runtime entitlements
 
 Binaries inside a bundled JRE/JDK/runtime require three additional entitlements that the standard
 hardened runtime blocks:
 
-| Entitlement | Why required |
-|---|---|
-| `com.apple.security.cs.allow-jit` | JVM JIT compilation via `pthread_jit_write_protect_np` |
-| `com.apple.security.cs.allow-unsigned-executable-memory` | JIT code page allocation |
-| `com.apple.security.cs.disable-library-validation` | Native libraries loaded by the JVM |
+|                       Entitlement                        |                      Why required                      |
+|----------------------------------------------------------|--------------------------------------------------------|
+| `com.apple.security.cs.allow-jit`                        | JVM JIT compilation via `pthread_jit_write_protect_np` |
+| `com.apple.security.cs.allow-unsigned-executable-memory` | JIT code page allocation                               |
+| `com.apple.security.cs.disable-library-validation`       | Native libraries loaded by the JVM                     |
 
 Without these, `libjvm.dylib` crashes with `EXC_BREAKPOINT` during `Threads::create_vm` on
 Apple Silicon (see [#54877](https://github.com/camunda/camunda/issues/54877)).


### PR DESCRIPTION
## Summary

Addresses the prevention suggestions from #54877 (bundled JRE crashed on Apple Silicon due to missing JIT entitlements).

- Introduce `JRE_PATH_PATTERNS` array as the single extension point for JVM runtime directory names — signing, entitlement verification, and the smoke test all derive their scope from it. Adding a new JRE/JDK bundle requires one entry in the array.
- Add **post-signing verification** (Step C.5) before notarization: `codesign --verify --strict` on every Mach-O, `--deep --strict` on every `.app` bundle, and `allow-jit` assertion on any binary under a `JRE_PATH_PATTERNS` path. Any failure blocks the release before Apple sees the artifact.
- Add **post-notarization JVM smoke test** (Step G): runs `java -version` against every `bin/java` found under `JRE_PATH_PATTERNS` in the re-packaged tree, catching runtime crashes before upload.
- Document signing requirements, the `JRE_PATH_PATTERNS` extension point, and both pipeline checks in `c8run/docs/release.md`.

## Test plan

- [ ] Trigger `c8run-release.yaml` on an ARM64 macOS runner with a package containing a bundled JRE — verify Step C.5 and Step G appear in the logs and pass
- [ ] Manually remove the `allow-jit` entitlement from a test binary and confirm Step C.5 exits non-zero with a descriptive error message

Closes #54877