### PR TITLE
ci: share frontend build outputs from build-platform-frontend to deploy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,13 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   build-platform-frontend:
-    if: needs.detect-changes.outputs.frontend-changes == 'true'
+    # Runs when the frontend changed, OR on any non-PR event targeting main/stable
+    # (push/schedule/workflow_dispatch) so the snapshot deploy jobs — which download
+    # these artifacts and run with `always()` on those refs — always have a producer.
+    if: >-
+      needs.detect-changes.outputs.frontend-changes == 'true' ||
+      (github.event_name != 'pull_request' &&
+       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')))
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,32 @@ jobs:
         id: build-optimize-fe
         with:
           directory: ./optimize/client
+      # Share the built frontend bundles so the snapshot deploy jobs download them
+      # instead of rebuilding (see issue #52693). Short retention: consumed within the same run.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fe-operate-${{ github.run_id }}
+          path: operate/client/build
+          retention-days: 1
+          if-no-files-found: error
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fe-tasklist-${{ github.run_id }}
+          path: tasklist/client/build
+          retention-days: 1
+          if-no-files-found: error
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fe-identity-${{ github.run_id }}
+          path: identity/client/dist
+          retention-days: 1
+          if-no-files-found: error
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fe-optimize-${{ github.run_id }}
+          path: optimize/client/dist
+          retention-days: 1
+          if-no-files-found: error
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -2145,7 +2171,7 @@ jobs:
 
   deploy-snapshots:
     name: Deploy snapshot artifacts
-    needs: [ check-results, utils-get-concurrency-group-for-maven-snapshot ]
+    needs: [ check-results, build-platform-frontend, utils-get-concurrency-group-for-maven-snapshot ]
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 25
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -2163,21 +2189,21 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - uses: ./.github/actions/build-frontend
-        id: build-operate-fe
+      # Frontend bundles are built once in build-platform-frontend and downloaded here
+      # instead of being rebuilt (issue #52693). mvn runs with -PskipFrontendBuild below.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          directory: ./operate/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        id: build-tasklist-fe
+          name: fe-operate-${{ github.run_id }}
+          path: operate/client/build
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          directory: ./tasklist/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        id: build-identity-fe
+          name: fe-tasklist-${{ github.run_id }}
+          path: tasklist/client/build
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          directory: ./identity/client
-          package-manager: "npm"
+          name: fe-identity-${{ github.run_id }}
+          path: identity/client/dist
+      # Not produced by build-platform-frontend, so still built inline here.
       - uses: ./.github/actions/build-frontend
         id: build-cpt-coverage-fe
         with:
@@ -2219,7 +2245,7 @@ jobs:
 
   deploy-camunda-docker-snapshot:
     name: Deploy snapshot Camunda Docker image
-    needs: [ check-results, utils-get-snapshot-docker-tag, utils-get-concurrency-group-for-docker-snapshot ]
+    needs: [ check-results, build-platform-frontend, utils-get-snapshot-docker-tag, utils-get-concurrency-group-for-docker-snapshot ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -2238,21 +2264,20 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
-      - uses: ./.github/actions/build-frontend
-        id: build-operate-fe
+      # Frontend bundles are built once in build-platform-frontend and downloaded here
+      # instead of being rebuilt (issue #52693). build-zeebe runs with -PskipFrontendBuild below.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          directory: ./operate/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        id: build-tasklist-fe
+          name: fe-operate-${{ github.run_id }}
+          path: operate/client/build
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          directory: ./tasklist/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        id: build-identity-fe
+          name: fe-tasklist-${{ github.run_id }}
+          path: tasklist/client/build
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          directory: ./identity/client
-          package-manager: "npm"
+          name: fe-identity-${{ github.run_id }}
+          path: identity/client/dist
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:
@@ -2290,7 +2315,7 @@ jobs:
 
   deploy-optimize-docker-snapshot:
     name: Deploy snapshot Optimize Docker image
-    needs: [ check-results, utils-get-snapshot-docker-tag, utils-get-concurrency-group-for-optimize-docker-snapshot ]
+    needs: [ check-results, build-platform-frontend, utils-get-snapshot-docker-tag, utils-get-concurrency-group-for-optimize-docker-snapshot ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -2311,10 +2336,12 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
-      - uses: ./.github/actions/build-frontend
-        id: build-optimize-fe
+      # Optimize frontend bundle is built once in build-platform-frontend and downloaded here
+      # instead of being rebuilt (issue #52693). The Optimize assembly runs with -PskipFrontendBuild below.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          directory: ./optimize/client
+          name: fe-optimize-${{ github.run_id }}
+          path: optimize/client/dist
       - name: Build zeebe-protocol from source
         uses: ./.github/actions/run-maven
         with:


### PR DESCRIPTION
## Summary

Part of #52693 (PR 7 of the build-elimination epic).

`build-platform-frontend` already builds all four frontend bundles (operate, tasklist, identity, optimize) purely to validate them, then discards the output. The three snapshot deploy jobs each rebuilt the same bundles from scratch.

This PR uploads the four bundles as run-scoped artifacts in `build-platform-frontend` and has the deploy jobs download them instead of rebuilding:

- **`build-platform-frontend`** — uploads `fe-{operate,tasklist,identity,optimize}-${{ github.run_id }}` (`retention-days: 1`).
- **`deploy-snapshots`** — downloads operate/tasklist/identity instead of building them.
- **`deploy-camunda-docker-snapshot`** — downloads operate/tasklist/identity instead of building them.
- **`deploy-optimize-docker-snapshot`** — downloads optimize instead of building it.

Each deploy job gains an explicit `needs: build-platform-frontend`.

## Why this is safe

The deploy jobs already run Maven with `-PskipFrontendBuild`, which skips only the npm/yarn rebuild — the Maven resource-copy of the build output (`*/client/build`, `*/client/dist`) into the JAR/assembly still runs. So the shared artifact is equivalent to what each job produced before; behaviour is unchanged.

`frontend-changes` resolves to `true` on every `push` event, so `build-platform-frontend` always runs on the `main`/`stable` pushes where the deploy jobs run — the producer is always present for the consumers. Fan-out is at most two consumers per artifact, so the artifact API is sufficient (no shared-cache/GCS transport needed).

## Expected impact (theoretical, from a recent main run)

| Job | Runner | FE build today | After (download) |
|---|---|---|---|
| `deploy-snapshots` | gcp (paid) | ~105s | ~30s |
| `deploy-camunda-docker-snapshot` | ubuntu | ~113s | ~30s |
| `deploy-optimize-docker-snapshot` | ubuntu | ~96s | ~10s |

Net-positive on day one (no transport regression): each deploy job ~75–86s faster and the paid gcp runner is freed sooner; producer gains ~35s of uploads on a free runner.

## Test plan

- [ ] `actionlint` clean (only pre-existing self-hosted runner-label findings)
- [ ] `conftest` policy check passes
- [ ] First `main`/`stable` push: all three deploy jobs download the bundles and publish snapshots successfully

## Test proof — end-to-end verification on a PR run

The snapshot deploy jobs are `main`/`stable`-only, so on a PR the artifact-share mechanic never runs. To validate it before merge, three temporary jobs mirrored each deploy job's build (same download + same Maven/build commands, minus the publish/push) and asserted the **downloaded** bundle is embedded in the produced artifact under `-PskipFrontendBuild`. All green (temporary jobs since reverted):

Run: https://github.com/camunda/camunda/actions/runs/28515398976

- ✅ [`verify-embed-webjars-throwaway`](https://github.com/camunda/camunda/actions/runs/28515398976/job/84527242837) — operate/tasklist/identity bundles embedded in their webjars at `META-INF/resources/{operate,tasklist,admin}` (mirrors `deploy-snapshots`).
- ✅ [`verify-embed-distball-throwaway`](https://github.com/camunda/camunda/actions/runs/28515398976/job/84527242784) — the camunda distball bundles those webjars carrying the FE (mirrors `deploy-camunda-docker-snapshot`).
- ✅ [`verify-embed-optimize-throwaway`](https://github.com/camunda/camunda/actions/runs/28515398976/job/84527242793) — the Optimize production assembly embeds the FE in the backend jar (mirrors `deploy-optimize-docker-snapshot`).

This proves the full mechanic (build → upload → download → embed) for all three deploy paths. Only the actual publish/push steps (unchanged by this PR) and the `workflow_dispatch` ref-guard (logic-only) are not exercisable on a PR.
