### PR TITLE
feat: introduce gRPC physical tenant server interceptor

### DIFF
--- a/configuration-api/src/main/java/io/camunda/configuration/api/physicaltenants/PhysicalTenantIds.java
+++ b/configuration-api/src/main/java/io/camunda/configuration/api/physicaltenants/PhysicalTenantIds.java
@@ -20,5 +20,8 @@ public interface PhysicalTenantIds {
   /** The canonical physical tenant ID used when no explicit tenant is configured. */
   String DEFAULT_PHYSICAL_TENANT_ID = "default";
 
+  /** Default implementation returning only the canonical physical tenant ID. */
+  PhysicalTenantIds DEFAULT = () -> Set.of(DEFAULT_PHYSICAL_TENANT_ID);
+
   Set<String> known();
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.broker;
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
-import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -71,7 +71,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final OidcClaimsProvider oidcClaimsProvider;
   private final SearchClientsProxy searchClientsProxy;
   private final NodeIdProvider nodeIdProvider;
-  private final PhysicalTenantResolver physicalTenantResolver;
+  private final PhysicalTenantIds physicalTenantIds;
 
   private Broker broker;
 
@@ -93,7 +93,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final OidcClaimsProvider oidcClaimsProvider,
       @Autowired(required = false) final SearchClientsProxy searchClientsProxy,
       final NodeIdProvider nodeIdProvider,
-      final PhysicalTenantResolver physicalTenantResolver) {
+      final PhysicalTenantIds physicalTenantIds) {
     this.configuration = configuration;
     this.identityConfiguration = identityConfiguration;
     this.springBrokerBridge = springBrokerBridge;
@@ -117,7 +117,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
         oidcClaimsProvider != null ? oidcClaimsProvider : new NoopOidcClaimsProvider();
     this.searchClientsProxy = searchClientsProxy;
     this.nodeIdProvider = nodeIdProvider;
-    this.physicalTenantResolver = physicalTenantResolver;
+    this.physicalTenantIds = physicalTenantIds;
   }
 
   @Bean
@@ -150,7 +150,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             searchClientsProxy,
             new BrokerRequestAuthorizationConverter(engineSecurityConfig),
             nodeIdProvider,
-            List.copyOf(physicalTenantResolver.getAll().keySet()));
+            physicalTenantIds);
     springBrokerBridge.registerShutdownHelper(
         (errorCode, reason) -> shutdownHelper.initiateShutdown(errorCode, reason));
     broker =

--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway;
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.GatewayBasedConfiguration;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.security.oidc.OidcClaimsProvider;
@@ -66,6 +67,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
   private final OidcClaimsProvider oidcClaimsProvider;
   private final MeterRegistry meterRegistry;
   private final int maxVariableNameLength;
+  private final PhysicalTenantIds physicalTenantIds;
 
   private Gateway gateway;
 
@@ -83,7 +85,8 @@ public class GatewayModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final JwtDecoder jwtDecoder,
       @Autowired(required = false) final OidcClaimsProvider oidcClaimsProvider,
       final MeterRegistry meterRegistry,
