### PR TITLE
fix: ensure RDBMS exporter can store large decision instance results

### DIFF
--- a/db/rdbms-schema/src/main/java/io/camunda/db/rdbms/LiquibaseScriptGenerator.java
+++ b/db/rdbms-schema/src/main/java/io/camunda/db/rdbms/LiquibaseScriptGenerator.java
@@ -14,9 +14,9 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import liquibase.Liquibase;
 import liquibase.change.AbstractSQLChange;
 import liquibase.change.Change;
@@ -28,6 +28,7 @@ import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 public class LiquibaseScriptGenerator {
@@ -69,11 +70,15 @@ public class LiquibaseScriptGenerator {
                 new PathMatchingResourcePatternResolver()
                     .getResources("classpath*:" + CHANGESET_PATH + "*.xml"))
             .filter(resource -> !Objects.equals(resource.getFilename(), "8.9.0.xml"))
+            // sorting as version numbers so e.g. 8.9.9 will appear before 8.10.0 (instead of
+            // lexical sorting, which would have 8.10.0 before 8.9.9)
+            .sorted(Comparator.comparing(LiquibaseScriptGenerator::versionNumberFromResource))
             .map(it -> CHANGESET_PATH + it.getFilename())
-            .collect(Collectors.toSet());
+            .distinct()
+            .toList();
 
     // Validate rolling-upgrade compatibility once, before generating any scripts.
-    validateRollingUpgradeCompatibility(upgradeChangesets.stream().toList());
+    validateRollingUpgradeCompatibility(upgradeChangesets);
 
     for (final var databaseVersion : DATABASE_VERSIONS) {
       // We generate create scripts for the latest version from the changelog-master.xml
@@ -263,6 +268,29 @@ public class LiquibaseScriptGenerator {
         .orElse(new DatabaseVersion(databaseId));
   }
 
+  private static VersionNumber versionNumberFromResource(final Resource resource) {
+    final var filename = resource.getFilename();
+    if (filename != null) {
+      return parseVersionNumber(filename.replace(".xml", ""));
+    }
+    throw new IllegalArgumentException(
+        "Expected resource with filename in format 'major.minor.patch.xml', but got: " + resource);
+  }
+
+  private static VersionNumber parseVersionNumber(final String str) {
+    final var parts = str.split("\\.");
+    if (parts.length == 3) {
+      try {
+        return new VersionNumber(
+            Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]));
+      } catch (final NumberFormatException e) {
+        // fall through to exception below
+      }
+    }
+    throw new IllegalArgumentException(
+        "Expected version number in format 'major.minor.patch', but got: " + str);
+  }
+
   /**
    * Pairs a database vendor name with an optional target version for SQL generation.
    *
@@ -273,6 +301,19 @@ public class LiquibaseScriptGenerator {
   public record DatabaseVersion(String vendor, Long targetVersion) {
     public DatabaseVersion(final String vendor) {
       this(vendor, null);
+    }
+  }
+
+  record VersionNumber(int major, int minor, int patch) implements Comparable<VersionNumber> {
+    @Override
+    public int compareTo(final VersionNumber other) {
+      if (major != other.major) {
+        return Integer.compare(major, other.major);
+      }
+      if (minor != other.minor) {
+        return Integer.compare(minor, other.minor);
+      }
+      return Integer.compare(patch, other.patch);
     }
   }
 }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changelog-master.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changelog-master.xml
@@ -17,6 +17,7 @@
         http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd">
 
   <include file="/db/changelog/rdbms-exporter/changesets/8.9.0.xml" />
+  <include file="/db/changelog/rdbms-exporter/changesets/8.9.9.xml" />
   <include file="/db/changelog/rdbms-exporter/changesets/8.10.0.xml" />
 
 </databaseChangeLog>

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.9.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.9.xml
@@ -33,4 +33,15 @@
     </addColumn>
   </changeSet>
 
+  <changeSet id="add_decision_instance_input_full_input_value_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}DECISION_INSTANCE_INPUT" columnName="FULL_INPUT_VALUE"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}DECISION_INSTANCE_INPUT">
+      <column name="FULL_INPUT_VALUE" type="CLOB"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.9.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.9.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!--suppress LiquibaseXmlUnresolvedProperty -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="add_decision_instance_full_result_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}DECISION_INSTANCE" columnName="FULL_RESULT"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}DECISION_INSTANCE">
+      <column name="FULL_RESULT" type="CLOB"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_decision_instance_output_full_output_value_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}DECISION_INSTANCE_OUTPUT" columnName="FULL_OUTPUT_VALUE"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}DECISION_INSTANCE_OUTPUT">
+      <column name="FULL_OUTPUT_VALUE" type="CLOB"/>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/db/rdbms-schema/src/test/resources/db/changelog/rdbms-exporter/changesets/golden/8.9.9.xml
+++ b/db/rdbms-schema/src/test/resources/db/changelog/rdbms-exporter/changesets/golden/8.9.9.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!--suppress LiquibaseXmlUnresolvedProperty -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="add_decision_instance_full_result_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}DECISION_INSTANCE" columnName="FULL_RESULT"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}DECISION_INSTANCE">
+      <column name="FULL_RESULT" type="CLOB"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_decision_instance_output_full_output_value_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}DECISION_INSTANCE_OUTPUT" columnName="FULL_OUTPUT_VALUE"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}DECISION_INSTANCE_OUTPUT">
+      <column name="FULL_OUTPUT_VALUE" type="CLOB"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_decision_instance_input_full_input_value_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}DECISION_INSTANCE_INPUT" columnName="FULL_INPUT_VALUE"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}DECISION_INSTANCE_INPUT">
+      <column name="FULL_INPUT_VALUE" type="CLOB"/>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -416,4 +416,17 @@
     </constructor>
   </resultMap>
 
+  <!--
+    Vendor-specific SQL fragment to let us COALESCE a CLOB column with a non-CLOB column
+     - ${clobColumn} is the name of the CLOB column (e.g. FULL_RESULT)
+     - ${nonClobColumn} is the name of the non-CLOB column (e.g. RESULT) that contains the same data for short values
+  -->
+  <sql id="coalesceCLOB">
+    COALESCE(${clobColumn}, ${nonClobColumn})
+  </sql>
+
+  <sql id="coalesceCLOB" databaseId="oracle">
+    COALESCE(${clobColumn}, TO_CLOB(${nonClobColumn}))
+  </sql>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -268,7 +268,7 @@
 
   <insert id="insertInput" parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel">
     INSERT INTO ${prefix}DECISION_INSTANCE_INPUT (DECISION_INSTANCE_ID, INPUT_ID, INPUT_NAME,
-    INPUT_VALUE)
+    FULL_INPUT_VALUE)
     VALUES
     <foreach collection="evaluatedInputs" item="item" separator=", ">
       (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value})
@@ -278,7 +278,7 @@
   <insert id="insertInput" parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel" databaseId="oracle">
     INSERT ALL
     <foreach collection="evaluatedInputs" item="item">
-      INTO ${prefix}DECISION_INSTANCE_INPUT (DECISION_INSTANCE_ID, INPUT_ID, INPUT_NAME, INPUT_VALUE)
+      INTO ${prefix}DECISION_INSTANCE_INPUT (DECISION_INSTANCE_ID, INPUT_ID, INPUT_NAME, FULL_INPUT_VALUE)
       VALUES (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value})
     </foreach>
     SELECT 1 FROM DUAL
@@ -291,7 +291,10 @@
     DECISION_INSTANCE_ID,
     INPUT_ID,
     INPUT_NAME,
-    INPUT_VALUE
+    <include refid="io.camunda.db.rdbms.sql.Commons.coalesceCLOB">
+      <property name="clobColumn" value="FULL_INPUT_VALUE"/>
+      <property name="nonClobColumn" value="INPUT_VALUE"/>
+    </include> AS INPUT_VALUE
     FROM ${prefix}DECISION_INSTANCE_INPUT
     WHERE DECISION_INSTANCE_ID IN (<foreach collection="list" item="id" separator=", ">
     #{id}</foreach>)

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -37,7 +37,7 @@
     di.STATE,
     di.TYPE, /* TODO really save it there? */
     di.EVALUATION_DATE,
