### PR TITLE
Retry logic for message-starts rejected on Business ID uniqueness or subscription distribution

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
+++ b/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_ASK_RETRY_GRACE;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_ASK_RETRY_INTERVAL;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_DEDUP_EXPIRATION_SWEEP_BATCH_LIMIT;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_DEDUP_EXPIRATION_SWEEP_INTERVAL;
@@ -53,6 +54,17 @@ public class ProcessInstanceCreation {
    * also drives the scheduler's tick frequency.
    */
   private Duration messageStartAskRetryInterval = DEFAULT_MESSAGE_START_ASK_RETRY_INTERVAL;
+
+  /**
+   * Grace by which the cross-partition message-start dedup row on {@code P_B} is kept valid (for
+   * re-reply lookups and the expiration sweep) beyond the originating message's deadline. It must
+   * cover the worst-case one-way inter-partition command latency plus clock skew so a retry ask
+   * sent just before the deadline, but processed slightly after it, still hits the dedup and
+   * re-replies the same instance instead of creating a duplicate. Over-sizing is essentially free
+   * (the dedup key is unique per publish); under-sizing re-opens the near-deadline duplicate
+   * window.
+   */
+  private Duration messageStartAskRetryGrace = DEFAULT_MESSAGE_START_ASK_RETRY_GRACE;
 
   /**
    * Base poll interval for the cross-partition correlation-key lock-release scheduler on {@code
@@ -111,6 +123,14 @@ public class ProcessInstanceCreation {
 
   public void setMessageStartAskRetryInterval(final Duration messageStartAskRetryInterval) {
     this.messageStartAskRetryInterval = messageStartAskRetryInterval;
+  }
+
+  public Duration getMessageStartAskRetryGrace() {
+    return messageStartAskRetryGrace;
+  }
+
+  public void setMessageStartAskRetryGrace(final Duration messageStartAskRetryGrace) {
+    this.messageStartAskRetryGrace = messageStartAskRetryGrace;
   }
 
   public Duration getMessageStartLockReleasePollInterval() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -1119,6 +1119,8 @@ public class BrokerBasedPropertiesOverride {
         processInstanceCreation.getMessageStartDedupExpirationSweepBatchLimit());
     processInstanceCreationCfg.setMessageStartAskRetryInterval(
         processInstanceCreation.getMessageStartAskRetryInterval());
+    processInstanceCreationCfg.setMessageStartAskRetryGrace(
+        processInstanceCreation.getMessageStartAskRetryGrace());
     processInstanceCreationCfg.setMessageStartLockReleasePollInterval(
         processInstanceCreation.getMessageStartLockReleasePollInterval());
     processInstanceCreationCfg.setMessageStartLockReleasePollMaxBackoff(

--- a/configuration/src/test/java/io/camunda/configuration/ProcessInstanceCreationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ProcessInstanceCreationTest.java
@@ -63,6 +63,13 @@ public class ProcessInstanceCreationTest {
     }
 
     @Test
+    void shouldSetDefaultMessageStartAskRetryGrace() {
+      assertThat(brokerCfg.getExperimental().getEngine().getProcessInstanceCreation())
+          .returns(
+              Duration.ofSeconds(30), ProcessInstanceCreationCfg::getMessageStartAskRetryGrace);
+    }
+
+    @Test
     void shouldSetDefaultMessageStartLockReleasePollInterval() {
       assertThat(brokerCfg.getExperimental().getEngine().getProcessInstanceCreation())
           .returns(
@@ -92,6 +99,7 @@ public class ProcessInstanceCreationTest {
         "camunda.process-instance-creation.message-start-dedup-expiration-sweep-interval=1m",
         "camunda.process-instance-creation.message-start-dedup-expiration-sweep-batch-limit=250",
         "camunda.process-instance-creation.message-start-ask-retry-interval=5s",
+        "camunda.process-instance-creation.message-start-ask-retry-grace=20s",
         "camunda.process-instance-creation.message-start-lock-release-poll-interval=2s",
         "camunda.process-instance-creation.message-start-lock-release-poll-max-backoff=45s",
         "camunda.process-instance-creation.message-start-lock-release-poll-batch-limit=128",
@@ -113,6 +121,7 @@ public class ProcessInstanceCreationTest {
           .returns(250, ProcessInstanceCreationCfg::getMessageStartDedupExpirationSweepBatchLimit)
           .returns(
               Duration.ofSeconds(5), ProcessInstanceCreationCfg::getMessageStartAskRetryInterval)
+          .returns(Duration.ofSeconds(20), ProcessInstanceCreationCfg::getMessageStartAskRetryGrace)
           .returns(
               Duration.ofSeconds(2),
               ProcessInstanceCreationCfg::getMessageStartLockReleasePollInterval)

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -239,6 +239,7 @@ monitoring.metrics.job-metrics.max-tenant-id-length
 monitoring.metrics.job-metrics.max-unique-keys
 monitoring.metrics.job-metrics.max-worker-name-length
 process-instance-creation.business-id-uniqueness-enabled
+process-instance-creation.message-start-ask-retry-grace
 process-instance-creation.message-start-ask-retry-interval
 process-instance-creation.message-start-dedup-expiration-sweep-batch-limit
 process-instance-creation.message-start-dedup-expiration-sweep-interval

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -224,6 +224,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setMessageStartDedupExpirationSweepBatchLimit(
             processInstanceCreation.getMessageStartDedupExpirationSweepBatchLimit())
         .setMessageStartAskRetryInterval(processInstanceCreation.getMessageStartAskRetryInterval())
+        .setMessageStartAskRetryGrace(processInstanceCreation.getMessageStartAskRetryGrace())
         .setMessageStartLockReleasePollInterval(
             processInstanceCreation.getMessageStartLockReleasePollInterval())
         .setMessageStartLockReleasePollMaxBackoff(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ProcessInstanceCreationCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ProcessInstanceCreationCfg.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.configuration.engine;
 
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_ASK_RETRY_GRACE;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_ASK_RETRY_INTERVAL;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_DEDUP_EXPIRATION_SWEEP_BATCH_LIMIT;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGE_START_DEDUP_EXPIRATION_SWEEP_INTERVAL;
@@ -26,6 +27,7 @@ public class ProcessInstanceCreationCfg implements ConfigurationEntry {
   private int messageStartDedupExpirationSweepBatchLimit =
       DEFAULT_MESSAGE_START_DEDUP_EXPIRATION_SWEEP_BATCH_LIMIT;
   private Duration messageStartAskRetryInterval = DEFAULT_MESSAGE_START_ASK_RETRY_INTERVAL;
+  private Duration messageStartAskRetryGrace = DEFAULT_MESSAGE_START_ASK_RETRY_GRACE;
   private Duration messageStartLockReleasePollInterval =
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL;
   private Duration messageStartLockReleasePollMaxBackoff =
@@ -67,6 +69,14 @@ public class ProcessInstanceCreationCfg implements ConfigurationEntry {
     this.messageStartAskRetryInterval = messageStartAskRetryInterval;
   }
 
+  public Duration getMessageStartAskRetryGrace() {
+    return messageStartAskRetryGrace;
+  }
+
+  public void setMessageStartAskRetryGrace(final Duration messageStartAskRetryGrace) {
+    this.messageStartAskRetryGrace = messageStartAskRetryGrace;
+  }
+
   public Duration getMessageStartLockReleasePollInterval() {
     return messageStartLockReleasePollInterval;
   }
@@ -105,6 +115,8 @@ public class ProcessInstanceCreationCfg implements ConfigurationEntry {
         + messageStartDedupExpirationSweepBatchLimit
         + ", messageStartAskRetryInterval="
         + messageStartAskRetryInterval
+        + ", messageStartAskRetryGrace="
+        + messageStartAskRetryGrace
         + ", messageStartLockReleasePollInterval="
         + messageStartLockReleasePollInterval
         + ", messageStartLockReleasePollMaxBackoff="

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -81,6 +81,28 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_MESSAGE_START_ASK_RETRY_INTERVAL = Duration.ofSeconds(10);
 
   /**
+   * Grace period by which the cross-partition message-start dedup row on {@code P_B} is kept valid
+   * (for both re-reply lookups and the expiration sweep) <em>beyond</em> the originating message's
+   * deadline. It closes the near-deadline duplicate window: a retry ask {@code P_K} sends just
+   * before the message deadline {@code T} can be processed on {@code P_B} only at {@code T + L}
+   * (inter-partition delivery + processing latency); without grace the dedup row is already expired
+   * at {@code T}, so that late retry misses the dedup, re-evaluates live state, and — if the holder
+   * it would have re-replied has since auto-completed and freed the businessId — creates a
+   * duplicate instance. With grace the late retry still hits the dedup and re-replies the same
+   * instance.
+   *
+   * <p>The value must therefore cover the worst-case one-way inter-partition command latency plus
+   * clock skew between partitions. The default is deliberately generous: an over-large grace is
+   * essentially free — the dedup key is {@code (processDefinitionKey, messageKey)} and {@code
+   * messageKey} is unique per publish, so a stale row can never collide with a new publish; it only
+   * lingers slightly longer before the sweep GCs it. An under-sized grace re-opens the duplicate
+   * window. 30s comfortably exceeds realistic inter-partition latency and NTP-level skew even under
+   * load, and aligns with the feature's other 30s timescales (dedup sweep interval, lock-release
+   * max back-off).
+   */
+  public static final Duration DEFAULT_MESSAGE_START_ASK_RETRY_GRACE = Duration.ofSeconds(30);
+
+  /**
    * Base cadence at which {@code P_K} polls {@code P_B} for the completion of a cross-partition
    * message-start holder instance, and the interval at which a newly observed lock entry is first
    * polled. Each lock entry then backs off exponentially up to {@link
@@ -163,6 +185,7 @@ public final class EngineConfiguration {
   private int messageStartDedupExpirationSweepBatchLimit =
       DEFAULT_MESSAGE_START_DEDUP_EXPIRATION_SWEEP_BATCH_LIMIT;
   private Duration messageStartAskRetryInterval = DEFAULT_MESSAGE_START_ASK_RETRY_INTERVAL;
+  private Duration messageStartAskRetryGrace = DEFAULT_MESSAGE_START_ASK_RETRY_GRACE;
   private Duration messageStartLockReleasePollInterval =
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL;
   private Duration messageStartLockReleasePollMaxBackoff =
@@ -584,6 +607,21 @@ public final class EngineConfiguration {
   public EngineConfiguration setMessageStartAskRetryInterval(
       final Duration messageStartAskRetryInterval) {
     this.messageStartAskRetryInterval = messageStartAskRetryInterval;
+    return this;
+  }
+
+  /**
+   * Grace by which the {@code P_B} dedup row is kept valid (lookup re-replies and the expiration
+   * sweep) beyond the message deadline, to absorb a late in-flight retry and avoid a near-deadline
+   * duplicate. See {@link #DEFAULT_MESSAGE_START_ASK_RETRY_GRACE} for sizing rationale.
+   */
+  public Duration getMessageStartAskRetryGrace() {
+    return messageStartAskRetryGrace;
+  }
+
+  public EngineConfiguration setMessageStartAskRetryGrace(
+      final Duration messageStartAskRetryGrace) {
+    this.messageStartAskRetryGrace = messageStartAskRetryGrace;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceAskState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -37,6 +38,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
   private final MessageStartEventSubscriptionState messageStartEventSubscriptionState;
   private final ElementInstanceState elementInstanceState;
   private final BannedInstanceState bannedInstanceState;
+  private final MessageStartProcessInstanceAskState messageStartProcessInstanceAskState;
   private final boolean businessIdUniquenessEnabled;
 
   private final MessageCorrelateBehavior messageCorrelateBehavior;
@@ -57,6 +59,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
     messageStartEventSubscriptionState = processingState.getMessageStartEventSubscriptionState();
     elementInstanceState = processingState.getElementInstanceState();
     bannedInstanceState = processingState.getBannedInstanceState();
+    messageStartProcessInstanceAskState = processingState.getMessageStartProcessInstanceAskState();
     this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
     this.clock = clock;
 
@@ -170,20 +173,19 @@ public final class BpmnBufferedMessageStartEventBehavior {
                 // entry is left in the buffer until its TTL or until another K-keyed completion
                 // triggers a rescan.
                 //
-                // This correlation-key-keyed scan cannot, on its own, pick up such a skipped entry
-                // the moment its businessId frees: the unblocking event (the holder PI completing)
-                // is businessId-scoped and may carry a different correlation key, or none at all,
-                // so
-                // it need not trigger a rescan for this correlation key at all. Closing that
-                // liveness gap requires a businessId-keyed retry, which is owned by the pending
-                // message-start ask registry rather than by this buffer. That retry is not yet
-                // wired up for rejected starts (planned work — the cross-partition message-start
-                // rejection-retry increment). Until it lands, a skipped entry relies on its TTL or
-                // an incidental same-correlation-key completion, exactly as described above.
+                // Also skip a message that has a live pending cross-partition ask: such a message
+                // is owned by the rejection-retry registry, which is its single retry owner. This
+                // correlation-key-keyed scan cannot retry it correctly anyway — the unblocking
+                // event (the holder PI completing) is businessId-scoped and may carry a different
+                // correlation key, or none at all, so it need not trigger a rescan for this
+                // correlation key. Picking the message up here would emit a redundant second ask
+                // (harmless under P_B's dedup, but wasteful); the registry's scheduler drives the
+                // retry under back-off until the message starts or its TTL expires.
                 if (storedMessage.getMessage().getDeadline() > clock.millis()
                     && !messageState.existMessageCorrelation(
                         storedMessage.getMessageKey(), process.getBpmnProcessId())
-                    && !isBusinessIdAlreadyHeld(storedMessage, bpmnProcessId)) {
+                    && !isBusinessIdAlreadyHeld(storedMessage, bpmnProcessId)
+                    && !hasLivePendingAsk(storedMessage.getMessageKey(), process.getKey())) {
 
                   // correlate the first published message across all message start events
                   // - using the message key to decide which message was published before
@@ -228,6 +230,28 @@ public final class BpmnBufferedMessageStartEventBehavior {
         bpmnProcessId,
         storedMessage.getMessage().getTenantId(),
         bannedInstanceState::isProcessInstanceBanned);
+  }
+
+  /**
+   * Returns {@code true} when a cross-partition message-start ask is still pending for this {@code
+   * (messageKey, processDefinitionKey)}. Such a message is owned by the rejection-retry registry,
+   * which re-sends the ask under back-off, so the correlation-key buffer scan must not pick it up.
+   *
+   * <p>This guard is not redundant with {@link #isBusinessIdAlreadyHeld}: that predicate only sees
+   * <em>local</em> active PIs, but the rejections this registry retries are precisely the ones it
+   * cannot see — a cross-partition {@code UNIQUENESS_REJECTED} (the holder lives on {@code P_B})
+   * and {@code NO_SUBSCRIPTION_REJECTED} (the businessId is not locally held at all) both leave
+   * {@code isBusinessIdAlreadyHeld} returning {@code false}. Without this guard the scan would
+   * re-pick such a message on the next same-correlation-key completion and emit a redundant second
+   * ask (harmless under {@code P_B}'s dedup, but wasteful). The registry's scheduler is the single
+   * owner of the retry. Short-circuits to {@code false} when the feature is disabled, since no asks
+   * exist then.
+   */
+  private boolean hasLivePendingAsk(final long messageKey, final long processDefinitionKey) {
+    if (!businessIdUniquenessEnabled) {
+      return false;
+    }
+    return messageStartProcessInstanceAskState.get(messageKey, processDefinitionKey) != null;
   }
 
   private static final class Correlation {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -168,9 +168,18 @@ public final class BpmnBufferedMessageStartEventBehavior {
                 // visitor returns true so the scan continues to subsequent buffered entries for
                 // the same correlation key — the queue itself is not stalled, only the skipped
                 // entry is left in the buffer until its TTL or until another K-keyed completion
-                // triggers a rescan. A businessId-keyed retry (so the skipped entry can be picked
-                // up the moment the holding PI ends, regardless of correlation key) is the job of
-                // the release-driven retry path added in a later increment.
+                // triggers a rescan.
+                //
+                // This correlation-key-keyed scan cannot, on its own, pick up such a skipped entry
+                // the moment its businessId frees: the unblocking event (the holder PI completing)
+                // is businessId-scoped and may carry a different correlation key, or none at all,
+                // so
+                // it need not trigger a rescan for this correlation key at all. Closing that
+                // liveness gap requires a businessId-keyed retry, which is owned by the pending
+                // message-start ask registry rather than by this buffer. That retry is not yet
+                // wired up for rejected starts (planned work — the cross-partition message-start
+                // rejection-retry increment). Until it lands, a skipped entry relies on its TTL or
+                // an incidental same-correlation-key completion, exactly as described above.
                 if (storedMessage.getMessage().getDeadline() > clock.millis()
                     && !messageState.existMessageCorrelation(
                         storedMessage.getMessageKey(), process.getBpmnProcessId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -351,13 +351,14 @@ public final class BpmnBufferedMessageStartEventBehavior {
    * {@code isBusinessIdAlreadyHeld} returning {@code false}. Without this guard the scan would
    * re-pick such a message on the next same-correlation-key completion and emit a redundant second
    * ask (harmless under {@code P_B}'s dedup, but wasteful). The registry's scheduler is the single
-   * owner of the retry. Short-circuits to {@code false} when the feature is disabled, since no asks
-   * exist then.
+   * owner of the retry.
+   *
+   * <p>The presence of a pending ask is respected regardless of {@code
+   * businessIdUniquenessEnabled}: a remote Business ID is delegated to {@code P_B} independently of
+   * the flag (see ADR 0002 D6), and {@code NO_SUBSCRIPTION_REJECTED} asks are retried whether or
+   * not uniqueness is enabled, so asks can be pending even when the flag is off.
    */
   private boolean hasLivePendingAsk(final long messageKey, final long processDefinitionKey) {
-    if (!businessIdUniquenessEnabled) {
-      return false;
-    }
     return messageStartProcessInstanceAskState.get(messageKey, processDefinitionKey) != null;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -95,19 +95,6 @@ public final class BpmnBufferedMessageStartEventBehavior {
     return Optional.ofNullable(messageState.getProcessInstanceCorrelationKey(processInstanceKey));
   }
 
-  public void correlateMessage(
-      final BpmnElementContext context, final DirectBuffer correlationKey) {
-
-    if (correlationKey != null) {
-      // the process instance was created by a message with a correlation key
-      // - other messages with same correlation key are not correlated to this process until this
-      // instance is ended (process-correlation-key lock)
-      // - now, after the instance is ended, correlate the next buffered message
-      correlateNextBufferedMessage(
-          context.getBpmnProcessId(), correlationKey, context.getTenantId());
-    }
-  }
-
   /**
    * Picks the next eligible buffered message-start message for the given {@code (process,
    * correlationKey)} and triggers it, if any.
@@ -123,29 +110,149 @@ public final class BpmnBufferedMessageStartEventBehavior {
 
     final var process = processState.getLatestProcessVersionByProcessId(bpmnProcessId, tenantId);
 
-    findNextMessageToCorrelate(process, correlationKey)
-        .ifPresent(
-            messageCorrelation -> {
-              final var storedMessage = messageState.getMessage(messageCorrelation.messageKey);
-              final var message = storedMessage.getMessage();
+    findNextMessageToCorrelate(process, correlationKey).ifPresent(this::triggerCorrelation);
+  }
 
-              // Route the picked-up message exactly as a fresh publish would be: a businessId that
-              // hashes to another partition is delegated to P_B via the cross-partition ask rather
-              // than started locally, so the buffered pick-up cannot bypass the uniqueness
-              // handshake
-              // or violate the invariant that every businessId-carrying PI lives on P_B.
-              messageCorrelateBehavior.triggerOrDelegateStartEvent(
-                  new MessageData(
-                      storedMessage.getMessageKey(),
-                      message.getNameBuffer(),
-                      message.getCorrelationKeyBuffer(),
-                      message.getVariablesBuffer(),
-                      message.getTenantId(),
-                      message.getBusinessIdBuffer(),
-                      message.getDeadline()),
-                  messageCorrelation.subscriptionKey,
-                  messageCorrelation.subscriptionRecord);
-            });
+  /**
+   * Picks up buffered message-starts unblocked by a holder instance completing/terminating, for
+   * both unblock reasons: the freed process-correlation-key lock and the freed Business ID. The
+   * holder's own correlation key and businessId are captured by the caller <em>before</em> the
+   * completion transition removes them.
+   *
+   * <p>A single completion may unblock a message in the correlation-key queue and, separately, a
+   * message held only on the Business ID (which may carry a different correlation key, or none).
+   * Both are re-driven. The Business ID hold of a freshly triggered start is applied via a
+   * follow-up command and is therefore <em>not</em> visible within this processing step, so this
+   * method must never trigger two starts carrying the same (freed) Business ID: when the
+   * correlation-key candidate also carries the freed Business ID, only the lower-message-key of the
+   * two is triggered; the other resumes on the next completion. Candidates carrying different
+   * Business IDs are independent and may both start.
+   */
+  public void correlateNextBufferedMessagesOnCompletion(
+      final BpmnElementContext context,
+      final DirectBuffer correlationKey,
+      final String businessId) {
+    final var bpmnProcessId = context.getBpmnProcessId();
+    final var tenantId = context.getTenantId();
+    final var process = processState.getLatestProcessVersionByProcessId(bpmnProcessId, tenantId);
+    if (process == null) {
+      return;
+    }
+
+    final var correlationKeyCandidate =
+        correlationKey != null
+            ? findNextMessageToCorrelate(process, correlationKey)
+            : Optional.<Correlation>empty();
+    final var businessIdCandidate =
+        businessIdUniquenessEnabled && businessId != null && !businessId.isEmpty()
+            ? findNextMessageToCorrelateByBusinessId(
+                process, tenantId, BufferUtil.wrapString(businessId))
+            : Optional.<Correlation>empty();
+
+    if (correlationKeyCandidate.isEmpty()) {
+      businessIdCandidate.ifPresent(this::triggerCorrelation);
+      return;
+    }
+    if (businessIdCandidate.isEmpty()) {
+      triggerCorrelation(correlationKeyCandidate.get());
+      return;
+    }
+
+    final var ck = correlationKeyCandidate.get();
+    final var bid = businessIdCandidate.get();
+    if (ck.messageKey == bid.messageKey) {
+      // both reasons resolve to the same buffered message: trigger it once
+      triggerCorrelation(ck);
+      return;
+    }
+
+    final var ckMessage = messageState.getMessage(ck.messageKey);
+    final var ckBusinessId =
+        ckMessage != null
+            ? BufferUtil.bufferAsString(ckMessage.getMessage().getBusinessIdBuffer())
+            : "";
+    if (businessId.equals(ckBusinessId)) {
+      // both candidates carry the freed Business ID — starting both would create two PIs holding
+      // it,
+      // since the first start's hold is not yet applied. Trigger only the earlier (FIFO) one.
+      triggerCorrelation(ck.messageKey <= bid.messageKey ? ck : bid);
+    } else {
+      // different Business IDs (or the correlation-key candidate carries none) — safe to start both
+      triggerCorrelation(ck);
+      triggerCorrelation(bid);
+    }
+  }
+
+  private void triggerCorrelation(final Correlation messageCorrelation) {
+    final var storedMessage = messageState.getMessage(messageCorrelation.messageKey);
+    final var message = storedMessage.getMessage();
+
+    // Route the picked-up message exactly as a fresh publish would be: a businessId that hashes to
+    // another partition is delegated to P_B via the cross-partition ask rather than started
+    // locally,
+    // so the buffered pick-up cannot bypass the uniqueness handshake or violate the invariant that
+    // every businessId-carrying PI lives on P_B.
+    messageCorrelateBehavior.triggerOrDelegateStartEvent(
+        new MessageData(
+            storedMessage.getMessageKey(),
+            message.getNameBuffer(),
+            message.getCorrelationKeyBuffer(),
+            message.getVariablesBuffer(),
+            message.getTenantId(),
+            message.getBusinessIdBuffer(),
+            message.getDeadline()),
+        messageCorrelation.subscriptionKey,
+        messageCorrelation.subscriptionRecord);
+  }
+
+  /**
+   * Business-ID analogue of {@link #findNextMessageToCorrelate}: picks the lowest-message-key
+   * eligible buffered message-start that carries {@code businessId} for one of {@code process}'s
+   * message-start subscriptions, applying the same eligibility guards. Mirrors the correlation-key
+   * scan but is driven by the Business-ID index (see ADR 0002 D5).
+   */
+  private Optional<Correlation> findNextMessageToCorrelateByBusinessId(
+      final DeployedProcess process, final String tenantId, final DirectBuffer businessId) {
+
+    final var messageCorrelation = new Correlation();
+    final var bpmnProcessId = BufferUtil.bufferAsString(process.getBpmnProcessId());
+
+    messageStartEventSubscriptionState.visitSubscriptionsByProcessDefinition(
+        process.getKey(),
+        subscription -> {
+          final var messageName = subscription.getRecord().getMessageNameBuffer();
+
+          messageState.visitMessagesWithBusinessId(
+              tenantId,
+              businessId,
+              storedMessage -> {
+                // the Business-ID index is not name-scoped, so match the subscription's name here;
+                // otherwise apply the same guards as the correlation-key scan
+                if (BufferUtil.equals(storedMessage.getMessage().getNameBuffer(), messageName)
+                    && storedMessage.getMessage().getDeadline() > clock.millis()
+                    && !messageState.existMessageCorrelation(
+                        storedMessage.getMessageKey(), process.getBpmnProcessId())
+                    && !isBusinessIdAlreadyHeld(storedMessage, bpmnProcessId)
+                    && !hasLivePendingAsk(storedMessage.getMessageKey(), process.getKey())) {
+
+                  if (storedMessage.getMessageKey() < messageCorrelation.messageKey) {
+                    messageCorrelation.messageKey = storedMessage.getMessageKey();
+                    messageCorrelation.subscriptionKey = subscription.getKey();
+                    messageCorrelation.subscriptionRecord.wrap(subscription.getRecord());
+                  }
+
+                  return false;
+                }
+
+                return true;
+              });
+        });
+
+    if (messageCorrelation.subscriptionKey > 0) {
+      return Optional.of(messageCorrelation);
+    } else {
+      return Optional.empty();
+    }
   }
 
   private Optional<Correlation> findNextMessageToCorrelate(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -96,6 +96,24 @@ public final class BpmnBufferedMessageStartEventBehavior {
   }
 
   /**
+   * Returns {@code true} when the completing/terminating instance holds a Business ID that the
+   * on-completion re-drive should act on — i.e. the feature is enabled and the instance carries a
+   * non-empty Business ID.
+   *
+   * <p>Unlike the correlation-key arm, the Business ID arm does <em>not</em> require the completing
+   * instance's own process to have a message start event. Business ID uniqueness is scoped per
+   * {@code (businessId, bpmnProcessId)} across versions, so the holder may be an older version — or
+   * a none-start instance created via {@code CreateProcessInstance} — whose version lacks a message
+   * start event, while the <em>latest</em> version that owns the buffered message-start
+   * subscription has one. Gating the re-drive on the holder's own {@code hasMessageStartEvent()}
+   * would strand such a buffered start until TTL (ADR 0002 D5).
+   */
+  public boolean shouldRedriveBlockedBusinessIdOnCompletion(final BpmnElementContext context) {
+    final var businessId = context.getBusinessId();
+    return businessIdUniquenessEnabled && businessId != null && !businessId.isEmpty();
+  }
+
+  /**
    * Picks the next eligible buffered message-start message for the given {@code (process,
    * correlationKey)} and triggers it, if any.
    *

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -242,12 +242,19 @@ public final class ProcessProcessor
         }
       };
 
-    } else if (processElement.hasMessageStartEvent()) {
-      // the process might be created by a message (but not by a call activity)
-      // capture the holder's correlation key and businessId now, before the completion transition
+    } else if (processElement.hasMessageStartEvent()
+        || bufferedMessageStartEventBehavior.shouldRedriveBlockedBusinessIdOnCompletion(context)) {
+      // The process might be created by a message (but not by a call activity), or it may simply
+      // hold a Business ID that is blocking a buffered message-start of the same bpmnProcessId.
+      // Capture the holder's correlation key and businessId now, before the completion transition
       // removes them; after the transition both are re-driven to pick up any message buffered
-      // behind
-      // the freed correlation-key lock and/or the freed Business ID (ADR 0002 D5)
+      // behind the freed correlation-key lock and/or the freed Business ID (ADR 0002 D5).
+      //
+      // The Business ID arm fires even when this instance's own process has no message start event:
+      // a none-start instance (e.g. CreateProcessInstance) or an older version can hold the
+      // Business ID that blocks a message-start owned by the latest version. The re-drive resolves
+      // the latest version, so it correctly finds (or finds nothing) regardless of the holder's own
+      // version.
       final var correlationKey =
           bufferedMessageStartEventBehavior.findCorrelationKey(context).orElse(null);
       final var businessId = context.getBusinessId();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -244,12 +244,17 @@ public final class ProcessProcessor
 
     } else if (processElement.hasMessageStartEvent()) {
       // the process might be created by a message (but not by a call activity)
-      final var correlationKey = bufferedMessageStartEventBehavior.findCorrelationKey(context);
+      // capture the holder's correlation key and businessId now, before the completion transition
+      // removes them; after the transition both are re-driven to pick up any message buffered
+      // behind
+      // the freed correlation-key lock and/or the freed Business ID (ADR 0002 D5)
+      final var correlationKey =
+          bufferedMessageStartEventBehavior.findCorrelationKey(context).orElse(null);
+      final var businessId = context.getBusinessId();
 
       return postTransitionContext ->
-          correlationKey.ifPresent(
-              key ->
-                  bufferedMessageStartEventBehavior.correlateMessage(postTransitionContext, key));
+          bufferedMessageStartEventBehavior.correlateNextBufferedMessagesOnCompletion(
+              postTransitionContext, correlationKey, businessId);
 
     } else {
       return NOOP;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -311,16 +311,20 @@ public final class MessageCorrelateBehavior {
   }
 
   /**
-   * The cross-partition arm is engaged only when (i) the feature is enabled, (ii) the publish
-   * carries a non-empty {@code businessId}, and (iii) the businessId hashes to a partition other
-   * than the one that owns the message. The partition lookup is the same {@code hash-mod} used for
-   * correlation keys so {@code hash(businessId)} and {@code hash(correlationKey)} share a routing
-   * policy.
+   * The cross-partition arm is engaged whenever (i) the publish carries a non-empty {@code
+   * businessId} and (ii) that businessId hashes to a partition other than the one that owns the
+   * message. The partition lookup is the same {@code hash-mod} used for correlation keys so {@code
+   * hash(businessId)} and {@code hash(correlationKey)} share a routing policy.
+   *
+   * <p>This is deliberately <em>independent of {@code businessIdUniquenessEnabled}</em>: the
+   * structural invariant "every root PI carrying a businessId lives on {@code P_B =
+   * hash(businessId)}" must hold regardless of whether uniqueness <em>rejection</em> is switched
+   * on, otherwise enabling the feature later would find businessId-carrying instances stranded on
+   * the wrong partition. The flag instead gates only the rejection itself, on {@code P_B} (see
+   * {@link
+   * io.camunda.zeebe.engine.processing.message.MessageStartProcessInstanceRequestRequestProcessor}).
    */
   private boolean shouldDelegateToBusinessIdPartition(final MessageData messageData) {
-    if (!businessIdUniquenessEnabled) {
-      return false;
-    }
     final var businessId = messageData.businessId();
     if (businessId == null || businessId.capacity() == 0) {
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -175,6 +175,7 @@ public final class MessageEventProcessors {
                 keyGenerator,
                 clock,
                 businessIdUniquenessEnabled,
+                config.getMessageStartAskRetryGrace(),
                 writers))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
@@ -184,6 +185,7 @@ public final class MessageEventProcessors {
                 writers.command(),
                 processingState.getMessageStartProcessInstanceDedupState(),
                 config.getMessageStartDedupExpirationSweepBatchLimit(),
+                config.getMessageStartAskRetryGrace(),
                 clock))
         // Reply command processors on P_K - these handle the cross-partition replies from P_B
         .onCommand(
@@ -225,7 +227,8 @@ public final class MessageEventProcessors {
         .withListener(
             new MessageStartDedupExpirationSweepScheduler(
                 config.getMessageStartDedupExpirationSweepInterval(),
-                scheduledTaskStateFactory.get().getMessageStartProcessInstanceDedupState()))
+                scheduledTaskStateFactory.get().getMessageStartProcessInstanceDedupState(),
+                config.getMessageStartAskRetryGrace()))
         .withListener(
             new PendingMessageStartAskCheckScheduler(
                 subscriptionCommandSender,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -174,6 +174,7 @@ public final class MessageEventProcessors {
                 subscriptionCommandSender,
                 keyGenerator,
                 clock,
+                businessIdUniquenessEnabled,
                 writers))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartDedupExpirationSweepScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartDedupExpirationSweepScheduler.java
@@ -37,19 +37,25 @@ public final class MessageStartDedupExpirationSweepScheduler
 
   private final Duration executionInterval;
   private final MessageStartProcessInstanceDedupState dedupState;
+  private final Duration retryGrace;
 
   private ProcessingScheduleService scheduleService;
   private InstantSource clock;
 
   public MessageStartDedupExpirationSweepScheduler(
-      final Duration executionInterval, final MessageStartProcessInstanceDedupState dedupState) {
+      final Duration executionInterval,
+      final MessageStartProcessInstanceDedupState dedupState,
+      final Duration retryGrace) {
     this.executionInterval = executionInterval;
     this.dedupState = dedupState;
+    this.retryGrace = retryGrace;
   }
 
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-    if (dedupState.hasExpiredEntry(clock.millis())) {
+    // a row is swept only once it is grace past its deadline, matching the request processor's
+    // grace-extended dedup-hit window
+    if (dedupState.hasExpiredEntry(clock.millis() - retryGrace.toMillis())) {
       taskResultBuilder.appendCommandRecord(
           MessageStartProcessInstanceRequestIntent.SWEEP_EXPIRED_DEDUPS,
           new MessageStartProcessInstanceRequestRecord());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessIn
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.time.Duration;
 import java.time.InstantSource;
 
 /**
@@ -37,15 +38,18 @@ import java.time.InstantSource;
  * dedup state. A hit short-circuits the live-state evaluation and re-replies {@link
  * MessageStartProcessInstanceRequestIntent#STARTED} with the cached process-instance key, so a
  * retry from {@code P_K}'s pending-ask state never produces a second PI. A hit is treated as valid
- * when its {@code deletionDeadline} has not yet passed <em>and</em> the cached PI is not banned;
- * otherwise (no entry, expired entry, or banned holder) the request falls through to live-state
- * evaluation. The dedup entry's {@code deletionDeadline} is taken directly from the request's
- * {@code messageDeadline} (= {@code publishTime + ttl} on {@code P_K}), so the dedup row on {@code
- * P_B} and the buffered message on {@code P_K} share the same lifetime without any engine-internal
- * time coupling; the entry exists to bound {@code P_K}'s retry window — the sole correctness
- * contract that prevents duplicate creates is {@code retryDeadline <= messageDeadline}, enforced on
- * {@code P_K} by the {@link io.camunda.zeebe.engine.state.appliers.MessageExpiredApplier}-driven
- * pending-ask cleanup.
+ * when its {@code deletionDeadline} has not yet passed <em>plus a grace window</em> ({@code
+ * messageStartAskRetryGrace}) <em>and</em> the cached PI is not banned; otherwise (no entry,
+ * expired entry, or banned holder) the request falls through to live-state evaluation. The dedup
+ * entry's {@code deletionDeadline} is taken directly from the request's {@code messageDeadline} (=
+ * {@code publishTime + ttl} on {@code P_K}), so the dedup row on {@code P_B} and the buffered
+ * message on {@code P_K} share the same base lifetime without any engine-internal time coupling;
+ * the grace extends the re-reply window past it to absorb a retry that {@code P_K} sent just before
+ * the deadline but that only reaches {@code P_B} after it (inter-partition latency + clock skew),
+ * closing the near-deadline duplicate window. The entry exists to bound {@code P_K}'s retry window
+ * — the sole correctness contract that prevents duplicate creates is {@code retryDeadline <=
+ * messageDeadline}, enforced on {@code P_K} by the {@link
+ * io.camunda.zeebe.engine.state.appliers.MessageExpiredApplier}-driven pending-ask cleanup.
  *
  * <p>On a cache miss the three live-state outcomes are the same as before:
  *
@@ -88,6 +92,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
   private final KeyGenerator keyGenerator;
   private final InstantSource clock;
   private final boolean businessIdUniquenessEnabled;
+  private final Duration retryGrace;
   private final MessageStartProcessInstanceRequestRecord startedEventBuffer =
       new MessageStartProcessInstanceRequestRecord();
 
@@ -104,6 +109,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
       final KeyGenerator keyGenerator,
       final InstantSource clock,
       final boolean businessIdUniquenessEnabled,
+      final Duration retryGrace,
       final Writers writers) {
     this.startEventSubscriptionState = startEventSubscriptionState;
     this.elementInstanceState = elementInstanceState;
@@ -114,6 +120,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
     this.keyGenerator = keyGenerator;
     this.clock = clock;
     this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
+    this.retryGrace = retryGrace;
     eventHandle =
         new EventHandle(
             keyGenerator,
@@ -176,9 +183,18 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
   /**
    * Returns the cached process-instance key when a valid dedup entry exists for the request, or
    * {@code null} when the request must fall through to live-state evaluation. A hit is valid when
-   * its {@code deletionDeadline} has not yet passed and the cached PI is not currently banned;
-   * banned holders are filtered out so a retry can produce a fresh PI, mirroring the lookup-time
-   * banned filter on the live-state uniqueness check.
+   * its {@code deletionDeadline} (the message deadline) has not yet passed <em>plus a grace
+   * window</em>, and the cached PI is not currently banned; banned holders are filtered out so a
+   * retry can produce a fresh PI, mirroring the lookup-time banned filter on the live-state
+   * uniqueness check.
+   *
+   * <p>The grace extends validity past the message deadline to absorb a near-deadline in-flight
+   * retry: a retry {@code P_K} sends just before the deadline {@code T} may only reach this
+   * processor at {@code T + latency}; without grace it would dedup-miss, re-evaluate live state,
+   * and — if the holder it would re-reply has since auto-completed — create a duplicate. The grace
+   * keeps the row a re-reply source for that window. The dedup key {@code (processDefinitionKey,
+   * messageKey)} is unique per publish, so a grace-retained row can never shadow a different
+   * publish.
    */
   private Long lookupValidDedupHit(final MessageStartProcessInstanceRequestRecord request) {
     final MessageStartProcessInstanceDedupEntry entry =
@@ -186,7 +202,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
     if (entry == null) {
       return null;
     }
-    if (entry.getDeletionDeadline() <= clock.millis()) {
+    if (entry.getDeletionDeadline() <= clock.millis() - retryGrace.toMillis()) {
       return null;
     }
     final long cachedPiKey = entry.getProcessInstanceKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
@@ -54,13 +54,20 @@ import java.time.InstantSource;
  *       {@link MessageStartProcessInstanceRequestIntent#REJECT_NO_SUBSCRIPTION}; the publisher's
  *       message stays buffered on {@code P_K};
  *   <li>an active root PI on this partition already holds the {@code businessId} for this process
- *       definition → reply {@link MessageStartProcessInstanceRequestIntent#REJECT_UNIQUENESS}; the
- *       publisher's message stays buffered on {@code P_K};
+ *       definition <em>and uniqueness is enabled</em> → reply {@link
+ *       MessageStartProcessInstanceRequestIntent#REJECT_UNIQUENESS}; the publisher's message stays
+ *       buffered on {@code P_K};
  *   <li>otherwise → activate the new PI locally, write a local {@link
  *       MessageStartProcessInstanceRequestIntent#STARTED} follow-up event (whose applier records
  *       the dedup entry), and dispatch the {@link MessageStartProcessInstanceRequestIntent#START}
  *       reply back to {@code P_K}.
  * </ul>
+ *
+ * <p>The {@code businessIdUniquenessEnabled} flag gates only the uniqueness <em>rejection</em>, not
+ * the routing: a remote businessId is always delegated here so the "every businessId PI lives on
+ * {@code P_B}" placement invariant holds regardless of the flag (see {@link
+ * io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior}). With the flag off this
+ * processor therefore still creates the PI on {@code P_B}, it just never rejects on uniqueness.
  *
  * <p>Rejection outcomes are deliberately not deduplicated: each retry re-evaluates live state on
  * {@code P_B}, so a holder PI that has since completed (or a deployment that has since arrived) can
@@ -80,6 +87,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
   private final EventHandle eventHandle;
   private final KeyGenerator keyGenerator;
   private final InstantSource clock;
+  private final boolean businessIdUniquenessEnabled;
   private final MessageStartProcessInstanceRequestRecord startedEventBuffer =
       new MessageStartProcessInstanceRequestRecord();
 
@@ -95,6 +103,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
       final SubscriptionCommandSender commandSender,
       final KeyGenerator keyGenerator,
       final InstantSource clock,
+      final boolean businessIdUniquenessEnabled,
       final Writers writers) {
     this.startEventSubscriptionState = startEventSubscriptionState;
     this.elementInstanceState = elementInstanceState;
@@ -104,6 +113,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
     stateWriter = writers.state();
     this.keyGenerator = keyGenerator;
     this.clock = clock;
+    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
     eventHandle =
         new EventHandle(
             keyGenerator,
@@ -132,7 +142,7 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
       return;
     }
 
-    if (isBusinessIdAlreadyHeld(request)) {
+    if (businessIdUniquenessEnabled && isBusinessIdAlreadyHeld(request)) {
       commandSender.sendStartProcessInstanceUniquenessRejected(request);
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceDedupS
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.time.Duration;
 import java.time.InstantSource;
 import org.agrona.collections.MutableLong;
 
@@ -39,6 +40,7 @@ public final class MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor
   private final TypedCommandWriter commandWriter;
   private final MessageStartProcessInstanceDedupState dedupState;
   private final int batchLimit;
+  private final Duration retryGrace;
   private final InstantSource clock;
 
   public MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor(
@@ -46,11 +48,13 @@ public final class MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor
       final TypedCommandWriter commandWriter,
       final MessageStartProcessInstanceDedupState dedupState,
       final int batchLimit,
+      final Duration retryGrace,
       final InstantSource clock) {
     this.stateWriter = stateWriter;
     this.commandWriter = commandWriter;
     this.dedupState = dedupState;
     this.batchLimit = batchLimit;
+    this.retryGrace = retryGrace;
     this.clock = clock;
   }
 
@@ -60,7 +64,9 @@ public final class MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor
     final var entry = new MessageStartProcessInstanceRequestRecord();
     final boolean hasMore =
         dedupState.visitExpiredEntries(
-            clock.millis(),
+            // keep a row for the grace window past its deadline so a near-deadline in-flight retry
+            // can still be re-replied from the dedup (see the request processor's lookup grace)
+            clock.millis() - retryGrace.toMillis(),
             (processDefinitionKey, messageKey) -> {
               if (visited.getAndIncrement() >= batchLimit) {
                 return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckScheduler.java
@@ -103,6 +103,11 @@ public final class PendingMessageStartAskCheckScheduler
     final long exponent = Math.min(rejectionCount, MAX_BACKOFF_EXPONENT);
     long interval = base;
     for (long i = 0; i < exponent; i++) {
+      if (interval > Long.MAX_VALUE / 2) {
+        // Saturate rather than overflow into a negative interval: a negative interval would make
+        // `lastSentTime + interval <= now` always true and turn the back-off into a retry storm.
+        return Long.MAX_VALUE;
+      }
       interval *= 2;
     }
     return interval;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckScheduler.java
@@ -21,27 +21,36 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Scheduled task that drains pending cross-partition message-start asks on {@code P_K}. Entries
- * whose last-sent time is before the configured retry interval are re-sent to {@code P_B} via
- * {@link SubscriptionCommandSender#sendDirectStartProcessInstanceRequest}.
+ * that are due for retry are re-sent to {@code P_B} via {@link
+ * SubscriptionCommandSender#sendDirectStartProcessInstanceRequest}.
  *
- * <p>The scheduler ticks every {@code retryInterval} and re-sends every ask whose last-sent time is
- * older than {@code now - retryInterval}, so the same value bounds both the scheduler cadence and
- * the per-ask retry frequency. After sending, the entry's timestamp is updated via {@link
- * MessageStartProcessInstanceAskState#updateLastSentTime}.
+ * <p>The scheduler ticks every base {@code retryInterval} and, on each tick, re-sends every ask
+ * that is due. An ask is due when its transient last-sent time plus its back-off interval has
+ * elapsed; the back-off interval grows with the ask's persisted {@code rejectionCount} as {@code
+ * baseInterval * 2^min(rejectionCount, MAX_BACKOFF_EXPONENT)}. An un-replied ask has a rejection
+ * count of {@code 0} and so retries at the base interval (at-least-once delivery), while a
+ * repeatedly-rejected ask backs off exponentially up to {@code baseInterval *
+ * 2^MAX_BACKOFF_EXPONENT} so it does not storm {@code P_B} while its Business ID stays held. After
+ * sending, the entry's transient last-sent time is updated via {@link
+ * MessageStartProcessInstanceAskState#updateLastSentTime}; the back-off magnitude itself is
+ * event-sourced (advanced by the rejection applier), so it survives leader changes.
  *
- * <p>Entries are removed from the state when any of the three reply intents ({@code STARTED},
- * {@code UNIQUENESS_REJECTED}, {@code NO_SUBSCRIPTION_REJECTED}) is applied on {@code P_K}; those
- * handlers land in a separate commit. Entries are also cleared when the originating buffered
- * message expires on {@code P_K}, so a retry never outlives the buffered message it refers to.
- *
- * <p>Each retry re-emits the same {@code messageDeadline} that the original ask carried (sourced
- * from the buffered message's {@code publishTime + ttl}). The dedup row on {@code P_B} is keyed by
- * that same deadline, so any retry either lands on a live dedup row (cache hit, same outcome) or
- * arrives after both the dedup row and the buffered message have expired together — in which case
- * the pending-ask has already been cleared locally and no retry is emitted.
+ * <p>Entries are removed from the state when the ask succeeds ({@code STARTED}) or the originating
+ * buffered message expires on {@code P_K}; a rejection keeps the entry and increments its rejection
+ * count. Each retry re-emits the same {@code messageDeadline} the original ask carried, so any
+ * retry either lands on a live dedup row on {@code P_B} (same outcome) or arrives after both the
+ * dedup row and the buffered message have expired together — in which case the pending-ask has
+ * already been cleared locally and no retry is emitted.
  */
 public final class PendingMessageStartAskCheckScheduler
     implements Runnable, StreamProcessorLifecycleAware {
+
+  /**
+   * Caps the back-off exponent so the retry interval saturates at {@code baseInterval * 2^6} (64x
+   * the base). Bounds the maximum re-probe interval independently of how long an ask stays blocked,
+   * and keeps {@code 2^exponent} from overflowing.
+   */
+  private static final long MAX_BACKOFF_EXPONENT = 6L;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(PendingMessageStartAskCheckScheduler.class);
@@ -57,10 +66,10 @@ public final class PendingMessageStartAskCheckScheduler
    * @param commandSender sender used to dispatch asks to {@code P_B}
    * @param state the pending ask state from which to read and update entries
    * @param routingInfo used to derive the target partition for a business ID
-   * @param retryInterval supplier returning how long to wait before retrying an ask; also used as
-   *     the scheduler tick cadence. Retries always re-emit the original {@code messageDeadline}, so
-   *     correctness does not depend on this interval relative to any window — it only controls the
-   *     retry cadence
+   * @param retryInterval supplier returning the base retry interval; also the scheduler tick
+   *     cadence. The per-ask interval is this value scaled by the ask's rejection count. Retries
+   *     always re-emit the original {@code messageDeadline}, so correctness does not depend on this
+   *     interval relative to any window — it only controls the retry cadence
    */
   public PendingMessageStartAskCheckScheduler(
       final SubscriptionCommandSender commandSender,
@@ -76,12 +85,27 @@ public final class PendingMessageStartAskCheckScheduler
   @Override
   public void run() {
     final long now = clock.millis();
-    // Entries whose lastSentTime < deadline are eligible for re-send
-    final long deadline = now - retryInterval.get().toMillis();
+    state.forEachPendingAsk(
+        (lastSentTime, ask) -> {
+          if (lastSentTime + retryIntervalMillis(ask.getRejectionCount()) <= now) {
+            sendAsk(ask, now);
+          }
+        });
+  }
 
-    for (final MessageStartProcessInstanceAsk ask : state.getPendingAsksPastDeadline(deadline)) {
-      sendAsk(ask, now);
+  /**
+   * Returns the back-off interval for an ask with the given rejection count: {@code baseInterval *
+   * 2^min(rejectionCount, MAX_BACKOFF_EXPONENT)}. A rejection count of {@code 0} yields the base
+   * interval.
+   */
+  private long retryIntervalMillis(final long rejectionCount) {
+    final long base = retryInterval.get().toMillis();
+    final long exponent = Math.min(rejectionCount, MAX_BACKOFF_EXPONENT);
+    long interval = base;
+    for (long i = 0; i < exponent; i++) {
+      interval *= 2;
     }
+    return interval;
   }
 
   private void sendAsk(final MessageStartProcessInstanceAsk ask, final long now) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceNoSubscriptionRejectedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceNoSubscriptionRejectedV1Applier.java
@@ -13,11 +13,12 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessIn
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 
 /**
- * Removes the pending cross-partition ask entry on {@code P_K} when a {@link
- * MessageStartProcessInstanceRequestIntent#NO_SUBSCRIPTION_REJECTED} reply is applied. The message
- * stays buffered (preserving the same semantics as when a local start-event subscription is
- * missing), but the pending-ask bookkeeping is cleared so commit 7's scheduler does not retry-storm
- * after a final rejection.
+ * Records a {@link MessageStartProcessInstanceRequestIntent#NO_SUBSCRIPTION_REJECTED} reply on
+ * {@code P_K} by backing the pending cross-partition ask off rather than dropping it. The message
+ * stays buffered (the start-event subscription has not yet been distributed to {@code P_B}) and the
+ * ask is kept with an incremented rejection count, so the scheduler re-sends it under exponential
+ * back-off: once the deployment reaches {@code P_B}, a later retry flips to {@code STARTED}. The
+ * ask is finally cleared only by a success or by the buffered message expiring at its TTL.
  *
  * <p>This applier is V1-only because the {@code NO_SUBSCRIPTION_REJECTED} intent has no production
  * stream history (it is introduced together with this feature).
@@ -35,6 +36,6 @@ final class MessageStartProcessInstanceNoSubscriptionRejectedV1Applier
 
   @Override
   public void applyState(final long key, final MessageStartProcessInstanceRequestRecord value) {
-    askState.remove(value.getMessageKey(), value.getProcessDefinitionKey());
+    askState.backOff(value.getMessageKey(), value.getProcessDefinitionKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceUniquenessRejectedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceUniquenessRejectedV1Applier.java
@@ -13,10 +13,12 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessIn
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 
 /**
- * Removes the pending cross-partition ask entry on {@code P_K} when a {@link
- * MessageStartProcessInstanceRequestIntent#UNIQUENESS_REJECTED} reply is applied. The message stays
- * buffered and waits for the pull-based release mechanism in Increment 4, but the pending-ask
- * bookkeeping is cleared so commit 7's scheduler does not retry-storm after a final rejection.
+ * Records a {@link MessageStartProcessInstanceRequestIntent#UNIQUENESS_REJECTED} reply on {@code
+ * P_K} by backing the pending cross-partition ask off rather than dropping it. The message stays
+ * buffered and the ask is kept with an incremented rejection count, so the scheduler re-sends it
+ * under exponential back-off: when the holder instance that currently owns the {@code businessId}
+ * completes (or is banned), a later retry flips to {@code STARTED}. The ask is finally cleared only
+ * by a success or by the buffered message expiring at its TTL.
  *
  * <p>This applier is V1-only because the {@code UNIQUENESS_REJECTED} intent has no production
  * stream history (it is introduced together with this feature).
@@ -34,6 +36,6 @@ final class MessageStartProcessInstanceUniquenessRejectedV1Applier
 
   @Override
   public void applyState(final long key, final MessageStartProcessInstanceRequestRecord value) {
-    askState.remove(value.getMessageKey(), value.getProcessDefinitionKey());
+    askState.backOff(value.getMessageKey(), value.getProcessDefinitionKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageStartProcessInstanceAskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageStartProcessInstanceAskState.java
@@ -39,13 +39,14 @@ public interface MessageStartProcessInstanceAskState {
   void forEach(AskVisitor visitor);
 
   /**
-   * Returns all pending asks whose last-sent timestamp is before the given deadline; intended for
-   * the scheduled retry loop.
+   * Visits every pending ask together with its transient last-sent timestamp, so the retry
+   * scheduler can decide per-ask eligibility from the ask's {@code rejectionCount} and the
+   * configured back-off it owns. The {@code ask} passed to the visitor is a freshly read instance
+   * that is safe to retain.
    *
-   * @param deadline epoch millis
-   * @return an iterable of pending asks past their deadline
+   * @param visitor called once per pending ask with its last-sent time and the ask
    */
-  Iterable<MessageStartProcessInstanceAsk> getPendingAsksPastDeadline(long deadline);
+  void forEachPendingAsk(PendingAskVisitor visitor);
 
   /**
    * Updates the in-memory last-sent timestamp for a pending ask. The retry scheduler calls this
@@ -67,5 +68,10 @@ public interface MessageStartProcessInstanceAskState {
   @FunctionalInterface
   interface AskVisitor {
     void visit(long messageKey, long processDefinitionKey, MessageStartProcessInstanceAsk ask);
+  }
+
+  @FunctionalInterface
+  interface PendingAskVisitor {
+    void visit(long lastSentTime, MessageStartProcessInstanceAsk ask);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageStartProcessInstanceAskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageStartProcessInstanceAskState.java
@@ -11,9 +11,10 @@ import io.camunda.zeebe.engine.state.message.MessageStartProcessInstanceAsk;
 
 /**
  * Read-only view of the pending cross-partition message-start ask state on {@code P_K}. An entry
- * exists for each outstanding ask (REQUEST sent, no reply yet). The entry is removed when any of
- * the three reply intents ({@code STARTED}, {@code UNIQUENESS_REJECTED}, {@code
- * NO_SUBSCRIPTION_REJECTED}) is applied locally.
+ * exists for each outstanding ask (REQUEST sent, no reply yet). The entry is removed when the ask
+ * succeeds ({@code STARTED} applied locally) or the buffered message expires; a rejection ({@code
+ * UNIQUENESS_REJECTED} / {@code NO_SUBSCRIPTION_REJECTED}) instead keeps the entry and increments
+ * its {@code rejectionCount} so it is retried under back-off.
  *
  * <p>Each entry is keyed by {@code (messageKey, processDefinitionKey)}; the pair uniquely
  * identifies an ask from this partition because a single message can only target one process

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageStartProcessInstanceAskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageStartProcessInstanceAskState.java
@@ -39,16 +39,6 @@ public interface MessageStartProcessInstanceAskState {
   void forEach(AskVisitor visitor);
 
   /**
-   * Returns {@code true} if there are pending asks whose last-sent timestamp suggests they are
-   * ready for retry (i.e., past the retry deadline).
-   *
-   * @param deadline epoch millis; returns true if any pending ask has {@code lastSentTime <
-   *     deadline}
-   * @return {@code true} if at least one ask is past its retry deadline
-   */
-  boolean hasPendingAsksPastDeadline(long deadline);
-
-  /**
    * Returns all pending asks whose last-sent timestamp is before the given deadline; intended for
    * the scheduled retry loop.
    *

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageStartProcessInstanceDedupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageStartProcessInstanceDedupState.java
@@ -36,23 +36,25 @@ public interface MessageStartProcessInstanceDedupState {
   MessageStartProcessInstanceDedupEntry get(long processDefinitionKey, long messageKey);
 
   /**
-   * Visits entries whose {@code deletionDeadline} is at or before {@code now}. The visitor returns
-   * {@code true} to continue or {@code false} to stop early (e.g. on hitting a batch limit). Do not
-   * mutate the column family from within the visitor — iteration is performed directly over the
-   * underlying CF; deletions must be enqueued and applied after this call returns.
+   * Visits entries whose {@code deletionDeadline} is at or before {@code expiryThreshold}. Callers
+   * pass an effective threshold (typically {@code now - grace}) so the grace window is applied at
+   * the call site rather than baked into the stored deadline. The visitor returns {@code true} to
+   * continue or {@code false} to stop early (e.g. on hitting a batch limit). Do not mutate the
+   * column family from within the visitor — iteration is performed directly over the underlying CF;
+   * deletions must be enqueued and applied after this call returns.
    *
    * @return {@code true} iff iteration stopped early because the visitor returned {@code false}
-   *     (i.e. more past-deadline entries may exist beyond what was visited); {@code false} when the
-   *     visitor consumed every past-deadline entry.
+   *     (i.e. more past-threshold entries may exist beyond what was visited); {@code false} when
+   *     the visitor consumed every past-threshold entry.
    */
-  boolean visitExpiredEntries(long now, ExpiredEntryVisitor visitor);
+  boolean visitExpiredEntries(long expiryThreshold, ExpiredEntryVisitor visitor);
 
   /**
    * Returns {@code true} when at least one entry's {@code deletionDeadline} is at or before {@code
-   * now}. Intended as the scheduler's cheap leader-side probe before it writes a sweep trigger
-   * command.
+   * expiryThreshold}. Callers pass an effective threshold (typically {@code now - grace}). Intended
+   * as the scheduler's cheap leader-side probe before it writes a sweep trigger command.
    */
-  boolean hasExpiredEntry(long now);
+  boolean hasExpiredEntry(long expiryThreshold);
 
   @FunctionalInterface
   interface ExpiredEntryVisitor {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageState.java
@@ -25,6 +25,16 @@ public interface MessageState {
       DirectBuffer correlationKey,
       MessageVisitor visitor);
 
+  /**
+   * Visits buffered messages that carry the given {@code businessId} (within the tenant), in
+   * message-key (publish) order. Only messages that were published with a business id are indexed,
+   * so this never visits a business-id-less message. Used to re-drive a same-partition
+   * message-start that was skipped on Business-ID uniqueness once the holder frees the business id
+   * (ADR 0002 D5).
+   */
+  void visitMessagesWithBusinessId(
+      final String tenantId, DirectBuffer businessId, MessageVisitor visitor);
+
   StoredMessage getMessage(long messageKey);
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskState.java
@@ -63,11 +63,18 @@ public final class DbMessageStartProcessInstanceAskState
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
-    // Rebuild the transient state from the persisted CF. All entries are added with lastSentTime=0
-    // so they are immediately eligible for re-send; the P_B dedup bounds the storm.
+    // Rebuild the transient last-sent tracking from the persisted CF. The back-off magnitude (the
+    // rejectionCount) survives in the CF; only the last-sent phase is rebuilt here. Fresh asks
+    // (never rejected) are seeded with lastSentTime=0 so they are immediately eligible, preserving
+    // at-least-once first delivery. Already-backed-off asks are seeded with the recovery time so
+    // they resume at their back-off cadence rather than every blocked ask re-probing P_B at once.
+    final long recoveryTime = context.getClock().millis();
     columnFamily.forEach(
-        (k, v) ->
-            transientState.add(new PendingAskKey(k.first().getValue(), k.second().getValue()), 0L));
+        (k, v) -> {
+          final long lastSentSeed = v.getRejectionCount() > 0 ? recoveryTime : 0L;
+          transientState.add(
+              new PendingAskKey(k.first().getValue(), k.second().getValue()), lastSentSeed);
+        });
   }
 
   @Override
@@ -84,15 +91,14 @@ public final class DbMessageStartProcessInstanceAskState
   }
 
   @Override
-  public Iterable<MessageStartProcessInstanceAsk> getPendingAsksPastDeadline(final long deadline) {
-    final List<MessageStartProcessInstanceAsk> result = new ArrayList<>();
-    for (final var askKey : transientState.entriesBefore(deadline)) {
+  public void forEachPendingAsk(final PendingAskVisitor visitor) {
+    for (final var entry : transientState.entries()) {
+      final var askKey = entry.getKey();
       final var ask = get(askKey.messageKey(), askKey.processDefinitionKey());
       if (ask != null) {
-        result.add(ask.copy());
+        visitor.visit(entry.getValue(), ask);
       }
     }
-    return result;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskState.java
@@ -34,6 +34,14 @@ import java.util.List;
 public final class DbMessageStartProcessInstanceAskState
     implements MutableMessageStartProcessInstanceAskState, StreamProcessorLifecycleAware {
 
+  /**
+   * Upper bound on the persisted rejection count. The scheduler derives the back-off interval as
+   * {@code min(baseInterval * 2^rejectionCount, cap)}, which saturates at the cap long before this
+   * bound; capping the stored count keeps the value bounded for a very long-blocked ask and avoids
+   * any overflow when the scheduler computes {@code 2^rejectionCount}.
+   */
+  private static final long MAX_REJECTION_COUNT = 30L;
+
   private final DbLong messageKey = new DbLong();
   private final DbLong processDefinitionKey = new DbLong();
   private final DbCompositeKey<DbLong, DbLong> key =
@@ -106,6 +114,22 @@ public final class DbMessageStartProcessInstanceAskState
     this.processDefinitionKey.wrapLong(processDefinitionKey);
     columnFamily.deleteIfExists(key);
     transientState.remove(new PendingAskKey(messageKey, processDefinitionKey));
+  }
+
+  @Override
+  public void backOff(final long messageKey, final long processDefinitionKey) {
+    final var ask = get(messageKey, processDefinitionKey);
+    if (ask == null) {
+      // The ask was already removed (e.g. by a racing success or message expiry); nothing to do.
+      return;
+    }
+    ask.setRejectionCount(Math.min(ask.getRejectionCount() + 1, MAX_REJECTION_COUNT));
+    this.messageKey.wrapLong(messageKey);
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    columnFamily.upsert(key, ask);
+    // Intentionally leave the transient last-sent tracking untouched: the scheduler uses it as the
+    // in-flight guard, and resetting it here would make the ask immediately eligible again and
+    // defeat the back-off the incremented count is meant to produce.
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskState.java
@@ -84,11 +84,6 @@ public final class DbMessageStartProcessInstanceAskState
   }
 
   @Override
-  public boolean hasPendingAsksPastDeadline(final long deadline) {
-    return transientState.entriesBefore(deadline).iterator().hasNext();
-  }
-
-  @Override
   public Iterable<MessageStartProcessInstanceAsk> getPendingAsksPastDeadline(final long deadline) {
     final List<MessageStartProcessInstanceAsk> result = new ArrayList<>();
     for (final var askKey : transientState.entriesBefore(deadline)) {
@@ -98,6 +93,12 @@ public final class DbMessageStartProcessInstanceAskState
       }
     }
     return result;
+  }
+
+  @Override
+  public void updateLastSentTime(
+      final long messageKey, final long processDefinitionKey, final long lastSentTime) {
+    transientState.update(new PendingAskKey(messageKey, processDefinitionKey), lastSentTime);
   }
 
   @Override
@@ -145,11 +146,5 @@ public final class DbMessageStartProcessInstanceAskState
     for (final long pdk : processDefinitionKeysToRemove) {
       remove(messageKey, pdk);
     }
-  }
-
-  @Override
-  public void updateLastSentTime(
-      final long messageKey, final long processDefinitionKey, final long lastSentTime) {
-    transientState.update(new PendingAskKey(messageKey, processDefinitionKey), lastSentTime);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceDedupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceDedupState.java
@@ -32,6 +32,14 @@ import org.agrona.collections.MutableBoolean;
  * io.camunda.zeebe.engine.state.appliers.MessageExpiredApplier}-driven pending-ask cleanup. There
  * is no PI-completion hook on this state and no reverse mapping by process-instance key — both are
  * unnecessary under write-time expiry.
+ *
+ * <p>The stored {@code deletionDeadline} is exactly the message deadline; callers ({@link
+ * #visitExpiredEntries} / {@link #hasExpiredEntry} and the request processor's dedup lookup) decide
+ * expiry by passing an effective {@code now}. The cross-partition request processor and the sweep
+ * pass {@code now - grace} so a row stays a valid re-reply source for a grace window past its
+ * deadline — absorbing a near-deadline in-flight retry without a duplicate. The grace lives in
+ * those callers, not in this state, keeping the stored value a pure function of the message
+ * deadline.
  */
 public final class DbMessageStartProcessInstanceDedupState
     implements MutableMessageStartProcessInstanceDedupState {
@@ -65,14 +73,15 @@ public final class DbMessageStartProcessInstanceDedupState
   }
 
   @Override
-  public boolean visitExpiredEntries(final long now, final ExpiredEntryVisitor visitor) {
+  public boolean visitExpiredEntries(
+      final long expiryThreshold, final ExpiredEntryVisitor visitor) {
     // Iterate the CF directly with early-exit so per-tick work is bounded by the visitor's batch
     // limit rather than the full CF size. The visitor must not mutate the column family — any
     // deletions are deferred to event appliers that run after this call returns.
     final var stoppedEarly = new MutableBoolean(false);
     columnFamily.whileTrue(
         (key, value) -> {
-          if (value.getDeletionDeadline() > now) {
+          if (value.getDeletionDeadline() > expiryThreshold) {
             // Keep scanning: ordering is by (processDefinitionKey, messageKey), not deadline.
             return true;
           }
@@ -86,11 +95,11 @@ public final class DbMessageStartProcessInstanceDedupState
   }
 
   @Override
-  public boolean hasExpiredEntry(final long now) {
+  public boolean hasExpiredEntry(final long expiryThreshold) {
     final var found = new MutableBoolean(false);
     columnFamily.whileTrue(
         (key, value) -> {
-          if (value.getDeletionDeadline() <= now) {
+          if (value.getDeletionDeadline() <= expiryThreshold) {
             found.set(true);
             return false;
           }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -449,7 +449,10 @@ public final class DbMessageState implements MutableMessageState {
     final DirectBuffer businessIdBuffer = storedMessage.getMessage().getBusinessIdBuffer();
     if (businessIdBuffer.capacity() > 0) {
       businessId.wrapBuffer(businessIdBuffer);
-      messageByBusinessIdColumnFamily.deleteExisting(businessIdMessageKey);
+      // deleteIfExists (not deleteExisting): the business-id index was added after buffered
+      // messages already carried a business id, so a message published before the index existed
+      // (upgraded RocksDB state) has no entry here. Removing it must not throw on the missing key.
+      messageByBusinessIdColumnFamily.deleteIfExists(businessIdMessageKey);
     }
 
     deadline.wrapLong(storedMessage.getMessage().getDeadline());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -98,6 +98,22 @@ public final class DbMessageState implements MutableMessageState {
       messageIdColumnFamily;
 
   /**
+   * <pre>tenant aware business id | message key -> []
+   *
+   * find buffered messages by business id. Only messages published with a business id are indexed.
+   * Lets a same-partition message-start that was skipped on Business-ID uniqueness be found again by
+   * the freed business id when a holder completes/terminates (ADR 0002 D5).
+   */
+  private final DbString businessId;
+
+  private final DbTenantAwareKey<DbString> tenantAwareBusinessId;
+  private final DbCompositeKey<DbTenantAwareKey<DbString>, DbForeignKey<DbLong>>
+      businessIdMessageKey;
+  private final ColumnFamily<
+          DbCompositeKey<DbTenantAwareKey<DbString>, DbForeignKey<DbLong>>, DbNil>
+      messageByBusinessIdColumnFamily;
+
+  /**
    * <pre>key | bpmn process id -> []
    *
    * check if a message is correlated to a process
@@ -201,6 +217,16 @@ public final class DbMessageState implements MutableMessageState {
             nameCorrelationMessageIdKey,
             DbNil.INSTANCE);
 
+    businessId = new DbString();
+    tenantAwareBusinessId = new DbTenantAwareKey<>(tenantIdKey, businessId, PlacementType.PREFIX);
+    businessIdMessageKey = new DbCompositeKey<>(tenantAwareBusinessId, fkMessage);
+    messageByBusinessIdColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.MESSAGE_BY_BUSINESS_ID,
+            transactionContext,
+            businessIdMessageKey,
+            DbNil.INSTANCE);
+
     bpmnProcessIdKey = new DbString();
     messageBpmnProcessIdKey = new DbCompositeKey<>(fkMessage, bpmnProcessIdKey);
     correlatedMessageColumnFamily =
@@ -270,6 +296,14 @@ public final class DbMessageState implements MutableMessageState {
     if (messageId.capacity() > 0) {
       this.messageId.wrapBuffer(messageId);
       messageIdColumnFamily.upsert(nameCorrelationMessageIdKey, DbNil.INSTANCE);
+    }
+
+    // index by business id so a same-partition start skipped on uniqueness can be re-found when the
+    // holder frees the business id (tenantIdKey and messageKey/fkMessage are wrapped above)
+    final DirectBuffer businessIdBuffer = record.getBusinessIdBuffer();
+    if (businessIdBuffer.capacity() > 0) {
+      businessId.wrapBuffer(businessIdBuffer);
+      messageByBusinessIdColumnFamily.insert(businessIdMessageKey, DbNil.INSTANCE);
     }
   }
 
@@ -412,6 +446,12 @@ public final class DbMessageState implements MutableMessageState {
       messageIdColumnFamily.deleteExisting(nameCorrelationMessageIdKey);
     }
 
+    final DirectBuffer businessIdBuffer = storedMessage.getMessage().getBusinessIdBuffer();
+    if (businessIdBuffer.capacity() > 0) {
+      businessId.wrapBuffer(businessIdBuffer);
+      messageByBusinessIdColumnFamily.deleteExisting(businessIdMessageKey);
+    }
+
     deadline.wrapLong(storedMessage.getMessage().getDeadline());
     deadlineColumnFamily.deleteExisting(deadlineMessageKey);
 
@@ -469,6 +509,21 @@ public final class DbMessageState implements MutableMessageState {
 
     nameCorrelationMessageColumnFamily.whileEqualPrefix(
         nameAndCorrelationKey,
+        (compositeKey, nil) -> {
+          final long messageKey = compositeKey.second().inner().getValue();
+          final StoredMessage message = getMessage(messageKey);
+          return visitor.visit(message);
+        });
+  }
+
+  @Override
+  public void visitMessagesWithBusinessId(
+      final String tenantId, final DirectBuffer businessId, final MessageVisitor visitor) {
+    tenantIdKey.wrapString(tenantId);
+    this.businessId.wrapBuffer(businessId);
+
+    messageByBusinessIdColumnFamily.whileEqualPrefix(
+        tenantAwareBusinessId,
         (compositeKey, nil) -> {
           final long messageKey = compositeKey.second().inner().getValue();
           final StoredMessage message = getMessage(messageKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageStartProcessInstanceAsk.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageStartProcessInstanceAsk.java
@@ -25,6 +25,18 @@ import org.agrona.concurrent.UnsafeBuffer;
  * <p>Keyed by {@code (messageKey, processDefinitionKey)} — the pair that uniquely identifies an
  * outstanding ask from this partition. When any of the three reply intents is applied, the entry is
  * removed.
+ *
+ * <p>The {@code retryBackoffMillis} field is {@code P_K}-local retry bookkeeping — the current
+ * back-off <em>magnitude</em> — not part of the cross-partition request. It is deliberately absent
+ * from {@link #wrap(MessageStartProcessInstanceRequestRecord)} and {@link
+ * #populateRecord(MessageStartProcessInstanceRequestRecord)}: an un-replied ask carries no back-off
+ * (default {@code 0} keeps it eligible for base-interval re-send), and a rejected ask has its
+ * magnitude doubled (capped) by the rejection applier on each rejection reply — a pure function of
+ * the prior persisted value, needing no clock or event timestamp. The scheduler derives the
+ * next-retry time as {@code lastSent + max(baseInterval, retryBackoffMillis)}. Persisting the
+ * magnitude — rather than holding it in the transient send tracker — keeps a long-blocked ask from
+ * resetting to base-interval storming on every leader change. It defaults to {@code 0} so values
+ * persisted before this field existed decode unchanged.
  */
 public final class MessageStartProcessInstanceAsk extends UnpackedObject implements DbValue {
 
@@ -42,9 +54,10 @@ public final class MessageStartProcessInstanceAsk extends UnpackedObject impleme
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty messageDeadlineProp = new LongProperty("messageDeadline", -1L);
+  private final LongProperty retryBackoffMillisProp = new LongProperty("retryBackoffMillis", 0L);
 
   public MessageStartProcessInstanceAsk() {
-    super(11);
+    super(12);
     declareProperty(messageKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(correlationKeyProp)
@@ -55,7 +68,8 @@ public final class MessageStartProcessInstanceAsk extends UnpackedObject impleme
         .declareProperty(messageStartEventSubscriptionKeyProp)
         .declareProperty(variablesProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(messageDeadlineProp);
+        .declareProperty(messageDeadlineProp)
+        .declareProperty(retryBackoffMillisProp);
   }
 
   /**
@@ -226,6 +240,20 @@ public final class MessageStartProcessInstanceAsk extends UnpackedObject impleme
 
   public MessageStartProcessInstanceAsk setMessageDeadline(final long messageDeadline) {
     messageDeadlineProp.setValue(messageDeadline);
+    return this;
+  }
+
+  /**
+   * The current retry back-off magnitude in millis. {@code 0} for an un-replied ask; doubled (up to
+   * a cap) by the rejection applier on each rejection reply. The scheduler derives the next-retry
+   * time as {@code lastSent + max(baseInterval, retryBackoffMillis)}.
+   */
+  public long getRetryBackoffMillis() {
+    return retryBackoffMillisProp.getValue();
+  }
+
+  public MessageStartProcessInstanceAsk setRetryBackoffMillis(final long retryBackoffMillis) {
+    retryBackoffMillisProp.setValue(retryBackoffMillis);
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageStartProcessInstanceAsk.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageStartProcessInstanceAsk.java
@@ -26,17 +26,18 @@ import org.agrona.concurrent.UnsafeBuffer;
  * outstanding ask from this partition. When any of the three reply intents is applied, the entry is
  * removed.
  *
- * <p>The {@code retryBackoffMillis} field is {@code P_K}-local retry bookkeeping — the current
- * back-off <em>magnitude</em> — not part of the cross-partition request. It is deliberately absent
+ * <p>The {@code rejectionCount} field is {@code P_K}-local retry bookkeeping — how many times this
+ * ask has been rejected so far — not part of the cross-partition request. It is deliberately absent
  * from {@link #wrap(MessageStartProcessInstanceRequestRecord)} and {@link
- * #populateRecord(MessageStartProcessInstanceRequestRecord)}: an un-replied ask carries no back-off
- * (default {@code 0} keeps it eligible for base-interval re-send), and a rejected ask has its
- * magnitude doubled (capped) by the rejection applier on each rejection reply — a pure function of
- * the prior persisted value, needing no clock or event timestamp. The scheduler derives the
- * next-retry time as {@code lastSent + max(baseInterval, retryBackoffMillis)}. Persisting the
- * magnitude — rather than holding it in the transient send tracker — keeps a long-blocked ask from
- * resetting to base-interval storming on every leader change. It defaults to {@code 0} so values
- * persisted before this field existed decode unchanged.
+ * #populateRecord(MessageStartProcessInstanceRequestRecord)}: an un-replied ask carries a count of
+ * {@code 0} (the base re-send cadence), and each rejection reply increments it via the rejection
+ * applier — a pure, clock-free function of the prior persisted value, so it stays deterministic on
+ * replay. The applier stores only the count, not a back-off duration: deriving the duration needs
+ * the configured base/cap, and appliers must not read mutable config. The scheduler (which may read
+ * config) turns the count into the next-retry interval, {@code min(baseInterval * 2^rejectionCount,
+ * cap)}. Persisting the count — rather than holding it in the transient send tracker — keeps a
+ * long-blocked ask from resetting to base-interval storming on every leader change. It defaults to
+ * {@code 0} so values persisted before this field existed decode unchanged.
  */
 public final class MessageStartProcessInstanceAsk extends UnpackedObject implements DbValue {
 
@@ -54,7 +55,7 @@ public final class MessageStartProcessInstanceAsk extends UnpackedObject impleme
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty messageDeadlineProp = new LongProperty("messageDeadline", -1L);
-  private final LongProperty retryBackoffMillisProp = new LongProperty("retryBackoffMillis", 0L);
+  private final LongProperty rejectionCountProp = new LongProperty("rejectionCount", 0L);
 
   public MessageStartProcessInstanceAsk() {
     super(12);
@@ -69,7 +70,7 @@ public final class MessageStartProcessInstanceAsk extends UnpackedObject impleme
         .declareProperty(variablesProp)
         .declareProperty(tenantIdProp)
         .declareProperty(messageDeadlineProp)
-        .declareProperty(retryBackoffMillisProp);
+        .declareProperty(rejectionCountProp);
   }
 
   /**
@@ -244,16 +245,16 @@ public final class MessageStartProcessInstanceAsk extends UnpackedObject impleme
   }
 
   /**
-   * The current retry back-off magnitude in millis. {@code 0} for an un-replied ask; doubled (up to
-   * a cap) by the rejection applier on each rejection reply. The scheduler derives the next-retry
-   * time as {@code lastSent + max(baseInterval, retryBackoffMillis)}.
+   * How many times this ask has been rejected. {@code 0} for an un-replied ask; incremented by the
+   * rejection applier on each rejection reply. The scheduler turns it into the next-retry interval,
+   * {@code min(baseInterval * 2^rejectionCount, cap)}.
    */
-  public long getRetryBackoffMillis() {
-    return retryBackoffMillisProp.getValue();
+  public long getRejectionCount() {
+    return rejectionCountProp.getValue();
   }
 
-  public MessageStartProcessInstanceAsk setRetryBackoffMillis(final long retryBackoffMillis) {
-    retryBackoffMillisProp.setValue(retryBackoffMillis);
+  public MessageStartProcessInstanceAsk setRejectionCount(final long rejectionCount) {
+    rejectionCountProp.setValue(rejectionCount);
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageStartProcessInstanceAsk.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageStartProcessInstanceAsk.java
@@ -23,8 +23,10 @@ import org.agrona.concurrent.UnsafeBuffer;
  * MessageStartProcessInstanceRequestRecord}.
  *
  * <p>Keyed by {@code (messageKey, processDefinitionKey)} — the pair that uniquely identifies an
- * outstanding ask from this partition. When any of the three reply intents is applied, the entry is
- * removed.
+ * outstanding ask from this partition. The entry is removed when the ask succeeds ({@code STARTED}
+ * applied locally) or the buffered message expires; a rejection ({@code UNIQUENESS_REJECTED} /
+ * {@code NO_SUBSCRIPTION_REJECTED}) instead keeps the entry and increments its {@code
+ * rejectionCount} so it is retried under back-off.
  *
  * <p>The {@code rejectionCount} field is {@code P_K}-local retry bookkeeping — how many times this
  * ask has been rejected so far — not part of the cross-partition request. It is deliberately absent

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/TransientPendingMessageStartProcessInstanceAskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/TransientPendingMessageStartProcessInstanceAskState.java
@@ -7,22 +7,23 @@
  */
 package io.camunda.zeebe.engine.state.message;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Transient (in-memory only) state that tracks when each pending cross-partition message-start ask
  * was last sent. Used by {@link DbMessageStartProcessInstanceAskState} to implement retry
  * scheduling.
  *
- * <p>On recovery the CF is walked and all entries are added with {@code lastSentTime = 0} so they
- * are immediately eligible for re-send. This is safe because the success-only dedup on {@code P_B}
- * bounds the storm.
+ * <p>On recovery the CF is walked and each entry is seeded with a last-sent timestamp (see {@link
+ * DbMessageStartProcessInstanceAskState#onRecovered}): fresh asks with {@code 0} (immediately
+ * eligible, preserving at-least-once first delivery), already-backed-off asks with the recovery
+ * time (so they resume at their back-off cadence instead of all re-probing at once).
  *
  * <p>This class is thread-safe. It is intended that one thread mutates (add/update/remove) while
- * another observes via {@link #entriesBefore(long)}.
+ * another observes via {@link #entries()}.
  */
 public final class TransientPendingMessageStartProcessInstanceAskState {
 
@@ -49,7 +50,7 @@ public final class TransientPendingMessageStartProcessInstanceAskState {
   }
 
   /**
-   * Removes a pending ask. Called when any of the three reply intents is applied on {@code P_K}.
+   * Removes a pending ask. Called when the ask succeeds or the buffered message expires.
    *
    * @param key the key identifying the ask
    */
@@ -58,19 +59,15 @@ public final class TransientPendingMessageStartProcessInstanceAskState {
   }
 
   /**
-   * Returns all pending asks whose last-sent timestamp is before the given deadline, ordered by
-   * that timestamp (oldest first). The returned iterable may include entries that were updated or
-   * removed concurrently; the caller must tolerate stale data.
+   * Returns a snapshot of all pending asks with their last-sent timestamps. The retry scheduler
+   * joins each entry with its persisted ask (for the rejection count and the re-send payload) to
+   * decide per-ask eligibility. A snapshot is returned so the caller may mutate the underlying
+   * state (e.g. {@link #update}) while iterating.
    *
-   * @param deadline epoch millis; entries with {@code lastSentTime < deadline} are returned
-   * @return an iterable of pending ask keys
+   * @return a snapshot of {@code (key, lastSentTime)} entries
    */
-  public Iterable<PendingAskKey> entriesBefore(final long deadline) {
-    return pending.entrySet().stream()
-        .sorted(Map.Entry.comparingByValue())
-        .takeWhile(entry -> entry.getValue() < deadline)
-        .map(Entry::getKey)
-        .collect(Collectors.toList());
+  public Iterable<Entry<PendingAskKey, Long>> entries() {
+    return List.copyOf(pending.entrySet());
   }
 
   /** Returns {@code true} if there are no pending asks. */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMessageStartProcessInstanceAskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMessageStartProcessInstanceAskState.java
@@ -35,6 +35,23 @@ public interface MutableMessageStartProcessInstanceAskState
   void remove(long messageKey, long processDefinitionKey);
 
   /**
+   * Records a rejection of the pending ask by incrementing its persisted {@code rejectionCount}
+   * (capped), keeping the ask so it is retried under back-off instead of being dropped. Called from
+   * the {@code UNIQUENESS_REJECTED} / {@code NO_SUBSCRIPTION_REJECTED} appliers in place of {@link
+   * #remove(long, long)}.
+   *
+   * <p>The advance is a pure, clock-free function of the prior persisted count, so it is
+   * deterministic on replay; the scheduler turns the count into the next-retry interval. This
+   * deliberately does <strong>not</strong> touch the transient last-sent tracking: resetting it
+   * would make the ask immediately eligible again and defeat the back-off. A no-op if no ask exists
+   * for the key (e.g. it was already removed by a racing success/expiry).
+   *
+   * @param messageKey the key of the message that triggered the ask
+   * @param processDefinitionKey the key of the process definition the ask targets
+   */
+  void backOff(long messageKey, long processDefinitionKey);
+
+  /**
    * Removes all pending asks for the given {@code messageKey}, regardless of process definition.
    * Called from the message-expire applier so that retries never outlive the buffered message they
    * refer to: when the message TTLs off on {@code P_K}, the dedup row on {@code P_B} (whose

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
@@ -63,6 +65,26 @@ public final class MessageStartEventBusinessIdUniquenessTest {
           .startEvent("start")
           .message(MESSAGE_NAME)
           .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .done();
+
+  private static final String DUAL_PROCESS_ID = "wf-dual";
+  private static final String HOLDER_JOB_TYPE = "holder";
+  private static final String MESSAGE_JOB_TYPE = "msg";
+
+  // A process with both a none-start and a message-start event sharing the same definition, so a
+  // PI created via CreateProcessInstance (none-start, no correlation key) and a message-start
+  // publish contend for the same businessId uniqueness index. Both arms have a service task so the
+  // holder can be completed deterministically and each started PI emits an observable JOB CREATED.
+  private static final BpmnModelInstance MESSAGE_AND_NONE_START_PROCESS =
+      Bpmn.createExecutableProcess(DUAL_PROCESS_ID)
+          .startEvent("noneStart")
+          .serviceTask("holderTask", t -> t.zeebeJobType(HOLDER_JOB_TYPE))
+          .endEvent()
+          .moveToProcess(DUAL_PROCESS_ID)
+          .startEvent("msgStart")
+          .message(MESSAGE_NAME)
+          .serviceTask("msgTask", t -> t.zeebeJobType(MESSAGE_JOB_TYPE))
           .endEvent()
           .done();
 
@@ -451,5 +473,114 @@ public final class MessageStartEventBusinessIdUniquenessTest {
                 .limit(2))
         .extracting(r -> r.getValue().getBusinessId())
         .containsExactly("biz-shared", "biz-shared");
+  }
+
+  @Test
+  public void shouldCorrelateBusinessIdBlockedMessageWhenHolderWithoutCorrelationKeyCompletes() {
+    // Pins that the businessId index + completion hook re-drives a blocked message even when the
+    // holder carries NO correlation key at all — a PI created via CreateProcessInstance on the
+    // none-start event. Such a holder never enters the message-start branch of the correlation-key
+    // buffer rescan, so only the businessId-keyed hook can free the blocked message.
+
+    // given a holder PI created via the none-start API holding "biz-shared" (no correlation key)
+    engine.deployment().withXmlResource(MESSAGE_AND_NONE_START_PROCESS).deploy();
+    final long holderPiKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(DUAL_PROCESS_ID)
+            .withBusinessId("biz-shared")
+            .create();
+    final var holderJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED).withType(HOLDER_JOB_TYPE).getFirst();
+
+    // and a message-start publish carrying the same businessId — blocked purely on uniqueness and
+    // therefore buffered
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-msg")
+        .withBusinessId("biz-shared")
+        .withTimeToLive(Duration.ofMinutes(5))
+        .publish();
+
+    // when the holder completes, freeing "biz-shared"
+    engine.job().withKey(holderJob.getKey()).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(holderPiKey)
+        .filterRootScope()
+        .await();
+
+    // then the buffered message-start correlates and a second PI is created, even though the
+    // holder never carried a correlation key
+    final var messagePiActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.PROCESS)
+            .withBpmnProcessId(DUAL_PROCESS_ID)
+            .limit(2)
+            .skip(1)
+            .getFirst();
+    assertThat(messagePiActivating.getValue().getBusinessId()).isEqualTo("biz-shared");
+    assertThat(messagePiActivating.getValue().getProcessInstanceKey()).isNotEqualTo(holderPiKey);
+
+    // and the same-partition retry is fully local — no cross-partition ask is ever emitted
+    final long crossPartitionAsks =
+        RecordingExporter.records()
+            .limit(
+                r ->
+                    r.getIntent() == ProcessInstanceIntent.ELEMENT_ACTIVATING
+                        && r.getKey() == messagePiActivating.getKey())
+            .filter(r -> r.getValueType() == ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST)
+            .count();
+    assertThat(crossPartitionAsks)
+        .as("a same-partition (P_K = P_B) blocked-start retry must not emit a cross-partition ask")
+        .isZero();
+  }
+
+  @Test
+  public void shouldNotRestartBusinessIdBlockedMessageWhenHolderIsBannedUntilTtl() {
+    // Pins the accepted boundary (mirrors the correlation-key buffer): banning frees the businessId
+    // WITHOUT a completion/termination event, so the completion hook never runs and a message
+    // blocked behind a banned holder is not re-driven promptly — it waits until its TTL and then
+    // expires unstarted. No duplicate, no leak.
+
+    // given a holder PI holds "biz-banned" and a message-start with the same businessId is blocked
+    engine.deployment().withXmlResource(MESSAGE_AND_NONE_START_PROCESS).deploy();
+    final long holderPiKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(DUAL_PROCESS_ID)
+            .withBusinessId("biz-banned")
+            .create();
+    RecordingExporter.jobRecords(JobIntent.CREATED).withType(HOLDER_JOB_TYPE).getFirst();
+
+    final var blockedPublish =
+        engine
+            .message()
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey("k-msg")
+            .withBusinessId("biz-banned")
+            .withTimeToLive(Duration.ofSeconds(5))
+            .publish();
+
+    // when the holder is banned (neither completes nor terminates) and the message's TTL elapses
+    engine.banInstanceInNewTransaction(1, holderPiKey);
+    engine.increaseTime(
+        Duration.ofSeconds(5).plus(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL));
+
+    // then the buffered message expires without ever starting a second PI — only the holder PI was
+    // ever activated, bounded by the EXPIRED terminal of the blocked publish
+    final long activations =
+        RecordingExporter.records()
+            .limit(
+                r ->
+                    r.getIntent() == MessageIntent.EXPIRED && r.getKey() == blockedPublish.getKey())
+            .processInstanceRecords()
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .count();
+    assertThat(activations)
+        .as(
+            "a banned holder does not trigger the completion hook; the blocked start expires at TTL")
+        .isEqualTo(1L);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -83,6 +84,28 @@ public final class MessageStartEventBusinessIdUniquenessTest {
           .endEvent()
           .moveToProcess(DUAL_PROCESS_ID)
           .startEvent("msgStart")
+          .message(MESSAGE_NAME)
+          .serviceTask("msgTask", t -> t.zeebeJobType(MESSAGE_JOB_TYPE))
+          .endEvent()
+          .done();
+
+  private static final String VERSIONED_PROCESS_ID = "wf-versioned";
+
+  // An older version (v1) of the process that has ONLY a none-start event — no message start event.
+  // An instance of it can hold a businessId via CreateProcessInstance.
+  private static final BpmnModelInstance VERSIONED_PROCESS_V1 =
+      Bpmn.createExecutableProcess(VERSIONED_PROCESS_ID)
+          .startEvent("noneStartV1")
+          .serviceTask("holderTask", t -> t.zeebeJobType(HOLDER_JOB_TYPE))
+          .endEvent()
+          .done();
+
+  // A newer version (v2) of the SAME bpmnProcessId that adds a message start event. The
+  // message-start
+  // subscription belongs to this latest version, while the businessId-holding instance runs v1.
+  private static final BpmnModelInstance VERSIONED_PROCESS_V2 =
+      Bpmn.createExecutableProcess(VERSIONED_PROCESS_ID)
+          .startEvent("msgStartV2")
           .message(MESSAGE_NAME)
           .serviceTask("msgTask", t -> t.zeebeJobType(MESSAGE_JOB_TYPE))
           .endEvent()
@@ -582,5 +605,63 @@ public final class MessageStartEventBusinessIdUniquenessTest {
         .as(
             "a banned holder does not trigger the completion hook; the blocked start expires at TTL")
         .isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldCorrelateBusinessIdBlockedMessageWhenHolderOfOlderVersionWithoutMessageStart() {
+    // Pins that the businessId re-drive does NOT depend on the *holder's own* version having a
+    // message start event. Business ID uniqueness is scoped per (businessId, bpmnProcessId) across
+    // versions, so a holder running an older version that has only a none-start event still frees
+    // the businessId on completion and must unblock a message-start owned by the latest version
+    // (ADR 0002 D5). Without the broadened guard, the holder's completion is skipped because its
+    // own
+    // process element has no message start event, and the buffered start strands until TTL.
+
+    // given v1 (none-start only) deployed and an instance of it holding "biz-versioned"
+    engine.deployment().withXmlResource(VERSIONED_PROCESS_V1).deploy();
+    final long holderPiKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(VERSIONED_PROCESS_ID)
+            .withBusinessId("biz-versioned")
+            .create();
+    final var holderJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED).withType(HOLDER_JOB_TYPE).getFirst();
+
+    // and v2 deployed afterwards, adding a message start event for the same bpmnProcessId
+    engine.deployment().withXmlResource(VERSIONED_PROCESS_V2).deploy();
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CREATED)
+        .withMessageName(MESSAGE_NAME)
+        .getFirst();
+
+    // and a message-start publish carrying the same businessId — blocked by the v1 holder
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-msg")
+        .withBusinessId("biz-versioned")
+        .withTimeToLive(Duration.ofMinutes(5))
+        .publish();
+
+    // when the v1 holder (whose own version has no message start event) completes, freeing the
+    // businessId
+    engine.job().withKey(holderJob.getKey()).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(holderPiKey)
+        .filterRootScope()
+        .await();
+
+    // then the buffered message-start (owned by v2) is re-driven and a new PI is created
+    final var messagePiActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.PROCESS)
+            .withBpmnProcessId(VERSIONED_PROCESS_ID)
+            .filter(r -> r.getValue().getProcessInstanceKey() != holderPiKey)
+            .getFirst();
+    assertThat(messagePiActivating.getValue().getBusinessId()).isEqualTo("biz-versioned");
+    assertThat(messagePiActivating.getValue().getVersion())
+        .as("the re-driven instance is created from the latest version that owns the message start")
+        .isEqualTo(2);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
@@ -360,4 +360,96 @@ public final class MessageStartEventBusinessIdUniquenessTest {
         .extracting(r -> r.getValue().getBusinessId())
         .containsExactly("biz-42", "biz-42");
   }
+
+  @Test
+  public void
+      shouldCorrelateBusinessIdBlockedMessageWhenHolderWithDifferentCorrelationKeyCompletes() {
+    // Pins the businessId index + completion hook (ADR 0002 D5): a message blocked purely on
+    // businessId uniqueness — whose correlation key differs from the holder's, so the
+    // correlation-key buffer scan can never reach it — is still re-driven once the holder frees the
+    // businessId on completion. This is the behaviour the correlation-key buffer could not provide.
+
+    // given a holder PI on correlation key "k-holder" carrying "biz-shared"
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-holder")
+        .withBusinessId("biz-shared")
+        .withVariables(Map.of("seq", 1))
+        .publish();
+    final var holderJob = RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
+
+    // and a message on a DIFFERENT, otherwise-free correlation key carrying the same businessId —
+    // blocked only by uniqueness and therefore buffered (the correlation-key lock for "k-other" is
+    // free, so the correlation-key buffer would never re-drive it)
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-other")
+        .withBusinessId("biz-shared")
+        .withTimeToLive(Duration.ofMinutes(5))
+        .withVariables(Map.of("seq", 2))
+        .publish();
+
+    // when the holder completes, freeing "biz-shared"
+    engine.job().withKey(holderJob.getKey()).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(holderJob.getValue().getProcessInstanceKey())
+        .filterRootScope()
+        .await();
+
+    // then the businessId-blocked message starts a new PI even though its correlation key never
+    // matched the holder's — proving the businessId index, not the correlation-key buffer, owns it
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withElementType(BpmnElementType.PROCESS)
+                .limit(2))
+        .extracting(r -> r.getValue().getBusinessId())
+        .containsExactly("biz-shared", "biz-shared");
+  }
+
+  @Test
+  public void shouldCorrelateBusinessIdBlockedMessageWhenHolderTerminates() {
+    // A businessId frees on termination as well as completion, and the completion hook runs on the
+    // termination transition too — so a message blocked on a businessId held by a (differently
+    // keyed) holder is re-driven when that holder is cancelled.
+
+    // given a holder PI on correlation key "k-holder" carrying "biz-shared"
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-holder")
+        .withBusinessId("biz-shared")
+        .withVariables(Map.of("seq", 1))
+        .publish();
+    final var holderJob = RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
+    final var holderProcessInstanceKey = holderJob.getValue().getProcessInstanceKey();
+
+    // and a businessId-blocked message on a different, free correlation key
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-other")
+        .withBusinessId("biz-shared")
+        .withTimeToLive(Duration.ofMinutes(5))
+        .withVariables(Map.of("seq", 2))
+        .publish();
+
+    // when the holder is terminated (cancelled) — freeing "biz-shared" without completing
+    engine.processInstance().withInstanceKey(holderProcessInstanceKey).cancel();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+        .withProcessInstanceKey(holderProcessInstanceKey)
+        .filterRootScope()
+        .await();
+
+    // then the businessId-blocked message starts a new PI
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withElementType(BpmnElementType.PROCESS)
+                .limit(2))
+        .extracting(r -> r.getValue().getBusinessId())
+        .containsExactly("biz-shared", "biz-shared");
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionHandshakeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionHandshakeTest.java
@@ -116,7 +116,12 @@ public final class MessageStartProcessInstanceCrossPartitionHandshakeTest {
                   config
                       .setBusinessIdUniquenessEnabled(true)
                       .setMessageStartDedupExpirationSweepInterval(SWEEP_INTERVAL)
-                      .setMessageStartAskRetryInterval(ASK_RETRY_INTERVAL));
+                      .setMessageStartAskRetryInterval(ASK_RETRY_INTERVAL)
+                      // These tests pin the dedup hit/miss boundary at the *message deadline*
+                      // itself, so the near-deadline grace is disabled here; the grace's own
+                      // behaviour is pinned separately (config default + the dedicated
+                      // near-deadline duplicate-window regression).
+                      .setMessageStartAskRetryGrace(Duration.ZERO));
 
   @Before
   public void assertCrossPartitionRouting() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionHandshakeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionHandshakeTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.message;
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -106,6 +107,26 @@ public final class MessageStartProcessInstanceCrossPartitionHandshakeTest {
           .startEvent(START_EVENT_ID)
           .message(MESSAGE_NAME)
           .connectTo("task")
+          .done();
+
+  /**
+   * Like {@link #DUAL_START_PROCESS} but the none-start arm waits on an intermediate timer instead
+   * of a service task, so a holder PI created on {@code P_B} via {@code CreateProcessInstance} can
+   * be completed on a clock-controlled schedule (the engine job client cannot reach a job living on
+   * {@code P_B}). Used by the rejection-then-retry-flips-to-success test: the holder blocks the
+   * first ask, then the timer fires and frees the businessId so a retried ask succeeds.
+   */
+  private static final String HOLDER_TIMER_DURATION = "PT2S";
+
+  private static final BpmnModelInstance TIMER_HOLDER_AND_MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("noneStart")
+          .intermediateCatchEvent("holderTimer", e -> e.timerWithDuration(HOLDER_TIMER_DURATION))
+          .endEvent()
+          .moveToProcess(PROCESS_ID)
+          .startEvent(START_EVENT_ID)
+          .message(MESSAGE_NAME)
+          .endEvent()
           .done();
 
   @Rule
@@ -535,6 +556,111 @@ public final class MessageStartProcessInstanceCrossPartitionHandshakeTest {
         .as("a banned holder must not block a retry from starting a fresh PI")
         .isPositive()
         .isNotEqualTo(bannedPiKey);
+  }
+
+  @Test
+  public void shouldStartPiWhenUniquenessRejectedAskIsRetriedAfterHolderCompletesOnPB() {
+    // Pins the headline Part-B "way out": a cross-partition ask rejected on businessId uniqueness
+    // is kept and retried, and once the holder PI on P_B completes (freeing the businessId) a
+    // retried ask flips to a successful start. The holder parks on an intermediate timer so it
+    // stays active — and keeps the businessId held — until the clock is advanced (the engine job
+    // client cannot reach a job living on P_B, so a service-task holder could not be completed).
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions(TIMER_HOLDER_AND_MESSAGE_START_PROCESS);
+    final long holderPiKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .onPartition(partitionFor(BUSINESS_ID))
+            .withBusinessId(BUSINESS_ID)
+            .create();
+    // wait until the holder PI has activated on P_B so the businessId uniqueness index is
+    // populated before the first ask arrives (ELEMENT_ACTIVATED follows the index-writing
+    // ACTIVATING applier)
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(holderPiKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst();
+
+    // when a message-start publish lands on P_K and asks P_B for the same businessId; the holder
+    // is still active so P_B replies UNIQUENESS_REJECTED (the ask is kept, not dropped)
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .withTimeToLive(Duration.ofMinutes(5))
+        .publish();
+    RecordingExporter.records()
+        .withIntent(MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED)
+        .getFirst();
+
+    // and the holder's timer fires, completing it and freeing the businessId
+    engine.increaseTime(Duration.ofSeconds(3));
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(holderPiKey)
+        .filterRootScope()
+        .await();
+
+    // and the ask retry scheduler re-dispatches the ask (advance past the worst-case backed-off
+    // interval, capped at base * 64, while still well inside the 5-minute message TTL)
+    engine.increaseTime(ASK_RETRY_INTERVAL.multipliedBy(64).plusSeconds(1));
+
+    // then the retried ask now succeeds: P_B starts a fresh message-start PI carrying BUSINESS_ID,
+    // distinct from the completed holder
+    final var messagePi =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.PROCESS)
+            .withBpmnProcessId(PROCESS_ID)
+            .filter(r -> r.getValue().getProcessInstanceKey() != holderPiKey)
+            .getFirst();
+    assertThat(messagePi.getValue().getBusinessId()).isEqualTo(BUSINESS_ID);
+    assertThat(Protocol.decodePartitionId(messagePi.getValue().getProcessInstanceKey()))
+        .as("the retried start lands on P_B = hash(businessId)")
+        .isEqualTo(partitionFor(BUSINESS_ID));
+  }
+
+  @Test
+  public void shouldExpireBlockedMessageAtTtlWhenHolderNeverClearsAcrossPartitions() {
+    // Pins the safe terminal of the retry loop: when the cross-partition holder never frees the
+    // businessId, every retry is rejected and the buffered message simply expires at its TTL —
+    // no start, no duplicate, no leak. The holder sits on a service task it never leaves (the
+    // engine job client cannot reach a job on P_B), so it holds the businessId for the whole test.
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions(DUAL_START_PROCESS);
+    final long holderPiKey = createHolderPiOnPBViaApi(BUSINESS_ID);
+    awaitHolderJobCreated(holderPiKey);
+
+    // when a message-start publish on P_K asks P_B for the same businessId with a short TTL
+    final var blockedPublish =
+        engine
+            .message()
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(CORRELATION_KEY)
+            .withBusinessId(BUSINESS_ID)
+            .withTimeToLive(MESSAGE_TTL.toMillis())
+            .publish();
+    RecordingExporter.records()
+        .withIntent(MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED)
+        .getFirst();
+
+    // and time advances past the messageDeadline so the buffered message expires on P_K
+    engine.increaseTime(
+        MESSAGE_TTL.plus(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL));
+
+    // then the buffered message expires and no message-start PI is ever created — only the holder
+    // PI exists on P_B, bounded by the EXPIRED terminal of the blocked publish
+    final long processActivations =
+        RecordingExporter.records()
+            .limit(
+                r ->
+                    r.getIntent() == MessageIntent.EXPIRED && r.getKey() == blockedPublish.getKey())
+            .processInstanceRecords()
+            .withBpmnProcessId(PROCESS_ID)
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .count();
+    assertThat(processActivations)
+        .as("a never-freed cross-partition holder lets the blocked message expire unstarted")
+        .isEqualTo(1L);
   }
 
   private void deployAndAwaitStartEventSubscriptionsOnAllPartitions(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionUniquenessDisabledTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionUniquenessDisabledTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Multi-partition pin for the rule that the {@code businessIdUniquenessEnabled} flag gates only the
+ * uniqueness <em>rejection</em>, never the cross-partition routing. A message-start whose Business
+ * ID hashes to a different partition than its correlation key is delegated to {@code P_B =
+ * hash(businessId)} <em>even when the flag is off</em>, so the structural invariant "every root PI
+ * carrying a Business ID lives on {@code P_B}" holds regardless of the flag; {@code P_B} just never
+ * rejects on uniqueness while the flag is off.
+ *
+ * <p>The constants are chosen so {@code hash(correlationKey) != hash(businessId)}; an
+ * {@code @Before} precondition fails loudly if a future hash change degenerates the scenario into a
+ * single-partition path.
+ */
+public final class MessageStartProcessInstanceCrossPartitionUniquenessDisabledTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  // hash("ck-1") -> P_K=1 and hash("biz-1") -> P_B=3 under PARTITION_COUNT=3, re-asserted in
+  // @Before.
+  private static final String CORRELATION_KEY = "ck-1";
+  private static final String OTHER_CORRELATION_KEY = "ck-2";
+  private static final String BUSINESS_ID = "biz-1";
+
+  private static final String PROCESS_ID = "wf-cross-disabled";
+  private static final String MESSAGE_NAME = "start-msg-disabled";
+
+  private static final BpmnModelInstance MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("start")
+          .message(MESSAGE_NAME)
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.multiplePartition(PARTITION_COUNT)
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+
+  @Before
+  public void assertCrossPartitionRouting() {
+    assertThat(partitionFor(CORRELATION_KEY))
+        .as("CORRELATION_KEY and BUSINESS_ID must hash to different partitions")
+        .isNotEqualTo(partitionFor(BUSINESS_ID));
+  }
+
+  @Test
+  public void shouldDelegateRemoteBusinessIdToPBEvenWhenUniquenessDisabled() {
+    // given
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions();
+
+    // when a message-start publish lands on P_K but its businessId hashes to P_B, with the
+    // uniqueness feature disabled
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .publish();
+
+    // then the new PI is still created on P_B — routing/placement is independent of the flag, so
+    // the "businessId PI lives on hash(businessId)" invariant holds even with uniqueness off
+    final var activating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.PROCESS)
+            .withBpmnProcessId(PROCESS_ID)
+            .getFirst();
+    assertThat(Protocol.decodePartitionId(activating.getValue().getProcessInstanceKey()))
+        .as("the new PI lives on P_B = hash(businessId), not on P_K = hash(correlationKey)")
+        .isEqualTo(partitionFor(BUSINESS_ID));
+    assertThat(activating.getValue().getBusinessId()).isEqualTo(BUSINESS_ID);
+  }
+
+  @Test
+  public void shouldNotRejectSecondRemoteBusinessIdStartWhenUniquenessDisabled() {
+    // given a first PI already started on P_B for businessId "biz-1"
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .publish();
+
+    // when a second message reuses the same businessId (different correlation key so the
+    // correlation-key lock is not the gate)
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(OTHER_CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .publish();
+
+    // then both PIs start on P_B — with uniqueness off, P_B never replies UNIQUENESS_REJECTED, so
+    // the duplicate businessId is allowed (the flag gates the rejection, not the routing)
+    final var activatings =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.PROCESS)
+            .withBpmnProcessId(PROCESS_ID)
+            .limit(2)
+            .asList();
+    assertThat(activatings)
+        .hasSize(2)
+        .allSatisfy(
+            r -> {
+              assertThat(r.getValue().getBusinessId()).isEqualTo(BUSINESS_ID);
+              assertThat(Protocol.decodePartitionId(r.getValue().getProcessInstanceKey()))
+                  .isEqualTo(partitionFor(BUSINESS_ID));
+            });
+    assertThat(activatings.get(0).getValue().getProcessInstanceKey())
+        .isNotEqualTo(activatings.get(1).getValue().getProcessInstanceKey());
+  }
+
+  private void deployAndAwaitStartEventSubscriptionsOnAllPartitions() {
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CREATED)
+        .withMessageName(MESSAGE_NAME)
+        .limit(PARTITION_COUNT)
+        .asList();
+  }
+
+  private static int partitionFor(final String key) {
+    return SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString(key), PARTITION_COUNT);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceDedupBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceDedupBehaviorTest.java
@@ -55,6 +55,11 @@ public final class MessageStartProcessInstanceDedupBehaviorTest {
   private static final Duration MESSAGE_TTL = Duration.ofSeconds(5);
   private static final Duration SWEEP_INTERVAL = Duration.ofSeconds(1);
 
+  // Explicit, comfortably-wide grace so the dedup row stays a valid re-reply source for
+  // (messageDeadline, messageDeadline + grace) — the near-deadline window the grace closes. Chosen
+  // larger than MESSAGE_TTL so a single clock advance can land strictly inside the grace window.
+  private static final Duration DEDUP_GRACE = Duration.ofSeconds(10);
+
   private static final BpmnModelInstance MESSAGE_START_PROCESS =
       Bpmn.createExecutableProcess(PROCESS_ID)
           .startEvent(START_EVENT_ID)
@@ -70,7 +75,8 @@ public final class MessageStartProcessInstanceDedupBehaviorTest {
               config ->
                   config
                       .setBusinessIdUniquenessEnabled(true)
-                      .setMessageStartDedupExpirationSweepInterval(SWEEP_INTERVAL));
+                      .setMessageStartDedupExpirationSweepInterval(SWEEP_INTERVAL)
+                      .setMessageStartAskRetryGrace(DEDUP_GRACE));
 
   @Test
   public void shouldReReplyStartedWithCachedKeyOnActiveDedupHit() {
@@ -129,16 +135,53 @@ public final class MessageStartProcessInstanceDedupBehaviorTest {
   }
 
   @Test
-  public void shouldReEvaluateAfterDedupDeletionDeadlineHasPassed() {
-    // given a PI was started, completed, and the dedup entry's deletionDeadline (= the request's
-    // messageDeadline) has elapsed
+  public void shouldReReplyCachedKeyWhenRetryArrivesAfterDeadlineButWithinGrace() {
+    // Pins the near-deadline grace (ADR 0002 / commit 8): a retry that crosses the message deadline
+    // but lands within the grace window still hits the dedup and re-replies the SAME PI key,
+    // instead
+    // of falling through to a fresh start. Without the grace this retry would dedup-miss past the
+    // deadline, re-evaluate live state (the holder has completed and freed the businessId), and
+    // create a duplicate — the exact near-deadline duplicate window the grace closes.
     engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
     final long subscriptionKey = waitForStartEventSubscriptionKey();
     writeRequest(subscriptionKey);
     final long firstPiKey = firstStartReplyPiKey();
     completeServiceTask(firstPiKey);
     waitForRootProcessCompletion(firstPiKey);
-    engine.increaseTime(MESSAGE_TTL.plus(SWEEP_INTERVAL).plusSeconds(1));
+
+    // advance past the message deadline but stay strictly inside the grace window
+    engine.increaseTime(MESSAGE_TTL.plusSeconds(1));
+
+    // when a retry arrives in the grace window
+    writeRequest(subscriptionKey);
+
+    // then the dedup still re-replies the original PI key (no duplicate)
+    final long secondPiKey =
+        RecordingExporter.records()
+            .filter(r -> r.getRecordType() == RecordType.COMMAND)
+            .filter(r -> r.getIntent() == MessageStartProcessInstanceRequestIntent.START)
+            .limit(2)
+            .skip(1)
+            .map(this::asRequest)
+            .findFirst()
+            .orElseThrow()
+            .getProcessInstanceKey();
+    assertThat(secondPiKey)
+        .as("a retry within the grace window re-replies the cached PI key, not a fresh start")
+        .isEqualTo(firstPiKey);
+  }
+
+  @Test
+  public void shouldReEvaluateAfterDedupDeletionDeadlineHasPassed() {
+    // given a PI was started, completed, and the dedup entry's deletionDeadline (= the request's
+    // messageDeadline) plus the grace has elapsed
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    final long subscriptionKey = waitForStartEventSubscriptionKey();
+    writeRequest(subscriptionKey);
+    final long firstPiKey = firstStartReplyPiKey();
+    completeServiceTask(firstPiKey);
+    waitForRootProcessCompletion(firstPiKey);
+    engine.increaseTime(MESSAGE_TTL.plus(DEDUP_GRACE).plus(SWEEP_INTERVAL).plusSeconds(1));
 
     // when a fresh REQUEST arrives after the window has passed
     writeRequest(subscriptionKey);
@@ -197,7 +240,7 @@ public final class MessageStartProcessInstanceDedupBehaviorTest {
     waitForRootProcessCompletion(firstPiKey);
 
     // when the scheduler observes a past-deadline dedup entry and the processor sweeps it
-    engine.increaseTime(MESSAGE_TTL.plus(SWEEP_INTERVAL).plusSeconds(1));
+    engine.increaseTime(MESSAGE_TTL.plus(DEDUP_GRACE).plus(SWEEP_INTERVAL).plusSeconds(1));
 
     // then a EXPIRED_DEDUP_DELETED event is written and its applier removes the entry; a subsequent
     // REQUEST is a cache miss and a fresh PI is created

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceNearDeadlineRetryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceNearDeadlineRetryTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Multi-partition regression for the dedup-deadline grace introduced to close the near-deadline
+ * duplicate window. Once rejected asks are retried, a message can succeed at {@code T − ε} with an
+ * <em>auto-completing</em> holder; a retry sent just before the message deadline {@code T} but
+ * <em>processed</em> on {@code P_B} after {@code T} would, without a grace, miss the dedup row,
+ * re-evaluate live state (the holder has since completed, freeing the businessId), and start a
+ * <em>duplicate</em> instance.
+ *
+ * <p>This test drops the {@code START} reply to {@code P_K} until the clock is past the message
+ * deadline but still within the grace, so the <em>first delivered</em> {@code STARTED} reply is the
+ * past-deadline re-reply. With the grace configured, {@code P_B} still treats the dedup row as a
+ * hit and re-replies the original process-instance key, so exactly one process instance is ever
+ * created on {@code P_B}. The grace-disabled counterpart — which starts a fresh PI once the
+ * deadline passes — is pinned by {@code
+ * MessageStartProcessInstanceCrossPartitionHandshakeTest#shouldStartFreshPiWhenRetryArrivesAfterMessageDeadlineHasPassed}.
+ */
+public final class MessageStartProcessInstanceNearDeadlineRetryTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  // hash("ck-1") → P_K=1 and hash("biz-1") → P_B=3 under PARTITION_COUNT=3 (re-asserted in
+  // @Before).
+  private static final String CORRELATION_KEY = "ck-1";
+  private static final String BUSINESS_ID = "biz-1";
+
+  private static final String PROCESS_ID = "wf-near-deadline";
+  private static final String MESSAGE_NAME = "start-msg-near-deadline";
+
+  private static final Duration MESSAGE_TTL = Duration.ofSeconds(5);
+  private static final Duration DEDUP_GRACE = Duration.ofSeconds(10);
+  private static final Duration SWEEP_INTERVAL = Duration.ofSeconds(1);
+  private static final Duration ASK_RETRY_INTERVAL = Duration.ofSeconds(1);
+
+  /**
+   * Auto-completing message-start process: the holder PI on {@code P_B} completes on its own (the
+   * engine job client cannot reach a job living on {@code P_B}), so the businessId frees while the
+   * dedup row is still the only thing standing between a retry and a duplicate start.
+   */
+  private static final BpmnModelInstance AUTO_COMPLETE_MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("autoStart")
+          .message(MESSAGE_NAME)
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.multiplePartition(PARTITION_COUNT)
+          .withEngineConfig(
+              config ->
+                  config
+                      .setBusinessIdUniquenessEnabled(true)
+                      .setMessageStartDedupExpirationSweepInterval(SWEEP_INTERVAL)
+                      .setMessageStartAskRetryInterval(ASK_RETRY_INTERVAL)
+                      .setMessageStartAskRetryGrace(DEDUP_GRACE));
+
+  @Before
+  public void assertCrossPartitionRouting() {
+    assertThat(partitionFor(CORRELATION_KEY))
+        .as("CORRELATION_KEY and BUSINESS_ID must hash to different partitions")
+        .isNotEqualTo(partitionFor(BUSINESS_ID));
+  }
+
+  @Test
+  public void shouldNotDuplicatePiWhenRetryIsProcessedAfterDeadlineButWithinGrace() {
+    // given an auto-completing message-start whose holder PI completes on P_B on its own
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions();
+
+    // drop every START reply to P_K until we cross the message deadline, so the first STARTED that
+    // P_K records is the past-deadline re-reply (dropped replies leave the pending ask alive and
+    // keep the scheduler re-asking)
+    final AtomicBoolean blockStartReply = new AtomicBoolean(true);
+    engine.interceptInterPartitionCommands(
+        (receiverPartitionId, valueType, intent, recordKey, command) ->
+            !(intent == MessageStartProcessInstanceRequestIntent.START && blockStartReply.get()));
+
+    // when the message is published; P_B creates PI_1, writes the dedup row, and PI_1
+    // auto-completes
+    final var publish =
+        engine
+            .message()
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(CORRELATION_KEY)
+            .withBusinessId(BUSINESS_ID)
+            .withTimeToLive(MESSAGE_TTL.toMillis())
+            .publish();
+    final long firstPiKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .withBpmnProcessId(PROCESS_ID)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    // and the clock advances past the message deadline but stays within the grace window (and well
+    // within the 1-minute TTL checker interval, so the buffered message on P_K is not yet expired
+    // and the ask keeps being retried)
+    engine.increaseTime(MESSAGE_TTL.plusSeconds(2));
+
+    // when the START reply is allowed through again and one more retry round completes
+    blockStartReply.set(false);
+    engine.increaseTime(ASK_RETRY_INTERVAL.multipliedBy(2).plusSeconds(1));
+
+    // then the late retry succeeds and consumes the buffered message (EXPIRED on P_K is the
+    // terminal of a successful handshake); bounded by that terminal, exactly one process instance
+    // was ever activated on P_B and it is the original PI — the dedup grace absorbed the late
+    // retry instead of letting it start a fresh, duplicate instance
+    final var activations =
+        RecordingExporter.records()
+            .limit(r -> r.getIntent() == MessageIntent.EXPIRED && r.getKey() == publish.getKey())
+            .processInstanceRecords()
+            .withBpmnProcessId(PROCESS_ID)
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .asList();
+    assertThat(activations)
+        .extracting(r -> r.getValue().getProcessInstanceKey())
+        .as("the near-deadline retry must re-reply the cached PI key, not start a duplicate on P_B")
+        .containsExactly(firstPiKey);
+  }
+
+  private void deployAndAwaitStartEventSubscriptionsOnAllPartitions() {
+    engine.deployment().withXmlResource(AUTO_COMPLETE_MESSAGE_START_PROCESS).deploy();
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CREATED)
+        .withMessageName(MESSAGE_NAME)
+        .limit(PARTITION_COUNT)
+        .asList();
+  }
+
+  private static int partitionFor(final String key) {
+    return SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString(key), PARTITION_COUNT);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckSchedulerTest.java
@@ -13,20 +13,22 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceAskState;
+import io.camunda.zeebe.engine.state.immutable.MessageStartProcessInstanceAskState.PendingAskVisitor;
 import io.camunda.zeebe.engine.state.message.MessageStartProcessInstanceAsk;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import java.time.Duration;
-import java.util.List;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -36,6 +38,7 @@ import org.mockito.ArgumentCaptor;
 public final class PendingMessageStartAskCheckSchedulerTest {
 
   private static final Duration RETRY_INTERVAL = Duration.ofSeconds(10);
+  private static final long BASE_MILLIS = RETRY_INTERVAL.toMillis();
   private static final long NOW = 100_000L;
 
   private SubscriptionCommandSender mockCommandSender;
@@ -64,6 +67,66 @@ public final class PendingMessageStartAskCheckSchedulerTest {
             mockCommandSender, mockState, mockRoutingInfo, () -> RETRY_INTERVAL);
   }
 
+  /**
+   * Makes the mocked state visit each given ask with the supplied last-sent time, so the scheduler
+   * applies its per-ask eligibility check ({@code lastSent + interval(rejectionCount) <= now}).
+   */
+  private void stubPendingAsks(
+      final long lastSentTime, final MessageStartProcessInstanceAsk... asks) {
+    doAnswer(
+            invocation -> {
+              final PendingAskVisitor visitor = invocation.getArgument(0);
+              for (final var ask : asks) {
+                visitor.visit(lastSentTime, ask);
+              }
+              return null;
+            })
+        .when(mockState)
+        .forEachPendingAsk(any());
+  }
+
+  private MessageStartProcessInstanceAsk createAsk(
+      final long messageKey, final long processDefinitionKey, final String businessId) {
+    return createAsk(messageKey, processDefinitionKey, businessId, 0L);
+  }
+
+  private MessageStartProcessInstanceAsk createAsk(
+      final long messageKey,
+      final long processDefinitionKey,
+      final String businessId,
+      final long rejectionCount) {
+    final var ask = new MessageStartProcessInstanceAsk();
+    ask.setMessageKey(messageKey);
+    ask.setProcessDefinitionKey(processDefinitionKey);
+    ask.setBusinessId(new UnsafeBuffer(businessId.getBytes()));
+    ask.setMessageName(new UnsafeBuffer("message-name".getBytes()));
+    ask.setCorrelationKey(new UnsafeBuffer("correlation".getBytes()));
+    ask.setBpmnProcessId(new UnsafeBuffer("process-id".getBytes()));
+    ask.setStartEventId(new UnsafeBuffer("start-event".getBytes()));
+    ask.setMessageStartEventSubscriptionKey(999L);
+    ask.setVariables(new UnsafeBuffer(new byte[0]));
+    ask.setTenantId("<default>");
+    ask.setRejectionCount(rejectionCount);
+    return ask;
+  }
+
+  private void verifyNoSend() {
+    verify(mockCommandSender, never())
+        .sendDirectStartProcessInstanceRequest(
+            anyInt(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            any(),
+            any(),
+            anyLong(),
+            any(),
+            anyLong(),
+            anyString());
+  }
+
   @Nested
   class Lifecycle {
 
@@ -81,12 +144,10 @@ public final class PendingMessageStartAskCheckSchedulerTest {
   class SendAsk {
 
     @Test
-    void shouldSendAskForEntryPastDeadline() {
-      // given
+    void shouldSendDueAsk() {
+      // given a fresh ask whose base interval has elapsed
       scheduler.onRecovered(mockContext);
-      final var ask = createAsk(1L, 100L, "my-business-id");
-      when(mockState.getPendingAsksPastDeadline(NOW - RETRY_INTERVAL.toMillis()))
-          .thenReturn(List.of(ask));
+      stubPendingAsks(NOW - BASE_MILLIS, createAsk(1L, 100L, "my-business-id"));
       when(mockRoutingInfo.partitionForCorrelationKey(any())).thenReturn(2);
 
       // when
@@ -113,8 +174,7 @@ public final class PendingMessageStartAskCheckSchedulerTest {
     void shouldUpdateLastSentTimeAfterSending() {
       // given
       scheduler.onRecovered(mockContext);
-      final var ask = createAsk(1L, 100L, "my-business-id");
-      when(mockState.getPendingAsksPastDeadline(anyLong())).thenReturn(List.of(ask));
+      stubPendingAsks(0L, createAsk(1L, 100L, "my-business-id"));
       when(mockRoutingInfo.partitionForCorrelationKey(any())).thenReturn(2);
 
       // when
@@ -125,38 +185,23 @@ public final class PendingMessageStartAskCheckSchedulerTest {
     }
 
     @Test
-    void shouldNotSendAskWhenNoneArePastDeadline() {
-      // given
+    void shouldNotSendAskThatIsNotYetDue() {
+      // given a fresh ask that was just sent (base interval has not elapsed)
       scheduler.onRecovered(mockContext);
-      when(mockState.getPendingAsksPastDeadline(anyLong())).thenReturn(List.of());
+      stubPendingAsks(NOW, createAsk(1L, 100L, "my-business-id"));
 
       // when
       scheduler.run();
 
       // then
-      verify(mockCommandSender, never())
-          .sendDirectStartProcessInstanceRequest(
-              anyInt(),
-              anyLong(),
-              any(),
-              any(),
-              any(),
-              anyLong(),
-              any(),
-              any(),
-              anyLong(),
-              any(),
-              anyLong(),
-              anyString());
+      verifyNoSend();
     }
 
     @Test
-    void shouldSendMultipleAsks() {
+    void shouldSendMultipleDueAsks() {
       // given
       scheduler.onRecovered(mockContext);
-      final var ask1 = createAsk(1L, 100L, "business-1");
-      final var ask2 = createAsk(2L, 200L, "business-2");
-      when(mockState.getPendingAsksPastDeadline(anyLong())).thenReturn(List.of(ask1, ask2));
+      stubPendingAsks(0L, createAsk(1L, 100L, "business-1"), createAsk(2L, 200L, "business-2"));
       when(mockRoutingInfo.partitionForCorrelationKey(any())).thenReturn(2);
 
       // when
@@ -164,7 +209,7 @@ public final class PendingMessageStartAskCheckSchedulerTest {
 
       // then
       final ArgumentCaptor<Long> messageKeyCaptor = ArgumentCaptor.forClass(Long.class);
-      verify(mockCommandSender, org.mockito.Mockito.times(2))
+      verify(mockCommandSender, times(2))
           .sendDirectStartProcessInstanceRequest(
               anyInt(),
               messageKeyCaptor.capture(),
@@ -186,8 +231,7 @@ public final class PendingMessageStartAskCheckSchedulerTest {
     void shouldCalculateTargetPartitionFromBusinessId() {
       // given
       scheduler.onRecovered(mockContext);
-      final var ask = createAsk(1L, 100L, "specific-business-id");
-      when(mockState.getPendingAsksPastDeadline(anyLong())).thenReturn(List.of(ask));
+      stubPendingAsks(0L, createAsk(1L, 100L, "specific-business-id"));
 
       final ArgumentCaptor<org.agrona.DirectBuffer> businessIdCaptor =
           ArgumentCaptor.forClass(org.agrona.DirectBuffer.class);
@@ -212,26 +256,72 @@ public final class PendingMessageStartAskCheckSchedulerTest {
               anyLong(),
               anyString());
 
-      // Verify businessId was used for routing
       final var capturedBusinessId = businessIdCaptor.getValue();
       assertThat(capturedBusinessId.getStringWithoutLengthUtf8(0, capturedBusinessId.capacity()))
           .isEqualTo("specific-business-id");
     }
+  }
 
-    private MessageStartProcessInstanceAsk createAsk(
-        final long messageKey, final long processDefinitionKey, final String businessId) {
-      final var ask = new MessageStartProcessInstanceAsk();
-      ask.setMessageKey(messageKey);
-      ask.setProcessDefinitionKey(processDefinitionKey);
-      ask.setBusinessId(new UnsafeBuffer(businessId.getBytes()));
-      ask.setMessageName(new UnsafeBuffer("message-name".getBytes()));
-      ask.setCorrelationKey(new UnsafeBuffer("correlation".getBytes()));
-      ask.setBpmnProcessId(new UnsafeBuffer("process-id".getBytes()));
-      ask.setStartEventId(new UnsafeBuffer("start-event".getBytes()));
-      ask.setMessageStartEventSubscriptionKey(999L);
-      ask.setVariables(new UnsafeBuffer(new byte[0]));
-      ask.setTenantId("<default>");
-      return ask;
+  @Nested
+  class BackOff {
+
+    @Test
+    void shouldRetryFreshAskAtBaseInterval() {
+      // given a never-rejected ask whose base interval has just elapsed
+      scheduler.onRecovered(mockContext);
+      stubPendingAsks(NOW - BASE_MILLIS, createAsk(1L, 100L, "b", 0L));
+      when(mockRoutingInfo.partitionForCorrelationKey(any())).thenReturn(2);
+
+      // when
+      scheduler.run();
+
+      // then it is re-sent
+      verify(mockState).updateLastSentTime(1L, 100L, NOW);
+    }
+
+    @Test
+    void shouldNotRetryBackedOffAskBeforeItsInterval() {
+      // given an ask rejected twice (interval = base * 2^2 = 4x) sent only 3x base ago
+      scheduler.onRecovered(mockContext);
+      stubPendingAsks(NOW - (3 * BASE_MILLIS), createAsk(1L, 100L, "b", 2L));
+
+      // when
+      scheduler.run();
+
+      // then it is not yet due
+      verifyNoSend();
+    }
+
+    @Test
+    void shouldRetryBackedOffAskAfterItsInterval() {
+      // given an ask rejected twice (interval = base * 4) whose interval has elapsed
+      scheduler.onRecovered(mockContext);
+      stubPendingAsks(NOW - (4 * BASE_MILLIS), createAsk(1L, 100L, "b", 2L));
+      when(mockRoutingInfo.partitionForCorrelationKey(any())).thenReturn(2);
+
+      // when
+      scheduler.run();
+
+      // then it is re-sent
+      verify(mockState).updateLastSentTime(1L, 100L, NOW);
+    }
+
+    @Test
+    void shouldCapBackoffInterval() {
+      // given an ask rejected far beyond the exponent cap (6): the interval saturates at base * 64,
+      // not base * 2^rejectionCount. Use a larger clock so the capped interval is representable.
+      scheduler.onRecovered(mockContext);
+      when(mockClock.millis()).thenReturn(1_000_000L);
+      // sent exactly base*64 ago: due only because the interval is capped at 64x (uncapped 2^20x
+      // would be nowhere near due)
+      stubPendingAsks(1_000_000L - (64 * BASE_MILLIS), createAsk(1L, 100L, "b", 20L));
+      when(mockRoutingInfo.partitionForCorrelationKey(any())).thenReturn(2);
+
+      // when
+      scheduler.run();
+
+      // then it is re-sent, proving the interval was capped at base * 64
+      verify(mockState).updateLastSentTime(1L, 100L, 1_000_000L);
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PendingMessageStartAskCheckSchedulerTest.java
@@ -323,5 +323,28 @@ public final class PendingMessageStartAskCheckSchedulerTest {
       // then it is re-sent, proving the interval was capped at base * 64
       verify(mockState).updateLastSentTime(1L, 100L, 1_000_000L);
     }
+
+    @Test
+    void shouldSaturateBackoffIntervalInsteadOfOverflowing() {
+      // given a pathologically large base interval such that doubling it for the back-off would
+      // overflow a long. A naive `interval *= 2` would wrap to a negative interval, making
+      // `lastSentTime + interval <= now` always true and turning the back-off into a retry storm.
+      final var hugeBaseScheduler =
+          new PendingMessageStartAskCheckScheduler(
+              mockCommandSender,
+              mockState,
+              mockRoutingInfo,
+              () -> Duration.ofMillis(Long.MAX_VALUE / 3));
+      hugeBaseScheduler.onRecovered(mockContext);
+      // a rejected ask (count 6) last sent long ago, evaluated at a normal clock value
+      stubPendingAsks(0L, createAsk(1L, 100L, "b", 6L));
+
+      // when
+      hugeBaseScheduler.run();
+
+      // then the interval saturates at Long.MAX_VALUE (effectively infinite) rather than going
+      // negative, so the ask is not yet due and is not re-sent — no storm
+      verifyNoSend();
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceReplyApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MessageStartProcessInstanceReplyApplierTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
  * Unit tests for the appliers that handle cross-partition message-start events. The STARTED applier
  * writes the dedup entry (using the deadline carried on the request record), removes the
  * pending-ask, and conditionally marks the lock entry as cross-partition; the rejection appliers
- * only remove the pending-ask.
+ * keep the pending-ask and back it off (increment its rejection count) so it is retried.
  */
 public final class MessageStartProcessInstanceReplyApplierTest {
 
@@ -148,7 +148,7 @@ public final class MessageStartProcessInstanceReplyApplierTest {
   class UniquenessRejectedApplier {
 
     @Test
-    void shouldRemovePendingAskOnUniquenessRejected() {
+    void shouldBackOffPendingAskOnUniquenessRejected() {
       // given
       final var applier = new MessageStartProcessInstanceUniquenessRejectedV1Applier(mockAskState);
       final var record = createRecord();
@@ -156,8 +156,10 @@ public final class MessageStartProcessInstanceReplyApplierTest {
       // when
       applier.applyState(1L, record);
 
-      // then
-      verify(mockAskState).remove(MESSAGE_KEY, PROCESS_DEFINITION_KEY);
+      // then the ask is kept and backed off (not removed), so the scheduler retries it under
+      // back-off and a later attempt can flip to STARTED once the holder completes
+      verify(mockAskState).backOff(MESSAGE_KEY, PROCESS_DEFINITION_KEY);
+      verify(mockAskState, never()).remove(anyLong(), anyLong());
     }
   }
 
@@ -165,7 +167,7 @@ public final class MessageStartProcessInstanceReplyApplierTest {
   class NoSubscriptionRejectedApplier {
 
     @Test
-    void shouldRemovePendingAskOnNoSubscriptionRejected() {
+    void shouldBackOffPendingAskOnNoSubscriptionRejected() {
       // given
       final var applier =
           new MessageStartProcessInstanceNoSubscriptionRejectedV1Applier(mockAskState);
@@ -174,8 +176,10 @@ public final class MessageStartProcessInstanceReplyApplierTest {
       // when
       applier.applyState(1L, record);
 
-      // then
-      verify(mockAskState).remove(MESSAGE_KEY, PROCESS_DEFINITION_KEY);
+      // then the ask is kept and backed off (not removed), so the scheduler retries it until the
+      // deployment reaches P_B and a later attempt flips to STARTED
+      verify(mockAskState).backOff(MESSAGE_KEY, PROCESS_DEFINITION_KEY);
+      verify(mockAskState, never()).remove(anyLong(), anyLong());
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskStateTest.java
@@ -130,46 +130,102 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldDefaultBackoffMagnitudeToZeroForFreshAsk() {
-    // given a fresh ask sourced from a request record (no back-off ever applied)
+  public void shouldDefaultRejectionCountToZeroForFreshAsk() {
+    // given a fresh ask sourced from a request record (never rejected)
     final var ask = new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 2L, "b", "p"));
 
-    // then the P_K-local retry bookkeeping defaults to zero, keeping the ask eligible for
-    // base-interval re-send and ensuring values persisted before this field existed decode
-    // unchanged
-    assertThat(ask.getRetryBackoffMillis()).isZero();
+    // then the P_K-local retry bookkeeping defaults to zero, keeping the ask at the base re-send
+    // cadence and ensuring values persisted before this field existed decode unchanged
+    assertThat(ask.getRejectionCount()).isZero();
   }
 
   @Test
-  public void shouldPersistBackoffMagnitude() {
+  public void shouldPersistRejectionCount() {
     // given
     final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
     final var ask =
         new MessageStartProcessInstanceAsk()
             .wrap(createRecord(123L, 456L, "b", "p"))
-            .setRetryBackoffMillis(4000L);
+            .setRejectionCount(3L);
 
     // when
     state.put(ask);
 
-    // then the back-off magnitude survives the RocksDB round-trip
+    // then the rejection count survives the RocksDB round-trip
     final var retrieved = state.get(123L, 456L);
-    assertThat(retrieved.getRetryBackoffMillis()).isEqualTo(4000L);
+    assertThat(retrieved.getRejectionCount()).isEqualTo(3L);
   }
 
   @Test
-  public void shouldPreserveBackoffMagnitudeOnCopy() {
+  public void shouldPreserveRejectionCountOnCopy() {
     // given
     final var ask =
         new MessageStartProcessInstanceAsk()
             .wrap(createRecord(1L, 2L, "b", "p"))
-            .setRetryBackoffMillis(8000L);
+            .setRejectionCount(5L);
 
     // when
     final var copy = ask.copy();
 
     // then
-    assertThat(copy.getRetryBackoffMillis()).isEqualTo(8000L);
+    assertThat(copy.getRejectionCount()).isEqualTo(5L);
+  }
+
+  @Test
+  public void shouldIncrementRejectionCountOnBackOff() {
+    // given a pending ask with no rejections yet
+    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 2L, "b", "p")));
+
+    // when backed off twice
+    state.backOff(1L, 2L);
+    state.backOff(1L, 2L);
+
+    // then the persisted rejection count reflects both rejections
+    assertThat(state.get(1L, 2L).getRejectionCount()).isEqualTo(2L);
+  }
+
+  @Test
+  public void shouldNotResetSendEligibilityOnBackOff() {
+    // given a pending ask that has already been sent (transient last-sent advanced past any
+    // positive deadline)
+    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 2L, "b", "p")));
+    state.updateLastSentTime(1L, 2L, 10_000L);
+
+    // when the ask is backed off
+    state.backOff(1L, 2L);
+
+    // then back-off does not reset the transient send-tracking: the ask is still considered sent at
+    // 10_000 and is not made immediately eligible again (which would defeat the back-off)
+    assertThat(state.getPendingAsksPastDeadline(10_000L)).isEmpty();
+    assertThat(state.getPendingAsksPastDeadline(10_001L)).hasSize(1);
+  }
+
+  @Test
+  public void shouldBeNoOpWhenBackingOffMissingAsk() {
+    // given no pending ask for the key
+    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+
+    // when / then no exception and nothing is created
+    state.backOff(7L, 8L);
+    assertThat(state.get(7L, 8L)).isNull();
+  }
+
+  @Test
+  public void shouldCapRejectionCount() {
+    // given a pending ask
+    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 2L, "b", "p")));
+
+    // when backed off far more often than the cap (30)
+    for (int i = 0; i < 100; i++) {
+      state.backOff(1L, 2L);
+    }
+
+    // then the persisted count saturates at the cap, so it never overflows when the scheduler
+    // computes 2^rejectionCount
+    assertThat(state.get(1L, 2L).getRejectionCount()).isEqualTo(30L);
   }
 
   private MessageStartProcessInstanceRequestRecord createRecord(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskStateTest.java
@@ -129,6 +129,49 @@ public class DbMessageStartProcessInstanceAskStateTest {
     assertThat(populatedRecord.getMessageDeadline()).isEqualTo(99999L);
   }
 
+  @Test
+  public void shouldDefaultBackoffMagnitudeToZeroForFreshAsk() {
+    // given a fresh ask sourced from a request record (no back-off ever applied)
+    final var ask = new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 2L, "b", "p"));
+
+    // then the P_K-local retry bookkeeping defaults to zero, keeping the ask eligible for
+    // base-interval re-send and ensuring values persisted before this field existed decode
+    // unchanged
+    assertThat(ask.getRetryBackoffMillis()).isZero();
+  }
+
+  @Test
+  public void shouldPersistBackoffMagnitude() {
+    // given
+    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    final var ask =
+        new MessageStartProcessInstanceAsk()
+            .wrap(createRecord(123L, 456L, "b", "p"))
+            .setRetryBackoffMillis(4000L);
+
+    // when
+    state.put(ask);
+
+    // then the back-off magnitude survives the RocksDB round-trip
+    final var retrieved = state.get(123L, 456L);
+    assertThat(retrieved.getRetryBackoffMillis()).isEqualTo(4000L);
+  }
+
+  @Test
+  public void shouldPreserveBackoffMagnitudeOnCopy() {
+    // given
+    final var ask =
+        new MessageStartProcessInstanceAsk()
+            .wrap(createRecord(1L, 2L, "b", "p"))
+            .setRetryBackoffMillis(8000L);
+
+    // when
+    final var copy = ask.copy();
+
+    // then
+    assertThat(copy.getRetryBackoffMillis()).isEqualTo(8000L);
+  }
+
   private MessageStartProcessInstanceRequestRecord createRecord(
       final long messageKey,
       final long processDefinitionKey,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/DbMessageStartProcessInstanceAskStateTest.java
@@ -8,9 +8,13 @@
 package io.camunda.zeebe.engine.state.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamClock;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -85,18 +89,22 @@ public class DbMessageStartProcessInstanceAskStateTest {
   }
 
   @Test
-  public void shouldGetPendingAsksPastDeadline() {
-    // given
+  public void shouldVisitPendingAsksWithLastSentTime() {
+    // given two pending asks; one already has a last-sent time recorded
     final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
-    // All entries are added with timestamp 0, so they are all past any positive deadline
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 10L, "b1", "p1")));
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(2L, 20L, "b2", "p2")));
+    state.updateLastSentTime(2L, 20L, 5_000L);
 
-    // when - check with a deadline in the future
-    final var pendingAsks = state.getPendingAsksPastDeadline(System.currentTimeMillis());
+    // when
+    final var lastSentByMessageKey = new java.util.HashMap<Long, Long>();
+    state.forEachPendingAsk(
+        (lastSentTime, ask) -> lastSentByMessageKey.put(ask.getMessageKey(), lastSentTime));
 
-    // then
-    assertThat(pendingAsks).hasSize(2);
+    // then both pending asks are visited with their transient last-sent time (0 until first send)
+    assertThat(lastSentByMessageKey).containsOnlyKeys(1L, 2L);
+    assertThat(lastSentByMessageKey.get(1L)).isZero();
+    assertThat(lastSentByMessageKey.get(2L)).isEqualTo(5_000L);
   }
 
   @Test
@@ -187,8 +195,7 @@ public class DbMessageStartProcessInstanceAskStateTest {
 
   @Test
   public void shouldNotResetSendEligibilityOnBackOff() {
-    // given a pending ask that has already been sent (transient last-sent advanced past any
-    // positive deadline)
+    // given a pending ask that has already been sent (transient last-sent advanced)
     final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
     state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 2L, "b", "p")));
     state.updateLastSentTime(1L, 2L, 10_000L);
@@ -197,9 +204,11 @@ public class DbMessageStartProcessInstanceAskStateTest {
     state.backOff(1L, 2L);
 
     // then back-off does not reset the transient send-tracking: the ask is still considered sent at
-    // 10_000 and is not made immediately eligible again (which would defeat the back-off)
-    assertThat(state.getPendingAsksPastDeadline(10_000L)).isEmpty();
-    assertThat(state.getPendingAsksPastDeadline(10_001L)).hasSize(1);
+    // 10_000 (resetting it would make the ask immediately eligible again and defeat the back-off)
+    final var lastSentByMessageKey = new java.util.HashMap<Long, Long>();
+    state.forEachPendingAsk(
+        (lastSentTime, ask) -> lastSentByMessageKey.put(ask.getMessageKey(), lastSentTime));
+    assertThat(lastSentByMessageKey).containsExactly(java.util.Map.entry(1L, 10_000L));
   }
 
   @Test
@@ -210,6 +219,32 @@ public class DbMessageStartProcessInstanceAskStateTest {
     // when / then no exception and nothing is created
     state.backOff(7L, 8L);
     assertThat(state.get(7L, 8L)).isNull();
+  }
+
+  @Test
+  public void shouldSeedRecoveryEligibilityByRejectionCount() {
+    // given a fresh ask (never rejected) and a backed-off ask
+    final var state = stateRule.getProcessingState().getMessageStartProcessInstanceAskState();
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(1L, 10L, "b1", "p1")));
+    state.put(new MessageStartProcessInstanceAsk().wrap(createRecord(2L, 20L, "b2", "p2")));
+    state.backOff(2L, 20L);
+
+    // when the partition recovers at a known time
+    final long recoveryTime = 50_000L;
+    final var context = mock(ReadonlyStreamProcessorContext.class);
+    final var clock = mock(StreamClock.class);
+    when(context.getClock()).thenReturn(clock);
+    when(clock.millis()).thenReturn(recoveryTime);
+    ((DbMessageStartProcessInstanceAskState) state).onRecovered(context);
+
+    // then the fresh ask is seeded immediately eligible (0, preserving at-least-once first
+    // delivery); the backed-off ask is seeded at the recovery time so it waits its back-off before
+    // re-probing instead of all blocked asks storming P_B at once
+    final var lastSentByMessageKey = new java.util.HashMap<Long, Long>();
+    state.forEachPendingAsk(
+        (lastSentTime, ask) -> lastSentByMessageKey.put(ask.getMessageKey(), lastSentTime));
+    assertThat(lastSentByMessageKey.get(1L)).isZero();
+    assertThat(lastSentByMessageKey.get(2L)).isEqualTo(recoveryTime);
   }
 
   @Test

--- a/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartProcessInstanceRequest_NO_SUBSCRIPTION_REJECTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartProcessInstanceRequest_NO_SUBSCRIPTION_REJECTED_v1.golden
@@ -13,11 +13,12 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessIn
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 
 /**
- * Removes the pending cross-partition ask entry on {@code P_K} when a {@link
- * MessageStartProcessInstanceRequestIntent#NO_SUBSCRIPTION_REJECTED} reply is applied. The message
- * stays buffered (preserving the same semantics as when a local start-event subscription is
- * missing), but the pending-ask bookkeeping is cleared so commit 7's scheduler does not retry-storm
- * after a final rejection.
+ * Records a {@link MessageStartProcessInstanceRequestIntent#NO_SUBSCRIPTION_REJECTED} reply on
+ * {@code P_K} by backing the pending cross-partition ask off rather than dropping it. The message
+ * stays buffered (the start-event subscription has not yet been distributed to {@code P_B}) and the
+ * ask is kept with an incremented rejection count, so the scheduler re-sends it under exponential
+ * back-off: once the deployment reaches {@code P_B}, a later retry flips to {@code STARTED}. The
+ * ask is finally cleared only by a success or by the buffered message expiring at its TTL.
  *
  * <p>This applier is V1-only because the {@code NO_SUBSCRIPTION_REJECTED} intent has no production
  * stream history (it is introduced together with this feature).
@@ -35,6 +36,6 @@ final class MessageStartProcessInstanceNoSubscriptionRejectedV1Applier
 
   @Override
   public void applyState(final long key, final MessageStartProcessInstanceRequestRecord value) {
-    askState.remove(value.getMessageKey(), value.getProcessDefinitionKey());
+    askState.backOff(value.getMessageKey(), value.getProcessDefinitionKey());
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartProcessInstanceRequest_UNIQUENESS_REJECTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartProcessInstanceRequest_UNIQUENESS_REJECTED_v1.golden
@@ -13,10 +13,12 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessIn
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 
 /**
- * Removes the pending cross-partition ask entry on {@code P_K} when a {@link
- * MessageStartProcessInstanceRequestIntent#UNIQUENESS_REJECTED} reply is applied. The message stays
- * buffered and waits for the pull-based release mechanism in Increment 4, but the pending-ask
- * bookkeeping is cleared so commit 7's scheduler does not retry-storm after a final rejection.
+ * Records a {@link MessageStartProcessInstanceRequestIntent#UNIQUENESS_REJECTED} reply on {@code
+ * P_K} by backing the pending cross-partition ask off rather than dropping it. The message stays
+ * buffered and the ask is kept with an incremented rejection count, so the scheduler re-sends it
+ * under exponential back-off: when the holder instance that currently owns the {@code businessId}
+ * completes (or is banned), a later retry flips to {@code STARTED}. The ask is finally cleared only
+ * by a success or by the buffered message expiring at its TTL.
  *
  * <p>This applier is V1-only because the {@code UNIQUENESS_REJECTED} intent has no production
  * stream history (it is introduced together with this feature).
@@ -34,6 +36,6 @@ final class MessageStartProcessInstanceUniquenessRejectedV1Applier
 
   @Override
   public void applyState(final long key, final MessageStartProcessInstanceRequestRecord value) {
-    askState.remove(value.getMessageKey(), value.getProcessDefinitionKey());
+    askState.backOff(value.getMessageKey(), value.getProcessDefinitionKey());
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -313,7 +313,17 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   // absent from this CF and continue to be released by today's local completion path.
   CROSS_PARTITION_MESSAGE_START_LOCK(147, PARTITION_LOCAL),
 
-  JOB_ACTIVATABLE_BY_PRIORITY(148, PARTITION_LOCAL);
+  JOB_ACTIVATABLE_BY_PRIORITY(148, PARTITION_LOCAL),
+
+  // Secondary index over buffered messages by Business ID, keyed by (tenantId, businessId,
+  // messageKey). Maintained on the buffered message's own lifecycle: an entry is written when a
+  // message that carries a businessId is buffered and removed when that message expires. It lets a
+  // same-partition message-start that was skipped on Business-ID uniqueness be found again by the
+  // freed businessId: when a holder instance completes/terminates, the post-transition re-drive
+  // looks up blocked starts by businessId here and re-attempts the ordinary local start. Mirrors
+  // the
+  // correlation-key buffer's completion-driven re-drive (see ADR 0002 D5).
+  MESSAGE_BY_BUSINESS_ID(149, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

This PR implements the retry mechanism for cross-partition message-start asks that are rejected on Business ID uniqueness or missing subscription distribution, and closes the near-deadline duplicate window in the dedup handshake.

## Design

This PR implements the solution specified in **ADR 0002** (rejection-retry strategy for cross-partition message-start asks), documented in #55010. Reviewers are encouraged to read ADR 0002 first for the full rationale behind the back-off model, the near-deadline duplicate window, the dedup grace, and the `P_K`/`P_B` placement invariant.

### Background

When a message-start whose Business ID hashes to a different partition (`P_B`) than the message owner (`P_K`) is sent, `P_K` registers a pending ask and forwards a `MESSAGE_START_PROCESS_INSTANCE_REQUEST` to `P_B`. Previously:

- A `UNIQUENESS_REJECTED` reply (holder PI already owns the Business ID on `P_B`) or a `NO_SUBSCRIPTION_REJECTED` reply (process not yet deployed on `P_B`) **dropped** the pending ask, leaving the buffered message blocked until an unrelated correlation-key completion event happened to re-scan it.
- A retry arriving at `P_B` *just after* the message deadline — due to inter-partition latency or clock skew — would **miss the dedup row** (already expired), re-evaluate live state, and potentially create a duplicate if the holder had since completed and freed the Business ID.

### Changes

#### 1. Exponential back-off retry for rejected asks (`P_K`)
- Both rejection appliers (`UNIQUENESS_REJECTED`, `NO_SUBSCRIPTION_REJECTED`) now call `backOff()` instead of `remove()` on the pending-ask state. This increments a persisted `rejectionCount` (capped at 30) and keeps the ask alive.
- The `PendingMessageStartAskCheckScheduler` derives a per-ask back-off interval of `baseInterval × 2^min(rejectionCount, 6)`, saturating at 64× the base interval. An un-replied ask (count = 0) retries at the base interval — preserving at-least-once delivery.
- On leader recovery, fresh asks are seeded with `lastSentTime = 0` (immediately eligible), while already-backed-off asks are seeded with the recovery timestamp to prevent a retry storm.

#### 2. Near-deadline dedup grace window (`P_B`)
- A new configurable `messageStartAskRetryGrace` (default: `30s`, configurable via `camunda.process-instance-creation.message-start-ask-retry-grace`) extends the dedup row's validity window past the message deadline.
- The `MessageStartProcessInstanceRequestRequestProcessor` checks `deletionDeadline <= now - grace` instead of `<= now`, keeping a dedup row as a valid re-reply source for a grace period after the deadline.
- The `MessageStartDedupExpirationSweepScheduler` and `MessageStartProcessInstanceRequestSweepExpiredDedupsProcessor` pass `now - grace` as the expiry threshold, ensuring the sweep does not GC a row while it can still absorb a late in-flight retry.
- The 30s default comfortably exceeds realistic inter-partition latency and NTP-level clock skew, and aligns with other 30s timescales in the feature (sweep interval, lock-release max back-off).

#### 3. Business-ID keyed completion hook (`P_K` same-partition path)
- A new `MESSAGE_BY_BUSINESS_ID` column family indexes buffered messages by their Business ID at publish time and removes the entry on expiry.
- `BpmnBufferedMessageStartEventBehavior` gains a new method `correlateNextBufferedMessagesOnCompletion` that, on holder PI completion/termination, scans for buffered messages blocked *purely* on Business ID uniqueness (using the new index) in addition to the existing correlation-key queue scan.
- This covers the case where the blocked message carries a **different** (or no) correlation key from the completed holder — a scenario the correlation-key buffer could never re-drive.
- When both scans resolve to candidates carrying the same freed Business ID, only the lower-message-key candidate is triggered to prevent a double-start within a single processing step.

#### 4. Cross-partition routing independent of `businessIdUniquenessEnabled`
- `MessageCorrelateBehavior.shouldDelegateToBusinessIdPartition()` no longer short-circuits on `!businessIdUniquenessEnabled`. A remote Business ID is always delegated to `P_B`, preserving the structural invariant "every root PI carrying a Business ID lives on `hash(businessId)`" regardless of the feature flag.
- The flag now gates **only** the uniqueness rejection inside `MessageStartProcessInstanceRequestRequestProcessor` — it does not affect routing or placement.

### Testing

- `MessageStartEventBusinessIdUniquenessTest`: new single-partition tests covering Business-ID-blocked messages re-driven on holder completion (different correlation key, termination, no-correlation-key none-start holder), and the boundary that banning a holder does not trigger the completion hook.
- `MessageStartProcessInstanceCrossPartitionHandshakeTest`: new multi-partition tests pinning that a `UNIQUENESS_REJECTED` ask retries and succeeds once the holder completes, and that a permanently-blocked ask lets the message expire cleanly at TTL without leaks.
- `MessageStartProcessInstanceCrossPartitionUniquenessDisabledTest`: new test class pinning that cross-partition routing works — and uniqueness is not enforced — when `businessIdUniquenessEnabled = false`.
- `MessageStartProcessInstanceDedupBehaviorTest`: new test pinning the near-deadline grace (retry within grace window re-replies cached PI key; updated existing tests to account for the extended sweep threshold).

### Configuration

| Property | Default | Description |
|---|---|---|
| `camunda.process-instance-creation.message-start-ask-retry-grace` | `30s` | Grace period beyond the message deadline for which the dedup row on `P_B` remains a valid re-reply source, absorbing near-deadline in-flight retries. |

## Related issues

closes #54924 
