### PR TITLE
feat: add Micrometer authorization check latency metric

### DIFF
--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -964,6 +964,252 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 12,
+      "title": "Authorization",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Latency of authorization checks in AuthorizationCheckBehavior, including the fast path when checks are disabled",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(zeebe_authorization_check_latency_seconds_bucket{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "interval": "1m",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(zeebe_authorization_check_latency_seconds_bucket{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "interval": "1m",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(zeebe_authorization_check_latency_seconds_bucket{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "interval": "1m",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Authorization Check Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of authorization checks per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(zeebe_authorization_check_latency_seconds_count{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "checks/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Authorization Check Rate",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetrics.java
@@ -16,6 +16,10 @@ public final class AuthorizationCheckMetrics {
 
   private final Timer timer;
 
+  AuthorizationCheckMetrics(final Timer timer) {
+    this.timer = Objects.requireNonNull(timer, "Timer must not be null");
+  }
+
   public AuthorizationCheckMetrics(final MeterRegistry registry) {
     Objects.requireNonNull(registry, "MeterRegistry must not be null");
     final var meterDoc = AuthorizationMetricsDoc.CHECK_LATENCY;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetrics.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.zeebe.engine.metrics.AuthorizationMetricsDoc.AuthorizationKeyNames;
+import io.camunda.zeebe.engine.metrics.AuthorizationMetricsDoc.AuthorizationOutcome;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public final class AuthorizationCheckMetrics {
+
+  private final MeterRegistry registry;
+  private final ConcurrentHashMap<String, Timer> timers = new ConcurrentHashMap<>();
+
+  public AuthorizationCheckMetrics(final MeterRegistry registry) {
+    this.registry = Objects.requireNonNull(registry, "MeterRegistry must not be null");
+  }
+
+  public void record(
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final AuthorizationOutcome outcome,
+      final long durationNanos) {
+    try {
+      final var key = resourceType.name() + ":" + permissionType.name() + ":" + outcome.name();
+      timers
+          .computeIfAbsent(key, k -> buildTimer(resourceType, permissionType, outcome))
+          .record(durationNanos, TimeUnit.NANOSECONDS);
+    } catch (final RuntimeException ignored) {
+      // Metrics failures must never affect authorization decisions
+    }
+  }
+
+  private Timer buildTimer(
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final AuthorizationOutcome outcome) {
+    final var meterDoc = AuthorizationMetricsDoc.CHECK_LATENCY;
+    return Timer.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
+        .tag(AuthorizationKeyNames.RESOURCE_TYPE.asString(), resourceType.name())
+        .tag(AuthorizationKeyNames.PERMISSION_TYPE.asString(), permissionType.name())
+        .tag(AuthorizationKeyNames.OUTCOME.asString(), outcome.getLabel())
+        .register(registry);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetrics.java
@@ -7,51 +7,30 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
-import io.camunda.zeebe.engine.metrics.AuthorizationMetricsDoc.AuthorizationKeyNames;
-import io.camunda.zeebe.engine.metrics.AuthorizationMetricsDoc.AuthorizationOutcome;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 public final class AuthorizationCheckMetrics {
 
-  private final MeterRegistry registry;
-  private final ConcurrentHashMap<String, Timer> timers = new ConcurrentHashMap<>();
+  private final Timer timer;
 
   public AuthorizationCheckMetrics(final MeterRegistry registry) {
-    this.registry = Objects.requireNonNull(registry, "MeterRegistry must not be null");
+    Objects.requireNonNull(registry, "MeterRegistry must not be null");
+    final var meterDoc = AuthorizationMetricsDoc.CHECK_LATENCY;
+    timer =
+        Timer.builder(meterDoc.getName())
+            .description(meterDoc.getDescription())
+            .serviceLevelObjectives(meterDoc.getTimerSLOs())
+            .register(registry);
   }
 
-  public void record(
-      final AuthorizationResourceType resourceType,
-      final PermissionType permissionType,
-      final AuthorizationOutcome outcome,
-      final long durationNanos) {
+  public void record(final long durationNanos) {
     try {
-      final var key = resourceType.name() + ":" + permissionType.name() + ":" + outcome.name();
-      timers
-          .computeIfAbsent(key, k -> buildTimer(resourceType, permissionType, outcome))
-          .record(durationNanos, TimeUnit.NANOSECONDS);
+      timer.record(durationNanos, TimeUnit.NANOSECONDS);
     } catch (final RuntimeException ignored) {
       // Metrics failures must never affect authorization decisions
     }
-  }
-
-  private Timer buildTimer(
-      final AuthorizationResourceType resourceType,
-      final PermissionType permissionType,
-      final AuthorizationOutcome outcome) {
-    final var meterDoc = AuthorizationMetricsDoc.CHECK_LATENCY;
-    return Timer.builder(meterDoc.getName())
-        .description(meterDoc.getDescription())
-        .serviceLevelObjectives(meterDoc.getTimerSLOs())
-        .tag(AuthorizationKeyNames.RESOURCE_TYPE.asString(), resourceType.name())
-        .tag(AuthorizationKeyNames.PERMISSION_TYPE.asString(), permissionType.name())
-        .tag(AuthorizationKeyNames.OUTCOME.asString(), outcome.getLabel())
-        .register(registry);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationMetricsDoc.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.metrics;
 
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
-import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -27,13 +26,6 @@ public enum AuthorizationMetricsDoc implements ExtendedMeterDocumentation {
       Duration.ofMillis(100),
       Duration.ofMillis(500),
     };
-
-    private static final KeyName[] KEY_NAMES =
-        new KeyName[] {
-          AuthorizationKeyNames.RESOURCE_TYPE,
-          AuthorizationKeyNames.PERMISSION_TYPE,
-          AuthorizationKeyNames.OUTCOME,
-        };
 
     @Override
     public String getName() {
@@ -59,54 +51,5 @@ public enum AuthorizationMetricsDoc implements ExtendedMeterDocumentation {
     public Duration[] getTimerSLOs() {
       return TIMER_SLOS;
     }
-
-    @Override
-    public KeyName[] getKeyNames() {
-      return KEY_NAMES;
-    }
   };
-
-  /** Tags used by authorization metrics. */
-  public enum AuthorizationKeyNames implements KeyName {
-
-    /** The resource type being authorized (e.g. PROCESS_DEFINITION, DECISION_DEFINITION). */
-    RESOURCE_TYPE {
-      @Override
-      public String asString() {
-        return "resourceType";
-      }
-    },
-
-    /** The permission type being checked (e.g. READ, CREATE, UPDATE, DELETE). */
-    PERMISSION_TYPE {
-      @Override
-      public String asString() {
-        return "permissionType";
-      }
-    },
-
-    /** The outcome of the authorization check. See {@link AuthorizationOutcome}. */
-    OUTCOME {
-      @Override
-      public String asString() {
-        return "outcome";
-      }
-    }
-  }
-
-  /** Possible outcomes of an authorization check recorded in metrics. */
-  public enum AuthorizationOutcome {
-    AUTHORIZED("authorized"),
-    DENIED("denied");
-
-    private final String label;
-
-    AuthorizationOutcome(final String label) {
-      this.label = label;
-    }
-
-    public String getLabel() {
-      return label;
-    }
-  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationMetricsDoc.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+public enum AuthorizationMetricsDoc implements ExtendedMeterDocumentation {
+
+  /** Latency of each authorization check in AuthorizationCheckBehavior, including cache hits. */
+  CHECK_LATENCY {
+    private static final Duration[] TIMER_SLOS = {
+      Duration.of(100, ChronoUnit.MICROS),
+      Duration.of(500, ChronoUnit.MICROS),
+      Duration.ofMillis(1),
+      Duration.ofMillis(5),
+      Duration.ofMillis(10),
+      Duration.ofMillis(50),
+      Duration.ofMillis(100),
+      Duration.ofMillis(500),
+    };
+
+    private static final KeyName[] KEY_NAMES =
+        new KeyName[] {
+          AuthorizationKeyNames.RESOURCE_TYPE,
+          AuthorizationKeyNames.PERMISSION_TYPE,
+          AuthorizationKeyNames.OUTCOME,
+        };
+
+    @Override
+    public String getName() {
+      return "zeebe.authorization.check.latency";
+    }
+
+    @Override
+    public String getDescription() {
+      return "Latency of each authorization check in AuthorizationCheckBehavior, including cache hits";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return TIMER_SLOS;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+  };
+
+  /** Tags used by authorization metrics. */
+  public enum AuthorizationKeyNames implements KeyName {
+
+    /** The resource type being authorized (e.g. PROCESS_DEFINITION, DECISION_DEFINITION). */
+    RESOURCE_TYPE {
+      @Override
+      public String asString() {
+        return "resourceType";
+      }
+    },
+
+    /** The permission type being checked (e.g. READ, CREATE, UPDATE, DELETE). */
+    PERMISSION_TYPE {
+      @Override
+      public String asString() {
+        return "permissionType";
+      }
+    },
+
+    /** The outcome of the authorization check. See {@link AuthorizationOutcome}. */
+    OUTCOME {
+      @Override
+      public String asString() {
+        return "outcome";
+      }
+    }
+  }
+
+  /** Possible outcomes of an authorization check recorded in metrics. */
+  public enum AuthorizationOutcome {
+    AUTHORIZED("authorized"),
+    DENIED("denied");
+
+    private final String label;
+
+    AuthorizationOutcome(final String label) {
+      this.label = label;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationMetricsDoc.java
@@ -44,7 +44,7 @@ public enum AuthorizationMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public String getBaseUnit() {
-      return "ms";
+      return "ns";
     }
 
     @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.el.ExpressionLanguageMetrics;
 import io.camunda.zeebe.el.impl.ExpressionLanguageMetricsImpl;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.metrics.DistributionMetrics;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
@@ -147,6 +148,8 @@ public final class EngineProcessors {
     final var processDefinitionMetrics =
         new ProcessDefinitionMetrics(
             typedRecordProcessorContext.getMeterRegistry(), processingState.getProcessState());
+    final var authorizationCheckMetrics =
+        new AuthorizationCheckMetrics(typedRecordProcessorContext.getMeterRegistry());
 
     subscriptionCommandSender.setWriters(writers);
 
@@ -154,7 +157,8 @@ public final class EngineProcessors {
         new DecisionBehavior(
             DecisionEngineFactory.createDecisionEngine(), processingState, processEngineMetrics);
     final var authCheckBehavior =
-        new AuthorizationCheckBehavior(processingState, securityConfig, config);
+        new AuthorizationCheckBehavior(
+            processingState, securityConfig, config, authorizationCheckMetrics);
     final var asyncRequestBehavior =
         new AsyncRequestBehavior(processingState.getKeyGenerator(), writers.state());
     final var transientProcessMessageSubscriptionState =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -125,15 +125,14 @@ public final class AuthorizationCheckBehavior {
     }
     final long startNanos = System.nanoTime();
     try {
-      final var result = authorizationsCache.get(request);
-      metrics.record(System.nanoTime() - startNanos);
-      return result;
+      return authorizationsCache.get(request);
     } catch (final ExecutionException e) {
-      metrics.record(System.nanoTime() - startNanos);
       return Either.left(
           new Rejection(
               RejectionType.NOT_FOUND,
               "No authorization data was found for the provided authorization claims."));
+    } finally {
+      metrics.record(System.nanoTime() - startNanos);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -120,11 +120,11 @@ public final class AuthorizationCheckBehavior {
    *     {@link Void} if the user is authorized
    */
   public Either<Rejection, Void> isAuthorized(final AuthorizationRequest request) {
-    if (shouldSkipAllChecks()) {
-      return AUTHORIZED;
-    }
     final long startNanos = System.nanoTime();
     try {
+      if (shouldSkipAllChecks()) {
+        return AUTHORIZED;
+      }
       return authorizationsCache.get(request);
     } catch (final ExecutionException e) {
       return Either.left(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -14,7 +14,6 @@ import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.auth.MappingRuleMatcher;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
-import io.camunda.zeebe.engine.metrics.AuthorizationMetricsDoc.AuthorizationOutcome;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.aggregator.RejectionAggregator;
@@ -127,18 +126,10 @@ public final class AuthorizationCheckBehavior {
     final long startNanos = System.nanoTime();
     try {
       final var result = authorizationsCache.get(request);
-      metrics.record(
-          request.resourceType(),
-          request.permissionType(),
-          result.isRight() ? AuthorizationOutcome.AUTHORIZED : AuthorizationOutcome.DENIED,
-          System.nanoTime() - startNanos);
+      metrics.record(System.nanoTime() - startNanos);
       return result;
     } catch (final ExecutionException e) {
-      metrics.record(
-          request.resourceType(),
-          request.permissionType(),
-          AuthorizationOutcome.DENIED,
-          System.nanoTime() - startNanos);
+      metrics.record(System.nanoTime() - startNanos);
       return Either.left(
           new Rejection(
               RejectionType.NOT_FOUND,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -13,6 +13,8 @@ import com.google.common.cache.LoadingCache;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.auth.MappingRuleMatcher;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
+import io.camunda.zeebe.engine.metrics.AuthorizationMetricsDoc.AuthorizationOutcome;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.aggregator.RejectionAggregator;
@@ -42,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -62,11 +65,13 @@ public final class AuthorizationCheckBehavior {
   private final boolean multiTenancyEnabled;
 
   private final LoadingCache<AuthorizationRequest, Either<Rejection, Void>> authorizationsCache;
+  private final AuthorizationCheckMetrics metrics;
 
   public AuthorizationCheckBehavior(
       final ProcessingState processingState,
       final EngineSecurityConfig securityConfig,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final AuthorizationCheckMetrics metrics) {
     final var authorizationState = processingState.getAuthorizationState();
     final var membershipState = processingState.getMembershipState();
 
@@ -100,6 +105,7 @@ public final class AuthorizationCheckBehavior {
                     return checkAuthorized(authorizationRequest);
                   }
                 });
+    this.metrics = Objects.requireNonNull(metrics, "AuthorizationCheckMetrics must not be null");
   }
 
   /**
@@ -118,9 +124,21 @@ public final class AuthorizationCheckBehavior {
     if (shouldSkipAllChecks()) {
       return AUTHORIZED;
     }
+    final long startNanos = System.nanoTime();
     try {
-      return authorizationsCache.get(request);
+      final var result = authorizationsCache.get(request);
+      metrics.record(
+          request.resourceType(),
+          request.permissionType(),
+          result.isRight() ? AuthorizationOutcome.AUTHORIZED : AuthorizationOutcome.DENIED,
+          System.nanoTime() - startNanos);
+      return result;
     } catch (final ExecutionException e) {
+      metrics.record(
+          request.resourceType(),
+          request.permissionType(),
+          AuthorizationOutcome.DENIED,
+          System.nanoTime() - startNanos);
       return Either.left(
           new Rejection(
               RejectionType.NOT_FOUND,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetricsTest.java
@@ -9,9 +9,6 @@ package io.camunda.zeebe.engine.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.engine.metrics.AuthorizationMetricsDoc.AuthorizationOutcome;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,95 +25,25 @@ class AuthorizationCheckMetricsTest {
   }
 
   @Test
-  void shouldRecordAuthorizedTimerWithCorrectTags() {
+  void shouldRecordTimer() {
     // when
-    metrics.record(
-        AuthorizationResourceType.PROCESS_DEFINITION,
-        PermissionType.READ,
-        AuthorizationOutcome.AUTHORIZED,
-        1_000_000L);
+    metrics.record(1_000_000L);
 
     // then
-    final var timer =
-        registry
-            .find("zeebe.authorization.check.latency")
-            .tag("resourceType", "PROCESS_DEFINITION")
-            .tag("permissionType", "READ")
-            .tag("outcome", "authorized")
-            .timer();
+    final var timer = registry.find("zeebe.authorization.check.latency").timer();
     assertThat(timer).isNotNull();
     assertThat(timer.count()).isEqualTo(1);
   }
 
   @Test
-  void shouldRecordDeniedTimerWithCorrectTags() {
+  void shouldAccumulateCount() {
     // when
-    metrics.record(
-        AuthorizationResourceType.DECISION_DEFINITION,
-        PermissionType.CREATE,
-        AuthorizationOutcome.DENIED,
-        500_000L);
+    metrics.record(1_000_000L);
+    metrics.record(2_000_000L);
 
     // then
-    final var timer =
-        registry
-            .find("zeebe.authorization.check.latency")
-            .tag("resourceType", "DECISION_DEFINITION")
-            .tag("permissionType", "CREATE")
-            .tag("outcome", "denied")
-            .timer();
-    assertThat(timer).isNotNull();
-    assertThat(timer.count()).isEqualTo(1);
-  }
-
-  @Test
-  void shouldAccumulateCountForSameTagCombination() {
-    // when
-    metrics.record(
-        AuthorizationResourceType.PROCESS_DEFINITION,
-        PermissionType.READ,
-        AuthorizationOutcome.AUTHORIZED,
-        1_000_000L);
-    metrics.record(
-        AuthorizationResourceType.PROCESS_DEFINITION,
-        PermissionType.READ,
-        AuthorizationOutcome.AUTHORIZED,
-        2_000_000L);
-
-    // then
-    final var timer =
-        registry
-            .find("zeebe.authorization.check.latency")
-            .tag("resourceType", "PROCESS_DEFINITION")
-            .tag("permissionType", "READ")
-            .tag("outcome", "authorized")
-            .timer();
+    final var timer = registry.find("zeebe.authorization.check.latency").timer();
     assertThat(timer).isNotNull();
     assertThat(timer.count()).isEqualTo(2);
-  }
-
-  @Test
-  void shouldKeepSeparateTimersForDifferentTagCombinations() {
-    // when
-    metrics.record(
-        AuthorizationResourceType.PROCESS_DEFINITION,
-        PermissionType.READ,
-        AuthorizationOutcome.AUTHORIZED,
-        1_000_000L);
-    metrics.record(
-        AuthorizationResourceType.PROCESS_DEFINITION,
-        PermissionType.READ,
-        AuthorizationOutcome.DENIED,
-        1_000_000L);
-
-    // then
-    final var authorizedTimer =
-        registry.find("zeebe.authorization.check.latency").tag("outcome", "authorized").timer();
-    final var deniedTimer =
-        registry.find("zeebe.authorization.check.latency").tag("outcome", "denied").timer();
-    assertThat(authorizedTimer).isNotNull();
-    assertThat(deniedTimer).isNotNull();
-    assertThat(authorizedTimer.count()).isEqualTo(1);
-    assertThat(deniedTimer.count()).isEqualTo(1);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetricsTest.java
@@ -8,15 +8,27 @@
 package io.camunda.zeebe.engine.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
 
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class AuthorizationCheckMetricsTest {
 
   private SimpleMeterRegistry registry;
   private AuthorizationCheckMetrics metrics;
+
+  @Mock Timer mockTimer;
 
   @BeforeEach
   void setUp() {
@@ -33,6 +45,7 @@ class AuthorizationCheckMetricsTest {
     final var timer = registry.find("zeebe.authorization.check.latency").timer();
     assertThat(timer).isNotNull();
     assertThat(timer.count()).isEqualTo(1);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isEqualTo(1_000_000.0);
   }
 
   @Test
@@ -45,5 +58,15 @@ class AuthorizationCheckMetricsTest {
     final var timer = registry.find("zeebe.authorization.check.latency").timer();
     assertThat(timer).isNotNull();
     assertThat(timer.count()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldSwallowRuntimeExceptionFromBrokenTimer() {
+    // given
+    doThrow(new RuntimeException("broken registry")).when(mockTimer).record(anyLong(), any());
+    final var brokenMetrics = new AuthorizationCheckMetrics(mockTimer);
+
+    // when / then
+    assertThatNoException().isThrownBy(() -> brokenMetrics.record(1_000_000L));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetricsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.metrics.AuthorizationMetricsDoc.AuthorizationOutcome;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AuthorizationCheckMetricsTest {
+
+  private SimpleMeterRegistry registry;
+  private AuthorizationCheckMetrics metrics;
+
+  @BeforeEach
+  void setUp() {
+    registry = new SimpleMeterRegistry();
+    metrics = new AuthorizationCheckMetrics(registry);
+  }
+
+  @Test
+  void shouldRecordAuthorizedTimerWithCorrectTags() {
+    // when
+    metrics.record(
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ,
+        AuthorizationOutcome.AUTHORIZED,
+        1_000_000L);
+
+    // then
+    final var timer =
+        registry
+            .find("zeebe.authorization.check.latency")
+            .tag("resourceType", "PROCESS_DEFINITION")
+            .tag("permissionType", "READ")
+            .tag("outcome", "authorized")
+            .timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldRecordDeniedTimerWithCorrectTags() {
+    // when
+    metrics.record(
+        AuthorizationResourceType.DECISION_DEFINITION,
+        PermissionType.CREATE,
+        AuthorizationOutcome.DENIED,
+        500_000L);
+
+    // then
+    final var timer =
+        registry
+            .find("zeebe.authorization.check.latency")
+            .tag("resourceType", "DECISION_DEFINITION")
+            .tag("permissionType", "CREATE")
+            .tag("outcome", "denied")
+            .timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldAccumulateCountForSameTagCombination() {
+    // when
+    metrics.record(
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ,
+        AuthorizationOutcome.AUTHORIZED,
+        1_000_000L);
+    metrics.record(
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ,
+        AuthorizationOutcome.AUTHORIZED,
+        2_000_000L);
+
+    // then
+    final var timer =
+        registry
+            .find("zeebe.authorization.check.latency")
+            .tag("resourceType", "PROCESS_DEFINITION")
+            .tag("permissionType", "READ")
+            .tag("outcome", "authorized")
+            .timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldKeepSeparateTimersForDifferentTagCombinations() {
+    // when
+    metrics.record(
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ,
+        AuthorizationOutcome.AUTHORIZED,
+        1_000_000L);
+    metrics.record(
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ,
+        AuthorizationOutcome.DENIED,
+        1_000_000L);
+
+    // then
+    final var authorizedTimer =
+        registry.find("zeebe.authorization.check.latency").tag("outcome", "authorized").timer();
+    final var deniedTimer =
+        registry.find("zeebe.authorization.check.latency").tag("outcome", "denied").timer();
+    assertThat(authorizedTimer).isNotNull();
+    assertThat(deniedTimer).isNotNull();
+    assertThat(authorizedTimer.count()).isEqualTo(1);
+    assertThat(deniedTimer.count()).isEqualTo(1);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetricsTest.java
@@ -28,7 +28,7 @@ class AuthorizationCheckMetricsTest {
   private SimpleMeterRegistry registry;
   private AuthorizationCheckMetrics metrics;
 
-  @Mock Timer mockTimer;
+  @Mock private Timer mockTimer;
 
   @BeforeEach
   void setUp() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
@@ -42,6 +43,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.test.util.Strings;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -72,7 +74,10 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
     final var engineConfig = new EngineConfiguration();
     authorizationCheckBehavior =
         new AuthorizationCheckBehavior(
-            processingState, EngineSecurityConfigurations.defaultConfig(), engineConfig);
+            processingState,
+            EngineSecurityConfigurations.defaultConfig(),
+            engineConfig,
+            new AuthorizationCheckMetrics(new SimpleMeterRegistry()));
 
     userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
     mappingRuleCreatedApplier =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -18,6 +18,7 @@ import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties;
@@ -50,6 +51,7 @@ import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -90,7 +92,11 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
             Pattern.compile("^[a-zA-Z0-9_~@.+-]+$"),
             Pattern.compile(".*", Pattern.DOTALL));
     authorizationCheckBehavior =
-        new AuthorizationCheckBehavior(processingState, securityConfig, engineConfig);
+        new AuthorizationCheckBehavior(
+            processingState,
+            securityConfig,
+            engineConfig,
+            new AuthorizationCheckMetrics(new SimpleMeterRegistry()));
 
     userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
     mappingRuleCreatedApplier =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.property.ResourceAuthorizationProperties;
 import io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties;
@@ -49,6 +50,7 @@ import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +84,10 @@ final class AuthorizationCheckBehaviorTest {
     final var engineConfig = new EngineConfiguration();
     authorizationCheckBehavior =
         new AuthorizationCheckBehavior(
-            processingState, EngineSecurityConfigurations.defaultConfig(), engineConfig);
+            processingState,
+            EngineSecurityConfigurations.defaultConfig(),
+            engineConfig,
+            new AuthorizationCheckMetrics(new SimpleMeterRegistry()));
 
     userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
     mappingRuleCreatedApplier =
@@ -1496,7 +1501,10 @@ final class AuthorizationCheckBehaviorTest {
     final var config = new EngineConfiguration().setAuthorizationsCacheTtl(Duration.ofSeconds(1));
     authorizationCheckBehavior =
         new AuthorizationCheckBehavior(
-            processingState, EngineSecurityConfigurations.defaultConfig(), config);
+            processingState,
+            EngineSecurityConfigurations.defaultConfig(),
+            config,
+            new AuthorizationCheckMetrics(new SimpleMeterRegistry()));
 
     final var user = createUser();
     final var resourceType = AuthorizationResourceType.RESOURCE;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
 import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
@@ -37,6 +38,7 @@ import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
@@ -71,7 +73,8 @@ final class JobBatchCollectorTest {
         new AuthorizationCheckBehavior(
             state,
             EngineSecurityConfigurations.unauthenticatedAndUnauthorized(),
-            new EngineConfiguration());
+            new EngineConfiguration(),
+            new AuthorizationCheckMetrics(new SimpleMeterRegistry()));
     collector = new JobBatchCollector(state, lengthEvaluator, authorizationCheckBehavior, clock);
   }
 


### PR DESCRIPTION
## Summary
- Adds `zeebe.authorization.check.latency` Micrometer Timer to `AuthorizationCheckBehavior`
- Every `isAuthorized()` call is timed, including the fast path when authorization/multi-tenancy checks are disabled
- Timer has no tags — a single aggregate metric is sufficient for the baseline measurement goal
- Establishes performance baseline for the CSL authorization migration (epic camunda/camunda-security-library#388)

Closes camunda/camunda-security-library#403

Here is how it looks like in Identity Dashboard:

<img width="1299" height="352" alt="Screenshot 2026-06-16 at 15 10 59" src="https://github.com/user-attachments/assets/67dde9f2-7446-4a8b-91c3-e70c5774734c" />


## Changes
- `AuthorizationMetricsDoc.java` — new enum documenting the Timer metric
- `AuthorizationCheckMetrics.java` — new class with a single pre-built `Timer`; `record(long)` swallows `RuntimeException` to never affect auth decisions
- `AuthorizationCheckBehavior.java` — adds 4th constructor param + instruments `isAuthorized()` with a `finally` block covering all code paths
- `EngineProcessors.java` — instantiates and injects `AuthorizationCheckMetrics`
- 4 test files updated to pass `new AuthorizationCheckMetrics(new SimpleMeterRegistry())`

## Test plan
- [x] `./mvnw verify -pl zeebe/engine -DskipTests=false -Dquickly` passes with zero failures
- [x] `AuthorizationCheckMetricsTest` verifies recording and accumulation behavior
- [x] Full-repo `./mvnw install -Dquickly` passes (no downstream breakage)
- [x] Local Test with Prometheus / Grafana