-    di.RESULT,
+    coalesce(di.FULL_RESULT, di.RESULT) as RESULT,
     di.EVALUATION_FAILURE,
     di.EVALUATION_FAILURE_MESSAGE,
     di.TENANT_ID,
@@ -243,7 +243,7 @@
                                             TYPE,
                                             STATE,
                                             EVALUATION_DATE,
-                                            RESULT,
+                                            FULL_RESULT,
                                             EVALUATION_FAILURE,
                                             EVALUATION_FAILURE_MESSAGE,
                                             TENANT_ID,
@@ -307,7 +307,7 @@
   <insert id="insertOutput"
     parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel">
     INSERT INTO ${prefix}DECISION_INSTANCE_OUTPUT
-    (DECISION_INSTANCE_ID, OUTPUT_ID, OUTPUT_NAME, OUTPUT_VALUE, RULE_ID, RULE_INDEX) VALUES
+    (DECISION_INSTANCE_ID, OUTPUT_ID, OUTPUT_NAME, FULL_OUTPUT_VALUE, RULE_ID, RULE_INDEX) VALUES
     <foreach collection="evaluatedOutputs" item="item" separator=", ">
       (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value}, #{item.ruleId},
       #{item.ruleIndex})
@@ -319,7 +319,7 @@
     databaseId="oracle">
     INSERT ALL
     <foreach collection="evaluatedOutputs" item="item">
