### PR TITLE
test: testing the load test CI

### DIFF
--- a/load-tests/load-tester/README.md
+++ b/load-tests/load-tester/README.md
@@ -3,6 +3,8 @@
 This project contains code for the starter and worker, which are used during our benchmarks.
 It is a Spring Boot application using the `camunda-spring-boot-starter`.
 
+Testing CI
+
 ## Running locally
 
 The application uses Spring profiles to select the role:
@@ -28,4 +30,3 @@ To build the docker images for the load test application, run the following comm
 ./mvnw -pl load-tests/load-tester jib:build -Pstarter
 ./mvnw -pl load-tests/load-tester jib:build -Pworker
 ```
-

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
@@ -26,6 +26,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+
 /**
  * End-to-end integration test activating both the {@code starter} and {@code worker} profiles in
  * the same Spring context. The starter deploys the BPMN, creates a small number of instances at a


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
