### PR TITLE
feat: prevent override of certain per PT properties

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidation.java
@@ -25,9 +25,10 @@ import org.springframework.core.env.Environment;
 
 /**
  * Override policy for physical-tenant configuration: an explicit <em>deny-list</em> of cluster-wide
- * properties that may not be overridden under {@code camunda.physical-tenants.<id>.*}. Every other
- * property is freely overridable (the physical-tenant model is "override anything except cluster
- * identity", so an allow-list would be enormous and perpetually out of date).
+ * and identity-security properties that may not be overridden under {@code
+ * camunda.physical-tenants.<id>.*}. Every other property is freely overridable (the physical-tenant
+ * model is "override anything except cluster identity and security policy", so an allow-list would
+ * be enormous and perpetually out of date).
  *
  * <p>Enforcement is pure <em>key inspection</em> over the declared {@code physical-tenants.<id>.*}
  * keys — the same walk {@link PhysicalTenantResolver#discover(Environment)} does — with no value
@@ -35,14 +36,15 @@ import org.springframework.core.env.Environment;
  * fails resolution.
  *
  * <p>The list below enumerates every non-overridable child of {@code camunda.cluster}, {@code
- * camunda.system} and {@code camunda.license} (see {@link io.camunda.configuration.Camunda}). It is
- * a flat enumeration rather than the broader subtrees plus carve-outs: the overridable properties
- * ({@code cluster.partition-count}, {@code cluster.replication-factor}, {@code
- * system.clock-controlled}) are simply absent from the list. Matching is by ancestor, so listing a
- * parent (e.g. {@code cluster.network}) also forbids all of its descendants.
+ * camunda.system}, {@code camunda.license}, and the identity-security subtrees of {@code
+ * camunda.security} (see {@link io.camunda.configuration.Camunda}). It is a flat enumeration rather
+ * than broader subtrees plus carve-outs: the overridable properties ({@code
+ * cluster.partition-count}, {@code cluster.replication-factor}, {@code system.clock-controlled})
+ * are simply absent from the list. Matching is by ancestor, so listing a parent (e.g. {@code
+ * cluster.network}) also forbids all of its descendants.
  *
- * <p>Keep this list in sync with {@code Camunda}'s {@code cluster}, {@code system} and {@code
- * license} sections when properties are added or removed.
+ * <p>Keep this list in sync with {@code Camunda}'s {@code cluster}, {@code system}, {@code
+ * license}, and {@code security} sections when properties are added or removed.
  */
 @NullMarked
 final class PhysicalTenantOverridePolicyValidation {
@@ -51,9 +53,10 @@ final class PhysicalTenantOverridePolicyValidation {
       ConfigurationPropertyName.of(Camunda.PREFIX + ".physical-tenants");
 
   /**
-   * Cluster-wide properties that may not be overridden per physical tenant. Enumerated from {@code
-   * camunda.cluster.*}, {@code camunda.system.*} and {@code camunda.license.*}; the overridable
-   * carve-outs ({@code cluster.partition-count}, {@code cluster.replication-factor}, {@code
+   * Cluster-wide and identity-security properties that may not be overridden per physical tenant.
+   * Enumerated from {@code camunda.cluster.*}, {@code camunda.system.*}, {@code camunda.license.*},
+   * and the identity-security subtrees of {@code camunda.security.*}; the overridable carve-outs
+   * ({@code cluster.partition-count}, {@code cluster.replication-factor}, {@code
    * system.clock-controlled}) are intentionally omitted.
    */
   private static final List<ConfigurationPropertyName> NON_OVERRIDABLE =
@@ -86,7 +89,15 @@ final class PhysicalTenantOverridePolicyValidation {
               // camunda.api.*
               "api.rest.executor",
               // camunda.data.* cluster wide
-              "data.secondary-storage.rdbms.max-varchar-field-length")
+              "data.secondary-storage.rdbms.max-varchar-field-length",
+              // camunda.security.* — identity-security settings that must apply uniformly
+              "security.authentication.method",
+              "security.authentication.unprotected-api",
+              "security.csrf",
+              "security.http-headers",
+              // forward declaration — property lands with #54898
+              "security.cluster-admin",
+              "security.multi-tenancy")
           .map(ConfigurationPropertyName::of)
           .toList();
 
@@ -108,8 +119,9 @@ final class PhysicalTenantOverridePolicyValidation {
               .map(entry -> entry.getKey() + "=" + entry.getValue())
               .collect(Collectors.joining(", "));
       throw new UnifiedConfigurationException(
-          "Cluster-wide properties may not be overridden per physical tenant; configure them once "
-              + "under the root 'camunda.*'. Forbidden tenant-level overrides: "
+          "Cluster-wide and identity security properties may not be overridden per physical "
+              + "tenant; configure them once under the root 'camunda.*'. "
+              + "Forbidden tenant-level overrides: "
               + detail);
     }
   }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidationTest.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import io.camunda.configuration.UnifiedConfigurationException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -172,6 +174,86 @@ class PhysicalTenantOverridePolicyValidationTest {
     final MockEnvironment environment = environmentWith(Map.of("camunda.cluster.size", 4));
 
     // when / then root-level cluster configuration is allowed
+    assertThatCode(() -> PhysicalTenantOverridePolicyValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  // --- identity security property tests -------------------------------------------------------
+
+  @Test
+  void shouldRejectTenantOverridingAuthenticationMethod() {
+    // given a tenant attempting to override the cluster-wide authentication method
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of("camunda.physical-tenants.tenanta.security.authentication.method", "basic"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantOverridePolicyValidation.validate(environment))
+        .withMessageContaining("may not be overridden per physical tenant")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("security.authentication.method");
+  }
+
+  @Test
+  void shouldRejectTenantOverridingAuthenticationUnprotectedApi() {
+    // given a tenant attempting to override the cluster-wide unprotected-api flag
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.physical-tenants.tenanta.security.authentication.unprotected-api", true));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantOverridePolicyValidation.validate(environment))
+        .withMessageContaining("may not be overridden per physical tenant")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("security.authentication.unprotected-api");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "security.csrf.enabled",
+        "security.csrf.cookie-name",
+        "security.http-headers.content-security-policy",
+        "security.cluster-admin.user-id",
+        "security.multi-tenancy.enabled"
+      })
+  void shouldRejectTenantOverridingNonOverridableSecuritySubpath(final String relativeKey) {
+    // given a tenant overriding a specific sub-key under a non-overridable security path
+    final MockEnvironment environment =
+        environmentWith(Map.of("camunda.physical-tenants.tenanta." + relativeKey, "somevalue"));
+
+    // when / then the entire subtree is blocked
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantOverridePolicyValidation.validate(environment))
+        .withMessageContaining("may not be overridden per physical tenant")
+        .withMessageContaining("tenanta")
+        .withMessageContaining(relativeKey);
+  }
+
+  @Test
+  void shouldAllowTenantOverridingOtherSecurityProperties() {
+    // given a tenant overriding a security property that is not on the deny-list
+    final MockEnvironment environment =
+        environmentWith(Map.of("camunda.physical-tenants.tenanta.security.session.timeout", "30m"));
+
+    // when / then freely overridable security properties are allowed
+    assertThatCode(() -> PhysicalTenantOverridePolicyValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAllowTenantOverridingOidcConfiguration() {
+    // given a tenant configuring its own OIDC provider
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.physical-tenants.tenanta.security.authentication.oidc.issuer-uri",
+                "https://idp.tenanta.example.com"));
+
+    // when / then per-tenant OIDC configuration remains overridable
     assertThatCode(() -> PhysicalTenantOverridePolicyValidation.validate(environment))
         .doesNotThrowAnyException();
   }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -70,6 +70,9 @@ cluster.size
 cluster.zone
 data.secondary-storage.rdbms.max-varchar-field-length
 license.key
+security.csrf
+security.http-headers
+security.multi-tenancy
 system.actor.idle.max-park-period
 system.actor.idle.max-spins
 system.actor.idle.max-yields

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -300,11 +300,8 @@ processing.scheduled-tasks-check-interval
 processing.skip-positions
 security.authentication
 security.authorizations
-security.csrf
-security.http-headers
 security.id-validation-pattern
 security.initialization
-security.multi-tenancy
 security.saas
 security.session
 security.transport-layer-security.cluster.certificate-chain-path


### PR DESCRIPTION
## Description

Implements acceptance criteria 1: Startup now fails with a clear error if a PT overrides a non-overridable key: camunda.security.authentication.method, camunda.security.authentication.unprotected-api, camunda.security.csrf, camunda.security.http-headers, camunda.security.cluster-admin, camunda.security.multi-tenancy.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

part of #54731
