### PR TITLE
feat: verify JavaVersion.class file version after compilation

### DIFF
--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -435,7 +435,7 @@ func verifyClassFileVersion(classFile string) error {
 	expected := 44 + helperJavaRelease
 	if major != expected {
 		return fmt.Errorf(
-			"%s compiled for Java %d (class file version %d), expected Java %d (version %d); "+
+			"%s compiled for Java %d (class file version %d), expected Java %d (class file version %d); "+
 				"ensure javac is invoked with --release %d",
 			classFile, major-44, major, helperJavaRelease, expected, helperJavaRelease,
 		)

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -397,6 +397,10 @@ func BuildJavaScripts() error {
 		if err := compileJavaHelper(javaFile); err != nil {
 			return err
 		}
+		classFile := strings.TrimSuffix(javaFile, ".java") + ".class"
+		if err := verifyClassFileVersion(classFile); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -415,6 +419,28 @@ func compileJavaHelper(javaFile string) error {
 
 func buildJavaHelperArgs(sourceFile string) []string {
 	return []string{"--release", strconv.Itoa(helperJavaRelease), sourceFile}
+}
+
+func verifyClassFileVersion(classFile string) error {
+	data, err := os.ReadFile(classFile)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", classFile, err)
+	}
+	// Java class file layout: magic 0xCAFEBABE (4 bytes), minor version (2 bytes), major version (2 bytes, big-endian).
+	// Major version = 44 + Java version, e.g. Java 21 → 65.
+	if len(data) < 8 || data[0] != 0xCA || data[1] != 0xFE || data[2] != 0xBA || data[3] != 0xBE {
+		return fmt.Errorf("%s is not a valid Java class file", classFile)
+	}
+	major := int(data[6])<<8 | int(data[7])
+	expected := 44 + helperJavaRelease
+	if major != expected {
+		return fmt.Errorf(
+			"%s compiled for Java %d (class file version %d), expected Java %d (version %d); "+
+				"ensure javac is invoked with --release %d",
+			classFile, major-44, major, helperJavaRelease, expected, helperJavaRelease,
+		)
+	}
+	return nil
 }
 
 func BuildJRE(camundaVersion, _ string) error {

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -434,6 +434,47 @@ func TestStripRocksDbNativeLibsErrorsWhenJarMissing(t *testing.T) {
 	}
 }
 
+func TestVerifyClassFileVersionAcceptsJava21Class(t *testing.T) {
+	// given — minimal class file header with major version 65 (Java 21)
+	dir := t.TempDir()
+	classFile := filepath.Join(dir, "JavaVersion.class")
+	// Java class file: magic (0xCAFEBABE), minor version (0x0000), major version big-endian
+	// Java 21 = major 65 = 0x0041
+	data := []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x41}
+	if err := os.WriteFile(classFile, data, 0o644); err != nil {
+		t.Fatalf("failed to write class file: %v", err)
+	}
+
+	// when
+	err := verifyClassFileVersion(classFile)
+
+	// then
+	if err != nil {
+		t.Fatalf("expected no error for Java 21 class file, got: %v", err)
+	}
+}
+
+func TestVerifyClassFileVersionRejectsWrongVersion(t *testing.T) {
+	// given — class file compiled for Java 25 (major version 69 = 0x0045)
+	dir := t.TempDir()
+	classFile := filepath.Join(dir, "JavaVersion.class")
+	data := []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x45}
+	if err := os.WriteFile(classFile, data, 0o644); err != nil {
+		t.Fatalf("failed to write class file: %v", err)
+	}
+
+	// when
+	err := verifyClassFileVersion(classFile)
+
+	// then
+	if err == nil {
+		t.Fatal("expected error for Java 25 class file, got nil")
+	}
+	if !strings.Contains(err.Error(), "expected Java 21") {
+		t.Fatalf("expected error to mention 'expected Java 21', got: %v", err)
+	}
+}
+
 func TestMaterializeSymlinksReplacesSymlinkWithRegularFile(t *testing.T) {
 	// given
 	root := t.TempDir()

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -435,12 +435,13 @@ func TestStripRocksDbNativeLibsErrorsWhenJarMissing(t *testing.T) {
 }
 
 func TestVerifyClassFileVersionAcceptsJava21Class(t *testing.T) {
-	// given — minimal class file header with major version 65 (Java 21)
+	// given — minimal class file header with major version matching helperJavaRelease
 	dir := t.TempDir()
 	classFile := filepath.Join(dir, "JavaVersion.class")
 	// Java class file: magic (0xCAFEBABE), minor version (0x0000), major version big-endian
-	// Java 21 = major 65 = 0x0041
-	data := []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x41}
+	// Major version = 44 + Java version; derive from helperJavaRelease so this stays correct if the target changes.
+	expectedMajor := 44 + helperJavaRelease
+	data := []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, byte(expectedMajor >> 8), byte(expectedMajor)}
 	if err := os.WriteFile(classFile, data, 0o644); err != nil {
 		t.Fatalf("failed to write class file: %v", err)
 	}
@@ -450,15 +451,16 @@ func TestVerifyClassFileVersionAcceptsJava21Class(t *testing.T) {
 
 	// then
 	if err != nil {
-		t.Fatalf("expected no error for Java 21 class file, got: %v", err)
+		t.Fatalf("expected no error for Java %d class file, got: %v", helperJavaRelease, err)
 	}
 }
 
 func TestVerifyClassFileVersionRejectsWrongVersion(t *testing.T) {
-	// given — class file compiled for Java 25 (major version 69 = 0x0045)
+	// given — class file compiled for a Java version above helperJavaRelease
 	dir := t.TempDir()
 	classFile := filepath.Join(dir, "JavaVersion.class")
-	data := []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x45}
+	wrongMajor := 44 + helperJavaRelease + 4
+	data := []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, byte(wrongMajor >> 8), byte(wrongMajor)}
 	if err := os.WriteFile(classFile, data, 0o644); err != nil {
 		t.Fatalf("failed to write class file: %v", err)
 	}
@@ -468,7 +470,7 @@ func TestVerifyClassFileVersionRejectsWrongVersion(t *testing.T) {
 
 	// then
 	if err == nil {
-		t.Fatal("expected error for Java 25 class file, got nil")
+		t.Fatalf("expected error for Java %d class file, got nil", helperJavaRelease+4)
 	}
 	if !strings.Contains(err.Error(), "expected Java 21") {
 		t.Fatalf("expected error to mention 'expected Java 21', got: %v", err)


### PR DESCRIPTION
## Summary

- Adds `verifyClassFileVersion` to `c8run/internal/packages/package.go`: reads the compiled `.class` header and asserts the major version equals `44 + helperJavaRelease`
- Called from `BuildJavaScripts` immediately after each `javac` invocation — packager fails loudly if class file version is wrong
- Single source of truth: `helperJavaRelease` constant drives both `--release` flag and the version assertion, so they cannot drift
- Adds two unit tests covering accept (Java 21) and reject (Java 25) cases

Closes #54876

## Why not a CI bash assertion

An earlier approach checked `javap | grep "major version"` in the composite action. Rejected because it hardcodes `65` separately from `helperJavaRelease`, creating drift risk. This Go check derives the expected version from the constant directly and runs on all platforms, locally and in CI.

## Test Plan

- [ ] `go test ./internal/packages/...` — 13 tests pass including `TestVerifyClassFileVersionAcceptsJava21Class` and `TestVerifyClassFileVersionRejectsWrongVersion`
- [ ] `go test ./...` — 86 tests pass
- [ ] c8run-build CI (auto-triggered by PR)