### PR TITLE
ci: adopt rebaseWhen conflicted via shared Renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "github>camunda/infra-renovate-config:herodevs.json5"
+    "github>camunda/infra-renovate-config:herodevs.json5",
+    "github>camunda/infra-renovate-config:rebase.json5"
   ],
   "commitMessagePrefix": "deps:",
   "baseBranchPatterns": [


### PR DESCRIPTION
## Description

Stop Renovate from rebasing PRs on every push by extending the shared `infra-renovate-config:rebase.json5` preset (rebaseWhen: "conflicted"), placed last so it overrides `config:recommended`. This avoids re-running the full CI matrix hundreds of times.

PR freshness custom strategies are ensured separately by a watcher, to be introduced via https://github.com/camunda/camunda/pull/55203.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

camunda/team-infrastructure#1053