### PR TITLE
feat: broker client dispatches requests per partition group

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -10,21 +10,22 @@ package io.camunda.zeebe.broker.client.api;
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.protocol.Protocol;
 
 public interface BrokerTopologyManager extends ClusterConfigurationUpdateListener {
+
+  /**
+   * Returns live topology for the given physical tenant (partition group). May return {@code null}
+   * or an uninitialized topology if the group is not (yet) known; callers must handle both.
+   */
+  BrokerClusterState getTopology(String physicalTenantId);
 
   /**
    * Returns live topology for the default partition group. Equivalent to {@code
    * getTopology("default")}.
    */
-  BrokerClusterState getTopology();
-
-  /**
-   * Returns live topology for the given physical tenant (partition group). Returns an uninitialized
-   * topology if the group is unknown.
-   */
-  default BrokerClusterState getTopology(final String physicalTenantId) {
-    return getTopology();
+  default BrokerClusterState getTopology() {
+    return getTopology(Protocol.DEFAULT_PARTITION_GROUP_NAME);
   }
 
   /**

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.protocol.Protocol;
+import org.jspecify.annotations.NonNull;
 
 public interface BrokerTopologyManager extends ClusterConfigurationUpdateListener {
 
@@ -18,7 +19,7 @@ public interface BrokerTopologyManager extends ClusterConfigurationUpdateListene
    * Returns live topology for the given physical tenant (partition group). May return {@code null}
    * or an uninitialized topology if the group is not (yet) known; callers must handle both.
    */
-  BrokerClusterState getTopology(String physicalTenantId);
+  BrokerClusterState getTopology(@NonNull String physicalTenantId);
 
   /**
    * Returns live topology for the default partition group. Equivalent to {@code

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/RequestDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/RequestDispatchStrategy.java
@@ -21,9 +21,13 @@ public interface RequestDispatchStrategy {
   int MAX_RANDOM_OFFSET = 128;
 
   /**
+   * Determines the partition to dispatch a request to within the given partition group. Numeric
+   * partition IDs overlap across partition groups, so the returned ID is only meaningful together
+   * with the group it was determined for.
+   *
    * @return {@link BrokerClusterState#PARTITION_ID_NULL} if no partition can be determined
    */
-  int determinePartition(final BrokerTopologyManager topologyManager);
+  int determinePartition(final BrokerTopologyManager topologyManager, final String partitionGroup);
 
   /**
    * Returns a dispatch strategy which will perform a stateful round robin between the partitions,

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -231,7 +231,7 @@ final class BrokerRequestManager extends Actor {
       final var strategy = request.requestDispatchStrategy().orElse(dispatchStrategy);
 
       // select next partition id for request
-      int partitionId = strategy.determinePartition(topologyManager);
+      int partitionId = strategy.determinePartition(topologyManager, request.getPartitionGroup());
       if (partitionId == BrokerClusterState.PARTITION_ID_NULL) {
         // could happen if the topology is not set yet, let's just try with partition 0 but we
         // should find a better solution

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -217,21 +217,23 @@ final class BrokerRequestManager extends Actor {
   }
 
   private BrokerAddressProvider determineBrokerNodeIdProvider(final BrokerRequest<?> request) {
+    final var partitionGroup = request.getPartitionGroup();
     if (request.getBrokerId().isPresent()) {
-      return new BrokerAddressProvider(clusterState -> request.getBrokerId().orElseThrow());
+      return new BrokerAddressProvider(
+          partitionGroup, clusterState -> request.getBrokerId().orElseThrow());
     } else if (request.addressesSpecificPartition()) {
-      final BrokerClusterState topology = topologyManager.getTopology();
+      final BrokerClusterState topology = topologyManager.getTopology(partitionGroup);
       if (topology != null && !topology.getPartitions().contains(request.getPartitionId())) {
         throw new PartitionNotFoundException(request.getPartitionId());
       }
-      throwIfPartitionInactive(request.getPartitionId());
+      throwIfPartitionInactive(partitionGroup, request.getPartitionId());
       // already know partition id
-      return new BrokerAddressProvider(request.getPartitionId());
+      return new BrokerAddressProvider(partitionGroup, request.getPartitionId());
     } else if (request.requiresPartitionId()) {
       final var strategy = request.requestDispatchStrategy().orElse(dispatchStrategy);
 
       // select next partition id for request
-      int partitionId = strategy.determinePartition(topologyManager, request.getPartitionGroup());
+      int partitionId = strategy.determinePartition(topologyManager, partitionGroup);
       if (partitionId == BrokerClusterState.PARTITION_ID_NULL) {
         // could happen if the topology is not set yet, let's just try with partition 0 but we
         // should find a better solution
@@ -240,17 +242,17 @@ final class BrokerRequestManager extends Actor {
       }
       request.setPartitionId(partitionId);
 
-      throwIfPartitionInactive(partitionId);
+      throwIfPartitionInactive(partitionGroup, partitionId);
 
-      return new BrokerAddressProvider(request.getPartitionId());
+      return new BrokerAddressProvider(partitionGroup, request.getPartitionId());
     } else {
-      // random broker
-      return new BrokerAddressProvider();
+      // random broker of the request's partition group
+      return new BrokerAddressProvider(partitionGroup);
     }
   }
 
-  private void throwIfPartitionInactive(final int partitionId) {
-    final BrokerClusterState topology = topologyManager.getTopology();
+  private void throwIfPartitionInactive(final String partitionGroup, final int partitionId) {
+    final BrokerClusterState topology = topologyManager.getTopology(partitionGroup);
     if (topology == null) {
       throw new NoTopologyAvailableException();
     }
@@ -301,24 +303,27 @@ final class BrokerRequestManager extends Actor {
   @NullMarked
   private class BrokerAddressProvider implements Supplier<@Nullable String> {
 
+    private final String partitionGroup;
     private final Function<BrokerClusterState, @Nullable BrokerMemberId> nodeIdSelector;
 
-    BrokerAddressProvider() {
-      this(BrokerClusterState::getRandomBroker);
+    BrokerAddressProvider(final String partitionGroup) {
+      this(partitionGroup, BrokerClusterState::getRandomBroker);
     }
 
-    BrokerAddressProvider(final int partitionId) {
-      this(state -> state.getLeaderForPartition(partitionId));
+    BrokerAddressProvider(final String partitionGroup, final int partitionId) {
+      this(partitionGroup, state -> state.getLeaderForPartition(partitionId));
     }
 
     BrokerAddressProvider(
+        final String partitionGroup,
         final Function<BrokerClusterState, @Nullable BrokerMemberId> nodeIdSelector) {
+      this.partitionGroup = partitionGroup;
       this.nodeIdSelector = nodeIdSelector;
     }
 
     @Override
     public @Nullable String get() {
-      final BrokerClusterState topology = topologyManager.getTopology();
+      final BrokerClusterState topology = topologyManager.getTopology(partitionGroup);
       if (topology != null) {
         final var brokerId = nodeIdSelector.apply(topology);
         if (brokerId != null) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +62,7 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   @Override
-  public BrokerClusterState getTopology(final String physicalTenantId) {
+  public BrokerClusterState getTopology(final @NonNull String physicalTenantId) {
     return topologyPerGroup.getOrDefault(
         physicalTenantId, BrokerClientTopologyImpl.uninitialized());
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -61,11 +61,6 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   @Override
-  public BrokerClusterState getTopology() {
-    return getTopology(Protocol.DEFAULT_PARTITION_GROUP_NAME);
-  }
-
-  @Override
   public BrokerClusterState getTopology(final String physicalTenantId) {
     return topologyPerGroup.getOrDefault(
         physicalTenantId, BrokerClientTopologyImpl.uninitialized());

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/PartitionIdIterator.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/PartitionIdIterator.java
@@ -22,19 +22,21 @@ public final class PartitionIdIterator implements Iterator<Integer> {
   public PartitionIdIterator(
       final int startPartitionId,
       final int partitionsCount,
-      final BrokerTopologyManager topologyManager) {
+      final BrokerTopologyManager topologyManager,
+      final String partitionGroup) {
     iterator =
         IntStream.range(0, partitionsCount)
             .map(
                 index ->
                     (index + startPartitionId - START_PARTITION_ID) % partitionsCount
                         + START_PARTITION_ID)
-            .filter(p -> hasLeader(topologyManager, p))
+            .filter(p -> hasLeader(topologyManager, partitionGroup, p))
             .iterator();
   }
 
-  private boolean hasLeader(final BrokerTopologyManager topologyManager, final int p) {
-    final var topology = topologyManager.getTopology();
+  private boolean hasLeader(
+      final BrokerTopologyManager topologyManager, final String partitionGroup, final int p) {
+    final var topology = topologyManager.getTopology(partitionGroup);
     return topology != null && topology.getLeaderForPartition(p) != null;
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -12,21 +12,26 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
+import io.camunda.zeebe.protocol.Protocol;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Return the next partition using a round-robin strategy, but skips the partitions where there is
  * no leader at the moment.
+ *
+ * <p>Round-robin state is kept per partition group: numeric partition IDs overlap across groups, so
+ * sharing one offset or partition ring between groups would let one group's traffic skew another's
+ * distribution.
  */
 public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy {
 
-  /** Holds the current partition ring. Starts off uninitialized and is updated on every request. */
-  private final AtomicReference<VersionedPartitionRing> partitionRing =
-      new AtomicReference<>(VersionedPartitionRing.uninitialized());
-
-  private final AtomicLong offset;
+  private final ConcurrentMap<String, GroupState> groups = new ConcurrentHashMap<>();
+  private final int initialOffset;
 
   public RoundRobinDispatchStrategy() {
     this(0);
@@ -37,22 +42,24 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
       throw new IllegalArgumentException(
           "Expected initialOffset to be >= 0, but got %d".formatted(initialOffset));
     }
-    offset = new AtomicLong(initialOffset);
+    this.initialOffset = initialOffset;
   }
 
   @Override
   public int determinePartition(
       final BrokerTopologyManager topologyManager, final String partitionGroup) {
-    final BrokerClusterState topology = topologyManager.getTopology();
+    final BrokerClusterState topology = topologyManager.getTopology(partitionGroup);
 
     if (topology == null || !topology.isInitialized()) {
       return BrokerClusterState.PARTITION_ID_NULL;
     }
 
-    final var partitions = updatePartitionRing(topologyManager);
+    final var state =
+        groups.computeIfAbsent(partitionGroup, group -> new GroupState(initialOffset));
+    final var partitions = updatePartitionRing(topologyManager, partitionGroup, topology, state);
 
     for (int i = 0; i < topology.getPartitionsCount(); i++) {
-      final int partition = partitions.partitionAtOffset(offset.getAndIncrement());
+      final int partition = partitions.partitionAtOffset(state.offset().getAndIncrement());
       if (topology.getLeaderForPartition(partition) != null) {
         return partition;
       }
@@ -62,17 +69,28 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
   }
 
   /**
-   * Updates the partition ring. This either initializes the partition ring to span over all
-   * statically configured partitions when routing state is not available (i.e. partition scaling is
-   * not enabled) or creates a new partition ring to span over the active partitions from the latest
-   * routing state.
+   * Updates the partition ring of the given group. This either initializes the partition ring to
+   * span over all statically configured partitions when routing state is not available (i.e.
+   * partition scaling is not enabled) or creates a new partition ring to span over the active
+   * partitions from the latest routing state.
+   *
+   * <p>Routing state is only consulted for the default partition group: it is a single cluster-wide
+   * state that describes scaling of the default group, while all other groups have a static
+   * partition distribution.
    */
-  private PartitionRing updatePartitionRing(final BrokerTopologyManager topologyManager) {
-    final var routingState = topologyManager.getClusterConfiguration().routingState();
+  private PartitionRing updatePartitionRing(
+      final BrokerTopologyManager topologyManager,
+      final String partitionGroup,
+      final BrokerClusterState topology,
+      final GroupState state) {
+    final var routingState =
+        Protocol.DEFAULT_PARTITION_GROUP_NAME.equals(partitionGroup)
+            ? topologyManager.getClusterConfiguration().routingState()
+            : Optional.<RoutingState>empty();
     final long expectedVersion =
         routingState.map(RoutingState::version).orElse(VersionedPartitionRing.NO_ROUTING_STATE);
 
-    var currentValue = partitionRing.get();
+    var currentValue = state.partitionRing().get();
     if (currentValue.version() >= expectedVersion) {
       return currentValue.partitions();
     }
@@ -82,14 +100,28 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
             .map(RoutingState::requestHandling)
             .map(RequestHandling::activePartitions)
             .map(PartitionRing::of)
-            .orElseGet(() -> PartitionRing.all(topologyManager.getTopology().getPartitionsCount()));
+            .orElseGet(
+                () ->
+                    // the configured partition count is currently shared across all groups (see
+                    // BrokerTopologyManagerImpl); the leader check in determinePartition skips any
+                    // ring slots that don't exist in this group
+                    PartitionRing.all(topology.getPartitionsCount()));
     final var newValue = new VersionedPartitionRing(expectedVersion, newPartitionRing);
 
     while (currentValue.version() < expectedVersion) {
-      currentValue = partitionRing.compareAndExchange(currentValue, newValue);
+      currentValue = state.partitionRing().compareAndExchange(currentValue, newValue);
     }
 
     return newPartitionRing;
+  }
+
+  private record GroupState(
+      AtomicLong offset, AtomicReference<VersionedPartitionRing> partitionRing) {
+    GroupState(final int initialOffset) {
+      this(
+          new AtomicLong(initialOffset),
+          new AtomicReference<>(VersionedPartitionRing.uninitialized()));
+    }
   }
 
   record VersionedPartitionRing(long version, PartitionRing partitions) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -41,7 +41,8 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
   }
 
   @Override
-  public int determinePartition(final BrokerTopologyManager topologyManager) {
+  public int determinePartition(
+      final BrokerTopologyManager topologyManager, final String partitionGroup) {
     final BrokerClusterState topology = topologyManager.getTopology();
 
     if (topology == null || !topology.isInitialized()) {

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -353,6 +353,44 @@ public final class BrokerClientTest {
   }
 
   @Test
+  void shouldPassPartitionGroupToDispatchStrategy() {
+    // given
+    final AtomicReference<String> groupRef = new AtomicReference<>();
+    final var request =
+        new TestCommand(
+            1L,
+            (topologyManager, partitionGroup) -> {
+              groupRef.set(partitionGroup);
+              return 1;
+            });
+    request.setPartitionGroup("tenant-b");
+
+    // when
+    final var responseFuture = client.sendRequest(request);
+
+    // then
+    assertThat(responseFuture).failsWithin(Duration.ofSeconds(10));
+    assertThat(groupRef).hasValue("tenant-b");
+  }
+
+  @Test
+  void shouldFailRequestAddressingPartitionOfUnknownGroup() {
+    // given - a request addressing a partition that only exists in the default group
+    final var request = new TestCommand();
+    request.setPartitionId(1);
+    request.setPartitionGroup("unknown-group");
+
+    // when
+    final Future<?> response = client.sendRequest(request);
+
+    // then
+    assertThat(response)
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableThat()
+        .withCauseInstanceOf(PartitionNotFoundException.class);
+  }
+
+  @Test
   void shouldReceiveJobAvailableNotification() {
     // given
     final AtomicReference<String> messageRef = new AtomicReference<>();

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -339,7 +339,7 @@ public final class BrokerClientTest {
     final var request =
         new TestCommand(
             1L,
-            topologyManager -> {
+            (topologyManager, partitionGroup) -> {
               managerRef.set(topologyManager);
               return 1;
             });
@@ -370,7 +370,7 @@ public final class BrokerClientTest {
   public void shouldThrowCorrectErrorForInactivePartitionAndNoLeaderRequest() {
     // given
     final var partitionId = 1;
-    final var request = new TestCommand(1, topologyManager -> partitionId);
+    final var request = new TestCommand(1, (topologyManager, partitionGroup) -> partitionId);
 
     // when
     broker.updateInfo(info -> info.setInactiveForPartition(partitionId));
@@ -392,7 +392,7 @@ public final class BrokerClientTest {
     // given
     final var partitionId = 1;
     final var leaderBrokerId = 2;
-    final var request = new TestCommand(1, topologyManager -> partitionId);
+    final var request = new TestCommand(1, (topologyManager, partitionGroup) -> partitionId);
 
     // when
     broker.updateInfo(info -> info.setInactiveForPartition(partitionId));
@@ -577,7 +577,7 @@ public final class BrokerClientTest {
     void shouldRouteRequestBasedOnDispatchStrategy() {
       // given - a second broker (1), which respond successfully for partition 2
       final BrokerResponse<?> response;
-      final var request = new TestCommand(1L, ignored -> 2);
+      final var request = new TestCommand(1L, (ignored, partitionGroup) -> 2);
 
       try (final var otherBroker = new StubBroker(1, 2).start()) {
         registerSuccessResponse(otherBroker);
@@ -600,7 +600,8 @@ public final class BrokerClientTest {
     void shouldRouteToDeploymentPartitionAsFallback() {
       // given - a dispatch strategy which returns "null"
       final BrokerResponse<?> response;
-      final var request = new TestCommand(1L, ignored -> BrokerClusterState.PARTITION_ID_NULL);
+      final var request =
+          new TestCommand(1L, (ignored, partitionGroup) -> BrokerClusterState.PARTITION_ID_NULL);
       registerSuccessResponse(broker);
 
       // when

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/PartitionIdIteratorTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/PartitionIdIteratorTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.client.impl;
 import static io.camunda.zeebe.broker.client.BrokerMemberIds.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.protocol.Protocol;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,8 @@ final class PartitionIdIteratorTest {
   @Test
   void shouldIterateOverAllPartitions() {
     // given
-    final var iterator = new PartitionIdIterator(1, 3, topologyManager);
+    final var iterator =
+        new PartitionIdIterator(1, 3, topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME);
     final List<Integer> ids = new ArrayList<>();
     topologyManager.addPartition(1, ZERO).addPartition(2, ZERO).addPartition(3, ZERO);
 
@@ -34,7 +36,8 @@ final class PartitionIdIteratorTest {
   @Test
   void shouldSkipPartitionsWithoutLeaders() {
     // given
-    final var iterator = new PartitionIdIterator(1, 3, topologyManager);
+    final var iterator =
+        new PartitionIdIterator(1, 3, topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME);
     final List<Integer> ids = new ArrayList<>();
     topologyManager.addPartition(1, ZERO).addPartition(3, ZERO);
 
@@ -46,12 +49,30 @@ final class PartitionIdIteratorTest {
   }
 
   @Test
+  void shouldFilterLeadersByPartitionGroup() {
+    // given - a leader for partition 2 only exists in group tenant-b
+    topologyManager.addPartition("tenant-b", 2, ZERO);
+
+    // when
+    final var defaultIterator =
+        new PartitionIdIterator(1, 3, topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME);
+    final var tenantIterator = new PartitionIdIterator(1, 3, topologyManager, "tenant-b");
+    final List<Integer> ids = new ArrayList<>();
+    tenantIterator.forEachRemaining(ids::add);
+
+    // then
+    assertThat(defaultIterator.hasNext()).isFalse();
+    assertThat(ids).containsExactly(2);
+  }
+
+  @Test
   void shouldSkipAllPartitionsWhenNoTopology() {
     // given
     final var topologyManager = new TestTopologyManager(null);
 
     // when
-    final var iterator = new PartitionIdIterator(1, 3, topologyManager);
+    final var iterator =
+        new PartitionIdIterator(1, 3, topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME);
 
     // then
     assertThat(iterator.hasNext()).isFalse();

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -186,4 +186,108 @@ final class RoundRobinDispatchStrategyTest {
                 topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
         .isEqualTo(3);
   }
+
+  @Test
+  void shouldKeepRoundRobinStatePerPartitionGroup() {
+    // given - two groups with the same three led partitions
+    final var dispatchStrategy = new RoundRobinDispatchStrategy();
+    final var topologyManager = new TestTopologyManager();
+    topologyManager
+        .addPartition(1, ZERO)
+        .addPartition(2, ONE)
+        .addPartition(3, TWO)
+        .addPartition("tenant-b", 1, ZERO)
+        .addPartition("tenant-b", 2, ONE)
+        .addPartition("tenant-b", 3, TWO);
+
+    // when - interleaving requests for both groups
+    // then - each group cycles independently from the initial offset
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(1);
+    assertThat(dispatchStrategy.determinePartition(topologyManager, "tenant-b")).isEqualTo(1);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(2);
+    assertThat(dispatchStrategy.determinePartition(topologyManager, "tenant-b")).isEqualTo(2);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(3);
+    assertThat(dispatchStrategy.determinePartition(topologyManager, "tenant-b")).isEqualTo(3);
+  }
+
+  @Test
+  void shouldSkipLeaderlessPartitionsPerGroup() {
+    // given - partition 1 is leaderless in the default group but has a leader in tenant-b
+    final var dispatchStrategy = new RoundRobinDispatchStrategy();
+    final var topologyManager = new TestTopologyManager();
+    topologyManager
+        .addPartition(1, null)
+        .addPartition(2, ZERO)
+        .addPartition("tenant-b", 1, ZERO)
+        .addPartition("tenant-b", 2, ZERO);
+
+    // when - then - the default group skips partition 1 while tenant-b returns it
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(2);
+    assertThat(dispatchStrategy.determinePartition(topologyManager, "tenant-b")).isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotApplyRoutingStateToNonDefaultGroups() {
+    // given - routing state restricting active partitions to 1 and 3
+    final var dispatchStrategy = new RoundRobinDispatchStrategy();
+    final var topologyManager = new TestTopologyManager();
+    topologyManager
+        .addPartition(1, ZERO)
+        .addPartition(2, ONE)
+        .addPartition(3, TWO)
+        .addPartition("tenant-b", 1, ZERO)
+        .addPartition("tenant-b", 2, ONE)
+        .addPartition("tenant-b", 3, TWO)
+        .withClusterConfiguration(
+            ClusterConfiguration.builder()
+                .version(1)
+                .routingState(
+                    Optional.of(
+                        new RoutingState(
+                            1,
+                            new ActivePartitions(1, Set.of(3), Set.of()),
+                            new MessageCorrelation.HashMod(3))))
+                .build());
+
+    // when - then - the default group cycles over the active partitions only
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(1);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(3);
+
+    // and tenant-b cycles over all of its partitions
+    assertThat(dispatchStrategy.determinePartition(topologyManager, "tenant-b")).isEqualTo(1);
+    assertThat(dispatchStrategy.determinePartition(topologyManager, "tenant-b")).isEqualTo(2);
+    assertThat(dispatchStrategy.determinePartition(topologyManager, "tenant-b")).isEqualTo(3);
+  }
+
+  @Test
+  void shouldReturnNullValueForUnknownGroup() {
+    // given - only the default group is known
+    final var dispatchStrategy = new RoundRobinDispatchStrategy();
+    final var topologyManager = new TestTopologyManager();
+    topologyManager.addPartition(1, ZERO);
+
+    // when
+    final var partitionId = dispatchStrategy.determinePartition(topologyManager, "unknown");
+
+    // then
+    assertThat(partitionId).isEqualTo(BrokerClusterState.PARTITION_ID_NULL);
+  }
 }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.protocol.Protocol;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,8 @@ final class RoundRobinDispatchStrategyTest {
     final var topologyManager = new TestTopologyManager(null);
 
     // when
-    final var partitionId = dispatchStrategy.determinePartition(topologyManager);
+    final var partitionId =
+        dispatchStrategy.determinePartition(topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME);
 
     // then - the null value will be used as fallback by the request manager to redirect to the
     // deployment partition
@@ -43,8 +45,14 @@ final class RoundRobinDispatchStrategyTest {
     topologyManager.addPartition(1, null).addPartition(2, ZERO).addPartition(3, ZERO);
 
     // when - then
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(2);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(3);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(2);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(3);
   }
 
   @Test
@@ -66,10 +74,22 @@ final class RoundRobinDispatchStrategyTest {
                 .build());
 
     // when - then
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(2);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(2);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(1);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(2);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(1);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(2);
   }
 
   @Test
@@ -93,10 +113,22 @@ final class RoundRobinDispatchStrategyTest {
                 .build());
 
     // when - then
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(3);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(3);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(1);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(3);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(1);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(3);
   }
 
   @Test
@@ -118,8 +150,14 @@ final class RoundRobinDispatchStrategyTest {
             .build());
 
     // then
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(3);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(1);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(3);
 
     // when -- updating to routing state version 2, with active partitions 1, 2 and 3
     topologyManager.withClusterConfiguration(
@@ -131,9 +169,21 @@ final class RoundRobinDispatchStrategyTest {
             .build());
 
     // then
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(3);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(2);
-    assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(3);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(3);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(1);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(2);
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(3);
   }
 }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -59,7 +60,7 @@ final class TestTopologyManager implements BrokerTopologyManager {
   }
 
   @Override
-  public BrokerClusterState getTopology(final String physicalTenantId) {
+  public BrokerClusterState getTopology(final @NonNull String physicalTenantId) {
     return topologies.get(physicalTenantId);
   }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,18 +23,27 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 final class TestTopologyManager implements BrokerTopologyManager {
-  private final TestBrokerClusterState topology;
+  private final Map<String, TestBrokerClusterState> topologies = new HashMap<>();
   private ClusterConfiguration clusterConfiguration = ClusterConfiguration.uninitialized();
 
   TestTopologyManager() {
-    topology = new TestBrokerClusterState();
+    this(new TestBrokerClusterState());
   }
 
   TestTopologyManager(final TestBrokerClusterState topology) {
-    this.topology = topology;
+    if (topology != null) {
+      topologies.put(Protocol.DEFAULT_PARTITION_GROUP_NAME, topology);
+    }
   }
 
   TestTopologyManager addPartition(final int id, final BrokerMemberId leaderId) {
+    return addPartition(Protocol.DEFAULT_PARTITION_GROUP_NAME, id, leaderId);
+  }
+
+  TestTopologyManager addPartition(
+      final String partitionGroup, final int id, final BrokerMemberId leaderId) {
+    final var topology =
+        topologies.computeIfAbsent(partitionGroup, group -> new TestBrokerClusterState());
     if (leaderId != null) {
       topology.addBrokerIfAbsent(leaderId);
       topology.setPartitionLeader(id, leaderId);
@@ -49,8 +59,8 @@ final class TestTopologyManager implements BrokerTopologyManager {
   }
 
   @Override
-  public BrokerClusterState getTopology() {
-    return topology;
+  public BrokerClusterState getTopology(final String physicalTenantId) {
+    return topologies.get(physicalTenantId);
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.transport.snapshotapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -103,6 +104,7 @@ public class SnapshotApiRequestHandlerTest {
     when(clusterState.getPartitions()).thenReturn(List.of(1));
 
     when(brokerTopology.getTopology()).thenReturn(clusterState);
+    when(brokerTopology.getTopology(anyString())).thenReturn(clusterState);
     final var metrics = mock(BrokerClientRequestMetrics.class);
     brokerClient =
         new BrokerClientImpl(

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.impl.job;
 import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -1162,6 +1163,7 @@ public final class LongPollingActivateJobsTest {
 
     final var topologyManager = mock(BrokerTopologyManager.class);
     when(topologyManager.getTopology()).thenReturn(clusterState);
+    when(topologyManager.getTopology(anyString())).thenReturn(clusterState);
     when(topologyManager.getClusterConfiguration())
         .thenReturn(ClusterConfiguration.uninitialized());
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategy.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategy.java
@@ -44,7 +44,8 @@ public final class HashBasedDispatchStrategy implements RequestDispatchStrategy 
   }
 
   @Override
-  public int determinePartition(final BrokerTopologyManager topologyManager) {
+  public int determinePartition(
+      final BrokerTopologyManager topologyManager, final String partitionGroup) {
     return topologyManager
         .getClusterConfiguration()
         .routingState()

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategy.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategy.java
@@ -50,7 +50,10 @@ public final class HashBasedDispatchStrategy implements RequestDispatchStrategy 
         .getClusterConfiguration()
         .routingState()
         .map(this::fromRoutingState)
-        .or(() -> Optional.ofNullable(topologyManager.getTopology()).map(this::fromTopology))
+        .or(
+            () ->
+                Optional.ofNullable(topologyManager.getTopology(partitionGroup))
+                    .map(this::fromTopology))
         .orElseThrow(
             () ->
                 new NoTopologyAvailableException(

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategy.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategy.java
@@ -24,7 +24,8 @@ public final class PublishMessageDispatchStrategy implements RequestDispatchStra
   }
 
   @Override
-  public int determinePartition(final BrokerTopologyManager topologyManager) {
-    return delegate.determinePartition(topologyManager);
+  public int determinePartition(
+      final BrokerTopologyManager topologyManager, final String partitionGroup) {
+    return delegate.determinePartition(topologyManager, partitionGroup);
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -87,7 +87,7 @@ public final class RequestRetryHandler {
           requestSender,
       final BrokerResponseConsumer<BrokerResponseT> responseConsumer,
       final Consumer<Throwable> throwableConsumer) {
-    final var topology = topologyManager.getTopology();
+    final var topology = topologyManager.getTopology(request.getPartitionGroup());
     if (topology == null || topology.getPartitionsCount() == 0) {
       throwableConsumer.accept(new NoTopologyAvailableException());
       return;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -129,7 +129,8 @@ public final class RequestRetryHandler {
       final BrokerResponseConsumer<BrokerResponseT> responseConsumer,
       final Consumer<Throwable> throwableConsumer) {
     try {
-      request.setPartitionId(strategy.determinePartition(topologyManager));
+      request.setPartitionId(
+          strategy.determinePartition(topologyManager, request.getPartitionGroup()));
     } catch (final Exception e) {
       throwableConsumer.accept(e);
       return;
@@ -157,7 +158,8 @@ public final class RequestRetryHandler {
       final Consumer<Throwable> throwableConsumer,
       final Collection<Throwable> errors) {
 
-    final int partitionId = determineNextPartition(triedPartitions, partitionCount);
+    final int partitionId =
+        determineNextPartition(triedPartitions, partitionCount, request.getPartitionGroup());
     if (partitionId == BrokerClusterState.PARTITION_ID_NULL) {
       final var exception = new RequestRetriesExhaustedException();
       errors.forEach(exception::addSuppressed);
@@ -196,10 +198,11 @@ public final class RequestRetryHandler {
    * concurrent retries scatter across partitions instead of all cascading to the same next
    * partition.
    */
-  private int determineNextPartition(final Set<Integer> triedPartitions, final int partitionCount) {
+  private int determineNextPartition(
+      final Set<Integer> triedPartitions, final int partitionCount, final String partitionGroup) {
     final var seen = new HashSet<Integer>();
     for (int i = 0; i < partitionCount; i++) {
-      final int partition = dispatchStrategy.determinePartition(topologyManager);
+      final int partition = dispatchStrategy.determinePartition(topologyManager, partitionGroup);
       if (partition == BrokerClusterState.PARTITION_ID_NULL) {
         return BrokerClusterState.PARTITION_ID_NULL;
       }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -98,7 +98,9 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
       final BiConsumer<Integer, Boolean> onCompleted) {
     final var jobType = request.getType();
     final var maxJobsToActivate = request.getMaxJobsToActivate();
-    final var partitionIterator = partitionIdIteratorForType(jobType, partitionsCount);
+    final var partitionIterator =
+        partitionIdIteratorForType(
+            jobType, partitionsCount, request.getRequest().getPartitionGroup());
 
     final var requestState =
         new InflightActivateJobsRequestState(partitionIterator, maxJobsToActivate);
@@ -297,11 +299,11 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
   }
 
   private PartitionIdIterator partitionIdIteratorForType(
-      final String jobType, final int partitionsCount) {
+      final String jobType, final int partitionsCount, final String partitionGroup) {
     final var nextPartitionSupplier =
         jobTypeToNextPartitionId.computeIfAbsent(jobType, t -> new RoundRobinDispatchStrategy());
     return new PartitionIdIterator(
-        nextPartitionSupplier.determinePartition(topologyManager),
+        nextPartitionSupplier.determinePartition(topologyManager, partitionGroup),
         partitionsCount,
         topologyManager);
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -75,7 +75,7 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
       final ResponseObserver<T> responseObserver,
       final Consumer<Runnable> setCancelHandler,
       final long requestTimeout) {
-    final var topology = topologyManager.getTopology();
+    final var topology = topologyManager.getTopology(request.getPartitionGroup());
     if (topology != null) {
       final var inflightRequest =
           new InflightActivateJobsRequest<>(
@@ -305,7 +305,8 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
     return new PartitionIdIterator(
         nextPartitionSupplier.determinePartition(topologyManager, partitionGroup),
         partitionsCount,
-        topologyManager);
+        topologyManager,
+        partitionGroup);
   }
 
   private record ResponseObserverDelegate(

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
 
 public final class StubbedTopologyManager implements BrokerTopologyManager {
 
@@ -39,7 +40,7 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
   }
 
   @Override
-  public BrokerClusterState getTopology(final String physicalTenantId) {
+  public BrokerClusterState getTopology(final @NonNull String physicalTenantId) {
     // a single shared state for all partition groups; group-specific stubbing not needed yet
     return clusterState;
   }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -39,7 +39,8 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
   }
 
   @Override
-  public BrokerClusterState getTopology() {
+  public BrokerClusterState getTopology(final String physicalTenantId) {
+    // a single shared state for all partition groups; group-specific stubbing not needed yet
     return clusterState;
   }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.gateway.api.util.TestBrokerClusterState;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.PartitionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Optional;
@@ -37,7 +38,9 @@ final class HashBasedDispatchStrategyTest {
             new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
 
     // then - the request is dispatched based on the partition count from the topology
-    assertThat(dispatchStrategy.determinePartition(topologyManager))
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
         .isEqualTo(PartitionUtil.getPartitionId(BufferUtil.wrapString(businessId), partitionCount));
   }
 
@@ -59,7 +62,9 @@ final class HashBasedDispatchStrategyTest {
         new TestTopologyManager(new TestBrokerClusterState(partitionCount), clusterConfiguration);
 
     // then - the request is dispatched based on the routing state
-    assertThat(dispatchStrategy.determinePartition(topologyManager))
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
         .isEqualTo(
             PartitionUtil.getPartitionId(BufferUtil.wrapString(businessId), messagePartitionCount));
   }
@@ -79,8 +84,9 @@ final class HashBasedDispatchStrategyTest {
     final var strategy2 = new HashBasedDispatchStrategy(businessId, "business id");
 
     // then - both should route to the same partition
-    assertThat(strategy1.determinePartition(topologyManager))
-        .isEqualTo(strategy2.determinePartition(topologyManager));
+    assertThat(strategy1.determinePartition(topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(
+            strategy2.determinePartition(topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME));
   }
 
   @Test
@@ -98,8 +104,12 @@ final class HashBasedDispatchStrategyTest {
     final var messageStrategy = new PublishMessageDispatchStrategy(key);
 
     // then - both strategies should route to the same partition for the same key
-    assertThat(hashBasedStrategy.determinePartition(topologyManager))
-        .isEqualTo(messageStrategy.determinePartition(topologyManager));
+    assertThat(
+            hashBasedStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .isEqualTo(
+            messageStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME));
   }
 
   private record TestTopologyManager(

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.PartitionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Optional;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 final class HashBasedDispatchStrategyTest {
@@ -117,7 +118,7 @@ final class HashBasedDispatchStrategyTest {
       implements BrokerTopologyManager {
 
     @Override
-    public BrokerClusterState getTopology(final String physicalTenantId) {
+    public BrokerClusterState getTopology(final @NonNull String physicalTenantId) {
       return topology;
     }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
@@ -107,7 +107,7 @@ final class HashBasedDispatchStrategyTest {
       implements BrokerTopologyManager {
 
     @Override
-    public BrokerClusterState getTopology() {
+    public BrokerClusterState getTopology(final String physicalTenantId) {
       return topology;
     }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.gateway.api.util.TestBrokerClusterState;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Optional;
@@ -37,7 +38,9 @@ final class PublishMessageDispatchStrategyTest {
             new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
 
     // then - the request is dispatched based on the partition count from the topology
-    assertThat(dispatchStrategy.determinePartition(topologyManager))
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
         .isEqualTo(
             SubscriptionUtil.getSubscriptionPartitionId(
                 BufferUtil.wrapString(correlationKey), partitionCount));
@@ -61,7 +64,9 @@ final class PublishMessageDispatchStrategyTest {
         new TestTopologyManager(new TestBrokerClusterState(partitionCount), clusterConfiguration);
 
     // then - the request is dispatched based on the routing state
-    assertThat(dispatchStrategy.determinePartition(topologyManager))
+    assertThat(
+            dispatchStrategy.determinePartition(
+                topologyManager, Protocol.DEFAULT_PARTITION_GROUP_NAME))
         .isEqualTo(
             SubscriptionUtil.getSubscriptionPartitionId(
                 BufferUtil.wrapString(correlationKey), messagePartitionCount));

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -72,7 +72,7 @@ final class PublishMessageDispatchStrategyTest {
       implements BrokerTopologyManager {
 
     @Override
-    public BrokerClusterState getTopology() {
+    public BrokerClusterState getTopology(final String physicalTenantId) {
       return topology;
     }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Optional;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 final class PublishMessageDispatchStrategyTest {
@@ -77,7 +78,7 @@ final class PublishMessageDispatchStrategyTest {
       implements BrokerTopologyManager {
 
     @Override
-    public BrokerClusterState getTopology(final String physicalTenantId) {
+    public BrokerClusterState getTopology(final @NonNull String physicalTenantId) {
       return topology;
     }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
@@ -60,7 +60,7 @@ final class RequestRetryHandlerTest {
   void shouldSendToFixedPartitionWhenDispatchStrategyIsPresent() {
     // given - a request with a specific dispatch strategy targeting partition 2
     final int targetPartition = 2;
-    final var request = new TestBrokerRequest(Optional.of(__ -> targetPartition));
+    final var request = new TestBrokerRequest(Optional.of((__, partitionGroup) -> targetPartition));
     brokerClient.setResponse(new BrokerResponse<>("result", targetPartition, 1));
 
     // when
@@ -76,7 +76,7 @@ final class RequestRetryHandlerTest {
   void shouldNotRetryOnOtherPartitionsWhenDispatchStrategyIsPresent() {
     // given - a request with a specific dispatch strategy that fails with a retryable error
     final int targetPartition = 2;
-    final var request = new TestBrokerRequest(Optional.of(__ -> targetPartition));
+    final var request = new TestBrokerRequest(Optional.of((__, partitionGroup) -> targetPartition));
     brokerClient.setError(new ConnectException("connection refused"));
 
     // when
@@ -125,7 +125,7 @@ final class RequestRetryHandlerTest {
   void shouldNotSpinWhenActivePartitionsFewerThanTopologyCount() {
     // given - topology reports 3 partitions, but the strategy always returns partition 1
     // (e.g. only one active partition in routing state)
-    final RequestDispatchStrategy fixedStrategy = ignored -> 1;
+    final RequestDispatchStrategy fixedStrategy = (ignored, partitionGroup) -> 1;
     final var handler = new RequestRetryHandler(brokerClient, topologyManager, fixedStrategy);
     final var request = new TestBrokerRequest(Optional.empty());
     brokerClient.setError(new ConnectException("connection refused"));
@@ -145,7 +145,7 @@ final class RequestRetryHandlerTest {
     final var request =
         new TestBrokerRequest(
             Optional.of(
-                __ -> {
+                (__, partitionGroup) -> {
                   throw new RuntimeException("no topology");
                 }));
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
@@ -158,6 +158,48 @@ final class RequestRetryHandlerTest {
     assertThat(brokerClient.sendCount.get()).isEqualTo(0);
   }
 
+  @Test
+  void shouldPassRequestPartitionGroupToFixedPartitionDispatchStrategy() {
+    // given - a request for a non-default group with its own dispatch strategy
+    final var groupRef = new AtomicReference<String>();
+    final var request =
+        new TestBrokerRequest(
+            Optional.of(
+                (__, partitionGroup) -> {
+                  groupRef.set(partitionGroup);
+                  return 2;
+                }));
+    request.setPartitionGroup("tenant-b");
+    brokerClient.setResponse(new BrokerResponse<>("result", 2, 1));
+
+    // when
+    retryHandler.sendRequest(request, (key, response) -> {}, error -> {});
+
+    // then - the strategy received the request's partition group
+    assertThat(groupRef).hasValue("tenant-b");
+  }
+
+  @Test
+  void shouldPassRequestPartitionGroupToRetryDispatchStrategy() {
+    // given - a request for a non-default group without its own dispatch strategy
+    final var groups = new ArrayList<String>();
+    final RequestDispatchStrategy recordingStrategy =
+        (__, partitionGroup) -> {
+          groups.add(partitionGroup);
+          return 1;
+        };
+    final var handler = new RequestRetryHandler(brokerClient, topologyManager, recordingStrategy);
+    final var request = new TestBrokerRequest(Optional.empty());
+    request.setPartitionGroup("tenant-b");
+    brokerClient.setResponse(new BrokerResponse<>("result", 1, 1));
+
+    // when
+    handler.sendRequest(request, (key, response) -> {}, error -> {});
+
+    // then - the retry strategy received the request's partition group
+    assertThat(groups).containsExactly("tenant-b");
+  }
+
   private static final class TestBrokerClient implements BrokerClient {
     final AtomicInteger sendCount = new AtomicInteger(0);
     final List<Integer> partitionsHit = new ArrayList<>();


### PR DESCRIPTION
The `BrokerClient` now routes every request within the partition group it targets, instead of always consulting the default group's topology.

`RoundRobinDispatchStrategy` keeps a separate offset and partition ring per partition group, so traffic to one group cannot skew another group's round-robin distribution (numeric partition IDs overlap across groups). `RequestDispatchStrategy.determinePartition` takes the request's partition group, and `BrokerRequestManager` scopes all topology lookups — partition existence, inactivity checks, and leader/random-broker address resolution — to `BrokerRequest.getPartitionGroup()`. `BrokerTopologyManager.getTopology(String)` is now the primary (abstract) method so implementations cannot silently ignore the group.

Routing state remains scoped to the default partition group by design: it is a single cluster-wide state describing default-group scaling, while all other groups have a static partition distribution. Two known limitations are unchanged: the configured partition count is currently shared across all groups (temp behavior in `BrokerTopologyManagerImpl`; oversized ring slots are skipped by the per-group leader check), and the `DEPLOYMENT_PARTITION` fallback when no partition can be determined still applies to all groups.

closes #50519