### PR TITLE
test: use @TenantDefinition annotation in tenancy, auth and client ITs

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterVariableAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterVariableAuthorizationIT.java
@@ -10,7 +10,6 @@ package io.camunda.it.auth;
 import static io.camunda.client.api.search.enums.PermissionType.*;
 import static io.camunda.client.api.search.enums.ResourceType.CLUSTER_VARIABLE;
 import static io.camunda.client.api.search.enums.ResourceType.TENANT;
-import static io.camunda.it.util.TestHelper.createTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
@@ -18,6 +17,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -90,11 +91,12 @@ class ClusterVariableAuthorizationIT {
   private static final TestUser NO_PERMISSION_USER_DEF =
       new TestUser(NO_PERMISSION_USER, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant TEST_TENANT =
+      new TestTenant(TEST_TENANT_ID).setName("Test Tenant");
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    // Create the test tenant
-    createTenant(adminClient, TEST_TENANT_ID, "Test Tenant");
-
     // Create globally scoped cluster variables
     adminClient
         .newGloballyScopedClusterVariableCreateRequest()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
@@ -19,6 +19,8 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.search.enums.JobState;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -35,7 +37,6 @@ import java.util.Set;
 import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -83,20 +84,13 @@ public class JobStreamAuthorizationIT {
                   UPDATE_PROCESS_INSTANCE,
                   List.of(PROCESS_ID_2, PROCESS_ID_4, PROCESS_ID_5))));
 
