### PR TITLE
feat: add conversation history to agent details

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import type {ReactNode} from 'react';
+import {mockSearchAgentInstanceHistory} from 'modules/mocks/api/v2/agentInstances/searchAgentInstanceHistory';
+import {ConversationHistory} from './index';
+import {searchResult} from 'modules/testUtils';
+import {mockAgentInstanceHistoryItem} from 'modules/mocks/mockAgentInstanceHistoryItem';
+
+const AGENT_INSTANCE_KEY = '2251799813851828';
+
+function createWrapper() {
+  const queryClient = getMockQueryClient();
+  return ({children}: {children: ReactNode}) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('<ConversationHistory />', () => {
+  it('should render skeleton while loading', () => {
+    mockSearchAgentInstanceHistory().withDelay(searchResult([]));
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    expect(
+      screen.getByTestId('conversation-history-skeleton'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render an error message when loading fails', async () => {
+    mockSearchAgentInstanceHistory().withServerError(500);
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    expect(
+      screen.getByText('Failed to load conversation history.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render conversation items with text', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '1',
+          role: 'USER',
+          content: [{contentType: 'TEXT', text: 'Hello, agent!'}],
+        }),
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '2',
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'Hello, user!'}],
+        }),
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '3',
+          role: 'TOOL_RESULT',
+          content: [{contentType: 'TEXT', text: 'Tool output here'}],
+        }),
+      ]),
+    );
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    const userMessage = within(screen.getByTestId('conversation-message-1'));
+    expect(
+      userMessage.getByRole('heading', {name: 'User'}),
+    ).toBeInTheDocument();
+    expect(userMessage.getByText('Hello, agent!')).toBeInTheDocument();
+
+    const agentMessage = within(screen.getByTestId('conversation-message-2'));
+    expect(
+      agentMessage.getByRole('heading', {name: 'Assistant'}),
+    ).toBeInTheDocument();
+    expect(agentMessage.getByText('Hello, user!')).toBeInTheDocument();
+
+    const toolResultMessage = within(
+      screen.getByTestId('conversation-message-3'),
+    );
+    expect(
+      toolResultMessage.getByRole('heading', {name: 'Tool Result'}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Tool output here')).toBeInTheDocument();
+  });
+
+  it('should render conversation items with formatted object content', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '1',
+          role: 'TOOL_RESULT',
+          content: [
+            {
+              contentType: 'OBJECT',
+              object: {message: 'Tool output here', hello: 'world'},
+            },
+          ],
+        }),
+      ]),
+    );
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    const toolResultMessage = within(
+      screen.getByTestId('conversation-message-1'),
+    );
+    expect(
+      toolResultMessage.getByRole('heading', {name: 'Tool Result'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '{\n  "message": "Tool output here",\n  "hello": "world"\n}',
+        {
+          normalizer: (text) => text,
+        },
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {SkeletonText} from '@carbon/react';
+import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
+import {ConversationMessage} from '../ConversationMessage';
+import {ConversationContainer, ErrorHint} from './styled';
+
+type ConversationHistoryProps = {
+  agentInstanceKey: string;
+  enablePeriodicRefetch: boolean;
+};
+
+const ConversationHistory: React.FC<ConversationHistoryProps> = ({
+  agentInstanceKey,
+  enablePeriodicRefetch,
+}) => {
+  const {data, status} = useAgentInstanceHistory(agentInstanceKey, {
+    enablePeriodicRefetch,
+  });
+
+  if (status === 'pending') {
+    return (
+      <div data-testid="conversation-history-skeleton">
+        <SkeletonText heading paragraph lineCount={3} />
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <ErrorHint data-testid="conversation-history-error">
+        Failed to load conversation history.
+      </ErrorHint>
+    );
+  }
+
+  return (
+    <ConversationContainer>
+      {data.items.map((item) => (
+        <ConversationMessage
+          key={item.historyItemKey}
+          historyItemKey={item.historyItemKey}
+          actor={item.role}
+          content={item.content}
+        />
+      ))}
+    </ConversationContainer>
+  );
+};
+
+export {ConversationHistory};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const ConversationContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-04);
+`;
+
+const ErrorHint = styled.span`
+  font-size: var(--cds-body-compact-01-font-size);
+  font-weight: var(--cds-body-compact-01-font-weight);
+  line-height: var(--cds-body-compact-01-line-height);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing);
+  color: var(--cds-text-primary);
+`;
+
+export {ConversationContainer, ErrorHint};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -9,39 +9,49 @@
 import {useReducer} from 'react';
 import {Button} from '@carbon/react';
 import {Maximize} from '@carbon/react/icons';
+import type {
+  AgentInstanceHistoryItem,
+  AgentInstanceHistoryRole,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 import {CopyButton} from 'modules/components/CopyButton';
 import {
   Container,
   MessageBlock,
   ActorLabel,
-  Message,
+  TextContent,
   MessageActions,
+  ObjectContent,
 } from './styled';
 import {MarkdownMessage} from './MarkdownMessage';
 import {RichTextEditorModal} from 'modules/components/RichTextEditorModal';
 
-type Actor = 'user' | 'assistant' | 'system';
+type Actor = AgentInstanceHistoryRole | 'SYSTEM';
+type ContentItem = AgentInstanceHistoryItem['content'][number];
 
 const editorModalTitleByActor: Record<Actor, string> = {
-  system: 'System prompt',
-  user: 'User message',
-  assistant: 'Assistant message',
+  SYSTEM: 'System prompt',
+  USER: 'User message',
+  ASSISTANT: 'Assistant message',
+  TOOL_RESULT: 'Tool result',
 };
 
 const labelByActor: Record<Actor, string> = {
-  system: 'System',
-  user: 'User',
-  assistant: 'Assistant',
+  SYSTEM: 'System',
+  USER: 'User',
+  ASSISTANT: 'Assistant',
+  TOOL_RESULT: 'Tool Result',
 };
 
 type ConversationMessageProps = {
   actor: Actor;
-  messages: string[];
+  content: ContentItem[];
+  historyItemKey?: string;
 };
 
 const ConversationMessage: React.FC<ConversationMessageProps> = ({
   actor,
-  messages,
+  content,
+  historyItemKey,
 }) => {
   const [messageDetails, dispatch] = useReducer(
     messageDetailsReducer,
@@ -49,31 +59,52 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
   );
 
   return (
-    <Container $actor={actor}>
+    <Container
+      $actor={actor}
+      data-testid={`conversation-message-${historyItemKey}`}
+    >
       <ActorLabel>{labelByActor[actor]}</ActorLabel>
-      {messages.map((message, index) => (
-        <MessageBlock key={index}>
-          <Message>
-            <MarkdownMessage content={message} />
-          </Message>
-          <MessageActions>
-            <Button
-              kind="ghost"
-              size="sm"
-              renderIcon={Maximize}
-              iconDescription="Expand"
-              hasIconOnly
-              onClick={() => dispatch({type: 'show', actor, message: message})}
-            />
-            <CopyButton value={message} hasIconOnly tooltipAlignment="end" />
-          </MessageActions>
-        </MessageBlock>
-      ))}
+      {content.map((entry, index) => {
+        switch (entry.contentType) {
+          case 'DOCUMENT': {
+            return null;
+          }
+          case 'OBJECT': {
+            const value = JSON.stringify(entry.object, null, 2);
+            return (
+              <MessageContent
+                key={index}
+                value={value}
+                onExpandClick={() =>
+                  dispatch({type: 'show-object', actor, value})
+                }
+              >
+                <ObjectContent>{value}</ObjectContent>
+              </MessageContent>
+            );
+          }
+          case 'TEXT': {
+            return (
+              <MessageContent
+                key={index}
+                value={entry.text}
+                onExpandClick={() =>
+                  dispatch({type: 'show-text', actor, text: entry.text})
+                }
+              >
+                <TextContent>
+                  <MarkdownMessage content={entry.text} />
+                </TextContent>
+              </MessageContent>
+            );
+          }
+        }
+      })}
       <RichTextEditorModal
         title={messageDetails.title}
-        language="markdown"
         readOnly
-        value={messageDetails.message}
+        language={messageDetails.language}
+        value={messageDetails.content}
         isVisible={messageDetails.state === 'visible'}
         onClose={() => dispatch({type: 'hide'})}
       />
@@ -81,18 +112,50 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
   );
 };
 
+type MessageContentProps = {
+  value: string;
+  children: React.ReactNode;
+  onExpandClick: () => void;
+};
+
+const MessageContent: React.FC<MessageContentProps> = ({
+  value,
+  children,
+  onExpandClick,
+}) => {
+  return (
+    <MessageBlock>
+      {children}
+      <MessageActions>
+        <Button
+          kind="ghost"
+          size="sm"
+          renderIcon={Maximize}
+          iconDescription="Expand"
+          hasIconOnly
+          onClick={onExpandClick}
+        />
+        <CopyButton value={value} hasIconOnly tooltipAlignment="end" />
+      </MessageActions>
+    </MessageBlock>
+  );
+};
+
 type MessageDetailsState = {
   state: 'visible' | 'hidden';
-  message: string;
+  language: 'markdown' | 'json';
+  content: string;
   title: string;
 };
 type MessageDetailsAction =
-  | {type: 'show'; actor: Actor; message: string}
+  | {type: 'show-text'; actor: Actor; text: string}
+  | {type: 'show-object'; actor: Actor; value: string}
   | {type: 'hide'};
 
 const initialMessageDetailsState: MessageDetailsState = {
   state: 'hidden',
-  message: '',
+  language: 'markdown',
+  content: '',
   title: '',
 };
 
@@ -101,10 +164,18 @@ function messageDetailsReducer(
   action: MessageDetailsAction,
 ): MessageDetailsState {
   switch (action.type) {
-    case 'show':
+    case 'show-text':
       return {
         state: 'visible',
-        message: action.message,
+        language: 'markdown',
+        content: action.text,
+        title: editorModalTitleByActor[action.actor],
+      };
+    case 'show-object':
+      return {
+        state: 'visible',
+        language: 'json',
+        content: action.value,
         title: editorModalTitleByActor[action.actor],
       };
     case 'hide':

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -61,7 +61,7 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
   return (
     <Container
       $actor={actor}
-      data-testid={`conversation-message-${historyItemKey}`}
+      data-testid={`conversation-message${historyItemKey ? `-${historyItemKey}` : ''}`}
     >
       <ActorLabel>{labelByActor[actor]}</ActorLabel>
       {content.map((entry, index) => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
@@ -6,14 +6,16 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type {AgentInstanceHistoryRole} from '@camunda/camunda-api-zod-schemas/8.10';
 import styled from 'styled-components';
 
-type ActorType = 'user' | 'assistant' | 'system';
+type ActorType = AgentInstanceHistoryRole | 'SYSTEM';
 
 const accentColorByActor: Record<ActorType, string> = {
-  system: 'var(--cds-status-gray)',
-  assistant: 'var(--cds-status-purple)',
-  user: 'var(--cds-status-blue)',
+  SYSTEM: 'var(--cds-status-gray)',
+  ASSISTANT: 'var(--cds-status-purple)',
+  USER: 'var(--cds-status-blue)',
+  TOOL_RESULT: 'var(--cds-status-yellow)',
 };
 
 const Container = styled.div<{$actor: ActorType}>`
@@ -54,7 +56,7 @@ const MessageBlock = styled.div`
   }
 `;
 
-const Message = styled.div`
+const TextContent = styled.div`
   flex: 1;
   overflow-y: auto;
   font-size: var(--cds-body-compact-01-font-size);
@@ -64,4 +66,26 @@ const Message = styled.div`
   color: var(--cds-text-primary);
 `;
 
-export {Container, MessageBlock, ActorLabel, Message, MessageActions};
+const ObjectContent = styled.pre`
+  flex: 1;
+  overflow: auto;
+  border-radius: 4px;
+  padding: var(--cds-spacing-03);
+  background-color: var(--cds-layer-03);
+  font-family: var(--cds-code-01-font-family);
+  font-size: var(--cds-code-01-font-size);
+  font-weight: var(--cds-code-01-font-weight);
+  line-height: var(--cds-code-01-line-height);
+  letter-spacing: var(--cds-code-01-letter-spacing);
+  white-space: pre-wrap;
+  word-break: break-word;
+`;
+
+export {
+  Container,
+  MessageBlock,
+  ActorLabel,
+  TextContent,
+  ObjectContent,
+  MessageActions,
+};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
@@ -15,7 +15,7 @@ const accentColorByActor: Record<ActorType, string> = {
   SYSTEM: 'var(--cds-status-gray)',
   ASSISTANT: 'var(--cds-status-purple)',
   USER: 'var(--cds-status-blue)',
-  TOOL_RESULT: 'var(--cds-status-yellow)',
+  TOOL_RESULT: 'var(--cds-status-gray)',
 };
 
 const Container = styled.div<{$actor: ActorType}>`

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -19,6 +19,7 @@ import {
   MeterAlt,
   Chip,
   DocumentBlank,
+  Chat,
 } from '@carbon/react/icons';
 import {
   AgentDetailsContainer,
@@ -33,6 +34,9 @@ import {TokensUsedMetric} from './AgentMetrics/TokensUsedMetric';
 import {ToolsCalledMetric} from './AgentMetrics/ToolsCalledMetric';
 import {SectionTitle} from './SectionTitle';
 import {ConversationMessage} from './ConversationMessage';
+import {ConversationHistory} from './ConversationHistory';
+import {IS_CONVERSATION_HISTORY_ENABLED} from 'modules/feature-flags';
+import {isAgentInstanceRunning} from 'modules/queries/agentInstances/useAgentInstance';
 
 const STATUS_LABELS: Record<AgentInstanceStatus, string> = {
   INITIALIZING: 'Initializing',
@@ -132,6 +136,21 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
             />
           </MetricsRow>
         </AccordionItem>
+        {IS_CONVERSATION_HISTORY_ENABLED && (
+          <AccordionItem
+            data-testid="agent-conversation-history-section"
+            title={
+              <SectionTitle icon={<Chat size={16} />}>
+                Conversation history
+              </SectionTitle>
+            }
+          >
+            <ConversationHistory
+              agentInstanceKey={agentInstance.agentInstanceKey}
+              enablePeriodicRefetch={isAgentInstanceRunning(agentInstance)}
+            />
+          </AccordionItem>
+        )}
         <AccordionItem
           data-testid="agent-system-prompt-section"
           title={
@@ -141,8 +160,8 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
           }
         >
           <ConversationMessage
-            actor="system"
-            messages={[definition.systemPrompt]}
+            actor="SYSTEM"
+            content={[{contentType: 'TEXT', text: definition.systemPrompt}]}
           />
         </AccordionItem>
         <AccordionItem

--- a/operate/client/src/modules/api/v2/agentInstances/searchAgentInstanceHistory.ts
+++ b/operate/client/src/modules/api/v2/agentInstances/searchAgentInstanceHistory.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type SearchAgentInstanceHistoryRequestBody,
+  type SearchAgentInstanceHistoryResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+
+const searchAgentInstanceHistory = async (
+  agentInstanceKey: string,
+  payload: SearchAgentInstanceHistoryRequestBody,
+  signal?: AbortSignal,
+) => {
+  return requestWithThrow<SearchAgentInstanceHistoryResponseBody>({
+    url: endpoints.searchAgentInstanceHistory.getUrl({agentInstanceKey}),
+    method: endpoints.searchAgentInstanceHistory.method,
+    body: payload,
+    signal,
+  });
+};
+
+export {searchAgentInstanceHistory};

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -6,4 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-export {};
+const IS_CONVERSATION_HISTORY_ENABLED =
+  localStorage.getItem('FEATURE_CONVERSATION_HISTORY_ENABLED') === 'true';
+
+export {IS_CONVERSATION_HISTORY_ENABLED};

--- a/operate/client/src/modules/mocks/api/v2/agentInstances/searchAgentInstanceHistory.ts
+++ b/operate/client/src/modules/mocks/api/v2/agentInstances/searchAgentInstanceHistory.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from '../../mockRequest';
+import {
+  type SearchAgentInstanceHistoryResponseBody,
+  endpoints,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const mockSearchAgentInstanceHistory = (
+  agentInstanceKey: string = ':agentInstanceKey',
+  contextPath = '',
+) =>
+  mockPostRequest<SearchAgentInstanceHistoryResponseBody>(
+    `${contextPath}${endpoints.searchAgentInstanceHistory.getUrl({agentInstanceKey})}`,
+  );
+
+export {mockSearchAgentInstanceHistory};

--- a/operate/client/src/modules/mocks/mockAgentInstanceHistoryItem.ts
+++ b/operate/client/src/modules/mocks/mockAgentInstanceHistoryItem.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {AgentInstanceHistoryItem} from '@camunda/camunda-api-zod-schemas/8.10';
+
+function mockAgentInstanceHistoryItem(
+  overwrites: Partial<AgentInstanceHistoryItem> = {},
+): AgentInstanceHistoryItem {
+  return {
+    historyItemKey: 'history-item-1',
+    agentInstanceKey: 'agent-instance-1',
+    elementInstanceKey: 'elem-1',
+    jobKey: 'job-1',
+    jobLease: 'lease-1',
+    iteration: 1,
+    role: 'ASSISTANT',
+    content: [{contentType: 'TEXT', text: 'Hello from assistant.'}],
+    toolCalls: [],
+    metrics: null,
+    commitStatus: 'COMMITTED',
+    producedAt: '2025-01-15T10:00:00.000Z',
+    ...overwrites,
+  };
+}
+
+export {mockAgentInstanceHistoryItem};

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {skipToken, useQuery} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 import type {SearchAgentInstanceHistoryRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
 import {searchAgentInstanceHistory} from 'modules/api/v2/agentInstances/searchAgentInstanceHistory';
 import {queryKeys} from '../queryKeys';
@@ -17,27 +17,25 @@ const HISTORY_PAYLOAD: SearchAgentInstanceHistoryRequestBody = {
 };
 
 const useAgentInstanceHistory = (
-  agentInstanceKey: string | undefined,
+  agentInstanceKey: string,
   options?: {enablePeriodicRefetch?: boolean},
 ) => {
   return useQuery({
     queryKey: queryKeys.agentInstanceHistory.search(
-      agentInstanceKey ?? '',
+      agentInstanceKey,
       HISTORY_PAYLOAD,
     ),
-    queryFn: agentInstanceKey
-      ? async ({signal}) => {
-          const {response, error} = await searchAgentInstanceHistory(
-            agentInstanceKey,
-            HISTORY_PAYLOAD,
-            signal,
-          );
-          if (response !== null) {
-            return response;
-          }
-          throw error;
-        }
-      : skipToken,
+    queryFn: async ({signal}) => {
+      const {response, error} = await searchAgentInstanceHistory(
+        agentInstanceKey,
+        HISTORY_PAYLOAD,
+        signal,
+      );
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
     refetchInterval: options?.enablePeriodicRefetch ? 5000 : undefined,
   });
 };

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {skipToken, useQuery} from '@tanstack/react-query';
+import type {SearchAgentInstanceHistoryRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import {searchAgentInstanceHistory} from 'modules/api/v2/agentInstances/searchAgentInstanceHistory';
+import {queryKeys} from '../queryKeys';
+
+const HISTORY_PAYLOAD: SearchAgentInstanceHistoryRequestBody = {
+  sort: [{field: 'producedAt', order: 'desc'}],
+  filter: {commitStatus: 'COMMITTED'},
+};
+
+const useAgentInstanceHistory = (
+  agentInstanceKey: string | undefined,
+  options?: {enablePeriodicRefetch?: boolean},
+) => {
+  return useQuery({
+    queryKey: queryKeys.agentInstanceHistory.search(
+      agentInstanceKey ?? '',
+      HISTORY_PAYLOAD,
+    ),
+    queryFn: agentInstanceKey
+      ? async ({signal}) => {
+          const {response, error} = await searchAgentInstanceHistory(
+            agentInstanceKey,
+            HISTORY_PAYLOAD,
+            signal,
+          );
+          if (response !== null) {
+            return response;
+          }
+          throw error;
+        }
+      : skipToken,
+    refetchInterval: options?.enablePeriodicRefetch ? 5000 : undefined,
+  });
+};
+
+export {useAgentInstanceHistory};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -27,6 +27,7 @@ import type {
   QueryProcessInstanceIncidentsRequestBody,
   QueryProcessInstancesRequestBody,
   QueryUserTasksRequestBody,
+  SearchAgentInstanceHistoryRequestBody,
   Variable,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
@@ -39,6 +40,12 @@ const queryKeys = {
       payload?: QueryAgentInstancesRequestBody,
       options?: {loadAllItems?: boolean},
     ) => ['agentInstancesSearch', payload, options],
+  },
+  agentInstanceHistory: {
+    search: (
+      agentInstanceKey: string,
+      payload?: SearchAgentInstanceHistoryRequestBody,
+    ) => ['agentInstanceHistorySearch', agentInstanceKey, payload],
   },
   variables: {
     search: () => ['searchVariables'],


### PR DESCRIPTION
## Description

This PR adds a basic conversation history implementation to the agent instance details. It:
- Adds a feature flag that enables the feature when `FEATURE_CONVERSATION_HISTORY_ENABLED` is set to `true` in local storage.
- Loads the conversation history for commited items (no pagination yet).
- Display conversation messages in a new "Conversation history" accordion item
  - Displays `TEXT` content as formatted markdown
  - Displays `OBJECT` content as code blocks
  - Skips `DOCUMENT` content for now
  - Adds support for the `TOOL_RESULT` role

**What is still missing (for follow-up PRs):**
- Pagination support
- Changing the message sort order
- Displaying tool calls
- Displaying documents
- Alignment with PM on potentially showing more information

## Related issues

relates #51928
