### PR TITLE
feat: detect runaway BPMN loops via configurable element activation limits

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -73,6 +73,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-cluster-config</artifactId>
     </dependency>
 

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -45,6 +45,9 @@ public class Engine {
   /** Configuration properties for the engine's secret resolution scheduler. */
   @NestedConfigurationProperty private EngineSecrets secrets = new EngineSecrets();
 
+  /** Configuration properties for the engine's loop detection. */
+  @NestedConfigurationProperty private LoopDetection loopDetection = new LoopDetection();
+
   /**
    * Configures the maximum depth of nested call activities allowed before an incident is raised, to
    * guard against unbounded process recursion.
@@ -149,5 +152,13 @@ public class Engine {
       final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
     this.evaluateDuplicateOutputMappingTargetsInOrder =
         evaluateDuplicateOutputMappingTargetsInOrder;
+  }
+
+  public LoopDetection getLoopDetection() {
+    return loopDetection;
+  }
+
+  public void setLoopDetection(final LoopDetection loopDetection) {
+    this.loopDetection = loopDetection;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/LoopDetection.java
+++ b/configuration/src/main/java/io/camunda/configuration/LoopDetection.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.core.ResolvableType;
+
+public class LoopDetection {
+
+  private static final String PREFIX = "camunda.processing.engine.loop-detection";
+
+  // Must stay in sync with EngineConfiguration.DEFAULT_MAX_ELEMENT_ACTIVATION_COUNT.
+  private static final int DEFAULT_MAX_ELEMENT_ACTIVATION_COUNT = 1000;
+  // Must stay in sync with EngineConfiguration.DEFAULT_ELEMENT_ACTIVATION_RETRY_COOLDOWN.
+  private static final int DEFAULT_ELEMENT_ACTIVATION_RETRY_COOLDOWN = 100;
+
+  private static final Set<String> LEGACY_MAX_ELEMENT_ACTIVATION_COUNT_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.loopDetection.maxElementActivationCount");
+  private static final Set<String> LEGACY_ELEMENT_ACTIVATION_RETRY_COOLDOWN_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.loopDetection.elementActivationRetryCooldown");
+  private static final Set<String> LEGACY_MAX_ELEMENT_ACTIVATION_COUNT_BY_TYPE_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.loopDetection.maxElementActivationCountByType");
+
+  /**
+   * The maximum number of times a single BPMN element may be activated within one process instance
+   * before a loop-detection incident is raised. Used as the default for element types without a
+   * per-type override in {@link #maxElementActivationCountByType}.
+   */
+  private int maxElementActivationCount = DEFAULT_MAX_ELEMENT_ACTIVATION_COUNT;
+
+  /**
+   * Once the threshold is first exceeded, the loop-detection incident is re-raised every {@code
+   * elementActivationRetryCooldown} further activations. This gives operators a window to resolve
+   * the incident before a new one is raised. A value of {@code 1} (or less) disables throttling, so
+   * the incident is re-raised on every activation beyond the threshold.
+   */
+  private int elementActivationRetryCooldown = DEFAULT_ELEMENT_ACTIVATION_RETRY_COOLDOWN;
+
+  /**
+   * Per-{@link BpmnElementType} overrides for {@link #maxElementActivationCount}. An element type
+   * present in this map uses the mapped value instead of the global default; a value of {@code 0}
+   * disables loop detection for that element type.
+   *
+   * <p><b>Multi-instance note:</b> for a multi-instance task the override is keyed by the inner
+   * element type (e.g. {@code SERVICE_TASK}) and applies to each child activation, including the
+   * parallel child-spawn batch bound; setting the inner type to {@code 0} disables both for those
+   * children. {@code MULTI_INSTANCE_BODY} acts as an on/off gate — setting it to {@code 0} disables
+   * detection for all multi-instance children regardless of their inner type.
+   *
+   * <p><b>Nesting note:</b> counters are keyed by process instance and element id, so elements
+   * nested inside an embedded subprocess used as a multi-instance inner activity accumulate on one
+   * shared counter across all of its children. Set per-type overrides for such nested elements
+   * above the largest expected collection to avoid raising incidents on legitimately large
+   * collections.
+   */
+  private Map<BpmnElementType, Integer> maxElementActivationCountByType = new HashMap<>();
+
+  public int getMaxElementActivationCount() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".max-element-activation-count",
+        maxElementActivationCount,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_ELEMENT_ACTIVATION_COUNT_PROPERTIES);
+  }
+
+  public void setMaxElementActivationCount(final int maxElementActivationCount) {
+    this.maxElementActivationCount = maxElementActivationCount;
+  }
+
+  public int getElementActivationRetryCooldown() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".element-activation-retry-cooldown",
+        elementActivationRetryCooldown,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ELEMENT_ACTIVATION_RETRY_COOLDOWN_PROPERTIES);
+  }
+
+  public void setElementActivationRetryCooldown(final int elementActivationRetryCooldown) {
+    this.elementActivationRetryCooldown = elementActivationRetryCooldown;
+  }
+
+  public Map<BpmnElementType, Integer> getMaxElementActivationCountByType() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".max-element-activation-count-by-type",
+        maxElementActivationCountByType,
+        ResolvableType.forClassWithGenerics(Map.class, BpmnElementType.class, Integer.class),
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_ELEMENT_ACTIVATION_COUNT_BY_TYPE_PROPERTIES);
+  }
+
+  public void setMaxElementActivationCountByType(
+      final Map<BpmnElementType, Integer> maxElementActivationCountByType) {
+    this.maxElementActivationCountByType =
+        maxElementActivationCountByType == null ? new HashMap<>() : maxElementActivationCountByType;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -268,6 +268,7 @@ public class BrokerBasedPropertiesOverride {
     populateFromUsageMetrics(override, camunda);
     populateFromValidators(override, camunda);
     populateFromSecretResolution(override, camunda);
+    populateFromLoopDetection(override, camunda);
 
     override
         .getExperimental()
@@ -350,6 +351,17 @@ public class BrokerBasedPropertiesOverride {
     batchOperationsCfg.setQueryRetryMaxDelay(engineBatchOperation.getQueryRetryMaxDelay());
     batchOperationsCfg.setQueryRetryBackoffFactor(
         engineBatchOperation.getQueryRetryBackoffFactor());
+  }
+
+  private static void populateFromLoopDetection(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var loopDetection = camunda.getProcessing().getEngine().getLoopDetection();
+    final var loopDetectionCfg = override.getExperimental().getEngine().getLoopDetection();
+    loopDetectionCfg.setMaxElementActivationCount(loopDetection.getMaxElementActivationCount());
+    loopDetectionCfg.setElementActivationRetryCooldown(
+        loopDetection.getElementActivationRetryCooldown());
+    loopDetectionCfg.setMaxElementActivationCountByType(
+        loopDetection.getMaxElementActivationCountByType());
   }
 
   private static void populateFromExpression(

--- a/configuration/src/test/java/io/camunda/configuration/LoopDetectionTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/LoopDetectionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.engine.LoopDetectionCfg;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class LoopDetectionTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.engine.loop-detection.max-element-activation-count=500",
+        "camunda.processing.engine.loop-detection.element-activation-retry-cooldown=50",
+        "camunda.processing.engine.loop-detection.max-element-activation-count-by-type.SERVICE_TASK=300",
+        "camunda.processing.engine.loop-detection.max-element-activation-count-by-type.USER_TASK=0",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetLoopDetection() {
+      final LoopDetectionCfg loopDetection =
+          brokerCfg.getExperimental().getEngine().getLoopDetection();
+      assertThat(loopDetection.getMaxElementActivationCount()).isEqualTo(500);
+      assertThat(loopDetection.getElementActivationRetryCooldown()).isEqualTo(50);
+      assertThat(loopDetection.getMaxElementActivationCountByType())
+          .containsEntry(BpmnElementType.SERVICE_TASK, 300)
+          .containsEntry(BpmnElementType.USER_TASK, 0);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.engine.loopDetection.maxElementActivationCount=500",
+        "zeebe.broker.experimental.engine.loopDetection.elementActivationRetryCooldown=50",
+        "zeebe.broker.experimental.engine.loopDetection.maxElementActivationCountByType.SERVICE_TASK=300",
+        "zeebe.broker.experimental.engine.loopDetection.maxElementActivationCountByType.USER_TASK=0",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetLoopDetectionFromLegacy() {
+      final LoopDetectionCfg loopDetection =
+          brokerCfg.getExperimental().getEngine().getLoopDetection();
+      assertThat(loopDetection.getMaxElementActivationCount()).isEqualTo(500);
+      assertThat(loopDetection.getElementActivationRetryCooldown()).isEqualTo(50);
+      assertThat(loopDetection.getMaxElementActivationCountByType())
+          .containsEntry(BpmnElementType.SERVICE_TASK, 300)
+          .containsEntry(BpmnElementType.USER_TASK, 0);
+    }
+  }
+
+  @Nested
+  class WithDefaults {
+    final BrokerBasedProperties brokerCfg;
+
+    WithDefaults(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldResolveSameDefaultsAsEngineConfiguration() {
+      // The unified-config LoopDetection layer duplicates these defaults from EngineConfiguration.
+      // Assert the resolved values match the engine constants, to avoid drift.
+      final LoopDetectionCfg loopDetection =
+          brokerCfg.getExperimental().getEngine().getLoopDetection();
+      assertThat(loopDetection.getMaxElementActivationCount())
+          .isEqualTo(EngineConfiguration.DEFAULT_MAX_ELEMENT_ACTIVATION_COUNT);
+      assertThat(loopDetection.getElementActivationRetryCooldown())
+          .isEqualTo(EngineConfiguration.DEFAULT_ELEMENT_ACTIVATION_RETRY_COOLDOWN);
+    }
+  }
+}

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -290,6 +290,9 @@ processing.engine.evaluate-duplicate-output-mapping-targets-in-order
 processing.engine.job.include-variables-in-job-completed-event
 processing.engine.job.timeout-checker-batch-limit
 processing.engine.job.timeout-checker-polling-interval
+processing.engine.loop-detection.element-activation-retry-cooldown
+processing.engine.loop-detection.max-element-activation-count
+processing.engine.loop-detection.max-element-activation-count-by-type
 processing.engine.max-process-depth
 processing.engine.messages.ttl-checker-batch-limit
 processing.engine.messages.ttl-checker-interval

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -27,6 +27,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private ExpressionCfg expression = new ExpressionCfg();
   private ProcessInstanceCreationCfg processInstanceCreation = new ProcessInstanceCreationCfg();
   private StartupCfg startup = new StartupCfg();
+  private LoopDetectionCfg loopDetection = new LoopDetectionCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -43,6 +44,7 @@ public final class EngineCfg implements ConfigurationEntry {
     expression.init(globalConfig, brokerBase);
     processInstanceCreation.init(globalConfig, brokerBase);
     startup.init(globalConfig, brokerBase);
+    loopDetection.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -157,6 +159,14 @@ public final class EngineCfg implements ConfigurationEntry {
     startup = startupCfg;
   }
 
+  public LoopDetectionCfg getLoopDetection() {
+    return loopDetection;
+  }
+
+  public void setLoopDetection(final LoopDetectionCfg loopDetection) {
+    this.loopDetection = loopDetection;
+  }
+
   @Override
   public String toString() {
     return "EngineCfg{"
@@ -188,6 +198,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + processInstanceCreation
         + ", startup="
         + startup
+        + ", loopDetection="
+        + loopDetection
         + '}';
   }
 
@@ -247,6 +259,9 @@ public final class EngineCfg implements ConfigurationEntry {
         .setMessageStartLockReleasePollBatchLimit(
             processInstanceCreation.getMessageStartLockReleasePollBatchLimit())
         .setIncludeVariablesInJobCompletedEvent(jobs.isIncludeVariablesInJobCompletedEvent())
-        .setEnableRpaReexportMigration(startup.isRpaReexportMigrationEnabled());
+        .setEnableRpaReexportMigration(startup.isRpaReexportMigrationEnabled())
+        .setMaxElementActivationCount(loopDetection.getMaxElementActivationCount())
+        .setElementActivationRetryCooldown(loopDetection.getElementActivationRetryCooldown())
+        .setMaxElementActivationCountByType(loopDetection.getMaxElementActivationCountByType());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/LoopDetectionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/LoopDetectionCfg.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_ELEMENT_ACTIVATION_RETRY_COOLDOWN;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MAX_ELEMENT_ACTIVATION_COUNT;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configures loop detection, which raises an incident when a BPMN element is activated more times
+ * than allowed within a single process instance.
+ *
+ * <p>The threshold can be configured per {@link BpmnElementType}: an entry in {@link
+ * #maxElementActivationCountByType} overrides {@link #maxElementActivationCount} for that element
+ * type, and a per-type value of {@code 0} disables loop detection for that element type.
+ *
+ * <p><b>Multi-instance note:</b> for a multi-instance task the per-type override is keyed by the
+ * inner element type (e.g. {@code SERVICE_TASK}) and applies to each child activation, including
+ * the parallel child-spawn batch bound; setting the inner type to {@code 0} disables both for those
+ * children. {@code MULTI_INSTANCE_BODY} acts as an on/off gate — setting it to {@code 0} disables
+ * detection for all multi-instance children regardless of their inner type.
+ *
+ * <p><b>Nesting note:</b> counters are keyed by process instance and element id, so elements nested
+ * inside an embedded subprocess used as a multi-instance inner activity accumulate on one shared
+ * counter across all of its children. Set per-type overrides for such nested elements above the
+ * largest expected collection to avoid raising incidents on legitimately large collections.
+ */
+public class LoopDetectionCfg implements ConfigurationEntry {
+
+  private int maxElementActivationCount = DEFAULT_MAX_ELEMENT_ACTIVATION_COUNT;
+  private int elementActivationRetryCooldown = DEFAULT_ELEMENT_ACTIVATION_RETRY_COOLDOWN;
+  private Map<BpmnElementType, Integer> maxElementActivationCountByType = new HashMap<>();
+
+  public int getMaxElementActivationCount() {
+    return maxElementActivationCount;
+  }
+
+  public void setMaxElementActivationCount(final int maxElementActivationCount) {
+    this.maxElementActivationCount = maxElementActivationCount;
+  }
+
+  public int getElementActivationRetryCooldown() {
+    return elementActivationRetryCooldown;
+  }
+
+  public void setElementActivationRetryCooldown(final int elementActivationRetryCooldown) {
+    this.elementActivationRetryCooldown = elementActivationRetryCooldown;
+  }
+
+  public Map<BpmnElementType, Integer> getMaxElementActivationCountByType() {
+    return maxElementActivationCountByType;
+  }
+
+  public void setMaxElementActivationCountByType(
+      final Map<BpmnElementType, Integer> maxElementActivationCountByType) {
+    this.maxElementActivationCountByType =
+        maxElementActivationCountByType == null ? new HashMap<>() : maxElementActivationCountByType;
+  }
+
+  @Override
+  public String toString() {
+    return "LoopDetectionCfg{"
+        + "maxElementActivationCount="
+        + maxElementActivationCount
+        + ", elementActivationRetryCooldown="
+        + elementActivationRetryCooldown
+        + ", maxElementActivationCountByType="
+        + maxElementActivationCountByType
+        + '}';
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.GlobalListenerConfiguration;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -85,6 +86,11 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR);
     assertThat(configuration.getSecretResolutionBatchLimit())
         .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_BATCH_LIMIT);
+    assertThat(configuration.getMaxElementActivationCount())
+        .isEqualTo(EngineConfiguration.DEFAULT_MAX_ELEMENT_ACTIVATION_COUNT);
+    assertThat(configuration.getElementActivationRetryCooldown())
+        .isEqualTo(EngineConfiguration.DEFAULT_ELEMENT_ACTIVATION_RETRY_COOLDOWN);
+    assertThat(configuration.getMaxElementActivationCountByType()).isEmpty();
   }
 
   @Test
@@ -126,6 +132,11 @@ final class EngineCfgTest {
     assertThat(configuration.isEnableRpaReexportMigration()).isFalse();
     assertThat(configuration.getGroupNameCacheCapacity()).isEqualTo(2000);
     assertThat(configuration.isCandidateGroupNameResolution()).isFalse();
+    assertThat(configuration.getMaxElementActivationCount()).isEqualTo(500);
+    assertThat(configuration.getElementActivationRetryCooldown()).isEqualTo(50);
+    assertThat(configuration.getMaxElementActivationCountByType())
+        .containsEntry(BpmnElementType.SERVICE_TASK, 300)
+        .containsEntry(BpmnElementType.USER_TASK, 0);
   }
 
   void assertListenerCfg(

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -48,3 +48,9 @@ zeebe:
           businessIdUniquenessEnabled: true
         startup:
           rpaReexportMigrationEnabled: false
+        loopDetection:
+          maxElementActivationCount: 500
+          elementActivationRetryCooldown: 50
+          maxElementActivationCountByType:
+            SERVICE_TASK: 300
+            USER_TASK: 0

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.engine;
 
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.time.Duration;
+import java.util.Map;
 
 public final class EngineConfiguration {
 
@@ -106,6 +108,14 @@ public final class EngineConfiguration {
 
   public static final boolean DEFAULT_ENABLE_RPA_REEXPORT_MIGRATION = true;
 
+  /**
+   * Maximum number of times a single BPMN element may be activated within one process instance
+   * before a loop-detected incident is raised. Defaults to 1000.
+   */
+  public static final int DEFAULT_MAX_ELEMENT_ACTIVATION_COUNT = 1000;
+
+  public static final int DEFAULT_ELEMENT_ACTIVATION_RETRY_COOLDOWN = 100;
+
   private int maxIdFieldLength = DEFAULT_MAX_ID_FIELD_LENGTH;
   private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
   private int maxWorkerTypeLength = DEFAULT_MAX_WORKER_TYPE_LENGTH;
@@ -181,6 +191,16 @@ public final class EngineConfiguration {
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_INTERVAL;
   private int messageStartLockReleasePollBatchLimit =
       DEFAULT_MESSAGE_START_LOCK_RELEASE_POLL_BATCH_LIMIT;
+  private int maxElementActivationCount = DEFAULT_MAX_ELEMENT_ACTIVATION_COUNT;
+  private int elementActivationRetryCooldown = DEFAULT_ELEMENT_ACTIVATION_RETRY_COOLDOWN;
+
+  /**
+   * Per-{@link BpmnElementType} overrides for the maximum element activation count used by loop
+   * detection. An element type present in this map uses the mapped value instead of {@link
+   * #maxElementActivationCount}. A value of {@code 0} disables loop detection for that element
+   * type.
+   */
+  private Map<BpmnElementType, Integer> maxElementActivationCountByType = Map.of();
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -705,6 +725,43 @@ public final class EngineConfiguration {
   public EngineConfiguration setEnableRpaReexportMigration(
       final boolean enableRpaReexportMigration) {
     this.enableRpaReexportMigration = enableRpaReexportMigration;
+    return this;
+  }
+
+  public int getMaxElementActivationCount() {
+    return maxElementActivationCount;
+  }
+
+  public EngineConfiguration setMaxElementActivationCount(final int maxElementActivationCount) {
+    this.maxElementActivationCount = maxElementActivationCount;
+    return this;
+  }
+
+  public int getElementActivationRetryCooldown() {
+    return elementActivationRetryCooldown;
+  }
+
+  /**
+   * Once the activation threshold is first exceeded, the loop-detection incident is re-raised every
+   * {@code elementActivationRetryCooldown} further activations. A value of {@code 1} (or less)
+   * disables throttling, so the incident is re-raised on every activation beyond the threshold.
+   */
+  public EngineConfiguration setElementActivationRetryCooldown(
+      final int elementActivationRetryCooldown) {
+    this.elementActivationRetryCooldown = elementActivationRetryCooldown;
+    return this;
+  }
+
+  public Map<BpmnElementType, Integer> getMaxElementActivationCountByType() {
+    return maxElementActivationCountByType;
+  }
+
+  public EngineConfiguration setMaxElementActivationCountByType(
+      final Map<BpmnElementType, Integer> maxElementActivationCountByType) {
+    this.maxElementActivationCountByType =
+        maxElementActivationCountByType == null
+            ? Map.of()
+            : Map.copyOf(maxElementActivationCountByType);
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstruc
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionCompleteProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnLoopDetectionBehavior;
 import io.camunda.zeebe.engine.processing.conditional.ConditionalSubscriptionTriggerProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
@@ -140,7 +141,8 @@ public final class BpmnProcessors {
         keyGenerator);
     addProcessInstanceBusinessIdStreamProcessors(
         typedRecordProcessors, processingState, writers, cslCheck, config);
-    addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
+    addProcessInstanceBatchStreamProcessors(
+        typedRecordProcessors, processingState, writers, bpmnBehaviors.loopDetectionBehavior());
     addAdHocSubProcessActivityStreamProcessors(
         typedRecordProcessors, processingState, writers, cslCheck, bpmnBehaviors);
 
@@ -364,7 +366,8 @@ public final class BpmnProcessors {
   private static void addProcessInstanceBatchStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
-      final Writers writers) {
+      final Writers writers,
+      final BpmnLoopDetectionBehavior loopDetectionBehavior) {
     typedRecordProcessors
         .onCommand(
             ValueType.PROCESS_INSTANCE_BATCH,
@@ -380,7 +383,8 @@ public final class BpmnProcessors {
                 writers,
                 processingState.getKeyGenerator(),
                 processingState.getElementInstanceState(),
-                processingState.getProcessState()));
+                processingState.getProcessState(),
+                loopDetectionBehavior));
   }
 
   private static void addAdHocSubProcessActivityStreamProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -15,8 +15,10 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementProcessor.TransitionOu
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnLoopDetectionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.LoopDetectionFilter;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.common.ValidationException;
@@ -66,6 +68,7 @@ public final class BpmnStreamProcessor
   private final EventTriggerBehavior eventTriggerBehavior;
   private final VariableBehavior variableBehavior;
   private final EventScopeInstanceState eventScopeInstanceState;
+  private final BpmnLoopDetectionBehavior loopDetectionBehavior;
 
   public BpmnStreamProcessor(
       final BpmnBehaviors bpmnBehaviors,
@@ -97,6 +100,7 @@ public final class BpmnStreamProcessor
     eventTriggerBehavior = bpmnBehaviors.eventTriggerBehavior();
     variableBehavior = bpmnBehaviors.variableBehavior();
     eventScopeInstanceState = processingState.getEventScopeInstanceState();
+    loopDetectionBehavior = bpmnBehaviors.loopDetectionBehavior();
   }
 
   private BpmnElementContainerProcessor<ExecutableFlowElement> getContainerProcessor(
@@ -180,9 +184,15 @@ public final class BpmnStreamProcessor
 
     switch (intent) {
       case ACTIVATE_ELEMENT:
+        // If the element instance already exists when its ACTIVATE_ELEMENT command is processed,
+        // the command is being re-processed to resolve an incident. Loop detection is then skipped
+        // so the retry can proceed instead of raising the same incident again; the retry cooldown
+        // governs re-raising on later (fresh) activations.
+        final boolean isIncidentResolution = stateBehavior.getElementInstance(context) != null;
         final var activatingContext = stateTransitionBehavior.transitionToActivating(context);
         stateTransitionBehavior
             .onElementActivating(element, activatingContext)
+            .flatMap(ok -> runLoopDetection(activatingContext, isIncidentResolution))
             .flatMap(ok -> beforeActivating(element, processor, activatingContext))
             .ifLeft(failure -> incidentBehavior.createIncident(failure, activatingContext));
         break;
@@ -440,6 +450,28 @@ public final class BpmnStreamProcessor
                   context.getElementInstanceKey(),
                   eventTrigger.getElementId());
             });
+  }
+
+  /**
+   * Runs the loop-detection activation-threshold check when it applies to this element activation,
+   * otherwise short-circuits to success.
+   */
+  private Either<Failure, ?> runLoopDetection(
+      final BpmnElementContext context, final boolean isIncidentResolution) {
+    if (isIncidentResolution) {
+      // Resolving a loop-detection incident lets the activation proceed instead of raising the same
+      // incident again; the retry cooldown governs re-raising on later fresh activations.
+      return BpmnElementProcessor.SUCCESS;
+    }
+    if (!LoopDetectionFilter.shouldCount(context.getRecordValue())) {
+      return BpmnElementProcessor.SUCCESS;
+    }
+    // Multi-instance children are gated on the body type being enabled and are checked against
+    // their own (inner) element type; all other elements use the plain activation-threshold check.
+    final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
+    return LoopDetectionFilter.isMultiInstanceChild(flowScopeInstance)
+        ? loopDetectionBehavior.checkMultiInstanceChildActivationThreshold(context)
+        : loopDetectionBehavior.checkActivationThreshold(context);
   }
 
   private ExecutableFlowElement getElement(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -66,4 +66,6 @@ public interface BpmnBehaviors {
   AgentInstanceBehavior agentInstanceBehavior();
 
   BpmnProcessDeletionBehavior processDeletionBehavior();
+
+  BpmnLoopDetectionBehavior loopDetectionBehavior();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -71,6 +71,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final ExpressionBehavior expressionBehavior;
   private final ExpressionLanguage expressionLanguage;
   private final AgentInstanceBehavior agentInstanceBehavior;
+  private final BpmnLoopDetectionBehavior loopDetectionBehavior;
 
   public BpmnBehaviorsImpl(
       final MutableProcessingState processingState,
@@ -310,6 +311,13 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     agentInstanceBehavior = new AgentInstanceBehavior(writers);
 
+    loopDetectionBehavior =
+        new BpmnLoopDetectionBehavior(
+            processingState.getElementInstanceState(),
+            config.getMaxElementActivationCount(),
+            config.getMaxElementActivationCountByType(),
+            config.getElementActivationRetryCooldown());
+
     processDeletionBehavior =
         new BpmnProcessDeletionBehavior(
             processingState.getProcessState(),
@@ -443,6 +451,11 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public BpmnProcessDeletionBehavior processDeletionBehavior() {
     return processDeletionBehavior;
+  }
+
+  @Override
+  public BpmnLoopDetectionBehavior loopDetectionBehavior() {
+    return loopDetectionBehavior;
   }
 
   public ExpressionBehavior expressionBehavior() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnLoopDetectionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnLoopDetectionBehavior.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+/**
+ * Detects unintended tight loops in a BPMN process by counting how many times each element is
+ * activated within a single process instance. When the count exceeds the configured threshold a
+ * {@link Failure} with {@link ErrorType#CONDITION_ERROR} is returned, raising an incident that
+ * halts the loop.
+ *
+ * <p>The threshold can be overridden per {@link BpmnElementType}; a value of {@code 0} disables
+ * detection for that type. Multi-instance children accumulate the count on the shared element-id
+ * counter and are checked individually via {@link #checkMultiInstanceChildActivationThreshold}. The
+ * activation batch of a parallel multi-instance body stops spawning children once {@link
+ * #isChildActivationThresholdExceeded} reports the limit is crossed, so a runaway collection is
+ * bounded to a single incident on the crossing child.
+ */
+public final class BpmnLoopDetectionBehavior {
+
+  private static final String CONDITION_ERROR_ACTIVATION_COUNT_EXCEEDED =
+      "Expected to activate element '%s' in process instance '%d', but the element has already"
+          + " been activated %d times, exceeding the maximum activation threshold of %d.";
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final int maxActivations;
+  private final Map<BpmnElementType, Integer> maxActivationsByType;
+  private final int retryCooldown;
+
+  public BpmnLoopDetectionBehavior(
+      final MutableElementInstanceState elementInstanceState,
+      final int maxActivations,
+      final Map<BpmnElementType, Integer> maxActivationsByType,
+      final int retryCooldown) {
+    this.elementInstanceState = elementInstanceState;
+    this.maxActivations = maxActivations;
+    this.maxActivationsByType = Map.copyOf(maxActivationsByType);
+    this.retryCooldown = retryCooldown;
+  }
+
+  /**
+   * Checks whether the activation count for the element has exceeded the configured threshold. The
+   * counter is incremented by {@code ProcessInstanceElementActivatingV4Applier} before this check
+   * runs, so it already reflects the current activation. A {@link Failure} is raised on the first
+   * activation beyond the threshold and then every {@code retryCooldown} activations after that.
+   *
+   * @param context the context of the element that is being activated
+   * @return {@code Either.right(null)} when within bounds, or {@code Either.left} with a {@link
+   *     Failure} when the threshold is exceeded
+   */
+  public Either<Failure, Void> checkActivationThreshold(final BpmnElementContext context) {
+    final int max = resolveMaxActivations(context.getBpmnElementType());
+    if (max <= 0) {
+      // Loop detection is disabled for this element type.
+      return Either.right(null);
+    }
+
+    // The counter was already incremented by ProcessInstanceElementActivatingV4Applier when the
+    // ELEMENT_ACTIVATING event was applied (during transitionToActivating, before this check runs),
+    // so it already reflects the current activation.
+    final long activationCount =
+        elementInstanceState.getElementActivationCounter(
+            context.getProcessInstanceKey(), context.getElementId());
+
+    if (activationCount <= max) {
+      return Either.right(null);
+    }
+    // The incident always fires on the first activation beyond the threshold and is then throttled
+    // to every retryCooldown activations after that (see shouldRaiseIncident).
+    final long activationsBeyondThreshold = activationCount - max;
+    if (!shouldRaiseIncident(activationsBeyondThreshold)) {
+      return Either.right(null);
+    }
+
+    final String elementId = BufferUtil.bufferAsString(context.getElementId());
+    final String message =
+        CONDITION_ERROR_ACTIVATION_COUNT_EXCEEDED.formatted(
+            elementId, context.getProcessInstanceKey(), activationCount, max);
+    return Either.left(new Failure(message, ErrorType.CONDITION_ERROR));
+  }
+
+  /**
+   * Runs the activation-threshold check for a child of a multi-instance body. Multi-instance
+   * children participate in loop detection only when detection is enabled for the {@code
+   * MULTI_INSTANCE_BODY} type, so disabling the body type also disables its children. The child is
+   * the inner activity, so the threshold and the retry-cooldown throttling are resolved against the
+   * child's own element type by delegating to {@link #checkActivationThreshold}.
+   *
+   * @param childContext the context of the multi-instance child being activated
+   * @return {@code Either.right(null)} when within bounds, or {@code Either.left} with a {@link
+   *     Failure} when the threshold is exceeded
+   */
+  public Either<Failure, Void> checkMultiInstanceChildActivationThreshold(
+      final BpmnElementContext childContext) {
+    if (resolveMaxActivations(BpmnElementType.MULTI_INSTANCE_BODY) <= 0) {
+      // Loop detection is disabled for the multi-instance body, so its children are not checked.
+      return Either.right(null);
+    }
+    return checkActivationThreshold(childContext);
+  }
+
+  /**
+   * Returns whether the multi-instance child-activation counter has already crossed the threshold,
+   * so the batch that spawns the children can stop instead of activating (and raising an incident
+   * for) every remaining child. Mirrors the gating of {@link
+   * #checkMultiInstanceChildActivationThreshold}: detection must be enabled for the {@code
+   * MULTI_INSTANCE_BODY} type and the resolved limit for the inner element type must be positive.
+   *
+   * @param processInstanceKey the process instance the multi-instance body belongs to
+   * @param elementId the shared element id of the multi-instance body and its children
+   * @param innerElementType the {@link BpmnElementType} of the inner (child) activity
+   * @return {@code true} if the counter is strictly above the resolved threshold
+   */
+  public boolean isChildActivationThresholdExceeded(
+      final long processInstanceKey,
+      final DirectBuffer elementId,
+      final BpmnElementType innerElementType) {
+    if (resolveMaxActivations(BpmnElementType.MULTI_INSTANCE_BODY) <= 0) {
+      return false;
+    }
+    final int max = resolveMaxActivations(innerElementType);
+    if (max <= 0) {
+      return false;
+    }
+    return elementInstanceState.getElementActivationCounter(processInstanceKey, elementId) > max;
+  }
+
+  /**
+   * Decides whether an incident should be raised for this breach of the threshold. The incident is
+   * always raised on the first breach so it is never skipped; after that, re-raising is throttled
+   * to once every {@code retryCooldown} breaches. A {@code retryCooldown} of {@code 1} or less
+   * disables throttling (every breach raises an incident) and avoids a divide-by-zero in the modulo
+   * below.
+   *
+   * @param breachCount how many activations have occurred at or beyond the breach point, counting
+   *     from {@code 1} for the first activation that breaches the threshold
+   */
+  private boolean shouldRaiseIncident(final long breachCount) {
+    return retryCooldown <= 1 || (breachCount - 1) % retryCooldown == 0;
+  }
+
+  /**
+   * Resolves the effective maximum activation count for the given element type. Returns the
+   * per-type override when configured, otherwise the global default. A value of {@code 0} means
+   * loop detection is disabled for that type.
+   */
+  private int resolveMaxActivations(final BpmnElementType elementType) {
+    final Integer override = maxActivationsByType.get(elementType);
+    return override != null ? override : maxActivations;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/LoopDetectionFilter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/LoopDetectionFilter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+
+/**
+ * Single source of truth deciding whether an element activation participates in loop detection.
+ *
+ * <p>The activation check (performed by {@code BpmnStreamProcessor}) and the activation counter
+ * increment (performed by {@code ProcessInstanceElementActivatingV4Applier}) both delegate to
+ * {@link #shouldCount} for the base decision. This guarantees the dangerous direction never
+ * happens: an element that is checked is always counted, so the threshold is never evaluated
+ * against a counter that was never incremented.
+ *
+ * <p>The check layers additional, config-based gates on top of {@link #shouldCount} (a per-type
+ * limit of {@code 0}, or a disabled {@code MULTI_INSTANCE_BODY} for multi-instance children), so a
+ * disabled element type may be counted but never checked. That direction is harmless: the counter
+ * accumulates unused and is removed when the process instance ends.
+ *
+ * <p>Multi-instance bodies are the only elements excluded from counting: the body itself is a
+ * container, and its children accumulate the count instead. This holds for both flavours:
+ *
+ * <ul>
+ *   <li>Sequential MI children are activated one-by-one, so each activation increments the counter.
+ *   <li>Parallel MI children are activated through the activation batch; each child activation
+ *       increments the same counter, so the batch is counted exactly rather than projected on the
+ *       body.
+ * </ul>
+ *
+ * <p>Because a multi-instance body and its inner activity share the same {@code elementId},
+ * counting the children accumulates on a single per-element counter across every body activation,
+ * giving the exact number of child activations even when the body is re-activated in a loop.
+ */
+public final class LoopDetectionFilter {
+
+  private LoopDetectionFilter() {}
+
+  /**
+   * @param value the record of the activated element
+   * @return {@code true} if this activation should be counted for loop detection
+   */
+  public static boolean shouldCount(final ProcessInstanceRecord value) {
+    // The multi-instance body itself is never counted; its children accumulate the activation count
+    // (sequential children one-by-one, parallel children through the activation batch). All other
+    // elements, including the MI children, are counted.
+    return value.getBpmnElementType() != BpmnElementType.MULTI_INSTANCE_BODY;
+  }
+
+  /**
+   * @param flowScopeInstance the flow scope of the activated element, or {@code null} if the
+   *     element has no flow scope
+   * @return {@code true} if the activated element is a child of a multi-instance body
+   */
+  public static boolean isMultiInstanceChild(final ElementInstance flowScopeInstance) {
+    return flowScopeInstance != null
+        && flowScopeInstance.getValue().getBpmnElementType() == BpmnElementType.MULTI_INSTANCE_BODY;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnCompensationSubscrip
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnLoopDetectionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.MultiInstanceInputCollectionBehavior;
@@ -65,6 +66,7 @@ public final class MultiInstanceBodyProcessor
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
   private final BpmnStateBehavior stateBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
+  private final BpmnLoopDetectionBehavior loopDetectionBehavior;
   private final MultiInstanceInputCollectionBehavior multiInstanceInputCollectionBehavior;
   private final MultiInstanceOutputCollectionBehavior multiInstanceOutputCollectionBehavior;
   private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
@@ -78,6 +80,7 @@ public final class MultiInstanceBodyProcessor
     stateBehavior = bpmnBehaviors.stateBehavior();
     expressionBehavior = bpmnBehaviors.expressionProcessor();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
+    loopDetectionBehavior = bpmnBehaviors.loopDetectionBehavior();
     multiInstanceInputCollectionBehavior = bpmnBehaviors.inputCollectionBehavior();
     multiInstanceOutputCollectionBehavior = bpmnBehaviors.outputCollectionBehavior();
     compensationSubscriptionBehaviour = bpmnBehaviors.compensationSubscriptionBehaviour();
@@ -246,22 +249,34 @@ public final class MultiInstanceBodyProcessor
 
     final ElementInstance multiInstanceElementInstance =
         stateBehavior.getElementInstance(flowScopeContext);
+    final int inputCollectionSize = inputCollectionOrFailure.get().size();
 
     if (loopCharacteristics.isSequential()) {
-      final var inputCollection = inputCollectionOrFailure.get();
       final var loopCounter = multiInstanceElementInstance.getMultiInstanceLoopCounter();
 
-      if (loopCounter < inputCollection.size()) {
+      if (loopCounter < inputCollectionSize) {
         createInnerInstance(element, flowScopeContext);
 
         // canBeCompleted() doesn't take the created child instance into account because
         // it wrote just a ACTIVATE command that create no new instance immediately
         childInstanceCreated = true;
       }
+    } else if (stateBehavior.canBeCompleted(childContext)
+        && multiInstanceElementInstance.getMultiInstanceLoopCounter() < inputCollectionSize
+        && loopDetectionBehavior.isChildActivationThresholdExceeded(
+            flowScopeContext.getProcessInstanceKey(),
+            flowScopeContext.getElementId(),
+            element.getInnerActivity().getElementType())) {
+      // The parallel multi-instance activation batch was stopped early by loop detection. Once all
+      // activated children have finished, drain the next collection item one at a time so the
+      // activation threshold keeps throttling child creation (the operator resolves each incident
+      // to advance) instead of flooding the instance or leaving it stuck with the collection only
+      // half-processed.
+      createInnerInstance(element, flowScopeContext);
+      childInstanceCreated = true;
     }
 
     if (!childInstanceCreated && stateBehavior.canBeCompleted(childContext)) {
-      final int inputCollectionSize = inputCollectionOrFailure.get().size();
       if (isAllChildrenHasCompletedOrTerminated(
           multiInstanceElementInstance, inputCollectionSize)) {
         stateTransitionBehavior.completeElement(flowScopeContext);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchActivateProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnLoopDetectionBehavior;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
@@ -40,17 +42,20 @@ public final class ProcessInstanceBatchActivateProcessor
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
   private final TypedRejectionWriter rejectionWriter;
+  private final BpmnLoopDetectionBehavior loopDetectionBehavior;
 
   public ProcessInstanceBatchActivateProcessor(
       final Writers writers,
       final KeyGenerator keyGenerator,
       final ElementInstanceState elementInstanceState,
-      final ProcessState processState) {
+      final ProcessState processState,
+      final BpmnLoopDetectionBehavior loopDetectionBehavior) {
     commandWriter = writers.command();
     stateWriter = writers.state();
     this.keyGenerator = keyGenerator;
     this.elementInstanceState = elementInstanceState;
     this.processState = processState;
+    this.loopDetectionBehavior = loopDetectionBehavior;
     rejectionWriter = writers.rejection();
   }
 
@@ -70,15 +75,28 @@ public final class ProcessInstanceBatchActivateProcessor
     }
 
     if (remainingChildrenToActivate > 0) {
-      writeActivateChildCommand(parentElementInstance);
+      final var childElement = getInnerActivity(parentElementInstance);
+      if (loopDetectionBehavior.isChildActivationThresholdExceeded(
+          parentElementInstance.getValue().getProcessInstanceKey(),
+          parentElementInstance.getValue().getElementIdBuffer(),
+          childElement.getElementType())) {
+        // A previously activated child has already crossed the loop-detection threshold (and raised
+        // an incident). Stop spawning the remaining children so the batch is bounded, instead of
+        // flooding the process instance with one incident per remaining child.
+        stateWriter.appendFollowUpEvent(
+            record.getKey(), ProcessInstanceBatchIntent.ACTIVATED, recordValue);
+        return;
+      }
+      writeActivateChildCommand(parentElementInstance, childElement);
     }
 
     writeNextBatchCommand(remainingChildrenToActivate - 1, record);
   }
 
-  private void writeActivateChildCommand(final ElementInstance parentElementInstance) {
+  private void writeActivateChildCommand(
+      final ElementInstance parentElementInstance, final ExecutableActivity childElement) {
     final ProcessInstanceRecord childInstanceRecord =
-        createChildInstanceRecord(parentElementInstance);
+        createChildInstanceRecord(parentElementInstance, childElement);
 
     commandWriter.appendFollowUpCommand(
         keyGenerator.nextKey(), ProcessInstanceIntent.ACTIVATE_ELEMENT, childInstanceRecord);
@@ -112,18 +130,7 @@ public final class ProcessInstanceBatchActivateProcessor
   }
 
   private ProcessInstanceRecord createChildInstanceRecord(
-      final ElementInstance parentElementInstance) {
-    final var processDefinition =
-        processState
-            .getProcessByKeyAndTenant(
-                parentElementInstance.getValue().getProcessDefinitionKey(),
-                parentElementInstance.getValue().getTenantId())
-            .getProcess();
-
-    final var parentElement =
-        processDefinition.getElementById(parentElementInstance.getValue().getElementId());
-    final var childElement = ((ExecutableMultiInstanceBody) parentElement).getInnerActivity();
-
+      final ElementInstance parentElementInstance, final ExecutableActivity childElement) {
     final var childInstanceRecord = new ProcessInstanceRecord();
     childInstanceRecord.wrap(parentElementInstance.getValue());
     childInstanceRecord
@@ -138,5 +145,18 @@ public final class ProcessInstanceBatchActivateProcessor
   public SuspensionBehavior suspensionBehavior(
       final TypedRecord<ProcessInstanceBatchRecord> record) {
     return SuspensionBehavior.BUFFER;
+  }
+
+  private ExecutableActivity getInnerActivity(final ElementInstance parentElementInstance) {
+    final var processDefinition =
+        processState
+            .getProcessByKeyAndTenant(
+                parentElementInstance.getValue().getProcessDefinitionKey(),
+                parentElementInstance.getValue().getTenantId())
+            .getProcess();
+
+    final var parentElement =
+        processDefinition.getElementById(parentElementInstance.getValue().getElementId());
+    return ((ExecutableMultiInstanceBody) parentElement).getInnerActivity();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -356,6 +356,11 @@ public final class EventAppliers implements EventApplier {
         new ProcessInstanceElementActivatingV3Applier(
             elementInstanceState, processState, eventScopeInstanceState));
     register(
+        ProcessInstanceIntent.ELEMENT_ACTIVATING,
+        4,
+        new ProcessInstanceElementActivatingV4Applier(
+            elementInstanceState, processState, eventScopeInstanceState));
+    register(
         ProcessInstanceIntent.ELEMENT_ACTIVATED,
         new ProcessInstanceElementActivatedApplier(elementInstanceState));
     register(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV4Applier.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.bpmn.behavior.LoopDetectionFilter;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableExclusiveGateway;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableInclusiveGateway;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.instance.EventTrigger;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.Collections;
+import java.util.List;
+
+/** Applies state changes for `ProcessInstance:Element_Activating` */
+final class ProcessInstanceElementActivatingV4Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+  private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
+
+  public ProcessInstanceElementActivatingV4Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableEventScopeInstanceState eventScopeInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    createEventScope(elementInstanceKey, value);
+    final var numberOfTakenSequenceFlows =
+        elementInstanceState.getNumberOfTakenSequenceFlows(
+            value.getFlowScopeKey(), value.getElementIdBuffer());
+    cleanupSequenceFlowsTaken(value);
+    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
+
+    if (shouldIncrementActivationCounter(value)) {
+      elementInstanceState.incrementElementActivationCounter(
+          value.getProcessInstanceKey(), value.getElementIdBuffer());
+    }
+    final var elementInstance =
+        elementInstanceState.newInstance(
+            flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && !value.hasParentProcessInstance()) {
+      insertBusinessIdIndex(value);
+    }
+    if (flowScopeInstance == null) {
+      applyRootProcessState(elementInstance, value);
+      return;
+    }
+    final var flowScopeElementType = flowScopeInstance.getValue().getBpmnElementType();
+    final var currentElementType = value.getBpmnElementType();
+    decrementActiveSequenceFlow(
+        value,
+        flowScopeInstance,
+        flowScopeElementType,
+        currentElementType,
+        numberOfTakenSequenceFlows);
+    if (currentElementType == BpmnElementType.START_EVENT
+        && flowScopeElementType == BpmnElementType.EVENT_SUB_PROCESS) {
+      final EventTrigger flowScopeEventTrigger =
+          eventScopeInstanceState.peekEventTrigger(flowScopeInstance.getParentKey());
+      moveVariablesToNewEventScope(
+          flowScopeEventTrigger, flowScopeInstance.getParentKey(), elementInstanceKey);
+    }
+    manageMultiInstance(elementInstanceKey, flowScopeInstance, flowScopeElementType);
+  }
+
+  private void cleanupSequenceFlowsTaken(final ProcessInstanceRecord value) {
+    if (value.getBpmnElementType() == BpmnElementType.PARALLEL_GATEWAY
+        || value.getBpmnElementType() == BpmnElementType.INCLUSIVE_GATEWAY) {
+      final var gateway =
+          processState.getFlowElement(
+              value.getProcessDefinitionKey(),
+              value.getTenantId(),
+              value.getElementIdBuffer(),
+              ExecutableFlowNode.class);
+      // before a parallel or inclusive gateway is activated, all incoming sequence flows of the
+      // gateway must
+      // be taken at least once. decrement the number of the taken sequence flows for each incoming
+      // sequence flow but keep the remaining numbers for the next activation of the gateway.
+      // (Tetris principle)
+      elementInstanceState.decrementNumberOfTakenSequenceFlows(
+          value.getFlowScopeKey(), gateway.getId());
+    }
+  }
+
+  private void moveVariablesToNewEventScope(
+      final EventTrigger eventTrigger, final long oldEventScopeKey, final long newEventScopeKey) {
+    // In order to pass the variables of the event trigger to the element instance, we need to
+    // create a new event trigger, using the element instance key as the event scope key.
+    if (eventTrigger != null) {
+      eventScopeInstanceState.triggerEvent(
+          newEventScopeKey,
+          eventTrigger.getEventKey(),
+          eventTrigger.getElementId(),
+          eventTrigger.getVariables(),
+          eventTrigger.getProcessInstanceKey());
+      eventScopeInstanceState.deleteTrigger(oldEventScopeKey, eventTrigger.getEventKey());
+    }
+  }
+
+  private void applyRootProcessState(
+      final ElementInstance elementInstance, final ProcessInstanceRecord value) {
+    final var parentElementInstance =
+        elementInstanceState.getInstance(value.getParentElementInstanceKey());
+    if (parentElementInstance != null) {
+      // this check is not really necessary: if parentElementInstance exists,
+      // it should always be a call-activity, but let's try to be safe
+      final var parentElementType = parentElementInstance.getValue().getBpmnElementType();
+      if (parentElementType == BpmnElementType.CALL_ACTIVITY) {
+        parentElementInstance.setCalledChildInstanceKey(elementInstance.getKey());
+        elementInstanceState.updateInstance(parentElementInstance);
+        final var parentProcessInstance =
+            elementInstanceState.getInstance(
+                elementInstance.getValue().getParentProcessInstanceKey());
+        elementInstance.setProcessDepth(parentProcessInstance.getProcessDepth() + 1);
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+
+  private void decrementActiveSequenceFlow(
+      final ProcessInstanceRecord value,
+      final ElementInstance flowScopeInstance,
+      final BpmnElementType flowScopeElementType,
+      final BpmnElementType currentElementType,
+      final int numberOfTakenSequenceFlows) {
+    // remove active sequence flows to this element
+    processState
+        .getFlowElement(
+            value.getProcessDefinitionKey(),
+            value.getTenantId(),
+            value.getElementIdBuffer(),
+            ExecutableFlowNode.class)
+        .getIncoming()
+        .stream()
+        .map(ExecutableSequenceFlow::getId)
+        .forEach(flowScopeInstance::removeActiveSequenceFlowId);
+    elementInstanceState.updateInstance(flowScopeInstance);
+    // We don't want to decrement the active sequence flow for elements which have no incoming
+    // sequence flow and for interrupting event sub processes we reset the count completely.
+    // Furthermore some elements are special and need to be handled separately.
+    switch (currentElementType) {
+      case START_EVENT:
+      case BOUNDARY_EVENT:
+        break;
+      case INTERMEDIATE_CATCH_EVENT:
+        decrementIntermediateCatchEventSequenceFlow(value, flowScopeInstance);
+        break;
+      case PARALLEL_GATEWAY:
+        decrementParallelGatewaySequenceFlow(value, flowScopeInstance);
+        break;
+      case INCLUSIVE_GATEWAY:
+        decrementInclusiveGatewaySequenceFlow(flowScopeInstance, numberOfTakenSequenceFlows);
+        break;
+      case EVENT_SUB_PROCESS:
+        decrementEventSubProcessSequenceFlow(value, flowScopeInstance);
+        break;
+      default:
+        if (flowScopeElementType != BpmnElementType.MULTI_INSTANCE_BODY) {
+          flowScopeInstance.decrementActiveSequenceFlows();
+          elementInstanceState.updateInstance(flowScopeInstance);
+        }
+        break;
+    }
+  }
+
+  private void decrementIntermediateCatchEventSequenceFlow(
+      final ProcessInstanceRecord value, final ElementInstance flowScopeInstance) {
+    // If we are an intermediate catch event and our previous element is an event based gateway,
+    // then we don't want to decrement the active flow, since based on the BPMN spec we DON'T take
+    // the sequence flow.
+    final var executableCatchEventElement =
+        processState.getFlowElement(
+            value.getProcessDefinitionKey(),
+            value.getTenantId(),
+            value.getElementIdBuffer(),
+            ExecutableCatchEventElement.class);
+    // When the catch event is of the link catch event type,
+    // the catch event has no incoming sequence flow
+    final List<ExecutableSequenceFlow> incoming = executableCatchEventElement.getIncoming();
+    if (!incoming.isEmpty()) {
+      final var incomingSequenceFlow = executableCatchEventElement.getIncoming().get(0);
+      final var previousElement = incomingSequenceFlow.getSource();
+      if (previousElement.getElementType() != BpmnElementType.EVENT_BASED_GATEWAY) {
+        flowScopeInstance.decrementActiveSequenceFlows();
+        elementInstanceState.updateInstance(flowScopeInstance);
+      }
+    }
+  }
+
+  private void decrementParallelGatewaySequenceFlow(
+      final ProcessInstanceRecord value, final ElementInstance flowScopeInstance) {
+    // Parallel gateways can have more than one incoming sequence flow, we need to decrement the
+    // active sequence flows based on the incoming count.
+    final var executableFlowNode =
+        processState.getFlowElement(
+            value.getProcessDefinitionKey(),
+            value.getTenantId(),
+            value.getElementIdBuffer(),
+            ExecutableFlowNode.class);
+    final var size = executableFlowNode.getIncoming().size();
+    flowScopeInstance.decrementActiveSequenceFlows(size);
+    elementInstanceState.updateInstance(flowScopeInstance);
+  }
+
+  private void decrementInclusiveGatewaySequenceFlow(
+      final ElementInstance flowScopeInstance, final int numberOfTakenSequenceFlows) {
+    // Inclusive gateways can have more than one incoming sequence flow, we need to decrement the
+    // active sequence flows based on the satisfied incoming sequence flows.
+    flowScopeInstance.decrementActiveSequenceFlows(numberOfTakenSequenceFlows);
+    elementInstanceState.updateInstance(flowScopeInstance);
+  }
+
+  private void decrementEventSubProcessSequenceFlow(
+      final ProcessInstanceRecord value, final ElementInstance flowScopeInstance) {
+    // For interrupting event sub processes we need to reset the active sequence flows, because
+    // we might have interrupted multiple sequence flows.
+    // For non interrupting we do nothing, since we had no incoming sequence flow.
+    final var executableFlowElementContainer = getExecutableFlowElementContainer(value);
+    final var executableStartEvent = executableFlowElementContainer.getStartEvents().get(0);
+    if (executableStartEvent.isInterrupting()) {
+      flowScopeInstance.resetActiveSequenceFlows();
+    }
+    elementInstanceState.updateInstance(flowScopeInstance);
+  }
+
+  private ExecutableFlowElementContainer getExecutableFlowElementContainer(
+      final ProcessInstanceRecord value) {
+    return processState.getFlowElement(
+        value.getProcessDefinitionKey(),
+        value.getTenantId(),
+        value.getElementIdBuffer(),
+        ExecutableFlowElementContainer.class);
+  }
+
+  private void manageMultiInstance(
+      final long elementInstanceKey,
+      final ElementInstance flowScopeInstance,
+      final BpmnElementType flowScopeElementType) {
+    if (flowScopeElementType == BpmnElementType.MULTI_INSTANCE_BODY) {
+      // update the loop counter of the multi-instance body (starting by 1)
+      flowScopeInstance.incrementMultiInstanceLoopCounter();
+      // update the numberOfInstances of the multi-instance body
+      flowScopeInstance.incrementNumberOfElementInstances();
+      elementInstanceState.updateInstance(flowScopeInstance);
+      // set the loop counter of the inner instance
+      final var loopCounter = flowScopeInstance.getMultiInstanceLoopCounter();
+      elementInstanceState.updateInstance(
+          elementInstanceKey, instance -> instance.setMultiInstanceLoopCounter(loopCounter));
+    }
+  }
+
+  private void createEventScope(
+      final long elementInstanceKey, final ProcessInstanceRecord elementRecord) {
+    Class<? extends ExecutableFlowNode> flowElementClass = ExecutableFlowNode.class;
+    // in the case of the multi instance body, it shares the same element ID as that of its
+    // contained activity; this means when doing a processState.getFlowElement, you don't know which
+    // you will get, and the boundary events will only be bound to the multi instance
+    if (elementRecord.getBpmnElementType() == BpmnElementType.MULTI_INSTANCE_BODY) {
+      flowElementClass = ExecutableMultiInstanceBody.class;
+    }
+    final var flowElement =
+        processState.getFlowElement(
+            elementRecord.getProcessDefinitionKey(),
+            elementRecord.getTenantId(),
+            elementRecord.getElementIdBuffer(),
+            flowElementClass);
+    if (flowElement instanceof final ExecutableCatchEventSupplier eventSupplier
+        && !eventSupplier.getEvents().isEmpty()) {
+      eventScopeInstanceState.createInstance(
+          elementInstanceKey,
+          eventSupplier.getInterruptingElementIds(),
+          eventSupplier.getBoundaryElementIds());
+    } else if (flowElement instanceof ExecutableJobWorkerElement
+        || flowElement instanceof ExecutableActivity
+        || flowElement instanceof ExecutableExclusiveGateway
+        || flowElement instanceof ExecutableInclusiveGateway) {
+      // executable elements without events
+      eventScopeInstanceState.createInstance(
+          elementInstanceKey, Collections.emptySet(), Collections.emptySet());
+    }
+  }
+
+  /**
+   * Inserts the business id index for root process instances. This maps the business id to the
+   * process instance key, scoped by process definition id and tenant id.
+   */
+  private void insertBusinessIdIndex(final ProcessInstanceRecord value) {
+    final var businessId = value.getBusinessId();
+    if (!businessId.isEmpty()) {
+      elementInstanceState.insertProcessInstanceKeyByBusinessId(
+          businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
+    }
+  }
+
+  /**
+   * Decides whether to increment the element activation counter for loop detection. Delegates to
+   * {@link LoopDetectionFilter#shouldCount} so the counter increment and the activation check (in
+   * {@code BpmnStreamProcessor}) are consistent.
+   */
+  private boolean shouldIncrementActivationCounter(final ProcessInstanceRecord value) {
+    return LoopDetectionFilter.shouldCount(value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -181,6 +181,16 @@ public interface ElementInstanceState {
    */
   long getActiveProcessInstanceCount();
 
+  /**
+   * Returns the current activation count for the given element, or {@code 0} when it has never been
+   * activated.
+   *
+   * @param processInstanceKey the key of the process instance
+   * @param elementId the BPMN element id of the element
+   * @return current activation count, or {@code 0} if not yet activated
+   */
+  long getElementActivationCounter(long processInstanceKey, DirectBuffer elementId);
+
   @FunctionalInterface
   interface TakenSequenceFlowVisitor {
     void visit(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -90,6 +90,14 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   private final DbLong activeProcessInstanceCounterValue;
   private final ColumnFamily<DbLong, DbLong> activeProcessInstanceCounterColumnFamily;
 
+  // element activation counters: [processInstanceKey | elementId] => count
+  private final DbLong activationCounterProcessInstanceKey = new DbLong();
+  private final DbString activationCounterElementId = new DbString();
+  private final DbCompositeKey<DbLong, DbString> elementActivationCounterKey;
+  private final DbLong elementActivationCount = new DbLong();
+  private final ColumnFamily<DbCompositeKey<DbLong, DbString>, DbLong>
+      elementActivationCountersColumnFamily;
+
   public DbElementInstanceState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
@@ -179,7 +187,16 @@ public final class DbElementInstanceState implements MutableElementInstanceState
             transactionContext,
             activeProcessInstanceCounterKey,
             activeProcessInstanceCounterValue);
+
     initializeActiveProcessInstanceCounterIfNeeded();
+    elementActivationCounterKey =
+        new DbCompositeKey<>(activationCounterProcessInstanceKey, activationCounterElementId);
+    elementActivationCountersColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.ELEMENT_ACTIVATION_COUNTERS,
+            transactionContext,
+            elementActivationCounterKey,
+            elementActivationCount);
   }
 
   @Override
@@ -228,6 +245,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
       processInstanceKeyByProcessDefinitionKeyColumnFamily.deleteExisting(
           processInstanceKeyByProcessDefinitionKey);
       decrementActiveProcessInstanceCount();
+      deleteAllElementActivationCounters(key);
     }
 
     if (parent > 0) {
@@ -648,6 +666,35 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     final var counter =
         activeProcessInstanceCounterColumnFamily.get(activeProcessInstanceCounterKey);
     return counter != null ? counter.getValue() : 0L;
+  }
+
+  @Override
+  public void incrementElementActivationCounter(
+      final long processInstanceKey, final DirectBuffer elementId) {
+    activationCounterProcessInstanceKey.wrapLong(processInstanceKey);
+    activationCounterElementId.wrapBuffer(elementId);
+
+    final var existing = elementActivationCountersColumnFamily.get(elementActivationCounterKey);
+    final long newCount = (existing != null ? existing.getValue() : 0L) + 1L;
+    elementActivationCount.wrapLong(newCount);
+    elementActivationCountersColumnFamily.upsert(
+        elementActivationCounterKey, elementActivationCount);
+  }
+
+  @Override
+  public long getElementActivationCounter(
+      final long processInstanceKey, final DirectBuffer elementId) {
+    activationCounterProcessInstanceKey.wrapLong(processInstanceKey);
+    activationCounterElementId.wrapBuffer(elementId);
+    final var existing = elementActivationCountersColumnFamily.get(elementActivationCounterKey);
+    return existing != null ? existing.getValue() : 0L;
+  }
+
+  @Override
+  public void deleteAllElementActivationCounters(final long processInstanceKey) {
+    activationCounterProcessInstanceKey.wrapLong(processInstanceKey);
+    elementActivationCountersColumnFamily.whileEqualPrefix(
+        activationCounterProcessInstanceKey, elementActivationCountersColumnFamily::deleteExisting);
   }
 
   private void removeNumberOfTakenSequenceFlows(final long flowScopeKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
@@ -146,4 +146,21 @@ public interface MutableElementInstanceState extends ElementInstanceState {
    */
   void deleteProcessInstanceKeyMappingByBusinessId(
       String businessId, String processDefinitionId, String tenantId, long processInstanceKey);
+
+  /**
+   * Increments the loop-detection activation counter for the given element within the given process
+   * instance.
+   *
+   * @param processInstanceKey the key of the process instance
+   * @param elementId the BPMN element id of the element being activated
+   */
+  void incrementElementActivationCounter(long processInstanceKey, DirectBuffer elementId);
+
+  /**
+   * Deletes all element activation counters that belong to the given process instance. Called when
+   * the process instance ends to avoid leaking state.
+   *
+   * @param processInstanceKey the key of the process instance whose counters should be removed
+   */
+  void deleteAllElementActivationCounters(long processInstanceKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnLoopDetectionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnLoopDetectionBehaviorTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the loop-detection threshold and retry-cooldown arithmetic. The engine-level
+ * behaviour (raising and resolving the incident) is covered by the {@code
+ * LoopDetection*IncidentTest} integration tests; here we verify the pure decision logic in
+ * isolation.
+ */
+final class BpmnLoopDetectionBehaviorTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 42L;
+  private static final DirectBuffer ELEMENT_ID = BufferUtil.wrapString("mi-task");
+
+  private final MutableElementInstanceState elementInstanceState =
+      mock(MutableElementInstanceState.class);
+  private final BpmnElementContext serviceTaskContext = mock(BpmnElementContext.class);
+
+  @BeforeEach
+  void setUp() {
+    when(serviceTaskContext.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(serviceTaskContext.getElementId()).thenReturn(ELEMENT_ID);
+    when(serviceTaskContext.getBpmnElementType()).thenReturn(BpmnElementType.SERVICE_TASK);
+  }
+
+  private BpmnLoopDetectionBehavior behavior(
+      final int max, final Map<BpmnElementType, Integer> byType, final int cooldown) {
+    return new BpmnLoopDetectionBehavior(elementInstanceState, max, byType, cooldown);
+  }
+
+  private void activationCount(final long count) {
+    when(elementInstanceState.getElementActivationCounter(PROCESS_INSTANCE_KEY, ELEMENT_ID))
+        .thenReturn(count);
+  }
+
+  private boolean regularRaisesAt(final BpmnLoopDetectionBehavior behavior, final long count) {
+    activationCount(count);
+    return behavior.checkActivationThreshold(serviceTaskContext).isLeft();
+  }
+
+  private boolean batchStopsAt(
+      final BpmnLoopDetectionBehavior behavior, final long childActivationCount) {
+    activationCount(childActivationCount);
+    return behavior.isChildActivationThresholdExceeded(
+        PROCESS_INSTANCE_KEY, ELEMENT_ID, BpmnElementType.SERVICE_TASK);
+  }
+
+  private boolean childRaisesAt(final BpmnLoopDetectionBehavior behavior, final long count) {
+    activationCount(count);
+    return behavior.checkMultiInstanceChildActivationThreshold(serviceTaskContext).isLeft();
+  }
+
+  // ---------------------------------------------------------------------------
+  // checkActivationThreshold
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldNotRaiseWithinThreshold() {
+    final var behavior = behavior(3, Map.of(), 1);
+
+    assertThat(regularRaisesAt(behavior, 1)).isFalse();
+    assertThat(regularRaisesAt(behavior, 2)).isFalse();
+    assertThat(regularRaisesAt(behavior, 3)).isFalse();
+  }
+
+  @Test
+  void shouldRaiseOnFirstActivationBeyondThreshold() {
+    final var behavior = behavior(3, Map.of(), 3);
+
+    assertThat(regularRaisesAt(behavior, 4)).isTrue();
+  }
+
+  @Test
+  void shouldThrottleRegularReRaisingByCooldown() {
+    final var behavior = behavior(3, Map.of(), 3);
+
+    // fires on the first breach (4), then every cooldown (3) activations after that
+    assertThat(regularRaisesAt(behavior, 4)).isTrue();
+    assertThat(regularRaisesAt(behavior, 5)).isFalse();
+    assertThat(regularRaisesAt(behavior, 6)).isFalse();
+    assertThat(regularRaisesAt(behavior, 7)).isTrue();
+    assertThat(regularRaisesAt(behavior, 8)).isFalse();
+    assertThat(regularRaisesAt(behavior, 9)).isFalse();
+    assertThat(regularRaisesAt(behavior, 10)).isTrue();
+  }
+
+  @Test
+  void shouldRaiseOnEveryActivationWhenCooldownIsOne() {
+    final var behavior = behavior(3, Map.of(), 1);
+
+    assertThat(regularRaisesAt(behavior, 4)).isTrue();
+    assertThat(regularRaisesAt(behavior, 5)).isTrue();
+    assertThat(regularRaisesAt(behavior, 6)).isTrue();
+  }
+
+  @Test
+  void shouldRaiseOnEveryActivationWhenCooldownIsZero() {
+    final var behavior = behavior(3, Map.of(), 0);
+
+    assertThat(regularRaisesAt(behavior, 4)).isTrue();
+    assertThat(regularRaisesAt(behavior, 5)).isTrue();
+    assertThat(regularRaisesAt(behavior, 6)).isTrue();
+  }
+
+  @Test
+  void shouldNotRaiseWhenElementTypeIsDisabled() {
+    final var behavior = behavior(3, Map.of(BpmnElementType.SERVICE_TASK, 0), 1);
+
+    assertThat(regularRaisesAt(behavior, 100)).isFalse();
+  }
+
+  @Test
+  void shouldUsePerTypeOverrideForRegularCheck() {
+    final var behavior = behavior(10, Map.of(BpmnElementType.SERVICE_TASK, 2), 1);
+
+    assertThat(regularRaisesAt(behavior, 2)).isFalse();
+    assertThat(regularRaisesAt(behavior, 3)).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // isChildActivationThresholdExceeded (batch stop condition)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldNotStopBatchWithinThreshold() {
+    final var behavior = behavior(4, Map.of(), 1);
+
+    // the counter is at the threshold but not beyond it, so the batch keeps spawning children
+    assertThat(batchStopsAt(behavior, 4)).isFalse();
+  }
+
+  @Test
+  void shouldStopBatchBeyondThreshold() {
+    final var behavior = behavior(4, Map.of(), 1);
+
+    assertThat(batchStopsAt(behavior, 5)).isTrue();
+  }
+
+  @Test
+  void shouldResolveBatchStopThresholdAgainstInnerType() {
+    // MULTI_INSTANCE_BODY falls back to the global default (10, enabled); SERVICE_TASK caps at 2
+    final var behavior = behavior(10, Map.of(BpmnElementType.SERVICE_TASK, 2), 1);
+
+    assertThat(batchStopsAt(behavior, 2)).isFalse();
+    assertThat(batchStopsAt(behavior, 3)).isTrue();
+  }
+
+  @Test
+  void shouldNotStopBatchWhenBodyTypeDisabled() {
+    // disabling MULTI_INSTANCE_BODY turns the batch stop off, even when the inner type would breach
+    final var behavior =
+        behavior(
+            10,
+            Map.of(
+                BpmnElementType.MULTI_INSTANCE_BODY, 0,
+                BpmnElementType.SERVICE_TASK, 2),
+            1);
+
+    assertThat(batchStopsAt(behavior, 100)).isFalse();
+  }
+
+  @Test
+  void shouldNotStopBatchWhenInnerTypeDisabled() {
+    final var behavior = behavior(10, Map.of(BpmnElementType.SERVICE_TASK, 0), 1);
+
+    assertThat(batchStopsAt(behavior, 100)).isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // checkMultiInstanceChildActivationThreshold
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldNotRaiseChildWithinThreshold() {
+    final var behavior = behavior(4, Map.of(), 1);
+
+    assertThat(childRaisesAt(behavior, 4)).isFalse();
+  }
+
+  @Test
+  void shouldRaiseChildBeyondThreshold() {
+    final var behavior = behavior(4, Map.of(), 1);
+
+    assertThat(childRaisesAt(behavior, 5)).isTrue();
+  }
+
+  @Test
+  void shouldThrottleChildReRaisingByCooldown() {
+    final var behavior = behavior(4, Map.of(), 3);
+
+    // fires on the first breach (5), then every cooldown (3) activations after that
+    assertThat(childRaisesAt(behavior, 5)).isTrue();
+    assertThat(childRaisesAt(behavior, 6)).isFalse();
+    assertThat(childRaisesAt(behavior, 7)).isFalse();
+    assertThat(childRaisesAt(behavior, 8)).isTrue();
+  }
+
+  @Test
+  void shouldDisableChildCheckWhenBodyTypeDisabled() {
+    // MULTI_INSTANCE_BODY = 0 disables loop detection for MI children, even though SERVICE_TASK
+    // caps
+    // at 2
+    final var behavior =
+        behavior(
+            10,
+            Map.of(
+                BpmnElementType.MULTI_INSTANCE_BODY, 0,
+                BpmnElementType.SERVICE_TASK, 2),
+            1);
+
+    assertThat(childRaisesAt(behavior, 100)).isFalse();
+  }
+
+  @Test
+  void shouldResolveChildThresholdAgainstChildType() {
+    // MULTI_INSTANCE_BODY enabled via the global default (10); the child is capped by
+    // SERVICE_TASK=2
+    final var behavior = behavior(10, Map.of(BpmnElementType.SERVICE_TASK, 2), 1);
+
+    assertThat(childRaisesAt(behavior, 2)).isFalse();
+    assertThat(childRaisesAt(behavior, 3)).isTrue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/behavior/LoopDetectionFilterTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/behavior/LoopDetectionFilterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import org.junit.jupiter.api.Test;
+
+final class LoopDetectionFilterTest {
+
+  private static final String ELEMENT_ID = "element";
+  private static final String FLOW_SCOPE_ID = "flowScope";
+
+  @Test
+  void shouldCountRegularElement() {
+    // given a regular (non multi-instance-body) element
+    final var value = record(BpmnElementType.SERVICE_TASK, ELEMENT_ID);
+
+    // when / then
+    assertThat(LoopDetectionFilter.shouldCount(value)).isTrue();
+  }
+
+  @Test
+  void shouldCountMultiInstanceChild() {
+    // given a child of a multi-instance body: its own type is not MULTI_INSTANCE_BODY
+    final var value = record(BpmnElementType.SERVICE_TASK, ELEMENT_ID);
+
+    // when / then: the children accumulate the activation count (parallel and sequential alike)
+    assertThat(LoopDetectionFilter.shouldCount(value)).isTrue();
+  }
+
+  @Test
+  void shouldNotCountMultiInstanceBody() {
+    // given a multi-instance body: the container is never counted, its children are
+    final var value = record(BpmnElementType.MULTI_INSTANCE_BODY, ELEMENT_ID);
+
+    // when / then
+    assertThat(LoopDetectionFilter.shouldCount(value)).isFalse();
+  }
+
+  @Test
+  void shouldNotDetectMultiInstanceChildWithoutFlowScope() {
+    assertThat(LoopDetectionFilter.isMultiInstanceChild(null)).isFalse();
+  }
+
+  @Test
+  void shouldNotDetectMultiInstanceChildInsideRegularFlowScope() {
+    final var flowScope = flowScope(BpmnElementType.SUB_PROCESS, FLOW_SCOPE_ID);
+
+    assertThat(LoopDetectionFilter.isMultiInstanceChild(flowScope)).isFalse();
+  }
+
+  @Test
+  void shouldDetectMultiInstanceChildInsideMultiInstanceBody() {
+    final var flowScope = flowScope(BpmnElementType.MULTI_INSTANCE_BODY, FLOW_SCOPE_ID);
+
+    assertThat(LoopDetectionFilter.isMultiInstanceChild(flowScope)).isTrue();
+  }
+
+  private static ProcessInstanceRecord record(final BpmnElementType elementType, final String id) {
+    return new ProcessInstanceRecord().setBpmnElementType(elementType).setElementId(id);
+  }
+
+  private static ElementInstance flowScope(final BpmnElementType elementType, final String id) {
+    return new ElementInstance(
+        2L, ProcessInstanceIntent.ELEMENT_ACTIVATED, record(elementType, id));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/LoopDetectionIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/LoopDetectionIncidentTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static io.camunda.zeebe.engine.processing.incident.IncidentHelper.assertIncidentCreated;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for the loop-detection mechanism that raises a {@link ErrorType#CONDITION_ERROR} incident
+ * when a BPMN element is activated more times than the configured threshold within one process
+ * instance.
+ *
+ * <p>The engine is configured with a very low threshold (3 activations) and a retry cooldown of 1
+ * (re-check on every single activation) so the tests run quickly without needing hundreds of loop
+ * iterations.
+ */
+public final class LoopDetectionIncidentTest {
+
+  /**
+   * Low threshold so tests don't need to run > 1000 loop iterations. A retry cooldown of 1 means
+   * the detection fires as soon as the cumulative count exceeds {@code MAX_ACTIVATIONS}.
+   */
+  private static final int MAX_ACTIVATIONS = 3;
+
+  private static final int RETRY_COOLDOWN = 1;
+
+  private static final String PROCESS_ID = "looping-process";
+  private static final String TASK_ID = "looping-task";
+  private static final String GATEWAY_ID = "xor-gateway";
+  private static final String JOB_TYPE = "loop-job";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  /**
+   * Each test method gets its own engine so the low threshold does not interfere with any shared
+   * class-level engine used by other tests in the suite.
+   */
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(
+              cfg ->
+                  cfg.setMaxElementActivationCount(MAX_ACTIVATIONS)
+                      .setElementActivationRetryCooldown(RETRY_COOLDOWN));
+
+  // ---------------------------------------------------------------------------
+  // BPMN model helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A process that loops indefinitely via an exclusive gateway whose default flow always returns to
+   * the service task.
+   *
+   * <pre>
+   * [Start] → [ServiceTask: looping-task]
+   *               ↑                    ↓
+   *               └── [XOR: default] ←─┘
+   * </pre>
+   */
+  private static BpmnModelInstance loopingProcess() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .serviceTask(TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
+        .exclusiveGateway(GATEWAY_ID)
+        .defaultFlow()
+        .connectTo(TASK_ID)
+        .done();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void shouldRaiseLoopDetectedIncidentWhenThresholdExceeded() {
+    // given
+    engine.deployment().withXmlResource(loopingProcess()).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: drive the loop by completing MAX_ACTIVATIONS jobs so the task is activated
+    // (MAX_ACTIVATIONS + 1) times in total. The activation that exceeds the threshold raises the
+    // incident.
+    for (int i = 0; i < MAX_ACTIVATIONS; i++) {
+      final long jobKey =
+          RecordingExporter.jobRecords(JobIntent.CREATED)
+              .withProcessInstanceKey(processInstanceKey)
+              .withType(JOB_TYPE)
+              .skip(i)
+              .getFirst()
+              .getKey();
+      engine.job().withKey(jobKey).complete();
+    }
+
+    // then
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .limit(1)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final Record<ProcessInstanceRecordValue> taskActivation =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ID)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .skip(MAX_ACTIVATIONS)
+            .getFirst();
+
+    assertIncidentCreated(incident, taskActivation);
+
+    Assertions.assertThat(incident.getValue())
+        .hasErrorType(ErrorType.CONDITION_ERROR)
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasElementId(TASK_ID);
+
+    // error message should mention the element id and the threshold
+    assertThat(incident.getValue().getErrorMessage())
+        .contains(TASK_ID)
+        .contains(String.valueOf(MAX_ACTIVATIONS));
+  }
+
+  @Test
+  public void shouldRaiseIncidentOnTheLoopingElementNotTheGateway() {
+    // given
+    engine.deployment().withXmlResource(loopingProcess()).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: the task is activated one more time than its threshold allows
+    for (int i = 0; i < MAX_ACTIVATIONS; i++) {
+      final long jobKey =
+          RecordingExporter.jobRecords(JobIntent.CREATED)
+              .withProcessInstanceKey(processInstanceKey)
+              .withType(JOB_TYPE)
+              .skip(i)
+              .getFirst()
+              .getKey();
+      engine.job().withKey(jobKey).complete();
+    }
+    // then: the incident is created on the repeatedly-activated SERVICE_TASK, not the gateway
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .limit(1)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(incident.getValue().getElementId()).isEqualTo(TASK_ID);
+    assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.CONDITION_ERROR);
+  }
+
+  @Test
+  public void shouldNotRaiseIncidentForNonLoopingProcess() {
+    // given: a straight-through process (no loop, task activated only once)
+    final String processId = "non-looping-process";
+    final BpmnModelInstance nonLoopingProcess =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("single-task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+
+    engine.deployment().withXmlResource(nonLoopingProcess).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    // when: complete the only job
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(JOB_TYPE)
+            .getFirst()
+            .getKey();
+    engine.job().withKey(jobKey).complete();
+
+    // then: process completes normally — limitToProcessInstanceCompleted() short-circuits on the
+    // root ELEMENT_COMPLETED event, so this assertion also proves no incident halted the process
+    RecordingExporter.processInstanceRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .limitToProcessInstanceCompleted()
+        .getLast();
+  }
+
+  @Test
+  public void shouldCountActivationsPerElementNotPerProcessInstance() {
+    // given: two distinct tasks each activated once (sum = 2, below per-element threshold of 3)
+    final String processId = "two-element-process";
+    final String taskA = "task-a";
+    final String taskB = "task-b";
+    final BpmnModelInstance twoTaskProcess =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask(taskA, t -> t.zeebeJobType("job-a"))
+            .serviceTask(taskB, t -> t.zeebeJobType("job-b"))
+            .endEvent()
+            .done();
+
+    engine.deployment().withXmlResource(twoTaskProcess).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    // when: complete both jobs
+    final long jobAKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("job-a")
+            .getFirst()
+            .getKey();
+    engine.job().withKey(jobAKey).complete();
+
+    final long jobBKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("job-b")
+            .getFirst()
+            .getKey();
+    engine.job().withKey(jobBKey).complete();
+
+    // then: process completes normally; limitToProcessInstanceCompleted() proves no incident
+    // halted either element — activation counts must be per-element, not aggregated
+    RecordingExporter.processInstanceRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .limitToProcessInstanceCompleted()
+        .getLast();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/LoopDetectionMultiInstanceIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/LoopDetectionMultiInstanceIncidentTest.java
@@ -1,0 +1,512 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static io.camunda.zeebe.engine.processing.incident.IncidentHelper.assertIncidentCreated;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies that the loop-detection mechanism raises an incident when a multi-instance (MI) element
+ * activates more child instances than {@code maxElementActivationCount}.
+ *
+ * <p>Parallel MI spawns children until the activation threshold is exceeded; the incident is raised
+ * on the child activation that crosses it and the remaining children are not spawned. When the body
+ * is re-activated in a loop and the cumulative child count crosses the threshold, the incident
+ * fires on the child activation that crosses it — the same way sequential MI counts its children
+ * one-by-one.
+ */
+public final class LoopDetectionMultiInstanceIncidentTest {
+
+  private static final int MAX_ACTIVATIONS = 4;
+  private static final int RETRY_COOLDOWN = 3;
+
+  /**
+   * Parallel MI: a collection strictly larger than {@code MAX_ACTIVATIONS} is blocked wholesale by
+   * the batch guard on the body.
+   */
+  private static final int LARGE_COLLECTION_SIZE = MAX_ACTIVATIONS + 1; // = 5
+
+  /**
+   * Parallel MI loop: a collection that fits within {@code MAX_ACTIVATIONS} (so the batch guard
+   * does not block) that is re-activated in a loop until the cumulative child count crosses the
+   * threshold.
+   */
+  private static final int LOOP_COLLECTION_SIZE = 3;
+
+  private static final String PARALLEL_PROCESS_ID = "parallel-mi-process";
+  private static final String PARALLEL_LOOP_PROCESS_ID = "parallel-mi-loop-process";
+  private static final String SEQUENTIAL_PROCESS_ID = "sequential-mi-loop-process";
+  private static final String TASK_ID = "mi-task";
+  private static final String GATEWAY_ID = "loop-gateway";
+  private static final String JOB_TYPE = "mi-job";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(
+              cfg ->
+                  cfg.setMaxElementActivationCount(MAX_ACTIVATIONS)
+                      .setElementActivationRetryCooldown(RETRY_COOLDOWN));
+
+  // ---------------------------------------------------------------------------
+  // BPMN model helpers
+  // ---------------------------------------------------------------------------
+
+  /** Straight process: start → parallel MI service task → end. No outer loop. */
+  private static BpmnModelInstance parallelMiProcess() {
+    return Bpmn.createExecutableProcess(PARALLEL_PROCESS_ID)
+        .startEvent()
+        .serviceTask(
+            TASK_ID,
+            t ->
+                t.zeebeJobType(JOB_TYPE)
+                    .multiInstance(
+                        mi ->
+                            mi.parallel().zeebeInputCollection("=items").zeebeInputElement("item")))
+        .endEvent()
+        .done();
+  }
+
+  /**
+   * Straight process with sequential MI: start → sequential MI service task → end.
+   *
+   * <p>Sequential MI children activations are counted individually. When the collection size
+   * exceeds {@code maxActivations}, the incident fires on the child activation that would exceed
+   * the threshold.
+   */
+  private static BpmnModelInstance sequentialMiLoopingProcess() {
+    return Bpmn.createExecutableProcess(SEQUENTIAL_PROCESS_ID)
+        .startEvent()
+        .serviceTask(
+            TASK_ID,
+            t ->
+                t.zeebeJobType(JOB_TYPE)
+                    .multiInstance(
+                        mi ->
+                            mi.sequential()
+                                .zeebeInputCollection("=items")
+                                .zeebeInputElement("item")))
+        .endEvent()
+        .done();
+  }
+
+  /**
+   * Looping process with a parallel MI: start → parallel MI service task → exclusive gateway that
+   * loops back to the MI body. Each loop iteration re-activates the parallel MI and spawns a fresh
+   * batch of children, so the shared child-activation counter accumulates across iterations.
+   */
+  private static BpmnModelInstance parallelMiLoopingProcess() {
+    return Bpmn.createExecutableProcess(PARALLEL_LOOP_PROCESS_ID)
+        .startEvent()
+        .serviceTask(
+            TASK_ID,
+            t ->
+                t.zeebeJobType(JOB_TYPE)
+                    .multiInstance(
+                        mi ->
+                            mi.parallel().zeebeInputCollection("=items").zeebeInputElement("item")))
+        .exclusiveGateway(GATEWAY_ID)
+        .defaultFlow()
+        .connectTo(TASK_ID)
+        .done();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A <b>parallel</b> MI whose collection is larger than {@code maxActivations} is bounded by loop
+   * detection: children activate up to the threshold and the incident is raised on the child that
+   * crosses it (the {@code (maxActivations + 1)}th) — not on the multi-instance body — and the
+   * batch stops there instead of materialising the whole collection. This is intentional and
+   * configurable (raise {@code maxElementActivationCount} or set a per-type override for genuinely
+   * large collections), not a false positive.
+   */
+  @Test
+  public void shouldRaiseIncidentForParallelMultiInstanceWhenCollectionExceedsMaxActivations() {
+    // given
+    final List<Integer> items =
+        IntStream.rangeClosed(1, LARGE_COLLECTION_SIZE).boxed().collect(Collectors.toList());
+    engine.deployment().withXmlResource(parallelMiProcess()).deploy();
+
+    // when: a process instance is created with a collection larger than maxActivations
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PARALLEL_PROCESS_ID)
+            .withVariable("items", items)
+            .create();
+
+    // then: incident fires on the child activation that crosses the threshold (the (MAX + 1)th
+    // SERVICE_TASK activation), not on the multi-instance body
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final var activatingRecord =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ID)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .skip(MAX_ACTIVATIONS)
+            .getFirst();
+
+    assertIncidentCreated(incident, activatingRecord);
+
+    Assertions.assertThat(incident.getValue())
+        .hasErrorType(ErrorType.CONDITION_ERROR)
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasElementId(TASK_ID);
+
+    assertThat(incident.getValue().getErrorMessage())
+        .contains(TASK_ID)
+        .contains(String.valueOf(MAX_ACTIVATIONS));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Baseline: a single non-looping parallel MI with a collection smaller than {@code
+   * maxActivations} completes without any incident (body counter = 1 after one run).
+   */
+  @Test
+  public void shouldNotRaiseIncidentBeforeThresholdIsReached() {
+    // given
+    final List<Integer> items = IntStream.rangeClosed(1, MAX_ACTIVATIONS).boxed().toList();
+
+    engine.deployment().withXmlResource(parallelMiProcess()).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PARALLEL_PROCESS_ID)
+            .withVariable("items", items)
+            .create();
+    // when: complete all jobs (one per item, total = MAX_ACTIVATIONS)
+    for (int i = 0; i < MAX_ACTIVATIONS; i++) {
+      final long jobKey =
+          RecordingExporter.jobRecords(JobIntent.CREATED)
+              .withProcessInstanceKey(processInstanceKey)
+              .withType(JOB_TYPE)
+              .skip(i)
+              .getFirst()
+              .getKey();
+      engine.job().withKey(jobKey).complete();
+    }
+
+    // then: process completes successfully, no incident is raised
+    RecordingExporter.processInstanceRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .limitToProcessInstanceCompleted()
+        .getLast();
+
+    assertThat(
+            RecordingExporter.records()
+                .betweenProcessInstance(processInstanceKey)
+                .filter(r -> r.getValueType() == ValueType.INCIDENT)
+                .filter(r -> r.getIntent() == IncidentIntent.CREATED)
+                .toList())
+        .as("no incident before threshold is reached")
+        .isEmpty();
+  }
+
+  /**
+   * A <b>sequential</b> MI with a collection larger than {@code maxActivations} raises a
+   * loop-detection incident when activating a child would exceed the threshold.
+   *
+   * <p>Sequential MI children are counted individually — each child activation increments the
+   * counter by 1. When the collection contains more items than {@code maxActivations}, the incident
+   * fires on the child that would cause the counter to exceed the threshold.
+   *
+   * <h2>Numeric example ({@code MAX=4, COLLECTION=5})</h2>
+   *
+   * <pre>
+   * Child 1 activation: count=1
+   * Child 2 activation: count=2
+   * Child 3 activation: count=3
+   * Child 4 activation: count=4 (equals MAX)
+   * Child 5 activation: would make count=5 &gt; MAX=4 ← incident fires
+   * </pre>
+   */
+  @Test
+  public void shouldRaiseIncidentForSequentialMultiInstanceWhenCollectionExceedsMaxActivations() {
+    // given
+    final List<Integer> items = IntStream.rangeClosed(1, LARGE_COLLECTION_SIZE).boxed().toList();
+
+    engine.deployment().withXmlResource(sequentialMiLoopingProcess()).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(SEQUENTIAL_PROCESS_ID)
+            .withVariable("items", items)
+            .create();
+
+    // when: complete MAX_ACTIVATIONS sequential child job instances.
+    // Sequential MI creates and processes children one at a time.
+    // The incident fires when attempting to activate the (MAX_ACTIVATIONS + 1)th child,
+    // which would exceed the activation threshold.
+    for (int i = 0; i < MAX_ACTIVATIONS; i++) {
+      final long jobKey =
+          RecordingExporter.jobRecords(JobIntent.CREATED)
+              .withProcessInstanceKey(processInstanceKey)
+              .withType(JOB_TYPE)
+              .skip(i)
+              .getFirst()
+              .getKey();
+      engine.job().withKey(jobKey).complete();
+    }
+
+    // then: incident fires when attempting to activate the next sequential child,
+    // which would exceed the activation threshold.
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final var activatingRecord =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ID)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .skip(MAX_ACTIVATIONS)
+            .getFirst();
+
+    assertIncidentCreated(incident, activatingRecord);
+
+    Assertions.assertThat(incident.getValue())
+        .hasErrorType(ErrorType.CONDITION_ERROR)
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasElementId(TASK_ID);
+
+    assertThat(incident.getValue().getErrorMessage())
+        .contains(TASK_ID)
+        .contains(String.valueOf(MAX_ACTIVATIONS));
+  }
+
+  /**
+   * A <b>parallel</b> MI whose collection fits within {@code maxActivations} (so the batch guard
+   * does not block) but which is re-activated in a loop raises the incident on the <b>child</b>
+   * activation that pushes the cumulative child count past the threshold — not on the body.
+   *
+   * <h2>Numeric example ({@code MAX=4, COLLECTION=3})</h2>
+   *
+   * <pre>
+   * Iteration 1: children activate at cumulative counts 1, 2, 3 (all &le; MAX)
+   * Iteration 2: child activates at count 4 (equals MAX), then
+   *              child activates at count 5 &gt; MAX=4 ← incident fires on this child
+   * </pre>
+   */
+  @Test
+  public void shouldRaiseIncidentOnChildWhenParallelMultiInstanceLoopExceedsMaxActivations() {
+    // given: a parallel MI whose collection (3) fits within the threshold (4), inside a loop
+    final List<Integer> items =
+        IntStream.rangeClosed(1, LOOP_COLLECTION_SIZE).boxed().collect(Collectors.toList());
+    engine.deployment().withXmlResource(parallelMiLoopingProcess()).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PARALLEL_LOOP_PROCESS_ID)
+            .withVariable("items", items)
+            .create();
+
+    // when: the first iteration's children are completed, so the body loops and re-activates its
+    // children, pushing the cumulative child count past the threshold in the second iteration
+    for (int i = 0; i < LOOP_COLLECTION_SIZE; i++) {
+      final long jobKey =
+          RecordingExporter.jobRecords(JobIntent.CREATED)
+              .withProcessInstanceKey(processInstanceKey)
+              .withType(JOB_TYPE)
+              .skip(i)
+              .getFirst()
+              .getKey();
+      engine.job().withKey(jobKey).complete();
+    }
+
+    // then: the incident fires on the child activation that crosses the threshold (the 5th child
+    // activation overall), not on the multi-instance body
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final var childActivatingRecord =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ID)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .skip(MAX_ACTIVATIONS)
+            .getFirst();
+
+    assertIncidentCreated(incident, childActivatingRecord);
+
+    Assertions.assertThat(incident.getValue())
+        .hasErrorType(ErrorType.CONDITION_ERROR)
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasElementId(TASK_ID);
+
+    assertThat(incident.getValue().getErrorMessage())
+        .contains(TASK_ID)
+        .contains(String.valueOf(MAX_ACTIVATIONS));
+  }
+
+  /**
+   * A parallel MI with a collection far larger than the threshold activates children only up to the
+   * threshold and then stops the batch at the crossing child, instead of activating every child and
+   * flooding the instance with one incident per child.
+   */
+  @Test
+  public void shouldStopActivatingChildrenOnceThresholdIsCrossed() {
+    // given: a parallel MI whose collection is far larger than the threshold
+    final int largeCollectionSize = 50;
+    final List<Integer> items =
+        IntStream.rangeClosed(1, largeCollectionSize).boxed().collect(Collectors.toList());
+    engine.deployment().withXmlResource(parallelMiProcess()).deploy();
+
+    // when: the instance is created, the batch activates children up to the threshold and stops
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PARALLEL_PROCESS_ID)
+            .withVariable("items", items)
+            .create();
+
+    // then: the batch finishes early (a single ACTIVATED event) once the threshold is crossed
+    RecordingExporter.processInstanceBatchRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(r -> r.getIntent() == ProcessInstanceBatchIntent.ACTIVATED)
+        .toList();
+
+    // only MAX_ACTIVATIONS + 1 children were activated (the threshold plus the crossing child that
+    // carries the incident) — far fewer than the collection size
+    final long childActivations =
+        RecordingExporter.getRecords().stream()
+            .filter(r -> r.getValueType() == ValueType.PROCESS_INSTANCE)
+            .filter(r -> r.getIntent() == ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .map(Record::getValue)
+            .map(ProcessInstanceRecordValue.class::cast)
+            .filter(v -> TASK_ID.equals(v.getElementId()))
+            .filter(v -> v.getBpmnElementType() == BpmnElementType.SERVICE_TASK)
+            .count();
+    assertThat(childActivations).isEqualTo(MAX_ACTIVATIONS + 1);
+  }
+
+  /**
+   * The child that crosses the threshold holds a loop-detection incident; resolving it must let
+   * that child proceed (create its job) instead of re-raising the same incident, so the process can
+   * be recovered.
+   */
+  @Test
+  public void shouldRecoverChildWhenResolvingItsLoopDetectionIncident() {
+    // given: a parallel MI over the threshold activates children up to the threshold, and the
+    // crossing child raises its own loop-detection incident
+    final List<Integer> items =
+        IntStream.rangeClosed(1, LARGE_COLLECTION_SIZE).boxed().collect(Collectors.toList());
+    engine.deployment().withXmlResource(parallelMiProcess()).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PARALLEL_PROCESS_ID)
+            .withVariable("items", items)
+            .create();
+
+    // the crossing child raises the loop-detection incident
+    final Record<IncidentRecordValue> childIncident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when: the child's loop-detection incident is resolved
+    engine.incident().ofInstance(processInstanceKey).withKey(childIncident.getKey()).resolve();
+
+    // then: the child recovers and creates its job, so every activated child now has a job
+    final var jobs =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(JOB_TYPE)
+            .limit(LARGE_COLLECTION_SIZE)
+            .collect(Collectors.toList());
+    assertThat(jobs).hasSize(LARGE_COLLECTION_SIZE);
+  }
+
+  /**
+   * After the batch is throttled and its crossing-child incident is resolved, the parallel MI
+   * drains the remaining collection items one at a time (through the sequential path), so the
+   * instance is not stuck with the collection half-processed and eventually completes.
+   */
+  @Test
+  public void shouldDrainRemainingParallelMiChildrenAndCompleteAfterResolving() {
+    // given: collection larger than the batch bound, so the tail item(s) must be drained after the
+    // batch (MAX_ACTIVATIONS + 1 children) is activated
+    final int collectionSize = MAX_ACTIVATIONS + 2;
+    final List<Integer> items =
+        IntStream.rangeClosed(1, collectionSize).boxed().collect(Collectors.toList());
+    engine.deployment().withXmlResource(parallelMiProcess()).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PARALLEL_PROCESS_ID)
+            .withVariable("items", items)
+            .create();
+
+    // resolve the crossing child's incident so it can run and, once finished, drain the tail item
+    final Record<IncidentRecordValue> childIncident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    engine.incident().ofInstance(processInstanceKey).withKey(childIncident.getKey()).resolve();
+
+    // complete every child job; the tail item is activated once the batch children have finished
+    for (int i = 0; i < collectionSize; i++) {
+      final long jobKey =
+          RecordingExporter.jobRecords(JobIntent.CREATED)
+              .withProcessInstanceKey(processInstanceKey)
+              .withType(JOB_TYPE)
+              .skip(i)
+              .getFirst()
+              .getKey();
+      engine.job().withKey(jobKey).complete();
+    }
+
+    // then: the instance is not stuck — it completes with every collection item processed
+    final Record<ProcessInstanceRecordValue> completed =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+    assertThat(completed).isNotNull();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/LoopDetectionPerTypeConfigTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/LoopDetectionPerTypeConfigTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies per-{@link BpmnElementType} loop-detection configuration: a per-type override is applied
+ * instead of the global default, and a per-type value of {@code 0} disables detection for that
+ * type. {@code SERVICE_TASK} uses a threshold ({@value #SERVICE_TASK_MAX}) below the global default
+ * ({@value #GLOBAL_MAX}), while {@code MULTI_INSTANCE_BODY} is disabled.
+ */
+public final class LoopDetectionPerTypeConfigTest {
+
+  private static final int GLOBAL_MAX = 5;
+  private static final int SERVICE_TASK_MAX = 2;
+
+  private static final String PROCESS_ID = "looping-process";
+  private static final String TASK_ID = "looping-task";
+  private static final String GATEWAY_ID = "xor-gateway";
+  private static final String JOB_TYPE = "loop-job";
+
+  private static final String MI_PROCESS_ID = "parallel-mi-process";
+  private static final String MI_TASK_ID = "mi-task";
+  private static final String MI_JOB_TYPE = "mi-job";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(
+              cfg ->
+                  cfg.setMaxElementActivationCount(GLOBAL_MAX)
+                      .setElementActivationRetryCooldown(1)
+                      .setMaxElementActivationCountByType(
+                          Map.of(
+                              BpmnElementType.SERVICE_TASK,
+                              SERVICE_TASK_MAX,
+                              BpmnElementType.MULTI_INSTANCE_BODY,
+                              0)));
+
+  @Test
+  public void shouldRaiseIncidentAtPerTypeOverrideThreshold() {
+    // given: a tight loop on a service task whose per-type threshold (2) is lower than the global
+    // default (5)
+    engine.deployment().withXmlResource(loopingProcess()).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: the task is activated (SERVICE_TASK_MAX + 1) times by completing SERVICE_TASK_MAX jobs
+    for (int i = 0; i < SERVICE_TASK_MAX; i++) {
+      final long jobKey =
+          RecordingExporter.jobRecords(JobIntent.CREATED)
+              .withProcessInstanceKey(processInstanceKey)
+              .withType(JOB_TYPE)
+              .skip(i)
+              .getFirst()
+              .getKey();
+      engine.job().withKey(jobKey).complete();
+    }
+
+    // then: the incident is raised on the service task at its per-type threshold, not the global
+    // one
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(incident.getValue().getElementId()).isEqualTo(TASK_ID);
+    assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.CONDITION_ERROR);
+    assertThat(incident.getValue().getErrorMessage())
+        .contains(TASK_ID)
+        .contains(String.valueOf(SERVICE_TASK_MAX));
+  }
+
+  @Test
+  public void shouldNotRaiseIncidentForDisabledElementType() {
+    // given: a parallel MI whose body would exceed the global threshold (collection > GLOBAL_MAX),
+    // but MULTI_INSTANCE_BODY is disabled via a per-type value of 0
+    final int collectionSize = GLOBAL_MAX * 2;
+    final List<Integer> items = IntStream.rangeClosed(1, collectionSize).boxed().toList();
+
+    engine.deployment().withXmlResource(parallelMiProcess()).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(MI_PROCESS_ID)
+            .withVariable("items", items)
+            .create();
+
+    // when: all child jobs are completed
+    for (int i = 0; i < collectionSize; i++) {
+      final long jobKey =
+          RecordingExporter.jobRecords(JobIntent.CREATED)
+              .withProcessInstanceKey(processInstanceKey)
+              .withType(MI_JOB_TYPE)
+              .skip(i)
+              .getFirst()
+              .getKey();
+      engine.job().withKey(jobKey).complete();
+    }
+
+    // then: the process completes without any loop-detection incident
+    RecordingExporter.processInstanceRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .limitToProcessInstanceCompleted()
+        .getLast();
+
+    assertThat(
+            RecordingExporter.records()
+                .betweenProcessInstance(processInstanceKey)
+                .filter(r -> r.getValueType() == ValueType.INCIDENT)
+                .filter(r -> r.getIntent() == IncidentIntent.CREATED)
+                .toList())
+        .as("loop detection disabled for MULTI_INSTANCE_BODY")
+        .isEmpty();
+  }
+
+  private static BpmnModelInstance loopingProcess() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .serviceTask(TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
+        .exclusiveGateway(GATEWAY_ID)
+        .defaultFlow()
+        .connectTo(TASK_ID)
+        .done();
+  }
+
+  private static BpmnModelInstance parallelMiProcess() {
+    return Bpmn.createExecutableProcess(MI_PROCESS_ID)
+        .startEvent()
+        .serviceTask(
+            MI_TASK_ID,
+            t ->
+                t.zeebeJobType(MI_JOB_TYPE)
+                    .multiInstance(
+                        mi ->
+                            mi.parallel().zeebeInputCollection("=items").zeebeInputElement("item")))
+        .endEvent()
+        .done();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -405,6 +405,39 @@ public final class ElementInstanceStateTest {
   }
 
   @Test
+  public void shouldRemoveElementActivationCountersOnProcessInstanceRemoval() {
+    // given
+    final var processInstanceRecord =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
+    final var processInstanceKey = 101L;
+    elementInstanceState.newInstance(
+        processInstanceKey, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    final DirectBuffer firstElementId = wrapString("task-a");
+    final DirectBuffer secondElementId = wrapString("task-b");
+    elementInstanceState.incrementElementActivationCounter(processInstanceKey, firstElementId);
+    elementInstanceState.incrementElementActivationCounter(processInstanceKey, firstElementId);
+    elementInstanceState.incrementElementActivationCounter(processInstanceKey, secondElementId);
+
+    // sanity check: counters are tracked before removal
+    assertThat(elementInstanceState.getElementActivationCounter(processInstanceKey, firstElementId))
+        .isEqualTo(2L);
+    assertThat(
+            elementInstanceState.getElementActivationCounter(processInstanceKey, secondElementId))
+        .isEqualTo(1L);
+
+    // when
+    elementInstanceState.removeInstance(processInstanceKey);
+
+    // then
+    assertThat(elementInstanceState.getElementActivationCounter(processInstanceKey, firstElementId))
+        .isZero();
+    assertThat(
+            elementInstanceState.getElementActivationCounter(processInstanceKey, secondElementId))
+        .isZero();
+  }
+
+  @Test
   public void shouldNotLeakMemoryOnRemoval() {
     // given
     final int parent = 100;

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v4.golden
@@ -1,0 +1,328 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.bpmn.behavior.LoopDetectionFilter;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableExclusiveGateway;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableInclusiveGateway;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.instance.EventTrigger;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.Collections;
+import java.util.List;
+
+/** Applies state changes for `ProcessInstance:Element_Activating` */
+final class ProcessInstanceElementActivatingV4Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+  private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
+
+  public ProcessInstanceElementActivatingV4Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableEventScopeInstanceState eventScopeInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    createEventScope(elementInstanceKey, value);
+    final var numberOfTakenSequenceFlows =
+        elementInstanceState.getNumberOfTakenSequenceFlows(
+            value.getFlowScopeKey(), value.getElementIdBuffer());
+    cleanupSequenceFlowsTaken(value);
+    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
+
+    if (shouldIncrementActivationCounter(value)) {
+      elementInstanceState.incrementElementActivationCounter(
+          value.getProcessInstanceKey(), value.getElementIdBuffer());
+    }
+    final var elementInstance =
+        elementInstanceState.newInstance(
+            flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && !value.hasParentProcessInstance()) {
+      insertBusinessIdIndex(value);
+    }
+    if (flowScopeInstance == null) {
+      applyRootProcessState(elementInstance, value);
+      return;
+    }
+    final var flowScopeElementType = flowScopeInstance.getValue().getBpmnElementType();
+    final var currentElementType = value.getBpmnElementType();
+    decrementActiveSequenceFlow(
+        value,
+        flowScopeInstance,
+        flowScopeElementType,
+        currentElementType,
+        numberOfTakenSequenceFlows);
+    if (currentElementType == BpmnElementType.START_EVENT
+        && flowScopeElementType == BpmnElementType.EVENT_SUB_PROCESS) {
+      final EventTrigger flowScopeEventTrigger =
+          eventScopeInstanceState.peekEventTrigger(flowScopeInstance.getParentKey());
+      moveVariablesToNewEventScope(
+          flowScopeEventTrigger, flowScopeInstance.getParentKey(), elementInstanceKey);
+    }
+    manageMultiInstance(elementInstanceKey, flowScopeInstance, flowScopeElementType);
+  }
+
+  private void cleanupSequenceFlowsTaken(final ProcessInstanceRecord value) {
+    if (value.getBpmnElementType() == BpmnElementType.PARALLEL_GATEWAY
+        || value.getBpmnElementType() == BpmnElementType.INCLUSIVE_GATEWAY) {
+      final var gateway =
+          processState.getFlowElement(
+              value.getProcessDefinitionKey(),
+              value.getTenantId(),
+              value.getElementIdBuffer(),
+              ExecutableFlowNode.class);
+      // before a parallel or inclusive gateway is activated, all incoming sequence flows of the
+      // gateway must
+      // be taken at least once. decrement the number of the taken sequence flows for each incoming
+      // sequence flow but keep the remaining numbers for the next activation of the gateway.
+      // (Tetris principle)
+      elementInstanceState.decrementNumberOfTakenSequenceFlows(
+          value.getFlowScopeKey(), gateway.getId());
+    }
+  }
+
+  private void moveVariablesToNewEventScope(
+      final EventTrigger eventTrigger, final long oldEventScopeKey, final long newEventScopeKey) {
+    // In order to pass the variables of the event trigger to the element instance, we need to
+    // create a new event trigger, using the element instance key as the event scope key.
+    if (eventTrigger != null) {
+      eventScopeInstanceState.triggerEvent(
+          newEventScopeKey,
+          eventTrigger.getEventKey(),
+          eventTrigger.getElementId(),
+          eventTrigger.getVariables(),
+          eventTrigger.getProcessInstanceKey());
+      eventScopeInstanceState.deleteTrigger(oldEventScopeKey, eventTrigger.getEventKey());
+    }
+  }
+
+  private void applyRootProcessState(
+      final ElementInstance elementInstance, final ProcessInstanceRecord value) {
+    final var parentElementInstance =
+        elementInstanceState.getInstance(value.getParentElementInstanceKey());
+    if (parentElementInstance != null) {
+      // this check is not really necessary: if parentElementInstance exists,
+      // it should always be a call-activity, but let's try to be safe
+      final var parentElementType = parentElementInstance.getValue().getBpmnElementType();
+      if (parentElementType == BpmnElementType.CALL_ACTIVITY) {
+        parentElementInstance.setCalledChildInstanceKey(elementInstance.getKey());
+        elementInstanceState.updateInstance(parentElementInstance);
+        final var parentProcessInstance =
+            elementInstanceState.getInstance(
+                elementInstance.getValue().getParentProcessInstanceKey());
+        elementInstance.setProcessDepth(parentProcessInstance.getProcessDepth() + 1);
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+
+  private void decrementActiveSequenceFlow(
+      final ProcessInstanceRecord value,
+      final ElementInstance flowScopeInstance,
+      final BpmnElementType flowScopeElementType,
+      final BpmnElementType currentElementType,
+      final int numberOfTakenSequenceFlows) {
+    // remove active sequence flows to this element
+    processState
+        .getFlowElement(
+            value.getProcessDefinitionKey(),
+            value.getTenantId(),
+            value.getElementIdBuffer(),
+            ExecutableFlowNode.class)
+        .getIncoming()
+        .stream()
+        .map(ExecutableSequenceFlow::getId)
+        .forEach(flowScopeInstance::removeActiveSequenceFlowId);
+    elementInstanceState.updateInstance(flowScopeInstance);
+    // We don't want to decrement the active sequence flow for elements which have no incoming
+    // sequence flow and for interrupting event sub processes we reset the count completely.
+    // Furthermore some elements are special and need to be handled separately.
+    switch (currentElementType) {
+      case START_EVENT:
+      case BOUNDARY_EVENT:
+        break;
+      case INTERMEDIATE_CATCH_EVENT:
+        decrementIntermediateCatchEventSequenceFlow(value, flowScopeInstance);
+        break;
+      case PARALLEL_GATEWAY:
+        decrementParallelGatewaySequenceFlow(value, flowScopeInstance);
+        break;
+      case INCLUSIVE_GATEWAY:
+        decrementInclusiveGatewaySequenceFlow(flowScopeInstance, numberOfTakenSequenceFlows);
+        break;
+      case EVENT_SUB_PROCESS:
+        decrementEventSubProcessSequenceFlow(value, flowScopeInstance);
+        break;
+      default:
+        if (flowScopeElementType != BpmnElementType.MULTI_INSTANCE_BODY) {
+          flowScopeInstance.decrementActiveSequenceFlows();
+          elementInstanceState.updateInstance(flowScopeInstance);
+        }
+        break;
+    }
+  }
+
+  private void decrementIntermediateCatchEventSequenceFlow(
+      final ProcessInstanceRecord value, final ElementInstance flowScopeInstance) {
+    // If we are an intermediate catch event and our previous element is an event based gateway,
+    // then we don't want to decrement the active flow, since based on the BPMN spec we DON'T take
+    // the sequence flow.
+    final var executableCatchEventElement =
+        processState.getFlowElement(
+            value.getProcessDefinitionKey(),
+            value.getTenantId(),
+            value.getElementIdBuffer(),
+            ExecutableCatchEventElement.class);
+    // When the catch event is of the link catch event type,
+    // the catch event has no incoming sequence flow
+    final List<ExecutableSequenceFlow> incoming = executableCatchEventElement.getIncoming();
+    if (!incoming.isEmpty()) {
+      final var incomingSequenceFlow = executableCatchEventElement.getIncoming().get(0);
+      final var previousElement = incomingSequenceFlow.getSource();
+      if (previousElement.getElementType() != BpmnElementType.EVENT_BASED_GATEWAY) {
+        flowScopeInstance.decrementActiveSequenceFlows();
+        elementInstanceState.updateInstance(flowScopeInstance);
+      }
+    }
+  }
+
+  private void decrementParallelGatewaySequenceFlow(
+      final ProcessInstanceRecord value, final ElementInstance flowScopeInstance) {
+    // Parallel gateways can have more than one incoming sequence flow, we need to decrement the
+    // active sequence flows based on the incoming count.
+    final var executableFlowNode =
+        processState.getFlowElement(
+            value.getProcessDefinitionKey(),
+            value.getTenantId(),
+            value.getElementIdBuffer(),
+            ExecutableFlowNode.class);
+    final var size = executableFlowNode.getIncoming().size();
+    flowScopeInstance.decrementActiveSequenceFlows(size);
+    elementInstanceState.updateInstance(flowScopeInstance);
+  }
+
+  private void decrementInclusiveGatewaySequenceFlow(
+      final ElementInstance flowScopeInstance, final int numberOfTakenSequenceFlows) {
+    // Inclusive gateways can have more than one incoming sequence flow, we need to decrement the
+    // active sequence flows based on the satisfied incoming sequence flows.
+    flowScopeInstance.decrementActiveSequenceFlows(numberOfTakenSequenceFlows);
+    elementInstanceState.updateInstance(flowScopeInstance);
+  }
+
+  private void decrementEventSubProcessSequenceFlow(
+      final ProcessInstanceRecord value, final ElementInstance flowScopeInstance) {
+    // For interrupting event sub processes we need to reset the active sequence flows, because
+    // we might have interrupted multiple sequence flows.
+    // For non interrupting we do nothing, since we had no incoming sequence flow.
+    final var executableFlowElementContainer = getExecutableFlowElementContainer(value);
+    final var executableStartEvent = executableFlowElementContainer.getStartEvents().get(0);
+    if (executableStartEvent.isInterrupting()) {
+      flowScopeInstance.resetActiveSequenceFlows();
+    }
+    elementInstanceState.updateInstance(flowScopeInstance);
+  }
+
+  private ExecutableFlowElementContainer getExecutableFlowElementContainer(
+      final ProcessInstanceRecord value) {
+    return processState.getFlowElement(
+        value.getProcessDefinitionKey(),
+        value.getTenantId(),
+        value.getElementIdBuffer(),
+        ExecutableFlowElementContainer.class);
+  }
+
+  private void manageMultiInstance(
+      final long elementInstanceKey,
+      final ElementInstance flowScopeInstance,
+      final BpmnElementType flowScopeElementType) {
+    if (flowScopeElementType == BpmnElementType.MULTI_INSTANCE_BODY) {
+      // update the loop counter of the multi-instance body (starting by 1)
+      flowScopeInstance.incrementMultiInstanceLoopCounter();
+      // update the numberOfInstances of the multi-instance body
+      flowScopeInstance.incrementNumberOfElementInstances();
+      elementInstanceState.updateInstance(flowScopeInstance);
+      // set the loop counter of the inner instance
+      final var loopCounter = flowScopeInstance.getMultiInstanceLoopCounter();
+      elementInstanceState.updateInstance(
+          elementInstanceKey, instance -> instance.setMultiInstanceLoopCounter(loopCounter));
+    }
+  }
+
+  private void createEventScope(
+      final long elementInstanceKey, final ProcessInstanceRecord elementRecord) {
+    Class<? extends ExecutableFlowNode> flowElementClass = ExecutableFlowNode.class;
+    // in the case of the multi instance body, it shares the same element ID as that of its
+    // contained activity; this means when doing a processState.getFlowElement, you don't know which
+    // you will get, and the boundary events will only be bound to the multi instance
+    if (elementRecord.getBpmnElementType() == BpmnElementType.MULTI_INSTANCE_BODY) {
+      flowElementClass = ExecutableMultiInstanceBody.class;
+    }
+    final var flowElement =
+        processState.getFlowElement(
+            elementRecord.getProcessDefinitionKey(),
+            elementRecord.getTenantId(),
+            elementRecord.getElementIdBuffer(),
+            flowElementClass);
+    if (flowElement instanceof final ExecutableCatchEventSupplier eventSupplier
+        && !eventSupplier.getEvents().isEmpty()) {
+      eventScopeInstanceState.createInstance(
+          elementInstanceKey,
+          eventSupplier.getInterruptingElementIds(),
+          eventSupplier.getBoundaryElementIds());
+    } else if (flowElement instanceof ExecutableJobWorkerElement
+        || flowElement instanceof ExecutableActivity
+        || flowElement instanceof ExecutableExclusiveGateway
+        || flowElement instanceof ExecutableInclusiveGateway) {
+      // executable elements without events
+      eventScopeInstanceState.createInstance(
+          elementInstanceKey, Collections.emptySet(), Collections.emptySet());
+    }
+  }
+
+  /**
+   * Inserts the business id index for root process instances. This maps the business id to the
+   * process instance key, scoped by process definition id and tenant id.
+   */
+  private void insertBusinessIdIndex(final ProcessInstanceRecord value) {
+    final var businessId = value.getBusinessId();
+    if (!businessId.isEmpty()) {
+      elementInstanceState.insertProcessInstanceKeyByBusinessId(
+          businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
+    }
+  }
+
+  /**
+   * Decides whether to increment the element activation counter for loop detection. Delegates to
+   * {@link LoopDetectionFilter#shouldCount} so the counter increment and the activation check (in
+   * {@code BpmnStreamProcessor}) are consistent.
+   */
+  private boolean shouldIncrementActivationCounter(final ProcessInstanceRecord value) {
+    return LoopDetectionFilter.shouldCount(value);
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -329,6 +329,7 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   // secondary index: (jobKey, jobLease, historyItemKey) → ∅; supports prefix iteration by job key
   // or job key + lease
   AGENT_HISTORY_BY_JOB_KEY(151, PARTITION_LOCAL),
+
   // secondary index: (processInstanceKey, agentInstanceKey) → ∅; supports prefix iteration by
   // process instance key to find every agent instance still associated with it
   AGENT_INSTANCES_BY_PROCESS_INSTANCE_KEY(152, PARTITION_LOCAL),
@@ -361,7 +362,9 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   // Present only on P_B — the symmetric STARTED on P_K writes nothing here. See
   // CrossPartitionMessageStartHolderOrigin and the STARTED / PUSHED appliers for the full
   // write/delete lifecycle and the migration rationale.
-  CROSS_PARTITION_MESSAGE_START_HOLDER_ORIGIN(160, PARTITION_LOCAL);
+  CROSS_PARTITION_MESSAGE_START_HOLDER_ORIGIN(160, PARTITION_LOCAL),
+  // tracks per-scope activation counters used for loop detection
+  ELEMENT_ACTIVATION_COUNTERS(161, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

This PR adds **loop detection** to the Zeebe engine to protect a partition from
runaway or infinite process loops (e.g. an exclusive gateway that always routes
back to an upstream task).

The engine now counts how often each BPMN element is
activated within a single process instance and raises an incident once a
configurable threshold is exceeded, halting the loop instead of letting it
consume the partition indefinitely.

<img width="740" height="323" alt="image" src="https://github.com/user-attachments/assets/85512952-9136-4f05-868c-b5cd6b2c421e" />

### How it works

- **Counting** - every element activation increments a per-`(processInstanceKey,
  elementId)` counter, persisted in a new `ELEMENT_ACTIVATION_COUNTERS` column
  family so the count survives restarts and snapshots. Counters are deleted when
  the process instance ends to avoid leaking state.
- **Checking** - `BpmnLoopDetectionBehavior` compares the count against the
  effective threshold. On breach it returns a `Failure` with
  `ErrorType.CONDITION_ERROR`, which is surfaced as a regular incident. The
  incident is raised on the first activation past the threshold and then
  re-raised every `elementActivationRetryCooldown` activations, giving operators
  a window to resolve it before a new one appears.
- **Multi-instance handling** - to avoid false positives on large collections,
  sequential MI bodies are not counted (they share the counter with their
  children) and parallel MI children are not counted individually. Instead,
  parallel MI bodies are ignored and children are batch activated until the max activations are exeeded and an incident is raised.

### Configuration

All settings live under `camunda.processing.engine.loop-detection` (legacy
`zeebe.broker.experimental.engine.loopDetection.*` keys are supported - don't know how useful they are though):

| Property | Default | Description |
| --- | --- | --- |
| `max-element-activation-count` | `1000` | Global activation threshold per element. |
| `element-activation-retry-cooldown` | `100` | Activations between re-raised incidents after the first breach. |
| `max-element-activation-count-by-type` | `{}` | Per-`BpmnElementType` override of the global threshold. A value of `0` disables detection for that type. |

### Note on Core Engine changes

- A **new event applier version** (`ProcessInstanceElementActivatingV4Applier`)
  was created
- A **new column family** `ELEMENT_ACTIVATION_COUNTERS` (`161`, partition-local)
  was added to `ZbColumnFamilies`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review.

## Related issues

closes #55361