### PR TITLE
fix: tighten chatops disable-cache workflow permissions and validate request

### DIFF
--- a/.github/workflows/chatops-command-disable-cache.yml
+++ b/.github/workflows/chatops-command-disable-cache.yml
@@ -12,7 +12,9 @@ env:
 
 jobs:
   chatops-command-disable-cache:
-    permissions: write-all
+    permissions:
+      contents: write       # for git push
+      pull-requests: write  # for gh pr edit --add-label/--remove-label
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -41,6 +43,21 @@ jobs:
         PAYLOAD_CONTEXT: ${{ toJson(github.event.client_payload) }}
       run: echo "$PAYLOAD_CONTEXT"
 
+    - name: Validate request
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+        COMMENTER: ${{ github.event.client_payload.github.actor }}
+        HEAD_REPO: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+      run: |
+        if [ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
+          echo "::error::Refusing to push to fork PR ($HEAD_REPO)"; exit 1
+        fi
+        PR_AUTHOR=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.user.login')
+        if [ "$COMMENTER" != "$PR_AUTHOR" ]; then
+          echo "::error::Commenter ($COMMENTER) is not the PR author ($PR_AUTHOR)"; exit 1
+        fi
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Git User Setup
@@ -56,9 +73,9 @@ jobs:
         GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
         PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
-        BRANCH: ${{ github.event.client_payload.pull_request.head.ref }}
       run: |
         if [[ -n "$PR_NUMBER" ]]; then
+            BRANCH=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.ref')
             gh pr edit "$PR_NUMBER" --add-label "$NO_CACHE_LABEL"
             echo "Checkout branch $BRANCH and pushing empty commit"
             git fetch && git checkout "$BRANCH"
@@ -75,9 +92,9 @@ jobs:
         GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
         PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
-        BRANCH: ${{ github.event.client_payload.pull_request.head.ref }}
       run: |
         if [[ -n "$PR_NUMBER" ]]; then
+            BRANCH=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.ref')
             gh pr edit "$PR_NUMBER" --remove-label "$NO_CACHE_LABEL"
             echo "Checkout branch $BRANCH and pushing empty commit"
             git fetch && git checkout "$BRANCH"

--- a/.github/workflows/chatops-command-disable-cache.yml
+++ b/.github/workflows/chatops-command-disable-cache.yml
@@ -14,7 +14,8 @@ jobs:
   chatops-command-disable-cache:
     permissions:
       contents: write       # for git push
-      pull-requests: write  # for gh pr edit --add-label/--remove-label
+      pull-requests: write  # for gh pr edit
+      issues: write         # for label management (gh pr edit --add/remove-label uses Issues API)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -47,13 +48,25 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
-        COMMENTER: ${{ github.event.client_payload.github.actor }}
-        HEAD_REPO: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+        COMMENT_ID: ${{ github.event.client_payload.github.payload.comment.id }}
       run: |
+        if [[ -z "$PR_NUMBER" ]]; then
+          echo "::error::Command was not executed on a PR"; exit 1
+        fi
+        # Derive PR data from API — not from attacker-controlled client_payload
+        PR_DATA=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+        HEAD_REPO=$(echo "$PR_DATA" | jq -r '.head.repo.full_name')
+        PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.user.login')
         if [ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
           echo "::error::Refusing to push to fork PR ($HEAD_REPO)"; exit 1
         fi
-        PR_AUTHOR=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.user.login')
+        # Derive commenter from comment API and verify comment belongs to this PR
+        COMMENT_DATA=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID")
+        COMMENTER=$(echo "$COMMENT_DATA" | jq -r '.user.login')
+        COMMENT_PR=$(echo "$COMMENT_DATA" | jq -r '.issue_url | split("/") | last')
+        if [ "$COMMENT_PR" != "$PR_NUMBER" ]; then
+          echo "::error::Comment $COMMENT_ID does not belong to PR #$PR_NUMBER"; exit 1
+        fi
         if [ "$COMMENTER" != "$PR_AUTHOR" ]; then
           echo "::error::Commenter ($COMMENTER) is not the PR author ($PR_AUTHOR)"; exit 1
         fi


### PR DESCRIPTION
## Summary

Fixes two security issues in `.github/workflows/chatops-command-disable-cache.yml` identified in [security-testing-findings#169](https://github.com/camunda/security-testing-findings/issues/169):

- **Excessive permissions**: replaced `permissions: write-all` with minimum required scopes (`contents: write` + `pull-requests: write`)
- **Unvalidated branch push target**: added a validation step that rejects fork PRs and requires the commenter to be the PR author, preventing any write-collaborator from pushing to arbitrary PR branches
- **Attacker-controlled branch ref**: branch name is now derived from the GitHub API using the PR number instead of trusting `client_payload.pull_request.head.ref`

## Details

Without this fix, any write-collaborator could comment `/ci-disable-cache <PR>` targeting any PR — causing the workflow to push an empty commit (attributed to `github-actions[bot]`) to that PR's branch, potentially dismissing approvals and masking the originating actor.

Closes camunda/security-testing-findings#169