### PR TITLE
refactor: physical tenants path segments for rest & mcp gateway

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
@@ -24,6 +24,7 @@ public class SecurityPathAdapter implements SecurityPathPort {
           "/api/**",
           "/v1/**",
           "/v2/**",
+          "/physical-tenants/{physicalTenantId}/v2/**",
           "/mcp/**",
           "/physical-tenants/{physicalTenantId}/mcp/**",
           "/.well-known/oauth-protected-resource/**");

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
@@ -22,6 +22,7 @@ class SecurityPathAdapterTest {
             "/api/**",
             "/v1/**",
             "/v2/**",
+            "/physical-tenants/{physicalTenantId}/v2/**",
             "/mcp/**",
             "/physical-tenants/{physicalTenantId}/mcp/**",
             "/.well-known/oauth-protected-resource/**");

--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpGatewayConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpGatewayConfiguration.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.application.commons.mcp;
 
-import static io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT;
-
 import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
 import io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration;
 import io.camunda.gateway.mcp.config.CamundaMcpToolSpecificationsAutoConfiguration;
@@ -72,6 +70,12 @@ public class McpGatewayConfiguration {
     registrationBean.setFilter(
         new OncePerRequestFilter() {
           @Override
+          protected boolean shouldNotFilter(final @NonNull HttpServletRequest request) {
+            final String path = request.getServletPath();
+            return path == null || !McpServerRequestObservationConvention.isMcpPath(path);
+          }
+
+          @Override
           protected void doFilterInternal(
               final @NonNull HttpServletRequest request,
               final @NonNull HttpServletResponse response,
@@ -80,7 +84,7 @@ public class McpGatewayConfiguration {
             filterChain.doFilter(new ContentCachingRequestWrapper(request, 0), response);
           }
         });
-    registrationBean.addUrlPatterns("/mcp/*", PHYSICAL_TENANTS_PATH_SEGMENT + "*/mcp/*");
+    registrationBean.addUrlPatterns("/*");
     registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
 
     return registrationBean;

--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpGatewayConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpGatewayConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.application.commons.mcp;
 
+import static io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT;
+
 import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
 import io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration;
 import io.camunda.gateway.mcp.config.CamundaMcpToolSpecificationsAutoConfiguration;
@@ -78,7 +80,7 @@ public class McpGatewayConfiguration {
             filterChain.doFilter(new ContentCachingRequestWrapper(request, 0), response);
           }
         });
-    registrationBean.addUrlPatterns("/mcp/*", "/physical-tenants/*/mcp/*");
+    registrationBean.addUrlPatterns("/mcp/*", PHYSICAL_TENANTS_PATH_SEGMENT + "*/mcp/*");
     registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
 
     return registrationBean;

--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpServerRequestObservationConvention.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpServerRequestObservationConvention.java
@@ -28,6 +28,8 @@ public class McpServerRequestObservationConvention
 
   public static final String URI_MCP_PREFIX = "/mcp";
 
+  private static final String PHYSICAL_TENANT_PATH_PREFIX = "/physical-tenants/";
+
   private static final Logger LOGGER =
       LoggerFactory.getLogger(McpServerRequestObservationConvention.class);
 
