### PR TITLE
feat: validate versionTag expression syntax at deployment time

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.model.bpmn.instance.Signal;
 import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
@@ -158,6 +159,12 @@ public final class ZeebeRuntimeValidators {
         ZeebeExpressionValidator.verifyThat(ZeebeCalledDecision.class)
             .hasValidExpression(
                 ZeebeCalledDecision::getDecisionId, ExpressionVerification::isMandatory)
+            .hasValidExpression(
+                calledDecision ->
+                    calledDecision.getBindingType() == ZeebeBindingType.versionTag
+                        ? calledDecision.getVersionTag()
+                        : null,
+                ExpressionVerification::isOptional)
             .build(expressionLanguage),
         // ----------------------------------------
         new ZeebeTaskHeadersValidator(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -518,6 +518,21 @@ public final class ZeebeRuntimeValidationTest {
             .done(),
         List.of(expect(ZeebeCalledDecision.class, INVALID_EXPRESSION_MESSAGE))
       },
+      {
+        // valid versionTag expression in business rule task with versionTag binding
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask(
+                "task",
+                t ->
+                    t.zeebeCalledDecisionId("decision")
+                        .zeebeBindingType(ZeebeBindingType.versionTag)
+                        .zeebeVersionTagExpression("versionTagVariable")
+                        .zeebeResultVariable("result"))
+            .endEvent()
+            .done(),
+        List.of()
+      },
     };
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.model.bpmn.instance.ConditionExpression;
 import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
@@ -500,6 +502,21 @@ public final class ZeebeRuntimeValidationTest {
             expect(
                 ZeebePriorityDefinition.class,
                 "Expected static value to be a valid Number between 0 and 100, but found '33.3'"))
+      },
+      {
+        // invalid versionTag expression in business rule task with versionTag binding
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask(
+                "task",
+                t ->
+                    t.zeebeCalledDecisionId("decision")
+                        .zeebeBindingType(ZeebeBindingType.versionTag)
+                        .zeebeVersionTagExpression(INVALID_EXPRESSION)
+                        .zeebeResultVariable("result"))
+            .endEvent()
+            .done(),
+        List.of(expect(ZeebeCalledDecision.class, INVALID_EXPRESSION_MESSAGE))
       },
     };
   }


### PR DESCRIPTION
## Summary

- Adds FEEL expression validation for the `versionTag` field of `ZeebeCalledDecision` in `ZeebeRuntimeValidators`, catching syntax errors at deployment time rather than at runtime
- Validation only triggers when `bindingType == versionTag`; other binding types are skipped (null supplier → optional skip)
- Adds a corresponding parameterized test case in `ZeebeRuntimeValidationTest` covering an invalid FEEL expression with `versionTag` binding

## Validation layers after this change

| Layer | What is checked |
|---|---|
| Design-time (`ZeebeBindingTypeValidator`) | `bindingType` is valid; `versionTag` present iff `bindingType=versionTag` |
| Deployment-time (`ZeebeRuntimeValidators`) | `versionTag` is syntactically valid FEEL (added here) |
| Runtime (`BpmnDecisionBehavior`) | expression evaluated; incident raised if decision not found |

closes #52911