### PR TITLE
feat: support tenant-scoped cluster variables via Spring Boot properties

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
@@ -107,6 +107,10 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
     if (tenantVariables != null && !tenantVariables.isEmpty()) {
       for (final Map.Entry<String, Map<String, Object>> entry : tenantVariables.entrySet()) {
         final String tenantId = entry.getKey();
+        if (tenantId == null || tenantId.isBlank()) {
+          throw new IllegalArgumentException(
+              "Invalid tenant ID in 'camunda.client.cluster-variables.tenant': tenant ID must not be null or blank");
+        }
         final Map<String, Object> variables = entry.getValue();
         if (variables != null && !variables.isEmpty()) {
           LOGGER.debug(

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
@@ -93,11 +93,29 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
 
   @Override
   public void start(final CamundaClient client) {
-    // Process variables from properties
-    final Map<String, Object> propertyVariables = properties.getVariables();
-    if (propertyVariables != null && !propertyVariables.isEmpty()) {
-      LOGGER.debug("Upserting {} cluster variable(s) from properties", propertyVariables.size());
-      upsertClusterVariables(client, propertyVariables, null);
+    // Process global variables from properties
+    final Map<String, Object> globalVariables = properties.getGlobal();
+    if (globalVariables != null && !globalVariables.isEmpty()) {
+      LOGGER.debug(
+          "Upserting {} globally-scoped cluster variable(s) from properties",
+          globalVariables.size());
+      upsertClusterVariables(client, globalVariables, null);
+    }
+
+    // Process tenant-scoped variables from properties
+    final Map<String, Map<String, Object>> tenantVariables = properties.getTenant();
+    if (tenantVariables != null && !tenantVariables.isEmpty()) {
+      for (final Map.Entry<String, Map<String, Object>> entry : tenantVariables.entrySet()) {
+        final String tenantId = entry.getKey();
+        final Map<String, Object> variables = entry.getValue();
+        if (variables != null && !variables.isEmpty()) {
+          LOGGER.debug(
+              "Upserting {} cluster variable(s) from properties for tenant '{}'",
+              variables.size(),
+              tenantId);
+          upsertClusterVariables(client, variables, tenantId);
+        }
+      }
     }
 
     // Process variables from annotations

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
@@ -25,8 +25,11 @@ public class CamundaClientClusterVariablesProperties {
    */
   private boolean enabled = true;
 
-  /** Cluster variables to set at startup as key-value pairs. */
-  private Map<String, Object> variables;
+  /** Globally-scoped cluster variables to set at startup as key-value pairs. */
+  private Map<String, Object> global;
+
+  /** Tenant-scoped cluster variables to set at startup, keyed by tenant ID. */
+  private Map<String, Map<String, Object>> tenant;
 
   public boolean isEnabled() {
     return enabled;
@@ -36,12 +39,20 @@ public class CamundaClientClusterVariablesProperties {
     this.enabled = enabled;
   }
 
-  public Map<String, Object> getVariables() {
-    return variables;
+  public Map<String, Object> getGlobal() {
+    return global;
   }
 
-  public void setVariables(final Map<String, Object> variables) {
-    this.variables = variables;
+  public void setGlobal(final Map<String, Object> global) {
+    this.global = global;
+  }
+
+  public Map<String, Map<String, Object>> getTenant() {
+    return tenant;
+  }
+
+  public void setTenant(final Map<String, Map<String, Object>> tenant) {
+    this.tenant = tenant;
   }
 
   @Override
@@ -49,8 +60,10 @@ public class CamundaClientClusterVariablesProperties {
     return "CamundaClientClusterVariablesProperties{"
         + "enabled="
         + enabled
-        + ", variables="
-        + variables
+        + ", global="
+        + global
+        + ", tenant="
+        + tenant
         + '}';
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
@@ -20,8 +20,10 @@ import java.util.Map;
 public class CamundaClientClusterVariablesProperties {
 
   /**
-   * Indicates if the <code>@ClusterVariables</code> annotation is processed and configured
-   * variables are applied.
+   * Indicates if cluster variable processing is enabled. When {@code true}, variables configured
+   * via <code>@ClusterVariables</code> annotations and via the {@code global}/{@code tenant}
+   * properties are applied at startup. When {@code false}, all cluster variable processing is
+   * skipped.
    */
   private boolean enabled = true;
 

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -236,8 +236,11 @@ public class AlignmentTest {
               "camunda.client.cluster-variables.enabled",
               new Getter(p -> p.getClusterVariables().isEnabled())),
           entry(
-              "camunda.client.cluster-variables.variables",
-              new Getter(p -> p.getClusterVariables().getVariables())));
+              "camunda.client.cluster-variables.global",
+              new Getter(p -> p.getClusterVariables().getGlobal())),
+          entry(
+              "camunda.client.cluster-variables.tenant",
+              new Getter(p -> p.getClusterVariables().getTenant())));
 
   @Autowired CamundaClientProperties camundaClientProperties;
 

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
@@ -254,7 +254,7 @@ public class ClusterVariablesAnnotationProcessorTest {
   @Test
   void shouldCreateVariablesFromProperties() {
     // given
-    properties.setVariables(Map.of("propVar1", "propValue1", "propVar2", 99));
+    properties.setGlobal(Map.of("propVar1", "propValue1", "propVar2", 99));
     mockGlobalCreateCommand();
 
     // when
@@ -263,6 +263,20 @@ public class ClusterVariablesAnnotationProcessorTest {
     // then
     verify(globalCreateStep).create("propVar1", "propValue1");
     verify(globalCreateStep).create("propVar2", 99);
+  }
+
+  @Test
+  void shouldCreateTenantScopedVariablesFromProperties() {
+    // given
+    properties.setTenant(Map.of("my-tenant", Map.of("tenantPropVar", "tenantPropValue")));
+    mockTenantCreateCommand();
+
+    // when
+    processor.start(client);
+
+    // then
+    verify(client).newTenantScopedClusterVariableCreateRequest("my-tenant");
+    verify(tenantCreateStep).create("tenantPropVar", "tenantPropValue");
   }
 
   @Test
@@ -282,7 +296,7 @@ public class ClusterVariablesAnnotationProcessorTest {
   @Test
   void shouldCreateVariablesFromPropertiesAndAnnotations() throws IOException {
     // given
-    properties.setVariables(Map.of("fromProp", "propValue"));
+    properties.setGlobal(Map.of("fromProp", "propValue"));
     final Resource resource = mockJsonResource("{\"fromResource\": \"resourceValue\"}");
     when(resourcePatternResolver.getResources("classpath:variables.json"))
         .thenReturn(new Resource[] {resource});

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
@@ -252,7 +252,7 @@ public class ClusterVariablesAnnotationProcessorTest {
   }
 
   @Test
-  void shouldCreateVariablesFromProperties() {
+  void shouldCreateGlobalVariablesFromProperties() {
     // given
     properties.setGlobal(Map.of("propVar1", "propValue1", "propVar2", 99));
     mockGlobalCreateCommand();
@@ -294,7 +294,7 @@ public class ClusterVariablesAnnotationProcessorTest {
   }
 
   @Test
-  void shouldCreateVariablesFromPropertiesAndAnnotations() throws IOException {
+  void shouldCreateGlobalVariablesFromPropertiesAndAnnotations() throws IOException {
     // given
     properties.setGlobal(Map.of("fromProp", "propValue"));
     final Resource resource = mockJsonResource("{\"fromResource\": \"resourceValue\"}");

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
@@ -280,6 +280,17 @@ public class ClusterVariablesAnnotationProcessorTest {
   }
 
   @Test
+  void shouldRejectBlankTenantIdFromProperties() {
+    // given
+    properties.setTenant(Map.of("", Map.of("var", "value")));
+
+    // when / then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> processor.start(client))
+        .withMessageContaining("camunda.client.cluster-variables.tenant");
+  }
+
+  @Test
   void shouldCreateVariablesFromPojoMethod() {
     // given
     mockGlobalCreateCommand();


### PR DESCRIPTION
## Summary

- Renames `camunda.client.cluster-variables.variables` → `camunda.client.cluster-variables.global` to make the global scope explicit
- Adds `camunda.client.cluster-variables.tenant.<tenantId>.*` for tenant-scoped cluster variables via properties, equivalent to `@ClusterVariables(tenantId = "...")`

## Example

```yaml
camunda:
  client:
    cluster-variables:
      global:
        environment: production
      tenant:
        myTenant:
          environment: staging
```

## Notes

- The `variables` rename is a breaking change; the feature has not been released yet so no deprecation path is needed.
- Property-based and annotation-based paths are now feature-equivalent for tenant scoping.

Closes #55200

🤖 Generated with [Claude Code](https://claude.com/claude-code)