-      final GatewayRestConfiguration gatewayRestConfiguration) {
+      final GatewayRestConfiguration gatewayRestConfiguration,
+      final PhysicalTenantIds physicalTenantIds) {
     this.configuration = configuration;
     this.engineSecurityConfig =
         new EngineSecurityConfig(
@@ -105,6 +108,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
         oidcClaimsProvider != null ? oidcClaimsProvider : new NoopOidcClaimsProvider();
     this.meterRegistry = meterRegistry;
     maxVariableNameLength = gatewayRestConfiguration.getMaxNameFieldLength();
+    this.physicalTenantIds = physicalTenantIds;
   }
 
   @Bean(destroyMethod = "close")
@@ -136,7 +140,8 @@ public class GatewayModuleConfiguration implements CloseableSilently {
             jwtDecoder,
             oidcClaimsProvider,
             meterRegistry,
-            maxVariableNameLength);
+            maxVariableNameLength,
+            physicalTenantIds);
     springGatewayBridge.registerGatewayStatusSupplier(gateway::getStatus);
     springGatewayBridge.registerClusterStateSupplier(
         () ->

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -19,6 +19,7 @@ import io.camunda.application.commons.broker.client.BrokerClientConfiguration;
 import io.camunda.application.commons.clustering.AtomixClusterConfiguration;
 import io.camunda.application.commons.clustering.DynamicClusterServices;
 import io.camunda.application.commons.configuration.GatewayBasedConfiguration;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -291,6 +292,7 @@ final class StandaloneGatewaySecurityTest {
         null,
         null,
         new SimpleMeterRegistry(),
-        gatewayRestConfiguration);
+        gatewayRestConfiguration,
+        PhysicalTenantIds.DEFAULT);
   }
 }

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -108,11 +108,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>configuration-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-logstreams</artifactId>
     </dependency>
 

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -108,6 +108,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>configuration-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-logstreams</artifactId>
     </dependency>
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.bootstrap;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -165,6 +166,6 @@ public interface BrokerStartupContext {
 
   NodeIdProvider getNodeIdProvider();
 
-  /** Returns the list of physical tenant IDs this broker should run. */
-  List<String> getPhysicalTenantIds();
+  /** Returns the physical tenant IDs this broker should run. */
+  PhysicalTenantIds getPhysicalTenantIds();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -11,6 +11,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -74,7 +75,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final OidcClaimsProvider oidcClaimsProvider;
   private final SearchClientsProxy searchClientsProxy;
   private final NodeIdProvider nodeIdProvider;
-  private final List<String> physicalTenantIds;
+  private final PhysicalTenantIds physicalTenantIds;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   private ConcurrencyControl concurrencyControl;
@@ -113,7 +114,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final NodeIdProvider nodeIdProvider,
-      final List<String> physicalTenantIds) {
+      final PhysicalTenantIds physicalTenantIds) {
 
     this.brokerInfo = requireNonNull(brokerInfo);
     this.configuration = requireNonNull(configuration);
@@ -133,7 +134,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.oidcClaimsProvider = oidcClaimsProvider;
     this.searchClientsProxy = searchClientsProxy;
     this.nodeIdProvider = requireNonNull(nodeIdProvider);
-    this.physicalTenantIds = List.copyOf(physicalTenantIds);
+    this.physicalTenantIds = requireNonNull(physicalTenantIds);
     partitionListeners.addAll(additionalPartitionListeners);
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
   }
