### PR TITLE
test: fix flaky tenant config validation tests

### DIFF
--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/SecondaryStorageIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/SecondaryStorageIsolationValidationTest.java
@@ -14,26 +14,35 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.UnifiedConfigurationHelper;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.env.MockEnvironment;
 
 /**
  * Unit tests for the {@link SecondaryStorageIsolationValidation} cross-tenant rule: no two physical
  * tenants may resolve to the same {@link StorageIdentity} (they would silently double-write into
  * the same database location).
- *
- * <p>Hand-constructs {@link Camunda} instances directly — no Spring, no environment. With no custom
- * environment pinned, the legacy-fallback getters ({@code getType}, {@code getUrl}, {@code
- * getIndexPrefix}, ...) return the raw field values, so these tests exercise the extraction and
- * grouping logic in isolation.
  */
 class SecondaryStorageIsolationValidationTest {
 
   private final SecondaryStorageIsolationValidation validation =
       new SecondaryStorageIsolationValidation();
+
+  @BeforeEach
+  void setUp() {
+    UnifiedConfigurationHelper.setCustomEnvironment(new MockEnvironment());
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
 
   @Test
   void shouldRejectTwoTenantsSharingSameElasticsearchUrlAndIndexPrefix() {

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/SecondaryStorageTypeHomogeneityValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/SecondaryStorageTypeHomogeneityValidationTest.java
@@ -13,9 +13,13 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.UnifiedConfigurationHelper;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
 
 /**
  * Unit tests for the {@link SecondaryStorageTypeHomogeneityValidation} cross-tenant rule: all
@@ -30,6 +34,16 @@ class SecondaryStorageTypeHomogeneityValidationTest {
 
   private final SecondaryStorageTypeHomogeneityValidation validation =
       new SecondaryStorageTypeHomogeneityValidation();
+
+  @BeforeEach
+  void setUp() {
+    UnifiedConfigurationHelper.setCustomEnvironment(new MockEnvironment());
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
 
   @Test
   void shouldPassWhenAllTenantsUseElasticsearch() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
SecondaryStorageTypeHomogeneityValidationTest and SecondaryStorageIsolationValidationTest were reported as flaky with the following exception
```
io.camunda.configuration.UnifiedConfigurationException: Ambiguous configuration. The value camunda.data.secondary-storage.type=rdbms conflicts with the values 'elasticsearch' from the legacy properties camunda.operate.database, camunda.tasklist.database, camunda.database.type, zeebe.broker.exporters.camundaexporter.args.connect.type
	at io.camunda.configuration.UnifiedConfigurationHelper.backwardsCompatibilitySupportedOnlyIfValuesMatch(UnifiedConfigurationHelper.java:558)
	at io.camunda.configuration.UnifiedConfigurationHelper.validateLegacyConfiguration(UnifiedConfigurationHelper.java:196)
	at io.camunda.configuration.UnifiedConfigurationHelper.validateLegacyConfiguration(UnifiedConfigurationHelper.java:157)
	at io.camunda.configuration.UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(UnifiedConfigurationHelper.java:69)
	at io.camunda.configuration.SecondaryStorage.getType(SecondaryStorage.java:68)
	at io.camunda.configuration.physicaltenants.StorageIdentity.of(StorageIdentity.java:56)
	at io.camunda.configuration.physicaltenants.SecondaryStorageIsolationValidation.lambda$validate$1(SecondaryStorageIsolationValidation.java:44)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:986)
	at io.camunda.configuration.physicaltenants.SecondaryStorageIsolationValidation.validate(SecondaryStorageIsolationValidation.java:42)
	at io.camunda.configuration.physicaltenants.SecondaryStorageIsolationValidationTest.lambda$shouldPassForRdbmsTenantsOnSameDbWithDifferentSchemasInUrl$9(SecondaryStorageIsolationValidationTest.java:165)
```


Isolate the environment objects used by tests to allow them to run in parallel

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