-  @BeforeAll
-  static void setUp() {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers("demo", USER1_USERNAME, USER2_USERNAME);
 
-    assignUserToTenant(adminClient, "demo", TENANT_A);
-    assignUserToTenant(adminClient, "demo", TENANT_B);
-    // user1 is only assigned to tenantA, but isn't authorized to handle any resources
-    assignUserToTenant(adminClient, USER1_USERNAME, TENANT_A);
-    // user2 is assigned to tenantA AND tenant B BUT is authorized to handle only PROCESS_2 on
-    // tenantB
-    assignUserToTenant(adminClient, USER2_USERNAME, TENANT_A);
-    assignUserToTenant(adminClient, USER2_USERNAME, TENANT_B);
-  }
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers("demo", USER2_USERNAME);
 
   @AfterEach
   void cleanUp() {
@@ -345,15 +339,6 @@ public class JobStreamAuthorizationIT {
                 JobStreamActuatorAssert.assertThat(actuator)
                     .remoteStreams()
                     .haveJobType(1, jobType));
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UsageMetricAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UsageMetricAuthorizationIT.java
@@ -28,6 +28,8 @@ import io.camunda.client.impl.statistics.response.UsageMetricsStatisticsImpl;
 import io.camunda.client.impl.statistics.response.UsageMetricsStatisticsItemImpl;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -99,6 +101,14 @@ public class UsageMetricAuthorizationIT {
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER = new TestUser(UNAUTHORIZED, PASSWORD, List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, RESTRICTED);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   private static void waitForUsageMetrics(
       final CamundaClient camundaClient, final Consumer<UsageMetricsStatistics> fnRequirements) {
     Awaitility.await("should export metrics to secondary storage")
@@ -137,11 +147,6 @@ public class UsageMetricAuthorizationIT {
 
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, RESTRICTED, TENANT_A);
     waitForUsersAssignedToTenant(adminClient, TENANT_A, ADMIN, RESTRICTED);
     waitForUsersAssignedToTenant(adminClient, TENANT_B, ADMIN);
 
@@ -193,15 +198,6 @@ public class UsageMetricAuthorizationIT {
         .tenantId(tenantId)
         .send()
         .join();
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void startProcessInstance(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIT.java
@@ -14,11 +14,12 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
@@ -28,10 +29,8 @@ public class ClientsByTenantIT {
   private static CamundaClient camundaClient;
   private static final String TENANT_ID = Strings.newRandomValidTenantId();
 
-  @BeforeAll
-  static void setup() {
-    camundaClient.newCreateTenantCommand().tenantId(TENANT_ID).name("tenantName").send().join();
-  }
+  @TenantDefinition
+  private static final TestTenant TENANT = new TestTenant(TENANT_ID).setName("tenantName");
 
   @Test
   void shouldSearchAssignedClientsByTenantAndSort() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableCommandIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableCommandIT.java
@@ -7,17 +7,17 @@
  */
 package io.camunda.it.client;
 
-import static io.camunda.it.util.TestHelper.createTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
@@ -28,12 +28,11 @@ public class ClusterVariableCommandIT {
 
   private static CamundaClient camundaClient;
 
-  @BeforeAll
-  static void setUp() {
-    // Create tenants needed for tests
-    createTenant(camundaClient, "tenant_1", "Tenant 1");
-    createTenant(camundaClient, "tenant_123", "Tenant 123");
-  }
+  @TenantDefinition
+  private static final TestTenant TENANT_1 = new TestTenant("tenant_1").setName("Tenant 1");
+
+  @TenantDefinition
+  private static final TestTenant TENANT_123 = new TestTenant("tenant_123").setName("Tenant 123");
 
   // ============ CREATE TESTS ============
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableFetchIT.java
@@ -7,17 +7,17 @@
  */
 package io.camunda.it.client;
 
-import static io.camunda.it.util.TestHelper.createTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.it.util.TestHelper;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
@@ -28,11 +28,8 @@ public class ClusterVariableFetchIT {
 
   private static CamundaClient camundaClient;
 
-  @BeforeAll
-  static void setUp() {
-    // Create tenants needed for tests
-    createTenant(camundaClient, "tenant_1", "Tenant 1");
-  }
+  @TenantDefinition
+  private static final TestTenant TENANT_1 = new TestTenant("tenant_1").setName("Tenant 1");
 
   // ============ GET TESTS ============
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchIT.java
@@ -7,13 +7,14 @@
  */
 package io.camunda.it.client;
 
-import static io.camunda.it.util.TestHelper.createTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
 import io.camunda.client.api.search.response.ClusterVariable;
 import io.camunda.it.util.TestHelper;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.util.Comparator;
@@ -62,13 +63,17 @@ public class ClusterVariableSearchIT {
   private static String largeVarValue;
   private static final int LARGE_VALUE_SIZE = 10000; // Create a large value to trigger truncation
 
+  @TenantDefinition
+  private static final TestTenant TENANT_1 = new TestTenant("tenant_1").setName("Tenant 1");
+
+  @TenantDefinition
+  private static final TestTenant TENANT_2 = new TestTenant("tenant_2").setName("Tenant 2");
+
+  @TenantDefinition
+  private static final TestTenant TENANT_3 = new TestTenant("tenant_3").setName("Tenant 3");
+
   @BeforeAll
   static void setupClusterVariables() {
-    // Create tenants needed for tests
-    createTenant(camundaClient, "tenant_1", "Tenant 1");
-    createTenant(camundaClient, "tenant_2", "Tenant 2");
-    createTenant(camundaClient, "tenant_3", "Tenant 3");
-
     // Setup global scoped variables
     globalVarName1 = "globalVarSearch1_" + UUID.randomUUID();
     globalVarValue1 = "testValue1_" + UUID.randomUUID();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationMultiTenantsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationMultiTenantsIT.java
@@ -7,12 +7,13 @@
  */
 package io.camunda.it.client;
 
-import static io.camunda.it.util.TestHelper.createTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
@@ -50,24 +51,21 @@ public class ExpressionEvaluationMultiTenantsIT {
   @UserDefinition
   private static final TestUser USER_2 = new TestUser(USERNAME_2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant TENANT_1 =
+      new TestTenant(TENANT_ID_1)
+          .setName(TENANT_ID_1)
+          .addUsers(InitializationConfiguration.DEFAULT_USER_USERNAME, USERNAME_1);
+
+  @TenantDefinition
+  private static final TestTenant TENANT_2 =
+      new TestTenant(TENANT_ID_2)
+          .setName(TENANT_ID_2)
+          .addUsers(InitializationConfiguration.DEFAULT_USER_USERNAME, USERNAME_2);
+
   @BeforeAll
   public static void beforeAll(@Authenticated final CamundaClient client) {
     adminClient = client;
-
-    // Create tenants and assign users
-    createTenant(
-        adminClient,
-        TENANT_ID_1,
-        TENANT_ID_1,
-        InitializationConfiguration.DEFAULT_USER_USERNAME,
-        USERNAME_1);
-
-    createTenant(
-        adminClient,
-        TENANT_ID_2,
-        TENANT_ID_2,
-        InitializationConfiguration.DEFAULT_USER_USERNAME,
-        USERNAME_2);
   }
 
   // ============ VARIABLE SCOPING TESTS ============

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByTenantIT.java
@@ -15,6 +15,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.TenantGroup;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
@@ -34,10 +36,11 @@ public class GroupsByTenantIT {
   private static final String B_GROUP_ID = "bGroupId";
   private static final String UNASSIGNED_GROUP_ID = Strings.newRandomValidIdentityId();
 
+  @TenantDefinition
+  private static final TestTenant TENANT = new TestTenant(TENANT_ID).setName("tenantName");
+
   @BeforeAll
   static void setup() {
-    camundaClient.newCreateTenantCommand().tenantId(TENANT_ID).name("tenantName").send().join();
-
     camundaClient.newCreateGroupCommand().groupId(A_GROUP_ID).name("firstGroupName").send().join();
     camundaClient.newCreateGroupCommand().groupId(B_GROUP_ID).name("secondGroupName").send().join();
     camundaClient

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByDefinitionIT.java
@@ -9,7 +9,6 @@ package io.camunda.it.client;
 
 import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployResourceForTenant;
 import static io.camunda.it.util.TestHelper.waitForJobs;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
@@ -24,6 +23,8 @@ import io.camunda.client.api.search.response.Job;
 import io.camunda.client.api.statistics.response.IncidentProcessInstanceStatisticsByDefinition;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
@@ -107,6 +108,54 @@ public class IncidentProcessInstanceStatisticsByDefinitionIT {
 
   @UserDefinition private static final TestUser U_MULTI_VERSION = testUser(USER_MULTI_VERSION);
 
+  @TenantDefinition
+  private static final TestTenant T_SINGLE_DEFINITION =
+      new TestTenant(TENANT_SINGLE_DEFINITION)
+          .setName(TENANT_SINGLE_DEFINITION)
+          .addUsers(USER_SINGLE_DEFINITION);
+
+  @TenantDefinition
+  private static final TestTenant T_MULTI_DEFINITION =
+      new TestTenant(TENANT_MULTI_DEFINITION)
+          .setName(TENANT_MULTI_DEFINITION)
+          .addUsers(USER_MULTI_DEFINITION);
+
+  @TenantDefinition
+  private static final TestTenant T_NO_READ_PROCESS_INSTANCE =
+      new TestTenant(TENANT_NO_READ_PROCESS_INSTANCE)
+          .setName(TENANT_NO_READ_PROCESS_INSTANCE)
+          .addUsers(DEFAULT_USER_USERNAME);
+
+  @TenantDefinition
+  private static final TestTenant T_HASH_COLLISION =
+      new TestTenant(TENANT_HASH_COLLISION)
+          .setName(TENANT_HASH_COLLISION)
+          .addUsers(USER_HASH_COLLISION);
+
+  @TenantDefinition
+  private static final TestTenant T_MULTI_TENANT_1 =
+      new TestTenant(TENANT_MULTI_TENANT_1)
+          .setName(TENANT_MULTI_TENANT_1)
+          .addUsers(USER_MULTI_TENANT);
+
+  @TenantDefinition
+  private static final TestTenant T_MULTI_TENANT_2 =
+      new TestTenant(TENANT_MULTI_TENANT_2)
+          .setName(TENANT_MULTI_TENANT_2)
+          .addUsers(USER_MULTI_TENANT);
+
+  @TenantDefinition
+  private static final TestTenant T_MULTI_VERSION =
+      new TestTenant(TENANT_MULTI_VERSION)
+          .setName(TENANT_MULTI_VERSION)
+          .addUsers(USER_MULTI_VERSION);
+
+  @TenantDefinition
+  private static final TestTenant T_SINGLE_DEFINITION_CACHE =
+      new TestTenant(TENANT_SINGLE_DEFINITION_CACHE)
+          .setName(TENANT_SINGLE_DEFINITION_CACHE)
+          .addUsers(USER_SINGLE_DEFINITION_CACHE);
+
   private static CamundaClient adminClient;
 
   private static TestUser testUser(final String userId) {
@@ -116,11 +165,6 @@ public class IncidentProcessInstanceStatisticsByDefinitionIT {
   @BeforeAll
   public static void beforeAll(@Authenticated final CamundaClient adminClient) {
     IncidentProcessInstanceStatisticsByDefinitionIT.adminClient = adminClient;
-  }
-
-  private static void ensureTenantExistsForUser(
-      final CamundaClient adminClient, final String tenantId, final String userId) {
-    createTenant(adminClient, tenantId, tenantId, userId);
   }
 
   private static BpmnModelInstance singleServiceTaskProcess(
@@ -214,8 +258,6 @@ public class IncidentProcessInstanceStatisticsByDefinitionIT {
   void shouldReturnSingleDefinitionStatisticForMultipleFailingInstances(
       @Authenticated(USER_SINGLE_DEFINITION) final CamundaClient userClient) {
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_SINGLE_DEFINITION, USER_SINGLE_DEFINITION);
-
     final String processId = SIMPLE_PROCESS_1;
     final BpmnModelInstance model = singleServiceTaskProcess(processId, PROCESS_NAME_1, JOB_TYPE_1);
 
@@ -269,8 +311,6 @@ public class IncidentProcessInstanceStatisticsByDefinitionIT {
       @Authenticated(USER_MULTI_DEFINITION) final CamundaClient userClient) {
 
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_MULTI_DEFINITION, USER_MULTI_DEFINITION);
-
     final String process1Id = SIMPLE_PROCESS_1;
     final String process2Id = SIMPLE_PROCESS_2;
 
@@ -348,8 +388,6 @@ public class IncidentProcessInstanceStatisticsByDefinitionIT {
   void shouldReturnNoStatisticsForUserWithoutReadProcessInstance(
       @Authenticated(USER_NO_READ_PROCESS_INSTANCE) final CamundaClient userClient) {
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_NO_READ_PROCESS_INSTANCE, DEFAULT_USER_USERNAME);
-
     final BpmnModelInstance process =
         singleServiceTaskProcess(SIMPLE_PROCESS_1, PROCESS_NAME_1, JOB_TYPE_1);
 
@@ -390,8 +428,6 @@ public class IncidentProcessInstanceStatisticsByDefinitionIT {
       @Authenticated(USER_HASH_COLLISION) final CamundaClient userClient) {
 
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_HASH_COLLISION, USER_HASH_COLLISION);
-
     final String processId = SIMPLE_PROCESS_1;
     final BpmnModelInstance model1 =
         singleServiceTaskProcess(processId, PROCESS_NAME_1, JOB_TYPE_1);
@@ -479,9 +515,6 @@ public class IncidentProcessInstanceStatisticsByDefinitionIT {
       @Authenticated(USER_MULTI_TENANT) final CamundaClient userClient) {
 
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_MULTI_TENANT_1, USER_MULTI_TENANT);
-    ensureTenantExistsForUser(adminClient, TENANT_MULTI_TENANT_2, USER_MULTI_TENANT);
-
     final String processId = SIMPLE_PROCESS_1;
     final BpmnModelInstance model = singleServiceTaskProcess(processId, PROCESS_NAME_1, JOB_TYPE_1);
 
@@ -557,8 +590,6 @@ public class IncidentProcessInstanceStatisticsByDefinitionIT {
       @Authenticated(USER_MULTI_VERSION) final CamundaClient userClient) {
 
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_MULTI_VERSION, USER_MULTI_VERSION);
-
     final String processId = SIMPLE_PROCESS_1;
 
     // Deploy v1 (jobType1)
@@ -641,9 +672,6 @@ public class IncidentProcessInstanceStatisticsByDefinitionIT {
   @Test
   void shouldUseCachedProcessDefinitionDataForRepeatedRequests(
       @Authenticated(USER_SINGLE_DEFINITION_CACHE) final CamundaClient userClient) {
-    ensureTenantExistsForUser(
-        adminClient, TENANT_SINGLE_DEFINITION_CACHE, USER_SINGLE_DEFINITION_CACHE);
-
     final BpmnModelInstance model =
         singleServiceTaskProcess(SIMPLE_PROCESS_1, PROCESS_NAME_1, JOB_TYPE_1);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByErrorIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByErrorIT.java
@@ -9,7 +9,6 @@ package io.camunda.it.client;
 
 import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployResourceForTenant;
 import static io.camunda.it.util.TestHelper.waitForJobs;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
@@ -26,6 +25,8 @@ import io.camunda.client.api.search.response.Job;
 import io.camunda.client.api.statistics.response.IncidentProcessInstanceStatisticsByError;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
@@ -92,6 +93,34 @@ public class IncidentProcessInstanceStatisticsByErrorIT {
   private static final TestUser U_NO_READ_PROCESS_INSTANCE =
       new TestUser(USER_NO_READ_PROCESS_INSTANCE, PASSWORD, List.of());
 
+  @TenantDefinition
+  private static final TestTenant T_SINGLE_ERROR =
+      new TestTenant(TENANT_SINGLE_ERROR).setName(TENANT_SINGLE_ERROR).addUsers(USER_SINGLE_ERROR);
+
+  @TenantDefinition
+  private static final TestTenant T_MULTI_ERROR =
+      new TestTenant(TENANT_MULTI_ERROR).setName(TENANT_MULTI_ERROR).addUsers(USER_MULTI_ERROR);
+
+  @TenantDefinition
+  private static final TestTenant T_ACTIVE_ONLY =
+      new TestTenant(TENANT_ACTIVE_ONLY).setName(TENANT_ACTIVE_ONLY).addUsers(USER_ACTIVE_ONLY);
+
+  @TenantDefinition
+  private static final TestTenant T_ERROR_HASH_COLLISION =
+      new TestTenant(TENANT_ERROR_HASH_COLLISION)
+          .setName(TENANT_ERROR_HASH_COLLISION)
+          .addUsers(USER_ERROR_HASH_COLLISION);
+
+  @TenantDefinition
+  private static final TestTenant T_PAGINATION =
+      new TestTenant(TENANT_PAGINATION).setName(TENANT_PAGINATION).addUsers(USER_PAGINATION);
+
+  @TenantDefinition
+  private static final TestTenant T_NO_READ_PROCESS_INSTANCE =
+      new TestTenant(TENANT_NO_READ_PROCESS_INSTANCE)
+          .setName(TENANT_NO_READ_PROCESS_INSTANCE)
+          .addUsers(DEFAULT_USER_USERNAME);
+
   private static CamundaClient adminClient;
 
   private static TestUser testUser(final String userId) {
@@ -101,11 +130,6 @@ public class IncidentProcessInstanceStatisticsByErrorIT {
   @BeforeAll
   public static void beforeAll(@Authenticated final CamundaClient adminClient) {
     IncidentProcessInstanceStatisticsByErrorIT.adminClient = adminClient;
-  }
-
-  private static void ensureTenantExistsForUser(
-      final CamundaClient adminClient, final String tenantId, final String userId) {
-    createTenant(adminClient, tenantId, tenantId, userId);
   }
 
   @Test
@@ -125,8 +149,6 @@ public class IncidentProcessInstanceStatisticsByErrorIT {
   void shouldReturnSingleErrorStatisticForMultipleFailingInstances(
       @Authenticated(USER_SINGLE_ERROR) final CamundaClient userClient) {
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_SINGLE_ERROR, USER_SINGLE_ERROR);
-
     final String processId = SIMPLE_PROCESS_1;
     final BpmnModelInstance model = singleServiceTaskProcess(processId, JOB_TYPE_1);
 
@@ -168,8 +190,6 @@ public class IncidentProcessInstanceStatisticsByErrorIT {
       @Authenticated(USER_MULTI_ERROR) final CamundaClient userClient) {
 
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_MULTI_ERROR, USER_MULTI_ERROR);
-
     final String process1Id = SIMPLE_PROCESS_1;
     final String process2Id = SIMPLE_PROCESS_2;
 
@@ -228,8 +248,6 @@ public class IncidentProcessInstanceStatisticsByErrorIT {
   void shouldPaginateIncidentStatisticsByErrorWithoutOverlapAndWithStableOrdering(
       @Authenticated(USER_PAGINATION) final CamundaClient userClient) {
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_PAGINATION, USER_PAGINATION);
-
     final String processId = SIMPLE_PROCESS_1;
     final BpmnModelInstance model = singleServiceTaskProcess(processId, JOB_TYPE_1);
     final long processDefinitionKey =
@@ -318,8 +336,6 @@ public class IncidentProcessInstanceStatisticsByErrorIT {
       @Authenticated(USER_ACTIVE_ONLY) final CamundaClient userClient) {
 
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_ACTIVE_ONLY, USER_ACTIVE_ONLY);
-
     final String processId = SIMPLE_PROCESS_1;
     final BpmnModelInstance model = singleServiceTaskProcess(processId, JOB_TYPE_1);
 
@@ -373,8 +389,6 @@ public class IncidentProcessInstanceStatisticsByErrorIT {
       @Authenticated(USER_ERROR_HASH_COLLISION) final CamundaClient userClient) {
 
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_ERROR_HASH_COLLISION, USER_ERROR_HASH_COLLISION);
-
     final String processId = SIMPLE_PROCESS_1;
     final BpmnModelInstance model1 = singleServiceTaskProcess(processId, JOB_TYPE_1);
     final BpmnModelInstance model2 = singleServiceTaskProcess(processId, JOB_TYPE_2);
@@ -439,8 +453,6 @@ public class IncidentProcessInstanceStatisticsByErrorIT {
   void shouldReturnNoStatisticsForUserWithoutReadProcessInstance(
       @Authenticated(USER_NO_READ_PROCESS_INSTANCE) final CamundaClient userClient) {
     // given
-    ensureTenantExistsForUser(adminClient, TENANT_NO_READ_PROCESS_INSTANCE, DEFAULT_USER_USERNAME);
-
     final BpmnModelInstance process = singleServiceTaskProcess(SIMPLE_PROCESS_1, JOB_TYPE_1);
 
     final long processDefinitionKey =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesByTenantSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesByTenantSearchIT.java
@@ -14,6 +14,8 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.MappingRule;
 import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
@@ -35,13 +37,14 @@ public class MappingRulesByTenantSearchIT {
   private static final String MAPPING_RULE_ID_3 = "c" + Strings.newRandomValidUsername();
   private static final String TENANT_ID = Strings.newRandomValidTenantId();
 
+  @TenantDefinition
+  private static final TestTenant TENANT = new TestTenant(TENANT_ID).setName("name");
+
   @BeforeAll
   static void setup() {
     createMappingRule(MAPPING_RULE_ID_1);
     createMappingRule(MAPPING_RULE_ID_2);
     createMappingRule(MAPPING_RULE_ID_3);
-
-    createTenant(TENANT_ID);
 
     assignMappingRuleToTenant(MAPPING_RULE_ID_1, TENANT_ID);
     assignMappingRuleToTenant(MAPPING_RULE_ID_2, TENANT_ID);
@@ -119,10 +122,6 @@ public class MappingRulesByTenantSearchIT {
         .claimValue(mappingRuleId + "claimValue")
         .send()
         .join();
-  }
-
-  private static void createTenant(final String tenantId) {
-    camundaClient.newCreateTenantCommand().tenantId(tenantId).name("name").send().join();
   }
 
   private static void assignMappingRuleToTenant(final String mappingRuleId, final String tenantId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionInstanceStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionInstanceStatisticsIT.java
@@ -10,7 +10,6 @@ package io.camunda.it.client;
 import static io.camunda.it.util.TestHelper.DEFAULT_TENANT_ID;
 import static io.camunda.it.util.TestHelper.cancelInstance;
 import static io.camunda.it.util.TestHelper.completeJob;
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployServiceTaskProcess;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForJobs;
@@ -24,6 +23,8 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.statistics.response.ProcessDefinitionInstanceStatistics;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
@@ -53,18 +54,18 @@ public class ProcessDefinitionInstanceStatisticsIT {
   @UserDefinition
   private static final TestUser USER_1 = new TestUser(USERNAME_1, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant TENANT_1 =
+      new TestTenant(TENANT_ID_1)
+          .setName(TENANT_ID_1)
+          .addUsers(InitializationConfiguration.DEFAULT_USER_USERNAME, USERNAME_1);
+
   @BeforeAll
   public static void beforeAll(@Authenticated final CamundaClient adminClient)
       throws InterruptedException {
 
     camundaClient = adminClient;
 
-    createTenant(
-        adminClient,
-        TENANT_ID_1,
-        TENANT_ID_1,
-        InitializationConfiguration.DEFAULT_USER_USERNAME,
-        USERNAME_1);
     adminClient.newAssignRoleToUserCommand().roleId("admin").username(USERNAME_1).execute();
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionInstanceVersionStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionInstanceVersionStatisticsIT.java
@@ -10,7 +10,6 @@ package io.camunda.it.client;
 import static io.camunda.it.util.TestHelper.DEFAULT_TENANT_ID;
 import static io.camunda.it.util.TestHelper.cancelInstance;
 import static io.camunda.it.util.TestHelper.completeJob;
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployServiceTaskProcess;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.startProcessInstanceForTenant;
@@ -27,6 +26,8 @@ import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.statistics.response.ProcessDefinitionInstanceVersionStatistics;
 import io.camunda.client.api.statistics.sort.ProcessDefinitionInstanceVersionStatisticsSort;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
@@ -60,18 +61,18 @@ public class ProcessDefinitionInstanceVersionStatisticsIT {
   @UserDefinition
   private static final TestUser USER_1 = new TestUser(USERNAME_1, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant TENANT_1 =
+      new TestTenant(TENANT_ID_1)
+          .setName(TENANT_ID_1)
+          .addUsers(InitializationConfiguration.DEFAULT_USER_USERNAME, USERNAME_1);
+
   @BeforeAll
   public static void beforeAll(@Authenticated final CamundaClient adminClient)
       throws InterruptedException {
 
     camundaClient = adminClient;
 
-    createTenant(
-        adminClient,
-        TENANT_ID_1,
-        TENANT_ID_1,
-        InitializationConfiguration.DEFAULT_USER_USERNAME,
-        USERNAME_1);
     adminClient.newAssignRoleToUserCommand().roleId("admin").username(USERNAME_1).execute();
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchMultiTenantsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchMultiTenantsIT.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.it.client;
 
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.deployResourceForTenant;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
@@ -18,6 +17,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.sort.ProcessDefinitionSort;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
@@ -91,18 +92,17 @@ public class ProcessDefinitionSearchMultiTenantsIT {
   @UserDefinition
   private static final TestUser USER_1 = new TestUser(USERNAME_1, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant TENANT_1 =
+      new TestTenant(TENANT_ID_1)
+          .setName(TENANT_ID_1)
+          .addUsers(InitializationConfiguration.DEFAULT_USER_USERNAME, USERNAME_1);
+
   @BeforeAll
   public static void beforeAll(@Authenticated final CamundaClient adminClient)
       throws InterruptedException {
 
     camundaClient = adminClient;
-
-    createTenant(
-        adminClient,
-        TENANT_ID_1,
-        TENANT_ID_1,
-        InitializationConfiguration.DEFAULT_USER_USERNAME,
-        USERNAME_1);
 
     deployResourceForTenant(camundaClient, "form/form.form", TENANT_ID_1);
     deployResourceForTenant(camundaClient, "form/form_v2.form", TENANT_ID_1);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnassignClientFromTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnassignClientFromTenantIT.java
@@ -14,11 +14,12 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
@@ -28,10 +29,8 @@ public class UnassignClientFromTenantIT {
   private static CamundaClient camundaClient;
   private static final String TENANT_ID = Strings.newRandomValidTenantId();
 
-  @BeforeAll
-  static void setup() {
-    camundaClient.newCreateTenantCommand().tenantId(TENANT_ID).name("tenantName").send().join();
-  }
+  @TenantDefinition
+  private static final TestTenant TENANT = new TestTenant(TENANT_ID).setName("tenantName");
 
   @Test
   void shouldUnassignClientFromTenant() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByTenantSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByTenantSearchIT.java
@@ -60,7 +60,7 @@ public class UsersByTenantSearchIT {
     assertThat(users.items().size()).isEqualTo(2);
     assertThat(users.items())
         .extracting(TenantUser::getUsername)
-        .containsExactly(USER_USERNAME_1, USER_USERNAME_2);
+        .containsExactlyInAnyOrder(USER_USERNAME_1, USER_USERNAME_2);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByTenantSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByTenantSearchIT.java
@@ -15,9 +15,12 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.TenantUser;
 import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -33,14 +36,18 @@ public class UsersByTenantSearchIT {
   private static final String USER_USERNAME_3 = Strings.newRandomValidUsername();
   private static final String TENANT_ID = Strings.newRandomValidTenantId();
 
+  @UserDefinition
+  private static final TestUser USER_1 = new TestUser(USER_USERNAME_1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_2 = new TestUser(USER_USERNAME_2, "password", List.of());
+
   @TenantDefinition
   private static final TestTenant TENANT =
       new TestTenant(TENANT_ID).setName("tenant_name").addUsers(USER_USERNAME_1, USER_USERNAME_2);
 
   @BeforeAll
   static void setup() {
-    createUser(USER_USERNAME_1);
-    createUser(USER_USERNAME_2);
     createUser(USER_USERNAME_3);
 
     waitForTenantToBeUpdated();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByTenantSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByTenantSearchIT.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.TenantUser;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
@@ -31,25 +33,15 @@ public class UsersByTenantSearchIT {
   private static final String USER_USERNAME_3 = Strings.newRandomValidUsername();
   private static final String TENANT_ID = Strings.newRandomValidTenantId();
 
+  @TenantDefinition
+  private static final TestTenant TENANT =
+      new TestTenant(TENANT_ID).setName("tenant_name").addUsers(USER_USERNAME_1, USER_USERNAME_2);
+
   @BeforeAll
   static void setup() {
     createUser(USER_USERNAME_1);
     createUser(USER_USERNAME_2);
     createUser(USER_USERNAME_3);
-
-    camundaClient.newCreateTenantCommand().tenantId(TENANT_ID).name("tenant_name").send().join();
-    camundaClient
-        .newAssignUserToTenantCommand()
-        .username(USER_USERNAME_1)
-        .tenantId(TENANT_ID)
-        .send()
-        .join();
-    camundaClient
-        .newAssignUserToTenantCommand()
-        .username(USER_USERNAME_2)
-        .tenantId(TENANT_ID)
-        .send()
-        .join();
 
     waitForTenantToBeUpdated();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AuthorizationTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AuthorizationTenancyIT.java
@@ -15,6 +15,8 @@ import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.response.Authorization;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -51,12 +53,16 @@ public class AuthorizationTenancyIT {
   @UserDefinition
   private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
     createGroup(adminClient, GROUP_A);
     createGroup(adminClient, GROUP_B);
     createAuthorization(adminClient, GROUP_A);
@@ -102,15 +108,6 @@ public class AuthorizationTenancyIT {
         .permissionTypes(PermissionType.READ_PROCESS_INSTANCE)
         .send()
         .join();
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void waitForAuthorizationsBeingExported(final CamundaClient camundaClient) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ClusterVariableTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ClusterVariableTenancyIT.java
@@ -14,6 +14,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.ClusterVariable;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -62,14 +64,16 @@ public class ClusterVariableTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     // Create tenant-scoped cluster variables
     adminClient
         .newTenantScopedClusterVariableCreateRequest(TENANT_A)
@@ -440,15 +444,6 @@ public class ClusterVariableTenancyIT {
     assertThat(result.getName()).isEqualTo(GLOBAL_VAR_NAME);
     assertThat(result.getValue()).isEqualTo(VALUE_RESULT.formatted(GLOBAL_VAR_VALUE));
     assertThat(result.getTenantId()).isNull();
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void waitForClusterVariablesBeingExported(final CamundaClient camundaClient) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java
@@ -14,6 +14,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -53,14 +55,16 @@ public class DecisionDefinitionTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     deployResource(adminClient, "decisions/decision_model.dmn", TENANT_A);
     deployResource(adminClient, "decisions/decision_model_1.dmn", TENANT_B);
 
@@ -167,15 +171,6 @@ public class DecisionDefinitionTenancyIT {
         .contains(
             "Decision Definition with key '%s' not found"
                 .formatted(decisionDefinition.getDecisionKey()));
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionInstanceTenancyIT.java
@@ -15,6 +15,8 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.EvaluateDecisionResponse;
 import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -54,14 +56,16 @@ public class DecisionInstanceTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     deployResource(adminClient, "decisions/decision_model.dmn", TENANT_A);
     deployResource(adminClient, "decisions/decision_model_1.dmn", TENANT_B);
 
@@ -168,15 +172,6 @@ public class DecisionInstanceTenancyIT {
         .contains(
             "Decision Instance with id '%s' not found"
                 .formatted(decisionInstance.getDecisionInstanceId()));
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionRequirementsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionRequirementsTenancyIT.java
@@ -14,6 +14,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DecisionRequirements;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -53,14 +55,16 @@ public class DecisionRequirementsTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     waitForUserAssignment(adminClient, TENANT_A, 2);
     waitForUserAssignment(adminClient, TENANT_B, 1);
 
@@ -172,15 +176,6 @@ public class DecisionRequirementsTenancyIT {
         .contains(
             "Decision Requirements with key '%s' not found"
                 .formatted(decisionRequirements.getDecisionRequirementsKey()));
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ElementInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ElementInstanceTenancyIT.java
@@ -15,6 +15,8 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -55,14 +57,16 @@ public class ElementInstanceTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
 
@@ -138,15 +142,6 @@ public class ElementInstanceTenancyIT {
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
         .contains("Element Instance with key '%s' not found".formatted(elementInstanceKey));
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GlobalJobStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GlobalJobStatisticsTenancyIT.java
@@ -9,7 +9,6 @@ package io.camunda.it.tenancy;
 
 import static io.camunda.it.util.TestHelper.activateAndCompleteJobsForTenant;
 import static io.camunda.it.util.TestHelper.activateAndFailJobsForTenant;
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployResourceForTenant;
 import static io.camunda.it.util.TestHelper.startProcessInstanceForTenant;
 import static io.camunda.it.util.TestHelper.waitForJobStatistics;
@@ -19,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.JobState;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -71,14 +72,17 @@ public class GlobalJobStatisticsTenancyIT {
   private static final TestUser USER_NO_TENANT_USER =
       new TestUser(USER_NO_TENANT, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER_TENANT_A);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN, USER_TENANT_B);
+
   @BeforeAll
   static void setup(@Authenticated(ADMIN) final CamundaClient adminClient)
       throws InterruptedException {
-    // Create tenants and assign users
-    createTenant(adminClient, TENANT_A, TENANT_A, ADMIN, USER_TENANT_A);
-    createTenant(adminClient, TENANT_B, TENANT_B, ADMIN, USER_TENANT_B);
-    // USER_NO_TENANT is not assigned to any tenant
-
     // Deploy processes for each tenant
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GroupTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GroupTenancyIT.java
@@ -13,6 +13,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -49,12 +51,16 @@ public class GroupTenancyIT {
   @UserDefinition
   private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
     createGroup(adminClient, GROUP_A);
     createGroup(adminClient, GROUP_B);
     assignUserToGroup(adminClient, ADMIN, GROUP_A);
@@ -108,15 +114,6 @@ public class GroupTenancyIT {
 
   private static void createGroup(final CamundaClient camundaClient, final String group) {
     camundaClient.newCreateGroupCommand().groupId(group).name(group).send().join();
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void assignUserToGroup(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/IncidentTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/IncidentTenancyIT.java
@@ -14,6 +14,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -54,14 +56,16 @@ public class IncidentTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     deployResource(adminClient, "process/incident_process_v1.bpmn", TENANT_A);
     startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
 
@@ -133,15 +137,6 @@ public class IncidentTenancyIT {
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
         .contains("Incident with key '%s' not found".formatted(incidentKey));
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobErrorStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobErrorStatisticsTenancyIT.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.it.tenancy;
 
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployResourceForTenant;
 import static io.camunda.it.util.TestHelper.startProcessInstanceForTenant;
 import static io.camunda.it.util.TestHelper.waitForJobErrorStatistics;
@@ -17,6 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -71,11 +72,16 @@ public class JobErrorStatisticsTenancyIT {
   private static final TestUser USER_NO_TENANT_USER =
       new TestUser(USER_NO_TENANT, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER_TENANT_A);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN, USER_TENANT_B);
+
   @BeforeAll
   static void setup(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A, TENANT_A, ADMIN, USER_TENANT_A);
-    createTenant(adminClient, TENANT_B, TENANT_B, ADMIN, USER_TENANT_B);
-
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTenancyIT.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.Job;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -52,14 +54,16 @@ public class JobTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
 
@@ -95,15 +99,6 @@ public class JobTenancyIT {
     final var result = camundaClient.newJobSearchRequest().send().join();
     // then
     assertThat(result.items()).hasSize(0);
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTimeSeriesStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTimeSeriesStatisticsTenancyIT.java
@@ -9,7 +9,6 @@ package io.camunda.it.tenancy;
 
 import static io.camunda.it.util.TestHelper.activateAndCompleteJobsForTenant;
 import static io.camunda.it.util.TestHelper.activateAndFailJobsForTenant;
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployResourceForTenant;
 import static io.camunda.it.util.TestHelper.startProcessInstanceForTenant;
 import static io.camunda.it.util.TestHelper.waitForJobTimeSeriesStatistics;
@@ -19,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.JobState;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -74,12 +75,17 @@ public class JobTimeSeriesStatisticsTenancyIT {
   private static final TestUser USER_NO_TENANT_USER =
       new TestUser(USER_NO_TENANT, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER_TENANT_A);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN, USER_TENANT_B);
+
   @BeforeAll
   static void setup(@Authenticated(ADMIN) final CamundaClient adminClient)
       throws InterruptedException {
-    createTenant(adminClient, TENANT_A, TENANT_A, ADMIN, USER_TENANT_A);
-    createTenant(adminClient, TENANT_B, TENANT_B, ADMIN, USER_TENANT_B);
-
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTypeStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTypeStatisticsTenancyIT.java
@@ -9,7 +9,6 @@ package io.camunda.it.tenancy;
 
 import static io.camunda.it.util.TestHelper.activateAndCompleteJobsForTenant;
 import static io.camunda.it.util.TestHelper.activateAndFailJobsForTenant;
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployResourceForTenant;
 import static io.camunda.it.util.TestHelper.startProcessInstanceForTenant;
 import static io.camunda.it.util.TestHelper.waitForJobTypeStatistics;
@@ -19,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.JobState;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -73,14 +74,17 @@ public class JobTypeStatisticsTenancyIT {
   private static final TestUser USER_NO_TENANT_USER =
       new TestUser(USER_NO_TENANT, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER_TENANT_A);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN, USER_TENANT_B);
+
   @BeforeAll
   static void setup(@Authenticated(ADMIN) final CamundaClient adminClient)
       throws InterruptedException {
-    // Create tenants and assign users
-    createTenant(adminClient, TENANT_A, TENANT_A, ADMIN, USER_TENANT_A);
-    createTenant(adminClient, TENANT_B, TENANT_B, ADMIN, USER_TENANT_B);
-    // USER_NO_TENANT is not assigned to any tenant
-
     // Deploy processes for each tenant
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobWorkerStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobWorkerStatisticsTenancyIT.java
@@ -9,7 +9,6 @@ package io.camunda.it.tenancy;
 
 import static io.camunda.it.util.TestHelper.activateAndCompleteJobsForTenant;
 import static io.camunda.it.util.TestHelper.activateAndFailJobsForTenant;
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.deployResourceForTenant;
 import static io.camunda.it.util.TestHelper.startProcessInstanceForTenant;
 import static io.camunda.it.util.TestHelper.waitForJobWorkerStatistics;
@@ -19,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.JobState;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -75,13 +76,17 @@ public class JobWorkerStatisticsTenancyIT {
   private static final TestUser USER_NO_TENANT_USER =
       new TestUser(USER_NO_TENANT, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER_TENANT_A);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN, USER_TENANT_B);
+
   @BeforeAll
   static void setup(@Authenticated(ADMIN) final CamundaClient adminClient)
       throws InterruptedException {
-    // Create tenants and assign users
-    createTenant(adminClient, TENANT_A, TENANT_A, ADMIN, USER_TENANT_A);
-    createTenant(adminClient, TENANT_B, TENANT_B, ADMIN, USER_TENANT_B);
-
     // Deploy processes for each tenant
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MappingRuleTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MappingRuleTenancyIT.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.MappingRule;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -48,12 +50,16 @@ public class MappingRuleTenancyIT {
   @UserDefinition
   private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
     createMappingRule(adminClient, MAPPING_RULE_A);
     createMappingRule(adminClient, MAPPING_RULE_B);
     waitForMappingRulesBeingExported(adminClient);
@@ -91,15 +97,6 @@ public class MappingRuleTenancyIT {
         .claimValue(mappingRule)
         .send()
         .join();
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void waitForMappingRulesBeingExported(final CamundaClient camundaClient) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MessageSubscriptionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MessageSubscriptionTenancyIT.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -52,14 +54,16 @@ public class MessageSubscriptionTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     deployResource(adminClient, "process/process_with_parallel_receive_tasks.bpmn", TENANT_A);
     startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
 
@@ -103,15 +107,6 @@ public class MessageSubscriptionTenancyIT {
     final var result = camundaClient.newMessageSubscriptionSearchRequest().send().join();
     // then
     assertThat(result.items()).hasSize(0);
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionStatisticsTenancyIT.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.it.tenancy;
 
-import static io.camunda.it.util.TestHelper.createTenant;
 import static io.camunda.it.util.TestHelper.waitForMessageSubscriptions;
 import static io.camunda.it.util.TestHelper.waitForProcessInstances;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +17,8 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.enums.MessageSubscriptionState;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -73,24 +74,22 @@ public class ProcessDefinitionStatisticsTenancyIT {
   @UserDefinition
   private static final TestUser USER_ALL = new TestUser(USER_ALL_TENANTS, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant TENANT_1_DEF =
+      new TestTenant(TENANT_1)
+          .setName("Tenant 1")
+          .addUsers(
+              InitializationConfiguration.DEFAULT_USER_USERNAME, USER_TENANT_1, USER_ALL_TENANTS);
+
+  @TenantDefinition
+  private static final TestTenant TENANT_2_DEF =
+      new TestTenant(TENANT_2)
+          .setName("Tenant 2")
+          .addUsers(
+              InitializationConfiguration.DEFAULT_USER_USERNAME, USER_TENANT_2, USER_ALL_TENANTS);
+
   @BeforeAll
   public static void beforeAll(@Authenticated final CamundaClient adminClient) {
-    // Create tenants and assign users
-    createTenant(
-        adminClient,
-        TENANT_1,
-        "Tenant 1",
-        InitializationConfiguration.DEFAULT_USER_USERNAME,
-        USER_TENANT_1,
-        USER_ALL_TENANTS);
-    createTenant(
-        adminClient,
-        TENANT_2,
-        "Tenant 2",
-        InitializationConfiguration.DEFAULT_USER_USERNAME,
-        USER_TENANT_2,
-        USER_ALL_TENANTS);
-
     // Deploy process with message subscriptions to each tenant
     processDefKeyDefaultTenant = deployProcessWithSubscriptions(adminClient, DEFAULT_TENANT);
     processDefKeyTenant1Version1 = deployProcessWithSubscriptions(adminClient, TENANT_1);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
@@ -14,6 +14,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -54,14 +56,16 @@ public class ProcessDefinitionTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
     waitForProcessBeingExported(adminClient);
@@ -139,15 +143,6 @@ public class ProcessDefinitionTenancyIT {
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
         .contains("Process Definition with key '%s' not found".formatted(processDefinitionKey));
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
@@ -14,6 +14,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -54,14 +56,16 @@ public class ProcessInstanceTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/RoleTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/RoleTenancyIT.java
@@ -13,6 +13,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.Role;
 import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -49,12 +51,16 @@ public class RoleTenancyIT {
   @UserDefinition
   private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
     createRole(adminClient, ROLE_A);
     createRole(adminClient, ROLE_B);
     assignUserToRole(adminClient, ADMIN, ROLE_A);
@@ -110,15 +116,6 @@ public class RoleTenancyIT {
 
   private static void createRole(final CamundaClient camundaClient, final String role) {
     camundaClient.newCreateRoleCommand().roleId(role).name(role).send().join();
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void assignUserToRole(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/SequenceFlowTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/SequenceFlowTenancyIT.java
@@ -13,6 +13,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.ProcessInstanceSequenceFlow;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -52,12 +54,12 @@ public class SequenceFlowTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     final var processInstance1 = startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
 
@@ -93,15 +95,6 @@ public class SequenceFlowTenancyIT {
         camundaClient.newProcessInstanceSequenceFlowsRequest(processInstanceKey).send().join();
     // then
     assertThat(result).hasSize(0);
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/UserTaskTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/UserTaskTenancyIT.java
@@ -14,6 +14,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -54,14 +56,16 @@ public class UserTaskTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
-
     deployResource(adminClient, "process/bpm_variable_test.bpmn", TENANT_A);
     startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
 
@@ -134,15 +138,6 @@ public class UserTaskTenancyIT {
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
         .contains("User Task with key '%s' not found".formatted(userTaskKey));
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void deployResource(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/UserTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/UserTenancyIT.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.User;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -46,12 +48,16 @@ public class UserTenancyIT {
   @UserDefinition
   private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
     waitForTenantMembershipBeingExported(adminClient);
   }
 
@@ -75,15 +81,6 @@ public class UserTenancyIT {
     assertThat(result.items()).hasSize(3);
     assertThat(result.items().stream().map(User::getUsername).toList())
         .containsExactlyInAnyOrder("demo", ADMIN, USER1);
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
   private static void waitForTenantMembershipBeingExported(final CamundaClient camundaClient) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -214,17 +214,6 @@ public final class TestHelper {
         .execute();
   }
 
-  public static void createTenant(
-      final CamundaClient client,
-      final String tenantId,
-      final String tenantName,
-      final String... usernames) {
-    client.newCreateTenantCommand().tenantId(tenantId).name(tenantName).execute();
-    for (final var username : usernames) {
-      client.newAssignUserToTenantCommand().username(username).tenantId(tenantId).execute();
-    }
-  }
-
   public static void deleteTenant(final CamundaClient camundaClient, final String tenant) {
     camundaClient.newDeleteTenantCommand(tenant).execute();
   }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Replaces the imperative `createTenant()` / `assignUserToTenant()` boilerplate in 38 acceptance test files with the declarative `@TenantDefinition` annotation introduced in #51569. The annotation is picked up by `CamundaMultiDBExtension` (which backs both `@MultiDbTest` and `@RegisterExtension`-based tests) and creates tenants with their member assignments before any `@BeforeAll` method runs.

The change removes a lot of copy-paste private helper methods and cleans up `@BeforeAll` methods that were otherwise only concerned with test preconditions.

A handful of files were intentionally left as-is: tests that exercise tenant CRUD or search operations directly (`TenantIT`, `TenantsSearchIT`, `TenantAuthorizationIT`, etc.), and tests that create tenants dynamically within individual test methods as part of their scenario.

## Checklist

<!-- Please check all applicable boxes. -->

- [ ] I have read the [contributing guidelines](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md)
- [ ] I have added tests where applicable
- [ ] I have updated the documentation where applicable

## Related issues

closes #51577