### PR TITLE
feat: export timer subscriptions to secondary storage

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/TimerWaitStateDetails.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/TimerWaitStateDetails.java
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.enums;
+package io.camunda.client.api.search.response;
 
-public enum WaitStateType {
-  JOB,
-  MESSAGE,
-  TIMER,
-  USER_TASK,
-  UNKNOWN_ENUM_VALUE;
+/** Details of an element instance waiting on an intermediate catch event timer. */
+public interface TimerWaitStateDetails extends WaitStateDetails {
+
+  /** When the timer is due, as a UNIX epoch timestamp in milliseconds. */
+  Long getDueDate();
+
+  /** The number of remaining timer repetitions (-1 for infinite, 0 for non-repeating). */
+  Integer getRepetitions();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
@@ -61,6 +61,9 @@ public class ElementInstanceWaitStateResultImpl implements ElementInstanceWaitSt
       case MESSAGE:
         return new MessageWaitStateDetailsImpl(
             (io.camunda.client.protocol.rest.MessageWaitStateDetails) item);
+      case TIMER:
+        return new TimerWaitStateDetailsImpl(
+            (io.camunda.client.protocol.rest.TimerWaitStateDetails) item);
       case USER_TASK:
         return new UserTaskWaitStateDetailsImpl(
             (io.camunda.client.protocol.rest.UserTaskWaitStateDetails) item);

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/TimerWaitStateDetailsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/TimerWaitStateDetailsImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.TimerWaitStateDetails;
+
+public class TimerWaitStateDetailsImpl implements TimerWaitStateDetails {
+
+  private final Long dueDate;
+  private final Integer repetitions;
+
+  public TimerWaitStateDetailsImpl(
+      final io.camunda.client.protocol.rest.TimerWaitStateDetails details) {
+    dueDate = details.getDueDate();
+    repetitions = details.getRepetitions();
+  }
+
+  @Override
+  public WaitStateType getWaitStateType() {
+    return WaitStateType.TIMER;
+  }
+
+  @Override
+  public Long getDueDate() {
+    return dueDate;
+  }
+
+  @Override
+  public Integer getRepetitions() {
+    return repetitions;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.WaitStateDetails.WaitStateType;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
+import io.camunda.search.entities.WaitStateTimerDetails;
 import io.camunda.search.entities.WaitStateUserTaskDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +60,7 @@ public class WaitStateEntityMapper {
         case JOB -> OBJECT_MAPPER.readValue(detailsJson, WaitStateJobDetails.class);
         case MESSAGE -> OBJECT_MAPPER.readValue(detailsJson, WaitStateMessageDetails.class);
         case USER_TASK -> OBJECT_MAPPER.readValue(detailsJson, WaitStateUserTaskDetails.class);
+        case TIMER -> OBJECT_MAPPER.readValue(detailsJson, WaitStateTimerDetails.class);
       };
     } catch (final Exception e) {
       LOG.warn("Failed to parse wait state details for type {}: {}", waitStateType, e.getMessage());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -16,7 +16,6 @@ import static java.util.Objects.requireNonNullElse;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
-import io.camunda.gateway.mapping.http.util.KeyUtil;
 import io.camunda.gateway.protocol.model.AgentInstanceDefinition;
 import io.camunda.gateway.protocol.model.AgentInstanceLimits;
 import io.camunda.gateway.protocol.model.AgentInstanceMetrics;
@@ -36,6 +35,7 @@ import io.camunda.gateway.protocol.model.AuthorizationSearchResult;
 import io.camunda.gateway.protocol.model.BatchOperationError;
 import io.camunda.gateway.protocol.model.BatchOperationError.TypeEnum;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse;
+import io.camunda.gateway.protocol.model.BatchOperationItemResponse.StateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationItemSearchQueryResult;
 import io.camunda.gateway.protocol.model.BatchOperationResponse;
 import io.camunda.gateway.protocol.model.BatchOperationSearchQueryResult;
@@ -146,8 +146,10 @@ import io.camunda.gateway.protocol.model.TenantResult;
 import io.camunda.gateway.protocol.model.TenantSearchQueryResult;
 import io.camunda.gateway.protocol.model.TenantUserResult;
 import io.camunda.gateway.protocol.model.TenantUserSearchResult;
+import io.camunda.gateway.protocol.model.TimerWaitStateDetails;
 import io.camunda.gateway.protocol.model.UsageMetricsResponse;
 import io.camunda.gateway.protocol.model.UsageMetricsResponseItem;
+import io.camunda.gateway.protocol.model.UsageMetricsResponseItem.Builder;
 import io.camunda.gateway.protocol.model.UserResult;
 import io.camunda.gateway.protocol.model.UserSearchResult;
 import io.camunda.gateway.protocol.model.UserTaskResult;
@@ -166,6 +168,7 @@ import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationErrorEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
@@ -197,6 +200,7 @@ import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEnti
 import io.camunda.search.entities.ProcessDefinitionMessageSubscriptionStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.RoleMemberEntity;
 import io.camunda.search.entities.SequenceFlowEntity;
@@ -212,6 +216,7 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
+import io.camunda.search.entities.WaitStateTimerDetails;
 import io.camunda.search.entities.WaitStateUserTaskDetails;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.authz.PermissionType;
@@ -258,7 +263,7 @@ public final class SearchQueryResponseMapper {
                       key -> {
                         final UsageMetricStatisticsEntityTenant stats = tenants1.get(key);
                         final UsageMetricTUStatisticsEntityTenant tuStats = tenants2.get(key);
-                        return UsageMetricsResponseItem.Builder.create()
+                        return Builder.create()
                             .processInstances(stats != null ? stats.rpi() : 0L)
                             .decisionInstances(stats != null ? stats.edi() : 0L)
                             .assignees(tuStats != null ? tuStats.tu() : 0L)
@@ -715,6 +720,14 @@ public final class SearchQueryResponseMapper {
                       .dueDate(dueDate == null || dueDate.isBlank() ? null : dueDate)
                       .build())
               .build();
+      case WaitStateTimerDetails(final var dueDate, final var repetitions) ->
+          base.details(
+                  TimerWaitStateDetails.Builder.create()
+                      .waitStateType(WaitStateTypeEnum.TIMER.name())
+                      .dueDate(dueDate)
+                      .repetitions(repetitions)
+                      .build())
+              .build();
     };
   }
 
@@ -897,9 +910,7 @@ public final class SearchQueryResponseMapper {
         .processDefinitionVersionTag(p.processDefinitionVersionTag())
         .startDate(requireNonNullElse(formatDateOrNull(p.startDate()), EPOCH_DATE_SENTINEL))
         .endDate(formatDateOrNull(p.endDate()))
-        .state(
-            toProtocolState(
-                requireNonNullElse(p.state(), ProcessInstanceEntity.ProcessInstanceState.ACTIVE)))
+        .state(toProtocolState(requireNonNullElse(p.state(), ProcessInstanceState.ACTIVE)))
         .hasIncident(Boolean.TRUE.equals(p.hasIncident()))
         .tenantId(p.tenantId())
         .processInstanceKey(keyToString(p.processInstanceKey()))
@@ -978,7 +989,7 @@ public final class SearchQueryResponseMapper {
         // `processInstanceKey` is null for batch-op targets that are not process instances (e.g.
         // DELETE_DECISION_INSTANCE, DELETE_DECISION_DEFINITION). Spec declares it nullable.
         .processInstanceKey(keyToStringOrNull(entity.processInstanceKey()))
-        .state(BatchOperationItemResponse.StateEnum.fromValue(entity.state().name()))
+        .state(StateEnum.fromValue(entity.state().name()))
         .build();
   }
 
@@ -1556,7 +1567,7 @@ public final class SearchQueryResponseMapper {
           case TENANT -> ClusterVariableScopeEnum.TENANT;
         };
     final String tenantId =
-        clusterVariableEntity.scope() == io.camunda.search.entities.ClusterVariableScope.TENANT
+        clusterVariableEntity.scope() == ClusterVariableScope.TENANT
             ? clusterVariableEntity.tenantId()
             : null;
     return ClusterVariableSearchResult.Builder.create()
@@ -1582,7 +1593,7 @@ public final class SearchQueryResponseMapper {
           case TENANT -> ClusterVariableScopeEnum.TENANT;
         };
     final String tenantId =
-        clusterVariableEntity.scope() == io.camunda.search.entities.ClusterVariableScope.TENANT
+        clusterVariableEntity.scope() == ClusterVariableScope.TENANT
             ? clusterVariableEntity.tenantId()
             : null;
     return ClusterVariableResult.Builder.create()
@@ -1695,9 +1706,8 @@ public final class SearchQueryResponseMapper {
         .build();
   }
 
-  private static ProcessInstanceStateEnum toProtocolState(
-      final ProcessInstanceEntity.ProcessInstanceState value) {
-    if (value == ProcessInstanceEntity.ProcessInstanceState.CANCELED) {
+  private static ProcessInstanceStateEnum toProtocolState(final ProcessInstanceState value) {
+    if (value == ProcessInstanceState.CANCELED) {
       return ProcessInstanceStateEnum.TERMINATED;
     }
     return ProcessInstanceStateEnum.fromValue(value.name());
@@ -1976,7 +1986,7 @@ public final class SearchQueryResponseMapper {
         .versionTag(entity.versionTag())
         .resourceId(entity.resourceId())
         .tenantId(entity.tenantId())
-        .resourceKey(KeyUtil.keyToString(entity.resourceKey()))
+        .resourceKey(keyToString(entity.resourceKey()))
         .build();
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -41,6 +41,7 @@ import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.filter.UserTaskFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.page.CursorForwardPage;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
 import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.client.api.search.response.Job;
 import io.camunda.client.api.search.response.ProcessInstance;
@@ -2121,5 +2122,16 @@ public final class TestHelper {
         "should wait until audit log entries are available",
         expectedEntries,
         page -> camundaClient.newAuditLogSearchRequest().filter(filter).page(page).execute());
+  }
+
+  public static void waitForWaitStates(final CamundaClient camundaClient, final int expectedCount) {
+    Awaitility.await("should export %d wait states".formatted(expectedCount))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final List<ElementInstanceWaitStateResult> items =
+                  camundaClient.newElementInstanceWaitStateSearchRequest().send().join().items();
+              assertThat(items).hasSize(expectedCount);
+            });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateTimerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateTimerIT.java
@@ -7,26 +7,41 @@
  */
 package io.camunda.it.waitstate;
 
+import static io.camunda.it.util.TestHelper.cancelInstance;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.search.enums.WaitStateElementType;
 import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
 import io.camunda.client.api.search.response.TimerWaitStateDetails;
-import io.camunda.it.util.TestHelper;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator.AddTimeRequest;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies that only intermediate catch event timers are exported as TIMER wait states. Boundary
- * timers are excluded by the transformer.
+ * Verifies timer wait-state export: only intermediate catch event timers are tracked, boundary
+ * timers and timer start events are excluded, migration updates the stored element id, and the
+ * wait-state entry is removed when a timer fires.
  */
 @MultiDbTest
 public class WaitStateTimerIT {
+
+  @MultiDbTestApplication
+  static final TestCamundaApplication CAMUNDA =
+      new TestCamundaApplication().withProperty("zeebe.clock.controlled", "true");
 
   private static CamundaClient camundaClient;
 
@@ -55,21 +70,24 @@ public class WaitStateTimerIT {
 
     deployProcessAndWaitForIt(camundaClient, process, "waitStateTimerProcess.bpmn");
 
-    final long pik =
-        startProcessInstance(camundaClient, "waitStateTimerProcess").getProcessInstanceKey();
+    final var instance = startProcessInstance(camundaClient, "waitStateTimerProcess");
+    final long pik = instance.getProcessInstanceKey();
 
-    TestHelper.waitForWaitStates(camundaClient, 2);
+    // when — wait for exactly one TIMER wait state for this instance
+    // when / then — verify all fields of the single TIMER wait state
+    final List<ElementInstanceWaitStateResult> items =
+        Awaitility.await("exactly one TIMER wait state should appear for the ICE")
+            .atMost(TIMEOUT_DATA_AVAILABILITY)
+            .until(
+                () ->
+                    camundaClient
+                        .newElementInstanceWaitStateSearchRequest()
+                        .filter(f -> f.processInstanceKey(pik).waitStateType(WaitStateType.TIMER))
+                        .send()
+                        .join()
+                        .items(),
+                list -> list.size() == 1);
 
-    // when
-    final var items =
-        camundaClient
-            .newElementInstanceWaitStateSearchRequest()
-            .filter(f -> f.processInstanceKey(pik).waitStateType(WaitStateType.TIMER))
-            .send()
-            .join()
-            .items();
-
-    assertThat(items).hasSize(1);
     final var item = items.getFirst();
 
     assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.TIMER);
@@ -84,5 +102,309 @@ public class WaitStateTimerIT {
     assertThat(details.getWaitStateType()).isEqualTo(WaitStateType.TIMER);
     assertThat(details.getDueDate()).isPositive();
     assertThat(details.getRepetitions()).isEqualTo(1); // single-fire timer has 1 remaining
+
+    // cleanup
+    cancelInstance(camundaClient, instance);
+  }
+
+  @Test
+  void shouldNotTrackTimerStartEventSubscriptions() {
+    // given — a process whose only timer is the start event; timer subscriptions with
+    //   processInstanceKey == -1 must never produce a wait-state entry
+    final BpmnModelInstance timerStartProcess =
+        Bpmn.createExecutableProcess("timerStartOnlyProcess")
+            .startEvent("timer-start")
+            .timerWithDuration("PT1H")
+            .endEvent()
+            .done();
+
+    // Deploy a second process with an ICE to generate known export traffic so we can verify
+    // the exporter has processed the timer subscription records before asserting.
+    final BpmnModelInstance iceProcess =
+        Bpmn.createExecutableProcess("timerStartTrafficProcess")
+            .startEvent()
+            .intermediateCatchEvent("ice-marker", e -> e.timerWithDuration("PT1H"))
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, timerStartProcess, "timerStartOnlyProcess.bpmn");
+    deployProcessAndWaitForIt(camundaClient, iceProcess, "timerStartTrafficProcess.bpmn");
+
+    final var trafficInstance = startProcessInstance(camundaClient, "timerStartTrafficProcess");
+    final long pik = trafficInstance.getProcessInstanceKey();
+
+    // when — wait for the ICE wait state; this proves the exporter has caught up on all
+    //   timer records, including the start-event subscription for timerStartOnlyProcess
+    Awaitility.await("ICE wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(
+                                f -> f.processInstanceKey(pik).waitStateType(WaitStateType.TIMER))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // then — ALL timer wait states in the system must have a positive processInstanceKey;
+    //   timer start-event subscriptions (processInstanceKey == -1) must not appear
+    final var allTimerWaitStates =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.waitStateType(WaitStateType.TIMER))
+            .send()
+            .join()
+            .items();
+
+    assertThat(allTimerWaitStates)
+        .hasSize(1)
+        .allSatisfy(ws -> assertThat(Long.parseLong(ws.getProcessInstanceKey())).isPositive());
+
+    // cleanup
+    cancelInstance(camundaClient, trafficInstance);
+  }
+
+  @Test
+  void shouldUpdateWaitStateWhenTimerElementIsMigrated() {
+    // given — V1 has ICE "ice-v1", V2 has ICE "ice-v2" at the same position
+    final BpmnModelInstance v1 =
+        Bpmn.createExecutableProcess("timerMigrationV1")
+            .startEvent()
+            .intermediateCatchEvent("ice-v1", e -> e.timerWithDuration("PT1H"))
+            .endEvent()
+            .done();
+    final BpmnModelInstance v2 =
+        Bpmn.createExecutableProcess("timerMigrationV2")
+            .startEvent()
+            .intermediateCatchEvent("ice-v2", e -> e.timerWithDuration("PT1H"))
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, v1, "timerMigrationV1.bpmn");
+    final long v2Key =
+        deployProcessAndWaitForIt(camundaClient, v2, "timerMigrationV2.bpmn")
+            .getProcessDefinitionKey();
+
+    final var instance = startProcessInstance(camundaClient, "timerMigrationV1");
+    final long pik = instance.getProcessInstanceKey();
+
+    Awaitility.await("wait state with ice-v1 should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("ice-v1")));
+
+    // when — migrate the process instance, remapping ice-v1 → ice-v2
+    camundaClient
+        .newMigrateProcessInstanceCommand(pik)
+        .migrationPlan(
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(v2Key)
+                .addMappingInstruction("ice-v1", "ice-v2")
+                .build())
+        .send()
+        .join();
+
+    // then — wait state is updated to reflect the new element id
+    Awaitility.await("wait state should be updated to ice-v2")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("ice-v2")));
+
+    // cleanup — cancelInstance also waits for process termination
+    cancelInstance(camundaClient, instance);
+    Awaitility.await("wait state should be removed after cancellation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldReplaceWaitStateWhenFirstOfTwoSequentialTimersFires() {
+    // given — two sequential ICE timers; when the first fires, the wait state for it must be
+    //   removed and a new one for the second timer must appear (ICE timers do not support
+    //   timeCycle — the "remove old / add new" lifecycle is verified via sequential timers)
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("timerSequentialProcess")
+            .startEvent()
+            .intermediateCatchEvent("ice-first", e -> e.timerWithDuration("PT5S"))
+            .intermediateCatchEvent("ice-second", e -> e.timerWithDuration("PT1H"))
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, process, "timerSequentialProcess.bpmn");
+
+    final var instance = startProcessInstance(camundaClient, "timerSequentialProcess");
+    final long pik = instance.getProcessInstanceKey();
+
+    // wait for the first timer wait state
+    Awaitility.await("wait state for ice-first should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("ice-first")));
+
+    // when — advance clock past the 5 s duration so the first timer fires
+    ActorClockActuator.of(CAMUNDA.actuatorUri("clock").toString())
+        .addTime(new AddTimeRequest(Duration.ofSeconds(10).toMillis()));
+
+    // then — wait state for ice-first is removed; wait state for ice-second appears
+    Awaitility.await("wait state should transition from ice-first to ice-second")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("ice-second")));
+
+    // cleanup
+    cancelInstance(camundaClient, instance);
+    Awaitility.await("wait state for ice-second should be removed after cancellation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldRemoveWaitStateWhenProcessInstanceIsCancelled() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("timerCancelProcess")
+            .startEvent()
+            .intermediateCatchEvent("ice-cancel", e -> e.timerWithDuration("PT1H"))
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, process, "timerCancelProcess.bpmn");
+
+    final var instance = startProcessInstance(camundaClient, "timerCancelProcess");
+    final long pik = instance.getProcessInstanceKey();
+
+    Awaitility.await("TIMER wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when — cancel the process instance; the TIMER_CANCELED record must remove the wait state
+    cancelInstance(camundaClient, instance);
+
+    // then
+    Awaitility.await("TIMER wait state should be removed after cancellation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldRemoveWaitStateWhenSingleFireTimerFires() {
+    // given — an ICE with a single-fire 5 s timer
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("timerSingleFireProcess")
+            .startEvent()
+            .intermediateCatchEvent("single-ice", e -> e.timerWithDuration("PT5S"))
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, process, "timerSingleFireProcess.bpmn");
+
+    final var instance = startProcessInstance(camundaClient, "timerSingleFireProcess");
+    final long pik = instance.getProcessInstanceKey();
+
+    Awaitility.await("TIMER wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when — advance clock past the 5 s duration; timer fires, process completes
+    ActorClockActuator.of(CAMUNDA.actuatorUri("clock").toString())
+        .addTime(new AddTimeRequest(Duration.ofSeconds(10).toMillis()));
+
+    // then — wait state is removed once the timer is triggered
+    Awaitility.await("TIMER wait state should be removed after timer fires")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateTimerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateTimerIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.waitstate;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.TimerWaitStateDetails;
+import io.camunda.it.util.TestHelper;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that only intermediate catch event timers are exported as TIMER wait states. Boundary
+ * timers are excluded by the transformer.
+ */
+@MultiDbTest
+public class WaitStateTimerIT {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldExportOnlyIntermediateCatchEventTimerAndNotBoundaryTimer() {
+    // given — a process with two concurrent timer branches:
+    //   branch 1: intermediate catch event timer (should be exported as a wait state)
+    //   branch 2: service task with a boundary timer (boundary should NOT be exported)
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateTimerProcess")
+            .startEvent()
+            .parallelGateway("fork")
+            .intermediateCatchEvent("ice-timer", e -> e.timerWithDuration("PT1H"))
+            .parallelGateway("join")
+            .moveToLastGateway()
+            .serviceTask("svc-task")
+            .zeebeJobType("svc")
+            .connectTo("join")
+            .endEvent()
+            // boundary
+            .moveToActivity("svc-task")
+            .boundaryEvent("boundary-timer")
+            .timerWithDuration("PT1H")
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateTimerProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateTimerProcess").getProcessInstanceKey();
+
+    TestHelper.waitForWaitStates(camundaClient, 2);
+
+    // when
+    final var items =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.processInstanceKey(pik).waitStateType(WaitStateType.TIMER))
+            .send()
+            .join()
+            .items();
+
+    assertThat(items).hasSize(1);
+    final var item = items.getFirst();
+
+    assertThat(item.getWaitStateType()).isEqualTo(WaitStateType.TIMER);
+    assertThat(item.getElementType()).isEqualTo(WaitStateElementType.INTERMEDIATE_CATCH_EVENT);
+    assertThat(item.getElementId()).isEqualTo("ice-timer");
+    assertThat(item.getProcessInstanceKey()).isEqualTo(String.valueOf(pik));
+    assertThat(item.getRootProcessInstanceKey()).isEqualTo(String.valueOf(pik));
+    assertThat(item.getBpmnProcessId()).isEqualTo("waitStateTimerProcess");
+
+    assertThat(item.getDetails()).isInstanceOf(TimerWaitStateDetails.class);
+    final var details = (TimerWaitStateDetails) item.getDetails();
+    assertThat(details.getWaitStateType()).isEqualTo(WaitStateType.TIMER);
+    assertThat(details.getDueDate()).isPositive();
+    assertThat(details.getRepetitions()).isEqualTo(1); // single-fire timer has 1 remaining
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.WaitStateDetails.WaitStateType;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
+import io.camunda.search.entities.WaitStateTimerDetails;
 import io.camunda.search.entities.WaitStateUserTaskDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,6 +62,7 @@ public class WaitStateEntityTransformer
         case JOB -> OBJECT_MAPPER.readValue(detailsJson, WaitStateJobDetails.class);
         case MESSAGE -> OBJECT_MAPPER.readValue(detailsJson, WaitStateMessageDetails.class);
         case USER_TASK -> OBJECT_MAPPER.readValue(detailsJson, WaitStateUserTaskDetails.class);
+        case TIMER -> OBJECT_MAPPER.readValue(detailsJson, WaitStateTimerDetails.class);
       };
     } catch (final Exception e) {
       LOG.warn("Failed to parse wait state details for type {}: {}", waitStateType, e.getMessage());

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateDetails.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateDetails.java
@@ -8,13 +8,17 @@
 package io.camunda.search.entities;
 
 public sealed interface WaitStateDetails
-    permits WaitStateJobDetails, WaitStateMessageDetails, WaitStateUserTaskDetails {
+    permits WaitStateJobDetails,
+        WaitStateMessageDetails,
+        WaitStateUserTaskDetails,
+        WaitStateTimerDetails {
 
   WaitStateType waitStateType();
 
   enum WaitStateType {
     JOB,
     MESSAGE,
-    USER_TASK
+    USER_TASK,
+    TIMER
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateTimerDetails.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateTimerDetails.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.util.ObjectBuilder;
+import org.jspecify.annotations.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WaitStateTimerDetails(@Nullable Long dueDate, @Nullable Integer repetitions)
+    implements WaitStateDetails {
+
+  @Override
+  public WaitStateDetails.WaitStateType waitStateType() {
+    return WaitStateDetails.WaitStateType.TIMER;
+  }
+
+  public static class Builder implements ObjectBuilder<WaitStateTimerDetails> {
+    private @Nullable Long dueDate;
+    private @Nullable Integer repetitions;
+
+    public Builder dueDate(final @Nullable Long dueDate) {
+      this.dueDate = dueDate;
+      return this;
+    }
+
+    public Builder repetitions(final @Nullable Integer repetitions) {
+      this.repetitions = repetitions;
+      return this;
+    }
+
+    @Override
+    public WaitStateTimerDetails build() {
+      return new WaitStateTimerDetails(dueDate, repetitions);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -441,6 +441,9 @@ public final class CatchEventBehavior {
                   context.getProcessDefinitionKey(),
                   event.getId(),
                   context.getTenantId(),
+                  context.getRootProcessInstanceKey(),
+                  BufferUtil.bufferAsString(context.getBpmnProcessId()),
+                  context.getBpmnElementType(),
                   timer);
             });
   }
@@ -451,6 +454,9 @@ public final class CatchEventBehavior {
       final long processDefinitionKey,
       final DirectBuffer handlerNodeId,
       final String tenantId,
+      final long rootProcessInstanceKey,
+      final String bpmnProcessId,
+      final BpmnElementType elementType,
       final Timer timer) {
     final long dueDate = timer.getDueDate(clock.millis());
     timerRecord.reset();
@@ -461,7 +467,10 @@ public final class CatchEventBehavior {
         .setProcessInstanceKey(processInstanceKey)
         .setTargetElementId(handlerNodeId)
         .setProcessDefinitionKey(processDefinitionKey)
-        .setTenantId(tenantId);
+        .setTenantId(tenantId)
+        .setRootProcessInstanceKey(rootProcessInstanceKey)
+        .setBpmnProcessId(bpmnProcessId)
+        .setElementType(elementType);
 
     sideEffectWriter.appendSideEffect(
         () -> {
@@ -606,7 +615,10 @@ public final class CatchEventBehavior {
         .setRepetitions(timer.getRepetitions())
         .setTargetElementId(timer.getHandlerNodeId())
         .setProcessDefinitionKey(timer.getProcessDefinitionKey())
-        .setTenantId(timer.getTenantId());
+        .setTenantId(timer.getTenantId())
+        .setRootProcessInstanceKey(timer.getRootProcessInstanceKey())
+        .setBpmnProcessId(timer.getBpmnProcessId())
+        .setElementType(timer.getElementType());
 
     stateWriter.appendFollowUpEvent(timer.getKey(), TimerIntent.CANCELED, timerRecord);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -59,6 +59,7 @@ import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -384,6 +385,9 @@ public final class DeploymentCreateProcessor
             processMetadata.getKey(),
             startEvent.getId(),
             processMetadata.getTenantId(),
+            NO_ELEMENT_INSTANCE,
+            processMetadata.getBpmnProcessId(),
+            BpmnElementType.START_EVENT,
             timerOrError.get());
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehavior.java
@@ -332,6 +332,7 @@ public class ProcessInstanceMigrationCatchEventBehavior {
           timerRecord.setTenantId(timerInstance.getTenantId());
           timerRecord.setRootProcessInstanceKey(timerInstance.getRootProcessInstanceKey());
           timerRecord.setBpmnProcessId(timerInstance.getBpmnProcessId());
+          timerRecord.setElementType(timerInstance.getElementType());
 
           stateWriter.appendFollowUpEvent(
               timerInstance.getKey(), TimerIntent.MIGRATED, timerRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehavior.java
@@ -330,6 +330,8 @@ public class ProcessInstanceMigrationCatchEventBehavior {
           timerRecord.setRepetitions(timerInstance.getRepetitions());
           timerRecord.setProcessDefinitionKey(targetProcessDefinition.getKey());
           timerRecord.setTenantId(timerInstance.getTenantId());
+          timerRecord.setRootProcessInstanceKey(timerInstance.getRootProcessInstanceKey());
+          timerRecord.setBpmnProcessId(timerInstance.getBpmnProcessId());
 
           stateWriter.appendFollowUpEvent(
               timerInstance.getKey(), TimerIntent.MIGRATED, timerRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/StartEventSubscriptions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/StartEventSubscriptions.java
@@ -17,7 +17,9 @@ import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManag
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public final class StartEventSubscriptions {
 
@@ -63,6 +65,9 @@ public final class StartEventSubscriptions {
                     deployedProcess.getKey(),
                     timerStartEvent.getId(),
                     deployedProcess.getTenantId(),
+                    NO_ELEMENT_INSTANCE,
+                    BufferUtil.bufferAsString(deployedProcess.getBpmnProcessId()),
+                    BpmnElementType.START_EVENT,
                     failureOrTimer.get());
               });
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckScheduler.java
@@ -125,7 +125,10 @@ public class DueDateTimerCheckScheduler implements StreamProcessorLifecycleAware
           .setTargetElementId(timer.getHandlerNodeId())
           .setRepetitions(timer.getRepetitions())
           .setProcessDefinitionKey(timer.getProcessDefinitionKey())
-          .setTenantId(timer.getTenantId());
+          .setTenantId(timer.getTenantId())
+          .setRootProcessInstanceKey(timer.getRootProcessInstanceKey())
+          .setBpmnProcessId(timer.getBpmnProcessId())
+          .setElementType(timer.getElementType());
 
       return taskResultBuilder.appendCommandRecord(
           timer.getKey(), TimerIntent.TRIGGER, timerRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
@@ -171,6 +171,9 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
         record.getProcessDefinitionKey(),
         event.getId(),
         record.getTenantId(),
+        record.getRootProcessInstanceKey(),
+        record.getBpmnProcessId(),
+        record.getElementType(),
         refreshedTimer);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -249,6 +249,7 @@ public final class EventAppliers implements EventApplier {
 
   private void registerTimeEventAppliers(final MutableProcessingState state) {
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
+    register(TimerIntent.CREATED, 2, new TimerCreatedV2Applier(state.getTimerState()));
     register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
     register(TimerIntent.TRIGGERED, new TimerTriggeredApplier(state.getTimerState()));
     register(TimerIntent.MIGRATED, new TimerInstanceMigratedApplier(state.getTimerState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerCreatedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerCreatedV2Applier.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.instance.TimerInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+
+final class TimerCreatedV2Applier implements TypedEventApplier<TimerIntent, TimerRecord> {
+
+  private final MutableTimerInstanceState timerInstanceState;
+  private final TimerInstance timerInstance = new TimerInstance();
+
+  TimerCreatedV2Applier(final MutableTimerInstanceState timerInstanceState) {
+    this.timerInstanceState = timerInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final TimerRecord value) {
+    timerInstance.setElementInstanceKey(value.getElementInstanceKey());
+    timerInstance.setDueDate(value.getDueDate());
+    timerInstance.setKey(key);
+    timerInstance.setHandlerNodeId(value.getTargetElementIdBuffer());
+    timerInstance.setRepetitions(value.getRepetitions());
+    timerInstance.setProcessDefinitionKey(value.getProcessDefinitionKey());
+    timerInstance.setProcessInstanceKey(value.getProcessInstanceKey());
+    timerInstance.setTenantId(value.getTenantId());
+    timerInstance.setRootProcessInstanceKey(value.getRootProcessInstanceKey());
+    timerInstance.setBpmnProcessId(value.getBpmnProcessId());
+    timerInstance.setElementType(value.getElementType());
+
+    timerInstanceState.store(timerInstance);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TimerInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TimerInstance.java
@@ -11,9 +11,12 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -32,9 +35,15 @@ public final class TimerInstance extends UnpackedObject implements DbValue, Tena
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty dueDateProp = new LongProperty("dueDate", 0L);
   private final IntegerProperty repetitionsProp = new IntegerProperty("repetitions", 0);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty("rootProcessInstanceKey", NO_ELEMENT_INSTANCE);
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final EnumProperty<BpmnElementType> elementTypeProp =
+      new EnumProperty<>(
+          new StringValue("elementType"), BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public TimerInstance() {
-    super(8);
+    super(11);
     declareProperty(handlerNodeIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(keyProp)
@@ -42,7 +51,10 @@ public final class TimerInstance extends UnpackedObject implements DbValue, Tena
         .declareProperty(processInstanceKeyProp)
         .declareProperty(dueDateProp)
         .declareProperty(repetitionsProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(elementTypeProp);
   }
 
   public long getElementInstanceKey() {
@@ -116,6 +128,33 @@ public final class TimerInstance extends UnpackedObject implements DbValue, Tena
 
   public TimerInstance setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public TimerInstance setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public TimerInstance setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public TimerInstance setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
     return this;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
@@ -54,6 +54,7 @@ class DueDateTimerCheckSchedulerTest {
       final var timerKey = 42L;
       when(mockTimer.getKey()).thenReturn(timerKey);
       when(mockTimer.getTenantId()).thenReturn(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      when(mockTimer.getBpmnProcessId()).thenReturn("bpmnProcessId");
 
       final var testActorClock = new TestActorClock();
 
@@ -96,6 +97,7 @@ class DueDateTimerCheckSchedulerTest {
       final var timerKey = 42L;
       when(mockTimer.getKey()).thenReturn(timerKey);
       when(mockTimer.getTenantId()).thenReturn(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      when(mockTimer.getBpmnProcessId()).thenReturn("bpmnProcessId");
 
       final var testActorClock = new TestActorClock();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState.TimerVisitor;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Instant;
@@ -55,6 +56,7 @@ class DueDateTimerCheckSchedulerTest {
       when(mockTimer.getKey()).thenReturn(timerKey);
       when(mockTimer.getTenantId()).thenReturn(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
       when(mockTimer.getBpmnProcessId()).thenReturn("bpmnProcessId");
+      when(mockTimer.getElementType()).thenReturn(BpmnElementType.INTERMEDIATE_CATCH_EVENT);
 
       final var testActorClock = new TestActorClock();
 
@@ -98,6 +100,7 @@ class DueDateTimerCheckSchedulerTest {
       when(mockTimer.getKey()).thenReturn(timerKey);
       when(mockTimer.getTenantId()).thenReturn(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
       when(mockTimer.getBpmnProcessId()).thenReturn("bpmnProcessId");
+      when(mockTimer.getElementType()).thenReturn(BpmnElementType.INTERMEDIATE_CATCH_EVENT);
 
       final var testActorClock = new TestActorClock();
 

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Timer_CREATED_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Timer_CREATED_v2.golden
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.instance.TimerInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+
+final class TimerCreatedV2Applier implements TypedEventApplier<TimerIntent, TimerRecord> {
+
+  private final MutableTimerInstanceState timerInstanceState;
+  private final TimerInstance timerInstance = new TimerInstance();
+
+  TimerCreatedV2Applier(final MutableTimerInstanceState timerInstanceState) {
+    this.timerInstanceState = timerInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final TimerRecord value) {
+    timerInstance.setElementInstanceKey(value.getElementInstanceKey());
+    timerInstance.setDueDate(value.getDueDate());
+    timerInstance.setKey(key);
+    timerInstance.setHandlerNodeId(value.getTargetElementIdBuffer());
+    timerInstance.setRepetitions(value.getRepetitions());
+    timerInstance.setProcessDefinitionKey(value.getProcessDefinitionKey());
+    timerInstance.setProcessInstanceKey(value.getProcessInstanceKey());
+    timerInstance.setTenantId(value.getTenantId());
+    timerInstance.setRootProcessInstanceKey(value.getRootProcessInstanceKey());
+    timerInstance.setBpmnProcessId(value.getBpmnProcessId());
+
+    timerInstanceState.store(timerInstance);
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Timer_CREATED_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Timer_CREATED_v2.golden
@@ -34,6 +34,7 @@ final class TimerCreatedV2Applier implements TypedEventApplier<TimerIntent, Time
     timerInstance.setTenantId(value.getTenantId());
     timerInstance.setRootProcessInstanceKey(value.getRootProcessInstanceKey());
     timerInstance.setBpmnProcessId(value.getBpmnProcessId());
+    timerInstance.setElementType(value.getElementType());
 
     timerInstanceState.store(timerInstance);
   }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.common.waitstate;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
 /**
@@ -34,6 +35,13 @@ public final class WaitStateConfigs {
           .withUpdateIntents(UserTaskIntent.MIGRATED, UserTaskIntent.UPDATED)
           .withRemoveIntents(UserTaskIntent.COMPLETED, UserTaskIntent.CANCELED)
           .withWaitStateType(WaitStateType.USER_TASK);
+
+  public static final WaitStateTransformerConfig TIMER_CONFIG =
+      WaitStateTransformerConfig.of(ValueType.TIMER)
+          .withAddIntents(TimerIntent.CREATED)
+          .withUpdateIntents(TimerIntent.MIGRATED)
+          .withRemoveIntents(TimerIntent.TRIGGERED, TimerIntent.CANCELED)
+          .withWaitStateType(WaitStateType.TIMER);
 
   private WaitStateConfigs() {}
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/TimerBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/TimerBasedWaitStateTransformer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import static io.camunda.zeebe.exporter.common.waitstate.WaitStateConfigs.TIMER_CONFIG;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformerConfig;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
+
+/**
+ * Transforms timer records into wait-state entries. Only intermediate catch event timers are
+ * exported. Records are skipped when:
+ *
+ * <ul>
+ *   <li>processInstanceKey is -1 (timer start event subscriptions — no process instance context)
+ *   <li>rootProcessInstanceKey is -1 or bpmnProcessId is empty (pre-8.10 V1 records written before
+ *       these fields existed — exporting partial data would be misleading)
+ *   <li>elementType is not INTERMEDIATE_CATCH_EVENT (boundary events are not tracked as wait states
+ *       because they represent interrupts, not explicit waits)
+ * </ul>
+ */
+public class TimerBasedWaitStateTransformer implements WaitStateTransformer<TimerRecordValue> {
+
+  @Override
+  public WaitStateTransformerConfig config() {
+    return TIMER_CONFIG;
+  }
+
+  @Override
+  public void extract(final Record<TimerRecordValue> record, final WaitStateEntry entry) {
+    final TimerRecordValue value = record.getValue();
+    entry
+        .setElementType(value.getElementType())
+        .setDetails(new TimerWaitStateDetails(value.getDueDate(), value.getRepetitions()));
+  }
+
+  @Override
+  public boolean triggersAdd(final Record<TimerRecordValue> record) {
+    return isProcessInstanceTimer(record) && WaitStateTransformer.super.triggersAdd(record);
+  }
+
+  @Override
+  public boolean triggersUpdate(final Record<TimerRecordValue> record) {
+    return isProcessInstanceTimer(record) && WaitStateTransformer.super.triggersUpdate(record);
+  }
+
+  @Override
+  public boolean triggersRemoval(final Record<TimerRecordValue> record) {
+    return isProcessInstanceTimer(record) && WaitStateTransformer.super.triggersRemoval(record);
+  }
+
+  private static boolean isProcessInstanceTimer(final Record<TimerRecordValue> record) {
+    final TimerRecordValue value = record.getValue();
+    return value.getProcessInstanceKey() != -1L
+        && value.getRootProcessInstanceKey() != -1L
+        && !value.getBpmnProcessId().isEmpty()
+        && value.getElementType() == BpmnElementType.INTERMEDIATE_CATCH_EVENT;
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/TimerWaitStateDetails.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/TimerWaitStateDetails.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
+
+public record TimerWaitStateDetails(long dueDate, int repetitions) implements WaitStateDetails {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
@@ -24,7 +24,10 @@ public final class WaitStateTransformerRegistry {
    */
   public static List<Supplier<WaitStateTransformer<?>>>
       getAllPartitionWaitStateTransformerSuppliers() {
-    return List.of(JobBasedWaitStateTransformer::new, UserTaskBasedWaitStateTransformer::new);
+    return List.of(
+        JobBasedWaitStateTransformer::new,
+        UserTaskBasedWaitStateTransformer::new,
+        TimerBasedWaitStateTransformer::new);
   }
 
   /**

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/TimerBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/TimerBasedWaitStateTransformerTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableTimerRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class TimerBasedWaitStateTransformerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final TimerBasedWaitStateTransformer transformer = new TimerBasedWaitStateTransformer();
+
+  @Test
+  void shouldExtractDetailsFromTimerCreatedRecord() {
+    // given
+    final TimerRecordValue value =
+        ImmutableTimerRecordValue.builder()
+            .from(factory.generateObject(TimerRecordValue.class))
+            .withRootProcessInstanceKey(100L)
+            .withProcessInstanceKey(200L)
+            .withElementInstanceKey(300L)
+            .withTargetElementId("timer-catch")
+            .withBpmnProcessId("my-process")
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .withDueDate(1_000_000L)
+            .withRepetitions(2)
+            .withProcessDefinitionKey(42L)
+            .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .build();
+
+    final Record<TimerRecordValue> record =
+        factory.generateRecord(
+            ValueType.TIMER,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TimerIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then — identity fields from WaitStateRelated
+    assertThat(entry.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entry.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entry.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entry.getElementId()).isEqualTo("timer-catch");
+    assertThat(entry.getBpmnProcessId()).isEqualTo("my-process");
+    assertThat(entry.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(entry.getPartitionId()).isEqualTo(record.getPartitionId());
+
+    // then — classification
+    assertThat(entry.getWaitStateType()).isEqualTo(WaitStateType.TIMER);
+    assertThat(entry.getElementType()).isEqualTo(BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // then — timer-specific details
+    assertThat(entry.getDetails()).isInstanceOf(TimerWaitStateDetails.class);
+    final var details = (TimerWaitStateDetails) entry.getDetails();
+    assertThat(details.dueDate()).isEqualTo(1_000_000L);
+    assertThat(details.repetitions()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldRemoveOnTriggeredAndCanceled() {
+    // given
+    final TimerRecordValue value =
+        ImmutableTimerRecordValue.builder()
+            .from(factory.generateObject(TimerRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(200L)
+            .withBpmnProcessId("my-process")
+            .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .build();
+
+    final Record<TimerRecordValue> triggered =
+        factory.generateRecord(
+            ValueType.TIMER,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TimerIntent.TRIGGERED)
+                    .withValue(value));
+    final Record<TimerRecordValue> canceled =
+        factory.generateRecord(
+            ValueType.TIMER,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TimerIntent.CANCELED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersAdd(triggered)).isFalse();
+    assertThat(transformer.triggersUpdate(triggered)).isFalse();
+    assertThat(transformer.triggersRemoval(triggered)).isTrue();
+
+    assertThat(transformer.triggersAdd(canceled)).isFalse();
+    assertThat(transformer.triggersUpdate(canceled)).isFalse();
+    assertThat(transformer.triggersRemoval(canceled)).isTrue();
+  }
+
+  @Test
+  void shouldTriggerUpdateOnMigratedWithoutChangingTimerState() {
+    // given
+    final TimerRecordValue value =
+        ImmutableTimerRecordValue.builder()
+            .from(factory.generateObject(TimerRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(200L)
+            .withBpmnProcessId("my-process")
+            .withDueDate(2_000_000L)
+            .withRepetitions(1)
+            .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .build();
+
+    final Record<TimerRecordValue> migrated =
+        factory.generateRecord(
+            ValueType.TIMER,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TimerIntent.MIGRATED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersAdd(migrated)).isFalse();
+    assertThat(transformer.triggersUpdate(migrated)).isTrue();
+    assertThat(transformer.triggersRemoval(migrated)).isFalse();
+
+    final var details = (TimerWaitStateDetails) transformer.transform(migrated).getDetails();
+    assertThat(details.dueDate()).isEqualTo(2_000_000L);
+    assertThat(details.repetitions()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldSkipTimerStartEventSubscriptions() {
+    // given — processInstanceKey == -1L means this is a start-event subscription
+    final TimerRecordValue value =
+        ImmutableTimerRecordValue.builder()
+            .from(factory.generateObject(TimerRecordValue.class))
+            .withProcessInstanceKey(-1L)
+            .withRootProcessInstanceKey(-1L)
+            .withBpmnProcessId("my-process")
+            .build();
+
+    final Record<TimerRecordValue> created =
+        factory.generateRecord(
+            ValueType.TIMER,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TimerIntent.CREATED)
+                    .withValue(value));
+    final Record<TimerRecordValue> triggered =
+        factory.generateRecord(
+            ValueType.TIMER,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TimerIntent.TRIGGERED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersAdd(created)).isFalse();
+    assertThat(transformer.triggersUpdate(triggered)).isFalse();
+    assertThat(transformer.triggersRemoval(triggered)).isFalse();
+  }
+
+  @Test
+  void shouldSkipV1TimerRecordsMissingProcessContext() {
+    // given — V1 records from before 8.10 have rootProcessInstanceKey=-1 and bpmnProcessId=""
+    final TimerRecordValue value =
+        ImmutableTimerRecordValue.builder()
+            .from(factory.generateObject(TimerRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(-1L)
+            .withBpmnProcessId("")
+            .build();
+
+    final Record<TimerRecordValue> created =
+        factory.generateRecord(
+            ValueType.TIMER,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TimerIntent.CREATED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersAdd(created)).isFalse();
+    assertThat(transformer.triggersUpdate(created)).isFalse();
+    assertThat(transformer.triggersRemoval(created)).isFalse();
+  }
+
+  @Test
+  void shouldTriggerAddOnTimerCreatedForProcessInstance() {
+    // given
+    final TimerRecordValue value =
+        ImmutableTimerRecordValue.builder()
+            .from(factory.generateObject(TimerRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(200L)
+            .withBpmnProcessId("my-process")
+            .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .build();
+
+    final Record<TimerRecordValue> record =
+        factory.generateRecord(
+            ValueType.TIMER,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TimerIntent.CREATED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.supports(record)).isTrue();
+    assertThat(transformer.triggersAdd(record)).isTrue();
+    assertThat(transformer.triggersUpdate(record)).isFalse();
+    assertThat(transformer.triggersRemoval(record)).isFalse();
+  }
+
+  @Test
+  void shouldSkipBoundaryTimerEvents() {
+    // given — boundary events interrupt the host element, not a standalone wait state
+    final TimerRecordValue value =
+        ImmutableTimerRecordValue.builder()
+            .from(factory.generateObject(TimerRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(200L)
+            .withBpmnProcessId("my-process")
+            .withElementType(BpmnElementType.BOUNDARY_EVENT)
+            .build();
+
+    final Record<TimerRecordValue> created =
+        factory.generateRecord(
+            ValueType.TIMER,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TimerIntent.CREATED)
+                    .withValue(value));
+    final Record<TimerRecordValue> triggered =
+        factory.generateRecord(
+            ValueType.TIMER,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(TimerIntent.TRIGGERED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersAdd(created)).isFalse();
+    assertThat(transformer.triggersUpdate(created)).isFalse();
+    assertThat(transformer.triggersRemoval(created)).isFalse();
+    assertThat(transformer.triggersRemoval(triggered)).isFalse();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -37,6 +37,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_MESSAGE_SUBSCRI
 import static io.camunda.zeebe.protocol.record.ValueType.RESOURCE;
 import static io.camunda.zeebe.protocol.record.ValueType.ROLE;
 import static io.camunda.zeebe.protocol.record.ValueType.TENANT;
+import static io.camunda.zeebe.protocol.record.ValueType.TIMER;
 import static io.camunda.zeebe.protocol.record.ValueType.USAGE_METRIC;
 import static io.camunda.zeebe.protocol.record.ValueType.USER;
 import static io.camunda.zeebe.protocol.record.ValueType.USER_TASK;
@@ -421,7 +422,8 @@ public class CamundaExporter implements Exporter {
             JOB_METRICS_BATCH,
             GLOBAL_LISTENER,
             AGENT_INSTANCE,
-            AGENT_HISTORY);
+            AGENT_HISTORY,
+            TIMER);
 
     @Override
     public boolean acceptType(final RecordType recordType) {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-timer-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-timer-template.json
@@ -28,6 +28,9 @@
             "targetElementId": {
               "type": "keyword"
             },
+            "elementId": {
+              "type": "keyword"
+            },
             "repetitions": {
               "type": "integer"
             },
@@ -38,6 +41,15 @@
               "type": "long"
             },
             "tenantId": {
+              "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "elementType": {
               "type": "keyword"
             }
           }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-timer-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-timer-template.json
@@ -34,6 +34,9 @@
             "targetElementId": {
               "type": "keyword"
             },
+            "elementId": {
+              "type": "keyword"
+            },
             "repetitions": {
               "type": "integer"
             },
@@ -44,6 +47,15 @@
               "type": "long"
             },
             "tenantId": {
+              "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "elementType": {
               "type": "keyword"
             }
           }

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -847,10 +847,12 @@ components:
           JOB: '#/components/schemas/JobWaitStateDetails'
           MESSAGE: '#/components/schemas/MessageWaitStateDetails'
           USER_TASK: '#/components/schemas/UserTaskWaitStateDetails'
+          TIMER: '#/components/schemas/TimerWaitStateDetails'
       oneOf:
         - $ref: '#/components/schemas/JobWaitStateDetails'
         - $ref: '#/components/schemas/MessageWaitStateDetails'
         - $ref: '#/components/schemas/UserTaskWaitStateDetails'
+        - $ref: '#/components/schemas/TimerWaitStateDetails'
 
     WaitStateTypeEnum:
       description: The type of waiting state an element instance is in.
@@ -859,6 +861,7 @@ components:
         - JOB
         - MESSAGE
         - USER_TASK
+        - TIMER
 
     BaseWaitStateDetails:
       description: Common fields shared by all wait-state details variants.
@@ -939,6 +942,26 @@ components:
           nullable: true
           type: string
           format: date-time
+
+    TimerWaitStateDetails:
+      type: object
+      required:
+        - waitStateType
+        - dueDate
+        - repetitions
+      allOf:
+        - $ref: '#/components/schemas/BaseWaitStateDetails'
+      properties:
+        dueDate:
+          description: When the timer is due, as a UNIX epoch timestamp in milliseconds.
+          nullable: true
+          type: integer
+          format: int64
+        repetitions:
+          description: The number of remaining timer repetitions (-1 for infinite, 0 for non-repeating).
+          nullable: true
+          type: integer
+          format: int32
 
     AdHocSubProcessActivateActivityReference:
       type: object

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/timer/TimerRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/timer/TimerRecord.java
@@ -10,10 +10,13 @@ package io.camunda.zeebe.protocol.impl.record.value.timer;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -29,16 +32,25 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
   private final LongProperty processDefinitionKeyProp = new LongProperty("processDefinitionKey");
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty("rootProcessInstanceKey", -1L);
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final EnumProperty<BpmnElementType> elementTypeProp =
+      new EnumProperty<>(
+          new StringValue("elementType"), BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public TimerRecord() {
-    super(7);
+    super(10);
     declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(dueDateProp)
         .declareProperty(targetElementId)
         .declareProperty(repetitionsProp)
         .declareProperty(processDefinitionKeyProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(elementTypeProp);
   }
 
   @JsonIgnore
@@ -113,6 +125,36 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
 
   public TimerRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public TimerRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public TimerRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public TimerRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1601,7 +1601,11 @@ final class JsonSerializableToJsonTest {
                   "targetElementId": "node1",
                   "repetitions": 3,
                   "processDefinitionKey": 13,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "rootProcessInstanceKey": -1,
+                  "bpmnProcessId": "",
+                  "elementId": "node1",
+                  "elementType": "UNSPECIFIED"
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/TimerRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/TimerRecord.golden
@@ -10,10 +10,13 @@ package io.camunda.zeebe.protocol.impl.record.value.timer;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -32,9 +35,12 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final EnumProperty<BpmnElementType> elementTypeProp =
+      new EnumProperty<>(
+          new StringValue("elementType"), BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public TimerRecord() {
-    super(9);
+    super(10);
     declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(dueDateProp)
@@ -43,7 +49,8 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
-        .declareProperty(bpmnProcessIdProp);
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(elementTypeProp);
   }
 
   @JsonIgnore
@@ -138,6 +145,16 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
 
   public TimerRecord setBpmnProcessId(final String bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementTypeProp.getValue();
+  }
+
+  public TimerRecord setElementType(final BpmnElementType elementType) {
+    elementTypeProp.setValue(elementType);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/TimerRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/TimerRecord.golden
@@ -29,16 +29,21 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
   private final LongProperty processDefinitionKeyProp = new LongProperty("processDefinitionKey");
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty("rootProcessInstanceKey", -1L);
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
 
   public TimerRecord() {
-    super(7);
+    super(9);
     declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(dueDateProp)
         .declareProperty(targetElementId)
         .declareProperty(repetitionsProp)
         .declareProperty(processDefinitionKeyProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(bpmnProcessIdProp);
   }
 
   @JsonIgnore
@@ -113,6 +118,26 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
 
   public TimerRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public TimerRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public TimerRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TimerRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TimerRecordValue.java
@@ -27,7 +27,14 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableTimerRecordValue.Builder.class)
-public interface TimerRecordValue extends RecordValue, ProcessInstanceRelated, TenantOwned {
+public interface TimerRecordValue
+    extends RecordValue, ProcessInstanceRelated, TenantOwned, WaitStateRelated {
+
+  /**
+   * @return the BPMN element type of the timer element (e.g. INTERMEDIATE_CATCH_EVENT,
+   *     BOUNDARY_EVENT, START_EVENT), or UNSPECIFIED if unknown.
+   */
+  BpmnElementType getElementType();
 
   /**
    * @return the key of the process in which this timer was created
@@ -64,4 +71,25 @@ public interface TimerRecordValue extends RecordValue, ProcessInstanceRelated, T
    * @return the number of times this timer should trigger
    */
   int getRepetitions();
+
+  /**
+   * @return the root process instance key, or -1L if this is a start-event subscription
+   */
+  @Override
+  long getRootProcessInstanceKey();
+
+  /**
+   * @return the BPMN process id of the process that owns this timer
+   */
+  @Override
+  String getBpmnProcessId();
+
+  /**
+   * Delegates to {@link #getTargetElementId()}: the target element id IS the BPMN element id of the
+   * timer catch/boundary event.
+   */
+  @Override
+  default String getElementId() {
+    return getTargetElementId();
+  }
 }


### PR DESCRIPTION
## Description

- **`TimerRecordValue` extends `WaitStateRelated`** — added `rootProcessInstanceKey`, `bpmnProcessId`, `elementType` fields to `TimerRecord` (msgpack props, getters/setters, golden updated)
- **`TimerInstance` state** — persists `rootProcessInstanceKey`, `bpmnProcessId`, `elementType` in RocksDB via new `TimerCreatedV2Applier` (v2 event applier registered in `EventAppliers`)
- **Engine propagation** — `CatchEventBehavior.subscribeToTimerEvent` accepts and writes all new fields; callers updated (`DeploymentCreateProcessor`, `StartEventSubscriptions`, `ProcessInstanceMigrationCatchEventBehavior`, `TimerTriggerProcessor`, `DueDateTimerCheckScheduler`)
- **`TimerBasedWaitStateTransformer`** — new transformer in `zeebe/exporter-common`; CREATED → add, TRIGGERED/CANCELED → remove; skips `processInstanceKey == -1L` (start-event subscriptions) and non-`INTERMEDIATE_CATCH_EVENT` element types (boundary timers)
- **Exporter wiring** — ES/OS timer index templates updated with new fields; `CamundaExporter` now accepts `ValueType.TIMER` for export
- **Search domain + REST API** — `WaitStateTimerDetails` entity added; `WaitStateEntityTransformer` maps TIMER type; `element-instances.yaml` OpenAPI spec extended with `TimerWaitStateDetails` schema
- **HTTP gateway + RDBMS** — `SearchQueryResponseMapper` converts `WaitStateTimerDetails` → REST response; `WaitStateEntityMapper` reads `dueDate`/`repetitions` from RDBMS for TIMER entries
- **Java client API** — `WaitStateType.TIMER` enum value, `TimerWaitStateDetails` interface + `TimerWaitStateDetailsImpl`; `ElementInstanceWaitStateResultImpl` deserializes TIMER details
- **Integration test** — `WaitStateTimerIT` (`@MultiDbTest`): process with parallel ICE + boundary timer asserts exactly 1 TIMER wait state with correct `elementType`, `elementId`, `dueDate`, `repetitions`
- **Review fixes** — golden files synced (`TimerRecord.golden` `super(10)`, `Timer_CREATED_v2.golden` `setElementType`); migration path sets `elementType` from `TimerInstance`; mock stubs fixed in `DueDateTimerCheckSchedulerTest`; dead `elementId` mapping removed from OS template

## Related issues

closes #51977
