### PR TITLE
fix: load test verification timeout

### DIFF
--- a/load-tests/docs/scripts/verify-test.sh
+++ b/load-tests/docs/scripts/verify-test.sh
@@ -6,8 +6,8 @@ usage() {
 Usage: verify-test.sh <namespace> [pod_timeout_seconds] [pod_ready_retries] [connectivity_timeout_seconds] [metrics_port]
 Arguments:
   namespace: Kubernetes namespace where the load test is deployed
-  pod_timeout_seconds: (optional) Timeout for waiting for pods to be ready in seconds (default: 800)
-  pod_ready_retries: (optional) Number of retries for waiting for pods to be ready (default: 3)
+  pod_timeout_seconds: (optional) Timeout for waiting for pods to be ready in seconds (default: 60)
+  pod_ready_retries: (optional) Number of retries for waiting for pods to be ready (default: 40)
   connectivity_timeout_seconds: (optional) Timeout for waiting for client connectivity in seconds (default: 1800)
   metrics_port: (optional) Port on which the client exposes metrics (default: 9600)
 EOF
@@ -26,8 +26,8 @@ if [ -z "$1" ]; then
 fi
 
 NAMESPACE=$1
-POD_TIMEOUT=${2:-800}
-POD_READY_RETRIES=${3:-3}
+POD_TIMEOUT=${2:-60}
+POD_READY_RETRIES=${3:-40}
 CONNECTIVITY_TIMEOUT=${4:-1800}
 METRICS_PORT=${5:-9600}
 GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"


### PR DESCRIPTION


## Description

Change the verification timeout logic: instead of waiting at most 3 x 800s, this now waits 40 x 60s (+ 40x10s of delay before retrying instead of only 3x10s)

This should improve the reliability of the verification + make it faster:

1. when the `kubectl wait --for=condition=ready pod` starts, it seems it first gets the list of pods, then waits on them
2. if a pod is rescheduled in the meantime, the pod name changes and `kubectl` waits up to 800s on previous pod name which doesn't exist anymore.

The total time is now the same, but we give more changes to kubectl to detect pods restarting during the setup.

The fix is similar in the intent to the one made in https://github.com/camunda/camunda/pull/50653/, which somehow got lost.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
