### PR TITLE
feat: support changing PartitionDistribution

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -116,7 +116,6 @@ final class ClusterApiUtils {
           case final ConnectException ignore -> 502;
           case final NoSuchMemberException ignore -> 502;
           case final TimeoutException ignore -> 504;
-          case final IllegalArgumentException ignore -> 400;
           default -> 500;
         };
     return ResponseEntity.status(status).body(errorResponse);
@@ -413,19 +412,13 @@ final class ClusterApiUtils {
 
   static PartitionDistributorConfig toPartitionDistributorConfig(
       final io.camunda.zeebe.management.cluster.PartitionDistributionConfig dto) {
-    if (dto.getType() != TypeEnum.ZONE_AWARE) {
-      throw new IllegalArgumentException(
-          "Only ZONE_AWARE partition distribution config is supported. Received: " + dto.getType());
-    }
     final List<PartitionDistributorConfig.ZoneSpec> zones =
-        dto.getZones() == null
-            ? List.of()
-            : dto.getZones().stream()
-                .map(
-                    z ->
-                        new PartitionDistributorConfig.ZoneSpec(
-                            z.getName(), z.getNumberOfReplicas(), z.getPriority()))
-                .toList();
+        dto.getZones().stream()
+            .map(
+                z ->
+                    new PartitionDistributorConfig.ZoneSpec(
+                        z.getName(), z.getNumberOfReplicas(), z.getPriority()))
+            .toList();
     return new ZoneAwareConfig(zones);
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -116,6 +116,7 @@ final class ClusterApiUtils {
           case final ConnectException ignore -> 502;
           case final NoSuchMemberException ignore -> 502;
           case final TimeoutException ignore -> 504;
+          case final IllegalArgumentException ignore -> 400;
           default -> 500;
         };
     return ResponseEntity.status(status).body(errorResponse);

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -410,6 +410,24 @@ final class ClusterApiUtils {
     return result;
   }
 
+  static PartitionDistributorConfig toPartitionDistributorConfig(
+      final io.camunda.zeebe.management.cluster.PartitionDistributionConfig dto) {
+    if (dto.getType() != TypeEnum.ZONE_AWARE) {
+      throw new IllegalArgumentException(
+          "Only ZONE_AWARE partition distribution config is supported. Received: " + dto.getType());
+    }
+    final List<PartitionDistributorConfig.ZoneSpec> zones =
+        dto.getZones() == null
+            ? List.of()
+            : dto.getZones().stream()
+                .map(
+                    z ->
+                        new PartitionDistributorConfig.ZoneSpec(
+                            z.getName(), z.getNumberOfReplicas(), z.getPriority()))
+                .toList();
+    return new ZoneAwareConfig(zones);
+  }
+
   private static io.camunda.zeebe.management.cluster.RoutingState mapRoutingState(
       final RoutingState routingState) {
     return new io.camunda.zeebe.management.cluster.RoutingState()

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -62,6 +62,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -479,7 +480,7 @@ public class ClusterEndpoint {
     }
   }
 
-  @PatchMapping(path = "/partition-distribution", consumes = "application/json")
+  @PutMapping(path = "/partition-distribution", consumes = "application/json")
   public ResponseEntity<?> updatePartitionDistribution(
       @RequestBody final PartitionDistributionConfig partitionDistributionConfig,
       @RequestParam(defaultValue = "false") final boolean dryRun) {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -33,6 +34,7 @@ import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.Error;
 import io.camunda.zeebe.management.cluster.MessageCorrelationHashMod;
+import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.RequestHandlingActivePartitions;
 import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
 import io.camunda.zeebe.management.cluster.RoutingState;
@@ -472,6 +474,21 @@ public class ClusterEndpoint {
       final var updateRequest = new UpdateRoutingStateRequest(internalRoutingState, dryRun);
       return ClusterApiUtils.mapOperationResponse(
           requestSender.updateRoutingState(updateRequest).join());
+    } catch (final Exception error) {
+      return ClusterApiUtils.mapError(error);
+    }
+  }
+
+  @PatchMapping(path = "/partition-distribution", consumes = "application/json")
+  public ResponseEntity<?> updatePartitionDistribution(
+      @RequestBody final PartitionDistributionConfig partitionDistributionConfig,
+      @RequestParam(defaultValue = "false") final boolean dryRun) {
+    try {
+      final var internalConfig =
+          ClusterApiUtils.toPartitionDistributorConfig(partitionDistributionConfig);
+      final var updateRequest = new UpdatePartitionDistributorConfigRequest(internalConfig, dryRun);
+      return ClusterApiUtils.mapOperationResponse(
+          requestSender.updatePartitionDistribution(updateRequest).join());
     } catch (final Exception error) {
       return ClusterApiUtils.mapError(error);
     }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -489,8 +489,8 @@ public class ClusterEndpoint {
       final var updateRequest = new UpdatePartitionDistributorConfigRequest(internalConfig, dryRun);
       return ClusterApiUtils.mapOperationResponse(
           requestSender.updatePartitionDistribution(updateRequest).join());
-    } catch (final Exception error) {
-      return ClusterApiUtils.mapError(error);
+    } catch (final Exception exception) {
+      return ClusterApiUtils.mapError(exception);
     }
   }
 

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -184,6 +184,39 @@ paths:
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
 
+  /partition-distribution:
+    patch:
+      summary:
+        Update the partition distribution configuration for a zone-aware cluster. The
+        new configuration is applied immediately by computing and executing the necessary
+        partition join, leave, and priority-reconfiguration operations. Only ZONE_AWARE
+        clusters and ZONE_AWARE config bodies are accepted.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "components.yaml#/schemas/PartitionDistributionConfig"
+      parameters:
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
 components:
   parameters:
     BrokerId:

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -185,7 +185,7 @@ paths:
           $ref: 'components.yaml#/responses/TimeoutError'
 
   /partition-distribution:
-    patch:
+    put:
       summary:
         Update the partition distribution configuration for a zone-aware cluster. The
         new configuration is applied immediately by computing and executing the necessary

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -61,6 +62,9 @@ public interface ClusterConfigurationManagementApi {
 
   ActorFuture<ClusterConfigurationChangeResponse> updateRoutingState(
       UpdateRoutingStateRequest updateRoutingStateRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> updatePartitionDistribution(
+      UpdatePartitionDistributorConfigRequest request);
 
   ActorFuture<ClusterConfigurationChangeResponse> purge(PurgeRequest purgeRequest);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import java.util.Optional;
 import java.util.Set;
@@ -62,6 +63,9 @@ public sealed interface ClusterConfigurationManagementRequest {
       implements ClusterConfigurationManagementRequest {}
 
   record UpdateRoutingStateRequest(Optional<RoutingState> routingState, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
+  record UpdatePartitionDistributorConfigRequest(PartitionDistributorConfig config, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
   record ForceRemoveBrokersRequest(Set<MemberId> membersToRemove, boolean dryRun)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationRequestsSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -227,6 +228,17 @@ public final class ClusterConfigurationManagementRequestSender {
         ClusterConfigurationRequestTopics.UPDATE_ROUTING_STATE.topic(),
         updateRoutingStateRequest,
         serializer::encodeUpdateRoutingStateRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      updatePartitionDistribution(final UpdatePartitionDistributorConfigRequest request) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.UPDATE_PARTITION_DISTRIBUTION.topic(),
+        request,
+        serializer::encodeUpdatePartitionDistributorConfigRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
@@ -167,6 +168,13 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         updateRoutingStateRequest.dryRun(),
         new UpdateRoutingStateTransformer(updateRoutingStateRequest.routingState()));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> updatePartitionDistribution(
+      final UpdatePartitionDistributorConfigRequest request) {
+    return handleRequest(
+        request.dryRun(), new UpdatePartitionDistributionTransformer(request.config()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -50,6 +50,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerClusterScaleRequestHandler();
     registerClusterPatchRequestHandler();
     registerUpdateRoutingStateHandler();
+    registerUpdatePartitionDistributionHandler();
     registerForceRemoveBrokersRequestHandler();
     registerPurgeRequestHandler();
   }
@@ -204,6 +205,15 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.UPDATE_ROUTING_STATE.topic(),
         serializer::decodeUpdateRoutingStateRequest,
         request -> mapResponse(clusterConfigurationManagementApi.updateRoutingState(request)),
+        this::encodeResponse);
+  }
+
+  private void registerUpdatePartitionDistributionHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.UPDATE_PARTITION_DISTRIBUTION.topic(),
+        serializer::decodeUpdatePartitionDistributorConfigRequest,
+        request ->
+            mapResponse(clusterConfigurationManagementApi.updatePartitionDistribution(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -25,7 +25,8 @@ public enum ClusterConfigurationRequestTopics {
   PATCH_CLUSTER("topology-cluster-patch"),
   PURGE("topology-cluster-purge"),
   FORCE_REMOVE_BROKERS("topology-broker-force-remove"),
-  UPDATE_ROUTING_STATE("topology-cluster-update-routing-state");
+  UPDATE_ROUTING_STATE("topology-cluster-update-routing-state"),
+  UPDATE_PARTITION_DISTRIBUTION("topology-cluster-update-partition-distribution");
 
   private final String topic;
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdatePartitionDistributorConfigOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Computes the operations needed to apply a new {@link ZoneAwareConfig} to a zone-aware cluster.
+ *
+ * <p>The transformer:
+ *
+ * <ol>
+ *   <li>Validates that the cluster is currently zone-aware.
+ *   <li>Validates that the requested config is a {@link ZoneAwareConfig} (no type switches).
+ *   <li>Prepends an {@link UpdatePartitionDistributorConfigOperation} so the new config is
+ *       persisted before redistribution begins.
+ *   <li>Delegates to {@link PartitionReassignRequestTransformer} against a temporary configuration
+ *       that already carries the new distributor, so the diff reflects the new placement strategy.
+ * </ol>
+ */
+public class UpdatePartitionDistributionTransformer implements ConfigurationChangeRequest {
+
+  private final PartitionDistributorConfig newConfig;
+
+  public UpdatePartitionDistributionTransformer(final PartitionDistributorConfig newConfig) {
+    this.newConfig = newConfig;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration currentConfiguration) {
+
+    if (!currentConfiguration.isZoneAware()) {
+      return Either.left(
+          new InvalidRequest(
+              "Partition distribution changes are only supported on zone-aware clusters."));
+    }
+
+    if (!(newConfig instanceof final ZoneAwareConfig zoneAwareConfig)) {
+      return Either.left(
+          new InvalidRequest(
+              "Only ZONE_AWARE partition distribution config is supported. Received: "
+                  + newConfig.getClass().getSimpleName()));
+    }
+
+    final var coordinator =
+        ClusterConfigurationCoordinatorSupplier.of(() -> currentConfiguration)
+            .getDefaultCoordinator();
+
+    // Apply the new config to produce a temporary configuration whose partitionDistributor()
+    // returns the new ZoneAwarePartitionDistributor. This is only used for distribution
+    // computation; the real version bump happens when the config-set operation is applied.
+    final var updatedConfiguration = currentConfiguration.setPartitionDistributorConfig(newConfig);
+
+    final var members = currentConfiguration.members().keySet();
+
+    return new PartitionReassignRequestTransformer(
+            members, Optional.of(zoneAwareConfig.replicationFactor()), Optional.empty())
+        .operations(updatedConfiguration)
+        .map(
+            ops -> {
+              final var allOps = new ArrayList<ClusterConfigurationChangeOperation>(ops.size() + 1);
+              allOps.add(new UpdatePartitionDistributorConfigOperation(coordinator, newConfig));
+              allOps.addAll(ops);
+              return allOps;
+            });
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -58,6 +58,12 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
                   + newConfig.getClass().getSimpleName()));
     }
 
+    if (zoneAwareConfig.zones().isEmpty()) {
+      return Either.left(
+          new InvalidRequest(
+              "Expected partition distribution config to be contain at least one zone, but was empty"));
+    }
+
     final var coordinator =
         ClusterConfigurationCoordinatorSupplier.of(() -> currentConfiguration)
             .getDefaultCoordinator();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -56,6 +57,9 @@ public interface ClusterConfigurationRequestsSerializer {
       ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest forceRemoveBrokersRequest);
 
   byte[] encodeUpdateRoutingStateRequest(UpdateRoutingStateRequest updateRoutingStateRequest);
+
+  byte[] encodeUpdatePartitionDistributorConfigRequest(
+      UpdatePartitionDistributorConfigRequest request);
 
   ClusterConfigurationManagementRequest.AddMembersRequest decodeAddMembersRequest(
       byte[] encodedState);
@@ -109,4 +113,7 @@ public interface ClusterConfigurationRequestsSerializer {
   Either<ErrorResponse, ClusterConfiguration> decodeClusterTopologyResponse(byte[] encodedResponse);
 
   UpdateRoutingStateRequest decodeUpdateRoutingStateRequest(byte[] bytes);
+
+  UpdatePartitionDistributorConfigRequest decodeUpdatePartitionDistributorConfigRequest(
+      byte[] bytes);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
@@ -1038,6 +1039,16 @@ public class ProtoBufSerializer
   }
 
   @Override
+  public byte[] encodeUpdatePartitionDistributorConfigRequest(
+      final UpdatePartitionDistributorConfigRequest request) {
+    return Requests.UpdatePartitionDistributorConfigRequest.newBuilder()
+        .setConfig(encodePartitionDistributorConfig(request.config()))
+        .setDryRun(request.dryRun())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
   public AddMembersRequest decodeAddMembersRequest(final byte[] encodedState) {
     try {
       final var addMemberRequest = Requests.AddMembersRequest.parseFrom(encodedState);
@@ -1325,6 +1336,25 @@ public class ProtoBufSerializer
     }
     final var routingState = decodeRoutingState(proto.getRoutingState());
     return new UpdateRoutingStateRequest(routingState, proto.getDryRun());
+  }
+
+  @Override
+  public UpdatePartitionDistributorConfigRequest decodeUpdatePartitionDistributorConfigRequest(
+      final byte[] bytes) {
+    final Requests.UpdatePartitionDistributorConfigRequest proto;
+    try {
+      proto = Requests.UpdatePartitionDistributorConfigRequest.parseFrom(bytes);
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+    final var config =
+        decodePartitionDistributorConfig(proto.getConfig())
+            .orElseThrow(
+                () ->
+                    new DecodingFailed(
+                        new IllegalArgumentException(
+                            "UpdatePartitionDistributorConfigRequest has empty config")));
+    return new UpdatePartitionDistributorConfigRequest(config, proto.getDryRun());
   }
 
   public Builder encodeTopologyChangeResponse(

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -58,6 +58,11 @@ message UpdateRoutingStateRequest{
   bool dryRun = 2;
 }
 
+message UpdatePartitionDistributorConfigRequest {
+  topology_protocol.PartitionDistributorConfig config = 1;
+  bool dryRun = 2;
+}
+
 message ForceRemoveBrokersRequest {
   repeated string membersToRemove = 1;
   bool dryRun = 2;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdatePartitionDistributorConfigOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class UpdatePartitionDistributionTransformerTest {
+
+  private static final DynamicPartitionConfig PARTITION_CONFIG = DynamicPartitionConfig.init();
+
+  // 3 partitions, 2 zones: zone-a (1 replica, priority 1000), zone-b (1 replica, priority 500)
+  // Members: zone-a_0, zone-a_1, zone-b_0 — RF = 2
+  private static final ZoneAwareConfig INITIAL_CONFIG =
+      new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1000), new ZoneSpec("zone-b", 1, 500)));
+
+  private static final Set<MemberId> MEMBERS =
+      Set.of(MemberId.from("zone-a", 0), MemberId.from("zone-a", 1), MemberId.from("zone-b", 0));
+
+  private static final List<PartitionId> PARTITION_IDS =
+      IntStream.rangeClosed(1, 3).mapToObj(i -> PartitionId.from("temp", i)).toList();
+
+  /** Builds a topology whose partitions are placed by ZoneAwarePartitionDistributor. */
+  private static io.camunda.zeebe.dynamic.config.state.ClusterConfiguration buildTopology(
+      final ZoneAwareConfig config, final Set<MemberId> members) {
+    final var distribution =
+        new ZoneAwarePartitionDistributor(config.zones())
+            .distributePartitions(members, PARTITION_IDS, config.replicationFactor());
+    final var topology =
+        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
+    return topology.setPartitionDistributorConfig(config);
+  }
+
+  @Test
+  void shouldPrependConfigOpAndEmitJoinOpsWhenRfIncreases() {
+    // given: initial RF=2, new RF=3 (add zone-a replica)
+    final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
+    final var newConfig =
+        new ZoneAwareConfig(
+            List.of(new ZoneSpec("zone-a", 2, 1000), new ZoneSpec("zone-b", 1, 500)));
+    final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
+
+    // when
+    final var result = transformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final var ops = result.get();
+
+    // first op must set the new config
+    assertThat(ops.get(0)).isInstanceOf(UpdatePartitionDistributorConfigOperation.class);
+    final var configOp = (UpdatePartitionDistributorConfigOperation) ops.get(0);
+    assertThat(configOp.config()).isEqualTo(newConfig);
+
+    // remaining ops must include join operations (RF went from 2 → 3)
+    final var joinOps = ops.stream().filter(PartitionJoinOperation.class::isInstance).toList();
+    assertThat(joinOps).as("expected one join per partition when adding a replica").hasSize(3);
+  }
+
+  @Test
+  void shouldPrependConfigOpAndEmitLeaveOpsWhenRfDecreases() {
+    // given: initial RF=2, new RF=1 (remove zone-b replica)
+    final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
+    final var newConfig = new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1000)));
+    final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
+
+    // when
+    final var result = transformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final var ops = result.get();
+
+    assertThat(ops.get(0)).isInstanceOf(UpdatePartitionDistributorConfigOperation.class);
+    // When RF decreases the distributor may still reassign replicas within zones (joins and
+    // leaves), but net replica count per partition must decrease: leaves > joins.
+    final long leaveCount = ops.stream().filter(PartitionLeaveOperation.class::isInstance).count();
+    final long joinCount = ops.stream().filter(PartitionJoinOperation.class::isInstance).count();
+    assertThat(leaveCount)
+        .as("leaves must exceed joins when RF decreases")
+        .isGreaterThan(joinCount);
+  }
+
+  @Test
+  void shouldEmitReconfigurePriorityOpsWhenOnlyPriorityChanges() {
+    // given: same zones and RF, only priority differs
+    final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
+    final var newConfig =
+        new ZoneAwareConfig(
+            List.of(new ZoneSpec("zone-a", 1, 500), new ZoneSpec("zone-b", 1, 1000)));
+    final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
+
+    // when
+    final var result = transformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final var ops = result.get();
+
+    assertThat(ops.get(0)).isInstanceOf(UpdatePartitionDistributorConfigOperation.class);
+
+    final var priorityOps =
+        ops.stream().filter(PartitionReconfigurePriorityOperation.class::isInstance).toList();
+    assertThat(priorityOps)
+        .as("expected reconfigure-priority ops for each partition replica when priority changes")
+        .isNotEmpty();
+  }
+
+  @Test
+  void shouldRejectNonZoneAwareCluster() {
+    // given: a plain round-robin cluster with plain-integer member IDs (no zone)
+    final var plainMembers = Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2"));
+    final var distribution =
+        new RoundRobinPartitionDistributor().distributePartitions(plainMembers, PARTITION_IDS, 2);
+    final var roundRobinTopology =
+        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
+    final var newConfig =
+        new ZoneAwareConfig(
+            List.of(new ZoneSpec("zone-a", 2, 1000), new ZoneSpec("zone-b", 1, 500)));
+    final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
+
+    // when
+    final var result = transformer.operations(roundRobinTopology);
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectRoundRobinConfigBody() {
+    // given: zone-aware cluster but requesting a ROUND_ROBIN config
+    final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
+    final var transformer =
+        new UpdatePartitionDistributionTransformer(
+            new PartitionDistributorConfig.RoundRobinConfig());
+
+    // when
+    final var result = transformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectFixedConfigBody() {
+    // given: zone-aware cluster but requesting a FIXED config
+    final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
+    final var transformer =
+        new UpdatePartitionDistributionTransformer(new PartitionDistributorConfig.FixedConfig());
+
+    // when
+    final var result = transformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
@@ -37,14 +38,19 @@ class UpdatePartitionDistributionTransformerTest {
   private static final ZoneAwareConfig INITIAL_CONFIG =
       new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1000), new ZoneSpec("zone-b", 1, 500)));
 
-  private static final Set<MemberId> MEMBERS =
-      Set.of(MemberId.from("zone-a", 0), MemberId.from("zone-a", 1), MemberId.from("zone-b", 0));
+  // Coordinator = lexicographically smallest member ID = zone-a_0
+  private static final MemberId ZONE_A_0 = MemberId.from("zone-a", 0);
+  private static final MemberId ZONE_A_1 = MemberId.from("zone-a", 1);
+  private static final MemberId ZONE_B_0 = MemberId.from("zone-b", 0);
+  private static final MemberId COORDINATOR = ZONE_A_0;
+
+  private static final Set<MemberId> MEMBERS = Set.of(ZONE_A_0, ZONE_A_1, ZONE_B_0);
 
   private static final List<PartitionId> PARTITION_IDS =
       IntStream.rangeClosed(1, 3).mapToObj(i -> PartitionId.from("temp", i)).toList();
 
   /** Builds a topology whose partitions are placed by ZoneAwarePartitionDistributor. */
-  private static io.camunda.zeebe.dynamic.config.state.ClusterConfiguration buildTopology(
+  private static ClusterConfiguration buildTopology(
       final ZoneAwareConfig config, final Set<MemberId> members) {
     final var distribution =
         new ZoneAwarePartitionDistributor(config.zones())
@@ -56,77 +62,83 @@ class UpdatePartitionDistributionTransformerTest {
 
   @Test
   void shouldPrependConfigOpAndEmitJoinOpsWhenRfIncreases() {
-    // given: initial RF=2, new RF=3 (add zone-a replica)
+    // given: initial RF=2, new RF=3 (add second zone-a replica per partition)
+    // Initial placement: P1→zone-a_0(2),zone-b_0(1) | P2→zone-a_1(2),zone-b_0(1) |
+    // P3→zone-a_0(2),zone-b_0(1)
+    // New placement: both zone-a brokers on each partition; existing replica promoted to priority
+    // 3,
+    // new replica joins at priority 2.
     final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
     final var newConfig =
         new ZoneAwareConfig(
             List.of(new ZoneSpec("zone-a", 2, 1000), new ZoneSpec("zone-b", 1, 500)));
-    final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
 
     // when
-    final var result = transformer.operations(currentTopology);
+    final var result =
+        new UpdatePartitionDistributionTransformer(newConfig).operations(currentTopology);
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var ops = result.get();
-
-    // first op must set the new config
-    assertThat(ops.get(0)).isInstanceOf(UpdatePartitionDistributorConfigOperation.class);
-    final var configOp = (UpdatePartitionDistributorConfigOperation) ops.get(0);
-    assertThat(configOp.config()).isEqualTo(newConfig);
-
-    // remaining ops must include join operations (RF went from 2 → 3)
-    final var joinOps = ops.stream().filter(PartitionJoinOperation.class::isInstance).toList();
-    assertThat(joinOps).as("expected one join per partition when adding a replica").hasSize(3);
+    assertThat(result.get())
+        .containsExactly(
+            new UpdatePartitionDistributorConfigOperation(COORDINATOR, newConfig),
+            new PartitionJoinOperation(ZONE_A_1, 1, 2),
+            new PartitionReconfigurePriorityOperation(ZONE_A_0, 1, 3),
+            new PartitionJoinOperation(ZONE_A_0, 2, 2),
+            new PartitionReconfigurePriorityOperation(ZONE_A_1, 2, 3),
+            new PartitionJoinOperation(ZONE_A_1, 3, 2),
+            new PartitionReconfigurePriorityOperation(ZONE_A_0, 3, 3));
   }
 
   @Test
   void shouldPrependConfigOpAndEmitLeaveOpsWhenRfDecreases() {
-    // given: initial RF=2, new RF=1 (remove zone-b replica)
+    // given: initial RF=2, new RF=1 (remove zone-b, keep only zone-a)
+    // The single-zone distributor reassigns zone-a replicas, causing some zone-a brokers to
+    // move partitions (P2: zone-a_1→leaves, P3: zone-a_1 joins, zone-a_0 and zone-b_0 leave).
     final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
     final var newConfig = new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1000)));
-    final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
 
     // when
-    final var result = transformer.operations(currentTopology);
+    final var result =
+        new UpdatePartitionDistributionTransformer(newConfig).operations(currentTopology);
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var ops = result.get();
-
-    assertThat(ops.get(0)).isInstanceOf(UpdatePartitionDistributorConfigOperation.class);
-    // When RF decreases the distributor may still reassign replicas within zones (joins and
-    // leaves), but net replica count per partition must decrease: leaves > joins.
-    final long leaveCount = ops.stream().filter(PartitionLeaveOperation.class::isInstance).count();
-    final long joinCount = ops.stream().filter(PartitionJoinOperation.class::isInstance).count();
-    assertThat(leaveCount)
-        .as("leaves must exceed joins when RF decreases")
-        .isGreaterThan(joinCount);
+    assertThat(result.get())
+        .containsExactly(
+            new UpdatePartitionDistributorConfigOperation(COORDINATOR, newConfig),
+            new PartitionLeaveOperation(ZONE_B_0, 1, 1),
+            new PartitionReconfigurePriorityOperation(ZONE_A_0, 1, 1),
+            new PartitionLeaveOperation(ZONE_A_1, 2, 1),
+            new PartitionJoinOperation(ZONE_A_1, 3, 1),
+            new PartitionLeaveOperation(ZONE_B_0, 3, 1),
+            new PartitionLeaveOperation(ZONE_A_0, 3, 1));
   }
 
   @Test
   void shouldEmitReconfigurePriorityOpsWhenOnlyPriorityChanges() {
-    // given: same zones and RF, only priority differs
+    // given: same zones and RF, priorities swapped (zone-b becomes higher priority than zone-a)
+    // zone-b replicas get promoted to priority 2, zone-a replicas demoted to priority 1.
     final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
     final var newConfig =
         new ZoneAwareConfig(
             List.of(new ZoneSpec("zone-a", 1, 500), new ZoneSpec("zone-b", 1, 1000)));
-    final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
 
     // when
-    final var result = transformer.operations(currentTopology);
+    final var result =
+        new UpdatePartitionDistributionTransformer(newConfig).operations(currentTopology);
 
     // then
     EitherAssert.assertThat(result).isRight();
-    final var ops = result.get();
-
-    assertThat(ops.get(0)).isInstanceOf(UpdatePartitionDistributorConfigOperation.class);
-
-    final var priorityOps =
-        ops.stream().filter(PartitionReconfigurePriorityOperation.class::isInstance).toList();
-    assertThat(priorityOps)
-        .as("expected reconfigure-priority ops for each partition replica when priority changes")
-        .isNotEmpty();
+    assertThat(result.get())
+        .containsExactly(
+            new UpdatePartitionDistributorConfigOperation(COORDINATOR, newConfig),
+            new PartitionReconfigurePriorityOperation(ZONE_B_0, 1, 2),
+            new PartitionReconfigurePriorityOperation(ZONE_A_0, 1, 1),
+            new PartitionReconfigurePriorityOperation(ZONE_A_1, 2, 1),
+            new PartitionReconfigurePriorityOperation(ZONE_B_0, 2, 2),
+            new PartitionReconfigurePriorityOperation(ZONE_B_0, 3, 2),
+            new PartitionReconfigurePriorityOperation(ZONE_A_0, 3, 1));
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
 import io.camunda.zeebe.management.cluster.Operation;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
+import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
 import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
@@ -229,6 +230,21 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
 
       final var topology = actuator.getTopology();
       assertThat(topology.getPartitionDistribution()).isEqualTo(config);
+    }
+  }
+
+  @Test
+  void shouldRejectPartitionDistributionWithoutZones() {
+    try (final var cluster = createCluster(minReplicationFactor())) {
+      // given
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      // when - then
+      final var config =
+          new PartitionDistributionConfig().type(TypeEnum.ZONE_AWARE).zones(List.of());
+      assertThatCode(() -> actuator.patchPartitionDistribution(config, false))
+          .isInstanceOf(FeignException.BadRequest.class);
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.cluster.management;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import feign.FeignException;
@@ -15,6 +16,9 @@ import io.camunda.configuration.Zone;
 import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
+import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
+import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
+import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import java.util.List;
@@ -151,6 +155,45 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       assertThatCode(() -> actuator.leavePartition(0, 1))
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("zone-aware");
+    }
+  }
+
+  @Test
+  void shouldUpdatePartitionDistributionDryRun() {
+    try (final var cluster = createCluster(minReplicationFactor())) {
+      // given
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      // when - dry-run with priority change (zoneA 100→200)
+      final var config =
+          new PartitionDistributionConfig()
+              .type(PartitionDistributionConfig.TypeEnum.ZONE_AWARE)
+              .zones(
+                  List.of(
+                      new ZoneSpec().name(ZONES[0]).numberOfReplicas(1).priority(200),
+                      new ZoneSpec().name(ZONES[1]).numberOfReplicas(1).priority(10)));
+      final var response = actuator.patchPartitionDistribution(config, true);
+
+      // then - planned changes include the config-set op
+      assertThat(response.getPlannedChanges()).isNotEmpty();
+      assertThat(response.getPlannedChanges().stream().map(op -> op.getOperation()))
+          .contains(OperationEnum.UPDATE_PARTITION_DISTRIBUTOR_CONFIG);
+    }
+  }
+
+  @Test
+  void shouldRejectRoundRobinConfigOnZoneAwareCluster() {
+    try (final var cluster = createCluster(minReplicationFactor())) {
+      // given
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      // when - then
+      final var config =
+          new PartitionDistributionConfig().type(PartitionDistributionConfig.TypeEnum.ROUND_ROBIN);
+      assertThatCode(() -> actuator.patchPartitionDistribution(config, false))
+          .isInstanceOf(FeignException.BadRequest.class);
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -16,6 +16,7 @@ import io.camunda.configuration.Zone;
 import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
+import io.camunda.zeebe.management.cluster.Operation;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.ZoneSpec;
@@ -69,12 +70,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
     return new BrokerId.String(memberIdForBroker(nodeIdx).toString());
   }
 
-
-  /**
-   * 0 -> zoneA_0
-   * 1 -> zoneB_0
-   * 2 -> zoneA_1
-   */
+  /** 0 -> zoneA_0 1 -> zoneB_0 2 -> zoneA_1 */
   @Override
   protected MemberId memberIdForBroker(final int nodeIdx) {
     return MemberId.from(zoneFor(nodeIdx), nodeIdx / ZONES.length);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -67,6 +67,12 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
     return new BrokerId.String(memberIdForBroker(nodeIdx).toString());
   }
 
+
+  /**
+   * 0 -> zoneA_0
+   * 1 -> zoneB_0
+   * 2 -> zoneA_1
+   */
   @Override
   protected MemberId memberIdForBroker(final int nodeIdx) {
     return MemberId.from(zoneFor(nodeIdx), nodeIdx / ZONES.length);
@@ -165,20 +171,32 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       cluster.awaitCompleteTopology();
       final var actuator = ClusterActuator.of(cluster.availableGateway());
 
-      // when - dry-run with priority change (zoneA 100→200)
+      // when - dry-run increasing zoneA replicas from 1→2 (RF 2→3)
+      // expects one PARTITION_JOIN per partition for the second zoneA broker
       final var config =
           new PartitionDistributionConfig()
               .type(PartitionDistributionConfig.TypeEnum.ZONE_AWARE)
               .zones(
                   List.of(
-                      new ZoneSpec().name(ZONES[0]).numberOfReplicas(1).priority(200),
+                      new ZoneSpec().name(ZONES[0]).numberOfReplicas(2).priority(100),
                       new ZoneSpec().name(ZONES[1]).numberOfReplicas(1).priority(10)));
       final var response = actuator.patchPartitionDistribution(config, true);
 
-      // then - planned changes include the config-set op
-      assertThat(response.getPlannedChanges()).isNotEmpty();
-      assertThat(response.getPlannedChanges().stream().map(op -> op.getOperation()))
-          .contains(OperationEnum.UPDATE_PARTITION_DISTRIBUTOR_CONFIG);
+      // then - exactly one config-set op followed by one PARTITION_JOIN per partition
+      final var ops = response.getPlannedChanges().stream().map(op -> op.getOperation()).toList();
+      assertThat(ops).first().isEqualTo(OperationEnum.UPDATE_PARTITION_DISTRIBUTOR_CONFIG);
+      assertThat(ops.subList(1, ops.size()))
+          .hasSize(partitionCount())
+          .containsOnly(OperationEnum.PARTITION_JOIN);
+      // all joins target the second zoneA broker (nodeIdx=2 → zoneA_1, not yet holding any
+      // partition)
+      final var joinBrokerIds =
+          response.getPlannedChanges().stream()
+              .filter(op -> op.getOperation() == OperationEnum.PARTITION_JOIN)
+              .map(op -> op.getBrokerId())
+              .distinct()
+              .toList();
+      assertThat(joinBrokerIds).singleElement().isEqualTo(brokerId(2));
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -21,7 +21,9 @@ import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
 import java.util.List;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
@@ -165,14 +167,13 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
   }
 
   @Test
-  void shouldUpdatePartitionDistributionDryRun() {
+  void shouldUpdatePartitionDistribution() {
     try (final var cluster = createCluster(minReplicationFactor())) {
       // given
       cluster.awaitCompleteTopology();
       final var actuator = ClusterActuator.of(cluster.availableGateway());
 
-      // when - dry-run increasing zoneA replicas from 1→2 (RF 2→3)
-      // expects one PARTITION_JOIN per partition for the second zoneA broker
+      // when - increase zoneA replicas from 1→2 (RF 2→3)
       final var config =
           new PartitionDistributionConfig()
               .type(PartitionDistributionConfig.TypeEnum.ZONE_AWARE)
@@ -180,23 +181,58 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
                   List.of(
                       new ZoneSpec().name(ZONES[0]).numberOfReplicas(2).priority(100),
                       new ZoneSpec().name(ZONES[1]).numberOfReplicas(1).priority(10)));
-      final var response = actuator.patchPartitionDistribution(config, true);
+      final var response = actuator.patchPartitionDistribution(config, false);
 
-      // then - exactly one config-set op followed by one PARTITION_JOIN per partition
-      final var ops = response.getPlannedChanges().stream().map(op -> op.getOperation()).toList();
-      assertThat(ops).first().isEqualTo(OperationEnum.UPDATE_PARTITION_DISTRIBUTOR_CONFIG);
-      assertThat(ops.subList(1, ops.size()))
-          .hasSize(partitionCount())
-          .containsOnly(OperationEnum.PARTITION_JOIN);
-      // all joins target the second zoneA broker (nodeIdx=2 → zoneA_1, not yet holding any
-      // partition)
-      final var joinBrokerIds =
-          response.getPlannedChanges().stream()
-              .filter(op -> op.getOperation() == OperationEnum.PARTITION_JOIN)
-              .map(op -> op.getBrokerId())
-              .distinct()
-              .toList();
-      assertThat(joinBrokerIds).singleElement().isEqualTo(brokerId(2));
+      // then - exact planned operations.
+      // Before (RF=2): zoneA_0 holds P1,P3 and zoneA_1 holds P2 (1 replica/zone, priority 2+1).
+      // After  (RF=3): each partition needs both zoneA brokers; existing zoneA replica gets
+      // promoted to priority 3, new zoneA replica joins at priority 2. zoneB unchanged.
+      // nodeIdx mapping: 0=zoneA_0, 1=zoneB_0, 2=zoneA_1
+      assertThat(response.getPlannedChanges())
+          .isEqualTo(
+              List.of(
+                  new Operation()
+                      .operation(OperationEnum.UPDATE_PARTITION_DISTRIBUTOR_CONFIG)
+                      // Coordinator
+                      .brokerId(brokerId(0))
+                      .partitionDistributionConfig(config),
+                  new Operation()
+                      .operation(OperationEnum.PARTITION_JOIN)
+                      .brokerId(brokerId(2))
+                      .partitionId(1)
+                      .priority(2),
+                  new Operation()
+                      .operation(OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
+                      .brokerId(brokerId(0))
+                      .partitionId(1)
+                      .priority(3),
+                  new Operation()
+                      .operation(OperationEnum.PARTITION_JOIN)
+                      .brokerId(brokerId(0))
+                      .partitionId(2)
+                      .priority(2),
+                  new Operation()
+                      .operation(OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
+                      .brokerId(brokerId(2))
+                      .partitionId(2)
+                      .priority(3),
+                  new Operation()
+                      .operation(OperationEnum.PARTITION_JOIN)
+                      .brokerId(brokerId(2))
+                      .partitionId(3)
+                      .priority(2),
+                  new Operation()
+                      .operation(OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
+                      .brokerId(brokerId(0))
+                      .partitionId(3)
+                      .priority(3)));
+
+      Awaitility.await()
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(response));
+
+      final var topology = actuator.getTopology();
+      assertThat(topology.getPartitionDistribution()).isEqualTo(config);
     }
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -354,7 +354,7 @@ public interface ClusterActuator {
   @Headers({"Content-Type: application/json", "accept: application/json"})
   void patchRoutingState(@Param boolean dryRun);
 
-  @RequestLine("PATCH /partition-distribution?dryRun={dryRun}")
+  @RequestLine("PUT /partition-distribution?dryRun={dryRun}")
   @Headers({"Content-Type: application/json", "accept: application/json"})
   PlannedOperationsResponse patchPartitionDistribution(
       @RequestBody final PartitionDistributionConfig config, @Param boolean dryRun);

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -23,6 +23,7 @@ import io.camunda.container.cluster.BrokerNode;
 import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
+import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.management.cluster.RoutingState;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
@@ -352,6 +353,11 @@ public interface ClusterActuator {
   @RequestLine("PATCH /routing-state?dryRun={dryRun}&force={force}")
   @Headers({"Content-Type: application/json", "accept: application/json"})
   void patchRoutingState(@Param boolean dryRun);
+
+  @RequestLine("PATCH /partition-distribution?dryRun={dryRun}")
+  @Headers({"Content-Type: application/json", "accept: application/json"})
+  PlannedOperationsResponse patchPartitionDistribution(
+      @RequestBody final PartitionDistributionConfig config, @Param boolean dryRun);
 
   // -- BrokerId dispatch methods (default) --
 


### PR DESCRIPTION
## Description

Adds `PATCH /actuator/cluster/partition-distribution` — a dedicated endpoint for changing how
partitions are distributed across zones on a zone-aware cluster.

Unlike the existing `patchCluster` flow (which rejects RF or scaling changes on zone-aware
clusters), this endpoint:

- Accepts a `ZONE_AWARE` partition distribution config and computes the actual redistribution
  operations (`PARTITION_JOIN`, `PARTITION_LEAVE`, `PARTITION_RECONFIGURE_PRIORITY`) needed to
  realize the new distribution immediately.
- Prepends an `UPDATE_PARTITION_DISTRIBUTOR_CONFIG` operation so the config intent is persisted
  before any partition movement begins — crash recovery converges toward the new distribution.
- Supports `?dryRun=true` to preview planned operations without applying them.

**Current limitation:** only `ZONE_AWARE` config bodies are accepted. `ROUND_ROBIN` and `FIXED`
requests are rejected with 400. This is intentional and temporary — `FIXED` support requires
additional spec work and `ROUND_ROBIN` switching is not yet a supported migration path. The
restriction lives in both the controller (`ClusterApiUtils.toPartitionDistributorConfig`) and the
transformer (`UpdatePartitionDistributionTransformer`), and will be relaxed as those paths are
defined.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55163