### PR TITLE
fix: return correct totalItems for process-definition & decision-definition search with isLatestVersion filter

### DIFF
--- a/operate/client/src/modules/queries/decisionDefinitions/useDecisionDefinitionsSearch.ts
+++ b/operate/client/src/modules/queries/decisionDefinitions/useDecisionDefinitionsSearch.ts
@@ -37,7 +37,10 @@ const useDecisionDefinitionsSearch = <
         throw error;
       }
 
-      if (response.page.totalItems <= response.items.length) {
+      if (
+        response.page.totalItems <= response.items.length ||
+        response.page.endCursor === null
+      ) {
         return response.items;
       }
 
@@ -45,8 +48,8 @@ const useDecisionDefinitionsSearch = <
         await searchDecisionDefinitions({
           ...options?.payload,
           page: {
-            from: response.items.length,
-            limit: response.page.totalItems,
+            after: response.page.endCursor,
+            limit: response.page.totalItems - response.items.length,
           },
         });
       if (remainingError) {

--- a/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionsSearch.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionsSearch.ts
@@ -37,7 +37,10 @@ function useProcessDefinitionsSearch<
         throw error;
       }
 
-      if (response.page.totalItems <= response.items.length) {
+      if (
+        response.page.totalItems <= response.items.length ||
+        response.page.endCursor === null
+      ) {
         return response.items;
       }
 
@@ -45,8 +48,8 @@ function useProcessDefinitionsSearch<
         await searchProcessDefinitions({
           ...options?.payload,
           page: {
-            from: response.items.length,
-            limit: response.page.totalItems,
+            after: response.page.endCursor,
+            limit: response.page.totalItems - response.items.length,
           },
         });
       if (remainingError) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchIT.java
@@ -670,6 +670,26 @@ class DecisionSearchIT {
     assertThat(results).containsExactlyInAnyOrderElementsOf(expectedLatest);
   }
 
+  @Test
+  void shouldReturnCorrectTotalItemsWhenFilteredByIsLatestVersion() {
+    // given - decision_model.dmn and decision_model_1.dmn (v1+v2) give 2 unique latest decisions
+    final var expectedTotalLatestVersions = (long) keepLatestDecisionDefinitionVersions().size();
+
+    // when - request fewer items than total unique count
+    final var result =
+        camundaClient
+            .newDecisionDefinitionSearchRequest()
+            .filter(f -> f.isLatestVersion(true))
+            .page(p -> p.limit(1))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.page().totalItems()).isEqualTo(expectedTotalLatestVersions);
+    assertThat(result.page().hasMoreTotalItems()).isFalse();
+  }
+
   private static Stream<Arguments> decisionSortOrderWithComparator() {
     return Stream.of(
         Arguments.of(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchIT.java
@@ -115,6 +115,27 @@ public class ProcessDefinitionSearchIT {
   }
 
   @Test
+  void shouldReturnCorrectTotalItemsWhenFilteredByIsLatestVersion() {
+    // given - multiple versions of processA_ID and processB_ID are deployed, so
+    // totalItems must reflect unique process IDs, not the page size
+    final var expectedTotalLatestVersions = (long) keepLatestProcessDefinitionVersions().size();
+
+    // when - request fewer items than the total unique count
+    final var result =
+        camundaClient
+            .newProcessDefinitionSearchRequest()
+            .filter(f -> f.isLatestVersion(true))
+            .page(p -> p.limit(1))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.page().totalItems()).isEqualTo(expectedTotalLatestVersions);
+    assertThat(result.page().hasMoreTotalItems()).isFalse();
+  }
+
+  @Test
   void shouldPaginateWithSortingByProcessDefinitionKey() {
     // given
     final var resultAll =

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchCardinalityAggregationTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchCardinalityAggregationTransformer.java
@@ -38,6 +38,8 @@ public final class SearchCardinalityAggregationTransformer
                           return s;
                         })));
     Optional.ofNullable(value.field()).ifPresent(cardinalityBuilder::field);
