### PR TITLE
docs: add AGENTS.md module map for zeebe/dynamic-config

### DIFF
--- a/zeebe/dynamic-config/AGENTS.md
+++ b/zeebe/dynamic-config/AGENTS.md
@@ -1,0 +1,32 @@
+# zeebe/dynamic-config — Module Map
+
+Manages cluster topology changes: membership, partition placement, exporter state, routing. Changes
+flow through a coordinator that serializes requests, computes operations, and applies them one by
+one across the cluster.
+
+## Request flow
+
+```
+REST controller (dist/)
+  └─ ClusterConfigurationManagementRequestSender   sends over Atomix ClusterCommunicationService
+       └─ ClusterConfigurationRequestServer        receives, deserializes, dispatches
+            └─ ClusterConfigurationManagementRequestsHandler   picks transformer, calls coordinator
+                 └─ ConfigurationChangeCoordinatorImpl         simulate (dry-run) or apply
+                      └─ ConfigurationChangeAppliersImpl       per-op applier executes on broker
+```
+
+## Package breakdown
+
+|    Package    |                                                                                                               What lives here                                                                                                                |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api/`        | **Request/response types** (`ClusterConfigurationManagementRequest.*`), **transformers** (one per operation family — convert a request into a `List<Op>`), request sender/server/handler, topics enum                                        |
+| `changes/`    | **Appliers** — one class per operation type (e.g. `PartitionJoinApplier`). Each applier executes an op against the live broker and advances `ClusterConfiguration`. Also `ConfigurationChangeCoordinator(Impl)` which drives the apply loop. |
+| `state/`      | **Immutable data model**: `ClusterConfiguration`, `MemberState`, `PartitionState`, `PartitionDistributorConfig`, `ClusterConfigurationChangeOperation` (sealed op hierarchy), `RoutingState`                                                 |
+| `serializer/` | `ProtoBufSerializer` — encode/decode all request and state types to/from proto bytes. `ClusterConfigurationSerializer` for the persisted topology snapshot.                                                                                  |
+| `util/`       | `ZoneAwarePartitionDistributor`, `RoundRobinPartitionDistributor`, `ConfigurationUtil` (build `ClusterConfiguration` from a distribution map)                                                                                                |
+| root          | Wiring: `ClusterConfigurationManagerImpl` (gossip listener + apply), `PersistedClusterConfiguration` (disk persistence), initializers (`PartitionDistributorInitializer`, `RoutingStateInitializer`, …)                                      |
+
+## Operational guides
+
+- [Adding a new operation](./docs/adding_new_operation.md)
+

--- a/zeebe/dynamic-config/docs/adding_new_operation.md
+++ b/zeebe/dynamic-config/docs/adding_new_operation.md
@@ -1,0 +1,13 @@
+## Adding a new operation
+
+1. **State**: add record to `ClusterConfigurationChangeOperation` sealed interface (in `state/`).
+2. **Proto**: add message to `requests.proto` + `topology.proto` if new config field needed.
+3. **Serializer**: add encode/decode in `ClusterConfigurationRequestsSerializer` interface + `ProtoBufSerializer`.
+4. **Request type**: add record to `ClusterConfigurationManagementRequest`.
+5. **Topic**: add entry to `ClusterConfigurationRequestTopics`.
+6. **Transformer**: new `ConfigurationChangeRequest` impl in `api/` — `operations(ClusterConfiguration)` returns `Either<Exception, List<Op>>`.
+7. **Handler**: implement in `ClusterConfigurationManagementRequestsHandler`, delegate to `handleRequest(dryRun, transformer)`.
+8. **Sender**: add method in `ClusterConfigurationManagementRequestSender`.
+9. **Server**: register `replyTo` handler in `ClusterConfigurationRequestServer.start()`.
+10. **Applier**: new `OperationApplier` in `changes/`, register in `ConfigurationChangeAppliersImpl`.
+


### PR DESCRIPTION
## Description

Adds a small AGENTS.md with some "bookmarks" with the description of the pacakges on how to behave when adding a new operation. 

I know it's not great, but it's a starting point :smile: 


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
