### PR TITLE
docs: update createDeployment description to enumerate supported resource types

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -12,7 +12,8 @@ paths:
         - basicAuth: []
       summary: Deploy resources
       description: |
-        Deploys one or more resources (e.g. processes, decision models, or forms).
+        Deploys one or more resources, including BPMN processes, DMN decision models, forms, RPA resources, and generic files.
+        A deployment can contain any file type. Files that are not interpreted as BPMN, DMN, form, or RPA resources are stored as deployable generic resources in the engine.
         This is an atomic call, i.e. either all resources are deployed or none of them are.
       requestBody:
         required: true


### PR DESCRIPTION
## Description

The `createDeployment` endpoint description was vague — it said "e.g. processes, decision models, or forms" which didn't cover RPA resources or generic files added in more recent releases.

This aligns the source description in `deployments.yaml` with the updated text proposed in [camunda/camunda-docs#9050](https://github.com/camunda/camunda-docs/pull/9050#discussion_r3394094342), which noted the docs MDX is generated from this spec.

## Checklist

<!-- For changes to the codebase: -->
- [ ] I have written unit and/or integration tests for my changes
- [ ] I have documented my changes (where applicable)

## Related issues

Relates to https://github.com/camunda/camunda-docs/pull/9050#discussion_r3394094342