-      INTO ${prefix}DECISION_INSTANCE_OUTPUT (DECISION_INSTANCE_ID, OUTPUT_ID, OUTPUT_NAME, OUTPUT_VALUE, RULE_ID, RULE_INDEX)
+      INTO ${prefix}DECISION_INSTANCE_OUTPUT (DECISION_INSTANCE_ID, OUTPUT_ID, OUTPUT_NAME, FULL_OUTPUT_VALUE, RULE_ID, RULE_INDEX)
       VALUES (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value}, #{item.ruleId}, #{item.ruleIndex})
     </foreach>
     SELECT 1 FROM DUAL
@@ -331,7 +331,7 @@
     DECISION_INSTANCE_ID,
     OUTPUT_ID,
     OUTPUT_NAME,
-    OUTPUT_VALUE,
+    COALESCE(FULL_OUTPUT_VALUE, OUTPUT_VALUE) AS OUTPUT_VALUE,
     RULE_ID,
     RULE_INDEX
     FROM ${prefix}DECISION_INSTANCE_OUTPUT

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -37,7 +37,10 @@
     di.STATE,
     di.TYPE, /* TODO really save it there? */
     di.EVALUATION_DATE,
-    coalesce(di.FULL_RESULT, di.RESULT) as RESULT,
+    <include refid="io.camunda.db.rdbms.sql.Commons.coalesceCLOB">
+      <property name="clobColumn" value="di.FULL_RESULT"/>
+      <property name="nonClobColumn" value="di.RESULT"/>
+    </include> AS RESULT,
     di.EVALUATION_FAILURE,
     di.EVALUATION_FAILURE_MESSAGE,
     di.TENANT_ID,
@@ -331,7 +334,10 @@
     DECISION_INSTANCE_ID,
     OUTPUT_ID,
     OUTPUT_NAME,
-    COALESCE(FULL_OUTPUT_VALUE, OUTPUT_VALUE) AS OUTPUT_VALUE,
+    <include refid="io.camunda.db.rdbms.sql.Commons.coalesceCLOB">
+      <property name="clobColumn" value="FULL_OUTPUT_VALUE"/>
+      <property name="nonClobColumn" value="OUTPUT_VALUE"/>
+    </include> AS OUTPUT_VALUE,
     RULE_ID,
     RULE_INDEX
     FROM ${prefix}DECISION_INSTANCE_OUTPUT

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -260,7 +260,7 @@
             #{flowNodeInstanceKey}, #{flowNodeId},
             #{rootDecisionDefinitionKey},
             #{decisionType}, #{state},
