### PR TITLE
fix: replace narrow backend build with full reactor install in Optimize E2E jobs

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -255,8 +255,10 @@ jobs:
           project_name: e2e
           additional_flags: "--profile self-managed"
 
-      - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
@@ -382,8 +384,10 @@ jobs:
         with:
           directory: ./optimize/client
           node-version: ${{ steps.pom-info.outputs.x_version_node }}
-      - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
       - name: Start backend

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -258,7 +258,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:
-          maven-extra-args: -PskipFrontendBuild
+          maven-extra-args: -PskipFrontendBuild -Dskip.docker
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
@@ -387,7 +387,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:
-          maven-extra-args: -PskipFrontendBuild
+          maven-extra-args: -PskipFrontendBuild -Dskip.docker
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
       - name: Start backend


### PR DESCRIPTION
Follow-up to #55146 which partially fixed INC-5968.

## What #55146 missed

`-Dmaven.test.skip=true` skips test compilation but **not dependency resolution**. Maven resolves all scopes (compile, test, provided, runtime) during the resolution phase regardless of test skip flags.

Modules in the `-am` closure (e.g. `zeebe-snapshots`) have test-scoped deps on test-jars from sibling modules (e.g. `zeebe-scheduler:jar:tests`). On release/merge-back branches at `8.8.28-SNAPSHOT`, those test-jars don't exist in nexus yet → resolution fails.

```
Could not find artifact io.camunda:zeebe-scheduler:jar:tests:8.8.28-SNAPSHOT
```

## Root cause

The narrow `-pl optimize/backend -am` approach fundamentally cannot work across a new SNAPSHOT bump: it only builds modules in the direct dependency closure, but resolution still reaches test-jar deps of those modules from nexus.

## Fix

Replace the narrow `mvnw install -pl ...` with the `build-zeebe` action (full reactor install), matching the pattern already used by `optimize-it-elasticsearch` and `optimize-it-opensearch`. The full build compiles all modules including test-jar producers, installs them to local `.m2`, and all transitive resolution succeeds locally.

Fixes INC-5968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)