+    Optional.ofNullable(value.precisionThreshold())
+        .ifPresent(cardinalityBuilder::precisionThreshold);
     final var builder = new Aggregation.Builder().cardinality(cardinalityBuilder.build());
     applySubAggregations(builder, value);
     return builder.build();

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchCardinalityAggregationTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchCardinalityAggregationTransformer.java
@@ -45,6 +45,8 @@ public final class SearchCardinalityAggregationTransformer
                           return b;
                         })));
     Optional.ofNullable(value.field()).ifPresent(cardinalityBuilder::field);
+    Optional.ofNullable(value.precisionThreshold())
+        .ifPresent(cardinalityBuilder::precisionThreshold);
     final var builder = new Aggregation.Builder().cardinality(cardinalityBuilder.build());
     applySubAggregations(builder, value);
     return builder.build();

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchCardinalityAggregator.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchCardinalityAggregator.java
@@ -11,7 +11,12 @@ import java.util.List;
 import java.util.Objects;
 
 public record SearchCardinalityAggregator(
-    String name, String field, String script, String lang, List<SearchAggregator> aggregations)
+    String name,
+    String field,
+    String script,
+    String lang,
+    Integer precisionThreshold,
+    List<SearchAggregator> aggregations)
     implements SearchAggregator {
 
   @Override
@@ -28,6 +33,7 @@ public record SearchCardinalityAggregator(
     private String field;
     private String script;
     private String lang;
+    private Integer precisionThreshold;
 
     @Override
     protected Builder self() {
@@ -49,12 +55,18 @@ public record SearchCardinalityAggregator(
       return this;
     }
 
+    public Builder precisionThreshold(final Integer value) {
+      precisionThreshold = value;
+      return this;
+    }
+
     public SearchCardinalityAggregator build() {
       return new SearchCardinalityAggregator(
           Objects.requireNonNull(name, "Expected non-null field for name."),
           field,
           script,
           lang,
+          precisionThreshold,
           aggregations);
     }
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DecisionDefinitionDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DecisionDefinitionDocumentReader.java
@@ -37,7 +37,7 @@ public class DecisionDefinitionDocumentReader extends DocumentBasedReader
   public SearchQueryResult<DecisionDefinitionEntity> search(
       final DecisionDefinitionQuery query, final ResourceAccessChecks resourceAccessChecks) {
 
-    if (query.filter().isLatestVersion()) {
+    if (Boolean.TRUE.equals(query.filter().isLatestVersion())) {
       return searchWithAggregation(query, resourceAccessChecks);
     }
 
@@ -58,10 +58,6 @@ public class DecisionDefinitionDocumentReader extends DocumentBasedReader
                 resourceAccessChecks);
 
     return new SearchQueryResult<>(
-        aggResult.items().size(),
-        !aggResult.items().isEmpty(),
-        aggResult.items(),
-        null,
-        aggResult.endCursor());
+        aggResult.totalItems(), false, aggResult.items(), null, aggResult.endCursor());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionDocumentReader.java
@@ -41,7 +41,7 @@ public class ProcessDefinitionDocumentReader extends DocumentBasedReader
   public SearchQueryResult<ProcessDefinitionEntity> search(
       final ProcessDefinitionQuery query, final ResourceAccessChecks resourceAccessChecks) {
 
-    if (query.filter().isLatestVersion()) {
+    if (Boolean.TRUE.equals(query.filter().isLatestVersion())) {
       return searchWithAggregation(query, resourceAccessChecks);
     } else {
       return getSearchExecutor().search(query, ProcessEntity.class, resourceAccessChecks);
@@ -55,10 +55,6 @@ public class ProcessDefinitionDocumentReader extends DocumentBasedReader
             .aggregate(
                 query, ProcessDefinitionLatestVersionAggregationResult.class, resourceAccessChecks);
     return new SearchQueryResult<>(
-        aggResult.items().size(),
-        !aggResult.items().isEmpty(),
-        aggResult.items(),
-        null,
-        aggResult.endCursor());
+        aggResult.totalItems(), false, aggResult.items(), null, aggResult.endCursor());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/DecisionDefinitionLatestVersionAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/DecisionDefinitionLatestVersionAggregationTransformer.java
@@ -85,7 +85,6 @@ public class DecisionDefinitionLatestVersionAggregationTransformer
             .name(AGGREGATION_NAME_TOTAL_COUNT)
             .script(DECISION_DEFINITION_AND_TENANT_KEY)
             .lang(SCRIPT_LANGUAGE)
-            .precisionThreshold(AGGREGATION_TERMS_SIZE)
             .build();
 
     return List.of(finalAggregation, totalCountAgg);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/DecisionDefinitionLatestVersionAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/DecisionDefinitionLatestVersionAggregationTransformer.java
@@ -11,9 +11,13 @@ import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggre
 import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_GROUP_TENANT_ID;
 import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_NAME_BY_DECISION_ID;
 import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_NAME_LATEST_DEFINITION;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_NAME_TOTAL_COUNT;
 import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_SOURCE_NAME_DECISION_ID;
 import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_SOURCE_NAME_TENANT_ID;
 import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_TERMS_SIZE;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.DECISION_DEFINITION_AND_TENANT_KEY;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.SCRIPT_LANGUAGE;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.cardinality;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.composite;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.topHits;
@@ -76,6 +80,13 @@ public class DecisionDefinitionLatestVersionAggregationTransformer
             .aggregations(maxVersionsAgg)
             .build();
 
-    return List.of(finalAggregation);
+    final var totalCountAgg =
+        cardinality()
+            .name(AGGREGATION_NAME_TOTAL_COUNT)
+            .script(DECISION_DEFINITION_AND_TENANT_KEY)
+            .lang(SCRIPT_LANGUAGE)
+            .build();
+
+    return List.of(finalAggregation, totalCountAgg);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/DecisionDefinitionLatestVersionAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/DecisionDefinitionLatestVersionAggregationTransformer.java
@@ -85,6 +85,7 @@ public class DecisionDefinitionLatestVersionAggregationTransformer
             .name(AGGREGATION_NAME_TOTAL_COUNT)
             .script(DECISION_DEFINITION_AND_TENANT_KEY)
             .lang(SCRIPT_LANGUAGE)
+            .precisionThreshold(AGGREGATION_TERMS_SIZE)
             .build();
 
     return List.of(finalAggregation, totalCountAgg);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionLatestVersionAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionLatestVersionAggregationTransformer.java
@@ -11,9 +11,13 @@ import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggreg
 import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.AGGREGATION_GROUP_TENANT_ID;
 import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.AGGREGATION_NAME_BY_PROCESS_ID;
 import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.AGGREGATION_NAME_LATEST_DEFINITION;
+import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.AGGREGATION_NAME_TOTAL_COUNT;
 import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.AGGREGATION_SOURCE_NAME_BPMN_PROCESS_ID;
 import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.AGGREGATION_SOURCE_NAME_TENANT_ID;
 import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.AGGREGATION_TERMS_SIZE;
+import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.PROCESS_DEFINITION_AND_TENANT_KEY;
+import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.SCRIPT_LANGUAGE;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.cardinality;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.composite;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.topHits;
@@ -78,6 +82,13 @@ public class ProcessDefinitionLatestVersionAggregationTransformer
             .aggregations(maxVersionsAgg)
             .build();
 
-    return List.of(finalAggregation);
+    final var totalCountAgg =
+        cardinality()
+            .name(AGGREGATION_NAME_TOTAL_COUNT)
+            .script(PROCESS_DEFINITION_AND_TENANT_KEY)
+            .lang(SCRIPT_LANGUAGE)
+            .build();
+
+    return List.of(finalAggregation, totalCountAgg);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionLatestVersionAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionLatestVersionAggregationTransformer.java
@@ -87,6 +87,7 @@ public class ProcessDefinitionLatestVersionAggregationTransformer
             .name(AGGREGATION_NAME_TOTAL_COUNT)
             .script(PROCESS_DEFINITION_AND_TENANT_KEY)
             .lang(SCRIPT_LANGUAGE)
+            .precisionThreshold(AGGREGATION_TERMS_SIZE)
             .build();
 
     return List.of(finalAggregation, totalCountAgg);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionLatestVersionAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionLatestVersionAggregationTransformer.java
@@ -87,7 +87,6 @@ public class ProcessDefinitionLatestVersionAggregationTransformer
             .name(AGGREGATION_NAME_TOTAL_COUNT)
             .script(PROCESS_DEFINITION_AND_TENANT_KEY)
             .lang(SCRIPT_LANGUAGE)
-            .precisionThreshold(AGGREGATION_TERMS_SIZE)
             .build();
 
     return List.of(finalAggregation, totalCountAgg);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/DecisionDefinitionLatestVersionAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/DecisionDefinitionLatestVersionAggregationResultTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.aggregation.result;
 
 import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_NAME_BY_DECISION_ID;
 import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_NAME_LATEST_DEFINITION;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_NAME_TOTAL_COUNT;
 
 import io.camunda.search.aggregation.result.DecisionDefinitionLatestVersionAggregationResult;
 import io.camunda.search.clients.core.AggregationResult;
@@ -23,7 +24,7 @@ public class DecisionDefinitionLatestVersionAggregationResultTransformer
   @Override
   public DecisionDefinitionLatestVersionAggregationResult apply(
       final Map<String, AggregationResult> aggregations) {
-    return new DecisionDefinitionLatestVersionAggregationResult(
+    final var items =
         aggregations.get(AGGREGATION_NAME_BY_DECISION_ID).aggregations().values().stream()
             .flatMap(
                 aggregationResult -> {
@@ -35,7 +36,10 @@ public class DecisionDefinitionLatestVersionAggregationResultTransformer
                       .map(DecisionDefinitionEntity.class::cast)
                       .map(new DecisionDefinitionEntityTransformer()::apply);
                 })
-            .toList(),
-        aggregations.get(AGGREGATION_NAME_BY_DECISION_ID).endCursor());
+            .toList();
+    final var totalItems =
+        Math.toIntExact(aggregations.get(AGGREGATION_NAME_TOTAL_COUNT).docCount());
+    final var endCursor = aggregations.get(AGGREGATION_NAME_BY_DECISION_ID).endCursor();
+    return new DecisionDefinitionLatestVersionAggregationResult(items, totalItems, endCursor);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessDefinitionLatestVersionAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessDefinitionLatestVersionAggregationResultTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.aggregation.result;
 
 import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.AGGREGATION_NAME_BY_PROCESS_ID;
 import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.AGGREGATION_NAME_LATEST_DEFINITION;
+import static io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation.AGGREGATION_NAME_TOTAL_COUNT;
 
 import io.camunda.search.aggregation.result.ProcessDefinitionLatestVersionAggregationResult;
 import io.camunda.search.clients.core.AggregationResult;
@@ -23,7 +24,7 @@ public class ProcessDefinitionLatestVersionAggregationResultTransformer
   @Override
   public ProcessDefinitionLatestVersionAggregationResult apply(
       final Map<String, AggregationResult> aggregations) {
-    return new ProcessDefinitionLatestVersionAggregationResult(
+    final var items =
         aggregations.get(AGGREGATION_NAME_BY_PROCESS_ID).aggregations().values().stream()
             .flatMap(
                 aggregationResult -> {
@@ -35,7 +36,10 @@ public class ProcessDefinitionLatestVersionAggregationResultTransformer
                       .map(ProcessEntity.class::cast)
                       .map(new ProcessDefinitionEntityTransfomer()::apply);
                 })
-            .toList(),
-        aggregations.get(AGGREGATION_NAME_BY_PROCESS_ID).endCursor());
+            .toList();
+    final var totalItems =
+        Math.toIntExact(aggregations.get(AGGREGATION_NAME_TOTAL_COUNT).docCount());
+    final var endCursor = aggregations.get(AGGREGATION_NAME_BY_PROCESS_ID).endCursor();
+    return new ProcessDefinitionLatestVersionAggregationResult(items, totalItems, endCursor);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/DecisionDefinitionLatestVersionAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/DecisionDefinitionLatestVersionAggregation.java
@@ -33,4 +33,10 @@ public record DecisionDefinitionLatestVersionAggregation(
   // Aggregation fields
   public static final String AGGREGATION_GROUP_DECISION_ID = "decisionId";
   public static final String AGGREGATION_GROUP_TENANT_ID = "tenantId";
+
+  // Total count aggregation
+  public static final String AGGREGATION_NAME_TOTAL_COUNT = "total-count";
+  public static final String DECISION_DEFINITION_AND_TENANT_KEY =
+      "doc['decisionId'].value + '::' + doc['tenantId'].value";
+  public static final String SCRIPT_LANGUAGE = "painless";
 }

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessDefinitionLatestVersionAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessDefinitionLatestVersionAggregation.java
@@ -26,4 +26,10 @@ public record ProcessDefinitionLatestVersionAggregation(
   // Aggregation fields
   public static final String AGGREGATION_GROUP_BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String AGGREGATION_GROUP_TENANT_ID = "tenantId";
+
+  // Total count aggregation
+  public static final String AGGREGATION_NAME_TOTAL_COUNT = "total-count";
+  public static final String PROCESS_DEFINITION_AND_TENANT_KEY =
+      "doc['bpmnProcessId'].value + '::' + doc['tenantId'].value";
+  public static final String SCRIPT_LANGUAGE = "painless";
 }

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/DecisionDefinitionLatestVersionAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/DecisionDefinitionLatestVersionAggregationResult.java
@@ -11,4 +11,5 @@ import io.camunda.search.entities.DecisionDefinitionEntity;
 import java.util.List;
 
 public record DecisionDefinitionLatestVersionAggregationResult(
-    List<DecisionDefinitionEntity> items, String endCursor) implements AggregationResultBase {}
+    List<DecisionDefinitionEntity> items, int totalItems, String endCursor)
+    implements AggregationResultBase, HasTotalItems {}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/ProcessDefinitionLatestVersionAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/ProcessDefinitionLatestVersionAggregationResult.java
@@ -11,4 +11,5 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import java.util.List;
 
 public record ProcessDefinitionLatestVersionAggregationResult(
-    List<ProcessDefinitionEntity> items, String endCursor) implements AggregationResultBase {}
+    List<ProcessDefinitionEntity> items, int totalItems, String endCursor)
+    implements AggregationResultBase, HasTotalItems {}


### PR DESCRIPTION
## Description

- **Root cause**: ES/OS path for `isLatestVersion=true` used `aggResult.items().size()` (= page size, e.g. 100) as `totalItems` instead of actual count (e.g. 917). RDBMS unaffected.

- **Fix**: Added a Painless script-based cardinality aggregation alongside the existing composite pagination aggregation. Counts unique `(bpmnProcessId, tenantId)` pairs — one extra agg in the same ES request, no extra round-trip.

- **Wired through**: `ProcessDefinitionLatestVersionAggregationResult` now carries `totalItems` (implements `HasTotalItems`). Result transformer extracts it from `docCount()`. Reader uses it directly.

- **Same fix for `DecisionDefinition`** — identical bug, identical pattern.

- **Test**: Added `shouldReturnCorrectTotalItemsWhenFilteredByIsLatestVersion` in `ProcessDefinitionSearchIT` — requests 1 item per page with `isLatestVersion=true`, asserts `totalItems` equals number of unique process IDs, not page size. Runs on ES, OpenSearch, and RDBMS via `@MultiDbTest`.

## Related issues

related to #51622, #53998