-            #{evaluationDate, jdbcType=TIMESTAMP}, #{result}, #{evaluationFailure},
+            #{evaluationDate, jdbcType=TIMESTAMP}, #{result, jdbcType=CLOB}, #{evaluationFailure},
             #{evaluationFailureMessage},
             #{tenantId}, #{partitionId},
             #{historyCleanupDate, jdbcType=TIMESTAMP})
@@ -271,7 +271,7 @@
     FULL_INPUT_VALUE)
     VALUES
     <foreach collection="evaluatedInputs" item="item" separator=", ">
-      (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value})
+      (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value, jdbcType=CLOB})
     </foreach>
   </insert>
 
@@ -279,7 +279,7 @@
     INSERT ALL
     <foreach collection="evaluatedInputs" item="item">
       INTO ${prefix}DECISION_INSTANCE_INPUT (DECISION_INSTANCE_ID, INPUT_ID, INPUT_NAME, FULL_INPUT_VALUE)
-      VALUES (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value})
+      VALUES (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value, jdbcType=CLOB})
     </foreach>
     SELECT 1 FROM DUAL
   </insert>
@@ -315,7 +315,7 @@
     INSERT INTO ${prefix}DECISION_INSTANCE_OUTPUT
     (DECISION_INSTANCE_ID, OUTPUT_ID, OUTPUT_NAME, FULL_OUTPUT_VALUE, RULE_ID, RULE_INDEX) VALUES
     <foreach collection="evaluatedOutputs" item="item" separator=", ">
-      (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value}, #{item.ruleId},
+      (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value, jdbcType=CLOB}, #{item.ruleId},
       #{item.ruleIndex})
     </foreach>
   </insert>
@@ -326,7 +326,7 @@
     INSERT ALL
     <foreach collection="evaluatedOutputs" item="item">
       INTO ${prefix}DECISION_INSTANCE_OUTPUT (DECISION_INSTANCE_ID, OUTPUT_ID, OUTPUT_NAME, FULL_OUTPUT_VALUE, RULE_ID, RULE_INDEX)
-      VALUES (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value}, #{item.ruleId}, #{item.ruleIndex})
+      VALUES (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value, jdbcType=CLOB}, #{item.ruleId}, #{item.ruleIndex})
     </foreach>
     SELECT 1 FROM DUAL
   </insert>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedOutput;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
 import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
