### PR TITLE
feat: server transport subscribes per partition group

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
@@ -10,8 +10,6 @@ package io.camunda.zeebe.broker.bootstrap;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
-import java.util.List;
 
 /** Starts the server transport which can receive commands from the gateway * */
 final class GatewayBrokerTransportStep extends AbstractBrokerStartupStep {
@@ -47,16 +45,9 @@ final class GatewayBrokerTransportStep extends AbstractBrokerStartupStep {
     final var requestIdGenerator = brokerStartupContext.getRequestIdGenerator();
 
     final var config = brokerStartupContext.getBrokerConfiguration().getExperimental();
-    final TopicSupplier legacyTopicSupplier = TopicSupplier.withLegacyTopicName();
-    final TopicSupplier topicSupplier = TopicSupplier.withPrefix(config.getDefaultTenantName());
-
-    final var receiveOnTopicSuppliers =
-        config.isReceiveOnLegacySubject()
-            ? List.of(legacyTopicSupplier, topicSupplier)
-            : List.of(topicSupplier);
-
     final var atomixServerTransport =
-        new AtomixServerTransport(messagingService, requestIdGenerator, receiveOnTopicSuppliers);
+        new AtomixServerTransport(
+            messagingService, requestIdGenerator, config.isReceiveOnLegacySubject());
 
     concurrencyControl.runOnCompletion(
         schedulingService.submitActor(atomixServerTransport),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/CommandApiServicePartitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/CommandApiServicePartitionStep.java
@@ -33,7 +33,7 @@ public final class CommandApiServicePartitionStep implements StartupStep<Partiti
 
     final var commandApiService =
         new CommandApiServiceImpl(
-            context.partitionId(),
+            context.partitionMetadata().id(),
             context.gatewayBrokerTransport(),
             context.schedulingService(),
             context.brokerConfig().getExperimental().getQueryApi());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
@@ -76,7 +76,7 @@ public final class BackupApiRequestHandlerStep implements PartitionTransitionSte
             checkpointState,
             checkpointMetadataState,
             backupRangeState,
-            context.getPartitionId(),
+            context.getRaftPartition().id(),
             isBackupEnabled);
     context.getActorSchedulingService().submitActor(requestHandler).onComplete(installed);
     installed.onComplete(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
@@ -23,7 +23,7 @@ public class SnapshotApiHandlerTransitionStep implements PartitionTransitionStep
   public ActorFuture<Void> prepareTransition(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     if (context.getCurrentRole().isLeader()) {
-      context.getSnapshotApiRequestHandler().removeTransferService(context.getPartitionId());
+      context.getSnapshotApiRequestHandler().removeTransferService(context.getRaftPartition().id());
     }
     return CompletableActorFuture.completed();
   }
@@ -40,7 +40,9 @@ public class SnapshotApiHandlerTransitionStep implements PartitionTransitionStep
               (from, to) ->
                   context.snapshotCopy().copySnapshot(from, to, Set.of(ColumnFamilyScope.GLOBAL)),
               context.getSnapshotApiRequestHandler());
-      context.getSnapshotApiRequestHandler().addTransferService(context.getPartitionId(), service);
+      context
+          .getSnapshotApiRequestHandler()
+          .addTransferService(context.getRaftPartition().id(), service);
     }
     return CompletableActorFuture.completed();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -49,12 +49,12 @@ public class AdminApiRequestHandler
 
   @Override
   protected void onActorStarting() {
-    transport.subscribe(raftPartition.id().id(), RequestType.ADMIN, this);
+    transport.subscribe(raftPartition.id(), RequestType.ADMIN, this);
   }
 
   @Override
   protected void onActorClosing() {
-    transport.unsubscribe(raftPartition.id().id(), RequestType.ADMIN);
+    transport.unsubscribe(raftPartition.id(), RequestType.ADMIN);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.backupapi;
 
+import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.BackupRangeStatus;
@@ -57,6 +58,7 @@ public final class BackupApiRequestHandler
   private final CheckpointState checkpointState;
   private final DbCheckpointMetadataState checkpointMetadataState;
   private final DbBackupRangeState backupRangeState;
+  private final PartitionId partition;
   private final int partitionId;
   private final boolean backupFeatureEnabled;
 
@@ -67,7 +69,7 @@ public final class BackupApiRequestHandler
       final CheckpointState checkpointState,
       final DbCheckpointMetadataState checkpointMetadataState,
       final DbBackupRangeState backupRangeState,
-      final int partitionId,
+      final PartitionId partition,
       final boolean backupFeatureEnabled) {
     super(BackupApiRequestReader::new, BackupApiResponseWriter::new);
     this.logStreamWriter = logStreamWriter;
@@ -76,17 +78,18 @@ public final class BackupApiRequestHandler
     this.checkpointState = checkpointState;
     this.checkpointMetadataState = checkpointMetadataState;
     this.backupRangeState = backupRangeState;
-    this.partitionId = partitionId;
+    this.partition = partition;
+    partitionId = partition.id();
     this.backupFeatureEnabled = backupFeatureEnabled;
-    transport.unsubscribe(partitionId, RequestType.BACKUP);
-    transport.subscribe(partitionId, RequestType.BACKUP, this);
+    transport.unsubscribe(partition, RequestType.BACKUP);
+    transport.subscribe(partition, RequestType.BACKUP, this);
   }
 
   @Override
   public void close() {
-    transport.unsubscribe(partitionId, RequestType.BACKUP);
+    transport.unsubscribe(partition, RequestType.BACKUP);
     // The broker is not the leader any more.
-    transport.subscribe(partitionId, RequestType.BACKUP, new NotPartitionLeaderHandler());
+    transport.subscribe(partition, RequestType.BACKUP, new NotPartitionLeaderHandler());
     super.close();
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.commandapi;
 
+import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
@@ -23,14 +24,14 @@ import io.camunda.zeebe.transport.ServerTransport;
 public final class CommandApiServiceImpl extends Actor
     implements DiskSpaceUsageListener, CommandApiService {
 
-  private final int partitionId;
+  private final PartitionId partitionId;
   private final ServerTransport serverTransport;
   private final CommandApiRequestHandler commandHandler;
   private final QueryApiRequestHandler queryHandler;
   private final ActorSchedulingService scheduler;
 
   public CommandApiServiceImpl(
-      final int partitionId,
+      final PartitionId partitionId,
       final ServerTransport serverTransport,
       final ActorSchedulingService scheduler,
       final QueryApiCfg queryApiCfg) {
@@ -54,7 +55,7 @@ public final class CommandApiServiceImpl extends Actor
 
   @Override
   protected void onActorClosing() {
-    unregisterHandlersActorless(partitionId);
+    unregisterHandlersActorless(partitionId.id());
     actor.runOnCompletion(
         commandHandler.closeAsync(),
         (ok, error) -> {
@@ -100,9 +101,9 @@ public final class CommandApiServiceImpl extends Actor
           // exception immediately
           final var logStreamWriter = logStream.newLogStreamWriter();
           queryHandler.addPartition(partitionId, queryService);
-          serverTransport.subscribe(partitionId, RequestType.QUERY, queryHandler);
+          serverTransport.subscribe(this.partitionId, RequestType.QUERY, queryHandler);
           commandHandler.addPartition(partitionId, logStreamWriter);
-          serverTransport.subscribe(partitionId, RequestType.COMMAND, commandHandler);
+          serverTransport.subscribe(this.partitionId, RequestType.COMMAND, commandHandler);
         });
   }
 
@@ -123,8 +124,8 @@ public final class CommandApiServiceImpl extends Actor
   private void unregisterHandlersActorless(final int partitionId) {
     commandHandler.removePartition(partitionId);
     queryHandler.removePartition(partitionId);
-    serverTransport.unsubscribe(partitionId, RequestType.COMMAND);
-    serverTransport.unsubscribe(partitionId, RequestType.QUERY);
+    serverTransport.unsubscribe(this.partitionId, RequestType.COMMAND);
+    serverTransport.unsubscribe(this.partitionId, RequestType.QUERY);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.snapshotapi;
 
+import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotRequest.DeleteSnapshotForBootstrapRequest;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotRequest.GetSnapshotChunk;
@@ -35,8 +36,7 @@ public class SnapshotApiRequestHandler
     extends AsyncApiRequestHandler<SnapshotApiRequestReader, SnapshotApiResponseWriter> {
 
   private static final Logger LOG = LoggerFactory.getLogger(SnapshotApiRequestHandler.class);
-  private final ConcurrentMap<Integer, SnapshotSenderService> transferServices =
-      new ConcurrentHashMap<>();
+  private final ConcurrentMap<Integer, Registration> transferServices = new ConcurrentHashMap<>();
   private final ServerTransport serverTransport;
   private final BrokerClient brokerClient;
 
@@ -48,17 +48,19 @@ public class SnapshotApiRequestHandler
   }
 
   public void addTransferService(
-      final int partitionId, final SnapshotSenderService transferService) {
+      final PartitionId partitionId, final SnapshotSenderService transferService) {
     serverTransport.subscribe(partitionId, RequestType.SNAPSHOT, this);
-    transferServices.put(partitionId, transferService);
+    transferServices.put(partitionId.id(), new Registration(partitionId, transferService));
     LOG.debug("Added SnapshotTransferService for partition {}.", partitionId);
   }
 
-  public void removeTransferService(final int partitionId) {
+  public void removeTransferService(final PartitionId partitionId) {
     serverTransport.unsubscribe(partitionId, RequestType.SNAPSHOT);
-    final var service = transferServices.remove(partitionId);
+    final var registration = transferServices.remove(partitionId.id());
     LOG.debug("Removed SnapshotTransferService for partition {}.", partitionId);
-    AsyncClosable.closeHelper(service);
+    if (registration != null) {
+      AsyncClosable.closeHelper(registration.service());
+    }
   }
 
   @Override
@@ -68,11 +70,12 @@ public class SnapshotApiRequestHandler
       final SnapshotApiRequestReader requestReader,
       final SnapshotApiResponseWriter responseWriter,
       final ErrorResponseWriter errorWriter) {
-    final var service = transferServices.get(partitionId);
-    if (service == null) {
+    final var registration = transferServices.get(partitionId);
+    if (registration == null) {
       return CompletableActorFuture.completed(
           Either.left(errorWriter.partitionUnavailable(partitionId)));
     } else {
+      final var service = registration.service();
       final var request = requestReader.getRequest();
       return switch (request) {
         case final GetSnapshotChunk snapshotChunkRequest ->
@@ -162,7 +165,8 @@ public class SnapshotApiRequestHandler
     LOG.debug(
         "Closing SnapshotApiRequestHandler. Removing transfer services. Registered partitions {}",
         transferServices.keySet());
-    transferServices.forEach((partitionId, service) -> removeTransferService(partitionId));
+    transferServices.forEach(
+        (partitionId, registration) -> removeTransferService(registration.partitionId()));
     super.close();
   }
 
@@ -181,4 +185,6 @@ public class SnapshotApiRequestHandler
         .whenCompleteAsync(lastProcessedPosition, actor);
     return lastProcessedPosition;
   }
+
+  private record Registration(PartitionId partitionId, SnapshotSenderService service) {}
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/steps/CommandApiServicePartitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/steps/CommandApiServicePartitionStepTest.java
@@ -16,10 +16,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
@@ -47,11 +50,16 @@ class CommandApiServicePartitionStepTest {
     mockSchedulingService = mock(ActorSchedulingService.class);
     mockDiskSpaceUsageMonitor = mock(DiskSpaceUsageMonitor.class);
 
+    final var partitionMetadata = mock(PartitionMetadata.class);
+    when(partitionMetadata.id())
+        .thenReturn(PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, PARTITION_ID));
+
     when(mockContext.concurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
     when(mockContext.schedulingService()).thenReturn(mockSchedulingService);
     when(mockContext.diskSpaceUsageMonitor()).thenReturn(mockDiskSpaceUsageMonitor);
     when(mockContext.gatewayBrokerTransport()).thenReturn(mock(AtomixServerTransport.class));
     when(mockContext.brokerConfig()).thenReturn(new BrokerCfg());
+    when(mockContext.partitionMetadata()).thenReturn(partitionMetadata);
 
     when(mockSchedulingService.submitActor(any()))
         .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStepTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
@@ -49,6 +50,9 @@ final class BackupApiRequestHandlerStepTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   BrokerCfg brokerCfg;
 
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  RaftPartition raftPartition;
+
   private final TestPartitionTransitionContext transitionContext =
       new TestPartitionTransitionContext();
   private BackupApiRequestHandlerStep step;
@@ -62,6 +66,7 @@ final class BackupApiRequestHandlerStepTest {
     transitionContext.setActorSchedulingService(actorSchedulingService);
     transitionContext.setBrokerCfg(brokerCfg);
     transitionContext.setZeebeDb(zeebeDb);
+    transitionContext.setRaftPartition(raftPartition);
 
     step = new BackupApiRequestHandlerStep();
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.BackupRangeStatus;
 import io.camunda.zeebe.backup.api.BackupStatus;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.BackupListResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupRangesResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupRangesResponse.CheckpointInfo;
@@ -102,7 +104,7 @@ class BackupApiRequestHandlerTest {
             checkpointState,
             checkpointMetadataState,
             backupRangeState,
-            1,
+            PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, 1),
             true);
     scheduler.submitActor(handler);
     scheduler.workUntilDone();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
@@ -17,10 +17,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -41,6 +43,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class CommandApiServiceImplTest {
+
+  private static final PartitionId PARTITION_ID =
+      PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, 1);
 
   @Mock private ServerTransport serverTransport;
   @Mock private QueryApiCfg queryApi;
@@ -63,7 +68,8 @@ public class CommandApiServiceImplTest {
             withSettings().strictness(org.mockito.quality.Strictness.LENIENT));
     when(cc.createCompletedFuture()).thenReturn(CompletableActorFuture.completed(null));
     commandApiService =
-        new CommandApiServiceImpl(1, serverTransport, scheduler.getActorScheduler(), queryApi);
+        new CommandApiServiceImpl(
+            PARTITION_ID, serverTransport, scheduler.getActorScheduler(), queryApi);
     when(transitionContext.getCommandApiService()).thenReturn(commandApiService);
     when(transitionContext.getConcurrencyControl()).thenReturn(cc);
     scheduler.submitActor(commandApiService);
@@ -92,8 +98,8 @@ public class CommandApiServiceImplTest {
 
     // then
     verify(logStream, times(1)).newLogStreamWriter();
-    verify(serverTransport, times(1)).subscribe(eq(1), eq(RequestType.QUERY), any());
-    verify(serverTransport, times(1)).subscribe(eq(1), eq(RequestType.COMMAND), any());
+    verify(serverTransport, times(1)).subscribe(eq(PARTITION_ID), eq(RequestType.QUERY), any());
+    verify(serverTransport, times(1)).subscribe(eq(PARTITION_ID), eq(RequestType.COMMAND), any());
 
     // when - transitions to follower/candidate: deactivate handlers but keep transport subscription
     final var prepareFollowerFuture =
@@ -102,8 +108,8 @@ public class CommandApiServiceImplTest {
     prepareFollowerFuture.join();
 
     // then - transport subscription is kept
-    verify(serverTransport, never()).unsubscribe(eq(1), eq(RequestType.QUERY));
-    verify(serverTransport, never()).unsubscribe(eq(1), eq(RequestType.COMMAND));
+    verify(serverTransport, never()).unsubscribe(eq(PARTITION_ID), eq(RequestType.QUERY));
+    verify(serverTransport, never()).unsubscribe(eq(PARTITION_ID), eq(RequestType.COMMAND));
   }
 
   @Test
@@ -129,8 +135,8 @@ public class CommandApiServiceImplTest {
     prepareInactiveFuture.join();
 
     // then - transport subscription is removed
-    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.QUERY));
-    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.COMMAND));
+    verify(serverTransport, times(1)).unsubscribe(eq(PARTITION_ID), eq(RequestType.QUERY));
+    verify(serverTransport, times(1)).unsubscribe(eq(PARTITION_ID), eq(RequestType.COMMAND));
   }
 
   @RegressionTest("https://github.com/camunda/camunda/issues/25897")
@@ -150,8 +156,8 @@ public class CommandApiServiceImplTest {
     transitionFollowerFuture.join();
 
     // then - no unsubscribe yet (kept subscription for graceful rejection)
-    verify(serverTransport, never()).unsubscribe(eq(1), eq(RequestType.QUERY));
-    verify(serverTransport, never()).unsubscribe(eq(1), eq(RequestType.COMMAND));
+    verify(serverTransport, never()).unsubscribe(eq(PARTITION_ID), eq(RequestType.QUERY));
+    verify(serverTransport, never()).unsubscribe(eq(PARTITION_ID), eq(RequestType.COMMAND));
 
     // when - transitions to INACTIVE
     final var unregisterFuture =
@@ -165,8 +171,8 @@ public class CommandApiServiceImplTest {
     transitionInactiveFuture.join();
 
     // then - unsubscribed exactly once
-    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.QUERY));
-    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.COMMAND));
+    verify(serverTransport, times(1)).unsubscribe(eq(PARTITION_ID), eq(RequestType.QUERY));
+    verify(serverTransport, times(1)).unsubscribe(eq(PARTITION_ID), eq(RequestType.COMMAND));
   }
 
   @RegressionTest("https://github.com/camunda/camunda/issues/25897")
@@ -179,8 +185,8 @@ public class CommandApiServiceImplTest {
     commandApiService.registerHandlers(1, logStream, transitionContext.getQueryService());
     scheduler.workUntilDone();
 
-    verify(serverTransport, times(1)).subscribe(eq(1), eq(RequestType.QUERY), any());
-    verify(serverTransport, times(1)).subscribe(eq(1), eq(RequestType.COMMAND), any());
+    verify(serverTransport, times(1)).subscribe(eq(PARTITION_ID), eq(RequestType.QUERY), any());
+    verify(serverTransport, times(1)).subscribe(eq(PARTITION_ID), eq(RequestType.COMMAND), any());
 
     // when - closing the actor
     final ActorFuture<Void> closeFuture = commandApiService.closeAsync();
@@ -188,7 +194,7 @@ public class CommandApiServiceImplTest {
     closeFuture.join();
 
     // then - subscriptions are cleaned up
-    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.QUERY));
-    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.COMMAND));
+    verify(serverTransport, times(1)).unsubscribe(eq(PARTITION_ID), eq(RequestType.QUERY));
+    verify(serverTransport, times(1)).unsubscribe(eq(PARTITION_ID), eq(RequestType.COMMAND));
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -16,6 +16,7 @@ import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.impl.NettyMessagingService;
+import io.atomix.primitive.partition.PartitionId;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.impl.BrokerClientImpl;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotTransferServiceClient;
 import io.camunda.zeebe.broker.transport.commandapi.CommandResponseWriterImpl;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -40,7 +42,6 @@ import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.camunda.zeebe.transport.impl.ServerResponseImpl;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -68,6 +69,8 @@ public class SnapshotApiRequestHandlerTest {
   @AutoClose MeterRegistry registry = new SimpleMeterRegistry();
   @TempDir Path temporaryFolder;
   final int partitionId = 1;
+  final PartitionId partition =
+      PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, partitionId);
   FileBasedSnapshotStore senderSnapshotStore;
   FileBasedSnapshotStore receiverSnapshotStore;
   private AtomixClientTransportAdapter clientTransport;
