### PR TITLE
feat: validate physical tenant id length

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -53,6 +53,7 @@ import org.springframework.core.env.Environment;
 public final class PhysicalTenantResolver {
 
   public static final String DEFAULT_PHYSICAL_TENANT_ID = "default";
+  static final int MAX_TENANT_ID_LENGTH = 64;
   private static final String PHYSICAL_TENANTS_PREFIX = Camunda.PREFIX + ".physical-tenants";
   static final ConfigurationPropertyName PREFIX_NAME =
       ConfigurationPropertyName.of(PHYSICAL_TENANTS_PREFIX);
@@ -147,6 +148,13 @@ public final class PhysicalTenantResolver {
 
   @VisibleForTesting
   static void validateTenantId(final String tenantId) {
+    if (tenantId.length() > MAX_TENANT_ID_LENGTH) {
+      throw new UnifiedConfigurationException(
+          String.format(
+              "Invalid physical tenant id '%s' under '%s.*'. "
+                  + "Tenant ids must not exceed %d characters.",
+              tenantId, PHYSICAL_TENANTS_PREFIX, MAX_TENANT_ID_LENGTH));
+    }
     if (!VALID_TENANT_ID.matcher(tenantId).matches()) {
       throw new UnifiedConfigurationException(
           String.format(

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
@@ -282,4 +282,25 @@ class PhysicalTenantResolverTest {
         .isThrownBy(() -> PhysicalTenantResolver.validateTenantId("tenant-a"))
         .withMessageContaining("Invalid physical tenant id");
   }
+
+  @Test
+  void shouldRejectTenantIdExceeding64Characters() {
+    // given a tenant id that is exactly one character over the limit
+    final String tooLong = "a".repeat(PhysicalTenantResolver.MAX_TENANT_ID_LENGTH + 1);
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantResolver.validateTenantId(tooLong))
+        .withMessageContaining("Invalid physical tenant id")
+        .withMessageContaining("must not exceed " + PhysicalTenantResolver.MAX_TENANT_ID_LENGTH);
+  }
+
+  @Test
+  void shouldAcceptTenantIdOfExactly64Characters() {
+    // given a tenant id at exactly the maximum allowed length — must not throw
+    final String maxLength = "a".repeat(PhysicalTenantResolver.MAX_TENANT_ID_LENGTH);
+
+    // when / then no exception
+    PhysicalTenantResolver.validateTenantId(maxLength);
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As discussed in https://camunda.slack.com/archives/C0AF7LM7CGK/p1781094355089289?thread_ts=1777894097.252419&cid=C0AF7LM7CGK

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to https://github.com/camunda/camunda/issues/52680
