### PR TITLE
feat: Cluster scale API support zones

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -254,7 +254,11 @@ public class ClusterEndpoint {
       if (isScale) {
         final var scaleRequest =
             new ClusterScaleRequest(
-                Optional.of(brokers.getCount()), newPartitionCount, newReplicationFactor, dryRun);
+                Optional.of(brokers.getCount()),
+                newPartitionCount,
+                newReplicationFactor,
+                Optional.ofNullable(request.getBrokers().getZone()).filter(z -> !z.isBlank()),
+                dryRun);
         return ClusterApiUtils.mapOperationResponse(
             requestSender.scaleCluster(scaleRequest).join());
       } else {

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -78,6 +78,12 @@ schemas:
             description: The new number of brokers. Can be omitted if the broker count is not changed
               or if the brokers to add or remove is provided.
             example: 12
+          zone:
+            type: string
+            description: On zone-aware clusters, the zone whose broker count should be changed to
+              'count'. Required when 'count' is set and the cluster is zone-aware; must be omitted
+              otherwise.
+            example: zone-a
       partitions:
         type: object
         properties:

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.util.Preconditions.assertNonEmpty;
+import static io.camunda.zeebe.util.Preconditions.assertPositive;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
@@ -67,7 +70,14 @@ public sealed interface ClusterConfigurationManagementRequest {
       Optional<Integer> newReplicationFactor,
       Optional<String> zone,
       boolean dryRun)
-      implements ClusterConfigurationManagementRequest {}
+      implements ClusterConfigurationManagementRequest {
+    public ClusterScaleRequest {
+      zone.ifPresent(assertNonEmpty("zone"));
+      brokerCount.ifPresent(assertPositive("brokerCount"));
+      newPartitionCount.ifPresent(assertPositive("newPartitionCount"));
+      newReplicationFactor.ifPresent(assertPositive("newReplicationFactor"));
+    }
+  }
 
   record ClusterPatchRequest(
       Set<MemberId> membersToAdd,
@@ -75,7 +85,13 @@ public sealed interface ClusterConfigurationManagementRequest {
       Optional<Integer> newPartitionCount,
       Optional<Integer> newReplicationFactor,
       boolean dryRun)
-      implements ClusterConfigurationManagementRequest {}
+      implements ClusterConfigurationManagementRequest {
+
+    public ClusterPatchRequest {
+      newPartitionCount.ifPresent(assertPositive("newPartitionCount"));
+      newReplicationFactor.ifPresent(assertPositive("newReplicationFactor"));
+    }
+  }
 
   record UpdateRoutingStateRequest(Optional<RoutingState> routingState, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -47,10 +47,25 @@ public sealed interface ClusterConfigurationManagementRequest {
     }
   }
 
+  /**
+   * Request to scale a cluster by target counts rather than by explicit broker ids.
+   *
+   * @param brokerCount the target number of brokers. On a plain (non-zone-aware) cluster this is
+   *     the total cluster size; when {@code zone} is set it is the target broker count <em>within
+   *     that zone</em>, leaving the other zones untouched. Empty leaves the broker count unchanged.
+   * @param newPartitionCount the target number of partitions, or empty to leave it unchanged.
+   *     Partitions can only be scaled up.
+   * @param newReplicationFactor the target replication factor, or empty to leave it unchanged. When
+   *     {@code zone} is set this is interpreted as that zone's replica count.
+   * @param zone the zone to scale, or empty to scale a plain cluster. Required when scaling a
+   *     zone-aware cluster and rejected on a plain one.
+   * @param dryRun when true, the resulting plan is computed and returned without being applied.
+   */
   record ClusterScaleRequest(
-      Optional<Integer> newClusterSize,
+      Optional<Integer> brokerCount,
       Optional<Integer> newPartitionCount,
       Optional<Integer> newReplicationFactor,
+      Optional<String> zone,
       boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -59,7 +59,8 @@ public sealed interface ClusterConfigurationManagementRequest {
    * @param newPartitionCount the target number of partitions, or empty to leave it unchanged.
    *     Partitions can only be scaled up.
    * @param newReplicationFactor the target replication factor, or empty to leave it unchanged. When
-   *     {@code zone} is set this is interpreted as that zone's replica count.
+   *     {@code zone} is set it must not be set. To change replication factor in zone aware clusters
+   *     use {@link UpdatePartitionDistributorConfigRequest}
    * @param zone the zone to scale, or empty to scale a plain cluster. Required when scaling a
    *     zone-aware cluster and rejected on a plain one.
    * @param dryRun when true, the resulting plan is computed and returned without being applied.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -144,9 +144,10 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         clusterScaleRequest.dryRun(),
         new ClusterScaleRequestTransformer(
-            clusterScaleRequest.newClusterSize(),
+            clusterScaleRequest.brokerCount(),
             clusterScaleRequest.newPartitionCount(),
-            clusterScaleRequest.newReplicationFactor()));
+            clusterScaleRequest.newReplicationFactor(),
+            clusterScaleRequest.zone()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -41,7 +41,8 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
       final ClusterConfiguration clusterConfiguration) {
     // Changing the replication factor on a zone-aware cluster requires adjusting zone specs,
     // which is not yet supported.
-    if (newReplicationFactor.isPresent() && clusterConfiguration.isZoneAware()) {
+    // !isNotZoneAware is required as not a single broker can be zoned.
+    if (newReplicationFactor.isPresent() && !clusterConfiguration.isNotZoneAware()) {
       return Either.left(
           new InvalidRequest(
               "Changing the replication factor is not supported on zone-aware clusters."));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -42,7 +42,7 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
     // Changing the replication factor on a zone-aware cluster requires adjusting zone specs,
     // which is not yet supported.
     // !isNotZoneAware is required as not a single broker can be zoned.
-    if (newReplicationFactor.isPresent() && !clusterConfiguration.isNotZoneAware()) {
+    if (newReplicationFactor.isPresent() && !clusterConfiguration.isUnzoned()) {
       return Either.left(
           new InvalidRequest(
               "Changing the replication factor is not supported on zone-aware clusters."));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -12,46 +12,96 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.util.Either;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public final class ClusterScaleRequestTransformer implements ConfigurationChangeRequest {
 
-  private final Optional<Integer> newClusterSize;
+  private final Optional<Integer> brokerCount;
   private final Optional<Integer> newPartitionCount;
   private final Optional<Integer> newReplicationFactor;
+  private final Optional<String> zone;
 
   public ClusterScaleRequestTransformer(
-      final Optional<Integer> newClusterSize,
+      final Optional<Integer> brokerCount,
       final Optional<Integer> newPartitionCount,
-      final Optional<Integer> newReplicationFactor) {
-    this.newClusterSize = newClusterSize;
+      final Optional<Integer> newReplicationFactor,
+      final Optional<String> zone) {
+    this.brokerCount = brokerCount;
     this.newPartitionCount = newPartitionCount;
     this.newReplicationFactor = newReplicationFactor;
+    this.zone = zone;
   }
 
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-    if (newClusterSize.isEmpty() && newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
+    if (brokerCount.isEmpty() && newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
       // Nothing to change
       return Either.right(List.of());
     }
 
-    if (clusterConfiguration.isZoneAware()) {
+    if (zone.isPresent() && newReplicationFactor.isPresent()) {
+      return Either.left(
+          new InvalidRequest(
+              "Change of replication factor is not allowed when zone is set. To change replication factor use `/partition-distribution` endpoint"));
+    }
+
+    if (clusterConfiguration.isNotZoneAware() && zone.isPresent()) {
+      return Either.left(
+          new InvalidRequest(
+              "Scaling operation with zone is only allowed when cluster is zone-aware"));
+    }
+
+    if (clusterConfiguration.isZoneAware() && zone.isEmpty()) {
       return Either.left(
           new InvalidRequest(
               "Scaling operation without zone is not allowed when cluster is zone-aware"));
     }
 
     // replicationFactor and partitionCount is validated in the delegated transformer.
-    final var newSetOfMembers =
-        IntStream.range(0, newClusterSize.orElse(clusterConfiguration.members().size()))
-            .mapToObj(i -> MemberId.from(String.valueOf(i)))
-            .collect(Collectors.toSet());
+    final Set<MemberId> newSetOfMembers;
+    if (zone.isPresent()) {
+      final var zoneName = zone.get();
+      final var knownZone =
+          clusterConfiguration
+              .partitionDistributorConfig()
+              .filter(ZoneAwareConfig.class::isInstance)
+              .map(ZoneAwareConfig.class::cast)
+              .map(cfg -> cfg.zones().stream().anyMatch(z -> z.name().equals(zoneName)))
+              .orElse(false);
+      if (!knownZone) {
+        return Either.left(new InvalidRequest("Unknown zone '" + zoneName + "'"));
+      }
+      final var otherZoneMembers =
+          clusterConfiguration.members().keySet().stream()
+              .filter(m -> !m.isInZone(zoneName))
+              .collect(Collectors.toSet());
+      final int currentZoneCount =
+          (int)
+              clusterConfiguration.members().keySet().stream()
+                  .filter(m -> m.isInZone(zoneName))
+                  .count();
+      final var targetZoneMembers =
+          IntStream.range(0, brokerCount.orElse(currentZoneCount))
+              .mapToObj(i -> MemberId.from(zoneName, i))
+              .collect(Collectors.toSet());
+      newSetOfMembers = new HashSet<>(otherZoneMembers);
+      newSetOfMembers.addAll(targetZoneMembers);
+    } else {
+      newSetOfMembers =
+          IntStream.range(0, brokerCount.orElse(clusterConfiguration.members().size()))
+              .mapToObj(i -> MemberId.from(zone.orElse(null), i))
+              .collect(Collectors.toSet());
+    }
     return new ScaleRequestTransformer(newSetOfMembers, newReplicationFactor, newPartitionCount)
         .operations(clusterConfiguration);
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.util.Either;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -55,13 +54,13 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
               "Change of replication factor is not allowed when zone is set. To change replication factor use `/partition-distribution` endpoint"));
     }
 
-    if (clusterConfiguration.isNotZoneAware() && zone.isPresent()) {
+    if (!clusterConfiguration.isFullyZoneAware() && zone.isPresent()) {
       return Either.left(
           new InvalidRequest(
               "Scaling operation with zone is only allowed when cluster is zone-aware"));
     }
 
-    if (clusterConfiguration.isZoneAware() && zone.isEmpty()) {
+    if (clusterConfiguration.isFullyZoneAware() && zone.isEmpty()) {
       return Either.left(
           new InvalidRequest(
               "Scaling operation without zone is not allowed when cluster is zone-aware"));
@@ -81,7 +80,7 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
       if (!knownZone) {
         return Either.left(new InvalidRequest("Unknown zone '" + zoneName + "'"));
       }
-      final var otherZoneMembers =
+      newSetOfMembers =
           clusterConfiguration.members().keySet().stream()
               .filter(m -> !m.isInZone(zoneName))
               .collect(Collectors.toSet());
@@ -90,19 +89,18 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
               clusterConfiguration.members().keySet().stream()
                   .filter(m -> m.isInZone(zoneName))
                   .count();
-      final var targetZoneMembers =
-          IntStream.range(0, brokerCount.orElse(currentZoneCount))
-              .mapToObj(i -> MemberId.from(zoneName, i))
-              .collect(Collectors.toSet());
-      newSetOfMembers = new HashSet<>(otherZoneMembers);
+      final var targetZoneMembers = membersInZone(currentZoneCount);
       newSetOfMembers.addAll(targetZoneMembers);
     } else {
-      newSetOfMembers =
-          IntStream.range(0, brokerCount.orElse(clusterConfiguration.members().size()))
-              .mapToObj(i -> MemberId.from(zone.orElse(null), i))
-              .collect(Collectors.toSet());
+      newSetOfMembers = membersInZone(clusterConfiguration.members().size());
     }
     return new ScaleRequestTransformer(newSetOfMembers, newReplicationFactor, newPartitionCount)
         .operations(clusterConfiguration);
+  }
+
+  private Set<MemberId> membersInZone(final int count) {
+    return IntStream.range(0, brokerCount.orElse(count))
+        .mapToObj(i -> MemberId.from(zone.orElse(null), i))
+        .collect(Collectors.toSet());
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -47,23 +47,23 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
       // Nothing to change
       return Either.right(List.of());
     }
-
-    if (zone.isPresent() && newReplicationFactor.isPresent()) {
-      return Either.left(
-          new InvalidRequest(
-              "Change of replication factor is not allowed when zone is set. To change replication factor use `/partition-distribution` endpoint"));
-    }
-
-    if (!clusterConfiguration.isFullyZoneAware() && zone.isPresent()) {
-      return Either.left(
-          new InvalidRequest(
-              "Scaling operation with zone is only allowed when cluster is zone-aware"));
-    }
-
-    if (clusterConfiguration.isFullyZoneAware() && zone.isEmpty()) {
-      return Either.left(
-          new InvalidRequest(
-              "Scaling operation without zone is not allowed when cluster is zone-aware"));
+    if (zone.isPresent()) {
+      if (newReplicationFactor.isPresent()) {
+        return Either.left(
+            new InvalidRequest(
+                "Change of replication factor is not allowed when zone is set. To change replication factor use `/partition-distribution` endpoint"));
+      }
+      if (!clusterConfiguration.isFullyZoneAware()) {
+        return Either.left(
+            new InvalidRequest(
+                "Scaling operation with zone is only allowed when cluster is zone-aware"));
+      }
+    } else {
+      if (!clusterConfiguration.isUnzoned()) {
+        return Either.left(
+            new InvalidRequest(
+                "Scaling operation without zone is allowed only when no broker is zone-aware"));
+      }
     }
 
     // replicationFactor and partitionCount is validated in the delegated transformer.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -45,7 +45,7 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
 
-    if (!currentConfiguration.isZoneAware()) {
+    if (!currentConfiguration.isFullyZoneAware()) {
       return Either.left(
           new InvalidRequest(
               "Partition distribution changes are only supported on zone-aware clusters."));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdatePartitionDistributorConfigApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdatePartitionDistributorConfigApplier.java
@@ -14,7 +14,9 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class UpdatePartitionDistributorConfigApplier implements ClusterOperationApplier {
 
   private final UpdatePartitionDistributorConfigOperation operation;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -991,9 +991,10 @@ public class ProtoBufSerializer
     final var builder =
         Requests.ClusterScaleRequest.newBuilder().setDryRun(clusterScaleRequest.dryRun());
 
-    clusterScaleRequest.newClusterSize().ifPresent(builder::setNewClusterSize);
+    clusterScaleRequest.brokerCount().ifPresent(builder::setNewClusterSize);
     clusterScaleRequest.newReplicationFactor().ifPresent(builder::setNewReplicationFactor);
     clusterScaleRequest.newPartitionCount().ifPresent(builder::setNewPartitionCount);
+    clusterScaleRequest.zone().ifPresent(builder::setZone);
 
     return builder.build().toByteArray();
   }
@@ -1198,8 +1199,16 @@ public class ProtoBufSerializer
           clusterScaleRequest.hasNewPartitionCount()
               ? Optional.of(clusterScaleRequest.getNewPartitionCount())
               : Optional.empty();
+      final Optional<String> zone =
+          clusterScaleRequest.hasZone()
+              ? Optional.of(clusterScaleRequest.getZone())
+              : Optional.empty();
       return new ClusterScaleRequest(
-          newClusterSize, newPartitionCount, newReplicationFactor, clusterScaleRequest.getDryRun());
+          newClusterSize,
+          newPartitionCount,
+          newReplicationFactor,
+          zone,
+          clusterScaleRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1211,6 +1211,8 @@ public class ProtoBufSerializer
           clusterScaleRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
+    } catch (final IllegalArgumentException e) {
+      throw new DecodingFailed(e);
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -342,15 +342,28 @@ public record ClusterConfiguration(
    * @return true if All brokers are not zoned and the partition distribution config is not
    *     ZoneAware, false otherwise.
    */
-  public boolean isNotZoneAware() {
+  public boolean isUnzoned() {
     return members().keySet().stream().allMatch(m -> m.zone() == null)
         && !partitionDistributorConfig.map(ZoneAwareConfig.class::isInstance).orElse(false);
   }
 
   /**
+   * @return true if at least one broker is zoned, indicating that the cluster is transitioning from
+   *     an "unzoned" cluster to a zoned one.
+   */
+  public boolean isPartiallyZoneAware() {
+    final var membersCount = members.size();
+    final var zonedCount = members().keySet().stream().filter(m -> m.zone() != null).count();
+    final var distributionIsNotZoned =
+        partitionDistributorConfig.filter(ZoneAwareConfig.class::isInstance).isEmpty();
+    return (zonedCount > 0 && zonedCount < membersCount) // not all brokers are zoned
+        || (zonedCount == membersCount && distributionIsNotZoned); // are all zoned, config isn't
+  }
+
+  /**
    * @return true if all brokers are zone aware and the partition distribution config is ZoneAware
    */
-  public boolean isZoneAware() {
+  public boolean isFullyZoneAware() {
     return members().keySet().stream().allMatch(m -> m.zone() != null)
         && partitionDistributorConfig.map(ZoneAwareConfig.class::isInstance).orElse(false);
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -353,6 +353,9 @@ public record ClusterConfiguration(
    */
   public boolean isPartiallyZoneAware() {
     final var membersCount = members.size();
+    if (membersCount == 0) {
+      return false;
+    }
     final var zonedCount = members().keySet().stream().filter(m -> m.zone() != null).count();
     final var distributionIsNotZoned =
         partitionDistributorConfig.filter(ZoneAwareConfig.class::isInstance).isEmpty();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -338,9 +338,21 @@ public record ClusterConfiguration(
     return Optional.of(pendingChanges.orElseThrow().nextPendingOperation());
   }
 
+  /**
+   * @return true if All brokers are not zoned and the partition distribution config is not
+   *     ZoneAware, false otherwise.
+   */
+  public boolean isNotZoneAware() {
+    return members().keySet().stream().allMatch(m -> m.zone() == null)
+        && !partitionDistributorConfig.map(ZoneAwareConfig.class::isInstance).orElse(false);
+  }
+
+  /**
+   * @return true if all brokers are zone aware and the partition distribution config is ZoneAware
+   */
   public boolean isZoneAware() {
-    return members().keySet().stream().anyMatch(m -> m.zone() != null)
-        || partitionDistributorConfig.map(ZoneAwareConfig.class::isInstance).orElse(false);
+    return members().keySet().stream().allMatch(m -> m.zone() != null)
+        && partitionDistributorConfig.map(ZoneAwareConfig.class::isInstance).orElse(false);
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -42,8 +42,8 @@ message ClusterScaleRequest {
   optional uint32 newClusterSize = 1;
   optional uint32 newPartitionCount = 2;
   optional uint32 newReplicationFactor = 3;
-  optional string zone= 5;
   bool dryRun = 4;
+  optional string zone= 5;
 }
 
 message ClusterPatchRequest {

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -42,6 +42,7 @@ message ClusterScaleRequest {
   optional uint32 newClusterSize = 1;
   optional uint32 newPartitionCount = 2;
   optional uint32 newReplicationFactor = 3;
+  optional string zone= 5;
   bool dryRun = 4;
 }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -361,7 +361,8 @@ final class ClusterConfigurationManagementApiTest {
   void shouldScaleClusterByNewClusterSizeAndPartitionCount() {
     // given
     final var request =
-        new ClusterScaleRequest(Optional.of(2), Optional.of(3), Optional.empty(), false);
+        new ClusterScaleRequest(
+            Optional.of(2), Optional.of(3), Optional.empty(), Optional.empty(), false);
     final ClusterConfiguration currentTopology =
         initialTopology
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -28,12 +28,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
-import net.jqwik.api.From;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import net.jqwik.api.constraints.IntRange;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -48,17 +44,11 @@ final class ClusterScaleRequestTransformerTest {
   private static final int ZONE_B_PRIORITY = 500;
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
-  @Provide
-  Arbitrary<Optional<String>> zones() {
-    return Arbitraries.of(Optional.<String>empty(), Optional.of(ZONE_A));
-  }
-
   @Property(tries = 10)
   void shouldScaleBrokersWhenPartitionsUnchanged(
       @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
       @ForAll @IntRange(min = 2, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 2, max = 100) final int newClusterSize,
-      @ForAll @From("zones") final Optional<String> zone) {
+      @ForAll @IntRange(min = 2, max = 100) final int newClusterSize) {
     shouldScaleBrokersAndPartitionsByCount(
         partitionCount,
         Optional.empty(),
@@ -66,15 +56,29 @@ final class ClusterScaleRequestTransformerTest {
         Optional.empty(),
         oldClusterSize,
         Optional.of(newClusterSize),
-        zone);
+        Optional.empty());
+  }
+
+  @Property(tries = 10)
+  void shouldScaleBrokersWhenPartitionsUnchangedWhenZoned(
+      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
+      @ForAll @IntRange(min = 2, max = 100) final int oldClusterSize,
+      @ForAll @IntRange(min = 2, max = 100) final int newClusterSize) {
+    shouldScaleBrokersAndPartitionsByCount(
+        partitionCount,
+        Optional.empty(),
+        2,
+        Optional.empty(),
+        oldClusterSize,
+        Optional.of(newClusterSize),
+        Optional.of(ZONE_A));
   }
 
   @Property(tries = 10)
   void shouldScalePartitionsWhenClusterSizeUnchanged(
       @ForAll @IntRange(min = 3, max = 100) final int clusterSize,
       @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
-      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount,
-      @ForAll @From("zones") final Optional<String> zone) {
+      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
     shouldScaleBrokersAndPartitionsByCount(
         oldPartitionCount,
         Optional.of(newPartitionCount),
@@ -82,7 +86,22 @@ final class ClusterScaleRequestTransformerTest {
         Optional.empty(),
         clusterSize,
         Optional.empty(),
-        zone);
+        Optional.empty());
+  }
+
+  @Property(tries = 10)
+  void shouldScalePartitionsWhenClusterSizeUnchangedWhenZoned(
+      @ForAll @IntRange(min = 3, max = 100) final int clusterSize,
+      @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
+      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
+    shouldScaleBrokersAndPartitionsByCount(
+        oldPartitionCount,
+        Optional.of(newPartitionCount),
+        3,
+        Optional.empty(),
+        clusterSize,
+        Optional.empty(),
+        Optional.of(ZONE_A));
   }
 
   @Property(tries = 10)
@@ -107,8 +126,7 @@ final class ClusterScaleRequestTransformerTest {
       @ForAll @IntRange(min = 3, max = 100) final int oldClusterSize,
       @ForAll @IntRange(min = 3, max = 100) final int newClusterSize,
       @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
-      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount,
-      @ForAll @From("zones") final Optional<String> zone) {
+      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
     shouldScaleBrokersAndPartitionsByCount(
         oldPartitionCount,
         Optional.of(newPartitionCount),
@@ -116,7 +134,23 @@ final class ClusterScaleRequestTransformerTest {
         Optional.empty(),
         oldClusterSize,
         Optional.of(newClusterSize),
-        zone);
+        Optional.of(ZONE_A));
+  }
+
+  @Property(tries = 10)
+  void shouldScaleBrokersAndPartitionsWhenZoned(
+      @ForAll @IntRange(min = 3, max = 100) final int oldClusterSize,
+      @ForAll @IntRange(min = 3, max = 100) final int newClusterSize,
+      @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
+      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
+    shouldScaleBrokersAndPartitionsByCount(
+        oldPartitionCount,
+        Optional.of(newPartitionCount),
+        3,
+        Optional.empty(),
+        oldClusterSize,
+        Optional.of(newClusterSize),
+        Optional.of(ZONE_A));
   }
 
   @Property(tries = 10)

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
@@ -16,54 +17,72 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
-import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
+import net.jqwik.api.From;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import net.jqwik.api.constraints.IntRange;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 final class ClusterScaleRequestTransformerTest {
 
-  private final MemberId id0 = MemberId.from("0");
-  private final MemberId id1 = MemberId.from("1");
-  private final MemberId id2 = MemberId.from("2");
-  private final MemberId id3 = MemberId.from("3");
-
+  private static final String ZONE_A = "zoneA";
+  private static final String ZONE_B = "zoneB";
+  private static final int ZONE_B_BROKERS = 1;
+  private static final int ZONE_B_REPLICAS = 1;
+  private static final int ZONE_A_PRIORITY = 1000;
+  private static final int ZONE_B_PRIORITY = 500;
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @Provide
+  Arbitrary<Optional<String>> zones() {
+    return Arbitraries.of(Optional.<String>empty(), Optional.of(ZONE_A));
+  }
 
   @Property(tries = 10)
   void shouldScaleBrokersWhenPartitionsUnchanged(
       @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
-      @ForAll @IntRange(min = 1, max = 100) final int oldClusterSize,
-      @ForAll @IntRange(min = 1, max = 100) final int newClusterSize) {
+      @ForAll @IntRange(min = 2, max = 100) final int oldClusterSize,
+      @ForAll @IntRange(min = 2, max = 100) final int newClusterSize,
+      @ForAll @From("zones") final Optional<String> zone) {
     shouldScaleBrokersAndPartitionsByCount(
         partitionCount,
         Optional.empty(),
-        1,
+        2,
         Optional.empty(),
         oldClusterSize,
-        Optional.of(newClusterSize));
+        Optional.of(newClusterSize),
+        zone);
   }
 
   @Property(tries = 10)
   void shouldScalePartitionsWhenClusterSizeUnchanged(
       @ForAll @IntRange(min = 3, max = 100) final int clusterSize,
       @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
-      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
+      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount,
+      @ForAll @From("zones") final Optional<String> zone) {
     shouldScaleBrokersAndPartitionsByCount(
         oldPartitionCount,
         Optional.of(newPartitionCount),
         3,
         Optional.empty(),
         clusterSize,
-        Optional.empty());
+        Optional.empty(),
+        zone);
   }
 
   @Property(tries = 10)
@@ -78,6 +97,8 @@ final class ClusterScaleRequestTransformerTest {
         oldReplicationFactor,
         Optional.of(newReplicationFactor),
         clusterSize,
+        Optional.empty(),
+        // replication factor cannot be changed for a zoned cluster
         Optional.empty());
   }
 
@@ -86,14 +107,16 @@ final class ClusterScaleRequestTransformerTest {
       @ForAll @IntRange(min = 3, max = 100) final int oldClusterSize,
       @ForAll @IntRange(min = 3, max = 100) final int newClusterSize,
       @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
-      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
+      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount,
+      @ForAll @From("zones") final Optional<String> zone) {
     shouldScaleBrokersAndPartitionsByCount(
         oldPartitionCount,
         Optional.of(newPartitionCount),
         3,
         Optional.empty(),
         oldClusterSize,
-        Optional.of(newClusterSize));
+        Optional.of(newClusterSize),
+        zone);
   }
 
   @Property(tries = 10)
@@ -110,49 +133,78 @@ final class ClusterScaleRequestTransformerTest {
         oldReplicationFactor,
         Optional.of(newReplicationFactor),
         oldClusterSize,
-        Optional.of(newClusterSize));
+        Optional.of(newClusterSize),
+        // replication factor cannot be changed for a zoned cluster
+        Optional.empty());
   }
 
   void shouldScaleBrokersAndPartitionsByCount(
       final int oldPartitionCount,
       final Optional<Integer> newPartitionCount,
-      final int oldReplicationFactor,
+      final int replicationFactor,
       final Optional<Integer> newReplicationFactor,
       final int oldClusterSize,
-      final Optional<Integer> newClusterSize) {
+      final Optional<Integer> newClusterSize,
+      final Optional<String> zone) {
     // given
+    final var effectiveConfig =
+        zone.isPresent() ? zoneAwareConfig(replicationFactor) : new RoundRobinConfig();
+    final var effectiveNewConfig =
+        zone.isPresent()
+            ? zoneAwareConfig(newReplicationFactor.orElse(replicationFactor))
+            : new RoundRobinConfig();
+    final var oldMembers =
+        zone.isPresent()
+            ? scaledMembers(oldClusterSize)
+            : membersInZone(Optional.empty(), oldClusterSize);
+    final var newMembers =
+        zone.isPresent()
+            ? scaledMembers(newClusterSize.orElse(oldClusterSize))
+            : membersInZone(Optional.empty(), newClusterSize.orElse(oldClusterSize));
+
     final var expectedNewDistribution =
-        new RoundRobinPartitionDistributor()
+        effectiveNewConfig
+            .toDistributor()
             .distributePartitions(
-                getClusterMembers(newClusterSize.orElse(oldClusterSize)),
+                newMembers,
                 getSortedPartitionIds(newPartitionCount.orElse(oldPartitionCount)),
-                newReplicationFactor.orElse(oldReplicationFactor));
+                zone.isPresent()
+                    ? ((ZoneAwareConfig) effectiveNewConfig).replicationFactor()
+                    : newReplicationFactor.orElse(replicationFactor));
 
     final var oldDistribution =
-        new RoundRobinPartitionDistributor()
+        effectiveConfig
+            .toDistributor()
             .distributePartitions(
-                getClusterMembers(oldClusterSize),
+                oldMembers,
                 getSortedPartitionIds(oldPartitionCount),
-                oldReplicationFactor);
+                // note that it's not really used for zone-aware
+                zone.isPresent()
+                    ? ((ZoneAwareConfig) effectiveConfig).replicationFactor()
+                    : replicationFactor);
     ClusterConfiguration oldClusterTopology =
         ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig, "clusterId");
-    for (final MemberId member : getClusterMembers(oldClusterSize)) {
+    if (zone.isPresent()) {
+      oldClusterTopology = oldClusterTopology.setPartitionDistributorConfig(effectiveConfig);
+    }
+    for (final MemberId member : oldMembers) {
       if (!oldClusterTopology.hasMember(member)) {
         oldClusterTopology =
             oldClusterTopology.addMember(member, MemberState.initializeAsActive(Map.of()));
       }
     }
-
     // when
     final var patchRequest =
-        new ClusterScaleRequest(newClusterSize, newPartitionCount, newReplicationFactor, false);
+        new ClusterScaleRequest(
+            newClusterSize, newPartitionCount, newReplicationFactor, zone, false);
 
     applyRequestAndVerifyResultingTopology(
         newPartitionCount.orElse(oldPartitionCount),
-        getClusterMembers(newClusterSize.orElse(oldClusterSize)),
+        newMembers,
         patchRequest,
         oldClusterTopology,
-        expectedNewDistribution);
+        expectedNewDistribution,
+        zone);
   }
 
   private void applyRequestAndVerifyResultingTopology(
@@ -160,14 +212,16 @@ final class ClusterScaleRequestTransformerTest {
       final Set<MemberId> expectedMembers,
       final ClusterScaleRequest patchRequest,
       final ClusterConfiguration oldClusterTopology,
-      final Set<PartitionMetadata> expectedNewDistribution) {
+      final Set<PartitionMetadata> expectedNewDistribution,
+      final Optional<String> zone) {
 
     // when
     final var result =
         new ClusterScaleRequestTransformer(
-                patchRequest.newClusterSize(),
+                patchRequest.brokerCount(),
                 patchRequest.newPartitionCount(),
-                patchRequest.newReplicationFactor())
+                patchRequest.newReplicationFactor(),
+                zone)
             .operations(oldClusterTopology);
     assertThat(result).isRight();
     final var operations = result.get();
@@ -178,14 +232,14 @@ final class ClusterScaleRequestTransformerTest {
 
     // then
     final var newDistribution = ConfigurationUtil.getPartitionDistributionFrom(newTopology, "temp");
-    Assertions.assertThat(newDistribution)
+    assertThat(newDistribution)
         .usingRecursiveComparison()
         .ignoringCollectionOrder()
         .isEqualTo(expectedNewDistribution);
-    Assertions.assertThat(newTopology.members().keySet())
+    assertThat(newTopology.members().keySet())
         .describedAs("Expected cluster members")
         .containsExactlyInAnyOrderElementsOf(expectedMembers);
-    Assertions.assertThat(newTopology.partitionCount()).isEqualTo(partitionCount);
+    assertThat(newTopology.partitionCount()).isEqualTo(partitionCount);
   }
 
   private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
@@ -194,10 +248,103 @@ final class ClusterScaleRequestTransformerTest {
         .collect(Collectors.toList());
   }
 
-  private Set<MemberId> getClusterMembers(final int newClusterSize) {
+  private Set<MemberId> membersInZone(final Optional<String> zone, final int newClusterSize) {
     return IntStream.range(0, newClusterSize)
-        .mapToObj(Integer::toString)
-        .map(MemberId::from)
+        .mapToObj(idx -> MemberId.from(zone.orElse(null), idx))
         .collect(Collectors.toSet());
+  }
+
+  @Test
+  void shouldRejectZoneWithReplicationFactor() {
+    // given
+    final var topology = zoneAwareTopology(2, 2, 3);
+
+    // when
+    final var result =
+        new ClusterScaleRequestTransformer(
+                Optional.of(3), Optional.empty(), Optional.of(3), Optional.of(ZONE_A))
+            .operations(topology);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectUnknownZone() {
+    // given
+    final var topology = zoneAwareTopology(2, 2, 3);
+
+    // when
+    final var result =
+        new ClusterScaleRequestTransformer(
+                Optional.of(3), Optional.empty(), Optional.empty(), Optional.of("zoneX"))
+            .operations(topology);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+        .satisfies(e -> Assertions.assertThat(e).hasMessageContaining("Unknown zone 'zoneX'"));
+  }
+
+  @Test
+  void shouldRejectNonZoneAwareCluster() {
+    // given
+    final var distribution =
+        new RoundRobinConfig()
+            .toDistributor()
+            .distributePartitions(
+                membersInZone(Optional.of(ZONE_A), 3), getSortedPartitionIds(3), 1);
+    final var topology =
+        ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "clusterId");
+
+    // when
+    final var result =
+        new ClusterScaleRequestTransformer(
+                Optional.of(4), Optional.empty(), Optional.empty(), Optional.of(ZONE_A))
+            .operations(topology);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
+  }
+
+  private ClusterConfiguration zoneAwareTopology(
+      final int zoneABrokers, final int zoneAReplicas, final int partitionCount) {
+    final var config = zoneAwareConfig(zoneAReplicas);
+    final var members = scaledMembers(zoneABrokers);
+    final var distribution =
+        config
+            .toDistributor()
+            .distributePartitions(
+                members, getSortedPartitionIds(partitionCount), config.replicationFactor());
+    var topology =
+        ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "temp")
+            .setPartitionDistributorConfig(config);
+    for (final MemberId member : members) {
+      if (!topology.hasMember(member)) {
+        topology = topology.addMember(member, MemberState.initializeAsActive(Map.of()));
+      }
+    }
+    return topology;
+  }
+
+  private ZoneAwareConfig zoneAwareConfig(final int zoneAReplicas) {
+    return new ZoneAwareConfig(
+        List.of(
+            new ZoneSpec(ZONE_A, zoneAReplicas, ZONE_A_PRIORITY),
+            new ZoneSpec(ZONE_B, ZONE_B_REPLICAS, ZONE_B_PRIORITY)));
+  }
+
+  private Set<MemberId> scaledMembers(final int zoneABrokers) {
+    final var members = new HashSet<>(membersInZone(Optional.of(ZONE_A), zoneABrokers));
+    members.addAll(membersInZone(Optional.of(ZONE_B), ZONE_B_BROKERS));
+    return members;
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.StartPartitionScaleUp;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
@@ -38,6 +39,7 @@ import net.jqwik.api.Property;
 import net.jqwik.api.ShrinkingMode;
 import net.jqwik.api.constraints.IntRange;
 import org.assertj.core.api.AssertionsForInterfaceTypes;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ScaleRequestTransformerTest {
@@ -305,5 +307,34 @@ class ScaleRequestTransformerTest {
 
   SortedSet<Integer> partitionsInRange(final int from, final int to) {
     return new TreeSet<>(IntStream.range(from, to).boxed().toList());
+  }
+
+  @Nested
+  class ZoneAwareScaling {
+    static final Set<MemberId> SCALED_MEMBERS =
+        Set.of(
+            MemberId.from("zone-a", 0),
+            MemberId.from("zone-a", 1),
+            MemberId.from("zone-a", 2),
+            MemberId.from("zone-a", 3),
+            MemberId.from("zone-b", 0),
+            MemberId.from("zone-b", 1));
+
+    static final Set<MemberId> UNSCALED_MEMBERS =
+        Set.of(MemberId.from("zone-a", 0), MemberId.from("zone-a", 1), MemberId.from("zone-b", 0));
+
+    static final ZoneAwareConfig ZONE_AWARE_CONFIG =
+        new PartitionDistributorConfig.ZoneAwareConfig(
+            List.of(new ZoneSpec("zone-a", 2, 1000), new ZoneSpec("zone-b", 1, 500)));
+
+    @Test
+    void shouldScaleOutZoneAwareCluster() {
+      shouldScaleAndReassign(3, 3, ZONE_AWARE_CONFIG, UNSCALED_MEMBERS, SCALED_MEMBERS);
+    }
+
+    @Test
+    void shouldScaleInZoneAwareCluster() {
+      shouldScaleAndReassign(3, 3, ZONE_AWARE_CONFIG, SCALED_MEMBERS, UNSCALED_MEMBERS);
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -39,6 +39,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 final class ProtoBufSerializerTest {
 
@@ -157,11 +159,13 @@ final class ProtoBufSerializerTest {
     assertThat(decodedRequest).isEqualTo(exporterEnableRequest);
   }
 
-  @Test
-  void shouldEncodeAndDecodeClusterScaleRequest() {
+  @ParameterizedTest
+  @ValueSource(strings = {"", "zoneA"})
+  void shouldEncodeAndDecodeClusterScaleRequest(final String zone) {
     // given
+    final var zoneOpt = Optional.of(zone).filter(s -> !s.isEmpty());
     final var clusterScaleRequest =
-        new ClusterScaleRequest(Optional.of(3), Optional.of(15), Optional.of(4), true);
+        new ClusterScaleRequest(Optional.of(3), Optional.of(15), Optional.of(4), zoneOpt, true);
 
     // when
     final var encodedRequest = protoBufSerializer.encodeClusterScaleRequest(clusterScaleRequest);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import java.time.Instant;
@@ -451,6 +452,69 @@ class ClusterConfigurationTest {
 
   private MemberId member(final int id) {
     return MemberId.from(Integer.toString(id));
+  }
+
+  @Nested
+  class ZoneAware {
+    @Test
+    void shouldClassifyZoneAwarenessForUnzoned() {
+      // given
+      final var config =
+          ClusterConfiguration.init()
+              .addMember(member(1), MemberState.initializeAsActive(Map.of()));
+
+      assertThat(config)
+          .returns(true, ClusterConfiguration::isUnzoned)
+          .returns(false, ClusterConfiguration::isPartiallyZoneAware)
+          .returns(false, ClusterConfiguration::isFullyZoneAware);
+    }
+
+    @Test
+    void shouldClassifyZoneAwarenessForPartiallyZoned() {
+      // given
+      final var config =
+          ClusterConfiguration.init()
+              .addMember(member(1), MemberState.initializeAsActive(Map.of()))
+              .addMember(MemberId.from("zoneA", 1), MemberState.initializeAsActive(Map.of()));
+
+      // then
+      assertThat(config)
+          .returns(false, ClusterConfiguration::isUnzoned)
+          .returns(true, ClusterConfiguration::isPartiallyZoneAware)
+          .returns(false, ClusterConfiguration::isFullyZoneAware);
+    }
+
+    @Test
+    void shouldClassifyZoneAwarenessForPartiallyZonedWhenDistributionIsNotConfigured() {
+      // given
+      final var config =
+          ClusterConfiguration.init()
+              .addMember(MemberId.from("zoneB", 1), MemberState.initializeAsActive(Map.of()))
+              .addMember(MemberId.from("zoneA", 1), MemberState.initializeAsActive(Map.of()));
+
+      // then
+      assertThat(config)
+          .returns(false, ClusterConfiguration::isUnzoned)
+          .returns(true, ClusterConfiguration::isPartiallyZoneAware)
+          .returns(false, ClusterConfiguration::isFullyZoneAware);
+    }
+
+    @Test
+    void shouldClassifyZoneAwarenessForFullyZoned() {
+      // given
+      final var config =
+          ClusterConfiguration.init()
+              .addMember(MemberId.from("zoneB", 1), MemberState.initializeAsActive(Map.of()))
+              .addMember(MemberId.from("zoneA", 1), MemberState.initializeAsActive(Map.of()))
+              .setPartitionDistributorConfig(
+                  new PartitionDistributorConfig.ZoneAwareConfig(
+                      List.of(new ZoneSpec("zoneA", 1, 100), new ZoneSpec("zoneB", 1, 100))));
+
+      assertThat(config)
+          .returns(false, ClusterConfiguration::isUnzoned)
+          .returns(false, ClusterConfiguration::isPartiallyZoneAware)
+          .returns(true, ClusterConfiguration::isFullyZoneAware);
+    }
   }
 
   @Nested

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -459,14 +459,18 @@ class ClusterConfigurationTest {
     @Test
     void shouldClassifyZoneAwarenessForUnzoned() {
       // given
-      final var config =
-          ClusterConfiguration.init()
-              .addMember(member(1), MemberState.initializeAsActive(Map.of()));
+      final var configs =
+          List.of(
+              ClusterConfiguration.init(),
+              ClusterConfiguration.init()
+                  .addMember(member(1), MemberState.initializeAsActive(Map.of())));
 
-      assertThat(config)
-          .returns(true, ClusterConfiguration::isUnzoned)
-          .returns(false, ClusterConfiguration::isPartiallyZoneAware)
-          .returns(false, ClusterConfiguration::isFullyZoneAware);
+      for (final var config : configs) {
+        assertThat(config)
+            .returns(true, ClusterConfiguration::isUnzoned)
+            .returns(false, ClusterConfiguration::isPartiallyZoneAware)
+            .returns(false, ClusterConfiguration::isFullyZoneAware);
+      }
     }
 
     @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.ArrayList;
 import java.util.List;
@@ -117,7 +118,7 @@ abstract class ClusterEndpointIT {
     }
   }
 
-  private static java.net.http.HttpResponse<String> sendBrokerScaleRequest(
+  private static HttpResponse<String> sendBrokerScaleRequest(
       final TestCluster cluster, final URI pathAndQuery) throws IOException, InterruptedException {
     final var baseClusterEndpoint = cluster.availableGateway().actuatorUri("cluster");
     final var request =

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Preconditions.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Preconditions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.function.Consumer;
+
+public class Preconditions {
+  private Preconditions() {}
+
+  public static void assertPositive(final long number, final String fieldName) {
+    if (number <= 0) {
+      throw new IllegalArgumentException(
+          String.format("Expected %s to be positive if set, but got %d", fieldName, number));
+    }
+  }
+
+  public static Consumer<Integer> assertPositive(final String fieldName) {
+    return (number -> assertPositive(number, fieldName));
+  }
+
+  public static void assertNonEmpty(final String s, final String fieldName) {
+    if (s.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected %s to be a non empty string if Optional is not empty, but got an empty string",
+              fieldName));
+    }
+  }
+
+  public static Consumer<String> assertNonEmpty(final String fieldName) {
+    return s -> assertNonEmpty(s, fieldName);
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Preconditions.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Preconditions.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.util;
 
 import java.util.function.Consumer;
 
-public class Preconditions {
+public final class Preconditions {
   private Preconditions() {}
 
   public static void assertPositive(final long number, final String fieldName) {


### PR DESCRIPTION
## Description
This PR adds the support to scale brokers via count using `PATCH /actuator/cluster`. 
A `zone` field is added so this payload can be used:
```json
{
  "brokers" : {
     "count": 5,
     "zone": "zoneA"
  }
}
```

`ClusterPatchRequest.newClusterSize` has been renamed to `brokerCount` as it might just refer to the number of broker in a zone.
`zone` is added to the BrokerScaleRequest in protobuf as well

To use this API the brokers must be all zoned (if used with the zone) or none of them (if zone is missing). 
Mixed clusters are not supported with this API, the exact brokerIds must be used.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55163