### PR TITLE
Incident rate tile with Scoped percentage calculation

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -127,7 +127,7 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   // ---------------------------------------------------------------------------
-  // Incident rate (count of resolved incidents on completed agentic instances)
+  // Incident rate (percentage of completed agentic instances with a resolved incident)
   // ---------------------------------------------------------------------------
 
   @Test
@@ -170,7 +170,8 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
     persistProcessInstances(List.of(withIncident, clean, running));
 
     final Double result = evaluateNumber(KPI_INCIDENT_RATE_REPORT_ID, noExtraFilters());
-    assertThat(result).isEqualTo(1.0);
+    // 1 instance with resolved incident / 2 completed agentic instances = 50%
+    assertThat(result).isEqualTo(50.0);
   }
 
   // ---------------------------------------------------------------------------
@@ -451,8 +452,9 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
     persistProcessInstances(List.of(recent, old));
 
+    // 1 instance with resolved incident / 1 completed agentic instance in window = 100%
     assertThat(evaluateNumber(KPI_INCIDENT_RATE_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
-        .isEqualTo(1.0);
+        .isEqualTo(100.0);
   }
 
   @Test
@@ -656,12 +658,12 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
                             .build()))
                 .build()));
 
-    // only procKeyA selected → 1 incident
+    // only procKeyA selected → 1 instance with incident / 1 completed agentic instance = 100%
     assertThat(
             evaluateNumber(
                 KPI_INCIDENT_RATE_REPORT_ID,
                 withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
-        .isEqualTo(1.0);
+        .isEqualTo(100.0);
   }
 
   @Test
@@ -683,6 +685,183 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
                 KPI_MEDIAN_TOKENS_REPORT_ID,
                 withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
         .isCloseTo(200.0, within(10.0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scoped baseline: denominator must exclude running and non-agentic instances
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldExcludeRunningInstancesFromIncidentRateDenominator() {
+    // given: 1 completed agentic with incident, 1 completed agentic without,
+    //        plus 5 running agentic instances (no incidents) — running must not count
+    final String withIncidentId = UUID.randomUUID().toString();
+    final ProcessInstanceDto withIncident =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .processInstanceId(withIncidentId)
+            .incidents(
+                List.of(
+                    IncidentDto.builder()
+                        .incidentStatus(IncidentStatus.RESOLVED)
+                        .processInstanceId(withIncidentId)
+                        .build()))
+            .build();
+    final ProcessInstanceDto completedClean = agenticInstance(PROC_KEY, 100L, 50L).build();
+    final List<ProcessInstanceDto> runningInstances =
+        java.util.stream.IntStream.range(0, 5)
+            .mapToObj(
+                i ->
+                    agenticInstance(PROC_KEY, 100L, 50L)
+                        .state(ProcessInstanceConstants.ACTIVE_STATE)
+                        .endDate(null)
+                        .duration(null)
+                        .build())
+            .toList();
+
+    persistProcessInstances(
+        java.util.stream.Stream.concat(
+                java.util.stream.Stream.of(withIncident, completedClean), runningInstances.stream())
+            .toList());
+
+    // denominator = 2 completed agentic instances (not 7); numerator = 1 → 50%
+    assertThat(evaluateNumber(KPI_INCIDENT_RATE_REPORT_ID, noExtraFilters())).isEqualTo(50.0);
+  }
+
+  @Test
+  void shouldExcludeNonAgenticInstancesFromIncidentRateDenominator() {
+    // given: 1 completed agentic with incident, 1 completed agentic without,
+    //        plus 8 completed non-agentic instances — non-agentic must not count
+    final String withIncidentId = UUID.randomUUID().toString();
+    final ProcessInstanceDto withIncident =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .processInstanceId(withIncidentId)
+            .incidents(
+                List.of(
+                    IncidentDto.builder()
+                        .incidentStatus(IncidentStatus.RESOLVED)
+                        .processInstanceId(withIncidentId)
+                        .build()))
+            .build();
+    final ProcessInstanceDto completedAgentic = agenticInstance(PROC_KEY, 100L, 50L).build();
+    final List<ProcessInstanceDto> nonAgenticInstances =
+        java.util.stream.IntStream.range(0, 8)
+            .mapToObj(i -> completedInstance(PROC_KEY).build())
+            .toList();
+
+    persistProcessInstances(
+        java.util.stream.Stream.concat(
+                java.util.stream.Stream.of(withIncident, completedAgentic),
+                nonAgenticInstances.stream())
+            .toList());
+
+    // denominator = 2 completed agentic instances (not 10); numerator = 1 → 50%
+    assertThat(evaluateNumber(KPI_INCIDENT_RATE_REPORT_ID, noExtraFilters())).isEqualTo(50.0);
+  }
+
+  @Test
+  void shouldScopeBothNumeratorAndDenominatorByDateFilter() {
+    // given: within window — 1 agentic with incident, 1 agentic without
+    //        outside window — 10 agentic with incidents (must not affect either side)
+    final String recentWithId = UUID.randomUUID().toString();
+    final ProcessInstanceDto recentWithIncident =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .processInstanceId(recentWithId)
+            .startDate(OffsetDateTime.now().minusHours(3))
+            .endDate(OffsetDateTime.now().minusHours(2))
+            .incidents(
+                List.of(
+                    IncidentDto.builder()
+                        .incidentStatus(IncidentStatus.RESOLVED)
+                        .processInstanceId(recentWithId)
+                        .build()))
+            .build();
+    final ProcessInstanceDto recentClean =
+        agenticInstance(PROC_KEY, 100L, 50L)
+            .startDate(OffsetDateTime.now().minusHours(3))
+            .endDate(OffsetDateTime.now().minusHours(2))
+            .build();
+    final List<ProcessInstanceDto> oldWithIncidents =
+        java.util.stream.IntStream.range(0, 10)
+            .mapToObj(
+                i -> {
+                  final String id = UUID.randomUUID().toString();
+                  return agenticInstance(PROC_KEY, 100L, 50L)
+                      .processInstanceId(id)
+                      .startDate(OffsetDateTime.now().minusDays(10))
+                      .endDate(OffsetDateTime.now().minusDays(9))
+                      .incidents(
+                          List.of(
+                              IncidentDto.builder()
+                                  .incidentStatus(IncidentStatus.RESOLVED)
+                                  .processInstanceId(id)
+                                  .build()))
+                      .build();
+                })
+            .toList();
+
+    persistProcessInstances(
+        java.util.stream.Stream.concat(
+                java.util.stream.Stream.of(recentWithIncident, recentClean),
+                oldWithIncidents.stream())
+            .toList());
+
+    // denominator = 2 (in-window completed agentic); numerator = 1 → 50%
+    assertThat(evaluateNumber(KPI_INCIDENT_RATE_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
+        .isEqualTo(50.0);
+  }
+
+  @Test
+  void shouldScopeBothNumeratorAndDenominatorByDefinitionFilter() {
+    // given: procKeyA — 1 with incident, 3 without → scoped rate = 25%
+    //        procKeyB — 5 all with incidents → must not inflate the procKeyA denominator
+    final String procKeyA = "proc-scope-a";
+    final String procKeyB = "proc-scope-b";
+
+    final String idA = UUID.randomUUID().toString();
+    final ProcessInstanceDto aWithIncident =
+        agenticInstance(procKeyA, 100L, 50L)
+            .processInstanceId(idA)
+            .incidents(
+                List.of(
+                    IncidentDto.builder()
+                        .incidentStatus(IncidentStatus.RESOLVED)
+                        .processInstanceId(idA)
+                        .build()))
+            .build();
+    final List<ProcessInstanceDto> aClean =
+        java.util.stream.IntStream.range(0, 3)
+            .mapToObj(i -> agenticInstance(procKeyA, 100L, 50L).build())
+            .toList();
+    final List<ProcessInstanceDto> bWithIncidents =
+        java.util.stream.IntStream.range(0, 5)
+            .mapToObj(
+                i -> {
+                  final String id = UUID.randomUUID().toString();
+                  return agenticInstance(procKeyB, 100L, 50L)
+                      .processInstanceId(id)
+                      .incidents(
+                          List.of(
+                              IncidentDto.builder()
+                                  .incidentStatus(IncidentStatus.RESOLVED)
+                                  .processInstanceId(id)
+                                  .build()))
+                      .build();
+                })
+            .toList();
+
+    persistProcessInstances(
+        java.util.stream.Stream.concat(
+                java.util.stream.Stream.concat(
+                    java.util.stream.Stream.of(aWithIncident), aClean.stream()),
+                bWithIncidents.stream())
+            .toList());
+
+    // denominator = 4 procKeyA instances (not 9); numerator = 1 → 25%
+    assertThat(
+            evaluateNumber(
+                KPI_INCIDENT_RATE_REPORT_ID,
+                withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
+        .isEqualTo(25.0);
   }
 
   // ---------------------------------------------------------------------------

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -210,7 +210,7 @@ public class AgenticControlDashboardService {
     final ProcessReportDataDto reportData =
         ProcessReportDataDto.builder()
             .definitions(Collections.emptyList())
-            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.FREQUENCY))
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.PERCENTAGE))
             .groupBy(new NoneGroupByDto())
             .distributedBy(new NoneDistributedByDto())
             .visualization(ProcessVisualization.NUMBER)

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterES.java
@@ -14,9 +14,11 @@ import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.CompletedInstancesOnlyFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FilterApplicationLevel;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeEndDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeStartDateFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.HasAgentInstancesFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceEndDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceStartDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
@@ -49,6 +51,18 @@ public abstract class AbstractProcessExecutionPlanInterpreterES
           InstanceEndDateFilterDto.class,
           FlowNodeStartDateFilterDto.class,
           FlowNodeEndDateFilterDto.class);
+
+  // For agentic reports the baseline must also be scoped to completed agentic instances so that the
+  // percentage denominator matches the same population as the numerator filter set.
+  private static final List<Class<? extends ProcessFilterDto<?>>>
+      FILTERS_AFFECTING_AGENTIC_BASELINE =
+          List.of(
+              InstanceStartDateFilterDto.class,
+              InstanceEndDateFilterDto.class,
+              FlowNodeStartDateFilterDto.class,
+              FlowNodeEndDateFilterDto.class,
+              CompletedInstancesOnlyFilterDto.class,
+              HasAgentInstancesFilterDto.class);
 
   protected abstract ProcessDefinitionReader getProcessDefinitionReader();
 
@@ -90,7 +104,13 @@ public abstract class AbstractProcessExecutionPlanInterpreterES
   @Override
   protected BoolQuery.Builder setupUnfilteredBaseQueryBuilder(
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
-    // Instance level date filters are also applied to the baseline so are included here
+    // Instance level date filters are also applied to the baseline so are included here.
+    // For agentic reports the baseline is further scoped to completed agentic instances so that the
+    // percentage denominator matches the correct population.
+    final List<Class<? extends ProcessFilterDto<?>>> effectiveBaselineFilters =
+        context.getReportData().isAgenticControlReport()
+            ? FILTERS_AFFECTING_AGENTIC_BASELINE
+            : FILTERS_AFFECTING_BASELINE;
     final Map<String, List<ProcessFilterDto<?>>> instanceLevelDateFiltersByDefinitionKey =
         context.getReportData().groupFiltersByDefinitionIdentifier().entrySet().stream()
             .collect(
@@ -101,8 +121,7 @@ public abstract class AbstractProcessExecutionPlanInterpreterES
                             .filter(
                                 filter ->
                                     filter.getFilterLevel() == FilterApplicationLevel.INSTANCE)
-                            .filter(
-                                filter -> FILTERS_AFFECTING_BASELINE.contains(filter.getClass()))
+                            .filter(filter -> effectiveBaselineFilters.contains(filter.getClass()))
                             .collect(Collectors.toList())));
     final BoolQuery.Builder multiDefinitionFilterQuery =
         buildDefinitionBaseQueryForFilters(context, instanceLevelDateFiltersByDefinitionKey);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/plan/process/ProcessExecutionPlanInterpreter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/plan/process/ProcessExecutionPlanInterpreter.java
@@ -8,9 +8,11 @@
 package io.camunda.optimize.service.db.report.interpreter.plan.process;
 
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.CompletedInstancesOnlyFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FilterApplicationLevel;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeEndDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeStartDateFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.filter.HasAgentInstancesFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceEndDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceStartDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
@@ -35,8 +37,23 @@ public interface ProcessExecutionPlanInterpreter
           FlowNodeStartDateFilterDto.class,
           FlowNodeEndDateFilterDto.class);
 
+  // For agentic reports the baseline must also be scoped to completed agentic instances so that the
+  // percentage denominator matches the same population as the numerator filter set.
+  static final List<Class<? extends ProcessFilterDto<?>>> FILTERS_AFFECTING_AGENTIC_BASELINE =
+      List.of(
+          InstanceStartDateFilterDto.class,
+          InstanceEndDateFilterDto.class,
+          FlowNodeStartDateFilterDto.class,
+          FlowNodeEndDateFilterDto.class,
+          CompletedInstancesOnlyFilterDto.class,
+          HasAgentInstancesFilterDto.class);
+
   default Map<String, List<ProcessFilterDto<?>>> getInstanceLevelDateFiltersByDefinitionKey(
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final List<Class<? extends ProcessFilterDto<?>>> effectiveBaselineFilters =
+        context.getReportData().isAgenticControlReport()
+            ? FILTERS_AFFECTING_AGENTIC_BASELINE
+            : FILTERS_AFFECTING_BASELINE;
     return context.getReportData().groupFiltersByDefinitionIdentifier().entrySet().stream()
         .collect(
             Collectors.toMap(
@@ -45,7 +62,7 @@ public interface ProcessExecutionPlanInterpreter
                     entry.getValue().stream()
                         .filter(
                             filter -> filter.getFilterLevel() == FilterApplicationLevel.INSTANCE)
-                        .filter(filter -> FILTERS_AFFECTING_BASELINE.contains(filter.getClass()))
+                        .filter(filter -> effectiveBaselineFilters.contains(filter.getClass()))
                         .toList()));
   }
 }


### PR DESCRIPTION
## Description

The incident rate tile on the Agentic Control Plane dashboard was returning a raw frequency count rather than a meaningful percentage. The fix extends the denominator baseline used by the percentage execution plan to scope it to completed agentic instances only (matching the numerator population), so the tile now correctly displays resolved incidents / completed agentic instances × 100. Without this, switching to PERCENTAGE would have divided against all instances in the date range, producing near-zero values regardless of actual incident rate.
## Related issues

closes #55045 
