### PR TITLE
fix: resolve user task processInstanceVariables filter via variable store

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskMigrationVariableSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskMigrationVariableSearchIT.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.orchestration;
+
+import static io.camunda.it.util.TestHelper.activateAndCompleteJobs;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.exporter.CamundaExporter;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbConfigurator;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.time.Duration;
+import java.util.Map;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Reproduces the gap described in <a
+ * href="https://github.com/camunda/camunda/issues/49963">#49963</a>.
+ *
+ * <p>Scenario:
+ *
+ * <ol>
+ *   <li>Deploy a process v1 that has <b>no user task</b> (just a service task that waits on a job).
+ *   <li>Start an instance of v1 with a process-instance variable, and let it wait on the service
+ *       task.
+ *   <li>Deploy a process v2 that <b>does</b> have a Camunda user task after the service task. The
+ *       user task has an input mapping that creates a local variable.
+ *   <li>Migrate the running instance from v1 to v2 (map the active service task to v2's service
+ *       task).
+ *   <li>Complete the service-task job so the instance proceeds into the user task.
+ *   <li>Search user tasks by variable filters.
+ * </ol>
+ *
+ * <p>This test requires the exporter optimization {@code skipVariableWriteWithoutUserTasks=true}
+ * (enabled below). With it on, variables of the no-user-task v1 instance are never written to the
+ * {@code tasklist-task} index, and migration does not back-fill them. Therefore, after the user
+ * task activates:
+ *
+ * <ul>
+ *   <li>the <b>localVariables</b> filter finds the task — the user task's own input variable is
+ *       exported normally at activation (works without any fix);
+ *   <li>the <b>processInstanceVariables</b> filter does <b>not</b> find the task — the
+ *       pre-migration process variable was skipped and never back-filled (the #49963 gap).
+ * </ul>
+ *
+ * <p>The process-instance-variable assertion is therefore a <b>characterization</b> of current
+ * (buggy) behavior: it asserts the result is empty. Once #49963 is fixed, flip that assertion to
+ * expect the task to be found.
+ */
+@Testcontainers
+@ZeebeIntegration
+public class UserTaskMigrationVariableSearchIT {
+
+  private static final String PROCESS_V1_ID = "migration-no-user-task";
+  private static final String PROCESS_V2_ID = "migration-with-user-task";
+  private static final String WAIT_TASK_ID = "wait";
+  private static final String USER_TASK_ID = "review";
+  private static final String JOB_TYPE = "wait-job";
+  private static final String INDEX_PREFIX = "usertaskmigrationvar";
+  private static final String PROCESS_VARIABLE_NAME = "amount";
+  private static final int PROCESS_VARIABLE_VALUE = 1000;
+  private static final String LOCAL_VARIABLE_NAME = "reviewLevel";
+  private static final String LOCAL_VARIABLE_VALUE = "senior";
+  private static final Duration TIMEOUT = Duration.ofSeconds(90);
+
+  @TestZeebe(autoStart = false)
+  private TestStandaloneApplication<?> app;
+
+  private CamundaClient client;
+  private GenericContainer<?> searchContainer;
+
+  @BeforeEach
+  void setup() {
+    searchContainer =
+        TestSearchContainers.createDefaultElasticsearchContainer()
+            .withStartupTimeout(Duration.ofMinutes(5));
+    searchContainer.start();
+    final String esUrl =
+        String.format(
+            "http://%s:%d", searchContainer.getHost(), searchContainer.getMappedPort(9200));
+
+    final TestCamundaApplication camundaApp =
+        new TestCamundaApplication()
+            .withAuthenticationMethod(AuthenticationMethod.BASIC)
+            .withUnauthenticatedAccess();
+    app = camundaApp;
+
+    final var configurator = new MultiDbConfigurator(camundaApp);
+    // secondary storage = Elasticsearch + the camunda-exporter writing into it
+    configurator.configureElasticsearchSupport(esUrl, INDEX_PREFIX);
+
+    // Enable the optimization this scenario depends on. The configurator above sets the
+    // camunda-exporter args; we add the skip flag on top before the app is started.
+    camundaApp.updateExporterArgs(
+        CamundaExporter.class.getSimpleName().toLowerCase(),
+        args -> args.put("skipVariableWriteWithoutUserTasks", true));
+
+    app.start().awaitCompleteTopology();
+    client = app.newClientBuilder().build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    CloseHelper.quietCloseAll(client);
+    if (app != null) {
+      app.stop();
+    }
+    if (searchContainer != null) {
+      searchContainer.stop();
+    }
+  }
+
+  @Test
+  void shouldFindMigratedTaskByLocalVariableButNotByProcessVariable() {
+    // given - v1 has NO user task: start -> service task (waits on a job) -> end
+    final BpmnModelInstance v1 =
+        Bpmn.createExecutableProcess(PROCESS_V1_ID)
+            .startEvent()
+            .serviceTask(WAIT_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    // v2 HAS a Camunda user task after the service task, with an input mapping that creates a
+    // LOCAL variable scoped to the user task
+    final BpmnModelInstance v2 =
+        Bpmn.createExecutableProcess(PROCESS_V2_ID)
+            .startEvent()
+            .serviceTask(WAIT_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
+            .userTask(
+                USER_TASK_ID,
+                u ->
+                    u.zeebeUserTask()
+                        .zeebeInput("=\"" + LOCAL_VARIABLE_VALUE + "\"", LOCAL_VARIABLE_NAME))
+            .endEvent()
+            .done();
+
+    final var deployment =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(v1, PROCESS_V1_ID + ".bpmn")
+            .addProcessModel(v2, PROCESS_V2_ID + ".bpmn")
+            .send()
+            .join();
+    final long targetProcessDefinitionKey =
+        deployment.getProcesses().stream()
+            .filter(p -> p.getBpmnProcessId().equals(PROCESS_V2_ID))
+            .findFirst()
+            .orElseThrow()
+            .getProcessDefinitionKey();
+
+    // start the v1 instance with a process-instance-scoped variable
+    final long processInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_V1_ID)
+            .latestVersion()
+            .variables(Map.of(PROCESS_VARIABLE_NAME, PROCESS_VARIABLE_VALUE))
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    // run up to the waiting service task - wait until it is active and exported before migrating
+    await()
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newElementInstanceSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .elementId(WAIT_TASK_ID)
+                                        .state(ElementInstanceState.ACTIVE))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when - migrate the active service task from v1 to v2's service task
+    client
+        .newMigrateProcessInstanceCommand(processInstanceKey)
+        .migrationPlan(
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                .addMappingInstruction(WAIT_TASK_ID, WAIT_TASK_ID)
+                .build())
+        .send()
+        .join();
+
+    // complete the service-task job so the instance proceeds into the user task (v2)
+    activateAndCompleteJobs(client, JOB_TYPE, "test-worker", 1);
+
+    // wait until the migrated instance's user task has been created and exported
+    await()
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newUserTaskSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .state(UserTaskState.CREATED))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // then - the LOCAL variable filter finds the task (works today, no fix required)
+    await()
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newUserTaskSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .localVariables(
+                                            // string values must be quoted as JSON in the filter,
+                                            // see https://github.com/camunda/camunda/issues/23724
+                                            Map.of(
+                                                LOCAL_VARIABLE_NAME,
+                                                "\"" + LOCAL_VARIABLE_VALUE + "\"")))
+                            .send()
+                            .join()
+                            .items())
+                    .describedAs("local variable filter should find the migrated user task")
+                    .hasSize(1));
+
+    // and - the PROCESS-INSTANCE variable filter does NOT find the task today.
+    // The pre-migration process variable was skipped from tasklist-task (no user task in v1) and
+    // migration does not back-fill it. This is the #49963 gap.
+    // CHARACTERIZATION: once #49963 is fixed, change this assertion to expect hasSize(1).
+    final var byProcessVariable =
+        client
+            .newUserTaskSearchRequest()
+            .filter(
+                f ->
+                    f.processInstanceKey(processInstanceKey)
+                        .processInstanceVariables(
+                            Map.of(PROCESS_VARIABLE_NAME, PROCESS_VARIABLE_VALUE)))
+            .send()
+            .join();
+    assertThat(byProcessVariable.items())
+        .describedAs(
+            "process-instance variable filter cannot match a migrated instance's pre-migration "
+                + "variables until #49963 is fixed")
+        .isEmpty();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskMigrationVariableSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskMigrationVariableSearchIT.java
@@ -44,29 +44,21 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  *   <li>Deploy a process v1 that has <b>no user task</b> (just a service task that waits on a job).
  *   <li>Start an instance of v1 with a process-instance variable, and let it wait on the service
  *       task.
- *   <li>Deploy a process v2 that <b>does</b> have a Camunda user task after the service task. The
- *       user task has an input mapping that creates a local variable.
+ *   <li>Deploy a process v2 that <b>does</b> have a Camunda user task after the service task.
  *   <li>Migrate the running instance from v1 to v2 (map the active service task to v2's service
  *       task).
  *   <li>Complete the service-task job so the instance proceeds into the user task.
- *   <li>Search user tasks by variable filters.
+ *   <li>Search user tasks by the {@code processInstanceVariables} filter.
  * </ol>
  *
  * <p>This test requires the exporter optimization {@code skipVariableWriteWithoutUserTasks=true}
  * (enabled below). With it on, variables of the no-user-task v1 instance are never written to the
  * {@code tasklist-task} index, and migration does not back-fill them. Therefore, after the user
