### PR TITLE
test: wait for variable indexing before filtered migration batch (nightly main)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
@@ -216,6 +216,33 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
       migrateMe: true,
     });
 
+    await test.step('Wait until instance is searchable by the migrateMe variable', async () => {
+      // The migration batch evaluates its filter against secondary storage at
+      // creation time. If the migrateMe variable has not been indexed yet, the
+      // batch matches zero instances, completes empty, and the instance is
+      // never migrated. Gate on the variable being queryable via the same
+      // filter the batch will use before issuing the migration.
+      await expect(async () => {
+        const res = await request.post(buildUrl('/process-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: localState.processInstanceKey2,
+              variables: [
+                {
+                  name: 'migrateMe',
+                  value: 'true',
+                },
+              ],
+            },
+          },
+        });
+        await assertStatusCode(res, 200);
+        const json = await res.json();
+        expect(json.items).toHaveLength(1);
+      }).toPass(defaultAssertionOptions);
+    });
+
     await test.step('Migrate only instance with specific variable', async () => {
       await expect(async () => {
         const res = await request.post(


### PR DESCRIPTION
## Root cause

The API test **"Create a Batch Operation to Migrate Process Instances - With Multiple Filters"** (`tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts`) migrates only `instance2` by filtering on its `migrateMe=true` variable.

A migration batch operation evaluates its filter against secondary storage **at creation time**. When the `migrateMe` variable had not yet been indexed, the batch matched **zero** instances, completed empty (a 0-item batch reports `COMPLETED` immediately), and `instance2` was never migrated. The subsequent element-instance search for `do_something_else` (ACTIVE) then returned `{"items":[],"page":{"totalItems":0,...}}`, failing `expect(...).toBe(1)` after the 60s budget.

Wrapping the migration POST in `toPass` did not help: each retry creates a new batch that returns 200 regardless of how many instances its filter matched.

## Fix

Before issuing the migration, gate on the instance being searchable via `/process-instances/search` using the **same** `processInstanceKey` + `variables` filter the batch will apply (`toPass(defaultAssertionOptions)`). Once the search returns the instance, the variable is indexed and the batch is guaranteed to match it. Minimal, test-side only.

## Tests fixed

- `tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts` — *Create a Batch Operation to Migrate Process Instances - With Multiple Filters* (api, elasticsearch)

## Not addressed (out of scope — product/infra)

The 19 Postgres 16 failures in `/tmp/test_specs.json` are part of a **systemic RDBMS read-path outage** in that nightly run: 96 specs across roles, tenants, users, user-tasks, variables, job-statistics, audit-log, usage-metrics, and resources all returned `404` (data never queryable in secondary storage). The same tests pass on Elasticsearch. There is no reasonable test-side change — this is an environment/product issue, so no fix is included here.

## Links

- Failing nightly (API ES): https://github.com/camunda/camunda/actions/runs/27390165297
- Failing nightly (API RDBMS): https://github.com/camunda/camunda/actions/runs/27390322675
- Triage run: https://github.com/camunda/camunda/actions/runs/27396643272

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/27396879917