@@ -417,7 +418,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public List<String> getPhysicalTenantIds() {
+  public PhysicalTenantIds getPhysicalTenantIds() {
     return physicalTenantIds;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -68,7 +68,7 @@ public final class BrokerStartupProcess {
     result.add(new SnapshotApiServiceStep());
     result.add(new PartitionGroupMigrationStep());
     result.add(new RocksDbResourcesStep());
-    for (final String physicalTenantId : startupContext.getPhysicalTenantIds()) {
+    for (final String physicalTenantId : startupContext.getPhysicalTenantIds().known()) {
       result.add(new PartitionManagerStep(physicalTenantId));
     }
     result.add(new BrokerAdminServiceStep());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -50,7 +50,8 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
             passwordEncoder,
             brokerStartupContext.getJwtDecoder(),
             brokerStartupContext.getOidcClaimsProvider(),
-            brokerStartupContext.getMeterRegistry());
+            brokerStartupContext.getMeterRegistry(),
+            brokerStartupContext.getPhysicalTenantIds());
 
     final var embeddedGatewayServiceFuture = embeddedGatewayService.start();
     concurrencyControl.runOnCompletion(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system;
 
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
@@ -42,7 +43,8 @@ public final class EmbeddedGatewayService implements AutoCloseable {
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
       final OidcClaimsProvider oidcClaimsProvider,
-      final MeterRegistry meterRegistry) {
+      final MeterRegistry meterRegistry,
+      final PhysicalTenantIds physicalTenantIds) {
     this.concurrencyControl = concurrencyControl;
     this.brokerClient = brokerClient;
     this.jobStreamClient = jobStreamClient;
@@ -59,7 +61,8 @@ public final class EmbeddedGatewayService implements AutoCloseable {
             jwtDecoder,
             oidcClaimsProvider,
             meterRegistry,
-            configuration.getExperimental().getEngine().getValidators().getMaxNameFieldLength());
+            configuration.getExperimental().getEngine().getValidators().getMaxNameFieldLength(),
+            physicalTenantIds);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system;
 import static io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector.MINIMUM_SNAPSHOT_PERIOD;
 
 import io.atomix.cluster.AtomixCluster;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -137,7 +138,7 @@ public final class SystemContext {
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
   private final NodeIdProvider nodeIdProvider;
-  private final List<String> physicalTenantIds;
+  private final PhysicalTenantIds physicalTenantIds;
   private final GlobalListenerValidator globalListenerValidator;
 
   public SystemContext(
@@ -156,7 +157,7 @@ public final class SystemContext {
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final NodeIdProvider nodeIdProvider,
-      final List<String> physicalTenantIds) {
+      final PhysicalTenantIds physicalTenantIds) {
     this.shutdownTimeout = shutdownTimeout;
     this.brokerCfg = brokerCfg;
     this.identityConfiguration = identityConfiguration;
@@ -173,7 +174,7 @@ public final class SystemContext {
     this.searchClientsProxy = searchClientsProxy;
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
     this.nodeIdProvider = nodeIdProvider;
-    this.physicalTenantIds = List.copyOf(physicalTenantIds);
+    this.physicalTenantIds = physicalTenantIds;
     globalListenerValidator = new GlobalListenerValidator();
     initSystemContext();
   }
@@ -736,7 +737,7 @@ public final class SystemContext {
     return nodeIdProvider;
   }
 
-  public List<String> getPhysicalTenantIds() {
+  public PhysicalTenantIds getPhysicalTenantIds() {
     return physicalTenantIds;
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -13,13 +13,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.AtomixCluster;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
@@ -36,7 +36,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import org.junit.Before;
 import org.junit.Rule;
@@ -87,7 +86,7 @@ public final class SimpleBrokerStartTest {
                       mock(SearchClientsProxy.class),
                       mock(BrokerRequestAuthorizationConverter.class),
                       mock(NodeIdProvider.class),
-                      List.of(PartitionManagerImpl.DEFAULT_GROUP_NAME));
+                      PhysicalTenantIds.DEFAULT);
               new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE, emptyList());
             });
 
@@ -124,7 +123,7 @@ public final class SimpleBrokerStartTest {
             mock(SearchClientsProxy.class),
             mock(BrokerRequestAuthorizationConverter.class),
             mock(NodeIdProvider.class),
-            List.of(PartitionManagerImpl.DEFAULT_GROUP_NAME));
+            PhysicalTenantIds.DEFAULT);
 
     final var leaderLatch = new CountDownLatch(1);
     final var listener =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -27,7 +28,6 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
-import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -95,7 +95,7 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private CheckpointSchedulingService checkpointSchedulingService =
       mock(CheckpointSchedulingService.class);
   private NodeIdProvider nodeIdProvider = mock(NodeIdProvider.class);
-  private List<String> physicalTenantIds = List.of(PartitionManagerImpl.DEFAULT_GROUP_NAME);
+  private PhysicalTenantIds physicalTenantIds = PhysicalTenantIds.DEFAULT;
 
   @Override
   public BrokerInfo getBrokerInfo() {
@@ -448,11 +448,11 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   @Override
-  public List<String> getPhysicalTenantIds() {
+  public PhysicalTenantIds getPhysicalTenantIds() {
     return physicalTenantIds;
   }
 
-  public void setPhysicalTenantIds(final List<String> physicalTenantIds) {
+  public void setPhysicalTenantIds(final PhysicalTenantIds physicalTenantIds) {
     this.physicalTenantIds = physicalTenantIds;
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.partitioning;
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddresses;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
@@ -129,7 +130,7 @@ final class PartitionJoinTest {
             null,
             null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()),
-            List.of(PartitionManagerImpl.DEFAULT_GROUP_NAME));
+            PhysicalTenantIds.DEFAULT);
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddres
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
@@ -245,7 +246,7 @@ final class PartitionLeaveTest {
             null,
             null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()),
-            List.of(PartitionManagerImpl.DEFAULT_GROUP_NAME));
+            PhysicalTenantIds.DEFAULT);
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PhysicalTenantPartitionManagerIT.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PhysicalTenantPartitionManagerIT.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.partitioning;
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddresses;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
@@ -24,6 +25,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -38,7 +40,7 @@ final class PhysicalTenantPartitionManagerIT {
     try (final var broker =
         buildBroker(
             tmp,
-            List.of(PartitionManagerImpl.DEFAULT_GROUP_NAME, "tenant2"),
+            () -> Set.of(PartitionManagerImpl.DEFAULT_GROUP_NAME, "tenant2"),
             brokerCfg -> {
               final var clusterCfg = brokerCfg.getCluster();
               clusterCfg.setClusterSize(1);
@@ -65,7 +67,9 @@ final class PhysicalTenantPartitionManagerIT {
   }
 
   private static Broker buildBroker(
-      final Path tmp, final List<String> physicalTenantIds, final Consumer<BrokerCfg> configure) {
+      final Path tmp,
+      final PhysicalTenantIds physicalTenantIds,
+      final Consumer<BrokerCfg> configure) {
     final var brokerCfg = new BrokerCfg();
     assignSocketAddresses(brokerCfg);
     configure.accept(brokerCfg);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -14,13 +14,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.AtomixCluster;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
@@ -393,7 +393,7 @@ final class SystemContextTest {
         mock(SearchClientsProxy.class),
         mock(BrokerRequestAuthorizationConverter.class),
         mock(NodeIdProvider.class),
-        List.of(PartitionManagerImpl.DEFAULT_GROUP_NAME));
+        PhysicalTenantIds.DEFAULT);
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -17,6 +17,7 @@ import static io.camunda.zeebe.broker.test.EmbeddedBrokerConfigurator.setInterna
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.impl.util.AddressUtil;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
@@ -24,7 +25,6 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.TestLoggers;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
-import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
@@ -50,7 +50,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -257,7 +256,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
             null,
             null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()),
-            List.of(PartitionManagerImpl.DEFAULT_GROUP_NAME));
+            PhysicalTenantIds.DEFAULT);
 
     final var additionalListeners = new ArrayList<>(Arrays.asList(listeners));
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());

--- a/zeebe/gateway-grpc/pom.xml
+++ b/zeebe/gateway-grpc/pom.xml
@@ -353,6 +353,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>configuration-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup</artifactId>
       <scope>test</scope>
     </dependency>

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway;
 
 import com.google.rpc.Code;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.security.oidc.OidcClaimsProvider;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationMetrics;
 import io.camunda.zeebe.gateway.interceptors.impl.ContextInjectingInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.DecoratedInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.InterceptorRepository;
+import io.camunda.zeebe.gateway.interceptors.impl.PhysicalTenantInterceptor;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
@@ -43,6 +45,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamer;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.TlsConfigUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.grpc.BindableService;
@@ -105,7 +108,9 @@ public final class Gateway implements CloseableSilently {
   private final OidcClaimsProvider oidcClaimsProvider;
   private final MeterRegistry meterRegistry;
   private final int maxVariableNameLength;
+  private final PhysicalTenantIds physicalTenantIds;
 
+  @VisibleForTesting
   public Gateway(
       final GatewayCfg gatewayCfg,
       final EngineSecurityConfig securityConfiguration,
@@ -128,33 +133,8 @@ public final class Gateway implements CloseableSilently {
         jwtDecoder,
         new NoopOidcClaimsProvider(),
         meterRegistry,
-        VariableNameLengthValidator.DEFAULT_MAX_NAME_FIELD_LENGTH);
-  }
-
-  public Gateway(
-      final Duration shutdownDuration,
-      final GatewayCfg gatewayCfg,
-      final EngineSecurityConfig securityConfiguration,
-      final BrokerClient brokerClient,
-      final ActorSchedulingService actorSchedulingService,
-      final ClientStreamer<JobActivationProperties> jobStreamer,
-      final UserServices userServices,
-      final PasswordEncoder passwordEncoder,
-      final JwtDecoder jwtDecoder,
-      final MeterRegistry meterRegistry) {
-    this(
-        shutdownDuration,
-        gatewayCfg,
-        securityConfiguration,
-        brokerClient,
-        actorSchedulingService,
-        jobStreamer,
-        userServices,
-        passwordEncoder,
-        jwtDecoder,
-        new NoopOidcClaimsProvider(),
-        meterRegistry,
-        VariableNameLengthValidator.DEFAULT_MAX_NAME_FIELD_LENGTH);
+        VariableNameLengthValidator.DEFAULT_MAX_NAME_FIELD_LENGTH,
+        PhysicalTenantIds.DEFAULT);
   }
 
   public Gateway(
@@ -169,7 +149,8 @@ public final class Gateway implements CloseableSilently {
       final JwtDecoder jwtDecoder,
       final OidcClaimsProvider oidcClaimsProvider,
       final MeterRegistry meterRegistry,
-      final int maxVariableNameLength) {
+      final int maxVariableNameLength,
+      final PhysicalTenantIds physicalTenantIds) {
     shutdownTimeout = shutdownDuration;
     this.gatewayCfg = gatewayCfg;
     this.securityConfiguration = securityConfiguration;
@@ -182,6 +163,7 @@ public final class Gateway implements CloseableSilently {
     this.oidcClaimsProvider = Objects.requireNonNull(oidcClaimsProvider);
     this.meterRegistry = meterRegistry;
     this.maxVariableNameLength = maxVariableNameLength;
+    this.physicalTenantIds = physicalTenantIds;
 
     healthManager = new GatewayHealthManagerImpl();
   }
@@ -450,6 +432,7 @@ public final class Gateway implements CloseableSilently {
     // chain
     Collections.reverse(interceptors);
     interceptors.add(new ContextInjectingInterceptor(queryApi));
+    interceptors.add(new PhysicalTenantInterceptor(physicalTenantIds));
 
     if (!securityConfiguration.getAuthentication().isUnprotectedApi()) {
       final var authMethod = securityConfiguration.getAuthentication().getMethod();

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
@@ -17,6 +17,8 @@ public final class InterceptorUtil {
   private static final Key<QueryApi> QUERY_API_KEY = Context.key("zeebe-query-api");
   private static final Context.Key<List<String>> AUTHORIZED_TENANTS_KEY =
       Context.key("io.camunda.zeebe:authorized_tenants");
+  private static final Key<String> PHYSICAL_TENANT_ID_KEY =
+      Context.key("io.camunda.zeebe:physical_tenant_id");
 
   private InterceptorUtil() {}
 
@@ -61,5 +63,9 @@ public final class InterceptorUtil {
    */
   public static Key<QueryApi> getQueryApiKey() {
     return QUERY_API_KEY;
+  }
+
+  public static Context.Key<String> getPhysicalTenantIdKey() {
+    return PHYSICAL_TENANT_ID_KEY;
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/PhysicalTenantInterceptor.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/PhysicalTenantInterceptor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+
+/**
+ * Reads the {@code Camunda-Physical-Tenant} gRPC header and stores the resolved physical tenant id
+ * in the current gRPC {@link Context}. When the header is absent the id defaults to {@link
+ * DEFAULT_PHYSICAL_TENANT_ID}.
+ *
+ * <p>If {@link PhysicalTenantIds} is provided, the resolved id is validated against the set of
+ * known tenants; unknown ids are rejected with {@link Status#NOT_FOUND}.
+ *
+ * <p>Downstream handlers retrieve the value via {@link InterceptorUtil#getPhysicalTenantIdKey()}.
+ */
+public final class PhysicalTenantInterceptor implements ServerInterceptor {
+
+  static final Metadata.Key<String> PHYSICAL_TENANT_HEADER =
+      Metadata.Key.of("Camunda-Physical-Tenant", Metadata.ASCII_STRING_MARSHALLER);
+
+  private final PhysicalTenantIds physicalTenantIds;
+
+  public PhysicalTenantInterceptor(final PhysicalTenantIds physicalTenantIds) {
+    this.physicalTenantIds = physicalTenantIds;
+  }
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      final ServerCall<ReqT, RespT> call,
+      final Metadata headers,
+      final ServerCallHandler<ReqT, RespT> next) {
+    final var tenantId = headers.get(PHYSICAL_TENANT_HEADER);
+    final var resolvedTenantId = tenantId != null ? tenantId : DEFAULT_PHYSICAL_TENANT_ID;
+
+    if (!physicalTenantIds.known().contains(resolvedTenantId)) {
+      call.close(
+          Status.NOT_FOUND.withDescription("Unknown physical tenant: " + resolvedTenantId),
+          new Metadata());
+      return new ServerCall.Listener<>() {};
+    }
+
+    final Context context =
+        Context.current().withValue(InterceptorUtil.getPhysicalTenantIdKey(), resolvedTenantId);
+    return Contexts.interceptCall(context, call, headers, next);
+  }
+}

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/PhysicalTenantInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/PhysicalTenantInterceptorTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class PhysicalTenantInterceptorTest {
+
+  @Test
+  void shouldStoreHeaderValueInContext() {
+    // given
+    final var interceptor = new PhysicalTenantInterceptor(() -> Set.of("my-tenant"));
+    final var headers = new Metadata();
+    headers.put(PhysicalTenantInterceptor.PHYSICAL_TENANT_HEADER, "my-tenant");
+    final AtomicReference<String> captured = new AtomicReference<>();
+
+    // when
+    interceptor.interceptCall(
+        new NoopServerCall<>() {},
+        headers,
+        (call, h) -> {
+          captured.set(InterceptorUtil.getPhysicalTenantIdKey().get());
+          return null;
+        });
+
+    // then
+    assertThat(captured).hasValue("my-tenant");
+  }
+
+  @Test
+  void shouldDefaultToDefaultTenantWhenHeaderAbsent() {
+    // given
+    final var interceptor = new PhysicalTenantInterceptor(PhysicalTenantIds.DEFAULT);
+    final AtomicReference<String> captured = new AtomicReference<>();
+
+    // when
+    interceptor.interceptCall(
+        new NoopServerCall<>() {},
+        new Metadata(),
+        (call, h) -> {
+          captured.set(InterceptorUtil.getPhysicalTenantIdKey().get());
+          return null;
+        });
+
+    // then
+    assertThat(captured).hasValue(DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  void shouldAllowKnownTenant() {
+    // given
+    final PhysicalTenantIds knownTenants = () -> Set.of("tenant-a", "tenant-b");
+    final var interceptor = new PhysicalTenantInterceptor(knownTenants);
+    final var headers = new Metadata();
+    headers.put(PhysicalTenantInterceptor.PHYSICAL_TENANT_HEADER, "tenant-a");
+    final AtomicReference<String> captured = new AtomicReference<>();
+
+    // when
+    interceptor.interceptCall(
+        new NoopServerCall<>() {},
+        headers,
+        (call, h) -> {
+          captured.set(InterceptorUtil.getPhysicalTenantIdKey().get());
+          return null;
+        });
+
+    // then
+    assertThat(captured).hasValue("tenant-a");
+  }
+
+  @Test
+  void shouldRejectUnknownTenant() {
+    // given
+    final PhysicalTenantIds knownTenants = () -> Set.of("tenant-a");
+    final var interceptor = new PhysicalTenantInterceptor(knownTenants);
+    final var headers = new Metadata();
+    headers.put(PhysicalTenantInterceptor.PHYSICAL_TENANT_HEADER, "unknown-tenant");
+    final var closedCall = new CloseStatusCapturingServerCall<String, String>();
+
+    // when
+    interceptor.interceptCall(closedCall, headers, (call, h) -> null);
+
+    // then
+    assertThat(closedCall.closeStatus)
+        .hasValueSatisfying(
+            status -> {
+              assertThat(status.getCode()).isEqualTo(Status.NOT_FOUND.getCode());
+              assertThat(status.getDescription()).contains("unknown-tenant");
+            });
+  }
+
+  @Test
+  void shouldRejectAnyTenantWhenKnownIsEmpty() {
+    // given
+    final var interceptor = new PhysicalTenantInterceptor(Set::of);
+    final var headers = new Metadata();
+    headers.put(PhysicalTenantInterceptor.PHYSICAL_TENANT_HEADER, "any-tenant");
+    final var closedCall = new CloseStatusCapturingServerCall<String, String>();
+
+    // when
+    interceptor.interceptCall(closedCall, headers, (call, h) -> null);
+
+    // then
+    assertThat(closedCall.closeStatus)
+        .hasValueSatisfying(
+            status -> {
+              assertThat(status.getCode()).isEqualTo(Status.NOT_FOUND.getCode());
+              assertThat(status.getDescription()).contains("any-tenant");
+            });
+  }
+
+  private static final class CloseStatusCapturingServerCall<ReqT, RespT>
+      extends NoopServerCall<ReqT, RespT> {
+    private final AtomicReference<Status> closeStatus = new AtomicReference<>();
+
+    @Override
+    public void close(final Status status, final Metadata trailers) {
+      closeStatus.set(status);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public MethodDescriptor<ReqT, RespT> getMethodDescriptor() {
+      return mock(MethodDescriptor.class);
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -634,6 +634,13 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>configuration-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>configuration</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -35,6 +35,7 @@ import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.response.BrokerInfo;
 import io.camunda.client.api.response.Topology;
 import io.camunda.client.impl.util.AddressUtil;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
@@ -405,7 +406,7 @@ public class ClusteringRule extends ExternalResource {
             null,
             null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()),
-            List.of(PartitionManagerImpl.DEFAULT_GROUP_NAME));
+            PhysicalTenantIds.DEFAULT);
 
     final Broker broker =
         new Broker(


### PR DESCRIPTION
## Description

This PR introduces gRPC support for propagating the `Camunda-Physical-Tenant` header into the server-side gRPC `Context`, and refactors broker/gateway wiring to use a `PhysicalTenantIds` abstraction to resolve/validate known physical tenants.

**Changes:**
- Added a gRPC `ServerInterceptor` (`PhysicalTenantInterceptor`) that reads `Camunda-Physical-Tenant`, defaults to `default`, validates against known tenants, and stores the resolved value in gRPC `Context`.
- Introduced/expanded `configuration-api`’s `PhysicalTenantIds` (including `DEFAULT_PHYSICAL_TENANT_ID` and `DEFAULT`) and updated broker/gateway bootstrapping code to pass/use `PhysicalTenantIds` instead of `List<String>` -- infrastructure for dynamically resolving known physical tenants
- Added unit tests for the interceptor and updated multiple broker/gateway tests and module wiring to use the new `PhysicalTenantIds` plumbing.

## Related issues
`PhysicalTenantIds` discussion in https://github.com/camunda/camunda/pull/55126
closes #50534