@@ -22,6 +23,7 @@ import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceOutputEntity;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.sort.DecisionInstanceSort;
@@ -392,15 +394,39 @@ public class DecisionInstanceIT {
     final DecisionInstanceDbReader decisionInstanceReader =
         rdbmsService.getDecisionInstanceReader();
 
-    final var largeResult = "x".repeat(9000);
+    final var largeResult = "x".repeat(9_000);
+    final var largeOutput = "y".repeat(10_000);
 
-    final var original = DecisionInstanceFixtures.createRandomized(b -> b.result(largeResult));
+    final var decisionInstanceKey = DecisionInstanceFixtures.nextKey();
+    final var decisionInstanceId = decisionInstanceKey + "-1";
+    final var evaluatedOutputId = DecisionInstanceFixtures.nextStringId();
+
+    final var original =
+        DecisionInstanceFixtures.createRandomized(
+            b ->
+                b.decisionInstanceId(decisionInstanceId)
+                    .decisionInstanceKey(decisionInstanceKey)
+                    .result(largeResult)
+                    .evaluatedOutputs(
+                        List.of(
+                            new EvaluatedOutput(
+                                decisionInstanceId,
+                                evaluatedOutputId,
+                                "outputName",
+                                largeOutput,
+                                "ruleId",
+                                123))));
     createAndSaveDecisionInstance(rdbmsWriters, original);
-    final var actual = decisionInstanceReader.findOne(original.decisionInstanceId()).orElseThrow();
+    final var actual = decisionInstanceReader.findOne(decisionInstanceId).orElseThrow();
 
     assertThat(actual).isNotNull();
-    assertThat(actual.decisionInstanceId()).isEqualTo(original.decisionInstanceId());
-    assertThat(actual.decisionInstanceKey()).isEqualTo(original.decisionInstanceKey());
+    assertThat(actual.decisionInstanceId()).isEqualTo(decisionInstanceId);
+    assertThat(actual.decisionInstanceKey()).isEqualTo(decisionInstanceKey);
     assertThat(actual.result()).isEqualTo(largeResult);
+    assertThat(actual.evaluatedOutputs())
+        .isEqualTo(
+            List.of(
+                new DecisionInstanceOutputEntity(
+                    evaluatedOutputId, "outputName", largeOutput, "ruleId", 123)));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
@@ -30,9 +30,12 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.sort.DecisionInstanceSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import javax.sql.DataSource;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -41,7 +44,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class DecisionInstanceIT {
-
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
@@ -439,5 +441,95 @@ public class DecisionInstanceIT {
     assertThat(actual.evaluatedInputs())
         .isEqualTo(
             List.of(new DecisionInstanceInputEntity(evaluatedInputId, "inputName", largeInput)));
+  }
+
+  @TestTemplate
+  public void shouldFallbackToOldColumnsWhenFindingDecisionInstanceById(
+      final CamundaRdbmsTestApplication testApplication) throws SQLException {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionInstanceDbReader decisionInstanceReader =
+        rdbmsService.getDecisionInstanceReader();
+
+    final var decisionInstanceKey = DecisionInstanceFixtures.nextKey();
+    final var decisionInstanceId = decisionInstanceKey + "-1";
+    final var evaluatedOutputId = DecisionInstanceFixtures.nextStringId();
+    final var evaluatedInputId = DecisionInstanceFixtures.nextStringId();
+
+    final var original =
+        DecisionInstanceFixtures.createRandomized(
+            b ->
+                b.decisionInstanceId(decisionInstanceId)
+                    .decisionInstanceKey(decisionInstanceKey)
+                    .result("fullResult")
+                    .evaluatedOutputs(
+                        List.of(
+                            new EvaluatedOutput(
+                                decisionInstanceId,
+                                evaluatedOutputId,
+                                "outputName",
+                                "fullOutput",
+                                "ruleId",
+                                123)))
+                    .evaluatedInputs(
+                        List.of(
+                            new EvaluatedInput(
+                                decisionInstanceId, evaluatedInputId, "inputName", "fullInput"))));
+    createAndSaveDecisionInstance(rdbmsWriters, original);
+
+    // manually change values in DB, so we can verify fallback behaviour for
+    // data written in older versions
+    final var oldColumnResult = "oldColumnResult";
+    final var oldColumnOutput = "oldColumnOutput";
+    final var oldColumnInput = "oldColumnInput";
+    final var dataSource = testApplication.bean(DataSource.class);
+
+    try (final var connection = dataSource.getConnection()) {
+      connection.setAutoCommit(false);
+      update(
+          connection,
+          "UPDATE DECISION_INSTANCE SET FULL_RESULT = NULL, RESULT = ? WHERE DECISION_INSTANCE_ID = ?",
+          oldColumnResult,
+          decisionInstanceId);
+      update(
+          connection,
+          "UPDATE DECISION_INSTANCE_OUTPUT SET FULL_OUTPUT_VALUE = NULL, OUTPUT_VALUE = ? WHERE DECISION_INSTANCE_ID = ? AND OUTPUT_ID = ?",
+          oldColumnOutput,
+          decisionInstanceId,
+          evaluatedOutputId);
+      update(
+          connection,
+          "UPDATE DECISION_INSTANCE_INPUT SET FULL_INPUT_VALUE = NULL, INPUT_VALUE = ? WHERE DECISION_INSTANCE_ID = ? AND INPUT_ID = ?",
+          oldColumnInput,
+          decisionInstanceId,
+          evaluatedInputId);
+      connection.commit();
+    }
+
+    final var actual = decisionInstanceReader.findOne(decisionInstanceId).orElseThrow();
+
+    assertThat(actual).isNotNull();
+    assertThat(actual.decisionInstanceId()).isEqualTo(decisionInstanceId);
+    assertThat(actual.decisionInstanceKey()).isEqualTo(decisionInstanceKey);
+    assertThat(actual.result()).isEqualTo(oldColumnResult);
+    assertThat(actual.evaluatedOutputs())
+        .isEqualTo(
+            List.of(
+                new DecisionInstanceOutputEntity(
+                    evaluatedOutputId, "outputName", oldColumnOutput, "ruleId", 123)));
+    assertThat(actual.evaluatedInputs())
+        .isEqualTo(
+            List.of(
+                new DecisionInstanceInputEntity(evaluatedInputId, "inputName", oldColumnInput)));
+  }
+
+  private void update(final Connection connection, final String sql, final String... params)
+      throws SQLException {
+    try (final var pstmt = connection.prepareStatement(sql)) {
+      for (var i = 0; i < params.length; i++) {
+        pstmt.setString(i + 1, params[i]);
+      }
+      pstmt.executeUpdate();
+    }
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
@@ -383,4 +383,24 @@ public class DecisionInstanceIT {
     assertThat(searchResult.items().stream().map(DecisionInstanceEntity::decisionInstanceKey))
         .containsExactlyInAnyOrder(item1.decisionInstanceKey(), item3.decisionInstanceKey());
   }
+
+  @TestTemplate
+  public void shouldSaveDecisionInstancesWithLargeResultsAndFindDecisionInstanceById(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionInstanceDbReader decisionInstanceReader =
+        rdbmsService.getDecisionInstanceReader();
+
+    final var largeResult = "x".repeat(9000);
+
+    final var original = DecisionInstanceFixtures.createRandomized(b -> b.result(largeResult));
+    createAndSaveDecisionInstance(rdbmsWriters, original);
+    final var actual = decisionInstanceReader.findOne(original.decisionInstanceId()).orElseThrow();
+
+    assertThat(actual).isNotNull();
+    assertThat(actual.decisionInstanceId()).isEqualTo(original.decisionInstanceId());
+    assertThat(actual.decisionInstanceKey()).isEqualTo(original.decisionInstanceKey());
+    assertThat(actual.result()).isEqualTo(largeResult);
+  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedInput;
 import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedOutput;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
@@ -23,6 +24,7 @@ import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceInputEntity;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceOutputEntity;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -387,7 +389,7 @@ public class DecisionInstanceIT {
   }
 
   @TestTemplate
-  public void shouldSaveDecisionInstancesWithLargeResultsAndFindDecisionInstanceById(
+  public void shouldSaveDecisionInstancesWithLargeInputOutputsAndResultsAndFindDecisionInstanceById(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -396,10 +398,12 @@ public class DecisionInstanceIT {
 
     final var largeResult = "x".repeat(9_000);
     final var largeOutput = "y".repeat(10_000);
+    final var largeInput = "z".repeat(10_000);
 
     final var decisionInstanceKey = DecisionInstanceFixtures.nextKey();
     final var decisionInstanceId = decisionInstanceKey + "-1";
     final var evaluatedOutputId = DecisionInstanceFixtures.nextStringId();
+    final var evaluatedInputId = DecisionInstanceFixtures.nextStringId();
 
     final var original =
         DecisionInstanceFixtures.createRandomized(
@@ -415,7 +419,11 @@ public class DecisionInstanceIT {
                                 "outputName",
                                 largeOutput,
                                 "ruleId",
-                                123))));
+                                123)))
+                    .evaluatedInputs(
+                        List.of(
+                            new EvaluatedInput(
+                                decisionInstanceId, evaluatedInputId, "inputName", largeInput))));
     createAndSaveDecisionInstance(rdbmsWriters, original);
     final var actual = decisionInstanceReader.findOne(decisionInstanceId).orElseThrow();
 
@@ -428,5 +436,8 @@ public class DecisionInstanceIT {
             List.of(
                 new DecisionInstanceOutputEntity(
                     evaluatedOutputId, "outputName", largeOutput, "ruleId", 123)));
+    assertThat(actual.evaluatedInputs())
+        .isEqualTo(
+            List.of(new DecisionInstanceInputEntity(evaluatedInputId, "inputName", largeInput)));
   }
 }


### PR DESCRIPTION
previously we were using a column with a limit. this adds a new columns that are CLOB instead.

the old data will still be visible when reading decision instances, but we will only write to the new column going forward.

This also updates the `LiquibaseScriptGenerator` to generate the correct scripts (it need to sort the files by version number first).

## Related issues

closes #55114