@@ -83,7 +85,23 @@ public class McpServerRequestObservationConvention
 
   private static boolean isMcpRequest(final HttpServletRequest carrier) {
     final String servletPath = carrier.getServletPath();
-    return servletPath != null && servletPath.startsWith(URI_MCP_PREFIX);
+    return servletPath != null && isMcpPath(servletPath);
+  }
+
+  static boolean isMcpPath(final String servletPath) {
+    if (servletPath.startsWith(URI_MCP_PREFIX)) {
+      return true;
+    }
+    // /physical-tenants/{tenantId}/mcp[/...]
+    if (!servletPath.startsWith(PHYSICAL_TENANT_PATH_PREFIX)) {
+      return false;
+    }
+    final int slashAfterTenant = servletPath.indexOf('/', PHYSICAL_TENANT_PATH_PREFIX.length());
+    if (slashAfterTenant < 0) {
+      return false;
+    }
+    final String rest = servletPath.substring(slashAfterTenant);
+    return rest.startsWith(URI_MCP_PREFIX);
   }
 
   private static String getRequestBody(final HttpServletRequest carrier) {

--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpServerRequestObservationConvention.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpServerRequestObservationConvention.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.application.commons.mcp;
 
+import static io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT;
+
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,8 +29,6 @@ public class McpServerRequestObservationConvention
     extends DefaultServerRequestObservationConvention {
 
   public static final String URI_MCP_PREFIX = "/mcp";
-
-  private static final String PHYSICAL_TENANT_PATH_PREFIX = "/physical-tenants/";
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(McpServerRequestObservationConvention.class);
@@ -93,10 +93,10 @@ public class McpServerRequestObservationConvention
       return true;
     }
     // /physical-tenants/{tenantId}/mcp[/...]
-    if (!servletPath.startsWith(PHYSICAL_TENANT_PATH_PREFIX)) {
+    if (!servletPath.startsWith(PHYSICAL_TENANTS_PATH_SEGMENT)) {
       return false;
     }
-    final int slashAfterTenant = servletPath.indexOf('/', PHYSICAL_TENANT_PATH_PREFIX.length());
+    final int slashAfterTenant = servletPath.indexOf('/', PHYSICAL_TENANTS_PATH_SEGMENT.length());
     if (slashAfterTenant < 0) {
       return false;
     }

--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpServerRequestObservationConvention.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpServerRequestObservationConvention.java
@@ -28,7 +28,7 @@ import tools.jackson.databind.json.JsonMapper;
 public class McpServerRequestObservationConvention
     extends DefaultServerRequestObservationConvention {
 
-  public static final String URI_MCP_PREFIX = "/mcp";
+  public static final String URI_MCP_PREFIX = "/mcp/";
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(McpServerRequestObservationConvention.class);
@@ -97,7 +97,7 @@ public class McpServerRequestObservationConvention
       return false;
     }
     final int slashAfterTenant = servletPath.indexOf('/', PHYSICAL_TENANTS_PATH_SEGMENT.length());
-    if (slashAfterTenant < 0) {
+    if (slashAfterTenant <= PHYSICAL_TENANTS_PATH_SEGMENT.length()) {
       return false;
     }
     final String rest = servletPath.substring(slashAfterTenant);

--- a/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
@@ -16,15 +16,22 @@ import io.camunda.gateway.mcp.tool.cluster.ClusterTools;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import jakarta.servlet.ServletRequest;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.micrometer.observation.autoconfigure.ObservationProperties;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 import tools.jackson.databind.json.JsonMapper;
 
 class McpGatewayConfigurationTest {
@@ -65,6 +72,60 @@ class McpGatewayConfigurationTest {
   private <T> WebApplicationContextRunner addMockedBean(
       final WebApplicationContextRunner runner, final Class<T> type) {
     return runner.withBean(type, () -> mock(type));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/mcp/cluster",
+        "/mcp/processes",
+        "/physical-tenants/tenant-a/mcp/cluster",
+        "/physical-tenants/tenant-a/mcp/processes",
+        "/physical-tenants/tenant-a/mcp/cluster/sub",
+      })
+  void shouldWrapMcpRequestsInContentCachingRequestWrapper(final String servletPath)
+      throws Exception {
+    // given
+    final OncePerRequestFilter filter =
+        new McpGatewayConfiguration().mcpContentCachingFilter().getFilter();
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setServletPath(servletPath);
+    final List<ServletRequest> captured = new ArrayList<>();
+
+    // when
+    filter.doFilter(request, new MockHttpServletResponse(), (req, res) -> captured.add(req));
+
+    // then
+    assertThat(captured).hasSize(1);
+    assertThat(captured.getFirst()).isInstanceOf(ContentCachingRequestWrapper.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/mcp",
+        "/v2/process-instances",
+        "/mcpfoo",
+        "/physical-tenants/tenant-a/mcp",
+        "/physical-tenants/tenant-a/v2/something",
+        "/physical-tenants/tenant-a/mcpfoo",
+        "/physical-tenants//mcp",
+      })
+  void shouldNotWrapNonMcpRequestsInContentCachingRequestWrapper(final String servletPath)
+      throws Exception {
+    // given
+    final OncePerRequestFilter filter =
+        new McpGatewayConfiguration().mcpContentCachingFilter().getFilter();
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setServletPath(servletPath);
+    final List<ServletRequest> captured = new ArrayList<>();
+
+    // when
+    filter.doFilter(request, new MockHttpServletResponse(), (req, res) -> captured.add(req));
+
+    // then
+    assertThat(captured).hasSize(1);
+    assertThat(captured.getFirst()).isNotInstanceOf(ContentCachingRequestWrapper.class);
   }
 
   @Test

--- a/dist/src/test/java/io/camunda/application/commons/mcp/McpServerRequestObservationConventionTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/mcp/McpServerRequestObservationConventionTest.java
@@ -45,6 +45,24 @@ class McpServerRequestObservationConventionTest {
     assertThat(keyValues).isEmpty();
   }
 
+  @Test
+  void doesNotTrackPhysicalTenantNonMcpPathAsMcp() {
+    // given
+    final ContentCachingRequestWrapper request = mock(ContentCachingRequestWrapper.class);
+    final ServerRequestObservationContext observationContext =
+        mock(ServerRequestObservationContext.class);
+    when(request.getMethod()).thenReturn(HttpMethod.POST.name());
+    when(request.getServletPath()).thenReturn("/physical-tenants/tenant-a/v2/something");
+    when(observationContext.getCarrier()).thenReturn(request);
+
+    // when
+    final KeyValues keyValues =
+        McpServerRequestObservationConvention.getMcpRequestLowCardinalityValues(
+            observationContext, JSON_MAPPER);
+    // then
+    assertThat(keyValues).isEmpty();
+  }
+
   @ParameterizedTest
   @MethodSource("mcpRequestCases")
   void tracksMcpDetailsInObservationTags(
@@ -101,6 +119,20 @@ class McpServerRequestObservationConventionTest {
         Arguments.of(
             "/mcp/processes/tenant/tenant1",
             "{\"method\":\"tools/call\",\"params\":{\"name\":\"deploy\"}}",
-            "/mcp/processes/tenant/tenant1/tools/call/deploy"));
+            "/mcp/processes/tenant/tenant1/tools/call/deploy"),
+        // /physical-tenants/{tenantId}/mcp paths
+        Arguments.of("/physical-tenants/tenant-a/mcp", null, "/physical-tenants/tenant-a/mcp"),
+        Arguments.of(
+            "/physical-tenants/tenant-a/mcp/cluster",
+            null,
+            "/physical-tenants/tenant-a/mcp/cluster"),
+        Arguments.of(
+            "/physical-tenants/tenant-a/mcp/cluster",
+            "{\"method\":\"tools/list\"}",
+            "/physical-tenants/tenant-a/mcp/cluster/tools/list"),
+        Arguments.of(
+            "/physical-tenants/tenant-a/mcp/cluster",
+            "{\"method\":\"tools/call\",\"params\":{\"name\":\"start\"}}",
+            "/physical-tenants/tenant-a/mcp/cluster/tools/call/start"));
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/mcp/McpServerRequestObservationConventionTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/mcp/McpServerRequestObservationConventionTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.web.util.ContentCachingRequestWrapper;
@@ -61,6 +62,36 @@ class McpServerRequestObservationConventionTest {
             observationContext, JSON_MAPPER);
     // then
     assertThat(keyValues).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/mcp/cluster",
+        "/mcp/processes",
+        "/mcp/anything/nested",
+        "/physical-tenants/tenant-a/mcp/cluster",
+        "/physical-tenants/tenant-a/mcp/processes/nested",
+      })
+  void shouldRecognizeMcpPaths(final String path) {
+    assertThat(McpServerRequestObservationConvention.isMcpPath(path)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/mcp", // no endpoint at bare /mcp
+        "/mcpfoo", // no slash after /mcp
+        "/mcp-cluster", // dash, not slash
+        "/v2/something",
+        "/physical-tenants/tenant-a/mcp", // no endpoint at bare /physical-tenants/{id}/mcp
+        "/physical-tenants/tenant-a/v2/something",
+        "/physical-tenants//mcp", // empty tenant id
+        "/physical-tenants/mcp", // no tenant segment (slash before mcp missing)
+        "/physical-tenants/tenant-a/mcpfoo", // no slash after /mcp
+      })
+  void shouldNotRecognizeNonMcpPathsAsMcp(final String path) {
+    assertThat(McpServerRequestObservationConvention.isMcpPath(path)).isFalse();
   }
 
   @ParameterizedTest
@@ -121,7 +152,6 @@ class McpServerRequestObservationConventionTest {
             "{\"method\":\"tools/call\",\"params\":{\"name\":\"deploy\"}}",
             "/mcp/processes/tenant/tenant1/tools/call/deploy"),
         // /physical-tenants/{tenantId}/mcp paths
-        Arguments.of("/physical-tenants/tenant-a/mcp", null, "/physical-tenants/tenant-a/mcp"),
         Arguments.of(
             "/physical-tenants/tenant-a/mcp/cluster",
             null,

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/physicaltenants/PhysicalTenantContext.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/physicaltenants/PhysicalTenantContext.java
@@ -24,8 +24,18 @@ public final class PhysicalTenantContext {
   /** Default physical tenant id used when no prefix is present in the request path. */
   public static final String DEFAULT_PHYSICAL_TENANT_ID = "default";
 
+  /** URL path prefix for physical-tenant-scoped routes (e.g. {@code /physical-tenants/foo/}). */
+  public static final String PHYSICAL_TENANTS_PATH_SEGMENT = "/physical-tenants/";
+
   /** URI template variable carrying the physical tenant id in prefixed routes. */
   public static final String PATH_VARIABLE_PHYSICAL_TENANT_ID = "physicalTenantId";
+
+  /**
+   * URI template prefix for physical-tenant-scoped routes (e.g. {@code
+   * /physical-tenants/{physicalTenantId}/...}).
+   */
+  public static final String PHYSICAL_TENANT_URI_PREFIX =
+      PHYSICAL_TENANTS_PATH_SEGMENT + "{" + PATH_VARIABLE_PHYSICAL_TENANT_ID + "}";
 
   /** Request attribute key under which the resolved id is stored. */
   public static final String REQUEST_ATTRIBUTE_PHYSICAL_TENANT_ID =

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.gateway.mcp.config;
 
+import static io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext.PATH_VARIABLE_PHYSICAL_TENANT_ID;
+import static io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext.PHYSICAL_TENANT_URI_PREFIX;
+
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext;
 import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
@@ -63,13 +66,6 @@ public class CamundaMcpServersAutoConfiguration {
 
   /** Processes MCP server endpoint. */
   private static final String PROCESSES_ENDPOINT = "/mcp/processes";
-
-  /**
-   * Path prefix that carries the {@code physicalTenantId} path variable. Nested in front of the
-   * base endpoints to serve the physical-tenant-scoped variant from the same transport.
-   */
-  private static final String PHYSICAL_TENANT_PREFIX =
-      "/physical-tenants/{" + PhysicalTenantContext.PATH_VARIABLE_PHYSICAL_TENANT_ID + "}";
 
   private static final String CLUSTER_SERVER_NAME = "Camunda 8 Orchestration API MCP Server";
   private static final String CLUSTER_SERVER_INSTRUCTIONS =
@@ -243,7 +239,7 @@ public class CamundaMcpServersAutoConfiguration {
    *
    * <p>The default branch stamps the {@link PhysicalTenantContext#DEFAULT_PHYSICAL_TENANT_ID
    * default} tenant. The tenant branch nests the same base router under {@link
-   * #PHYSICAL_TENANT_PREFIX} so the {@code physicalTenantId} path variable is captured, then
+   * #PHYSICAL_TENANT_URI_PREFIX} so the {@code physicalTenantId} path variable is captured, then
    * validates and stamps it via {@link #tenantFilter}. The transport handler reads only the request
    * body, so the same instance serves both routes.
    */
@@ -254,7 +250,7 @@ public class CamundaMcpServersAutoConfiguration {
 
     final RouterFunction<ServerResponse> global = base.filter(defaultTenantFilter());
     final RouterFunction<ServerResponse> tenant =
-        RouterFunctions.nest(RequestPredicates.path(PHYSICAL_TENANT_PREFIX), base)
+        RouterFunctions.nest(RequestPredicates.path(PHYSICAL_TENANT_URI_PREFIX), base)
             .filter(tenantFilter(resolverProvider));
 
     return global.and(tenant);
@@ -294,8 +290,7 @@ public class CamundaMcpServersAutoConfiguration {
             ? resolver.getAll().keySet()
             : Set.of(PhysicalTenantContext.DEFAULT_PHYSICAL_TENANT_ID);
     return (request, next) -> {
-      final String tenantId =
-          request.pathVariable(PhysicalTenantContext.PATH_VARIABLE_PHYSICAL_TENANT_ID);
+      final String tenantId = request.pathVariable(PATH_VARIABLE_PHYSICAL_TENANT_ID);
       if (!knownTenants.contains(tenantId)) {
         return unknownPhysicalTenantResponse(tenantId);
       }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/ClusterScoped.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/ClusterScoped.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
 /**
  * Marker for {@code @CamundaRestController}s that expose cluster-level concerns and therefore must
  * not be exposed under the per-physical-tenant path prefix ({@code
- * /v2/physical-tenants/{physicalTenantId}/...}).
+ * /physical-tenants/{physicalTenantId}/v2/...}).
  *
  * <p>Annotated controllers keep their original path mapping only.
  */

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.config;
 
+import static io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT;
 import static io.camunda.security.api.model.config.MultiTenancyConfiguration.API_ENABLED_PROPERTY;
 import static io.camunda.security.api.model.config.oidc.OidcConfiguration.GROUPS_CLAIM_PROPERTY;
 
@@ -57,7 +58,7 @@ public class ApiFiltersConfiguration {
         new EndpointAccessErrorFilter(
             objectMapper,
             GROUPS_API_DISABLED_ERROR_MESSAGE,
-            patterns("/v2/groups/**", "/physical-tenants/*/v2/groups/**")));
+            patterns("/v2/groups/**", PHYSICAL_TENANTS_PATH_SEGMENT + "*/v2/groups/**")));
     registration.addUrlPatterns("/*");
     registration.setOrder(1);
     return registration;
@@ -73,7 +74,7 @@ public class ApiFiltersConfiguration {
         new EndpointAccessErrorFilter(
             objectMapper,
             USERS_API_DISABLED_ERROR_MESSAGE,
-            patterns("/v2/users/**", "/physical-tenants/*/v2/users/**")));
+            patterns("/v2/users/**", PHYSICAL_TENANTS_PATH_SEGMENT + "*/v2/users/**")));
     registration.addUrlPatterns("/*");
     registration.setOrder(1);
     return registration;
@@ -89,7 +90,7 @@ public class ApiFiltersConfiguration {
         new EndpointAccessErrorFilter(
             objectMapper,
             TENANTS_API_DISABLED_ERROR_MESSAGE,
-            patterns("/v2/tenants/**", "/physical-tenants/*/v2/tenants/**")));
+            patterns("/v2/tenants/**", PHYSICAL_TENANTS_PATH_SEGMENT + "*/v2/tenants/**")));
     registration.addUrlPatterns("/*");
     registration.setOrder(1);
     return registration;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -45,7 +45,7 @@ public class ApiFiltersConfiguration {
         new FilterRegistrationBean<>();
     registration.setFilter(
         new EndpointAccessErrorFilter(objectMapper, GROUPS_API_DISABLED_ERROR_MESSAGE));
-    registration.addUrlPatterns("/v2/groups/*");
+    registration.addUrlPatterns("/v2/groups/*", "/physical-tenants/*/v2/groups/*");
     registration.setOrder(1);
     return registration;
   }
@@ -58,7 +58,7 @@ public class ApiFiltersConfiguration {
         new FilterRegistrationBean<>();
     registration.setFilter(
         new EndpointAccessErrorFilter(objectMapper, USERS_API_DISABLED_ERROR_MESSAGE));
-    registration.addUrlPatterns("/v2/users/*");
+    registration.addUrlPatterns("/v2/users/*", "/physical-tenants/*/v2/users/*");
     registration.setOrder(1);
     return registration;
   }
@@ -71,7 +71,7 @@ public class ApiFiltersConfiguration {
         new FilterRegistrationBean<>();
     registration.setFilter(
         new EndpointAccessErrorFilter(objectMapper, TENANTS_API_DISABLED_ERROR_MESSAGE));
-    registration.addUrlPatterns("/v2/tenants/*");
+    registration.addUrlPatterns("/v2/tenants/*", "/physical-tenants/*/v2/tenants/*");
     registration.setOrder(1);
     return registration;
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -15,10 +15,14 @@ import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
 import io.camunda.zeebe.gateway.rest.controller.EndpointAccessErrorFilter;
 import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
 
 @Configuration
 public class ApiFiltersConfiguration {
@@ -37,6 +41,12 @@ public class ApiFiltersConfiguration {
       "Tenants API is disabled. Enable the API by setting '%s' to true."
           .formatted(API_ENABLED_PROPERTY);
 
+  private static final PathPatternParser PATTERN_PARSER = new PathPatternParser();
+
+  private static List<PathPattern> patterns(final String... patterns) {
+    return Arrays.stream(patterns).map(PATTERN_PARSER::parse).toList();
+  }
+
   @ConditionalOnExpression("'${camunda.security.authentication.oidc.groupsClaim:}' != ''")
   @Bean
   public FilterRegistrationBean<EndpointAccessErrorFilter> disableGroupApiFilter(
@@ -44,8 +54,11 @@ public class ApiFiltersConfiguration {
     final FilterRegistrationBean<EndpointAccessErrorFilter> registration =
         new FilterRegistrationBean<>();
     registration.setFilter(
-        new EndpointAccessErrorFilter(objectMapper, GROUPS_API_DISABLED_ERROR_MESSAGE));
-    registration.addUrlPatterns("/v2/groups/*", "/physical-tenants/*/v2/groups/*");
+        new EndpointAccessErrorFilter(
+            objectMapper,
+            GROUPS_API_DISABLED_ERROR_MESSAGE,
+            patterns("/v2/groups/**", "/physical-tenants/*/v2/groups/**")));
+    registration.addUrlPatterns("/*");
     registration.setOrder(1);
     return registration;
   }
@@ -57,8 +70,11 @@ public class ApiFiltersConfiguration {
     final FilterRegistrationBean<EndpointAccessErrorFilter> registration =
         new FilterRegistrationBean<>();
     registration.setFilter(
-        new EndpointAccessErrorFilter(objectMapper, USERS_API_DISABLED_ERROR_MESSAGE));
-    registration.addUrlPatterns("/v2/users/*", "/physical-tenants/*/v2/users/*");
+        new EndpointAccessErrorFilter(
+            objectMapper,
+            USERS_API_DISABLED_ERROR_MESSAGE,
+            patterns("/v2/users/**", "/physical-tenants/*/v2/users/**")));
+    registration.addUrlPatterns("/*");
     registration.setOrder(1);
     return registration;
   }
@@ -70,8 +86,11 @@ public class ApiFiltersConfiguration {
     final FilterRegistrationBean<EndpointAccessErrorFilter> registration =
         new FilterRegistrationBean<>();
     registration.setFilter(
-        new EndpointAccessErrorFilter(objectMapper, TENANTS_API_DISABLED_ERROR_MESSAGE));
-    registration.addUrlPatterns("/v2/tenants/*", "/physical-tenants/*/v2/tenants/*");
+        new EndpointAccessErrorFilter(
+            objectMapper,
+            TENANTS_API_DISABLED_ERROR_MESSAGE,
+            patterns("/v2/tenants/**", "/physical-tenants/*/v2/tenants/**")));
+    registration.addUrlPatterns("/*");
     registration.setOrder(1);
     return registration;
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
@@ -28,7 +28,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  * <p>{@link WebMvcRegistrations#getRequestMappingHandlerMapping()} is the supported extension point
  * for replacing the auto-configured {@link RequestMappingHandlerMapping}, so every future
  * {@code @CamundaRestController} automatically gets the {@code
- * /v2/physical-tenants/{physicalTenantId}/...} sibling registration.
+ * /physical-tenants/{physicalTenantId}/v2/...} sibling registration.
  */
 @Configuration
 public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/EndpointAccessErrorFilter.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/EndpointAccessErrorFilter.java
@@ -10,29 +10,43 @@ package io.camunda.zeebe.gateway.rest.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.server.PathContainer;
+import org.springframework.web.util.pattern.PathPattern;
 
 public class EndpointAccessErrorFilter extends HttpFilter {
   private final ObjectMapper objectMapper;
   private final String errorMessage;
+  private final List<PathPattern> pathPatterns;
 
   public EndpointAccessErrorFilter(
-      @Autowired final ObjectMapper objectMapper, final String errorMessage) {
+      @Autowired final ObjectMapper objectMapper,
+      final String errorMessage,
+      final List<PathPattern> pathPatterns) {
     this.objectMapper = objectMapper;
     this.errorMessage = errorMessage;
+    this.pathPatterns = pathPatterns;
   }
 
   @Override
   protected void doFilter(
       final HttpServletRequest req, final HttpServletResponse res, final FilterChain chain)
-      throws IOException {
+      throws IOException, ServletException {
+    final var requestPath =
+        PathContainer.parsePath(req.getRequestURI().substring(req.getContextPath().length()));
+    if (pathPatterns.stream().noneMatch(p -> p.matches(requestPath))) {
+      chain.doFilter(req, res);
+      return;
+    }
     res.setStatus(HttpServletResponse.SC_FORBIDDEN);
     res.setContentType(MediaType.APPLICATION_PROBLEM_JSON.toString());
     final var detail =

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/PhysicalTenantInterceptor.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/interceptor/PhysicalTenantInterceptor.java
@@ -21,7 +21,7 @@ import org.springframework.web.servlet.HandlerMapping;
  *
  * <ul>
  *   <li>If the request matches a tenant-prefixed route ({@code
- *       /v2/physical-tenants/{physicalTenantId}/...}) and the id is unknown, the request is
+ *       /physical-tenants/{physicalTenantId}/v2/...}) and the id is unknown, the request is
  *       rejected with HTTP 404 before reaching the controller.
  *   <li>If no prefix is present, the resolved id defaults to {@link
  *       PhysicalTenantContext#DEFAULT_PHYSICAL_TENANT_ID}.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.gateway.rest.mapper;
 import io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext;
 import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
-import io.camunda.zeebe.gateway.rest.interceptor.PhysicalTenantInterceptor;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.lang.reflect.Method;
 import java.util.LinkedHashSet;
@@ -19,20 +18,9 @@ import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
-/**
- * Custom {@link RequestMappingHandlerMapping} that, in addition to the original path declared on
- * each {@link CamundaRestController}, registers a tenant-prefixed variant under {@code
- * /v2/physical-tenants/{physicalTenantId}/...}.
- *
- * <p>Controllers annotated with {@link ClusterScoped} are skipped — their endpoints stay
- * cluster-level and remain reachable only under their original path.
- *
- * <p>Validation of the {@code physicalTenantId} captured by the prefix and propagation to the
- * request scope is performed by {@link PhysicalTenantInterceptor}.
- */
 public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHandlerMapping {
 
-  /** Path segment inserted between {@code /v2} and the original resource path. */
+  /** Path segment prefixed before {@code /v2} in the physical-tenant addressing scheme. */
   private static final String PREFIX_SEGMENT =
       "physical-tenants/{" + PhysicalTenantContext.PATH_VARIABLE_PHYSICAL_TENANT_ID + "}";
 
@@ -45,7 +33,7 @@ public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHa
     super.registerHandlerMethod(handler, method, mapping);
 
     final Class<?> beanType = resolveBeanType(handler);
-    if (beanType == null || !shouldPrefix(beanType)) {
+    if (!shouldPrefix(beanType)) {
       return;
     }
 
@@ -57,31 +45,35 @@ public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHa
 
   @VisibleForTesting
   boolean shouldPrefix(final Class<?> beanType) {
-    return AnnotatedElementUtils.hasAnnotation(beanType, CamundaRestController.class)
+    return beanType != null
+        && AnnotatedElementUtils.hasAnnotation(beanType, CamundaRestController.class)
         && !AnnotatedElementUtils.hasAnnotation(beanType, ClusterScoped.class);
   }
 
   @VisibleForTesting
-  RequestMappingInfo withPhysicalTenantPrefix(final RequestMappingInfo mapping) {
-    final Set<String> patterns = extractPatterns(mapping);
-    final Set<String> prefixed = new LinkedHashSet<>();
-    for (final String pattern : patterns) {
-      final String rewritten = prefix(pattern);
-      if (rewritten != null) {
-        prefixed.add(rewritten);
+  protected RequestMappingInfo withPhysicalTenantPrefix(final RequestMappingInfo mapping) {
+    final Set<String> prefixedPaths = buildPrefixedPaths(mapping);
+    return prefixedPaths.isEmpty()
+        ? null
+        : mapping.mutate().paths(prefixedPaths.toArray(String[]::new)).build();
+  }
+
+  private Set<String> buildPrefixedPaths(final RequestMappingInfo mapping) {
+    final Set<String> result = new LinkedHashSet<>();
+
+    for (final String pattern : extractPatterns(mapping)) {
+      final String prefixed = prefix(pattern);
+      if (prefixed != null) {
+        result.add(prefixed);
       }
     }
-    if (prefixed.isEmpty()) {
-      return null;
-    }
-    return mapping.mutate().paths(prefixed.toArray(String[]::new)).build();
+
+    return result;
   }
 
   private Set<String> extractPatterns(final RequestMappingInfo mapping) {
-    if (mapping.getPathPatternsCondition() != null) {
-      return mapping.getPathPatternsCondition().getPatternValues();
-    }
-    return Set.of();
+    final var condition = mapping.getPathPatternsCondition();
+    return condition != null ? condition.getPatternValues() : Set.of();
   }
 
   private String prefix(final String pattern) {
@@ -90,14 +82,11 @@ public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHa
       return null;
     }
     final String tail = pattern.substring(V2.length());
-    if (tail.isEmpty()) {
-      return V2 + "/" + PREFIX_SEGMENT;
-    }
-    if (!tail.startsWith("/")) {
+    if (!tail.isEmpty() && !tail.startsWith("/")) {
       // Avoid prefixing things like "/v2foo".
       return null;
     }
-    return V2 + "/" + PREFIX_SEGMENT + tail;
+    return "/" + PREFIX_SEGMENT + pattern;
   }
 
   private Class<?> resolveBeanType(final Object handler) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
@@ -51,7 +51,7 @@ public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHa
   }
 
   @VisibleForTesting
-  protected RequestMappingInfo withPhysicalTenantPrefix(final RequestMappingInfo mapping) {
+  RequestMappingInfo withPhysicalTenantPrefix(final RequestMappingInfo mapping) {
     final Set<String> prefixedPaths = buildPrefixedPaths(mapping);
     return prefixedPaths.isEmpty()
         ? null

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.zeebe.gateway.rest.mapper;
 
-import io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext;
+import static io.camunda.gateway.mapping.http.physicaltenants.PhysicalTenantContext.PHYSICAL_TENANT_URI_PREFIX;
+
 import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -19,10 +20,6 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHandlerMapping {
-
-  /** Path segment prefixed before {@code /v2} in the physical-tenant addressing scheme. */
-  private static final String PREFIX_SEGMENT =
-      "physical-tenants/{" + PhysicalTenantContext.PATH_VARIABLE_PHYSICAL_TENANT_ID + "}";
 
   private static final String V2 = "/v2";
 
@@ -86,7 +83,7 @@ public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHa
       // Avoid prefixing things like "/v2foo".
       return null;
     }
-    return "/" + PREFIX_SEGMENT + pattern;
+    return PHYSICAL_TENANT_URI_PREFIX + pattern;
   }
 
   private Class<?> resolveBeanType(final Object handler) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/resolver/PhysicalTenantIdArgumentResolver.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/resolver/PhysicalTenantIdArgumentResolver.java
@@ -24,7 +24,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  *
  * <p>The interceptor that populates the request attribute runs before this resolver, so the value
  * is always present (defaulting to {@link PhysicalTenantContext#DEFAULT_PHYSICAL_TENANT_ID} when
- * the request did not carry the {@code /v2/physical-tenants/{physicalTenantId}/...} prefix).
+ * the request did not carry the {@code /physical-tenants/{physicalTenantId}/v2/...} prefix).
  */
 public class PhysicalTenantIdArgumentResolver implements HandlerMethodArgumentResolver {
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.controller.tenant;
 
 import static io.camunda.security.spring.CamundaSecurityLibraryProperties.DEFAULT_EXTERNAL_ID_PATTERN;
 import static io.camunda.zeebe.gateway.rest.config.ApiFiltersConfiguration.TENANTS_API_DISABLED_ERROR_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -73,6 +74,7 @@ public class TenantControllerTest {
 
   @Nested
   @WebMvcTest(TenantController.class)
+  @Import(ApiFiltersConfiguration.class)
   public class TenantsApiEnabledTest extends RestControllerTest {
     @MockitoBean private TenantServices tenantServices;
     @MockitoBean private UserServices userServices;
@@ -716,6 +718,20 @@ public class TenantControllerTest {
       verify(tenantServices, times(1)).removeMember(eq(request), any());
     }
 
+    @Test
+    void shouldNotBlockPhysicalTenantPrefixedPath() {
+      // given
+      final var uri = "/physical-tenants/default/v2/tenants/tenantId";
+
+      // when/then
+      webClient
+          .get()
+          .uri(uri)
+          .exchange()
+          .expectStatus()
+          .value(status -> assertThat(status).isNotEqualTo(403));
+    }
+
     @TestConfiguration
     static class AdditionalConfig {
       @Bean
@@ -865,6 +881,22 @@ public class TenantControllerTest {
               (Function<WebTestClient, ResponseSpec>)
                   webClient ->
                       webClient.post().uri("/v2/tenants/tenantId/clients/search").exchange()));
+    }
+
+    @Test
+    void shouldReturnErrorOnPhysicalTenantPrefixedPath() {
+      // given
+      final var uri = "/physical-tenants/acme/v2/tenants/tenantId";
+
+      // when/then
+      webClient
+          .get()
+          .uri(uri)
+          .exchange()
+          .expectStatus()
+          .isForbidden()
+          .expectBody()
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
 import static io.camunda.zeebe.gateway.rest.config.ApiFiltersConfiguration.GROUPS_API_DISABLED_ERROR_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -214,10 +215,29 @@ public class GroupControllerTest {
           .expectBody()
           .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
     }
+
+    @Test
+    void shouldReturnErrorOnPhysicalTenantPrefixedPath() {
+      // given
+      final var groupId = "111";
+      final var uri = "/physical-tenants/acme/v2/groups/" + groupId;
+
+      // when
+      webClient
+          .delete()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isForbidden()
+          .expectBody()
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
+    }
   }
 
   @Nested
   @WebMvcTest(GroupController.class)
+  @Import(ApiFiltersConfiguration.class)
   @TestPropertySource(properties = "camunda.security.authentication.oidc.groupsClaim=")
   public class CamundaGroupsEnabledTest extends RestControllerTest {
     @MockitoBean private GroupServices groupServices;
@@ -1119,6 +1139,22 @@ public class GroupControllerTest {
                   .formatted(CamundaSecurityLibraryProperties.DEFAULT_ID_REGEX, path),
               JsonCompareMode.STRICT);
       verifyNoInteractions(groupServices);
+    }
+
+    @Test
+    void shouldNotBlockPhysicalTenantPrefixedPath() {
+      // given
+      final var groupId = "111";
+      final var uri = "/physical-tenants/default/v2/groups/" + groupId;
+
+      // when
+      webClient
+          .delete()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .value(status -> assertThat(status).isNotEqualTo(403));
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
 import static io.camunda.zeebe.gateway.rest.config.ApiFiltersConfiguration.USERS_API_DISABLED_ERROR_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -56,6 +57,7 @@ public class UserControllerTest {
 
   @Nested
   @WebMvcTest(UserController.class)
+  @Import(ApiFiltersConfiguration.class)
   @TestPropertySource(properties = "camunda.security.authentication.method=basic")
   public class CamundaUsersEnabledTest extends RestControllerTest {
 
@@ -428,6 +430,22 @@ public class UserControllerTest {
           .expectBody()
           .json(expectedError, JsonCompareMode.STRICT);
     }
+
+    @Test
+    void shouldNotBlockPhysicalTenantPrefixedPath() {
+      // given
+      final var username = "alice-test";
+      final var uri = "/physical-tenants/default/v2/users/" + username;
+
+      // when/then
+      webClient
+          .get()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .value(status -> assertThat(status).isNotEqualTo(403));
+    }
   }
 
   @Nested
@@ -540,6 +558,24 @@ public class UserControllerTest {
           .uri(uri)
           .accept(MediaType.APPLICATION_JSON)
           .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isForbidden()
+          .expectBody()
+          .json(FORBIDDEN_MESSAGE.formatted(uri, uri), JsonCompareMode.STRICT);
+    }
+
+    @Test
+    void shouldReturnErrorOnPhysicalTenantPrefixedPath() {
+      // given
+      final var username = "alice-test";
+      final var uri = "/physical-tenants/acme/v2/users/" + username;
+
+      // when/then
+      webClient
+          .get()
+          .uri(uri)
+          .accept(MediaType.APPLICATION_JSON)
           .exchange()
           .expectStatus()
           .isForbidden()

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantPathPatternMatchingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantPathPatternMatchingTest.java
@@ -41,7 +41,7 @@ class PhysicalTenantPathPatternMatchingTest extends RestTest {
             "Spring MVC must be configured with PathPatternParser. "
                 + "AntPathMatcher leaves RequestMappingInfo#getPathPatternsCondition() null, "
                 + "so PhysicalTenantRequestMappingHandlerMapping would silently skip registering "
-                + "the /v2/physical-tenants/{id}/... sibling routes.")
+                + "the /physical-tenants/{id}/v2/... sibling routes.")
         .isInstanceOf(PathPatternParser.class);
   }
 
@@ -60,12 +60,23 @@ class PhysicalTenantPathPatternMatchingTest extends RestTest {
     // tenant-prefixed sibling resolves to the same controller method
     webClient
         .get()
-        .uri("/v2/physical-tenants/default/widgets")
+        .uri("/physical-tenants/default/v2/widgets")
         .exchange()
         .expectStatus()
         .isOk()
         .expectBody(String.class)
         .isEqualTo("ok");
+  }
+
+  @Test
+  void oldTenantInfixPathShouldNotResolve() {
+    // /v2/physical-tenants/{id}/... is no longer registered
+    webClient
+        .get()
+        .uri("/v2/physical-tenants/default/widgets")
+        .exchange()
+        .expectStatus()
+        .isNotFound();
   }
 
   @CamundaRestController

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMappingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMappingTest.java
@@ -26,7 +26,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
 class PhysicalTenantRequestMappingHandlerMappingTest {
 
   private static final String EXPECTED_PREFIX =
-      "/v2/physical-tenants/{" + PhysicalTenantContext.PATH_VARIABLE_PHYSICAL_TENANT_ID + "}";
+      "/physical-tenants/{" + PhysicalTenantContext.PATH_VARIABLE_PHYSICAL_TENANT_ID + "}";
 
   private final PhysicalTenantRequestMappingHandlerMapping mapping =
       new PhysicalTenantRequestMappingHandlerMapping();
@@ -55,9 +55,9 @@ class PhysicalTenantRequestMappingHandlerMappingTest {
 
   static Stream<Arguments> patternCases() {
     return Stream.of(
-        Arguments.of("/v2", EXPECTED_PREFIX),
-        Arguments.of("/v2/widgets", EXPECTED_PREFIX + "/widgets"),
-        Arguments.of("/v2/widgets/{id}", EXPECTED_PREFIX + "/widgets/{id}"),
+        Arguments.of("/v2", EXPECTED_PREFIX + "/v2"),
+        Arguments.of("/v2/widgets", EXPECTED_PREFIX + "/v2/widgets"),
+        Arguments.of("/v2/widgets/{id}", EXPECTED_PREFIX + "/v2/widgets/{id}"),
         Arguments.of("/v1/widgets", null),
         Arguments.of("/v2foo", null),
         Arguments.of("/", null));
@@ -90,7 +90,7 @@ class PhysicalTenantRequestMappingHandlerMappingTest {
             "tenant-scoped /v2 keeps original and adds prefixed sibling",
             new TenantScopedController(),
             "/v2/widgets",
-            List.of("/v2/widgets", EXPECTED_PREFIX + "/widgets")),
+            List.of("/v2/widgets", EXPECTED_PREFIX + "/v2/widgets")),
         Arguments.of(
             "cluster-scoped controller keeps only original — no sibling",
             new ClusterScopedController(),


### PR DESCRIPTION
## Description

Handles
- [x] Refactor to /physical-tenants/:physicalTenantId/v2/*
- [x] Enhance mcp observation convention accepting servlet path starting also with `/physical-tenants/:physicalTenantsId/mcp` ([ref](https://github.com/camunda/camunda/pull/53409/changes#r3372726008))

## Related issues

relates #54651
