### PR TITLE
ci: remove dead dispatch-optimize-command chatops job

### DIFF
--- a/.github/workflows/chatops-command-dispatch.yml
+++ b/.github/workflows/chatops-command-dispatch.yml
@@ -8,55 +8,6 @@ on:
     types: [created]
 
 jobs:
-  dispatch-optimize-command:
-    if: ${{ contains(github.event.issue.labels.*.name, 'component/optimize') }}
-    name: Dispatch Optimize Command
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Create URL to the run output
-        id: vars
-        run: |
-          {
-            echo "run_url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Generate a GitHub token
-        id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
-        with:
-          github-app-id-vault-key: GITHUB_OPTIMIZE_APP_ID
-          github-app-id-vault-path: secret/data/products/optimize/ci/camunda-optimize
-          github-app-private-key-vault-key: GITHUB_OPTIMIZE_APP_KEY
-          github-app-private-key-vault-path: secret/data/products/optimize/ci/camunda-optimize
-          vault-auth-method: approle
-          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
-          vault-url: ${{ secrets.VAULT_ADDR }}
-
-      - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2
-        with:
-          token: ${{ steps.github-token.outputs.token }}
-          reaction-token: ${{ steps.github-token.outputs.token }}
-          permission: none
-          commands: |
-            assign
-            eng
-            help
-            hold
-            pm
-            qa
-
-      - name: Update comment in case of failure
-        if: failure()
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        with:
-          comment-id: ${{ github.event.comment.id }}
-          body: |
-            > Had issues fulfilling your command, check the [logs](${{ steps.vars.outputs.run_url }})
-          reactions: confused
-
   dispatch-pr-command:
     if: ${{ github.event.issue.pull_request }}
     name: Dispatch PR Command


### PR DESCRIPTION
## Summary

Deletes the `dispatch-optimize-command` job from `.github/workflows/chatops-command-dispatch.yml`.

### How this came to light

Security assessment finding [camunda/security-testing-findings#168](https://github.com/camunda/security-testing-findings/issues/168) flagged that `dispatch-optimize-command` used `permission: none` in the `peter-evans/slash-command-dispatch` step. In v5 of that action, `permission: none` disables the built-in author-association check, meaning **any external GitHub user** could trigger the listed slash commands (`/assign`, `/eng`, `/help`, `/hold`, `/pm`, `/qa`) on any `component/optimize`-labeled issue. Each trigger mints a short-lived Vault/GitHub App token for the Optimize App, adding audit noise and burning rate-limit quota even when nothing useful happens.

### Why we deleted instead of patching

Investigation of the job's actual behavior showed it is entirely dead:

- **No receivers in this repo.** The six dispatched event types (`assign-command`, `eng-command`, `help-command`, `hold-command`, `pm-command`, `qa-command`) have no `repository_dispatch` listener anywhere in `.github/workflows/`. The `slash-command-dispatch` step has no `repository:` override, so events are sent to `camunda/camunda` — where nothing catches them.
- **Confirmed dead across 100 sampled runs.** Every execution logs `"The first line of the comment is not a valid slash command."` The action exits 0 on no-match, making the job appear green in the UI while never having dispatched a single event. The Optimize team's slash-command receivers were almost certainly in the now-merged `camunda/camunda-optimize` repo and were never migrated.
- **Vault quota burned for nothing.** Each comment on a `component/optimize` issue — thousands of times per day across the repo — triggers a Vault AppRole mint + GitHub App installation-token exchange with zero downstream effect.

Fixing `permission: none → permission: write` would address the security finding but leave dead, quota-burning code running. Deletion removes both the security surface and the waste.

### What is unaffected

The `dispatch-pr-command` job (`/ci-problems`, `/ci-disable-cache`, `/ci-enable-cache`) is untouched. It has working receiver workflows, defaults to `permission: write`, and is actively used.

## Test plan

- [ ] Confirm `dispatch-pr-command` job still fires on a PR comment with `/ci-problems`
- [ ] Confirm no `dispatch-optimize-command` job appears in workflow run list after merge
- [ ] Close security finding [#168](https://github.com/camunda/security-testing-findings/issues/168) post-merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)