@@ -116,10 +119,7 @@ public class SnapshotApiRequestHandlerTest {
 
     serverTransport =
         submitActor(
-            new AtomixServerTransport(
-                messagingService,
-                new SnowflakeIdGenerator(1L),
-                List.of(TopicSupplier.withLegacyTopicName(), TopicSupplier.withPrefix("default"))));
+            new AtomixServerTransport(messagingService, new SnowflakeIdGenerator(1L), true));
 
     scaleUpProgressInvocationCount = new AtomicInteger();
 
@@ -145,7 +145,7 @@ public class SnapshotApiRequestHandlerTest {
             1,
             SnapshotCopyUtil::copyAllFiles,
             snapshotHandler);
-    snapshotHandler.addTransferService(1, transferService);
+    snapshotHandler.addTransferService(partition, transferService);
 
     receiverSnapshotStore =
         submitActor(
@@ -213,7 +213,7 @@ public class SnapshotApiRequestHandlerTest {
 
   private void mockBootstrappedAtWith(final long position) {
     serverTransport.subscribe(
-        1,
+        partition,
         RequestType.COMMAND,
         (output, partition, requestId, buffer, offset, length) -> {
           // assume the request is a GetScaleUpProgress

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
@@ -9,7 +9,9 @@ package io.camunda.zeebe.test.broker.protocol.brokerapi;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.Member;
+import io.atomix.primitive.partition.PartitionId;
 import io.atomix.utils.net.Address;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.Loggers;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -21,7 +23,6 @@ import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerTransport;
 import io.camunda.zeebe.transport.TransportFactory;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -98,12 +99,13 @@ public final class StubBroker implements AutoCloseable {
     final var requestIdGenerator = new SnowflakeIdGenerator(nodeId);
     serverTransport =
         transportFactory.createServerTransport(
-            cluster.getMessagingService(),
-            requestIdGenerator,
-            List.of(TopicSupplier.withLegacyTopicName(), TopicSupplier.withPrefix("default")));
+            cluster.getMessagingService(), requestIdGenerator, true);
 
     channelHandler = new StubRequestHandler(msgPackHelper);
-    serverTransport.subscribe(partitionId, RequestType.COMMAND, channelHandler);
+    serverTransport.subscribe(
+        PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, partitionId),
+        RequestType.COMMAND,
+        channelHandler);
 
     writeBrokerInfoProperties();
     return this;

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
@@ -7,20 +7,21 @@
  */
 package io.camunda.zeebe.transport;
 
+import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 
 public interface ServerTransport extends ServerOutput, AutoCloseable {
 
   /**
    * Subscribes to the given partition and call's the given handler on each new request of the given
-   * type.
+   * type. The partition's group determines the topics to listen on.
    *
    * @param partitionId the partition, for which should be subscribed
    * @param requestType the type of request that should be handled
    * @param requestHandler the handler which should be called.
    */
   ActorFuture<Void> subscribe(
-      int partitionId, RequestType requestType, RequestHandler requestHandler);
+      PartitionId partitionId, RequestType requestType, RequestHandler requestHandler);
 
   /**
    * Unsubscribe from the given partition, the registered handler will no longer be called on new
@@ -29,5 +30,5 @@ public interface ServerTransport extends ServerOutput, AutoCloseable {
    * @param partitionId the partition, from which we should unsubscribe
    * @param requestType
    */
-  ActorFuture<Void> unsubscribe(int partitionId, RequestType requestType);
+  ActorFuture<Void> unsubscribe(PartitionId partitionId, RequestType requestType);
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -12,7 +12,6 @@ import io.atomix.cluster.messaging.MessagingService;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.ClientStreamService;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
@@ -25,7 +24,6 @@ import io.camunda.zeebe.transport.stream.impl.RemoteStreamServiceImpl;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamTransport;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamerImpl;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import java.util.List;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.IdGenerator;
@@ -41,10 +39,10 @@ public final class TransportFactory {
   public ServerTransport createServerTransport(
       final MessagingService messagingService,
       final IdGenerator requestIdGenerator,
-      final List<TopicSupplier> topicSuppliers) {
+      final boolean receiveOnLegacySubject) {
 
     final var atomixServerTransport =
-        new AtomixServerTransport(messagingService, requestIdGenerator, topicSuppliers);
+        new AtomixServerTransport(messagingService, requestIdGenerator, receiveOnLegacySubject);
     actorSchedulingService.submitActor(atomixServerTransport);
     return atomixServerTransport;
   }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -8,17 +8,20 @@
 package io.camunda.zeebe.transport.impl;
 
 import io.atomix.cluster.messaging.MessagingService;
+import io.atomix.primitive.partition.PartitionId;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.RequestHandler;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerResponse;
 import io.camunda.zeebe.transport.ServerTransport;
-import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiFunction;
-import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.concurrent.IdGenerator;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -29,24 +32,25 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
   private static final String LEGACY_API_TOPIC_FORMAT = "%s-api-%d";
   private static final String API_TOPIC_FORMAT = "%s-%s-api-%d";
-  private static final String ERROR_MSG_MISSING_PARTITION_MAP =
-      "Node already unsubscribed from partition %d, this can only happen when atomix does not cleanly remove its handlers.";
+  private static final String ERROR_MSG_NOT_SUBSCRIBED =
+      "Node already unsubscribed from topic %s, this can only happen when atomix does not cleanly remove its handlers.";
 
-  private final Int2ObjectHashMap<Long2ObjectHashMap<CompletableFuture<byte[]>>>
-      partitionsRequestMap;
+  private final Long2ObjectHashMap<CompletableFuture<byte[]>> pendingRequests;
+  private final Map<PartitionId, Set<String>> subscribedTopics;
   private final MessagingService messagingService;
 
   private final IdGenerator requestIdGenerator;
-  private final List<TopicSupplier> topicSuppliers;
+  private final boolean receiveOnLegacySubject;
 
   public AtomixServerTransport(
       final MessagingService messagingService,
       final IdGenerator requestIdGenerator,
-      final List<TopicSupplier> topicSuppliers) {
+      final boolean receiveOnLegacySubject) {
     this.messagingService = messagingService;
     this.requestIdGenerator = requestIdGenerator;
-    partitionsRequestMap = new Int2ObjectHashMap<>();
-    this.topicSuppliers = topicSuppliers;
+    this.receiveOnLegacySubject = receiveOnLegacySubject;
+    pendingRequests = new Long2ObjectHashMap<>();
+    subscribedTopics = new HashMap<>();
   }
 
   @Override
@@ -59,9 +63,11 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
     actor
         .call(
             () -> {
-              for (final int partitionId : partitionsRequestMap.keySet()) {
-                removePartition(partitionId);
-              }
+              subscribedTopics.values().stream()
+                  .flatMap(Set::stream)
+                  .forEach(this::unregisterHandler);
+              subscribedTopics.clear();
+              pendingRequests.clear();
               actor.close();
             })
         .join();
@@ -69,48 +75,48 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
 
   @Override
   public ActorFuture<Void> subscribe(
-      final int partitionId, final RequestType requestType, final RequestHandler requestHandler) {
+      final PartitionId partitionId,
+      final RequestType requestType,
+      final RequestHandler requestHandler) {
     return actor.call(
         () -> {
-          partitionsRequestMap.computeIfAbsent(partitionId, id -> new Long2ObjectHashMap<>());
-          topicSuppliers.stream()
-              .map(s -> s.apply(partitionId, requestType))
-              .forEach(t -> registerHandler(t, partitionId, requestType, requestHandler));
+          final var topics = topicNames(partitionId, requestType);
+          topics.forEach(topic -> registerHandler(topic, partitionId, requestHandler));
+          subscribedTopics.computeIfAbsent(partitionId, id -> new HashSet<>()).addAll(topics);
         });
   }
 
   @Override
-  public ActorFuture<Void> unsubscribe(final int partitionId, final RequestType requestType) {
-    return actor.call(() -> removeRequestHandlers(partitionId, requestType));
+  public ActorFuture<Void> unsubscribe(
+      final PartitionId partitionId, final RequestType requestType) {
+    return actor.call(
+        () -> {
+          final var topics = topicNames(partitionId, requestType);
+          topics.forEach(this::unregisterHandler);
+          final var registered = subscribedTopics.get(partitionId);
+          if (registered != null) {
+            topics.forEach(registered::remove);
+            if (registered.isEmpty()) {
+              subscribedTopics.remove(partitionId);
+            }
+          }
+        });
+  }
+
+  private List<String> topicNames(final PartitionId partitionId, final RequestType requestType) {
+    final var topic = topicName(partitionId.group(), partitionId.id(), requestType);
+    if (receiveOnLegacySubject
+        && Protocol.DEFAULT_PARTITION_GROUP_NAME.equals(partitionId.group())) {
+      return List.of(topic, legacyTopicName(partitionId.id(), requestType));
+    }
+    return List.of(topic);
   }
 
   private void registerHandler(
-      final String topic,
-      final int partitionId,
-      final RequestType requestType,
-      final RequestHandler handler) {
+      final String topic, final PartitionId partitionId, final RequestHandler handler) {
     LOG.trace("Subscribe for topic {}", topic);
     messagingService.registerHandler(
-        topic,
-        (sender, request) ->
-            handleAtomixRequest(request, topic, partitionId, requestType, handler));
-  }
-
-  private void removePartition(final int partitionId) {
-    // to unsubscribe from the partition, we can simply unsubscribe from all possible request types
-    // for that partition id, even if we're not yet subscribed to some
-    Arrays.stream(RequestType.values())
-        .forEach(requestType -> removeRequestHandlers(partitionId, requestType));
-    final var requestMap = partitionsRequestMap.remove(partitionId);
-    if (requestMap != null) {
-      requestMap.clear();
-    }
-  }
-
-  private void removeRequestHandlers(final int partitionId, final RequestType requestType) {
-    topicSuppliers.stream()
-        .map(s -> s.apply(partitionId, requestType))
-        .forEach(this::unregisterHandler);
+        topic, (sender, request) -> handleAtomixRequest(request, topic, partitionId, handler));
   }
 
   private void unregisterHandler(final String topic) {
@@ -121,16 +127,15 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   private CompletableFuture<byte[]> handleAtomixRequest(
       final byte[] requestBytes,
       final String topicName,
-      final int partitionId,
-      final RequestType requestType,
+      final PartitionId partitionId,
       final RequestHandler requestHandler) {
     final var completableFuture = new CompletableFuture<byte[]>();
     actor.call(
         () -> {
           final long requestId = requestIdGenerator.nextId();
-          final var requestMap = partitionsRequestMap.get(partitionId);
-          if (requestMap == null) {
-            final var errorMsg = String.format(ERROR_MSG_MISSING_PARTITION_MAP, partitionId);
+          final var topics = subscribedTopics.get(partitionId);
+          if (topics == null || !topics.contains(topicName)) {
+            final var errorMsg = String.format(ERROR_MSG_NOT_SUBSCRIBED, topicName);
             LOG.trace(errorMsg);
             completableFuture.completeExceptionally(new IllegalStateException(errorMsg));
             return;
@@ -139,7 +144,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
           try {
             requestHandler.onRequest(
                 this,
-                partitionId,
+                partitionId.id(),
                 requestId,
                 new UnsafeBuffer(requestBytes),
                 0,
@@ -148,7 +153,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
               LOG.trace("Handled request {} for topic {}", requestId, topicName);
             }
             // we only add the request to the map after successful handling
-            requestMap.put(requestId, completableFuture);
+            pendingRequests.put(requestId, completableFuture);
           } catch (final Exception exception) {
             LOG.error(
                 "Unexpected exception on handling request for partition {}.",
@@ -164,7 +169,6 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   @Override
   public void sendResponse(final ServerResponse response) {
     final var requestId = response.getRequestId();
-    final var partitionId = response.getPartitionId();
     final var length = response.getLength();
     final var bytes = new byte[length];
 
@@ -174,16 +178,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
 
     actor.run(
         () -> {
-          final var requestMap = partitionsRequestMap.get(partitionId);
-          if (requestMap == null) {
-            LOG.warn(
-                "Node is no longer leader for partition {}, tried to respond on request with id {}",
-                partitionId,
-                requestId);
-            return;
-          }
-
-          final var completableFuture = requestMap.remove(requestId);
+          final var completableFuture = pendingRequests.remove(requestId);
           if (completableFuture != null) {
             if (LOG.isTraceEnabled()) {
               LOG.trace("Send response to request {}", requestId);
@@ -191,7 +186,10 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
 
             completableFuture.complete(bytes);
           } else if (LOG.isTraceEnabled()) {
-            LOG.trace("Wasn't able to send response to request {}", requestId);
+            LOG.trace(
+                "Wasn't able to send response to request {} of partition {}",
+                requestId,
+                response.getPartitionId());
           }
         });
   }
@@ -203,18 +201,5 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
 
   static String legacyTopicName(final int partitionId, final RequestType requestType) {
     return String.format(LEGACY_API_TOPIC_FORMAT, requestType.getId(), partitionId);
-  }
-
-  public interface TopicSupplier extends BiFunction<Integer, RequestType, String> {
-    @Override
-    String apply(Integer partitionId, RequestType requestType);
-
-    static TopicSupplier withLegacyTopicName() {
-      return AtomixServerTransport::legacyTopicName;
-    }
-
-    static TopicSupplier withPrefix(final String prefix) {
-      return (p, r) -> topicName(prefix, p, r);
-    }
   }
 }

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -15,6 +15,7 @@ import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.cluster.messaging.impl.NettyMessagingService;
+import io.atomix.primitive.partition.PartitionId;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
@@ -26,7 +27,6 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.transport.ServerTransport;
 import io.camunda.zeebe.transport.TransportFactory;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -34,7 +34,6 @@ import java.net.ConnectException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -50,6 +49,7 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.SnowflakeIdGenerator;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -67,9 +67,6 @@ public class AtomixTransportTest {
 
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(15);
   private static final Duration REQUEST_TIMEOUT_NO_SUCCESS = Duration.ofMillis(200);
-  private static final String TOPIC_PREFIX = "default";
-  private static final List<TopicSupplier> TOPIC_SUPPLIERS =
-      List.of(TopicSupplier.withLegacyTopicName(), TopicSupplier.withPrefix(TOPIC_PREFIX));
 
   private static Supplier<String> nodeAddressSupplier;
   private static AtomixCluster cluster;
@@ -93,6 +90,7 @@ public class AtomixTransportTest {
 
   private ClientTransport clientTransport;
   private ServerTransport serverTransport;
+  private PartitionId partitionId;
   private Request request;
 
   @Parameters(name = "{0}")
@@ -101,7 +99,7 @@ public class AtomixTransportTest {
     return Arrays.asList(
         new Object[][] {
           {
-            "use same messaging service (default topic)",
+            "use same messaging service (default group)",
             (Function<AtomixCluster, ClientTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
@@ -111,12 +109,12 @@ public class AtomixTransportTest {
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
                   return transportFactory.createServerTransport(
-                      messagingService, requestIdGenerator, TOPIC_SUPPLIERS);
+                      messagingService, requestIdGenerator, true);
                 },
             "default"
           },
           {
-            "use same messaging service (non-default topic)",
+            "use same messaging service (non-default group)",
             (Function<AtomixCluster, ClientTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
@@ -126,14 +124,12 @@ public class AtomixTransportTest {
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
                   return transportFactory.createServerTransport(
-                      messagingService,
-                      requestIdGenerator,
-                      List.of(TopicSupplier.withPrefix("tenant1")));
+                      messagingService, requestIdGenerator, true);
                 },
             "tenant1"
           },
           {
-            "use different messaging service (default topic)",
+            "use different messaging service (default group)",
             (Function<AtomixCluster, ClientTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
@@ -143,12 +139,12 @@ public class AtomixTransportTest {
                 (cluster) -> {
                   createNettyMessagingServiceIfNull();
                   return transportFactory.createServerTransport(
-                      nettyMessagingService, requestIdGenerator, TOPIC_SUPPLIERS);
+                      nettyMessagingService, requestIdGenerator, true);
                 },
             "default"
           },
           {
-            "use different messaging service (non-default topic)",
+            "use different messaging service (non-default group)",
             (Function<AtomixCluster, ClientTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
@@ -158,9 +154,7 @@ public class AtomixTransportTest {
                 (cluster) -> {
                   createNettyMessagingServiceIfNull();
                   return transportFactory.createServerTransport(
-                      nettyMessagingService,
-                      requestIdGenerator,
-                      List.of(TopicSupplier.withPrefix("tenant1")));
+                      nettyMessagingService, requestIdGenerator, true);
                 },
             "tenant1"
           }
@@ -200,6 +194,7 @@ public class AtomixTransportTest {
   public void beforeTest() {
     clientTransport = clientTransportFunction.apply(cluster);
     serverTransport = serverTransportFunction.apply(cluster);
+    partitionId = PartitionId.from(topicPrefix, 0);
     request = new Request(MESSAGE_CONTENT).withPartitionGroup(topicPrefix);
   }
 
@@ -224,7 +219,10 @@ public class AtomixTransportTest {
     // given
     final var incomingRequestFuture = new CompletableFuture<byte[]>();
     serverTransport
-        .subscribe(0, RequestType.COMMAND, new DirectlyResponder(incomingRequestFuture::complete))
+        .subscribe(
+            partitionId,
+            RequestType.COMMAND,
+            new DirectlyResponder(incomingRequestFuture::complete))
         .join();
 
     // when
@@ -242,7 +240,10 @@ public class AtomixTransportTest {
     // given
     final var retryLatch = new CountDownLatch(2);
     serverTransport
-        .subscribe(0, RequestType.COMMAND, new DirectlyResponder(bytes -> retryLatch.countDown()))
+        .subscribe(
+            partitionId,
+            RequestType.COMMAND,
+            new DirectlyResponder(bytes -> retryLatch.countDown()))
         .join();
 
     // when
@@ -260,7 +261,7 @@ public class AtomixTransportTest {
     // given
     serverTransport
         .subscribe(
-            0,
+            partitionId,
             RequestType.COMMAND,
             new DirectlyResponder(
                 bytes -> {
@@ -283,11 +284,14 @@ public class AtomixTransportTest {
     // given
     final var incomingRequestFuture = new CompletableFuture<byte[]>();
     serverTransport
-        .subscribe(0, RequestType.COMMAND, new DirectlyResponder(incomingRequestFuture::complete))
+        .subscribe(
+            partitionId,
+            RequestType.COMMAND,
+            new DirectlyResponder(incomingRequestFuture::complete))
         .join();
 
     // when
-    serverTransport.unsubscribe(0, RequestType.COMMAND).join();
+    serverTransport.unsubscribe(partitionId, RequestType.COMMAND).join();
 
     final var requestFuture =
         clientTransport.sendRequestWithRetry(
@@ -296,6 +300,75 @@ public class AtomixTransportTest {
     // then
     assertThatThrownBy(requestFuture::join).hasCauseInstanceOf(TimeoutException.class);
     assertThat(incomingRequestFuture).isNotCompleted();
+  }
+
+  @Test
+  public void shouldReceiveRequestOnLegacyTopicForDefaultGroup() {
+    // given
+    Assume.assumeTrue(Protocol.DEFAULT_PARTITION_GROUP_NAME.equals(topicPrefix));
+    serverTransport.subscribe(partitionId, RequestType.COMMAND, new DirectlyResponder()).join();
+
+    // when -- requests are sent on the legacy, non-prefixed topic
+    final var responseFuture =
+        cluster
+            .getMessagingService()
+            .sendAndReceive(
+                Address.from(serverAddress), "command-api-0", MESSAGE_CONTENT.getBytes());
+
+    // then
+    assertThat(responseFuture.join()).isEqualTo(MESSAGE_CONTENT.getBytes());
+  }
+
+  @Test
+  public void shouldNotReceiveRequestOnLegacyTopicForNonDefaultGroup() {
+    // given
+    Assume.assumeFalse(Protocol.DEFAULT_PARTITION_GROUP_NAME.equals(topicPrefix));
+    serverTransport.subscribe(partitionId, RequestType.COMMAND, new DirectlyResponder()).join();
+
+    // when -- requests are sent on the legacy, non-prefixed topic
+    final var responseFuture =
+        cluster
+            .getMessagingService()
+            .sendAndReceive(
+                Address.from(serverAddress), "command-api-0", MESSAGE_CONTENT.getBytes());
+
+    // then
+    assertThatThrownBy(responseFuture::join)
+        .hasCauseInstanceOf(MessagingException.NoRemoteHandler.class);
+  }
+
+  @Test
+  public void shouldNotReceiveRequestOnLegacyTopicWhenLegacyReceiveIsDisabled() {
+    // given -- a server transport that doesn't receive on legacy subjects
+    final var transport =
+        transportFactory.createServerTransport(
+            cluster.getMessagingService(), new SnowflakeIdGenerator(1), false);
+    try {
+      final var partition = PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, 5);
+      transport.subscribe(partition, RequestType.COMMAND, new DirectlyResponder()).join();
+      final var serverAddress = cluster.getMessagingService().address();
+
+      // when -- requests are sent on the legacy and the prefixed topic
+      final var legacyResponseFuture =
+          cluster
+              .getMessagingService()
+              .sendAndReceive(serverAddress, "command-api-5", MESSAGE_CONTENT.getBytes());
+      final var prefixedResponseFuture =
+          cluster
+              .getMessagingService()
+              .sendAndReceive(serverAddress, "default-command-api-5", MESSAGE_CONTENT.getBytes());
+
+      // then -- only the prefixed topic is handled
+      assertThatThrownBy(legacyResponseFuture::join)
+          .hasCauseInstanceOf(MessagingException.NoRemoteHandler.class);
+      assertThat(prefixedResponseFuture.join()).isEqualTo(MESSAGE_CONTENT.getBytes());
+    } finally {
+      try {
+        transport.close();
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   @Test
@@ -329,7 +402,7 @@ public class AtomixTransportTest {
     // given
     final var nodeAddressRef = new AtomicReference<String>();
     final var retryLatch = new CountDownLatch(3);
-    serverTransport.subscribe(0, RequestType.COMMAND, new DirectlyResponder()).join();
+    serverTransport.subscribe(partitionId, RequestType.COMMAND, new DirectlyResponder()).join();
 
     final var requestFuture =
         clientTransport.sendRequestWithRetry(
@@ -354,7 +427,10 @@ public class AtomixTransportTest {
     // given
     final var retryLatch = new CountDownLatch(2);
     serverTransport
-        .subscribe(0, RequestType.COMMAND, new DirectlyResponder(bytes -> retryLatch.countDown()))
+        .subscribe(
+            partitionId,
+            RequestType.COMMAND,
+            new DirectlyResponder(bytes -> retryLatch.countDown()))
         .join();
 
     final var responseValidation = new AtomicBoolean(false);
@@ -402,7 +478,7 @@ public class AtomixTransportTest {
 
     // when
     retryLatch.await(REQUEST_TIMEOUT.dividedBy(2).toMillis(), TimeUnit.MILLISECONDS);
-    serverTransport.subscribe(0, RequestType.COMMAND, new DirectlyResponder()).join();
+    serverTransport.subscribe(partitionId, RequestType.COMMAND, new DirectlyResponder()).join();
 
     // then
     final var response = requestFuture.join();
@@ -412,8 +488,8 @@ public class AtomixTransportTest {
   @Test
   public void shouldOnlyHandleRequestsOfSubscribedTypes() {
     // given
-    serverTransport.subscribe(0, RequestType.COMMAND, new DirectlyResponder()).join();
-    serverTransport.subscribe(0, RequestType.UNKNOWN, new FailingResponder()).join();
+    serverTransport.subscribe(partitionId, RequestType.COMMAND, new DirectlyResponder()).join();
+    serverTransport.subscribe(partitionId, RequestType.UNKNOWN, new FailingResponder()).join();
 
     // when
     final var requestFuture =
@@ -428,7 +504,7 @@ public class AtomixTransportTest {
   public void shouldCreateUniqueRequestsIds() {
     final DirectlyResponder directlyResponder = new DirectlyResponder();
 
-    serverTransport.subscribe(0, RequestType.COMMAND, directlyResponder).join();
+    serverTransport.subscribe(partitionId, RequestType.COMMAND, directlyResponder).join();
 
     // when
     final var requestFuture1 =


### PR DESCRIPTION
The server transport now derives its topics from the partition group of the subscribed partition: subscriptions register on the group-prefixed topic (e.g. `default-command-api-1`), and subscriptions for the default partition group additionally register on the legacy non-prefixed topic (e.g. `command-api-1`), gated on the existing `experimental.receiveOnLegacySubject` flag. Non-default groups only listen on their prefixed topics. `ServerTransport.subscribe`/`unsubscribe` take the composite `PartitionId` and all broker call sites (`CommandApiServiceImpl`, `AdminApiRequestHandler`, `BackupApiRequestHandler`, `SnapshotApiRequestHandler`) pass the real partition id from their contexts. The now-unused `TopicSupplier` indirection is removed.

Internally, pending requests are tracked by the globally unique request id instead of per numeric partition id, which would silently alias across partition groups once numeric partition ids overlap; the genuinely per-partition state (registered topic names) is keyed by the composite `PartitionId`.

Rolling upgrades stay safe: 8.9 brokers already listen on prefixed topics and 8.10 clients send prefixed-only (#54556), while legacy reception for the default group keeps requests from old senders working.

closes #54828