- * task activates:
+ * task activates the {@code processInstanceVariables} filter does <b>not</b> find the task — the
+ * pre-migration process variable was skipped and never back-filled (the #49963 gap).
  *
- * <ul>
- *   <li>the <b>localVariables</b> filter finds the task — the user task's own input variable is
- *       exported normally at activation (works without any fix);
- *   <li>the <b>processInstanceVariables</b> filter does <b>not</b> find the task — the
- *       pre-migration process variable was skipped and never back-filled (the #49963 gap).
- * </ul>
- *
- * <p>The process-instance-variable assertion is therefore a <b>characterization</b> of current
- * (buggy) behavior: it asserts the result is empty. Once #49963 is fixed, flip that assertion to
- * expect the task to be found.
+ * <p>The assertion is a <b>characterization</b> of current (buggy) behavior: it asserts the result
+ * is empty. Once #49963 is fixed, flip that assertion to expect the task to be found.
  */
 @Testcontainers
 @ZeebeIntegration
@@ -80,8 +72,6 @@ public class UserTaskMigrationVariableSearchIT {
   private static final String INDEX_PREFIX = "usertaskmigrationvar";
   private static final String PROCESS_VARIABLE_NAME = "amount";
   private static final int PROCESS_VARIABLE_VALUE = 1000;
-  private static final String LOCAL_VARIABLE_NAME = "reviewLevel";
-  private static final String LOCAL_VARIABLE_VALUE = "senior";
   private static final Duration TIMEOUT = Duration.ofSeconds(90);
 
   @TestZeebe(autoStart = false)
@@ -132,7 +122,7 @@ public class UserTaskMigrationVariableSearchIT {
   }
 
   @Test
-  void shouldFindMigratedTaskByLocalVariableButNotByProcessVariable() {
+  void shouldNotFindTaskByProcessInstanceVariablesAfterMigration() {
     // given - v1 has NO user task: start -> service task (waits on a job) -> end
     final BpmnModelInstance v1 =
         Bpmn.createExecutableProcess(PROCESS_V1_ID)
@@ -140,17 +130,12 @@ public class UserTaskMigrationVariableSearchIT {
             .serviceTask(WAIT_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
             .endEvent()
             .done();
-    // v2 HAS a Camunda user task after the service task, with an input mapping that creates a
-    // LOCAL variable scoped to the user task
+    // v2 HAS a Camunda user task after the service task
     final BpmnModelInstance v2 =
         Bpmn.createExecutableProcess(PROCESS_V2_ID)
             .startEvent()
             .serviceTask(WAIT_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
-            .userTask(
-                USER_TASK_ID,
-                u ->
-                    u.zeebeUserTask()
-                        .zeebeInput("=\"" + LOCAL_VARIABLE_VALUE + "\"", LOCAL_VARIABLE_NAME))
+            .userTask(USER_TASK_ID, u -> u.zeebeUserTask())
             .endEvent()
             .done();
 
@@ -228,30 +213,7 @@ public class UserTaskMigrationVariableSearchIT {
                             .items())
                     .hasSize(1));
 
-    // then - the LOCAL variable filter finds the task (works today, no fix required)
-    await()
-        .atMost(TIMEOUT)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        client
-                            .newUserTaskSearchRequest()
-                            .filter(
-                                f ->
-                                    f.processInstanceKey(processInstanceKey)
-                                        .localVariables(
-                                            // string values must be quoted as JSON in the filter,
-                                            // see https://github.com/camunda/camunda/issues/23724
-                                            Map.of(
-                                                LOCAL_VARIABLE_NAME,
-                                                "\"" + LOCAL_VARIABLE_VALUE + "\"")))
-                            .send()
-                            .join()
-                            .items())
-                    .describedAs("local variable filter should find the migrated user task")
-                    .hasSize(1));
-
-    // and - the PROCESS-INSTANCE variable filter does NOT find the task today.
+    // then - the processInstanceVariables filter does NOT find the task today.
     // The pre-migration process variable was skipped from tasklist-task (no user task in v1) and
     // migration does not back-fill it. This is the #49963 gap.
     // CHARACTERIZATION: once #49963 is fixed, change this assertion to expect hasSize(1).

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/PostImporterQueueTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/PostImporterQueueTemplate.java
@@ -25,6 +25,7 @@ public class PostImporterQueueTemplate extends AbstractTemplateDescriptor
   public static final String CREATION_TIME = "creationTime";
   public static final String INTENT = "intent";
   public static final String PARTITION_ID = "partitionId";
+  public static final String POSITION = "position";
   public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public PostImporterQueueTemplate(final String indexPrefix, final boolean isElasticsearch) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/post/PostImporterActionType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/post/PostImporterActionType.java
@@ -8,5 +8,6 @@
 package io.camunda.webapps.schema.entities.post;
 
 public enum PostImporterActionType {
-  INCIDENT
+  INCIDENT,
+  PROCESS_INSTANCE_MIGRATION
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -53,6 +53,7 @@ import io.camunda.exporter.handlers.MessageSubscriptionFromMessageStartEventSubs
 import io.camunda.exporter.handlers.MessageSubscriptionFromProcessMessageSubscriptionHandler;
 import io.camunda.exporter.handlers.MigratedVariableHandler;
 import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
+import io.camunda.exporter.handlers.PostImporterQueueFromProcessInstanceMigrationHandler;
 import io.camunda.exporter.handlers.ProcessHandler;
 import io.camunda.exporter.handlers.ResourceCreatedHandler;
 import io.camunda.exporter.handlers.ResourceDeletedHandler;
@@ -274,6 +275,10 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 decisionRequirementsCache),
             new PostImporterQueueFromIncidentHandler(
                 indexDescriptors.get(PostImporterQueueTemplate.class).getFullQualifiedName()),
+            new PostImporterQueueFromProcessInstanceMigrationHandler(
+                indexDescriptors.get(PostImporterQueueTemplate.class).getFullQualifiedName(),
+                processCache,
+                configuration.isSkipVariableWriteWithoutUserTasks()),
             new FlowNodeInstanceFromIncidentHandler(
                 indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
             new FlowNodeInstanceFromProcessInstanceHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterMetadata.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterMetadata.java
@@ -31,11 +31,16 @@ public final class ExporterMetadata {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExporterMetadata.class);
   private static final AtomicLongFieldUpdater<ExporterMetadata> INCIDENT_POSITION_SETTER =
       AtomicLongFieldUpdater.newUpdater(ExporterMetadata.class, "lastIncidentUpdatePosition");
+  private static final AtomicLongFieldUpdater<ExporterMetadata>
+      MIGRATION_VARIABLE_BACKFILL_POSITION_SETTER =
+          AtomicLongFieldUpdater.newUpdater(
+              ExporterMetadata.class, "lastMigrationVariableBackfillPosition");
   private static final int UNSET_POSITION = -1;
 
   @JsonIgnore private final ObjectWriter objectWriter;
   @JsonIgnore private final ObjectReader objectReader;
   private volatile long lastIncidentUpdatePosition = UNSET_POSITION;
+  private volatile long lastMigrationVariableBackfillPosition = UNSET_POSITION;
   private Map<TaskImplementation, Long> firstUserTaskKeys =
       new HashMap<>() {
         {
@@ -59,6 +64,15 @@ public final class ExporterMetadata {
     INCIDENT_POSITION_SETTER.updateAndGet(
         this,
         prev -> updateLastIncidentUpdatePositionMonotonic(newLastIncidentUpdatePosition, prev));
+  }
+
+  public long getLastMigrationVariableBackfillPosition() {
+    return lastMigrationVariableBackfillPosition;
+  }
+
+  public void setLastMigrationVariableBackfillPosition(final long newPosition) {
+    MIGRATION_VARIABLE_BACKFILL_POSITION_SETTER.updateAndGet(
+        this, prev -> Math.max(prev, newPosition));
   }
 
   public long getFirstUserTaskKey(final TaskImplementation implementation) {
@@ -114,7 +128,10 @@ public final class ExporterMetadata {
   @Override
   public int hashCode() {
     return Objects.hash(
-        lastIncidentUpdatePosition, firstUserTaskKeys, firstProcessMessageSubscriptionKey);
+        lastIncidentUpdatePosition,
+        lastMigrationVariableBackfillPosition,
+        firstUserTaskKeys,
+        firstProcessMessageSubscriptionKey);
   }
 
   @Override
@@ -127,6 +144,7 @@ public final class ExporterMetadata {
     }
     final ExporterMetadata that = (ExporterMetadata) o;
     return lastIncidentUpdatePosition == that.lastIncidentUpdatePosition
+        && lastMigrationVariableBackfillPosition == that.lastMigrationVariableBackfillPosition
         && firstUserTaskKeys == that.firstUserTaskKeys
         && firstProcessMessageSubscriptionKey == that.firstProcessMessageSubscriptionKey;
   }
@@ -136,6 +154,8 @@ public final class ExporterMetadata {
     return "ExporterMetadata{"
         + "lastIncidentUpdatePosition="
         + lastIncidentUpdatePosition
+        + ", lastMigrationVariableBackfillPosition="
+        + lastMigrationVariableBackfillPosition
         + ", firstUserTaskKeys="
         + firstUserTaskKeys
         + ", firstProcessMessageSubscriptionKey="

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterMetadata.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterMetadata.java
@@ -31,16 +31,11 @@ public final class ExporterMetadata {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExporterMetadata.class);
   private static final AtomicLongFieldUpdater<ExporterMetadata> INCIDENT_POSITION_SETTER =
       AtomicLongFieldUpdater.newUpdater(ExporterMetadata.class, "lastIncidentUpdatePosition");
-  private static final AtomicLongFieldUpdater<ExporterMetadata>
-      MIGRATION_VARIABLE_BACKFILL_POSITION_SETTER =
-          AtomicLongFieldUpdater.newUpdater(
-              ExporterMetadata.class, "lastMigrationVariableBackfillPosition");
   private static final int UNSET_POSITION = -1;
 
   @JsonIgnore private final ObjectWriter objectWriter;
   @JsonIgnore private final ObjectReader objectReader;
   private volatile long lastIncidentUpdatePosition = UNSET_POSITION;
-  private volatile long lastMigrationVariableBackfillPosition = UNSET_POSITION;
   private Map<TaskImplementation, Long> firstUserTaskKeys =
       new HashMap<>() {
         {
@@ -64,15 +59,6 @@ public final class ExporterMetadata {
     INCIDENT_POSITION_SETTER.updateAndGet(
         this,
         prev -> updateLastIncidentUpdatePositionMonotonic(newLastIncidentUpdatePosition, prev));
-  }
-
-  public long getLastMigrationVariableBackfillPosition() {
-    return lastMigrationVariableBackfillPosition;
-  }
-
-  public void setLastMigrationVariableBackfillPosition(final long newPosition) {
-    MIGRATION_VARIABLE_BACKFILL_POSITION_SETTER.updateAndGet(
-        this, prev -> Math.max(prev, newPosition));
   }
 
   public long getFirstUserTaskKey(final TaskImplementation implementation) {
@@ -128,10 +114,7 @@ public final class ExporterMetadata {
   @Override
   public int hashCode() {
     return Objects.hash(
-        lastIncidentUpdatePosition,
-        lastMigrationVariableBackfillPosition,
-        firstUserTaskKeys,
-        firstProcessMessageSubscriptionKey);
+        lastIncidentUpdatePosition, firstUserTaskKeys, firstProcessMessageSubscriptionKey);
   }
 
   @Override
@@ -144,7 +127,6 @@ public final class ExporterMetadata {
     }
     final ExporterMetadata that = (ExporterMetadata) o;
     return lastIncidentUpdatePosition == that.lastIncidentUpdatePosition
-        && lastMigrationVariableBackfillPosition == that.lastMigrationVariableBackfillPosition
         && firstUserTaskKeys == that.firstUserTaskKeys
         && firstProcessMessageSubscriptionKey == that.firstProcessMessageSubscriptionKey;
   }
@@ -154,8 +136,6 @@ public final class ExporterMetadata {
     return "ExporterMetadata{"
         + "lastIncidentUpdatePosition="
         + lastIncidentUpdatePosition
-        + ", lastMigrationVariableBackfillPosition="
-        + lastMigrationVariableBackfillPosition
         + ", firstUserTaskKeys="
         + firstUserTaskKeys
         + ", firstProcessMessageSubscriptionKey="

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromProcessInstanceMigrationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromProcessInstanceMigrationHandler.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.post.PostImporterActionType;
+import io.camunda.webapps.schema.entities.post.PostImporterQueueEntity;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Enqueues a backfill entry into the post-importer queue when a process instance is migrated from a
+ * process definition with no user tasks to one that has user tasks. The backfill is only needed
+ * when {@code skipVariableWriteWithoutUserTasks} is enabled, because in that case the instance's
+ * variables were never written to the {@code tasklist-task} index.
+ *
+ * <p>The entry is consumed by {@link
+ * io.camunda.exporter.tasks.migrationvariablebackfill.MigrationVariableBackfillTask}.
+ */
+public class PostImporterQueueFromProcessInstanceMigrationHandler
+    implements ExportHandler<PostImporterQueueEntity, ProcessInstanceMigrationRecordValue> {
+
+  private final String indexName;
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+  private final boolean skipVariableWriteWithoutUserTasks;
+
+  public PostImporterQueueFromProcessInstanceMigrationHandler(
+      final String indexName,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final boolean skipVariableWriteWithoutUserTasks) {
+    this.indexName = indexName;
+    this.processCache = processCache;
+    this.skipVariableWriteWithoutUserTasks = skipVariableWriteWithoutUserTasks;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.PROCESS_INSTANCE_MIGRATION;
+  }
+
+  @Override
+  public Class<PostImporterQueueEntity> getEntityType() {
+    return PostImporterQueueEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<ProcessInstanceMigrationRecordValue> record) {
+    if (!ProcessInstanceMigrationIntent.MIGRATED.equals(record.getIntent())) {
+      return false;
+    }
+    if (!skipVariableWriteWithoutUserTasks) {
+      return false;
+    }
+    final long sourceKey = record.getValue().getProcessDefinitionKey();
+    final long targetKey = record.getValue().getTargetProcessDefinitionKey();
+    final var sourceProcess = processCache.get(sourceKey);
+    final var targetProcess = processCache.get(targetKey);
+    // Backfill is needed only when source definitely had no user tasks but target has them.
+    // On a cache miss for either process we skip (safe default: assume backfill not needed).
+    return sourceProcess.isPresent()
+        && !sourceProcess.get().hasUserTasks()
+        && targetProcess.isPresent()
+        && targetProcess.get().hasUserTasks();
+  }
+
+  @Override
+  public List<String> generateIds(final Record<ProcessInstanceMigrationRecordValue> record) {
+    // Use the processInstanceKey as the queue entry ID so that multiple qualifying migrations
+    // of the same instance overwrite the same entry rather than accumulate unboundedly.
+    return List.of(String.valueOf(record.getValue().getProcessInstanceKey()));
+  }
+
+  @Override
+  public PostImporterQueueEntity createNewEntity(final String id) {
+    return new PostImporterQueueEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<ProcessInstanceMigrationRecordValue> record,
+      final PostImporterQueueEntity entity) {
+    final var value = record.getValue();
+    entity
+        .setId(String.valueOf(value.getProcessInstanceKey()))
+        .setActionType(PostImporterActionType.PROCESS_INSTANCE_MIGRATION)
+        .setKey(value.getProcessInstanceKey())
+        .setProcessInstanceKey(value.getProcessInstanceKey())
+        .setPosition(record.getPosition())
+        .setCreationTime(OffsetDateTime.now())
+        .setPartitionId(record.getPartitionId())
+        .setIntent(ProcessInstanceMigrationIntent.MIGRATED.name());
+    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
+  }
+
+  @Override
+  public void flush(final PostImporterQueueEntity entity, final BatchRequest batchRequest) {
+    batchRequest.add(indexName, entity);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManager.java
@@ -12,6 +12,7 @@ import io.camunda.exporter.tasks.archiver.AuditLogArchiverRepository;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.historydeletion.HistoryDeletionRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository;
+import io.camunda.exporter.tasks.migrationvariablebackfill.MigrationVariableBackfillRepository;
 import io.camunda.zeebe.exporter.common.tasks.BackgroundTaskManager;
 import io.camunda.zeebe.exporter.common.tasks.RunnableTask;
 import io.camunda.zeebe.util.CloseableSilently;
@@ -35,6 +36,7 @@ public final class CamundaBackgroundTaskManager implements CloseableSilently {
   private final IncidentUpdateRepository incidentRepository;
   private final BatchOperationUpdateRepository batchOperationUpdateRepository;
   private final HistoryDeletionRepository historyDeletionRepository;
+  private final MigrationVariableBackfillRepository migrationVariableBackfillRepository;
   private final Logger logger;
   private final BackgroundTaskManager delegate;
 
@@ -45,6 +47,8 @@ public final class CamundaBackgroundTaskManager implements CloseableSilently {
       final @WillCloseWhenClosed IncidentUpdateRepository incidentRepository,
       final @WillCloseWhenClosed BatchOperationUpdateRepository batchOperationUpdateRepository,
       final @WillCloseWhenClosed HistoryDeletionRepository historyDeletionRepository,
+      final @WillCloseWhenClosed MigrationVariableBackfillRepository
+              migrationVariableBackfillRepository,
       final Logger logger,
       final @WillCloseWhenClosed ScheduledThreadPoolExecutor executor,
       final List<RunnableTask> tasks,
@@ -63,6 +67,10 @@ public final class CamundaBackgroundTaskManager implements CloseableSilently {
     this.historyDeletionRepository =
         Objects.requireNonNull(
             historyDeletionRepository, "must specify a history deletion repository");
+    this.migrationVariableBackfillRepository =
+        Objects.requireNonNull(
+            migrationVariableBackfillRepository,
+            "must specify a migration variable backfill repository");
     this.logger = Objects.requireNonNull(logger, "must specify a logger");
     delegate = new BackgroundTaskManager(partitionId, logger, executor, tasks, closeTimeout);
   }
@@ -79,7 +87,8 @@ public final class CamundaBackgroundTaskManager implements CloseableSilently {
         auditLogArchiverRepository,
         incidentRepository,
         batchOperationUpdateRepository,
-        historyDeletionRepository);
+        historyDeletionRepository,
+        migrationVariableBackfillRepository);
   }
 
   public void start() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
@@ -438,7 +438,6 @@ public final class CamundaBackgroundTaskManagerFactory {
     final var postExport = config.getPostExport();
     return new ReschedulingTask(
         new MigrationVariableBackfillTask(
-            metadata,
             migrationVariableBackfillRepository,
             postExport.getBatchSize(),
             config.getIndex().getVariableSizeThreshold(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
@@ -45,6 +45,10 @@ import io.camunda.exporter.tasks.incident.ElasticsearchIncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateTask;
 import io.camunda.exporter.tasks.incident.OpenSearchIncidentUpdateRepository;
+import io.camunda.exporter.tasks.migrationvariablebackfill.ElasticsearchMigrationVariableBackfillRepository;
+import io.camunda.exporter.tasks.migrationvariablebackfill.MigrationVariableBackfillRepository;
+import io.camunda.exporter.tasks.migrationvariablebackfill.MigrationVariableBackfillTask;
+import io.camunda.exporter.tasks.migrationvariablebackfill.OpenSearchMigrationVariableBackfillRepository;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.BatchOperationDependant;
@@ -60,8 +64,10 @@ import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.PostImporterQueueTemplate;
+import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
+import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.exporter.common.tasks.BackgroundTask;
@@ -92,6 +98,7 @@ public final class CamundaBackgroundTaskManagerFactory {
   private BatchOperationUpdateRepository batchOperationUpdateRepository;
   private HistoryDeletionRepository historyDeletionRepository;
   private AuditLogArchiverRepository auditLogArchiverRepository;
+  private MigrationVariableBackfillRepository migrationVariableBackfillRepository;
   private final ExporterEntityCacheImpl<Long, CachedProcessEntity> processCache;
   private final InstantSource clock;
 
@@ -133,6 +140,7 @@ public final class CamundaBackgroundTaskManagerFactory {
       batchOperationUpdateRepository = createBatchOperationRepository(asyncClient);
       historyDeletionRepository = createHistoryDeletionRepository(asyncClient);
       auditLogArchiverRepository = createAuditLogArchiverRepository(asyncClient);
+      migrationVariableBackfillRepository = createMigrationVariableBackfillRepository(asyncClient);
     } else {
       final var connector = new ElasticsearchConnector(config.getConnect());
       final ElasticsearchAsyncClient asyncClient = connector.createAsyncClient();
@@ -142,6 +150,7 @@ public final class CamundaBackgroundTaskManagerFactory {
       batchOperationUpdateRepository = createBatchOperationRepository(asyncClient);
       historyDeletionRepository = createHistoryDeletionRepository(asyncClient);
       auditLogArchiverRepository = createAuditLogArchiverRepository(asyncClient);
+      migrationVariableBackfillRepository = createMigrationVariableBackfillRepository(asyncClient);
     }
 
     final List<RunnableTask> tasks = buildTasks();
@@ -153,6 +162,7 @@ public final class CamundaBackgroundTaskManagerFactory {
         incidentRepository,
         batchOperationUpdateRepository,
         historyDeletionRepository,
+        migrationVariableBackfillRepository,
         logger,
         executor,
         tasks,
@@ -260,6 +270,9 @@ public final class CamundaBackgroundTaskManagerFactory {
     final List<RunnableTask> tasks = new ArrayList<>();
 
     tasks.add(buildIncidentMarkerTask());
+    if (config.isSkipVariableWriteWithoutUserTasks()) {
+      tasks.add(buildMigrationVariableBackfillTask());
+    }
     if (config.getHistory().isProcessInstanceEnabled()) {
       tasks.add(buildProcessInstanceArchiverJob());
       if (config.getHistory().isTrackArchivalMetricsForProcessInstance()) {
@@ -379,6 +392,56 @@ public final class CamundaBackgroundTaskManagerFactory {
             executor,
             incidentNotifier,
             metrics,
+            logger),
+        1,
+        postExport.getDelayBetweenRuns(),
+        postExport.getMaxDelayBetweenRuns(),
+        executor,
+        logger);
+  }
+
+  private MigrationVariableBackfillRepository createMigrationVariableBackfillRepository(
+      final OpenSearchAsyncClient asyncClient) {
+    final var postImporterTemplate =
+        resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+    final var variableTemplate =
+        resourceProvider.getIndexTemplateDescriptor(VariableTemplate.class);
+    final var taskTemplate = resourceProvider.getIndexTemplateDescriptor(TaskTemplate.class);
+    return new OpenSearchMigrationVariableBackfillRepository(
+        partitionId,
+        postImporterTemplate.getAlias(),
+        variableTemplate.getAlias(),
+        taskTemplate.getFullQualifiedName(),
+        asyncClient,
+        executor,
+        logger);
+  }
+
+  private MigrationVariableBackfillRepository createMigrationVariableBackfillRepository(
+      final ElasticsearchAsyncClient asyncClient) {
+    final var postImporterTemplate =
+        resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+    final var variableTemplate =
+        resourceProvider.getIndexTemplateDescriptor(VariableTemplate.class);
+    final var taskTemplate = resourceProvider.getIndexTemplateDescriptor(TaskTemplate.class);
+    return new ElasticsearchMigrationVariableBackfillRepository(
+        partitionId,
+        postImporterTemplate.getAlias(),
+        variableTemplate.getAlias(),
+        taskTemplate.getFullQualifiedName(),
+        asyncClient,
+        executor,
+        logger);
+  }
+
+  private ReschedulingTask buildMigrationVariableBackfillTask() {
+    final var postExport = config.getPostExport();
+    return new ReschedulingTask(
+        new MigrationVariableBackfillTask(
+            metadata,
+            migrationVariableBackfillRepository,
+            postExport.getBatchSize(),
+            config.getIndex().getVariableSizeThreshold(),
             logger),
         1,
         postExport.getDelayBetweenRuns(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/ElasticsearchMigrationVariableBackfillRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/ElasticsearchMigrationVariableBackfillRepository.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.migrationvariablebackfill;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import io.camunda.exporter.tasks.util.ElasticsearchRepository;
+import io.camunda.webapps.schema.descriptors.template.PostImporterQueueTemplate;
+import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
+import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.post.PostImporterActionType;
+import io.camunda.webapps.schema.entities.usertask.TaskVariableEntity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+import javax.annotation.WillCloseWhenClosed;
+import org.slf4j.Logger;
+
+public final class ElasticsearchMigrationVariableBackfillRepository extends ElasticsearchRepository
+    implements MigrationVariableBackfillRepository {
+
+  private static final int RETRY_COUNT = 3;
+
+  private final int partitionId;
+  private final String postImporterQueueAlias;
+  private final String variableAlias;
+  private final String taskIndexName;
+
+  public ElasticsearchMigrationVariableBackfillRepository(
+      final int partitionId,
+      final String postImporterQueueAlias,
+      final String variableAlias,
+      final String taskIndexName,
+      @WillCloseWhenClosed final ElasticsearchAsyncClient client,
+      final Executor executor,
+      final Logger logger) {
+    super(client, executor, logger);
+    this.partitionId = partitionId;
+    this.postImporterQueueAlias = postImporterQueueAlias;
+    this.variableAlias = variableAlias;
+    this.taskIndexName = taskIndexName;
+  }
+
+  @Override
+  public CompletionStage<MigrationVariableBackfillRepository.PendingBackfillBatch>
+      getPendingBackfillBatch(final long fromPosition, final int size) {
+    final var query = createPendingBackfillQuery(fromPosition);
+    final var request =
+        new SearchRequest.Builder()
+            .index(postImporterQueueAlias)
+            .query(query)
+            .ignoreUnavailable(true)
+            .allowNoIndices(true)
+            .source(
+                s ->
+                    s.filter(
+                        f ->
+                            f.includes(
+                                PostImporterQueueTemplate.PROCESS_INSTANCE_KEY,
+                                PostImporterQueueTemplate.POSITION)))
+            .sort(
+                s -> s.field(f -> f.field(PostImporterQueueTemplate.POSITION).order(SortOrder.Asc)))
+            .size(size)
+            .build();
+
+    return client
+        .search(request, PendingBackfillEntry.class)
+        .thenApplyAsync(this::toPendingBackfillBatch, executor);
+  }
+
+  @Override
+  public CompletionStage<List<VariableEntity>> getVariablesByProcessInstanceKey(
+      final long processInstanceKey) {
+    final var query =
+        QueryBuilders.term(
+            t -> t.field(VariableTemplate.PROCESS_INSTANCE_KEY).value(processInstanceKey));
+    final var requestBuilder = new SearchRequest.Builder().index(variableAlias).query(query);
+
+    return fetchUnboundedDocumentCollection(
+            requestBuilder, VariableEntity.class, hit -> hit.source())
+        .thenApplyAsync(c -> new ArrayList<>(c), executor);
+  }
+
+  @Override
+  public CompletionStage<Void> bulkUpsertTaskVariables(final List<TaskVariableEntity> variables) {
+    if (variables.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final var operations =
+        variables.stream().map(this::createUpsertOperation).collect(Collectors.toList());
+    final var request =
+        new BulkRequest.Builder()
+            .operations(operations)
+            .source(s -> s.fetch(false))
+            .refresh(Refresh.WaitFor)
+            .build();
+
+    return client
+        .bulk(request)
+        .thenComposeAsync(
+            r -> {
+              if (r.errors()) {
+                return CompletableFuture.failedFuture(collectBulkErrors(r.items()));
+              }
+              return CompletableFuture.completedFuture(null);
+            },
+            executor);
+  }
+
+  private BulkOperation createUpsertOperation(final TaskVariableEntity variable) {
+    final Map<String, Object> updateFields =
+        Map.of(
+            TaskTemplate.VARIABLE_VALUE, variable.getValue(),
+            TaskTemplate.IS_TRUNCATED, variable.getIsTruncated());
+    return BulkOperation.of(
+        o ->
+            o.update(
+                u ->
+                    u.index(taskIndexName)
+                        .id(variable.getId())
+                        .routing(String.valueOf(variable.getProcessInstanceId()))
+                        .retryOnConflict(RETRY_COUNT)
+                        .action(a -> a.doc(updateFields).upsert(variable))));
+  }
+
+  private Query createPendingBackfillQuery(final long fromPosition) {
+    final var positionQ =
+        QueryBuilders.range(
+            r ->
+                r.number(
+                    n -> n.field(PostImporterQueueTemplate.POSITION).gt((double) fromPosition)));
+    final var typeQ =
+        QueryBuilders.term(
+            t ->
+                t.field(PostImporterQueueTemplate.ACTION_TYPE)
+                    .value(PostImporterActionType.PROCESS_INSTANCE_MIGRATION.name()));
+    final var partitionQ =
+        QueryBuilders.term(t -> t.field(PostImporterQueueTemplate.PARTITION_ID).value(partitionId));
+    return QueryBuilders.bool(b -> b.must(positionQ, typeQ, partitionQ));
+  }
+
+  private MigrationVariableBackfillRepository.PendingBackfillBatch toPendingBackfillBatch(
+      final co.elastic.clients.elasticsearch.core.SearchResponse<PendingBackfillEntry> response) {
+    final var hits = response.hits().hits();
+    if (hits.isEmpty()) {
+      return new MigrationVariableBackfillRepository.PendingBackfillBatch(-1L, List.of());
+    }
+    final var highestPosition = hits.getLast().source().position();
+    final var processInstanceKeys =
+        hits.stream().map(h -> h.source().processInstanceKey()).collect(Collectors.toList());
+    return new MigrationVariableBackfillRepository.PendingBackfillBatch(
+        highestPosition, processInstanceKeys);
+  }
+
+  private record PendingBackfillEntry(long processInstanceKey, long position) {}
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/ElasticsearchMigrationVariableBackfillRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/ElasticsearchMigrationVariableBackfillRepository.java
@@ -9,7 +9,6 @@ package io.camunda.exporter.tasks.migrationvariablebackfill;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch._types.Refresh;
-import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
@@ -58,30 +57,43 @@ public final class ElasticsearchMigrationVariableBackfillRepository extends Elas
   }
 
   @Override
-  public CompletionStage<MigrationVariableBackfillRepository.PendingBackfillBatch>
-      getPendingBackfillBatch(final long fromPosition, final int size) {
-    final var query = createPendingBackfillQuery(fromPosition);
+  public CompletionStage<List<Long>> getPendingBackfillBatch(final int size) {
     final var request =
         new SearchRequest.Builder()
             .index(postImporterQueueAlias)
-            .query(query)
+            .query(createPendingBackfillQuery())
             .ignoreUnavailable(true)
             .allowNoIndices(true)
-            .source(
-                s ->
-                    s.filter(
-                        f ->
-                            f.includes(
-                                PostImporterQueueTemplate.PROCESS_INSTANCE_KEY,
-                                PostImporterQueueTemplate.POSITION)))
-            .sort(
-                s -> s.field(f -> f.field(PostImporterQueueTemplate.POSITION).order(SortOrder.Asc)))
+            .source(s -> s.filter(f -> f.includes(PostImporterQueueTemplate.PROCESS_INSTANCE_KEY)))
             .size(size)
             .build();
 
     return client
         .search(request, PendingBackfillEntry.class)
-        .thenApplyAsync(this::toPendingBackfillBatch, executor);
+        .thenApplyAsync(
+            r ->
+                r.hits().hits().stream()
+                    .map(h -> h.source().processInstanceKey())
+                    .collect(Collectors.toList()),
+            executor);
+  }
+
+  @Override
+  public CompletionStage<Void> deletePendingBackfillEntries(final List<Long> processInstanceKeys) {
+    if (processInstanceKeys.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+    final var operations =
+        processInstanceKeys.stream()
+            .map(
+                key ->
+                    BulkOperation.of(
+                        o ->
+                            o.delete(d -> d.index(postImporterQueueAlias).id(String.valueOf(key)))))
+            .collect(Collectors.toList());
+    final var request =
+        new BulkRequest.Builder().operations(operations).refresh(Refresh.WaitFor).build();
+    return client.bulk(request).thenApplyAsync(r -> null, executor);
   }
 
   @Override
@@ -140,12 +152,7 @@ public final class ElasticsearchMigrationVariableBackfillRepository extends Elas
                         .action(a -> a.doc(updateFields).upsert(variable))));
   }
 
-  private Query createPendingBackfillQuery(final long fromPosition) {
-    final var positionQ =
-        QueryBuilders.range(
-            r ->
-                r.number(
-                    n -> n.field(PostImporterQueueTemplate.POSITION).gt((double) fromPosition)));
+  private Query createPendingBackfillQuery() {
     final var typeQ =
         QueryBuilders.term(
             t ->
@@ -153,21 +160,8 @@ public final class ElasticsearchMigrationVariableBackfillRepository extends Elas
                     .value(PostImporterActionType.PROCESS_INSTANCE_MIGRATION.name()));
     final var partitionQ =
         QueryBuilders.term(t -> t.field(PostImporterQueueTemplate.PARTITION_ID).value(partitionId));
-    return QueryBuilders.bool(b -> b.must(positionQ, typeQ, partitionQ));
+    return QueryBuilders.bool(b -> b.must(typeQ, partitionQ));
   }
 
-  private MigrationVariableBackfillRepository.PendingBackfillBatch toPendingBackfillBatch(
-      final co.elastic.clients.elasticsearch.core.SearchResponse<PendingBackfillEntry> response) {
-    final var hits = response.hits().hits();
-    if (hits.isEmpty()) {
-      return new MigrationVariableBackfillRepository.PendingBackfillBatch(-1L, List.of());
-    }
-    final var highestPosition = hits.getLast().source().position();
-    final var processInstanceKeys =
-        hits.stream().map(h -> h.source().processInstanceKey()).collect(Collectors.toList());
-    return new MigrationVariableBackfillRepository.PendingBackfillBatch(
-        highestPosition, processInstanceKeys);
-  }
-
-  private record PendingBackfillEntry(long processInstanceKey, long position) {}
+  private record PendingBackfillEntry(long processInstanceKey) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillRepository.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.migrationvariablebackfill;
+
+import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.usertask.TaskVariableEntity;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Storage access layer for {@link MigrationVariableBackfillTask}. Encapsulates all reads from the
+ * post-importer queue and the variable store, and all writes to the task-variable index, so the
+ * task logic stays search-engine-agnostic.
+ */
+public interface MigrationVariableBackfillRepository extends AutoCloseable {
+
+  /**
+   * Returns the next batch of process instance keys that need variable backfilling. Only entries
+   * written by {@link
+   * io.camunda.exporter.handlers.PostImporterQueueFromProcessInstanceMigrationHandler} (action type
+   * {@code PROCESS_INSTANCE_MIGRATION}) are returned, and only those with a position strictly
+   * greater than {@code fromPosition}.
+   *
+   * @param fromPosition the exclusive lower bound on the position field
+   * @param size the maximum number of entries to return
+   * @return a batch; {@link PendingBackfillBatch#isEmpty()} is true when there is no work to do
+   */
+  CompletionStage<PendingBackfillBatch> getPendingBackfillBatch(long fromPosition, int size);
+
+  /**
+   * Fetches all variables for a process instance from the variable store.
+   *
+   * @param processInstanceKey the process instance to fetch variables for
+   * @return a list of variable entities; may be empty if none exist yet
+   */
+  CompletionStage<List<VariableEntity>> getVariablesByProcessInstanceKey(long processInstanceKey);
+
+  /**
+   * Writes the given task variable documents to the task-variable index as upserts (creating
+   * entries that are missing, updating existing entries). Each document is written with routing set
+   * to its {@code processInstanceId}.
+   *
+   * @param variables the task-variable documents to write
+   */
+  CompletionStage<Void> bulkUpsertTaskVariables(List<TaskVariableEntity> variables);
+
+  /** A batch of pending migration variable backfill work. */
+  record PendingBackfillBatch(long highestPosition, List<Long> processInstanceKeys) {
+    public boolean isEmpty() {
+      return processInstanceKeys.isEmpty();
+    }
+  }
+
+  /** No-op implementation for use in environments where the feature is disabled. */
+  class Noop implements MigrationVariableBackfillRepository {
+
+    @Override
+    public CompletionStage<PendingBackfillBatch> getPendingBackfillBatch(
+        final long fromPosition, final int size) {
+      return java.util.concurrent.CompletableFuture.completedFuture(
+          new PendingBackfillBatch(-1, List.of()));
+    }
+
+    @Override
+    public CompletionStage<List<VariableEntity>> getVariablesByProcessInstanceKey(
+        final long processInstanceKey) {
+      return java.util.concurrent.CompletableFuture.completedFuture(List.of());
+    }
+
+    @Override
+    public CompletionStage<Void> bulkUpsertTaskVariables(final List<TaskVariableEntity> variables) {
+      return java.util.concurrent.CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillRepository.java
@@ -23,14 +23,20 @@ public interface MigrationVariableBackfillRepository extends AutoCloseable {
    * Returns the next batch of process instance keys that need variable backfilling. Only entries
    * written by {@link
    * io.camunda.exporter.handlers.PostImporterQueueFromProcessInstanceMigrationHandler} (action type
-   * {@code PROCESS_INSTANCE_MIGRATION}) are returned, and only those with a position strictly
-   * greater than {@code fromPosition}.
+   * {@code PROCESS_INSTANCE_MIGRATION}) are returned.
    *
-   * @param fromPosition the exclusive lower bound on the position field
    * @param size the maximum number of entries to return
-   * @return a batch; {@link PendingBackfillBatch#isEmpty()} is true when there is no work to do
+   * @return a list of process instance keys; empty when there is no work to do
    */
-  CompletionStage<PendingBackfillBatch> getPendingBackfillBatch(long fromPosition, int size);
+  CompletionStage<List<Long>> getPendingBackfillBatch(int size);
+
+  /**
+   * Removes the processed backfill entries for the given process instance keys from the queue.
+   * Called after all variables have been successfully upserted.
+   *
+   * @param processInstanceKeys the process instance keys whose queue entries should be deleted
+   */
+  CompletionStage<Void> deletePendingBackfillEntries(List<Long> processInstanceKeys);
 
   /**
    * Fetches all variables for a process instance from the variable store.
@@ -49,21 +55,18 @@ public interface MigrationVariableBackfillRepository extends AutoCloseable {
    */
   CompletionStage<Void> bulkUpsertTaskVariables(List<TaskVariableEntity> variables);
 
-  /** A batch of pending migration variable backfill work. */
-  record PendingBackfillBatch(long highestPosition, List<Long> processInstanceKeys) {
-    public boolean isEmpty() {
-      return processInstanceKeys.isEmpty();
-    }
-  }
-
   /** No-op implementation for use in environments where the feature is disabled. */
   class Noop implements MigrationVariableBackfillRepository {
 
     @Override
-    public CompletionStage<PendingBackfillBatch> getPendingBackfillBatch(
-        final long fromPosition, final int size) {
-      return java.util.concurrent.CompletableFuture.completedFuture(
-          new PendingBackfillBatch(-1, List.of()));
+    public CompletionStage<List<Long>> getPendingBackfillBatch(final int size) {
+      return java.util.concurrent.CompletableFuture.completedFuture(List.of());
+    }
+
+    @Override
+    public CompletionStage<Void> deletePendingBackfillEntries(
+        final List<Long> processInstanceKeys) {
+      return java.util.concurrent.CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillTask.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.exporter.tasks.migrationvariablebackfill;
 
-import io.camunda.exporter.ExporterMetadata;
-import io.camunda.exporter.tasks.migrationvariablebackfill.MigrationVariableBackfillRepository.PendingBackfillBatch;
 import io.camunda.webapps.schema.entities.VariableEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
@@ -32,26 +30,23 @@ import org.slf4j.Logger;
  *
  * <p>This task reads pending backfill entries written by {@link
  * io.camunda.exporter.handlers.PostImporterQueueFromProcessInstanceMigrationHandler}, fetches the
- * current variable values from {@code operate-variable}, and upserts them as {@code
- * PROCESS_VARIABLE} join documents into {@code tasklist-task}.
+ * current variable values from {@code operate-variable}, upserts them as {@code PROCESS_VARIABLE}
+ * join documents into {@code tasklist-task}, then deletes the consumed queue entries.
  */
 public final class MigrationVariableBackfillTask implements BackgroundTask {
 
   private static final String ID_PATTERN = "%s-%s";
 
-  private final ExporterMetadata metadata;
   private final MigrationVariableBackfillRepository repository;
   private final int batchSize;
   private final int variableSizeThreshold;
   private final Logger logger;
 
   public MigrationVariableBackfillTask(
-      final ExporterMetadata metadata,
       final MigrationVariableBackfillRepository repository,
       final int batchSize,
       final int variableSizeThreshold,
       final Logger logger) {
-    this.metadata = metadata;
     this.repository = repository;
     this.batchSize = batchSize;
     this.variableSizeThreshold = variableSizeThreshold;
@@ -73,31 +68,27 @@ public final class MigrationVariableBackfillTask implements BackgroundTask {
   }
 
   private int processNextBatch() {
-    final PendingBackfillBatch batch =
-        repository
-            .getPendingBackfillBatch(metadata.getLastMigrationVariableBackfillPosition(), batchSize)
-            .toCompletableFuture()
-            .join();
+    final List<Long> processInstanceKeys =
+        repository.getPendingBackfillBatch(batchSize).toCompletableFuture().join();
 
-    if (batch.isEmpty()) {
+    if (processInstanceKeys.isEmpty()) {
       return 0;
     }
 
     logger.trace(
-        "Backfilling task variables for {} migrated process instances",
-        batch.processInstanceKeys().size());
+        "Backfilling task variables for {} migrated process instances", processInstanceKeys.size());
 
     int totalVariablesWritten = 0;
-    for (final long processInstanceKey : batch.processInstanceKeys()) {
+    for (final long processInstanceKey : processInstanceKeys) {
       totalVariablesWritten += backfillForInstance(processInstanceKey);
     }
 
-    metadata.setLastMigrationVariableBackfillPosition(batch.highestPosition());
+    repository.deletePendingBackfillEntries(processInstanceKeys).toCompletableFuture().join();
 
     logger.debug(
         "Backfilled {} task variable documents for {} migrated process instances",
         totalVariablesWritten,
-        batch.processInstanceKeys().size());
+        processInstanceKeys.size());
 
     return totalVariablesWritten;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillTask.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.migrationvariablebackfill;
+
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.tasks.migrationvariablebackfill.MigrationVariableBackfillRepository.PendingBackfillBatch;
+import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship;
+import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.usertask.TaskVariableEntity;
+import io.camunda.zeebe.exporter.common.tasks.BackgroundTask;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.slf4j.Logger;
+
+/**
+ * Background task that backfills process-instance variable documents into the {@code tasklist-task}
+ * index for process instances that were migrated from a process definition with no user tasks to
+ * one that does have user tasks.
+ *
+ * <p>When {@code skipVariableWriteWithoutUserTasks} is enabled, an instance started on a
+ * no-user-task definition never has its variables exported to {@code tasklist-task}. After
+ * migration to a definition with user tasks, the {@code processInstanceVariables} filter on {@code
+ * POST /user-tasks/search} would return no results because the required {@code PROCESS_VARIABLE}
+ * join documents are absent.
+ *
+ * <p>This task reads pending backfill entries written by {@link
+ * io.camunda.exporter.handlers.PostImporterQueueFromProcessInstanceMigrationHandler}, fetches the
+ * current variable values from {@code operate-variable}, and upserts them as {@code
+ * PROCESS_VARIABLE} join documents into {@code tasklist-task}.
+ */
+public final class MigrationVariableBackfillTask implements BackgroundTask {
+
+  private static final String ID_PATTERN = "%s-%s";
+
+  private final ExporterMetadata metadata;
+  private final MigrationVariableBackfillRepository repository;
+  private final int batchSize;
+  private final int variableSizeThreshold;
+  private final Logger logger;
+
+  public MigrationVariableBackfillTask(
+      final ExporterMetadata metadata,
+      final MigrationVariableBackfillRepository repository,
+      final int batchSize,
+      final int variableSizeThreshold,
+      final Logger logger) {
+    this.metadata = metadata;
+    this.repository = repository;
+    this.batchSize = batchSize;
+    this.variableSizeThreshold = variableSizeThreshold;
+    this.logger = logger;
+  }
+
+  @Override
+  public CompletionStage<Integer> execute() {
+    try {
+      return CompletableFuture.completedFuture(processNextBatch());
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  @Override
+  public String getCaption() {
+    return "Migration variable backfill task";
+  }
+
+  private int processNextBatch() {
+    final PendingBackfillBatch batch =
+        repository
+            .getPendingBackfillBatch(metadata.getLastMigrationVariableBackfillPosition(), batchSize)
+            .toCompletableFuture()
+            .join();
+
+    if (batch.isEmpty()) {
+      return 0;
+    }
+
+    logger.trace(
+        "Backfilling task variables for {} migrated process instances",
+        batch.processInstanceKeys().size());
+
+    int totalVariablesWritten = 0;
+    for (final long processInstanceKey : batch.processInstanceKeys()) {
+      totalVariablesWritten += backfillForInstance(processInstanceKey);
+    }
+
+    metadata.setLastMigrationVariableBackfillPosition(batch.highestPosition());
+
+    logger.debug(
+        "Backfilled {} task variable documents for {} migrated process instances",
+        totalVariablesWritten,
+        batch.processInstanceKeys().size());
+
+    return totalVariablesWritten;
+  }
+
+  private int backfillForInstance(final long processInstanceKey) {
+    final List<VariableEntity> variables =
+        repository
+            .getVariablesByProcessInstanceKey(processInstanceKey)
+            .toCompletableFuture()
+            .join();
+
+    if (variables.isEmpty()) {
+      logger.trace("No variables found for process instance {}", processInstanceKey);
+      return 0;
+    }
+
+    final List<TaskVariableEntity> taskVariables =
+        variables.stream().map(this::buildTaskVariable).toList();
+
+    repository.bulkUpsertTaskVariables(taskVariables).toCompletableFuture().join();
+    return taskVariables.size();
+  }
+
+  private TaskVariableEntity buildTaskVariable(final VariableEntity source) {
+    final var entity = new TaskVariableEntity();
+
+    entity
+        .setId(ID_PATTERN.formatted(source.getScopeKey(), source.getName()))
+        .setKey(source.getKey())
+        .setPartitionId(source.getPartitionId())
+        .setTenantId(source.getTenantId())
+        .setName(source.getName())
+        .setScopeKey(source.getScopeKey())
+        .setProcessInstanceId(source.getProcessInstanceKey());
+
+    // Replicate the truncation state from operate-variable: isPreview=true means the value was
+    // already truncated and fullValue held the original; we mirror that as isTruncated.
+    entity.setValue(source.getValue()).setIsTruncated(source.getIsPreview());
+
+    if (source.getRootProcessInstanceKey() != null && source.getRootProcessInstanceKey() > 0) {
+      entity.setRootProcessInstanceKey(source.getRootProcessInstanceKey());
+    }
+
+    final var join = new TaskJoinRelationship();
+    join.setName(TaskJoinRelationshipType.PROCESS_VARIABLE.getType());
+    join.setParent(source.getProcessInstanceKey());
+    entity.setJoin(join);
+
+    return entity;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/OpenSearchMigrationVariableBackfillRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/OpenSearchMigrationVariableBackfillRepository.java
@@ -23,11 +23,9 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import javax.annotation.WillCloseWhenClosed;
-import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Refresh;
-import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch.core.BulkRequest;
@@ -61,31 +59,48 @@ public final class OpenSearchMigrationVariableBackfillRepository extends Opensea
   }
 
   @Override
-  public CompletionStage<MigrationVariableBackfillRepository.PendingBackfillBatch>
-      getPendingBackfillBatch(final long fromPosition, final int size) {
-    final var query = createPendingBackfillQuery(fromPosition);
+  public CompletionStage<List<Long>> getPendingBackfillBatch(final int size) {
     final var request =
         new SearchRequest.Builder()
             .index(postImporterQueueAlias)
-            .query(query)
+            .query(createPendingBackfillQuery())
             .ignoreUnavailable(true)
             .allowNoIndices(true)
-            .source(
-                s ->
-                    s.filter(
-                        f ->
-                            f.includes(
-                                PostImporterQueueTemplate.PROCESS_INSTANCE_KEY,
-                                PostImporterQueueTemplate.POSITION)))
-            .sort(
-                s -> s.field(f -> f.field(PostImporterQueueTemplate.POSITION).order(SortOrder.Asc)))
+            .source(s -> s.filter(f -> f.includes(PostImporterQueueTemplate.PROCESS_INSTANCE_KEY)))
             .size(size)
             .build();
 
     try {
       return client
           .search(request, PendingBackfillEntry.class)
-          .thenApplyAsync(this::toPendingBackfillBatch, executor);
+          .thenApplyAsync(
+              r ->
+                  r.hits().hits().stream()
+                      .map(h -> h.source().processInstanceKey())
+                      .collect(Collectors.toList()),
+              executor);
+    } catch (final IOException e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  @Override
+  public CompletionStage<Void> deletePendingBackfillEntries(final List<Long> processInstanceKeys) {
+    if (processInstanceKeys.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+    final var operations =
+        processInstanceKeys.stream()
+            .map(
+                key ->
+                    BulkOperation.of(
+                        o ->
+                            o.delete(d -> d.index(postImporterQueueAlias).id(String.valueOf(key)))))
+            .collect(Collectors.toList());
+    final var request =
+        new BulkRequest.Builder().operations(operations).refresh(Refresh.WaitFor).build();
+    try {
+      return client.bulk(request).thenApplyAsync(r -> null, executor);
     } catch (final IOException e) {
       return CompletableFuture.failedFuture(e);
     }
@@ -155,13 +170,7 @@ public final class OpenSearchMigrationVariableBackfillRepository extends Opensea
                         .upsert(variable)));
   }
 
-  private Query createPendingBackfillQuery(final long fromPosition) {
-    final var positionQ =
-        QueryBuilders.range()
-            .field(PostImporterQueueTemplate.POSITION)
-            .gt(JsonData.of(fromPosition))
-            .build()
-            .toQuery();
+  private Query createPendingBackfillQuery() {
     final var typeQ =
         QueryBuilders.term()
             .field(PostImporterQueueTemplate.ACTION_TYPE)
@@ -174,21 +183,8 @@ public final class OpenSearchMigrationVariableBackfillRepository extends Opensea
             .value(v -> v.longValue(partitionId))
             .build()
             .toQuery();
-    return QueryBuilders.bool().must(positionQ, typeQ, partitionQ).build().toQuery();
+    return QueryBuilders.bool().must(typeQ, partitionQ).build().toQuery();
   }
 
-  private MigrationVariableBackfillRepository.PendingBackfillBatch toPendingBackfillBatch(
-      final org.opensearch.client.opensearch.core.SearchResponse<PendingBackfillEntry> response) {
-    final var hits = response.hits().hits();
-    if (hits.isEmpty()) {
-      return new MigrationVariableBackfillRepository.PendingBackfillBatch(-1L, List.of());
-    }
-    final var highestPosition = hits.getLast().source().position();
-    final var processInstanceKeys =
-        hits.stream().map(h -> h.source().processInstanceKey()).collect(Collectors.toList());
-    return new MigrationVariableBackfillRepository.PendingBackfillBatch(
-        highestPosition, processInstanceKeys);
-  }
-
-  private record PendingBackfillEntry(long processInstanceKey, long position) {}
+  private record PendingBackfillEntry(long processInstanceKey) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/OpenSearchMigrationVariableBackfillRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/migrationvariablebackfill/OpenSearchMigrationVariableBackfillRepository.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.migrationvariablebackfill;
+
+import io.camunda.exporter.tasks.util.OpensearchRepository;
+import io.camunda.webapps.schema.descriptors.template.PostImporterQueueTemplate;
+import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
+import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.post.PostImporterActionType;
+import io.camunda.webapps.schema.entities.usertask.TaskVariableEntity;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+import javax.annotation.WillCloseWhenClosed;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.slf4j.Logger;
+
+public final class OpenSearchMigrationVariableBackfillRepository extends OpensearchRepository
+    implements MigrationVariableBackfillRepository {
+
+  private static final int RETRY_COUNT = 3;
+
+  private final int partitionId;
+  private final String postImporterQueueAlias;
+  private final String variableAlias;
+  private final String taskIndexName;
+
+  public OpenSearchMigrationVariableBackfillRepository(
+      final int partitionId,
+      final String postImporterQueueAlias,
+      final String variableAlias,
+      final String taskIndexName,
+      @WillCloseWhenClosed final OpenSearchAsyncClient client,
+      final Executor executor,
+      final Logger logger) {
+    super(client, executor, logger);
+    this.partitionId = partitionId;
+    this.postImporterQueueAlias = postImporterQueueAlias;
+    this.variableAlias = variableAlias;
+    this.taskIndexName = taskIndexName;
+  }
+
+  @Override
+  public CompletionStage<MigrationVariableBackfillRepository.PendingBackfillBatch>
+      getPendingBackfillBatch(final long fromPosition, final int size) {
+    final var query = createPendingBackfillQuery(fromPosition);
+    final var request =
+        new SearchRequest.Builder()
+            .index(postImporterQueueAlias)
+            .query(query)
+            .ignoreUnavailable(true)
+            .allowNoIndices(true)
+            .source(
+                s ->
+                    s.filter(
+                        f ->
+                            f.includes(
+                                PostImporterQueueTemplate.PROCESS_INSTANCE_KEY,
+                                PostImporterQueueTemplate.POSITION)))
+            .sort(
+                s -> s.field(f -> f.field(PostImporterQueueTemplate.POSITION).order(SortOrder.Asc)))
+            .size(size)
+            .build();
+
+    try {
+      return client
+          .search(request, PendingBackfillEntry.class)
+          .thenApplyAsync(this::toPendingBackfillBatch, executor);
+    } catch (final IOException e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  @Override
+  public CompletionStage<List<VariableEntity>> getVariablesByProcessInstanceKey(
+      final long processInstanceKey) {
+    final var query =
+        QueryBuilders.term()
+            .field(VariableTemplate.PROCESS_INSTANCE_KEY)
+            .value(FieldValue.of(processInstanceKey))
+            .build()
+            .toQuery();
+    final var requestBuilder = new SearchRequest.Builder().index(variableAlias).query(query);
+
+    return fetchUnboundedDocumentCollection(
+            requestBuilder, VariableEntity.class, hit -> hit.source())
+        .thenApplyAsync(c -> new ArrayList<>(c), executor);
+  }
+
+  @Override
+  public CompletionStage<Void> bulkUpsertTaskVariables(final List<TaskVariableEntity> variables) {
+    if (variables.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final var operations =
+        variables.stream().map(this::createUpsertOperation).collect(Collectors.toList());
+    final var request =
+        new BulkRequest.Builder()
+            .operations(operations)
+            .source(s -> s.fetch(false))
+            .refresh(Refresh.WaitFor)
+            .build();
+
+    try {
+      return client
+          .bulk(request)
+          .thenComposeAsync(
+              r -> {
+                if (r.errors()) {
+                  return CompletableFuture.failedFuture(collectBulkErrors(r.items()));
+                }
+                return CompletableFuture.completedFuture(null);
+              },
+              executor);
+    } catch (final IOException e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  private BulkOperation createUpsertOperation(final TaskVariableEntity variable) {
+    final Map<String, Object> updateFields =
+        Map.of(
+            TaskTemplate.VARIABLE_VALUE, variable.getValue(),
+            TaskTemplate.IS_TRUNCATED, variable.getIsTruncated());
+    return BulkOperation.of(
+        o ->
+            o.update(
+                u ->
+                    u.index(taskIndexName)
+                        .id(variable.getId())
+                        .routing(String.valueOf(variable.getProcessInstanceId()))
+                        .retryOnConflict(RETRY_COUNT)
+                        .document(updateFields)
+                        .upsert(variable)));
+  }
+
+  private Query createPendingBackfillQuery(final long fromPosition) {
+    final var positionQ =
+        QueryBuilders.range()
+            .field(PostImporterQueueTemplate.POSITION)
+            .gt(JsonData.of(fromPosition))
+            .build()
+            .toQuery();
+    final var typeQ =
+        QueryBuilders.term()
+            .field(PostImporterQueueTemplate.ACTION_TYPE)
+            .value(FieldValue.of(PostImporterActionType.PROCESS_INSTANCE_MIGRATION.name()))
+            .build()
+            .toQuery();
+    final var partitionQ =
+        QueryBuilders.term()
+            .field(PostImporterQueueTemplate.PARTITION_ID)
+            .value(v -> v.longValue(partitionId))
+            .build()
+            .toQuery();
+    return QueryBuilders.bool().must(positionQ, typeQ, partitionQ).build().toQuery();
+  }
+
+  private MigrationVariableBackfillRepository.PendingBackfillBatch toPendingBackfillBatch(
+      final org.opensearch.client.opensearch.core.SearchResponse<PendingBackfillEntry> response) {
+    final var hits = response.hits().hits();
+    if (hits.isEmpty()) {
+      return new MigrationVariableBackfillRepository.PendingBackfillBatch(-1L, List.of());
+    }
+    final var highestPosition = hits.getLast().source().position();
+    final var processInstanceKeys =
+        hits.stream().map(h -> h.source().processInstanceKey()).collect(Collectors.toList());
+    return new MigrationVariableBackfillRepository.PendingBackfillBatch(
+        highestPosition, processInstanceKeys);
+  }
+
+  private record PendingBackfillEntry(long processInstanceKey, long position) {}
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromProcessInstanceMigrationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromProcessInstanceMigrationHandlerTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.post.PostImporterActionType;
+import io.camunda.webapps.schema.entities.post.PostImporterQueueEntity;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class PostImporterQueueFromProcessInstanceMigrationHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-post-import-queue";
+
+  @SuppressWarnings("unchecked")
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache =
+      mock(ExporterEntityCache.class);
+
+  private final PostImporterQueueFromProcessInstanceMigrationHandler underTest =
+      new PostImporterQueueFromProcessInstanceMigrationHandler(indexName, processCache, true);
+
+  @Test
+  void shouldHandleProcessInstanceMigrationValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.PROCESS_INSTANCE_MIGRATION);
+  }
+
+  @Test
+  void shouldReturnPostImporterQueueEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(PostImporterQueueEntity.class);
+  }
+
+  @Test
+  void shouldNotHandleRecordWithMigrateIntent() {
+    // given
+    final long sourceKey = 10L;
+    final long targetKey = 20L;
+    setupCacheWithUserTaskTransition(sourceKey, targetKey);
+    final Record<ProcessInstanceMigrationRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE_MIGRATION,
+            r -> r.withIntent(ProcessInstanceMigrationIntent.MIGRATE));
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleRecordWhenSkipFlagIsDisabled() {
+    // given
+    final long sourceKey = 10L;
+    final long targetKey = 20L;
+    setupCacheWithUserTaskTransition(sourceKey, targetKey);
+    final var handlerWithFlagOff =
+        new PostImporterQueueFromProcessInstanceMigrationHandler(indexName, processCache, false);
+    final var record = buildMigratedRecord(sourceKey, targetKey, /* processInstanceKey= */ 100L);
+
+    // when - then
+    assertThat(handlerWithFlagOff.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleRecordWhenSourceProcessHasUserTasks() {
+    // given
+    final long sourceKey = 10L;
+    final long targetKey = 20L;
+    setupCache(sourceKey, /* hasUserTasks= */ true);
+    setupCache(targetKey, /* hasUserTasks= */ true);
+    final var record = buildMigratedRecord(sourceKey, targetKey, 100L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleRecordWhenTargetProcessHasNoUserTasks() {
+    // given
+    final long sourceKey = 10L;
+    final long targetKey = 20L;
+    setupCache(sourceKey, /* hasUserTasks= */ false);
+    setupCache(targetKey, /* hasUserTasks= */ false);
+    final var record = buildMigratedRecord(sourceKey, targetKey, 100L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleRecordOnSourceCacheMiss() {
+    // given
+    final long sourceKey = 10L;
+    final long targetKey = 20L;
+    org.mockito.Mockito.when(processCache.get(sourceKey)).thenReturn(Optional.empty());
+    setupCache(targetKey, /* hasUserTasks= */ true);
+    final var record = buildMigratedRecord(sourceKey, targetKey, 100L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleRecordOnTargetCacheMiss() {
+    // given
+    final long sourceKey = 10L;
+    final long targetKey = 20L;
+    setupCache(sourceKey, /* hasUserTasks= */ false);
+    org.mockito.Mockito.when(processCache.get(targetKey)).thenReturn(Optional.empty());
+    final var record = buildMigratedRecord(sourceKey, targetKey, 100L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldHandleRecordWhenSourceHasNoUserTasksAndTargetDoes() {
+    // given
+    final long sourceKey = 10L;
+    final long targetKey = 20L;
+    setupCacheWithUserTaskTransition(sourceKey, targetKey);
+    final var record = buildMigratedRecord(sourceKey, targetKey, 100L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIdFromProcessInstanceKey() {
+    // given
+    final long processInstanceKey = 999L;
+    final var value =
+        ImmutableProcessInstanceMigrationRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceMigrationRecordValue.class))
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+    final Record<ProcessInstanceMigrationRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE_MIGRATION,
+            r -> r.withIntent(ProcessInstanceMigrationIntent.MIGRATED).withValue(value));
+
+    // when
+    final var ids = underTest.generateIds(record);
+
+    // then
+    assertThat(ids).containsExactly(String.valueOf(processInstanceKey));
+  }
+
+  @Test
+  void shouldCreateNewEntityWithId() {
+    // when
+    final var entity = underTest.createNewEntity("42");
+
+    // then
+    assertThat(entity).isNotNull();
+    assertThat(entity.getId()).isEqualTo("42");
+  }
+
+  @Test
+  void shouldFlushEntityViaBatchRequestAdd() {
+    // given
+    final PostImporterQueueEntity entity = new PostImporterQueueEntity().setId("1");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(indexName, entity);
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final long processInstanceKey = 100L;
+    final long rootProcessInstanceKey = 50L;
+    final int partitionId = 3;
+    final long position = 77L;
+
+    final var value =
+        ImmutableProcessInstanceMigrationRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceMigrationRecordValue.class))
+            .withProcessInstanceKey(processInstanceKey)
+            .withRootProcessInstanceKey(rootProcessInstanceKey)
+            .build();
+    final Record<ProcessInstanceMigrationRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE_MIGRATION,
+            r ->
+                r.withIntent(ProcessInstanceMigrationIntent.MIGRATED)
+                    .withValue(value)
+                    .withPartitionId(partitionId)
+                    .withPosition(position));
+
+    // when
+    final var entity = new PostImporterQueueEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getId()).isEqualTo(String.valueOf(processInstanceKey));
+    assertThat(entity.getKey()).isEqualTo(processInstanceKey);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
+    assertThat(entity.getActionType()).isEqualTo(PostImporterActionType.PROCESS_INSTANCE_MIGRATION);
+    assertThat(entity.getIntent()).isEqualTo(ProcessInstanceMigrationIntent.MIGRATED.name());
+    assertThat(entity.getPartitionId()).isEqualTo(partitionId);
+    assertThat(entity.getPosition()).isEqualTo(position);
+    assertThat(entity.getCreationTime()).isNotNull();
+  }
+
+  @Test
+  void shouldNotSetRootProcessInstanceKeyWhenDefault() {
+    // given
+    final var value =
+        ImmutableProcessInstanceMigrationRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceMigrationRecordValue.class))
+            .withRootProcessInstanceKey(-1L)
+            .build();
+    final Record<ProcessInstanceMigrationRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE_MIGRATION,
+            r -> r.withIntent(ProcessInstanceMigrationIntent.MIGRATED).withValue(value));
+
+    // when
+    final var entity = new PostImporterQueueEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getRootProcessInstanceKey()).isNull();
+  }
+
+  // --- helpers ---
+
+  private Record<ProcessInstanceMigrationRecordValue> buildMigratedRecord(
+      final long sourceDefinitionKey,
+      final long targetDefinitionKey,
+      final long processInstanceKey) {
+    final var value =
+        ImmutableProcessInstanceMigrationRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceMigrationRecordValue.class))
+            .withProcessDefinitionKey(sourceDefinitionKey)
+            .withTargetProcessDefinitionKey(targetDefinitionKey)
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE_MIGRATION,
+        r -> r.withIntent(ProcessInstanceMigrationIntent.MIGRATED).withValue(value));
+  }
+
+  private void setupCache(final long processDefinitionKey, final boolean hasUserTasks) {
+    final var entity = new CachedProcessEntity(null, 0, null, null, null, hasUserTasks, null);
+    org.mockito.Mockito.when(processCache.get(processDefinitionKey))
+        .thenReturn(Optional.of(entity));
+  }
+
+  private void setupCacheWithUserTaskTransition(final long sourceKey, final long targetKey) {
+    setupCache(sourceKey, /* hasUserTasks= */ false);
+    setupCache(targetKey, /* hasUserTasks= */ true);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerTest.java
@@ -16,6 +16,7 @@ import io.camunda.exporter.tasks.archiver.NoopArchiverRepository;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.NoopBatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.historydeletion.HistoryDeletionRepository.NoopHistoryDeletionRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NoopIncidentUpdateRepository;
+import io.camunda.exporter.tasks.migrationvariablebackfill.MigrationVariableBackfillRepository.Noop;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -42,6 +43,8 @@ final class CamundaBackgroundTaskManagerTest {
         new CloseableBatchOperationUpdateRepository();
     private final CloseableHistoryDeletionRepository historyDeletionRepository =
         new CloseableHistoryDeletionRepository();
+    private final CloseableMigrationVariableBackfillRepository migrationVariableBackfillRepository =
+        new CloseableMigrationVariableBackfillRepository();
     private final CamundaBackgroundTaskManager taskManager =
         new CamundaBackgroundTaskManager(
             1,
@@ -50,6 +53,7 @@ final class CamundaBackgroundTaskManagerTest {
             incidentRepository,
             batchOperationUpdateRepository,
             historyDeletionRepository,
+            migrationVariableBackfillRepository,
             LoggerFactory.getLogger(CamundaBackgroundTaskManagerTest.class),
             executor,
             java.util.List.of(),
@@ -70,6 +74,7 @@ final class CamundaBackgroundTaskManagerTest {
       assertThat(incidentRepository.isClosed).isTrue();
       assertThat(batchOperationUpdateRepository.isClosed).isTrue();
       assertThat(historyDeletionRepository.isClosed).isTrue();
+      assertThat(migrationVariableBackfillRepository.isClosed).isTrue();
     }
 
     @Test
@@ -112,6 +117,15 @@ final class CamundaBackgroundTaskManagerTest {
     void shouldNotThrowOnHistoryDeletionRepositoryCloseError() {
       // given
       historyDeletionRepository.exception = new RuntimeException("foo");
+
+      // when
+      assertThatCode(taskManager::close).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldNotThrowOnMigrationVariableBackfillRepositoryCloseError() {
+      // given
+      migrationVariableBackfillRepository.exception = new RuntimeException("foo");
 
       // when
       assertThatCode(taskManager::close).doesNotThrowAnyException();
@@ -194,6 +208,20 @@ final class CamundaBackgroundTaskManagerTest {
 
       @Override
       public void close() throws Exception {
+        if (exception != null) {
+          throw exception;
+        }
+
+        isClosed = true;
+      }
+    }
+
+    private static final class CloseableMigrationVariableBackfillRepository extends Noop {
+      private boolean isClosed;
+      private RuntimeException exception;
+
+      @Override
+      public void close() {
         if (exception != null) {
           throw exception;
         }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillTaskTest.java
@@ -9,16 +9,11 @@ package io.camunda.exporter.tasks.migrationvariablebackfill;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.exporter.ExporterMetadata;
-import io.camunda.exporter.tasks.migrationvariablebackfill.MigrationVariableBackfillRepository.PendingBackfillBatch;
-import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.entities.VariableEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.usertask.TaskVariableEntity;
@@ -38,13 +33,11 @@ final class MigrationVariableBackfillTaskTest {
   private static final int BATCH_SIZE = 10;
   private static final int VARIABLE_SIZE_THRESHOLD = 8191;
 
-  private final ExporterMetadata metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
   private final MigrationVariableBackfillRepository repository =
       Mockito.mock(MigrationVariableBackfillRepository.class);
 
   private final MigrationVariableBackfillTask underTest =
       new MigrationVariableBackfillTask(
-          metadata,
           repository,
           BATCH_SIZE,
           VARIABLE_SIZE_THRESHOLD,
@@ -52,9 +45,11 @@ final class MigrationVariableBackfillTaskTest {
 
   @BeforeEach
   void setUp() {
-    when(repository.getPendingBackfillBatch(anyLong(), anyInt()))
-        .thenReturn(CompletableFuture.completedFuture(new PendingBackfillBatch(-1L, List.of())));
+    when(repository.getPendingBackfillBatch(anyInt()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
     when(repository.bulkUpsertTaskVariables(Mockito.anyList()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(repository.deletePendingBackfillEntries(Mockito.anyList()))
         .thenReturn(CompletableFuture.completedFuture(null));
   }
 
@@ -68,24 +63,12 @@ final class MigrationVariableBackfillTaskTest {
   }
 
   @Test
-  void shouldQueryUsingMetadataPosition() {
-    // given
-    metadata.setLastMigrationVariableBackfillPosition(42L);
-
-    // when
-    underTest.execute().toCompletableFuture().join();
-
-    // then
-    verify(repository).getPendingBackfillBatch(eq(42L), anyInt());
-  }
-
-  @Test
   void shouldQueryUsingConfiguredBatchSize() {
     // when
     underTest.execute().toCompletableFuture().join();
 
     // then
-    verify(repository).getPendingBackfillBatch(anyLong(), eq(BATCH_SIZE));
+    verify(repository).getPendingBackfillBatch(BATCH_SIZE);
   }
 
   @Test
@@ -94,7 +77,7 @@ final class MigrationVariableBackfillTaskTest {
     underTest.execute().toCompletableFuture().join();
 
     // then
-    verify(repository, never()).getVariablesByProcessInstanceKey(anyLong());
+    verify(repository, never()).getVariablesByProcessInstanceKey(Mockito.anyLong());
   }
 
   @Test
@@ -106,18 +89,26 @@ final class MigrationVariableBackfillTaskTest {
     verify(repository, never()).bulkUpsertTaskVariables(Mockito.anyList());
   }
 
+  @Test
+  void shouldNotDeleteWhenBatchIsEmpty() {
+    // when
+    underTest.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository, never()).deletePendingBackfillEntries(Mockito.anyList());
+  }
+
   @Nested
   final class WithPendingBatch {
 
     private final long processInstanceKey = 100L;
-    private final long highestPosition = 50L;
 
     @BeforeEach
     void setUp() {
-      when(repository.getPendingBackfillBatch(anyLong(), anyInt()))
-          .thenReturn(
-              CompletableFuture.completedFuture(
-                  new PendingBackfillBatch(highestPosition, List.of(processInstanceKey))));
+      when(repository.getPendingBackfillBatch(anyInt()))
+          .thenReturn(CompletableFuture.completedFuture(List.of(processInstanceKey)));
+      when(repository.deletePendingBackfillEntries(Mockito.anyList()))
+          .thenReturn(CompletableFuture.completedFuture(null));
     }
 
     @Test
@@ -148,7 +139,22 @@ final class MigrationVariableBackfillTaskTest {
     }
 
     @Test
-    void shouldUpdateMetadataPositionAfterBatch() {
+    void shouldDeleteProcessedEntriesAfterBackfill() {
+      // given
+      when(repository.getVariablesByProcessInstanceKey(processInstanceKey))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  List.of(buildVariable(processInstanceKey, 1L, "x", "1"))));
+
+      // when
+      underTest.execute().toCompletableFuture().join();
+
+      // then
+      verify(repository, times(1)).deletePendingBackfillEntries(List.of(processInstanceKey));
+    }
+
+    @Test
+    void shouldDeleteEvenWhenInstanceHasNoVariables() {
       // given
       when(repository.getVariablesByProcessInstanceKey(processInstanceKey))
           .thenReturn(CompletableFuture.completedFuture(List.of()));
@@ -157,21 +163,7 @@ final class MigrationVariableBackfillTaskTest {
       underTest.execute().toCompletableFuture().join();
 
       // then
-      assertThat(metadata.getLastMigrationVariableBackfillPosition()).isEqualTo(highestPosition);
-    }
-
-    @Test
-    void shouldNotUpdateMetadataPositionWhenBatchIsEmpty() {
-      // given
-      metadata.setLastMigrationVariableBackfillPosition(7L);
-      when(repository.getPendingBackfillBatch(anyLong(), anyInt()))
-          .thenReturn(CompletableFuture.completedFuture(new PendingBackfillBatch(-1L, List.of())));
-
-      // when
-      underTest.execute().toCompletableFuture().join();
-
-      // then
-      assertThat(metadata.getLastMigrationVariableBackfillPosition()).isEqualTo(7L);
+      verify(repository, times(1)).deletePendingBackfillEntries(List.of(processInstanceKey));
     }
 
     @Test
@@ -238,11 +230,9 @@ final class MigrationVariableBackfillTaskTest {
     void shouldUpsertVariablesForEachProcessInstanceInBatch() {
       // given
       final long secondInstanceKey = 200L;
-      when(repository.getPendingBackfillBatch(anyLong(), anyInt()))
+      when(repository.getPendingBackfillBatch(anyInt()))
           .thenReturn(
-              CompletableFuture.completedFuture(
-                  new PendingBackfillBatch(
-                      highestPosition, List.of(processInstanceKey, secondInstanceKey))));
+              CompletableFuture.completedFuture(List.of(processInstanceKey, secondInstanceKey)));
 
       when(repository.getVariablesByProcessInstanceKey(processInstanceKey))
           .thenReturn(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/migrationvariablebackfill/MigrationVariableBackfillTaskTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.migrationvariablebackfill;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.tasks.migrationvariablebackfill.MigrationVariableBackfillRepository.PendingBackfillBatch;
+import io.camunda.search.test.utils.TestObjectMapper;
+import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.usertask.TaskVariableEntity;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+
+final class MigrationVariableBackfillTaskTest {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+  private static final int BATCH_SIZE = 10;
+  private static final int VARIABLE_SIZE_THRESHOLD = 8191;
+
+  private final ExporterMetadata metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
+  private final MigrationVariableBackfillRepository repository =
+      Mockito.mock(MigrationVariableBackfillRepository.class);
+
+  private final MigrationVariableBackfillTask underTest =
+      new MigrationVariableBackfillTask(
+          metadata,
+          repository,
+          BATCH_SIZE,
+          VARIABLE_SIZE_THRESHOLD,
+          LoggerFactory.getLogger(MigrationVariableBackfillTaskTest.class));
+
+  @BeforeEach
+  void setUp() {
+    when(repository.getPendingBackfillBatch(anyLong(), anyInt()))
+        .thenReturn(CompletableFuture.completedFuture(new PendingBackfillBatch(-1L, List.of())));
+    when(repository.bulkUpsertTaskVariables(Mockito.anyList()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+  }
+
+  @Test
+  void shouldReturnZeroWhenBatchIsEmpty() {
+    // when
+    final var result = underTest.execute();
+
+    // then
+    assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(0);
+  }
+
+  @Test
+  void shouldQueryUsingMetadataPosition() {
+    // given
+    metadata.setLastMigrationVariableBackfillPosition(42L);
+
+    // when
+    underTest.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository).getPendingBackfillBatch(eq(42L), anyInt());
+  }
+
+  @Test
+  void shouldQueryUsingConfiguredBatchSize() {
+    // when
+    underTest.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository).getPendingBackfillBatch(anyLong(), eq(BATCH_SIZE));
+  }
+
+  @Test
+  void shouldNotFetchVariablesWhenBatchIsEmpty() {
+    // when
+    underTest.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository, never()).getVariablesByProcessInstanceKey(anyLong());
+  }
+
+  @Test
+  void shouldNotUpsertWhenBatchIsEmpty() {
+    // when
+    underTest.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository, never()).bulkUpsertTaskVariables(Mockito.anyList());
+  }
+
+  @Nested
+  final class WithPendingBatch {
+
+    private final long processInstanceKey = 100L;
+    private final long highestPosition = 50L;
+
+    @BeforeEach
+    void setUp() {
+      when(repository.getPendingBackfillBatch(anyLong(), anyInt()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new PendingBackfillBatch(highestPosition, List.of(processInstanceKey))));
+    }
+
+    @Test
+    void shouldReturnVariableCountWhenVariablesExist() {
+      // given
+      final var variables = List.of(buildVariable(processInstanceKey, 1L, "foo", "bar"));
+      when(repository.getVariablesByProcessInstanceKey(processInstanceKey))
+          .thenReturn(CompletableFuture.completedFuture(variables));
+
+      // when
+      final var result = underTest.execute();
+
+      // then
+      assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(1);
+    }
+
+    @Test
+    void shouldReturnZeroWhenNoVariablesFoundForInstance() {
+      // given
+      when(repository.getVariablesByProcessInstanceKey(processInstanceKey))
+          .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+      // when
+      final var result = underTest.execute();
+
+      // then
+      assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(0);
+    }
+
+    @Test
+    void shouldUpdateMetadataPositionAfterBatch() {
+      // given
+      when(repository.getVariablesByProcessInstanceKey(processInstanceKey))
+          .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+      // when
+      underTest.execute().toCompletableFuture().join();
+
+      // then
+      assertThat(metadata.getLastMigrationVariableBackfillPosition()).isEqualTo(highestPosition);
+    }
+
+    @Test
+    void shouldNotUpdateMetadataPositionWhenBatchIsEmpty() {
+      // given
+      metadata.setLastMigrationVariableBackfillPosition(7L);
+      when(repository.getPendingBackfillBatch(anyLong(), anyInt()))
+          .thenReturn(CompletableFuture.completedFuture(new PendingBackfillBatch(-1L, List.of())));
+
+      // when
+      underTest.execute().toCompletableFuture().join();
+
+      // then
+      assertThat(metadata.getLastMigrationVariableBackfillPosition()).isEqualTo(7L);
+    }
+
+    @Test
+    void shouldUpsertTaskVariableWithCorrectFields() {
+      // given
+      final long scopeKey = 200L;
+      final var variable = buildVariable(processInstanceKey, scopeKey, "price", "42");
+      variable.setPartitionId(1);
+      variable.setTenantId("tenant-a");
+
+      when(repository.getVariablesByProcessInstanceKey(processInstanceKey))
+          .thenReturn(CompletableFuture.completedFuture(List.of(variable)));
+
+      @SuppressWarnings("unchecked")
+      final ArgumentCaptor<List<TaskVariableEntity>> captor = ArgumentCaptor.forClass(List.class);
+
+      // when
+      underTest.execute().toCompletableFuture().join();
+
+      // then
+      verify(repository, times(1)).bulkUpsertTaskVariables(captor.capture());
+      final var taskVar = captor.getValue().getFirst();
+      assertThat(taskVar.getId()).isEqualTo(scopeKey + "-price");
+      assertThat(taskVar.getName()).isEqualTo("price");
+      assertThat(taskVar.getValue()).isEqualTo("42");
+      assertThat(taskVar.getScopeKey()).isEqualTo(scopeKey);
+      assertThat(taskVar.getProcessInstanceId()).isEqualTo(processInstanceKey);
+      assertThat(taskVar.getPartitionId()).isEqualTo(1);
+      assertThat(taskVar.getTenantId()).isEqualTo("tenant-a");
+      assertThat(taskVar.getJoin().getName())
+          .isEqualTo(TaskJoinRelationshipType.PROCESS_VARIABLE.getType());
+      assertThat(taskVar.getJoin().getParent()).isEqualTo(processInstanceKey);
+    }
+
+    @Test
+    void shouldMapIsPreviewToIsTruncated() {
+      // given
+      final var truncatedVariable = buildVariable(processInstanceKey, 200L, "x", "truncated");
+      truncatedVariable.setIsPreview(true);
+
+      final var fullVariable = buildVariable(processInstanceKey, 201L, "y", "full");
+      fullVariable.setIsPreview(false);
+
+      when(repository.getVariablesByProcessInstanceKey(processInstanceKey))
+          .thenReturn(CompletableFuture.completedFuture(List.of(truncatedVariable, fullVariable)));
+
+      @SuppressWarnings("unchecked")
+      final ArgumentCaptor<List<TaskVariableEntity>> captor = ArgumentCaptor.forClass(List.class);
+
+      // when
+      underTest.execute().toCompletableFuture().join();
+
+      // then
+      verify(repository).bulkUpsertTaskVariables(captor.capture());
+      final var vars = captor.getValue();
+      assertThat(vars).hasSize(2);
+      assertThat(vars.stream().filter(v -> v.getName().equals("x")).findFirst())
+          .hasValueSatisfying(v -> assertThat(v.getIsTruncated()).isTrue());
+      assertThat(vars.stream().filter(v -> v.getName().equals("y")).findFirst())
+          .hasValueSatisfying(v -> assertThat(v.getIsTruncated()).isFalse());
+    }
+
+    @Test
+    void shouldUpsertVariablesForEachProcessInstanceInBatch() {
+      // given
+      final long secondInstanceKey = 200L;
+      when(repository.getPendingBackfillBatch(anyLong(), anyInt()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new PendingBackfillBatch(
+                      highestPosition, List.of(processInstanceKey, secondInstanceKey))));
+
+      when(repository.getVariablesByProcessInstanceKey(processInstanceKey))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  List.of(buildVariable(processInstanceKey, 10L, "a", "1"))));
+      when(repository.getVariablesByProcessInstanceKey(secondInstanceKey))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  List.of(
+                      buildVariable(secondInstanceKey, 20L, "b", "2"),
+                      buildVariable(secondInstanceKey, 21L, "c", "3"))));
+
+      // when
+      final var result = underTest.execute();
+
+      // then
+      assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(3);
+      verify(repository, times(1)).bulkUpsertTaskVariables(Mockito.argThat(l -> l.size() == 1));
+      verify(repository, times(1)).bulkUpsertTaskVariables(Mockito.argThat(l -> l.size() == 2));
+    }
+
+    @Test
+    void shouldNotUpsertWhenInstanceHasNoVariables() {
+      // given
+      when(repository.getVariablesByProcessInstanceKey(processInstanceKey))
+          .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+      // when
+      underTest.execute().toCompletableFuture().join();
+
+      // then
+      verify(repository, never()).bulkUpsertTaskVariables(Mockito.anyList());
+    }
+  }
+
+  // --- helpers ---
+
+  private static VariableEntity buildVariable(
+      final long processInstanceKey, final long scopeKey, final String name, final String value) {
+    final var v = new VariableEntity();
+    v.setProcessInstanceKey(processInstanceKey);
+    v.setScopeKey(scopeKey);
+    v.setName(name);
+    v.setValue(value);
+    v.setIsPreview(false);
+    return v;
+  }
+}


### PR DESCRIPTION
## Description

`POST /user-tasks/search` with a `processInstanceVariables` filter is resolved (ES/OS) via a parent/child join inside the `tasklist-task` index. With the exporter optimization `skipVariableWriteWithoutUserTasks` enabled, instances started on a process version **without** user tasks never get their variables written to the task index, and migrating such an instance to a version **with** user tasks does not back-fill them (the `VARIABLE.MIGRATED` event carries no value). The filter therefore wrongly returned no tasks even though the task exists and the variable matches.

The variable store is complete for all instances, so the filter is now resolved there, **by the backend-specific reader** (the service layer is untouched):

- **RDBMS** — no change: with the filter reaching the reader again, the mapper's native SQL `EXISTS` subquery on the variable table resolves it in a single statement (unlimited, native pagination/sorting/totals).
- **ES/OS** — `UserTaskDocumentReader` collects the `processInstanceKey`s of matching variables with a **cursor-paginated variable search** (sorted by `variableKey` for stable `search_after` pagination, looped to exhaustion — **no result-set limit**, bounded memory per page), narrowed by any caller-supplied `processInstanceKey`/`processDefinitionKey` filters and intersected across filter pairs (AND). The query is then rewritten — variable filter stripped, `processInstanceKey IN (keys)` appended — and runs through the unchanged search path, so authorization, tenant checks, pagination, sorting and totals remain fully native. An empty key set short-circuits to an empty result.
- **Terms chunking** — `SearchQueryBuilders.longTerms` now splits value sets larger than `index.max_terms_count` (65,536) into multiple terms clauses OR-ed within the same request (a terms query is one boolean clause regardless of value count), so the rewritten query handles arbitrarily many matched instances in a single search request.

Variables at **any scope** within the instance qualify, preserving the established semantics of the previous join (which indexes every variable as a process variable) and of the RDBMS implementation. The aggregation runs with disabled access checks as an internal lookup (same model as other internal sub-queries); the final user task search enforces the caller's authorization.

Closes #49963
