### PR TITLE
fix: skip test compilation in Optimize E2E backend build steps

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -256,7 +256,7 @@ jobs:
           additional_flags: "--profile self-managed"
 
       - name: Build backend
-        run: ./mvnw -T1C clean install -DskipTests -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
@@ -383,7 +383,7 @@ jobs:
           directory: ./optimize/client
           node-version: ${{ steps.pom-info.outputs.x_version_node }}
       - name: Build backend
-        run: ./mvnw -T1C clean install -DskipTests -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
       - name: Start backend

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -256,7 +256,7 @@ jobs:
           additional_flags: "--profile self-managed"
 
       - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
@@ -383,7 +383,7 @@ jobs:
           directory: ./optimize/client
           node-version: ${{ steps.pom-info.outputs.x_version_node }}
       - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
       - name: Start backend


### PR DESCRIPTION
Cherry-pick of #55052 onto `release-8.8.27`.

## Summary

- The `optimize-e2e-smoke` and `e2e-cloud-test` jobs build the backend with `-pl optimize/backend -am -DskipTests`, which compiles test sources and resolves test-scoped dependencies
- Maven's `-am` does not follow test-scoped dependencies, so `camunda-client-java` (test scope) → `zeebe-client-java` (transitive) falls through to nexus
- On release/merge-back branches the version is bumped to the next SNAPSHOT (e.g. `8.8.28-SNAPSHOT`) before `deploy-snapshots` has run, so `zeebe-client-java:8.8.28-SNAPSHOT` is not in nexus → build fails
- `-Dmaven.test.skip=true` skips test compilation entirely, removing the problematic dependency chain
- `-DskipChecks` is required alongside it: without test compilation, `maven-dependency-plugin:analyze-only` (controlled by `mdep.analyze.skip` in `parent/pom.xml`) sees test-scoped deps as unused declared dependencies and fails

Fixes INC-5968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)