### PR TITLE
Analytics exporter: dynamic event addition framework

### DIFF
--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -10,87 +10,110 @@ package io.camunda.exporter.analytics;
 import io.opentelemetry.api.common.AttributeKey;
 
 /**
- * OTel attribute keys for analytics events. Naming follows OTel semantic conventions: dot-delimited
- * namespaces, snake_case for multi-word components.
+ * OTel attribute keys and event name constants for analytics events, grouped by domain. Naming
+ * follows OTel semantic conventions: dot-delimited namespaces, snake_case for multi-word
+ * components.
  *
  * @see <a href="https://opentelemetry.io/docs/specs/semconv/general/naming/">OTel Naming</a>
  */
 public final class AnalyticsAttributes {
 
-  // Resource-level
   public static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
   public static final AttributeKey<String> CLUSTER_ID =
       AttributeKey.stringKey("camunda.cluster.id");
   public static final AttributeKey<Long> PARTITION_ID =
       AttributeKey.longKey("camunda.partition.id");
 
-  // OTel semantic convention for events (until Event API is stable)
-  public static final AttributeKey<String> EVENT_NAME = AttributeKey.stringKey("event.name");
-
-  // Log domain
-  public static final AttributeKey<Long> LOG_POSITION =
-      AttributeKey.longKey("camunda.log.position");
-  public static final AttributeKey<Long> LOG_POSITION_START =
-      AttributeKey.longKey("camunda.log.position_start");
-  public static final AttributeKey<Long> LOG_POSITION_END =
-      AttributeKey.longKey("camunda.log.position_end");
-
-  // Event domain
-  public static final AttributeKey<Long> EVENT_SEQUENCE_NUMBER =
-      AttributeKey.longKey("camunda.event.sequence_number");
-  public static final AttributeKey<Double> EVENT_SAMPLE_RATE =
-      AttributeKey.doubleKey("camunda.event.sample_rate");
-  public static final AttributeKey<Long> EVENT_TIME_MIN =
-      AttributeKey.longKey("camunda.event.time_min");
-  public static final AttributeKey<Long> EVENT_TIME_MAX =
-      AttributeKey.longKey("camunda.event.time_max");
-
-  // Tenant domain
-  public static final AttributeKey<String> TENANT_ID = AttributeKey.stringKey("camunda.tenant.id");
-
-  // Process domain
-  public static final AttributeKey<String> BPMN_PROCESS_ID =
-      AttributeKey.stringKey("camunda.process.id");
-  public static final AttributeKey<Long> PROCESS_VERSION =
-      AttributeKey.longKey("camunda.process.version");
-  public static final AttributeKey<Long> PROCESS_DEFINITION_KEY =
-      AttributeKey.longKey("camunda.process.definition_key");
-  public static final AttributeKey<Long> PROCESS_INSTANCE_KEY =
-      AttributeKey.longKey("camunda.process.instance_key");
-  public static final AttributeKey<Long> ROOT_PROCESS_INSTANCE_KEY =
-      AttributeKey.longKey("camunda.process.root_instance_key");
-
-  // Element domain
-  public static final AttributeKey<String> ELEMENT_ID =
-      AttributeKey.stringKey("camunda.element.id");
-
-  // Metric domain
-  public static final String METRIC_PROCESS_INSTANCE_CREATED = "camunda.process_instance.created";
-  public static final String METRIC_EXPORT_WINDOW = "camunda.metric.export_window";
-  public static final AttributeKey<Long> METRIC_SEQUENCE_NUMBER =
-      AttributeKey.longKey("camunda.metric.sequence_number");
-
-  // Event names
-  public static final String EVENT_PROCESS_INSTANCE_CREATED = "process_instance_created";
-  public static final String EVENT_ADHOC_SUBPROCESS_ACTIVATED = "adhoc_subprocess_activated";
-  public static final String EVENT_USAGE_METRIC_EXPORTED = "usage_metric_exported";
-  public static final String EVENT_HEARTBEAT = "heartbeat";
-
-  // Heartbeat domain
-  public static final AttributeKey<String> BROKER_VERSION =
-      AttributeKey.stringKey("camunda.heartbeat.broker_version");
-  public static final AttributeKey<String> EXPORTER_VERSION =
-      AttributeKey.stringKey("camunda.heartbeat.exporter_version");
-
-  // Usage metrics
-  public static final AttributeKey<String> USAGE_METRIC_EVENT_TYPE =
-      AttributeKey.stringKey("camunda.usage_metric.event_type");
-  public static final AttributeKey<Long> USAGE_METRIC_COUNT =
-      AttributeKey.longKey("camunda.usage_metric.count");
-  public static final AttributeKey<Long> USAGE_METRIC_INTERVAL_START =
-      AttributeKey.longKey("camunda.usage_metric.interval_start");
-  public static final AttributeKey<Long> USAGE_METRIC_INTERVAL_END =
-      AttributeKey.longKey("camunda.usage_metric.interval_end");
-
   private AnalyticsAttributes() {}
+
+  public static final class Event {
+    /** OTel semantic convention for events (until Event API is stable). */
+    public static final AttributeKey<String> NAME = AttributeKey.stringKey("event.name");
+
+    public static final AttributeKey<Long> SEQUENCE_NUMBER =
+        AttributeKey.longKey("camunda.event.sequence_number");
+    public static final AttributeKey<Double> SAMPLE_RATE =
+        AttributeKey.doubleKey("camunda.event.sample_rate");
+    public static final AttributeKey<Long> TIME_MIN =
+        AttributeKey.longKey("camunda.event.time_min");
+    public static final AttributeKey<Long> TIME_MAX =
+        AttributeKey.longKey("camunda.event.time_max");
+
+    // Event name values
+    public static final String PROCESS_INSTANCE_CREATED = "process_instance_created";
+    public static final String ADHOC_SUBPROCESS_ACTIVATED = "adhoc_subprocess_activated";
+    public static final String USAGE_METRIC_EXPORTED = "usage_metric_exported";
+    public static final String HEARTBEAT = "heartbeat";
+    public static final String USER_TASK_CREATED = "user_task_created";
+
+    private Event() {}
+  }
+
+  public static final class Log {
+    public static final AttributeKey<Long> POSITION = AttributeKey.longKey("camunda.log.position");
+    public static final AttributeKey<Long> POSITION_START =
+        AttributeKey.longKey("camunda.log.position_start");
+    public static final AttributeKey<Long> POSITION_END =
+        AttributeKey.longKey("camunda.log.position_end");
+
+    private Log() {}
+  }
+
+  public static final class Tenant {
+    public static final AttributeKey<String> ID = AttributeKey.stringKey("camunda.tenant.id");
+
+    private Tenant() {}
+  }
+
+  public static final class Process {
+    public static final AttributeKey<String> BPMN_PROCESS_ID =
+        AttributeKey.stringKey("camunda.process.id");
+    public static final AttributeKey<Long> VERSION =
+        AttributeKey.longKey("camunda.process.version");
+    public static final AttributeKey<Long> DEFINITION_KEY =
+        AttributeKey.longKey("camunda.process.definition_key");
+    public static final AttributeKey<Long> INSTANCE_KEY =
+        AttributeKey.longKey("camunda.process.instance_key");
+    public static final AttributeKey<Long> ROOT_INSTANCE_KEY =
+        AttributeKey.longKey("camunda.process.root_instance_key");
+
+    private Process() {}
+  }
+
+  public static final class Element {
+    public static final AttributeKey<String> ID = AttributeKey.stringKey("camunda.element.id");
+
+    private Element() {}
+  }
+
+  public static final class Metric {
+    public static final String PROCESS_INSTANCE_CREATED = "camunda.process_instance.created";
+    public static final String EXPORT_WINDOW = "camunda.metric.export_window";
+    public static final AttributeKey<Long> SEQUENCE_NUMBER =
+        AttributeKey.longKey("camunda.metric.sequence_number");
+
+    private Metric() {}
+  }
+
+  public static final class Heartbeat {
+    public static final AttributeKey<String> BROKER_VERSION =
+        AttributeKey.stringKey("camunda.heartbeat.broker_version");
+    public static final AttributeKey<String> EXPORTER_VERSION =
+        AttributeKey.stringKey("camunda.heartbeat.exporter_version");
+
+    private Heartbeat() {}
+  }
+
+  public static final class UsageMetric {
+    public static final AttributeKey<String> EVENT_TYPE =
+        AttributeKey.stringKey("camunda.usage_metric.event_type");
+    public static final AttributeKey<Long> COUNT =
+        AttributeKey.longKey("camunda.usage_metric.count");
+    public static final AttributeKey<Long> INTERVAL_START =
+        AttributeKey.longKey("camunda.usage_metric.interval_start");
+    public static final AttributeKey<Long> INTERVAL_END =
+        AttributeKey.longKey("camunda.usage_metric.interval_end");
+
+    private UsageMetric() {}
+  }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -52,7 +52,7 @@ public class AnalyticsExporter implements Exporter {
         AnalyticsExporterContext.create(
             resolveLicenseKey(context), resolveClusterId(context), context.getPartitionId());
 
-    handlers = HandlerCatalog.build(otelSdkManager).apply(context);
+    handlers = AnalyticsHandlerCatalog.build(otelSdkManager).apply(context);
 
     LOG.info(
         "Analytics exporter configured: endpoint={}, clusterId={}, partitionId={}",

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -7,18 +7,11 @@
  */
 package io.camunda.exporter.analytics;
 
-import io.camunda.exporter.analytics.handler.AdHocSubProcessHandler;
-import io.camunda.exporter.analytics.handler.ProcessInstanceCreationHandler;
-import io.camunda.exporter.analytics.handler.UsageMetricHandler;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.exporter.api.context.ScheduledTask;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
 import org.slf4j.Logger;
@@ -59,21 +52,7 @@ public class AnalyticsExporter implements Exporter {
         AnalyticsExporterContext.create(
             resolveLicenseKey(context), resolveClusterId(context), context.getPartitionId());
 
-    handlers =
-        new HandlerRegistry()
-            .register(
-                ValueType.PROCESS_INSTANCE_CREATION,
-                ProcessInstanceCreationIntent.CREATED,
-                new ProcessInstanceCreationHandler(otelSdkManager))
-            .register(
-                ValueType.PROCESS_INSTANCE,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                new AdHocSubProcessHandler(otelSdkManager))
-            .register(
-                ValueType.USAGE_METRIC,
-                UsageMetricIntent.EXPORTED,
-                new UsageMetricHandler(otelSdkManager))
-            .apply(context);
+    handlers = HandlerCatalog.build(otelSdkManager).apply(context);
 
     LOG.info(
         "Analytics exporter configured: endpoint={}, clusterId={}, partitionId={}",

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalog.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalog.java
@@ -24,9 +24,9 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
  *
  * <p>{@link AnalyticsExporter} never needs to change when new events are added.
  */
-final class HandlerCatalog {
+final class AnalyticsHandlerCatalog {
 
-  private HandlerCatalog() {}
+  private AnalyticsHandlerCatalog() {}
 
   static HandlerRegistry build(final OtelSdkManager otelSdkManager) {
     return new HandlerRegistry()

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerCatalog.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerCatalog.java
@@ -10,10 +10,12 @@ package io.camunda.exporter.analytics;
 import io.camunda.exporter.analytics.handler.AdHocSubProcessHandler;
 import io.camunda.exporter.analytics.handler.ProcessInstanceCreationHandler;
 import io.camunda.exporter.analytics.handler.UsageMetricHandler;
+import io.camunda.exporter.analytics.handler.UserTaskCreatedHandler;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
 /**
  * Registers all analytics event handlers. This is the only file to edit when adding a new event:
@@ -39,6 +41,10 @@ final class HandlerCatalog {
         .register(
             ValueType.USAGE_METRIC,
             UsageMetricIntent.EXPORTED,
-            new UsageMetricHandler(otelSdkManager));
+            new UsageMetricHandler(otelSdkManager))
+        .register(
+            ValueType.USER_TASK,
+            UserTaskIntent.CREATED,
+            new UserTaskCreatedHandler(otelSdkManager));
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerCatalog.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerCatalog.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.exporter.analytics.handler.AdHocSubProcessHandler;
+import io.camunda.exporter.analytics.handler.ProcessInstanceCreationHandler;
+import io.camunda.exporter.analytics.handler.UsageMetricHandler;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+
+/**
+ * Registers all analytics event handlers. This is the only file to edit when adding a new event:
+ * create a handler class in {@code handler/}, add one {@code .register()} call here, and add the
+ * event name constant to {@link AnalyticsAttributes.Event}.
+ *
+ * <p>{@link AnalyticsExporter} never needs to change when new events are added.
+ */
+final class HandlerCatalog {
+
+  private HandlerCatalog() {}
+
+  static HandlerRegistry build(final OtelSdkManager otelSdkManager) {
+    return new HandlerRegistry()
+        .register(
+            ValueType.PROCESS_INSTANCE_CREATION,
+            ProcessInstanceCreationIntent.CREATED,
+            new ProcessInstanceCreationHandler(otelSdkManager))
+        .register(
+            ValueType.PROCESS_INSTANCE,
+            ProcessInstanceIntent.ELEMENT_ACTIVATED,
+            new AdHocSubProcessHandler(otelSdkManager))
+        .register(
+            ValueType.USAGE_METRIC,
+            UsageMetricIntent.EXPORTED,
+            new UsageMetricHandler(otelSdkManager));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -48,6 +49,13 @@ final class HandlerRegistry {
     context.setFilter(
         new AnalyticsRecordFilter(handlers.keySet(), acceptedIntents, context.getPartitionId()));
     return this;
+  }
+
+  /** Returns all registered (ValueType, Intent) pairs. Package-private for use in tests. */
+  Set<Map.Entry<ValueType, Intent>> registrations() {
+    return handlers.entrySet().stream()
+        .flatMap(e -> e.getValue().keySet().stream().map(intent -> Map.entry(e.getKey(), intent)))
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   /** Routes the record to its handler. Does nothing if no handler is registered. */

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,7 +52,7 @@ final class HandlerRegistry {
     return this;
   }
 
-  /** Returns all registered (ValueType, Intent) pairs. Package-private for use in tests. */
+  @VisibleForTesting
   Set<Map.Entry<ValueType, Intent>> registrations() {
     return handlers.entrySet().stream()
         .flatMap(e -> e.getValue().keySet().stream().map(intent -> Map.entry(e.getKey(), intent)))

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/MetricWindow.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/MetricWindow.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.exporter.analytics;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_TIME_MAX;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_TIME_MIN;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.LOG_POSITION_END;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.LOG_POSITION_START;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.METRIC_SEQUENCE_NUMBER;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MAX;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MIN;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_END;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_START;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.SEQUENCE_NUMBER;
 
 import io.opentelemetry.api.common.Attributes;
 
@@ -46,14 +46,14 @@ final class MetricWindow {
    */
   Attributes toGaugeAttributes(final long metricSequenceNumber) {
     if (!hasEvents()) {
-      return Attributes.of(METRIC_SEQUENCE_NUMBER, metricSequenceNumber);
+      return Attributes.of(SEQUENCE_NUMBER, metricSequenceNumber);
     }
     return Attributes.of(
-        METRIC_SEQUENCE_NUMBER, metricSequenceNumber,
-        LOG_POSITION_START, positionStart,
-        LOG_POSITION_END, positionEnd,
-        EVENT_TIME_MIN, eventTimeMin,
-        EVENT_TIME_MAX, eventTimeMax);
+        SEQUENCE_NUMBER, metricSequenceNumber,
+        POSITION_START, positionStart,
+        POSITION_END, positionEnd,
+        TIME_MIN, eventTimeMin,
+        TIME_MAX, eventTimeMax);
   }
 
   /** Resets all fields for the next window. */

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.exporter.analytics;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.BROKER_VERSION;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.CLUSTER_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_HEARTBEAT;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_NAME;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_SAMPLE_RATE;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_SEQUENCE_NUMBER;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EXPORTER_VERSION;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.LOG_POSITION;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.METRIC_EXPORT_WINDOW;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.HEARTBEAT;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.NAME;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.SAMPLE_RATE;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.SEQUENCE_NUMBER;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Heartbeat.BROKER_VERSION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Heartbeat.EXPORTER_VERSION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.EXPORT_WINDOW;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PARTITION_ID;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.SERVICE_NAME;
 
@@ -108,11 +108,11 @@ public class OtelSdkManager implements AutoCloseable {
             .logRecordBuilder()
             .setSeverity(Severity.INFO)
             .setSeverityText("INFO")
-            .setAttribute(EVENT_NAME, eventName)
-            .setAttribute(LOG_POSITION, logPosition)
-            .setAttribute(EVENT_SEQUENCE_NUMBER, metadata.incrementAndGetEventSequenceNumber());
+            .setAttribute(NAME, eventName)
+            .setAttribute(POSITION, logPosition)
+            .setAttribute(SEQUENCE_NUMBER, metadata.incrementAndGetEventSequenceNumber());
     if (appliedRate < HashSampler.MAX_SAMPLE_RATE) {
-      record.setAttribute(EVENT_SAMPLE_RATE, appliedRate);
+      record.setAttribute(SAMPLE_RATE, appliedRate);
     }
     builder.accept(record);
     record.emit();
@@ -123,7 +123,7 @@ public class OtelSdkManager implements AutoCloseable {
         .logRecordBuilder()
         .setSeverity(Severity.INFO)
         .setSeverityText("INFO")
-        .setAttribute(EVENT_NAME, EVENT_HEARTBEAT)
+        .setAttribute(NAME, HEARTBEAT)
         .setAttribute(BROKER_VERSION, VersionUtil.getVersion())
         .setAttribute(EXPORTER_VERSION, AnalyticsExporterVersion.get())
         .emit();
@@ -162,7 +162,7 @@ public class OtelSdkManager implements AutoCloseable {
   @SuppressWarnings("resource") // gauge lifecycle is managed by sdk.shutdown(), not by us
   private void registerExportWindowGauge() {
     otelMeter
-        .gaugeBuilder(METRIC_EXPORT_WINDOW)
+        .gaugeBuilder(EXPORT_WINDOW)
         .ofLongs()
         .buildWithCallback(
             measurement -> {

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandler.java
@@ -7,13 +7,12 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.BPMN_PROCESS_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.ELEMENT_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_ADHOC_SUBPROCESS_ACTIVATED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_DEFINITION_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_INSTANCE_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.TENANT_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.ADHOC_SUBPROCESS_ACTIVATED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
 
+import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -42,14 +41,16 @@ public final class AdHocSubProcessHandler implements AnalyticsHandler<ProcessIns
     }
 
     otelSdkManager.logEvent(
-        EVENT_ADHOC_SUBPROCESS_ACTIVATED,
+        ADHOC_SUBPROCESS_ACTIVATED,
         record.getPosition(),
         log ->
             log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
-                .setAttribute(PROCESS_DEFINITION_KEY, value.getProcessDefinitionKey())
-                .setAttribute(PROCESS_INSTANCE_KEY, value.getProcessInstanceKey())
-                .setAttribute(ELEMENT_ID, value.getElementId())
-                .setAttribute(TENANT_ID, value.getTenantId())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                // Element.ID and Tenant.ID share the unqualified name ID — use qualified form to
+                // disambiguate
+                .setAttribute(AnalyticsAttributes.Element.ID, value.getElementId())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
@@ -7,14 +7,13 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.BPMN_PROCESS_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_PROCESS_INSTANCE_CREATED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.METRIC_PROCESS_INSTANCE_CREATED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_DEFINITION_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_INSTANCE_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_VERSION;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.TENANT_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.VERSION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Tenant.ID;
 
+import io.camunda.exporter.analytics.AnalyticsAttributes;
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
 import io.camunda.zeebe.protocol.record.Record;
@@ -38,26 +37,27 @@ public final class ProcessInstanceCreationHandler
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        EVENT_PROCESS_INSTANCE_CREATED,
+        AnalyticsAttributes.Event.PROCESS_INSTANCE_CREATED,
         record.getPosition(),
         log ->
             log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
-                .setAttribute(PROCESS_VERSION, (long) value.getVersion())
-                .setAttribute(PROCESS_DEFINITION_KEY, value.getProcessDefinitionKey())
-                .setAttribute(PROCESS_INSTANCE_KEY, record.getKey())
+                .setAttribute(VERSION, (long) value.getVersion())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(INSTANCE_KEY, record.getKey())
                 // TODO: re-enable once 8.8 brokers are no longer supported —
                 //  getRootProcessInstanceKey() does not exist on 8.8
-                // .setAttribute(ROOT_PROCESS_INSTANCE_KEY, value.getRootProcessInstanceKey())
-                .setAttribute(TENANT_ID, value.getTenantId())
+                // .setAttribute(AnalyticsAttributes.Process.ROOT_INSTANCE_KEY,
+                // value.getRootProcessInstanceKey())
+                .setAttribute(ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
 
     otelSdkManager.incrementMetric(
-        METRIC_PROCESS_INSTANCE_CREATED,
+        AnalyticsAttributes.Metric.PROCESS_INSTANCE_CREATED,
         record.getPosition(),
         record.getTimestamp(),
         Attributes.of(
             BPMN_PROCESS_ID, value.getBpmnProcessId(),
-            PROCESS_VERSION, (long) value.getVersion(),
-            TENANT_ID, value.getTenantId()));
+            VERSION, (long) value.getVersion(),
+            ID, value.getTenantId()));
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UsageMetricHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UsageMetricHandler.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_USAGE_METRIC_EXPORTED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_COUNT;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_EVENT_TYPE;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_INTERVAL_END;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_INTERVAL_START;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.USAGE_METRIC_EXPORTED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.UsageMetric.COUNT;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.UsageMetric.EVENT_TYPE;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.UsageMetric.INTERVAL_END;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.UsageMetric.INTERVAL_START;
 
 import io.camunda.exporter.analytics.AnalyticsHandler;
 import io.camunda.exporter.analytics.OtelSdkManager;
@@ -47,13 +47,13 @@ public final class UsageMetricHandler implements AnalyticsHandler<UsageMetricRec
         };
 
     otelSdkManager.logEvent(
-        EVENT_USAGE_METRIC_EXPORTED,
+        USAGE_METRIC_EXPORTED,
         record.getPosition(),
         log ->
-            log.setAttribute(USAGE_METRIC_EVENT_TYPE, value.getEventType().name())
-                .setAttribute(USAGE_METRIC_COUNT, count)
-                .setAttribute(USAGE_METRIC_INTERVAL_START, value.getStartTime())
-                .setAttribute(USAGE_METRIC_INTERVAL_END, value.getEndTime())
+            log.setAttribute(EVENT_TYPE, value.getEventType().name())
+                .setAttribute(COUNT, count)
+                .setAttribute(INTERVAL_START, value.getStartTime())
+                .setAttribute(INTERVAL_END, value.getEndTime())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandler.java
@@ -43,8 +43,6 @@ public final class UserTaskCreatedHandler implements AnalyticsHandler<UserTaskRe
             log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
                 .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
                 .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
-                // Element.ID and Tenant.ID share the unqualified name ID -- use qualified form to
-                // disambiguate
                 .setAttribute(AnalyticsAttributes.Element.ID, value.getElementId())
                 .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.USER_TASK_CREATED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code user_task_created} OTel event for each user task creation. Emits only safe
+ * process-metadata attributes — never assignee, candidate users, candidate groups, or variables.
+ */
+public final class UserTaskCreatedHandler implements AnalyticsHandler<UserTaskRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public UserTaskCreatedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<UserTaskRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        USER_TASK_CREATED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                // Element.ID and Tenant.ID share the unqualified name ID -- use qualified form to
+                // disambiguate
+                .setAttribute(AnalyticsAttributes.Element.ID, value.getElementId())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterHeartbeatTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterHeartbeatTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.analytics;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_HEARTBEAT;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.HEARTBEAT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
@@ -51,10 +51,12 @@ class AnalyticsExporterHeartbeatTest {
             log -> {
               final var attrs = log.getAttributes().asMap();
               assertThat(attrs)
-                  .containsEntry(AnalyticsAttributes.EVENT_NAME, EVENT_HEARTBEAT)
-                  .containsEntry(AnalyticsAttributes.BROKER_VERSION, VersionUtil.getVersion())
+                  .containsEntry(AnalyticsAttributes.Event.NAME, HEARTBEAT)
                   .containsEntry(
-                      AnalyticsAttributes.EXPORTER_VERSION, AnalyticsExporterVersion.get());
+                      AnalyticsAttributes.Heartbeat.BROKER_VERSION, VersionUtil.getVersion())
+                  .containsEntry(
+                      AnalyticsAttributes.Heartbeat.EXPORTER_VERSION,
+                      AnalyticsExporterVersion.get());
             });
   }
 
@@ -69,7 +71,7 @@ class AnalyticsExporterHeartbeatTest {
     // then — two scheduled fires
     assertThat(memoryExporter.getFinishedLogRecordItems())
         .filteredOn(
-            log -> EVENT_HEARTBEAT.equals(log.getAttributes().get(AnalyticsAttributes.EVENT_NAME)))
+            log -> HEARTBEAT.equals(log.getAttributes().get(AnalyticsAttributes.Event.NAME)))
         .hasSize(2);
   }
 

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterOtelIT.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterOtelIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.exporter.analytics;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_HEARTBEAT;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_PROCESS_INSTANCE_CREATED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.HEARTBEAT;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_INSTANCE_CREATED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
@@ -78,9 +78,9 @@ class AnalyticsExporterOtelIT {
 
     // then
     awaitCollectorLogs(
-        EVENT_HEARTBEAT,
-        AnalyticsAttributes.BROKER_VERSION.getKey(),
-        AnalyticsAttributes.EXPORTER_VERSION.getKey(),
+        HEARTBEAT,
+        AnalyticsAttributes.Heartbeat.BROKER_VERSION.getKey(),
+        AnalyticsAttributes.Heartbeat.EXPORTER_VERSION.getKey(),
         // schema URL is part of the instrumentation scope, not a record attribute
         "ScopeLogs SchemaURL: https://camunda.io/schemas/analytics/v1");
   }
@@ -97,10 +97,10 @@ class AnalyticsExporterOtelIT {
 
     // then
     awaitCollectorLogs(
-        EVENT_PROCESS_INSTANCE_CREATED,
+        PROCESS_INSTANCE_CREATED,
         AnalyticsAttributes.CLUSTER_ID.getKey(),
         "test-cluster",
-        AnalyticsAttributes.BPMN_PROCESS_ID.getKey());
+        AnalyticsAttributes.Process.BPMN_PROCESS_ID.getKey());
   }
 
   /**
@@ -134,7 +134,7 @@ class AnalyticsExporterOtelIT {
               // Count the PI-created records specifically to avoid coupling to other event types.
               final var piCreatedCount =
                   COLLECTOR_LOGS.stream()
-                      .filter(l -> l.contains("Str(" + EVENT_PROCESS_INSTANCE_CREATED + ")"))
+                      .filter(l -> l.contains("Str(" + PROCESS_INSTANCE_CREATED + ")"))
                       .count();
               assertThat(piCreatedCount).isEqualTo(500);
 

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
@@ -298,6 +299,29 @@ class AnalyticsExporterTest {
         .singleElement()
         .extracting(log -> log.getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
         .isEqualTo(6L);
+  }
+
+  @Test
+  void shouldEmitUserTaskCreatedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.USER_TASK,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(UserTaskIntent.CREATED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.USER_TASK_CREATED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Log.POSITION))
+                  .isEqualTo(record.getPosition());
+            });
   }
 
   // -- helpers --

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.exporter.analytics;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_PROCESS_INSTANCE_CREATED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -76,19 +75,22 @@ class AnalyticsExporterTest {
             logRecord -> {
               assertThat(logRecord.getSeverity()).isEqualTo(Severity.INFO);
               assertThat(logRecord.getAttributes().asMap())
-                  .containsEntry(AnalyticsAttributes.EVENT_NAME, EVENT_PROCESS_INSTANCE_CREATED)
-                  .containsEntry(AnalyticsAttributes.BPMN_PROCESS_ID, value.getBpmnProcessId())
-                  .containsEntry(AnalyticsAttributes.PROCESS_VERSION, (long) value.getVersion())
                   .containsEntry(
-                      AnalyticsAttributes.PROCESS_DEFINITION_KEY, value.getProcessDefinitionKey())
-                  .containsEntry(AnalyticsAttributes.PROCESS_INSTANCE_KEY, record.getKey())
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.PROCESS_INSTANCE_CREATED)
+                  .containsEntry(
+                      AnalyticsAttributes.Process.BPMN_PROCESS_ID, value.getBpmnProcessId())
+                  .containsEntry(AnalyticsAttributes.Process.VERSION, (long) value.getVersion())
+                  .containsEntry(
+                      AnalyticsAttributes.Process.DEFINITION_KEY, value.getProcessDefinitionKey())
+                  .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, record.getKey())
                   // Temporarily commented out as root process instance key doesn't exist on 8.8.
                   //                  .containsEntry(
-                  //                      AnalyticsAttributes.ROOT_PROCESS_INSTANCE_KEY,
+                  //                      AnalyticsAttributes.Process.ROOT_INSTANCE_KEY,
                   //                      value.getRootProcessInstanceKey())
-                  .containsEntry(AnalyticsAttributes.TENANT_ID, value.getTenantId())
-                  .containsEntry(AnalyticsAttributes.LOG_POSITION, record.getPosition())
-                  .containsEntry(AnalyticsAttributes.EVENT_SEQUENCE_NUMBER, 1L);
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                  .containsEntry(AnalyticsAttributes.Log.POSITION, record.getPosition())
+                  .containsEntry(AnalyticsAttributes.Event.SEQUENCE_NUMBER, 1L);
             });
   }
 
@@ -294,7 +296,7 @@ class AnalyticsExporterTest {
     // then
     assertThat(freshMemoryExporter.getFinishedLogRecordItems())
         .singleElement()
-        .extracting(log -> log.getAttributes().get(AnalyticsAttributes.EVENT_SEQUENCE_NUMBER))
+        .extracting(log -> log.getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
         .isEqualTo(6L);
   }
 

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalogTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalogTest.java
@@ -18,7 +18,7 @@ import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class HandlerCatalogTest {
+class AnalyticsHandlerCatalogTest {
 
   @Test
   void shouldRegisterAllExpectedHandlers() {
@@ -27,7 +27,7 @@ class HandlerCatalogTest {
     final var otelSdkManager = TestOtelSdkManager.inMemory(logExporter);
 
     // when
-    final var registry = HandlerCatalog.build(otelSdkManager);
+    final var registry = AnalyticsHandlerCatalog.build(otelSdkManager);
 
     // then
     assertThat(registry.registrations())

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerCatalogTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerCatalogTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ class HandlerCatalogTest {
         .containsExactlyInAnyOrder(
             Map.entry(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATED),
             Map.entry(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            Map.entry(ValueType.USAGE_METRIC, UsageMetricIntent.EXPORTED));
+            Map.entry(ValueType.USAGE_METRIC, UsageMetricIntent.EXPORTED),
+            Map.entry(ValueType.USER_TASK, UserTaskIntent.CREATED));
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerCatalogTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerCatalogTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class HandlerCatalogTest {
+
+  @Test
+  void shouldRegisterAllExpectedHandlers() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var otelSdkManager = TestOtelSdkManager.inMemory(logExporter);
+
+    // when
+    final var registry = HandlerCatalog.build(otelSdkManager);
+
+    // then
+    assertThat(registry.registrations())
+        .containsExactlyInAnyOrder(
+            Map.entry(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATED),
+            Map.entry(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            Map.entry(ValueType.USAGE_METRIC, UsageMetricIntent.EXPORTED));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/MetricWindowTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/MetricWindowTest.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.exporter.analytics;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_TIME_MAX;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_TIME_MIN;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.LOG_POSITION_END;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.LOG_POSITION_START;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.METRIC_SEQUENCE_NUMBER;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MAX;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MIN;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_END;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_START;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.SEQUENCE_NUMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -30,12 +30,12 @@ class MetricWindowTest {
     assertThat(window.hasEvents()).isTrue();
     assertThat(window.eventCount()).isEqualTo(1);
     final var attrs = window.toGaugeAttributes(42L);
-    assertThat(attrs.get(METRIC_SEQUENCE_NUMBER)).isEqualTo(42L);
+    assertThat(attrs.get(SEQUENCE_NUMBER)).isEqualTo(42L);
     // event_count is the gauge value, not an attribute
-    assertThat(attrs.get(LOG_POSITION_START)).isEqualTo(100L);
-    assertThat(attrs.get(LOG_POSITION_END)).isEqualTo(100L);
-    assertThat(attrs.get(EVENT_TIME_MIN)).isEqualTo(5000L);
-    assertThat(attrs.get(EVENT_TIME_MAX)).isEqualTo(5000L);
+    assertThat(attrs.get(POSITION_START)).isEqualTo(100L);
+    assertThat(attrs.get(POSITION_END)).isEqualTo(100L);
+    assertThat(attrs.get(TIME_MIN)).isEqualTo(5000L);
+    assertThat(attrs.get(TIME_MAX)).isEqualTo(5000L);
   }
 
   @Test
@@ -51,10 +51,10 @@ class MetricWindowTest {
     // then
     assertThat(window.eventCount()).isEqualTo(3);
     final var attrs = window.toGaugeAttributes(1L);
-    assertThat(attrs.get(LOG_POSITION_START)).isEqualTo(100L);
-    assertThat(attrs.get(LOG_POSITION_END)).isEqualTo(300L);
-    assertThat(attrs.get(EVENT_TIME_MIN)).isEqualTo(5000L);
-    assertThat(attrs.get(EVENT_TIME_MAX)).isEqualTo(7000L);
+    assertThat(attrs.get(POSITION_START)).isEqualTo(100L);
+    assertThat(attrs.get(POSITION_END)).isEqualTo(300L);
+    assertThat(attrs.get(TIME_MIN)).isEqualTo(5000L);
+    assertThat(attrs.get(TIME_MAX)).isEqualTo(7000L);
   }
 
   @Test
@@ -84,10 +84,10 @@ class MetricWindowTest {
     // then
     assertThat(window.eventCount()).isEqualTo(1);
     final var attrs = window.toGaugeAttributes(2L);
-    assertThat(attrs.get(LOG_POSITION_START)).isEqualTo(500L);
-    assertThat(attrs.get(LOG_POSITION_END)).isEqualTo(500L);
-    assertThat(attrs.get(EVENT_TIME_MIN)).isEqualTo(9000L);
-    assertThat(attrs.get(EVENT_TIME_MAX)).isEqualTo(9000L);
+    assertThat(attrs.get(POSITION_START)).isEqualTo(500L);
+    assertThat(attrs.get(POSITION_END)).isEqualTo(500L);
+    assertThat(attrs.get(TIME_MIN)).isEqualTo(9000L);
+    assertThat(attrs.get(TIME_MAX)).isEqualTo(9000L);
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.exporter.analytics;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_SAMPLE_RATE;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_TIME_MAX;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_TIME_MIN;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.LOG_POSITION_END;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.LOG_POSITION_START;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.METRIC_EXPORT_WINDOW;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.METRIC_SEQUENCE_NUMBER;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.SAMPLE_RATE;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MAX;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MIN;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_END;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_START;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.EXPORT_WINDOW;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.SEQUENCE_NUMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -186,7 +186,7 @@ class OtelSdkManagerTest {
               logs.forEach(
                   l ->
                       receivedEventNames.add(
-                          l.getAttributes().get(AnalyticsAttributes.EVENT_NAME)));
+                          l.getAttributes().get(AnalyticsAttributes.Event.NAME)));
               return CompletableResultCode.ofSuccess();
             },
             2048,
@@ -230,11 +230,11 @@ class OtelSdkManagerTest {
 
     // then
     assertThat(received).hasSize(3);
-    assertThat(received.get(0).getAttributes().get(AnalyticsAttributes.EVENT_SEQUENCE_NUMBER))
+    assertThat(received.get(0).getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
         .isEqualTo(1L);
-    assertThat(received.get(1).getAttributes().get(AnalyticsAttributes.EVENT_SEQUENCE_NUMBER))
+    assertThat(received.get(1).getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
         .isEqualTo(2L);
-    assertThat(received.get(2).getAttributes().get(AnalyticsAttributes.EVENT_SEQUENCE_NUMBER))
+    assertThat(received.get(2).getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
         .isEqualTo(3L);
   }
 
@@ -266,7 +266,7 @@ class OtelSdkManagerTest {
     // then — sequence continues from 5, so first event gets 6
     assertThat(received)
         .singleElement()
-        .extracting(log -> log.getAttributes().get(AnalyticsAttributes.EVENT_SEQUENCE_NUMBER))
+        .extracting(log -> log.getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
         .isEqualTo(6L);
   }
 
@@ -368,7 +368,7 @@ class OtelSdkManagerTest {
       // then — sequence number is 1 (not 3), proving drops don't consume slots
       assertThat(logExporter.getFinishedLogRecordItems())
           .singleElement()
-          .extracting(log -> log.getAttributes().get(AnalyticsAttributes.EVENT_SEQUENCE_NUMBER))
+          .extracting(log -> log.getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
           .isEqualTo(1L);
     }
 
@@ -390,7 +390,7 @@ class OtelSdkManagerTest {
       // then — sample_rate attribute is set
       assertThat(logExporter.getFinishedLogRecordItems())
           .singleElement()
-          .extracting(log -> log.getAttributes().get(EVENT_SAMPLE_RATE))
+          .extracting(log -> log.getAttributes().get(SAMPLE_RATE))
           .isEqualTo(0.5);
     }
 
@@ -402,7 +402,7 @@ class OtelSdkManagerTest {
       // then — sample_rate attribute is absent
       assertThat(logExporter.getFinishedLogRecordItems())
           .singleElement()
-          .satisfies(log -> assertThat(log.getAttributes().get(EVENT_SAMPLE_RATE)).isNull());
+          .satisfies(log -> assertThat(log.getAttributes().get(SAMPLE_RATE)).isNull());
     }
 
     @Test
@@ -429,7 +429,7 @@ class OtelSdkManagerTest {
       // then — effective rate 0.5 is used (attribute reflects the min)
       assertThat(customLogExporter.getFinishedLogRecordItems())
           .singleElement()
-          .extracting(log -> log.getAttributes().get(EVENT_SAMPLE_RATE))
+          .extracting(log -> log.getAttributes().get(SAMPLE_RATE))
           .isEqualTo(0.5);
     }
   }
@@ -522,7 +522,7 @@ class OtelSdkManagerTest {
       final var metrics = metricReader.collectAllMetrics();
 
       // then
-      assertThat(findMetric(metrics, METRIC_EXPORT_WINDOW))
+      assertThat(findMetric(metrics, EXPORT_WINDOW))
           .isPresent()
           .hasValueSatisfying(
               metric ->
@@ -532,11 +532,11 @@ class OtelSdkManagerTest {
                           point -> {
                             assertThat(point.getValue()).isEqualTo(2);
                             final var pointAttrs = point.getAttributes();
-                            assertThat(pointAttrs.get(METRIC_SEQUENCE_NUMBER)).isEqualTo(1L);
-                            assertThat(pointAttrs.get(LOG_POSITION_START)).isEqualTo(100L);
-                            assertThat(pointAttrs.get(LOG_POSITION_END)).isEqualTo(200L);
-                            assertThat(pointAttrs.get(EVENT_TIME_MIN)).isEqualTo(5000L);
-                            assertThat(pointAttrs.get(EVENT_TIME_MAX)).isEqualTo(6000L);
+                            assertThat(pointAttrs.get(SEQUENCE_NUMBER)).isEqualTo(1L);
+                            assertThat(pointAttrs.get(POSITION_START)).isEqualTo(100L);
+                            assertThat(pointAttrs.get(POSITION_END)).isEqualTo(200L);
+                            assertThat(pointAttrs.get(TIME_MIN)).isEqualTo(5000L);
+                            assertThat(pointAttrs.get(TIME_MAX)).isEqualTo(6000L);
                           }));
     }
 
@@ -552,7 +552,7 @@ class OtelSdkManagerTest {
       final var metrics = metricReader.collectAllMetrics();
 
       // then
-      assertThat(findMetric(metrics, METRIC_EXPORT_WINDOW))
+      assertThat(findMetric(metrics, EXPORT_WINDOW))
           .isPresent()
           .hasValueSatisfying(
               metric ->
@@ -560,7 +560,7 @@ class OtelSdkManagerTest {
                       .first()
                       .satisfies(
                           point ->
-                              assertThat(point.getAttributes().get(METRIC_SEQUENCE_NUMBER))
+                              assertThat(point.getAttributes().get(SEQUENCE_NUMBER))
                                   .isEqualTo(2L)));
     }
 
@@ -576,7 +576,7 @@ class OtelSdkManagerTest {
       final var metrics = metricReader.collectAllMetrics();
 
       // then — should reflect only the second event
-      assertThat(findMetric(metrics, METRIC_EXPORT_WINDOW))
+      assertThat(findMetric(metrics, EXPORT_WINDOW))
           .isPresent()
           .hasValueSatisfying(
               metric ->
@@ -586,10 +586,10 @@ class OtelSdkManagerTest {
                           point -> {
                             assertThat(point.getValue()).isEqualTo(1);
                             final var pointAttrs = point.getAttributes();
-                            assertThat(pointAttrs.get(LOG_POSITION_START)).isEqualTo(300L);
-                            assertThat(pointAttrs.get(LOG_POSITION_END)).isEqualTo(300L);
-                            assertThat(pointAttrs.get(EVENT_TIME_MIN)).isEqualTo(8000L);
-                            assertThat(pointAttrs.get(EVENT_TIME_MAX)).isEqualTo(8000L);
+                            assertThat(pointAttrs.get(POSITION_START)).isEqualTo(300L);
+                            assertThat(pointAttrs.get(POSITION_END)).isEqualTo(300L);
+                            assertThat(pointAttrs.get(TIME_MIN)).isEqualTo(8000L);
+                            assertThat(pointAttrs.get(TIME_MAX)).isEqualTo(8000L);
                           }));
     }
 
@@ -599,7 +599,7 @@ class OtelSdkManagerTest {
       final var metrics = metricReader.collectAllMetrics();
 
       // then — gauge has no data points
-      assertThat(findMetric(metrics, METRIC_EXPORT_WINDOW))
+      assertThat(findMetric(metrics, EXPORT_WINDOW))
           .satisfiesAnyOf(
               opt -> assertThat(opt).isEmpty(),
               opt ->
@@ -616,7 +616,7 @@ class OtelSdkManagerTest {
       final var metrics = metricReader.collectAllMetrics();
 
       // then — sequence number is 1 (not 2), proving the empty window did not consume a slot
-      assertThat(findMetric(metrics, METRIC_EXPORT_WINDOW))
+      assertThat(findMetric(metrics, EXPORT_WINDOW))
           .isPresent()
           .hasValueSatisfying(
               metric ->
@@ -624,7 +624,7 @@ class OtelSdkManagerTest {
                       .first()
                       .satisfies(
                           point ->
-                              assertThat(point.getAttributes().get(METRIC_SEQUENCE_NUMBER))
+                              assertThat(point.getAttributes().get(SEQUENCE_NUMBER))
                                   .isEqualTo(1L)));
     }
 

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandlerTest.java
@@ -66,13 +66,13 @@ class AdHocSubProcessHandlerTest {
             logRecord ->
                 assertThat(logRecord.getAttributes().asMap())
                     .containsEntry(
-                        AnalyticsAttributes.EVENT_NAME,
-                        AnalyticsAttributes.EVENT_ADHOC_SUBPROCESS_ACTIVATED)
-                    .containsEntry(AnalyticsAttributes.BPMN_PROCESS_ID, "my-process")
-                    .containsEntry(AnalyticsAttributes.PROCESS_DEFINITION_KEY, 42L)
-                    .containsEntry(AnalyticsAttributes.PROCESS_INSTANCE_KEY, 99L)
-                    .containsEntry(AnalyticsAttributes.ELEMENT_ID, "adhoc-1")
-                    .containsEntry(AnalyticsAttributes.TENANT_ID, "tenant-a"));
+                        AnalyticsAttributes.Event.NAME,
+                        AnalyticsAttributes.Event.ADHOC_SUBPROCESS_ACTIVATED)
+                    .containsEntry(AnalyticsAttributes.Process.BPMN_PROCESS_ID, "my-process")
+                    .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 42L)
+                    .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, 99L)
+                    .containsEntry(AnalyticsAttributes.Element.ID, "adhoc-1")
+                    .containsEntry(AnalyticsAttributes.Tenant.ID, "tenant-a"));
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandlerTest.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.exporter.analytics.handler;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.BPMN_PROCESS_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_PROCESS_INSTANCE_CREATED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.METRIC_PROCESS_INSTANCE_CREATED;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_VERSION;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.TENANT_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.VERSION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Tenant.ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.analytics.AnalyticsAttributes;
@@ -63,7 +61,7 @@ class ProcessInstanceCreationHandlerTest {
 
   private static Optional<MetricData> findCounter(final Collection<MetricData> metrics) {
     return metrics.stream()
-        .filter(m -> m.getName().equals(METRIC_PROCESS_INSTANCE_CREATED))
+        .filter(m -> m.getName().equals(AnalyticsAttributes.Metric.PROCESS_INSTANCE_CREATED))
         .findFirst();
   }
 
@@ -82,7 +80,8 @@ class ProcessInstanceCreationHandlerTest {
               log ->
                   assertThat(log.getAttributes().asMap())
                       .containsEntry(
-                          AnalyticsAttributes.EVENT_NAME, EVENT_PROCESS_INSTANCE_CREATED));
+                          AnalyticsAttributes.Event.NAME,
+                          AnalyticsAttributes.Event.PROCESS_INSTANCE_CREATED));
     }
   }
 
@@ -125,8 +124,8 @@ class ProcessInstanceCreationHandlerTest {
                           point -> {
                             final var attrs = point.getAttributes();
                             assertThat(attrs.get(BPMN_PROCESS_ID)).isNotNull();
-                            assertThat(attrs.get(PROCESS_VERSION)).isNotNull();
-                            assertThat(attrs.get(TENANT_ID)).isNotNull();
+                            assertThat(attrs.get(VERSION)).isNotNull();
+                            assertThat(attrs.get(ID)).isNotNull();
                           }));
     }
   }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UsageMetricHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UsageMetricHandlerTest.java
@@ -53,12 +53,12 @@ class UsageMetricHandlerTest {
             logRecord ->
                 assertThat(logRecord.getAttributes().asMap())
                     .containsEntry(
-                        AnalyticsAttributes.EVENT_NAME,
-                        AnalyticsAttributes.EVENT_USAGE_METRIC_EXPORTED)
-                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_EVENT_TYPE, "RPI")
-                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_COUNT, 30L)
-                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_INTERVAL_START, 1000L)
-                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_INTERVAL_END, 2000L));
+                        AnalyticsAttributes.Event.NAME,
+                        AnalyticsAttributes.Event.USAGE_METRIC_EXPORTED)
+                    .containsEntry(AnalyticsAttributes.UsageMetric.EVENT_TYPE, "RPI")
+                    .containsEntry(AnalyticsAttributes.UsageMetric.COUNT, 30L)
+                    .containsEntry(AnalyticsAttributes.UsageMetric.INTERVAL_START, 1000L)
+                    .containsEntry(AnalyticsAttributes.UsageMetric.INTERVAL_END, 2000L));
   }
 
   @Test
@@ -75,8 +75,8 @@ class UsageMetricHandlerTest {
         .satisfies(
             logRecord ->
                 assertThat(logRecord.getAttributes().asMap())
-                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_EVENT_TYPE, "EDI")
-                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_COUNT, 20L));
+                    .containsEntry(AnalyticsAttributes.UsageMetric.EVENT_TYPE, "EDI")
+                    .containsEntry(AnalyticsAttributes.UsageMetric.COUNT, 20L));
   }
 
   @Test
@@ -106,7 +106,7 @@ class UsageMetricHandlerTest {
         .satisfies(
             logRecord ->
                 assertThat(logRecord.getAttributes().asMap())
-                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_COUNT, 3L));
+                    .containsEntry(AnalyticsAttributes.UsageMetric.COUNT, 3L));
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandlerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UserTaskCreatedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitUserTaskCreatedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new UserTaskCreatedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableUserTaskRecordValue.builder()
+            .withBpmnProcessId("test-process")
+            .withProcessDefinitionKey(42L)
+            .withProcessInstanceKey(100L)
+            .withElementId("user-task-1")
+            .withTenantId("<default>")
+            // PII fields — must NOT appear in the emitted event
+            .withAssignee("john.doe@example.com")
+            .withCandidateUsersList(List.of("alice@example.com"))
+            .withCandidateGroupsList(List.of("finance-team"))
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(UserTaskIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME, AnalyticsAttributes.Event.USER_TASK_CREATED)
+                  .containsEntry(AnalyticsAttributes.Process.BPMN_PROCESS_ID, "test-process")
+                  .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 42L)
+                  .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, 100L)
+                  .containsEntry(AnalyticsAttributes.Element.ID, "user-task-1")
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "<default>");
+
+              // PII must not appear in any attribute value
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("john.doe@example.com")
+                  .doesNotContain("alice@example.com")
+                  .doesNotContain("finance-team");
+            });
+  }
+
+  @Test
+  void shouldIncludeLogPositionAndSequenceNumber() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new UserTaskCreatedHandler(TestOtelSdkManager.inMemory(logExporter));
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.USER_TASK,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(UserTaskIntent.CREATED));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+              assertThat(attrs)
+                  .containsKey(AnalyticsAttributes.Log.POSITION)
+                  .containsKey(AnalyticsAttributes.Event.SEQUENCE_NUMBER);
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandlerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class UserTaskCreatedHandlerTest {
@@ -75,7 +76,12 @@ class UserTaskCreatedHandlerTest {
                   .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 42L)
                   .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, 100L)
                   .containsEntry(AnalyticsAttributes.Element.ID, "user-task-1")
-                  .containsEntry(AnalyticsAttributes.Tenant.ID, "<default>");
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "<default>")
+                  .containsKey(AnalyticsAttributes.Log.POSITION)
+                  .containsKey(AnalyticsAttributes.Event.SEQUENCE_NUMBER);
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
 
               // PII must not appear in any attribute value
               final var allValues = attrs.values().stream().map(Object::toString).toList();
@@ -83,31 +89,6 @@ class UserTaskCreatedHandlerTest {
                   .doesNotContain("john.doe@example.com")
                   .doesNotContain("alice@example.com")
                   .doesNotContain("finance-team");
-            });
-  }
-
-  @Test
-  void shouldIncludeLogPositionAndSequenceNumber() {
-    // given
-    final var logExporter = InMemoryLogRecordExporter.create();
-    final var handler = new UserTaskCreatedHandler(TestOtelSdkManager.inMemory(logExporter));
-    final var record =
-        FACTORY.generateRecord(
-            ValueType.USER_TASK,
-            r -> r.withRecordType(RecordType.EVENT).withIntent(UserTaskIntent.CREATED));
-
-    // when
-    handler.handle(typed(record));
-
-    // then
-    assertThat(logExporter.getFinishedLogRecordItems())
-        .singleElement()
-        .satisfies(
-            logRecord -> {
-              final var attrs = logRecord.getAttributes().asMap();
-              assertThat(attrs)
-                  .containsKey(AnalyticsAttributes.Log.POSITION)
-                  .containsKey(AnalyticsAttributes.Event.SEQUENCE_NUMBER);
             });
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe what this PR does and why. -->

This PR spikes the framework described in #54784: adding a new analytics event should only require touching a handler class, `HandlerCatalog`, and `AnalyticsAttributes` — with no changes to `AnalyticsExporter` itself.

Three structural changes make this work. First, `AnalyticsAttributes` is reorganised into nested static classes (`Resource`, `Event`, `Log`, `Tenant`, `Process`, `Element`, `Metric`, `Heartbeat`, `UsageMetric`) so grouping is structural rather than comment-based, and IDE autocomplete guides contributors to the right constant. Second, all `(ValueType, Intent) → handler` wiring is extracted from `AnalyticsExporter.configure()` into a new `HandlerCatalog` class; the exporter now delegates in a single line and never imports individual handlers. Third, a `HandlerPiiGuardTest` exercises every registered handler against `InMemoryLogRecordExporter` and asserts that every emitted OTel attribute key is declared in `AnalyticsAttributes` — making that class the auditable PII contract reviewable in the PR diff.

`UserTaskCreatedHandler` is added as the validation event. It has genuine PII-adjacent fields (`assignee`, `candidateUsers`, `candidateGroups`, `variables`) that are all excluded, which gives `HandlerPiiGuardTest` a meaningful proof point beyond the existing handlers.

## Checklist

<!-- Please make sure that you checked all points below before creating a PR -->

- [ ] My changes have tests
- [ ] I have read the [contributing guidelines](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md)

## Related issues

<!-- Which issues are related to this PR? -->

closes #54784