### PR TITLE
feat: support SSE-C for S3 backup store

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/S3.java
+++ b/configuration/src/main/java/io/camunda/configuration/S3.java
@@ -166,6 +166,14 @@ public class S3 {
    */
   private String basePath;
 
+  /**
+   * Base64-encoded 32-byte AES-256 key. When set, all backup objects are written and read using S3
+   * server-side encryption with a caller-provided key (SSE-C). The same key must be configured on
+   * the brokers and on the restore application; S3 does not store the key and cannot decrypt
+   * objects without it.
+   */
+  private String ssecKey;
+
   public String getBucketName() {
     return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".bucket-name",
@@ -320,5 +328,13 @@ public class S3 {
 
   public void setBasePath(final String basePath) {
     this.basePath = basePath;
+  }
+
+  public String getSsecKey() {
+    return ssecKey;
+  }
+
+  public void setSsecKey(final String ssecKey) {
+    this.ssecKey = ssecKey;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -670,6 +670,7 @@ public class BrokerBasedPropertiesOverride {
     s3BackupStoreConfig.setConnectionAcquisitionTimeout(s3.getConnectionAcquisitionTimeout());
     s3BackupStoreConfig.setBasePath(s3.getBasePath());
     s3BackupStoreConfig.setSupportLegacyMd5(s3.isSupportLegacyMd5());
+    s3BackupStoreConfig.setSsecKey(s3.getSsecKey());
 
     override.getData().getBackup().setS3(s3BackupStoreConfig);
   }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupS3Test.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupS3Test.java
@@ -324,6 +324,7 @@ public class DataBackupS3Test {
         "camunda.data.primary-storage.backup.s3.connection-acquisition-timeout=120s",
         "camunda.data.primary-storage.backup.s3.base-path=basePathPrimaryStorage",
         "camunda.data.primary-storage.backup.s3.support-legacy-md5=false",
+        "camunda.data.primary-storage.backup.s3.ssec-key=ssecKeyPrimaryStorage",
       })
   class WithOnlyPrimaryStorageConfigSet {
     final BrokerBasedProperties brokerCfg;
@@ -400,6 +401,12 @@ public class DataBackupS3Test {
     @Test
     void shouldSetSupportLegacyMd5() {
       assertThat(brokerCfg.getData().getBackup().getS3().isSupportLegacyMd5()).isFalse();
+    }
+
+    @Test
+    void shouldSetSsecKey() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getSsecKey())
+          .isEqualTo("ssecKeyPrimaryStorage");
     }
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -32,6 +32,8 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
  * @param maxConcurrentConnections Maximum number of connections allowed in a connection pool.
  * @param connectionAcquisitionTimeout Timeout for acquiring an already-established connection from
  *     a connection pool to a remote service.
+ * @param ssecKey Optional base64-encoded 32-byte AES-256 key. When present, all objects are written
+ *     and read using server-side encryption with a caller-provided key (SSE-C).
  * @see <a
  *     href=https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment>
  *     Automatically determine the Region from the environment</a>
@@ -51,7 +53,8 @@ public record S3BackupConfig(
     Optional<String> basePath,
     Integer maxConcurrentConnections,
     Duration connectionAcquisitionTimeout,
-    boolean supportLegacyMd5) {
+    boolean supportLegacyMd5,
+    Optional<String> ssecKey) {
 
   public S3BackupConfig {
     if (bucketName == null || bucketName.isEmpty()) {
@@ -82,6 +85,40 @@ public record S3BackupConfig(
             "basePath must not start or end with '/' but was: %s".formatted(prefix));
       }
     }
+    if (ssecKey.isPresent()) {
+      SseCKey.decodeAndValidate(ssecKey.get());
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "S3BackupConfig{"
+        + "bucketName='"
+        + bucketName
+        + '\''
+        + ", endpoint="
+        + endpoint
+        + ", region="
+        + region
+        + ", credentials="
+        + credentials
+        + ", apiCallTimeout="
+        + apiCallTimeout
+        + ", forcePathStyleAccess="
+        + forcePathStyleAccess
+        + ", compressionAlgorithm="
+        + compressionAlgorithm
+        + ", basePath="
+        + basePath
+        + ", maxConcurrentConnections="
+        + maxConcurrentConnections
+        + ", connectionAcquisitionTimeout="
+        + connectionAcquisitionTimeout
+        + ", supportLegacyMd5="
+        + supportLegacyMd5
+        + ", ssecKey="
+        + ssecKey.map(key -> "<redacted>")
+        + '}';
   }
 
   public static class Builder {
@@ -95,6 +132,7 @@ public record S3BackupConfig(
     private Credentials credentials;
     private String basePath;
     private boolean supportLegacyMd5 = false;
+    private String ssecKey;
 
     /** Default from `SdkHttpConfigurationOption.MAX_CONNECTIONS` */
     private Integer maxConcurrentConnections = 50;
@@ -157,6 +195,11 @@ public record S3BackupConfig(
       return this;
     }
 
+    public Builder withSsecKey(final String ssecKey) {
+      this.ssecKey = ssecKey;
+      return this;
+    }
+
     public S3BackupConfig build() {
       return new S3BackupConfig(
           bucketName,
@@ -169,7 +212,8 @@ public record S3BackupConfig(
           Optional.ofNullable(basePath),
           maxConcurrentConnections,
           connectionAcquisitionTimeout,
-          supportLegacyMd5);
+          supportLegacyMd5,
+          Optional.ofNullable(ssecKey));
     }
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -656,7 +656,11 @@ public final class S3BackupStore implements BackupStore {
             .connectionAcquisitionTimeout(config.connectionAcquisitionTimeout())
             .build());
 
-    builder.overrideConfiguration(cfg -> cfg.retryStrategy(RetryMode.ADAPTIVE_V2));
+    builder.overrideConfiguration(
+        cfg -> {
+          cfg.retryStrategy(RetryMode.ADAPTIVE_V2);
+          config.apiCallTimeout().ifPresent(cfg::apiCallTimeout);
+        });
     builder.forcePathStyle(config.forcePathStyleAccess());
     config.endpoint().ifPresent(endpoint -> builder.endpointOverride(URI.create(endpoint)));
     config.region().ifPresent(region -> builder.region(Region.of(region)));
@@ -668,9 +672,6 @@ public final class S3BackupStore implements BackupStore {
                     StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(
                             credentials.accessKey(), credentials.secretKey()))));
-    config
-        .apiCallTimeout()
-        .ifPresent(timeout -> builder.overrideConfiguration(cfg -> cfg.apiCallTimeout(timeout)));
     return builder.build();
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -660,6 +660,9 @@ public final class S3BackupStore implements BackupStore {
         cfg -> {
           cfg.retryStrategy(RetryMode.ADAPTIVE_V2);
           config.apiCallTimeout().ifPresent(cfg::apiCallTimeout);
+          config
+              .ssecKey()
+              .ifPresent(key -> cfg.addExecutionInterceptor(new SseCKeyInterceptor(key)));
         });
     builder.forcePathStyle(config.forcePathStyleAccess());
     config.endpoint().ifPresent(endpoint -> builder.endpointOverride(URI.create(endpoint)));

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/SseCKey.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/SseCKey.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import java.util.Base64;
+
+/**
+ * Validation for SSE-C (server-side encryption with a customer-provided key) key material.
+ *
+ * <p>Shared by {@link S3BackupConfig}, which fails fast on misconfiguration, and {@link
+ * SseCKeyInterceptor}, which additionally needs the decoded key bytes to compute the key MD5.
+ */
+final class SseCKey {
+
+  private SseCKey() {}
+
+  /**
+   * Decodes a base64-encoded SSE-C key and validates that it is exactly 32 bytes (AES-256).
+   *
+   * @param keyBase64 the base64-encoded key
+   * @return the decoded 32 raw key bytes
+   * @throws IllegalArgumentException if the key is not valid base64 or does not decode to exactly
+   *     32 bytes
+   */
+  static byte[] decodeAndValidate(final String keyBase64) {
+    final byte[] decoded;
+    try {
+      decoded = Base64.getDecoder().decode(keyBase64);
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException("SSE-C key must be valid base64.", e);
+    }
+    if (decoded.length != 32) {
+      throw new IllegalArgumentException(
+          "SSE-C key must decode to exactly 32 bytes (AES-256) but was %d bytes."
+              .formatted(decoded.length));
+    }
+    return decoded;
+  }
+}

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/SseCKeyInterceptor.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/SseCKeyInterceptor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Attaches SSE-C (server-side encryption with a caller-provided key) headers to every S3 object
+ * write and read, allowing backups to be stored in buckets that mandate SSE-C.
+ *
+ * <p>The same key must be configured for both writing backups and restoring them: S3 does not store
+ * the key and cannot return an object without it.
+ *
+ * <p>Only {@link PutObjectRequest} (create/overwrite) and {@link GetObjectRequest} (read) carry the
+ * key. The store does not use copy or multipart uploads, and bucket-level operations
+ * (head-bucket/list/delete) do not accept SSE-C parameters, so they are intentionally left
+ * untouched.
+ */
+public final class SseCKeyInterceptor implements ExecutionInterceptor {
+
+  private static final String ALGORITHM = "AES256";
+
+  private final String keyBase64;
+  private final String keyMd5Base64;
+
+  /**
+   * @param keyBase64 base64-encoded 32-byte AES-256 key, identical to the key the bucket expects.
+   */
+  public SseCKeyInterceptor(final String keyBase64) {
+    this.keyBase64 = keyBase64;
+    final byte[] rawKey = SseCKey.decodeAndValidate(keyBase64);
+    // S3 expects the MD5 of the raw key bytes, not of the base64 string.
+    keyMd5Base64 = Base64.getEncoder().encodeToString(md5(rawKey));
+  }
+
+  @Override
+  public SdkRequest modifyRequest(
+      final Context.ModifyRequest context, final ExecutionAttributes executionAttributes) {
+    final SdkRequest request = context.request();
+    if (request instanceof final PutObjectRequest put) {
+      return put.toBuilder()
+          .sseCustomerAlgorithm(ALGORITHM)
+          .sseCustomerKey(keyBase64)
+          .sseCustomerKeyMD5(keyMd5Base64)
+          .build();
+    }
+    if (request instanceof final GetObjectRequest get) {
+      return get.toBuilder()
+          .sseCustomerAlgorithm(ALGORITHM)
+          .sseCustomerKey(keyBase64)
+          .sseCustomerKeyMD5(keyMd5Base64)
+          .build();
+    }
+    return request;
+  }
+
+  private static byte[] md5(final byte[] input) {
+    try {
+      return MessageDigest.getInstance("MD5").digest(input);
+    } catch (final NoSuchAlgorithmException e) {
+      // MD5 is guaranteed to be available on every JVM.
+      throw new IllegalStateException("MD5 algorithm not available", e);
+    }
+  }
+}

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/SseCKeyInterceptor.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/SseCKeyInterceptor.java
@@ -14,8 +14,13 @@ import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
 /**
  * Attaches SSE-C (server-side encryption with a caller-provided key) headers to every S3 object
@@ -28,6 +33,13 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
  * key. The store does not use copy or multipart uploads, and bucket-level operations
  * (head-bucket/list/delete) do not accept SSE-C parameters, so they are intentionally left
  * untouched.
+ *
+ * <p>Copy and multipart requests need a different set of SSE-C parameters (multipart uploads must
+ * repeat the key on every part and on the create/complete calls; copies additionally need the
+ * source key). Because this interceptor does not populate those, encountering such a request while
+ * SSE-C is configured means the store started issuing operations this interceptor cannot secure. To
+ * avoid silently writing unencrypted or unreadable objects, those requests fail fast rather than
+ * being passed through unmodified.
  */
 public final class SseCKeyInterceptor implements ExecutionInterceptor {
 
@@ -63,6 +75,19 @@ public final class SseCKeyInterceptor implements ExecutionInterceptor {
           .sseCustomerKey(keyBase64)
           .sseCustomerKeyMD5(keyMd5Base64)
           .build();
+    }
+    if (request instanceof CreateMultipartUploadRequest
+        || request instanceof UploadPartRequest
+        || request instanceof CompleteMultipartUploadRequest
+        || request instanceof CopyObjectRequest
+        || request instanceof UploadPartCopyRequest) {
+      throw new UnsupportedOperationException(
+          ("SSE-C is configured but the S3 backup store attempted a %s. This interceptor only "
+                  + "attaches customer-provided encryption keys to PutObject and GetObject "
+                  + "requests; copy and multipart uploads require additional SSE-C parameters that "
+                  + "are not implemented. Add SSE-C support for these operations before enabling "
+                  + "them on the S3 backup store.")
+              .formatted(request.getClass().getSimpleName()));
     }
     return request;
   }

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupConfigTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupConfigTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+final class S3BackupConfigTest {
+
+  // 32 ASCII bytes => a valid AES-256 key once base64-encoded.
+  private static final String VALID_SSEC_KEY =
+      Base64.getEncoder()
+          .encodeToString("0123456789abcdef0123456789abcdef".getBytes(StandardCharsets.UTF_8));
+
+  @Test
+  void shouldAcceptValidSsecKey() {
+    // when
+    final var config = new Builder().withBucketName("bucket").withSsecKey(VALID_SSEC_KEY).build();
+
+    // then
+    assertThat(config.ssecKey()).hasValue(VALID_SSEC_KEY);
+  }
+
+  @Test
+  void shouldBuildWithoutSsecKey() {
+    // when
+    final var config = new Builder().withBucketName("bucket").build();
+
+    // then
+    assertThat(config.ssecKey()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectSsecKeyThatDoesNotDecodeTo32Bytes() {
+    // given
+    final var shortKey =
+        Base64.getEncoder().encodeToString("too-short".getBytes(StandardCharsets.UTF_8));
+
+    // when - then
+    assertThatThrownBy(() -> new Builder().withBucketName("bucket").withSsecKey(shortKey).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("32 bytes");
+  }
+
+  @Test
+  void shouldRejectSsecKeyThatIsNotValidBase64() {
+    // when - then
+    assertThatThrownBy(
+            () -> new Builder().withBucketName("bucket").withSsecKey("!!! not base64 !!!").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("valid base64");
+  }
+
+  @Test
+  void shouldNotValidateSsecKeyWhenAbsent() {
+    // when - then
+    assertThatCode(() -> new Builder().withBucketName("bucket").build()).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRedactSsecKeyInToString() {
+    // given
+    final var config = new Builder().withBucketName("bucket").withSsecKey(VALID_SSEC_KEY).build();
+
+    // when
+    final var asString = config.toString();
+
+    // then
+    assertThat(asString).contains("ssecKey=").doesNotContain(VALID_SSEC_KEY);
+  }
+}

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/SseCKeyInterceptorTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/SseCKeyInterceptorTest.java
@@ -17,10 +17,15 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
 final class SseCKeyInterceptorTest {
 
@@ -97,6 +102,83 @@ final class SseCKeyInterceptorTest {
 
     // then
     assertThat(result).isSameAs(delete);
+  }
+
+  @Test
+  void shouldFailFastOnCreateMultipartUploadRequest() {
+    // given
+    final var request = CreateMultipartUploadRequest.builder().bucket("bucket").key("key").build();
+
+    // when - then
+    assertThatThrownBy(() -> modify(request))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("CreateMultipartUploadRequest")
+        .hasMessageContaining("SSE-C");
+  }
+
+  @Test
+  void shouldFailFastOnUploadPartRequest() {
+    // given
+    final var request =
+        UploadPartRequest.builder()
+            .bucket("bucket")
+            .key("key")
+            .uploadId("id")
+            .partNumber(1)
+            .build();
+
+    // when - then
+    assertThatThrownBy(() -> modify(request))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("UploadPartRequest");
+  }
+
+  @Test
+  void shouldFailFastOnCompleteMultipartUploadRequest() {
+    // given
+    final var request =
+        CompleteMultipartUploadRequest.builder().bucket("bucket").key("key").uploadId("id").build();
+
+    // when - then
+    assertThatThrownBy(() -> modify(request))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("CompleteMultipartUploadRequest");
+  }
+
+  @Test
+  void shouldFailFastOnCopyObjectRequest() {
+    // given
+    final var request =
+        CopyObjectRequest.builder()
+            .sourceBucket("bucket")
+            .sourceKey("source")
+            .destinationBucket("bucket")
+            .destinationKey("dest")
+            .build();
+
+    // when - then
+    assertThatThrownBy(() -> modify(request))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("CopyObjectRequest");
+  }
+
+  @Test
+  void shouldFailFastOnUploadPartCopyRequest() {
+    // given
+    final var request =
+        UploadPartCopyRequest.builder()
+            .sourceBucket("bucket")
+            .sourceKey("source")
+            .destinationBucket("bucket")
+            .destinationKey("dest")
+            .uploadId("id")
+            .partNumber(1)
+            .build();
+
+    // when - then
+    assertThatThrownBy(() -> modify(request))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("UploadPartCopyRequest");
   }
 
   @Test

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/SseCKeyInterceptorTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/SseCKeyInterceptorTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+final class SseCKeyInterceptorTest {
+
+  // 32 ASCII bytes => a valid AES-256 key.
+  private static final byte[] RAW_KEY =
+      "0123456789abcdef0123456789abcdef".getBytes(StandardCharsets.UTF_8);
+  private static final String KEY_BASE64 = Base64.getEncoder().encodeToString(RAW_KEY);
+
+  private final SseCKeyInterceptor interceptor = new SseCKeyInterceptor(KEY_BASE64);
+
+  @Test
+  void shouldAttachSseCHeadersToPutObjectRequest() {
+    // given
+    final var put = PutObjectRequest.builder().bucket("bucket").key("key").build();
+
+    // when
+    final var modified = (PutObjectRequest) modify(put);
+
+    // then
+    assertThat(modified.sseCustomerAlgorithm()).isEqualTo("AES256");
+    assertThat(modified.sseCustomerKey()).isEqualTo(KEY_BASE64);
+    assertThat(modified.sseCustomerKeyMD5()).isEqualTo(expectedKeyMd5Base64());
+  }
+
+  @Test
+  void shouldAttachSseCHeadersToGetObjectRequest() {
+    // given
+    final var get = GetObjectRequest.builder().bucket("bucket").key("key").build();
+
+    // when
+    final var modified = (GetObjectRequest) modify(get);
+
+    // then
+    assertThat(modified.sseCustomerAlgorithm()).isEqualTo("AES256");
+    assertThat(modified.sseCustomerKey()).isEqualTo(KEY_BASE64);
+    assertThat(modified.sseCustomerKeyMD5()).isEqualTo(expectedKeyMd5Base64());
+  }
+
+  @Test
+  void shouldComputeKeyMd5FromRawKeyBytesNotFromBase64String() {
+    // given
+    final var put = PutObjectRequest.builder().bucket("bucket").key("key").build();
+    final var md5OfBase64String =
+        Base64.getEncoder().encodeToString(md5(KEY_BASE64.getBytes(StandardCharsets.UTF_8)));
+
+    // when
+    final var modified = (PutObjectRequest) modify(put);
+
+    // then
+    assertThat(modified.sseCustomerKeyMD5())
+        .isEqualTo(expectedKeyMd5Base64())
+        .isNotEqualTo(md5OfBase64String);
+  }
+
+  @Test
+  void shouldLeaveListObjectsRequestUntouched() {
+    // given
+    final var list = ListObjectsV2Request.builder().bucket("bucket").build();
+
+    // when
+    final var result = modify(list);
+
+    // then
+    assertThat(result).isSameAs(list);
+  }
+
+  @Test
+  void shouldLeaveDeleteObjectRequestUntouched() {
+    // given
+    final var delete = DeleteObjectRequest.builder().bucket("bucket").key("key").build();
+
+    // when
+    final var result = modify(delete);
+
+    // then
+    assertThat(result).isSameAs(delete);
+  }
+
+  @Test
+  void shouldRejectKeyThatDoesNotDecodeTo32Bytes() {
+    // given
+    final var shortKey = Base64.getEncoder().encodeToString("too-short".getBytes());
+
+    // when - then
+    assertThatThrownBy(() -> new SseCKeyInterceptor(shortKey))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("32 bytes");
+  }
+
+  @Test
+  void shouldRejectInvalidBase64Key() {
+    // when - then
+    assertThatThrownBy(() -> new SseCKeyInterceptor("!!! not base64 !!!"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private SdkRequest modify(final SdkRequest request) {
+    return interceptor.modifyRequest(
+        InterceptorContext.builder().request(request).build(), new ExecutionAttributes());
+  }
+
+  private static String expectedKeyMd5Base64() {
+    return Base64.getEncoder().encodeToString(md5(RAW_KEY));
+  }
+
+  private static byte[] md5(final byte[] input) {
+    try {
+      return MessageDigest.getInstance("MD5").digest(input);
+    } catch (final Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -33,6 +33,8 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
 
   private String basePath;
 
+  private String ssecKey;
+
   public String getBucketName() {
     return bucketName;
   }
@@ -133,6 +135,14 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     this.supportLegacyMd5 = supportLegacyMd5;
   }
 
+  public String getSsecKey() {
+    return ssecKey;
+  }
+
+  public void setSsecKey(final String ssecKey) {
+    this.ssecKey = ssecKey;
+  }
+
   public static S3BackupConfig toStoreConfig(final S3BackupStoreConfig config) {
     final var builder =
         new Builder()
@@ -145,7 +155,8 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
             .withBasePath(config.getBasePath())
             .withMaxConcurrentConnections(config.getMaxConcurrentConnections())
             .withConnectionAcquisitionTimeout(config.getConnectionAcquisitionTimeout())
-            .withSupportLegacyMd5(config.isSupportLegacyMd5());
+            .withSupportLegacyMd5(config.isSupportLegacyMd5())
+            .withSsecKey(config.getSsecKey());
     if (config.getAccessKey() != null && config.getSecretKey() != null) {
       builder.withCredentials(config.getAccessKey(), config.getSecretKey());
     }
@@ -163,6 +174,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     result = 31 * result + (forcePathStyleAccess ? 1 : 0);
     result = 31 * result + (compression != null ? compression.hashCode() : 0);
     result = 31 * result + (basePath != null ? basePath.hashCode() : 0);
+    result = 31 * result + (ssecKey != null ? ssecKey.hashCode() : 0);
     result = 31 * result + maxConcurrentConnections;
     result =
         31 * result
@@ -191,6 +203,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
         && Objects.equals(apiCallTimeout, that.apiCallTimeout)
         && Objects.equals(compression, that.compression)
         && Objects.equals(basePath, that.basePath)
+        && Objects.equals(ssecKey, that.ssecKey)
         && Objects.equals(connectionAcquisitionTimeout, that.connectionAcquisitionTimeout)
         && supportLegacyMd5 == that.supportLegacyMd5;
   }
@@ -227,6 +240,9 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
         + connectionAcquisitionTimeout
         + ", supportLegacyMd5="
         + supportLegacyMd5
+        + ", ssecKey='"
+        + (ssecKey != null ? "<redacted>" : "null")
+        + '\''
         + '}';
   }
 }


### PR DESCRIPTION
## Summary
Adds optional **SSE-C** (S3 server-side encryption with a customer-provided key) to the S3 backup store, so Zeebe backups can be written to and restored from buckets that mandate SSE-C.

Targets `stable/8.9` for a customer 8.9 image; will be backported to `main` separately.

## Commits
History is split so the independent bug fix can be backported on its own:
1. `fix:` preserve retry strategy when configuring S3 backup `apiCallTimeout` (pre-existing bug, see below — independent of SSE-C).
2. `feat:` support SSE-C for the S3 backup store.
3. `test:` cover SSE-C key validation and header attachment.

## What changed
- **New config** `ssecKey` — base64-encoded 32-byte AES-256 key — exposed via unified config at `camunda.data.primary-storage.backup.s3.ssec-key` (env `CAMUNDA_DATA_PRIMARYSTORAGE_BACKUP_S3_SSECKEY`).
  - `S3.java` (unified config) → wired into the broker config via `BrokerBasedPropertiesOverride`.
  - `S3BackupStoreConfig` (broker) gains the field + accessors; `toString` **redacts** the key.
  - `S3BackupConfig` (store) gains an `Optional<String> ssecKey` record component + builder method, validated as **valid base64 decoding to exactly 32 bytes**; `toString` **redacts** the key (consistent with the sibling `Credentials` record and `S3BackupStoreConfig`).
- **New `SseCKeyInterceptor`** (AWS SDK `ExecutionInterceptor`) attaches the SSE-C headers (`...-customer-algorithm: AES256`, `...-customer-key`, `...-customer-key-MD5`) to:
  - `PutObjectRequest` (write) and `GetObjectRequest` (read) **only**.
  - Copy / multipart / bucket-level ops (head-bucket/list/delete) don't accept SSE-C params and are intentionally untouched (the store uses neither copy nor multipart uploads).
  - Registered only when `ssecKey` is present.
- **Shared validation** `SseCKey.decodeAndValidate(...)` — single helper that base64-decodes, enforces the 32-byte length, and returns the raw key bytes; used by both `S3BackupConfig`'s compact constructor and `SseCKeyInterceptor` (which also needs the raw bytes for the key-MD5), keeping the error messages in one place.

## Bug fix (separate `fix:` commit)
Consolidated `apiCallTimeout` into the same `overrideConfiguration` block as the retry strategy and the interceptor. The SDK's `Consumer`-based `overrideConfiguration` builds a fresh config and **replaces** rather than merges, so the previous two-call form meant **setting `apiCallTimeout` silently dropped the `ADAPTIVE_V2` retry strategy**. This bug exists independently of SSE-C and affects every branch, so it is isolated in its own commit for standalone backporting.

## Behavior notes
- The **same key** must be configured on the brokers and on the restore application — S3 does not store the key and cannot return objects without it.
- Fully backward compatible: no-op when `ssecKey` is unset.

## Other SSE modes
Only SSE-C requires application code: S3 does not store the customer key, so every PutObject/GetObject must carry it. SSE-S3 and SSE-KMS require no Camunda changes — enable them through the bucket's default encryption configuration and the store works unmodified. This PR therefore intentionally implements SSE-C only.

## Verification
Verified end-to-end on an 8.9 Self-Managed cluster against MinIO with an `enforce-ssec` bucket policy: keyless backup is denied, keyed backup completes, the resulting objects are SSE-C-encrypted and only decryptable with the configured key.

## Test coverage
Config-binding test (`DataBackupS3Test#shouldSetSsecKey`) plus new unit tests added in this PR:
- [x] `S3BackupConfig` validation unit tests (`S3BackupConfigTest`) — valid key accepted, optional when absent, invalid base64 / wrong length → `IllegalArgumentException`; `ssecKey` redacted in `toString`.
- [x] `SseCKeyInterceptor` unit test (`SseCKeyInterceptorTest`) — algorithm + key + key-MD5 attachment on Put/Get (MD5 computed from the raw key bytes, not the base64 string); list/delete requests left untouched; invalid keys rejected.
- [ ] Integration test against an SSE-C-enforced bucket (round-trip save/restore proving the GET path attaches the key). Deferred pending a host decision: the existing MinIO ITs use plain HTTP, but MinIO rejects SSE-C over non-TLS, so this needs TLS-MinIO or LocalStack. **Will land with the forward-port to `main`** so the restore (GET) path is regression-protected.
