### PR TITLE
Implement AgentHistory.CREATE processor

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.agenthistory.AgentHistoryProcessors;
 import io.camunda.zeebe.engine.processing.agentinstance.AgentInstanceProcessors;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationSetupProcessors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
@@ -426,6 +427,9 @@ public final class EngineProcessors {
         clock);
 
     AgentInstanceProcessors.addAgentInstanceProcessors(
+        keyGenerator, typedRecordProcessors, writers, authCheckBehavior, processingState);
+
+    AgentHistoryProcessors.addAgentHistoryProcessors(
         keyGenerator, typedRecordProcessors, writers, authCheckBehavior, processingState);
 
     return typedRecordProcessors;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<AgentHistoryRecord> {
+
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final AgentInstanceState agentInstanceState;
+  private final JobState jobState;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final KeyGenerator keyGenerator;
+
+  public AgentHistoryCreateProcessor(
+      final Writers writers,
+      final ProcessingState processingState,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final KeyGenerator keyGenerator) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    agentInstanceState = processingState.getAgentInstanceState();
+    jobState = processingState.getJobState();
+    this.authCheckBehavior = authCheckBehavior;
+    this.keyGenerator = keyGenerator;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<AgentHistoryRecord> command) {
+    final var commandValue = command.getValue();
+
+    final var agentInstanceKey = commandValue.getAgentInstanceKey();
+    final var agentInstanceRecord = agentInstanceState.getRecord(agentInstanceKey);
+    if (agentInstanceRecord == null) {
+      writeRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          "Expected to create agent history entry for agent instance with key '%d', but no such agent instance was found."
+              .formatted(agentInstanceKey));
+      return;
+    }
+
+    final var authRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .permissionType(PermissionType.UPDATE_PROCESS_INSTANCE)
+            .tenantId(agentInstanceRecord.getTenantId())
+            .addResourceId(agentInstanceRecord.getBpmnProcessId())
+            .build();
+    final var authResult = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
+    if (authResult.isLeft()) {
+      final var rejection = authResult.getLeft();
+      writeRejection(command, rejection.type(), rejection.reason());
+      return;
+    }
+
+    final var jobKey = commandValue.getJobKey();
+    if (jobState.getState(jobKey) != JobState.State.ACTIVATED) {
+      writeRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          "Expected to create agent history entry for job with key '%d', but the job is not active."
+              .formatted(jobKey));
+      return;
+    }
+    final var job = jobState.getJob(jobKey);
+
+    final var jobElementInstanceKey = job.getElementInstanceKey();
+    final var commandElementInstanceKey = commandValue.getElementInstanceKey();
+    if (jobElementInstanceKey != commandElementInstanceKey) {
+      writeRejection(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          "Expected element instance key '%d' for agent history entry, but job '%d' is associated with element instance '%d'."
+              .formatted(commandElementInstanceKey, jobKey, jobElementInstanceKey));
+      return;
+    }
+
+    if (!agentInstanceRecord.getElementInstanceKeys().contains(jobElementInstanceKey)) {
+      writeRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          "Expected to create agent history entry for element instance with key '%d', but it is not associated with agent instance with key '%d'."
+              .formatted(jobElementInstanceKey, agentInstanceKey));
+      return;
+    }
+
+    final var historyKey = keyGenerator.nextKey();
+    final var event =
+        new AgentHistoryRecord()
+            .setAgentInstanceKey(commandValue.getAgentInstanceKey())
+            .setElementInstanceKey(jobElementInstanceKey)
+            .setProcessInstanceKey(job.getProcessInstanceKey())
+            .setRootProcessInstanceKey(job.getRootProcessInstanceKey())
+            .setProcessDefinitionKey(job.getProcessDefinitionKey())
+            .setTenantId(job.getTenantId())
+            .setJobKey(commandValue.getJobKey())
+            .setJobLease(commandValue.getJobLease())
+            .setIteration(commandValue.getIteration())
+            .setRole(commandValue.getRole())
+            .setProducedAt(commandValue.getProducedAt())
+            .setContent(commandValue.getContent())
+            .setToolCalls(commandValue.getToolCalls());
+
+    event
+        .getMetrics()
+        .setInputTokens(commandValue.getMetrics().getInputTokens())
+        .setOutputTokens(commandValue.getMetrics().getOutputTokens())
+        .setDurationMs(commandValue.getMetrics().getDurationMs());
+
+    stateWriter.appendFollowUpEvent(historyKey, AgentHistoryIntent.CREATED, event);
+    responseWriter.writeEventOnCommand(historyKey, AgentHistoryIntent.CREATED, event, command);
+
+    // TODO: remove once the pending-commit lifecycle is implemented (#55033); at that point
+    // COMMITTED will be emitted by AgentHistoryCommitProcessor after the job completes.
+    stateWriter.appendFollowUpEvent(historyKey, AgentHistoryIntent.COMMITTED, event);
+  }
+
+  private void writeRejection(
+      final TypedRecord<AgentHistoryRecord> command,
+      final RejectionType rejectionType,
+      final String reason) {
+    rejectionWriter.appendRejection(command, rejectionType, reason);
+    responseWriter.writeRejectionOnCommand(command, rejectionType, reason);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -113,7 +113,7 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
     final var historyKey = keyGenerator.nextKey();
     final var event =
         new AgentHistoryRecord()
-            .setHistoryItemKey(historyKey)
+            .setAgentHistoryKey(historyKey)
             .setAgentInstanceKey(commandValue.getAgentInstanceKey())
             .setElementInstanceKey(jobElementInstanceKey)
             .setProcessInstanceKey(job.getProcessInstanceKey())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -113,6 +113,7 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
     final var historyKey = keyGenerator.nextKey();
     final var event =
         new AgentHistoryRecord()
+            .setHistoryItemKey(historyKey)
             .setAgentInstanceKey(commandValue.getAgentInstanceKey())
             .setElementInstanceKey(jobElementInstanceKey)
             .setProcessInstanceKey(job.getProcessInstanceKey())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryProcessors.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public final class AgentHistoryProcessors {
+
+  private AgentHistoryProcessors() {}
+
+  public static void addAgentHistoryProcessors(
+      final KeyGenerator keyGenerator,
+      final TypedRecordProcessors typedRecordProcessors,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final ProcessingState processingState) {
+    typedRecordProcessors.onCommand(
+        ValueType.AGENT_HISTORY,
+        AgentHistoryIntent.CREATE,
+        new AgentHistoryCreateProcessor(writers, processingState, authCheckBehavior, keyGenerator));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateAuthorizationTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/**
+ * Engine-level authorization coverage for AgentHistory CREATE. The auth check is sourced from the
+ * agent instance record (bpmnProcessId + tenantId), not from the job or element instance directly,
+ * so permission and tenant denials are independently verifiable.
+ */
+public final class AgentHistoryCreateAuthorizationTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String SERVICE_TASK_ID = "agent-task";
+  private static final String CUSTOM_TENANT = "custom-tenant";
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withMultiTenancyChecksEnabled(true)
+          .withSecurityConfig(
+              cfg -> {
+                final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
+                defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getInitialization().setDefaultRoles(defaultRoles);
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Before
+  public void before() {
+    engine.tenant().newTenant().withTenantId(CUSTOM_TENANT).withName("Custom Tenant").create();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, DEFAULT_USER.getUsername());
+    assignUserToTenant(CUSTOM_TENANT, DEFAULT_USER.getUsername());
+  }
+
+  @Test
+  public void shouldAuthorizeWithUpdateProcessInstancePermission() {
+    final var setup = deployAndSetupUnderTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.UPDATE_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
+        PROCESS_ID);
+
+    final var created =
+        engine
+            .agentHistories()
+            .withAgentInstanceKey(setup.agentInstanceKey())
+            .withJobKey(setup.jobKey())
+            .withElementInstanceKey(setup.elementInstanceKey())
+            .create(user.getUsername());
+
+    assertThat(created.getIntent()).isEqualTo(AgentHistoryIntent.CREATED);
+  }
+
+  @Test
+  public void shouldRejectWhenCallerNotAuthorized() {
+    final var setup = deployAndSetupUnderTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
+
+    final var rejection =
+        engine
+            .agentHistories()
+            .withAgentInstanceKey(setup.agentInstanceKey())
+            .withJobKey(setup.jobKey())
+            .withElementInstanceKey(setup.elementInstanceKey())
+            .expectRejection()
+            .create(user.getUsername());
+
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.FORBIDDEN);
+  }
+
+  @Test
+  public void shouldRejectWhenAuthorizedTenantsExcludeAgentInstanceTenant() {
+    final var setup = deployAndSetupUnderTenant(CUSTOM_TENANT);
+    final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.UPDATE_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
+        PROCESS_ID);
+
+    final var rejection =
+        engine
+            .agentHistories()
+            .withAgentInstanceKey(setup.agentInstanceKey())
+            .withJobKey(setup.jobKey())
+            .withElementInstanceKey(setup.elementInstanceKey())
+            .withAuthorizedTenantIds(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .expectRejection()
+            .create(user.getUsername());
+
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+  }
+
+  private TestSetup deployAndSetupUnderTenant(final String tenantId) {
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .endEvent()
+                .done())
+        .withTenantId(tenantId)
+        .deploy(DEFAULT_USER.getUsername());
+
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withTenantId(tenantId)
+            .create(DEFAULT_USER.getUsername());
+
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+
+    final long agentInstanceKey =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withAuthorizedTenantIds(tenantId)
+            .create(DEFAULT_USER.getUsername())
+            .getKey();
+
+    engine.jobs().withType("agent").withTenantId(tenantId).activate(DEFAULT_USER.getUsername());
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("agent")
+            .getFirst()
+            .getKey();
+
+    return new TestSetup(agentInstanceKey, jobKey, elementInstanceKey);
+  }
+
+  private void assignUserToTenant(final String tenantId, final String username) {
+    engine
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityType(EntityType.USER)
+        .withEntityId(username)
+        .add();
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+
+  private void addPermissionsToUser(
+      final UserRecordValue user,
+      final AuthorizationResourceType authorization,
+      final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
+      final String resourceId) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(authorization)
+        .withResourceMatcher(matcher)
+        .withResourceId(resourceId)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private record TestSetup(long agentInstanceKey, long jobKey, long elementInstanceKey) {}
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
@@ -62,6 +62,13 @@ public class AgentHistoryCreateTest {
     assertThat(created.getValue().getAgentInstanceKey()).isEqualTo(agentInstanceKey);
     assertThat(created.getValue().getJobKey()).isEqualTo(jobKey);
     assertThat(created.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+
+    final var committed =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+            .withAgentInstanceKey(agentInstanceKey)
+            .getFirst();
+    assertThat(committed.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(committed.getKey()).isEqualTo(created.getKey());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AgentHistoryCreateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String SERVICE_TASK_ID = "agent-task";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldEmitCreatedEventOnHappyPath() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+
+    final var agentInstanceRecord = createAgentInstance(elementInstanceKey);
+    final var agentInstanceKey = agentInstanceRecord.getKey();
+
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    final Record<AgentHistoryRecordValue> created =
+        ENGINE
+            .agentHistories()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withJobKey(jobKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withRole(AgentHistoryRole.USER)
+            .create();
+
+    assertThat(created.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(created.getIntent()).isEqualTo(AgentHistoryIntent.CREATED);
+    assertThat(created.getValue().getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(created.getValue().getAgentInstanceKey()).isEqualTo(agentInstanceKey);
+    assertThat(created.getValue().getJobKey()).isEqualTo(jobKey);
+    assertThat(created.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+  }
+
+  @Test
+  public void shouldRejectWhenAgentInstanceNotFound() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    final Record<AgentHistoryRecordValue> rejection =
+        ENGINE
+            .agentHistories()
+            .withAgentInstanceKey(999999999L)
+            .withJobKey(jobKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .expectRejection()
+            .create();
+
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason()).contains("999999999");
+  }
+
+  @Test
+  public void shouldRejectWhenJobNotActivated() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+
+    final var agentInstanceRecord = createAgentInstance(elementInstanceKey);
+    final var agentInstanceKey = agentInstanceRecord.getKey();
+
+    final Record<AgentHistoryRecordValue> rejection =
+        ENGINE
+            .agentHistories()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withJobKey(888888888L)
+            .withElementInstanceKey(elementInstanceKey)
+            .expectRejection()
+            .create();
+
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason()).contains("888888888");
+  }
+
+  @Test
+  public void shouldRejectWhenElementInstanceKeyMismatch() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+
+    final var agentInstanceRecord = createAgentInstance(elementInstanceKey);
+    final var agentInstanceKey = agentInstanceRecord.getKey();
+
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    final Record<AgentHistoryRecordValue> rejection =
+        ENGINE
+            .agentHistories()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withJobKey(jobKey)
+            .withElementInstanceKey(elementInstanceKey + 9999L)
+            .expectRejection()
+            .create();
+
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldRejectWhenElementInstanceNotInAgentInstance() {
+    // Two separate process instances; an agent instance is created only for the first.
+    // The history command supplies the second job (whose elementInstanceKey is the second element
+    // instance) together with the first agent instance — the element instance is not in the agent
+    // instance's list, so the engine must reject with NOT_FOUND.
+    final var firstServiceTask = deployAndCreateProcessInstance();
+    final var firstElementInstanceKey = firstServiceTask.getKey();
+    final var firstProcessInstanceKey = firstServiceTask.getValue().getProcessInstanceKey();
+
+    // Activate the first job so it is no longer available for subsequent activate calls.
+    activateJobForProcessInstance(firstProcessInstanceKey);
+
+    final var secondProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var secondServiceTask =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(secondProcessInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst();
+    final var secondElementInstanceKey = secondServiceTask.getKey();
+
+    final var agentInstanceRecord = createAgentInstance(firstElementInstanceKey);
+    final var agentInstanceKey = agentInstanceRecord.getKey();
+
+    final var secondJobKey = activateJobForProcessInstance(secondProcessInstanceKey);
+
+    final Record<AgentHistoryRecordValue> rejection =
+        ENGINE
+            .agentHistories()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withJobKey(secondJobKey)
+            .withElementInstanceKey(secondElementInstanceKey)
+            .expectRejection()
+            .create();
+
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason()).contains(String.valueOf(secondElementInstanceKey));
+  }
+
+  // --- helpers ---
+
+  private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .withElementId(SERVICE_TASK_ID)
+        .getFirst();
+  }
+
+  private static long activateJobForProcessInstance(final long processInstanceKey) {
+    ENGINE.jobs().withType("agent").activate();
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType("agent")
+        .getFirst()
+        .getKey();
+  }
+
+  private static Record<?> createAgentInstance(final long elementInstanceKey) {
+    return ENGINE
+        .agentInstances()
+        .withElementInstanceKey(elementInstanceKey)
+        .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+        .create();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.engine.state.immutable.RoutingState;
 import io.camunda.zeebe.engine.state.migration.DbMigratorImpl;
 import io.camunda.zeebe.engine.util.TestInterPartitionCommandSender.CommandInterceptor;
 import io.camunda.zeebe.engine.util.client.AdHocSubProcessActivityClient;
+import io.camunda.zeebe.engine.util.client.AgentHistoryClient;
 import io.camunda.zeebe.engine.util.client.AgentInstanceClient;
 import io.camunda.zeebe.engine.util.client.AuthorizationClient;
 import io.camunda.zeebe.engine.util.client.BatchOperationClient;
@@ -552,6 +553,10 @@ public final class EngineRule extends ExternalResource {
 
   public AgentInstanceClient agentInstances() {
     return new AgentInstanceClient(environmentRule);
+  }
+
+  public AgentHistoryClient agentHistories() {
+    return new AgentHistoryClient(environmentRule);
   }
 
   public SignalClient signal() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
@@ -95,4 +95,14 @@ public final class AgentHistoryClient {
             AgentHistoryIntent.CREATE, record, authorizedTenantIds.toArray(new String[0]));
     return (expectRejection ? CREATE_REJECTION_EXPECTATION : CREATED_EXPECTATION).apply(position);
   }
+
+  public Record<AgentHistoryRecordValue> create(final String username) {
+    final long position =
+        writer.writeCommand(
+            AgentHistoryIntent.CREATE,
+            username,
+            record,
+            authorizedTenantIds.toArray(new String[0]));
+    return (expectRejection ? CREATE_REJECTION_EXPECTATION : CREATED_EXPECTATION).apply(position);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
+import java.util.function.Function;
+
+public final class AgentHistoryClient {
+
+  private static final Function<Long, Record<AgentHistoryRecordValue>> CREATED_EXPECTATION =
+      (position) ->
+          RecordingExporter.agentHistoryRecords()
+              .withIntent(AgentHistoryIntent.CREATED)
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private static final Function<Long, Record<AgentHistoryRecordValue>>
+      CREATE_REJECTION_EXPECTATION =
+          (position) ->
+              RecordingExporter.agentHistoryRecords()
+                  .onlyCommandRejections()
+                  .withIntent(AgentHistoryIntent.CREATE)
+                  .withSourceRecordPosition(position)
+                  .getFirst();
+
+  private final CommandWriter writer;
+  private final AgentHistoryRecord record = new AgentHistoryRecord();
+  private List<String> authorizedTenantIds = List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private boolean expectRejection = false;
+
+  public AgentHistoryClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public AgentHistoryClient withAgentInstanceKey(final long agentInstanceKey) {
+    record.setAgentInstanceKey(agentInstanceKey);
+    return this;
+  }
+
+  public AgentHistoryClient withJobKey(final long jobKey) {
+    record.setJobKey(jobKey);
+    return this;
+  }
+
+  public AgentHistoryClient withJobLease(final String jobLease) {
+    record.setJobLease(jobLease);
+    return this;
+  }
+
+  public AgentHistoryClient withElementInstanceKey(final long elementInstanceKey) {
+    record.setElementInstanceKey(elementInstanceKey);
+    return this;
+  }
+
+  public AgentHistoryClient withIteration(final int iteration) {
+    record.setIteration(iteration);
+    return this;
+  }
+
+  public AgentHistoryClient withRole(final AgentHistoryRole role) {
+    record.setRole(role);
+    return this;
+  }
+
+  public AgentHistoryClient withTenantId(final String tenantId) {
+    record.setTenantId(tenantId);
+    return this;
+  }
+
+  public AgentHistoryClient withAuthorizedTenantIds(final String... tenantIds) {
+    authorizedTenantIds = List.of(tenantIds);
+    return this;
+  }
+
+  public AgentHistoryClient expectRejection() {
+    expectRejection = true;
+    return this;
+  }
+
+  public Record<AgentHistoryRecordValue> create() {
+    final long position =
+        writer.writeCommand(
+            AgentHistoryIntent.CREATE, record, authorizedTenantIds.toArray(new String[0]));
+    return (expectRejection ? CREATE_REJECTION_EXPECTATION : CREATED_EXPECTATION).apply(position);
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -24,7 +24,7 @@ import java.util.List;
 public final class AgentHistoryRecord extends UnifiedRecordValue
     implements AgentHistoryRecordValue {
 
-  private final LongProperty historyItemKeyProp = new LongProperty("historyItemKey", -1L);
+  private final LongProperty agentHistoryKeyProp = new LongProperty("agentHistoryKey", -1L);
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
@@ -52,7 +52,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord() {
     super(16);
-    declareProperty(historyItemKeyProp)
+    declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
@@ -71,12 +71,12 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   }
 
   @Override
-  public long getHistoryItemKey() {
-    return historyItemKeyProp.getValue();
+  public long getAgentHistoryKey() {
+    return agentHistoryKeyProp.getValue();
   }
 
-  public AgentHistoryRecord setHistoryItemKey(final long historyItemKey) {
-    historyItemKeyProp.setValue(historyItemKey);
+  public AgentHistoryRecord setAgentHistoryKey(final long agentHistoryKey) {
+    agentHistoryKeyProp.setValue(agentHistoryKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -24,6 +24,7 @@ import java.util.List;
 public final class AgentHistoryRecord extends UnifiedRecordValue
     implements AgentHistoryRecordValue {
 
+  private final LongProperty historyItemKeyProp = new LongProperty("historyItemKey", -1L);
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
@@ -50,8 +51,9 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new ObjectProperty<>("metrics", new AgentHistoryMetrics());
 
   public AgentHistoryRecord() {
-    super(15);
-    declareProperty(agentInstanceKeyProp)
+    super(16);
+    declareProperty(historyItemKeyProp)
+        .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
@@ -66,6 +68,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         .declareProperty(contentProp)
         .declareProperty(toolCallsProp)
         .declareProperty(metricsProp);
+  }
+
+  @Override
+  public long getHistoryItemKey() {
+    return historyItemKeyProp.getValue();
+  }
+
+  public AgentHistoryRecord setHistoryItemKey(final long historyItemKey) {
+    historyItemKeyProp.setValue(historyItemKey);
+    return this;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4859,7 +4859,7 @@ final class JsonSerializableToJsonTest {
             () -> {
               final AgentHistoryRecord record =
                   new AgentHistoryRecord()
-                      .setHistoryItemKey(2251799813685250L)
+                      .setAgentHistoryKey(2251799813685250L)
                       .setAgentInstanceKey(2251799813685251L)
                       .setElementInstanceKey(2251799813685249L)
                       .setJobKey(2251799813685252L)
@@ -4915,7 +4915,7 @@ final class JsonSerializableToJsonTest {
             },
         """
         {
-          "historyItemKey": 2251799813685250,
+          "agentHistoryKey": 2251799813685250,
           "agentInstanceKey": 2251799813685251,
           "elementInstanceKey": 2251799813685249,
           "jobKey": 2251799813685252,
@@ -4971,7 +4971,7 @@ final class JsonSerializableToJsonTest {
         (Supplier<UnifiedRecordValue>) AgentHistoryRecord::new,
         """
         {
-          "historyItemKey": -1,
+          "agentHistoryKey": -1,
           "agentInstanceKey": -1,
           "elementInstanceKey": -1,
           "jobKey": -1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4859,6 +4859,7 @@ final class JsonSerializableToJsonTest {
             () -> {
               final AgentHistoryRecord record =
                   new AgentHistoryRecord()
+                      .setHistoryItemKey(2251799813685250L)
                       .setAgentInstanceKey(2251799813685251L)
                       .setElementInstanceKey(2251799813685249L)
                       .setJobKey(2251799813685252L)
@@ -4914,6 +4915,7 @@ final class JsonSerializableToJsonTest {
             },
         """
         {
+          "historyItemKey": 2251799813685250,
           "agentInstanceKey": 2251799813685251,
           "elementInstanceKey": 2251799813685249,
           "jobKey": 2251799813685252,
@@ -4969,6 +4971,7 @@ final class JsonSerializableToJsonTest {
         (Supplier<UnifiedRecordValue>) AgentHistoryRecord::new,
         """
         {
+          "historyItemKey": -1,
           "agentInstanceKey": -1,
           "elementInstanceKey": -1,
           "jobKey": -1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -27,6 +27,7 @@ final class AgentHistoryRecordTest {
     final AgentHistoryRecord record = new AgentHistoryRecord();
 
     // then
+    assertThat(record.getHistoryItemKey()).isEqualTo(-1L);
     assertThat(record.getAgentInstanceKey()).isEqualTo(-1L);
     assertThat(record.getElementInstanceKey()).isEqualTo(-1L);
     assertThat(record.getJobKey()).isEqualTo(-1L);
@@ -46,6 +47,7 @@ final class AgentHistoryRecordTest {
     // given
     final AgentHistoryRecord original =
         new AgentHistoryRecord()
+            .setHistoryItemKey(2251799813685250L)
             .setAgentInstanceKey(2251799813685251L)
             .setElementInstanceKey(2251799813685249L)
             .setJobKey(2251799813685252L)
@@ -60,6 +62,7 @@ final class AgentHistoryRecordTest {
     copy.copyFrom(original);
 
     // then
+    assertThat(copy.getHistoryItemKey()).isEqualTo(original.getHistoryItemKey());
     assertThat(copy.getAgentInstanceKey()).isEqualTo(original.getAgentInstanceKey());
     assertThat(copy.getElementInstanceKey()).isEqualTo(original.getElementInstanceKey());
     assertThat(copy.getJobKey()).isEqualTo(original.getJobKey());

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -27,7 +27,7 @@ final class AgentHistoryRecordTest {
     final AgentHistoryRecord record = new AgentHistoryRecord();
 
     // then
-    assertThat(record.getHistoryItemKey()).isEqualTo(-1L);
+    assertThat(record.getAgentHistoryKey()).isEqualTo(-1L);
     assertThat(record.getAgentInstanceKey()).isEqualTo(-1L);
     assertThat(record.getElementInstanceKey()).isEqualTo(-1L);
     assertThat(record.getJobKey()).isEqualTo(-1L);
@@ -47,7 +47,7 @@ final class AgentHistoryRecordTest {
     // given
     final AgentHistoryRecord original =
         new AgentHistoryRecord()
-            .setHistoryItemKey(2251799813685250L)
+            .setAgentHistoryKey(2251799813685250L)
             .setAgentInstanceKey(2251799813685251L)
             .setElementInstanceKey(2251799813685249L)
             .setJobKey(2251799813685252L)
@@ -62,7 +62,7 @@ final class AgentHistoryRecordTest {
     copy.copyFrom(original);
 
     // then
-    assertThat(copy.getHistoryItemKey()).isEqualTo(original.getHistoryItemKey());
+    assertThat(copy.getAgentHistoryKey()).isEqualTo(original.getAgentHistoryKey());
     assertThat(copy.getAgentInstanceKey()).isEqualTo(original.getAgentInstanceKey());
     assertThat(copy.getElementInstanceKey()).isEqualTo(original.getElementInstanceKey());
     assertThat(copy.getJobKey()).isEqualTo(original.getJobKey());

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
@@ -24,6 +24,7 @@ import java.util.List;
 public final class AgentHistoryRecord extends UnifiedRecordValue
     implements AgentHistoryRecordValue {
 
+  private final LongProperty agentHistoryKeyProp = new LongProperty("agentHistoryKey", -1L);
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
@@ -50,8 +51,9 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new ObjectProperty<>("metrics", new AgentHistoryMetrics());
 
   public AgentHistoryRecord() {
-    super(15);
-    declareProperty(agentInstanceKeyProp)
+    super(16);
+    declareProperty(agentHistoryKeyProp)
+        .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
@@ -66,6 +68,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         .declareProperty(contentProp)
         .declareProperty(toolCallsProp)
         .declareProperty(metricsProp);
+  }
+
+  @Override
+  public long getAgentHistoryKey() {
+    return agentHistoryKeyProp.getValue();
+  }
+
+  public AgentHistoryRecord setAgentHistoryKey(final long agentHistoryKey) {
+    agentHistoryKeyProp.setValue(agentHistoryKey);
+    return this;
   }
 
   @Override

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
 public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, ProcessInstanceRelated {
 
   /** Returns the system-generated key for this history entry. */
-  long getHistoryItemKey();
+  long getAgentHistoryKey();
 
   /** Returns the key of the agent instance that produced this history entry. */
   long getAgentInstanceKey();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -25,6 +25,9 @@ import org.immutables.value.Value;
 @ImmutableProtocol(builder = ImmutableAgentHistoryRecordValue.Builder.class)
 public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, ProcessInstanceRelated {
 
+  /** Returns the system-generated key for this history entry. */
+  long getHistoryItemKey();
+
   /** Returns the key of the agent instance that produced this history entry. */
   long getAgentInstanceKey();
 


### PR DESCRIPTION
## Description

Implements engine-side processing for `AgentHistory.CREATE`, wiring up the first operational step of the agent history lifecycle (#51795). No command processors existed for `AGENT_HISTORY` before this PR.

### Scope

- **CREATE processor** — validates and resolves the request in order:
  1. Looks up the agent instance; rejects `NOT_FOUND` if absent.
  2. Authorizes via `UPDATE_PROCESS_INSTANCE` on the agent instance's `PROCESS_DEFINITION` with fused tenant check (auth sourced from agent instance record, not from the job).
  3. Verifies the job is `ACTIVATED`; rejects `NOT_FOUND` otherwise.
  4. Resolves `elementInstanceKey` and process-context fields (`processInstanceKey`, `rootProcessInstanceKey`, `processDefinitionKey`, `tenantId`) from the job record.
  5. Cross-checks that the command's `elementInstanceKey` matches the job's; rejects `INVALID_ARGUMENT` on mismatch.
  6. Verifies the element instance is in the agent instance's key list; rejects `NOT_FOUND` otherwise.
  7. Emits `CREATED`, writes the response, then emits `COMMITTED` (see below).
- **Short-circuit `COMMITTED`** — emits `COMMITTED` in the same processor step as a temporary measure, so consumers immediately see a terminal state without a separate commit step. The pending-commit lifecycle (#55033) will introduce a dedicated `AgentHistoryCommitProcessor`; a TODO comment marks the removal point. `commitStatus` is intentionally left `UNSPECIFIED` — the field is not set by the processor nor the NOOP applier; a follow-up will remove it from the record schema entirely, at which point the `COMMITTED` event becomes the sole terminal signal.
- **NOOP appliers** — `CREATED`, `COMMITTED`, and `DISCARDED` event appliers are registered as NOOP. No RocksDB state changes in this scope.
- **Tests** — happy path (asserts `CREATED` + `COMMITTED` events with correct field values), agent-instance-not-found, job-not-activated, element-instance-key mismatch (`INVALID_ARGUMENT`), element-instance-not-in-agent-instance. Authorization tests: permission granted → `CREATED`, no permission → `FORBIDDEN`, wrong tenant → `NOT_FOUND`.

### Deliberately out of scope

- Exporter handler (`AgentHistoryCreatedHandler` / `AgentHistoryCommittedHandler`) — separate epic.
- `COMMIT` command processor — part of #55033.
- `DISCARD` intent — separate processor.
- RocksDB state (column family, state reader/writer) — not needed until the commit lifecycle lands.
- Webapps-schema layer (`AgentHistoryTemplate`, `AgentHistoryEntity`) — separate PR.
- Golden files for appliers (NOOP).

## Checklist

- [ ] Enable backports when necessary
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the on-demand workflow

## Related issues

related to #51795

## Follow-ups

- #55033 — Implement pending-commit lifecycle; remove inline `COMMITTED` emission from `AgentHistoryCreateProcessor` and drop `commitStatus` from the record schema