### PR TITLE
refactor: extract toppanel diagram overlays into seperate functionality

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/index.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {observer} from 'mobx-react';
+import {diagramOverlaysStore} from 'modules/stores/diagramOverlays';
+import {StateOverlay} from 'modules/components/StateOverlay';
+import {WaitingStateOverlay} from 'modules/components/WaitingStateOverlay';
+import {ModificationBadgeOverlay} from '../ModificationBadgeOverlay';
+import {AgentStatusOverlay} from '../AgentStatusOverlay';
+import {AgentShineOverlay} from '../AgentShineOverlay';
+import {useModificationsByElement} from 'modules/hooks/modifications';
+import {hasPendingCancelOrMoveModification} from 'modules/utils/modifications';
+import {
+  OVERLAY_TYPE_STATE,
+  OVERLAY_TYPE_MODIFICATIONS_BADGE,
+  OVERLAY_TYPE_WAITING_STATE,
+  OVERLAY_TYPE_AGENT_STATUS,
+  OVERLAY_TYPE_AGENT_SHINE,
+  isStatisticsPayload,
+  isModificationBadgePayload,
+  isWaitingStatePayload,
+  isAgentStatusPayload,
+  isAgentShinePayload,
+} from 'modules/bpmn-js/overlayTypes';
+
+const DiagramOverlays: React.FC = observer(() => {
+  const modificationsByElement = useModificationsByElement();
+  const {overlays} = diagramOverlaysStore.state;
+
+  const stateOverlays = overlays.filter(
+    ({type}) => type === OVERLAY_TYPE_STATE,
+  );
+  const modificationBadgeOverlays = overlays.filter(
+    ({type}) => type === OVERLAY_TYPE_MODIFICATIONS_BADGE,
+  );
+  const waitingOverlays = overlays.filter(
+    ({type}) => type === OVERLAY_TYPE_WAITING_STATE,
+  );
+  const agentStatusOverlays = overlays.filter(
+    ({type}) => type === OVERLAY_TYPE_AGENT_STATUS,
+  );
+  const agentShineOverlays = overlays.filter(
+    ({type}) => type === OVERLAY_TYPE_AGENT_SHINE,
+  );
+
+  return (
+    <>
+      {stateOverlays.map((overlay) => {
+        const payload = overlay.payload;
+        if (!isStatisticsPayload(payload)) {
+          return null;
+        }
+
+        return (
+          <StateOverlay
+            key={`${overlay.elementId}-${payload.elementState}`}
+            state={payload.elementState}
+            count={payload.count}
+            container={overlay.container}
+            isFaded={hasPendingCancelOrMoveModification({
+              elementId: overlay.elementId,
+              elementInstanceKey: undefined,
+              modificationsByElement,
+            })}
+            title={
+              payload.elementState === 'completed'
+                ? 'Execution Count'
+                : undefined
+            }
+          />
+        );
+      })}
+      {modificationBadgeOverlays.map((overlay) => {
+        const payload = overlay.payload;
+        if (!isModificationBadgePayload(payload)) {
+          return null;
+        }
+
+        return (
+          <ModificationBadgeOverlay
+            key={overlay.elementId}
+            container={overlay.container}
+            newTokenCount={payload.newTokenCount}
+            cancelledTokenCount={payload.cancelledTokenCount}
+          />
+        );
+      })}
+      {waitingOverlays.map((overlay) => {
+        const payload = overlay.payload;
+        if (!isWaitingStatePayload(payload)) {
+          return null;
+        }
+
+        return (
+          <WaitingStateOverlay
+            key={`waiting-${overlay.elementId}`}
+            container={overlay.container}
+            label={payload.label}
+          />
+        );
+      })}
+      {agentStatusOverlays.map((overlay) => {
+        const payload = overlay.payload;
+        if (!isAgentStatusPayload(payload)) {
+          return null;
+        }
+        return (
+          <AgentStatusOverlay
+            key={`${payload.agentInstanceKey}-status`}
+            container={overlay.container}
+            status={payload.status}
+          />
+        );
+      })}
+      {agentShineOverlays.map((overlay) => {
+        const payload = overlay.payload;
+        if (!isAgentShinePayload(payload)) {
+          return null;
+        }
+        return (
+          <AgentShineOverlay
+            key={`${payload.agentInstanceKey}-shine`}
+            container={overlay.container}
+            elementId={overlay.elementId}
+          />
+        );
+      })}
+    </>
+  );
+});
+
+export {DiagramOverlays};

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -13,89 +13,34 @@ import {diagramOverlaysStore} from 'modules/stores/diagramOverlays';
 import {tracking} from 'modules/tracking';
 import {modificationsStore} from 'modules/stores/modifications';
 import {Container, DiagramPanel} from './styled';
-import {
-  CANCELED_BADGE,
-  MODIFICATIONS,
-  ACTIVE_BADGE,
-  INCIDENTS_BADGE,
-  COMPLETED_BADGE,
-  COMPLETED_END_EVENT_BADGE,
-  SUBPROCESS_WITH_INCIDENTS,
-  WAITING_BADGE,
-  AGENT_STATUS_TAG,
-  AGENT_SHINE,
-} from 'modules/bpmn-js/badgePositions';
 import {DiagramShell} from 'modules/components/DiagramShell';
-import {computed} from 'mobx';
-import {type OverlayPosition} from 'bpmn-js/lib/NavigatedViewer';
 import {Diagram} from 'modules/components/Diagram';
-import {ModificationBadgeOverlay} from './ModificationBadgeOverlay';
 import {ModificationInfoBanner} from './ModificationInfoBanner';
 import {ModificationDropdown} from './ModificationDropdown';
-import {AgentStatusOverlay} from './AgentStatusOverlay';
-import {AgentShineOverlay} from './AgentShineOverlay';
-import {StateOverlay} from 'modules/components/StateOverlay';
-import {WaitingStateOverlay} from 'modules/components/WaitingStateOverlay';
-import {useProcessInstanceAgentInstances} from 'modules/queries/agentInstances/useProcessInstanceAgentInstances';
-import {executionCountToggleStore} from 'modules/stores/executionCountToggle';
-import {useElementStatistics} from 'modules/queries/elementInstancesStatistics/useElementStatistics';
 import {useSelectableElements} from 'modules/queries/elementInstancesStatistics/useSelectableElements';
 import {useExecutedElements} from 'modules/queries/elementInstancesStatistics/useExecutedElements';
-import {useModificationsByElement} from 'modules/hooks/modifications';
 import {useModifiableElements} from 'modules/hooks/processInstanceDetailsDiagram';
 import {
   useTotalRunningInstancesByElement,
   useTotalRunningInstancesForElement,
   useTotalRunningInstancesVisibleForElement,
 } from 'modules/queries/elementInstancesStatistics/useTotalRunningInstancesForElement';
-import {
-  finishMovingToken,
-  hasPendingCancelOrMoveModification,
-} from 'modules/utils/modifications';
+import {finishMovingToken} from 'modules/utils/modifications';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {isCompensationAssociation} from 'modules/bpmn-js/utils/isCompensationAssociation';
 import {useProcessSequenceFlows} from 'modules/queries/sequenceFlows/useProcessSequenceFlows';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
-import {useElementInstanceInspection} from 'modules/queries/elementInstanceInspection/useElementInstanceInspection';
-import {getSubprocessOverlayFromIncidentElements} from 'modules/utils/elements';
-import {getWaitStateLabel} from 'modules/utils/waitStates';
-import type {
-  AgentShinePayload,
-  AgentStatusPayload,
-  ElementState,
-  OverlayData,
-} from 'modules/bpmn-js/overlayTypes';
 import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
 import {isRequestError} from 'modules/request';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {useDrillDownNavigation} from 'modules/hooks/useDrilldownNavigation';
 import {getAncestorScopeType} from 'modules/utils/processInstanceDetailsDiagram';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-const OVERLAY_TYPE_STATE = 'elementState';
-const OVERLAY_TYPE_MODIFICATIONS_BADGE = 'modificationsBadge';
-const OVERLAY_TYPE_WAITING_STATE = 'waitingState';
-const OVERLAY_TYPE_AGENT_STATUS = 'agentStatus';
-const OVERLAY_TYPE_AGENT_SHINE = 'agentShine';
-
-const overlayPositions = {
-  active: ACTIVE_BADGE,
-  incidents: INCIDENTS_BADGE,
-  canceled: CANCELED_BADGE,
-  completed: COMPLETED_BADGE,
-  completedEndEvents: COMPLETED_END_EVENT_BADGE,
-  subprocessWithIncidents: SUBPROCESS_WITH_INCIDENTS,
-} as const;
-
-type ModificationBadgePayload = {
-  newTokenCount: number;
-  cancelledTokenCount: number;
-};
+import {useDiagramOverlaysData} from './useDiagramOverlaysData';
+import {DiagramOverlays} from './DiagramOverlays';
 
 const TopPanel: React.FC = observer(() => {
-  const clientConfig = getClientConfig();
   const {
     clearSelection,
     selectedElementId,
@@ -108,7 +53,6 @@ const TopPanel: React.FC = observer(() => {
     sourceElementIdForMoveOperation,
     sourceElementInstanceKeyForMoveOperation,
   } = modificationsStore.state;
-  const {data: statistics} = useElementStatistics();
   const {data: selectableElements} = useSelectableElements();
   const {data: executedElements} = useExecutedElements();
   const {data: totalRunningInstancesByElement} =
@@ -123,13 +67,6 @@ const TopPanel: React.FC = observer(() => {
       sourceElementIdForMoveOperation || undefined,
     );
   const {data: processInstance} = useProcessInstance();
-  const {data: inspectionData} = useElementInstanceInspection({
-    processInstanceKey: processInstanceId,
-    enabled:
-      clientConfig.waitStatesEnabled && processInstance?.state === 'ACTIVE',
-  });
-  const {data: agentInstancesData} = useProcessInstanceAgentInstances();
-  const modificationsByElement = useModificationsByElement();
   const affectedTokenCount = sourceElementInstanceKeyForMoveOperation
     ? 1
     : totalMoveOperationRunningInstances || 1;
@@ -140,7 +77,6 @@ const TopPanel: React.FC = observer(() => {
   const {data: processedSequenceFlowsFromHook} =
     useProcessSequenceFlows(processInstanceId);
   const processDefinitionKey = useProcessDefinitionKeyContext();
-  const {isExecutionCountVisible} = executionCountToggleStore.state;
 
   const {data: selectedElementRunningInstancesCount} =
     useTotalRunningInstancesForElement(selectedElementId ?? undefined);
@@ -155,132 +91,13 @@ const TopPanel: React.FC = observer(() => {
     error: xmlError,
   } = useProcessInstanceXml({processDefinitionKey});
 
+  const overlaysData = useDiagramOverlaysData();
+
   useEffect(() => {
     return () => {
       diagramOverlaysStore.reset();
     };
   }, [processInstanceId]);
-
-  const elementStateOverlays = useMemo(() => {
-    const elementIdsWithIncidents = statistics
-      ?.filter(({elementState}) => elementState === 'incidents')
-      ?.map((element) => element.id);
-
-    const selectableElementsWithIncidents = elementIdsWithIncidents?.map(
-      (elementId) => businessObjects?.[elementId],
-    );
-
-    const subprocessOverlays = getSubprocessOverlayFromIncidentElements(
-      selectableElementsWithIncidents,
-    );
-
-    const allElementStateOverlays = [
-      ...(statistics?.map(({elementState, count, id: elementId}) => ({
-        payload: {elementState: elementState, count},
-        type: OVERLAY_TYPE_STATE,
-        elementId,
-        position: overlayPositions[elementState],
-      })) || []),
-      ...subprocessOverlays,
-    ];
-
-    const notCompletedElementStateOverlays = allElementStateOverlays?.filter(
-      (stateOverlay) => stateOverlay.payload.elementState !== 'completed',
-    );
-
-    return isExecutionCountVisible
-      ? allElementStateOverlays
-      : notCompletedElementStateOverlays;
-  }, [statistics, businessObjects, isExecutionCountVisible]);
-
-  const allWaitingStateOverlays = useMemo(() => {
-    if (!inspectionData?.items?.length) {
-      return [];
-    }
-
-    // Group wait states by elementId (show only 1 label per element)
-    const waitStatesByElement = new Map<string, typeof inspectionData.items>();
-    for (const item of inspectionData.items) {
-      const existing = waitStatesByElement.get(item.elementId) ?? [];
-      existing.push(item);
-      waitStatesByElement.set(item.elementId, existing);
-    }
-
-    const overlays: Array<{
-      elementId: string;
-      type: string;
-      position: typeof WAITING_BADGE;
-      payload: {label: string};
-    }> = [];
-
-    for (const [elementId, waitStates] of waitStatesByElement) {
-      const label = getWaitStateLabel(waitStates);
-      if (label) {
-        overlays.push({
-          elementId,
-          type: OVERLAY_TYPE_WAITING_STATE,
-          position: WAITING_BADGE,
-          payload: {label},
-        });
-      }
-    }
-
-    return overlays;
-  }, [inspectionData]);
-
-  const {agentOverlays, elementsWithAgent} = useMemo(() => {
-    if (!agentInstancesData?.items?.length) {
-      return {agentOverlays: [], elementsWithAgent: new Set<string>()};
-    }
-
-    const elementsWithAgent = new Set<string>();
-
-    const agentOverlays = agentInstancesData.items.flatMap<OverlayData>(
-      (agentInstance) => {
-        // We expect only one active agent instance per element. But there *can* be multiple.
-        // For now, only add an overlay to an element for first matching agent instance.
-        if (elementsWithAgent.has(agentInstance.elementId)) {
-          return [];
-        }
-
-        elementsWithAgent.add(agentInstance.elementId);
-        return [
-          {
-            type: OVERLAY_TYPE_AGENT_STATUS,
-            elementId: agentInstance.elementId,
-            position: AGENT_STATUS_TAG,
-            payload: {
-              status: agentInstance.status,
-              agentInstanceKey: agentInstance.agentInstanceKey,
-            } satisfies AgentStatusPayload,
-          },
-          {
-            type: OVERLAY_TYPE_AGENT_SHINE,
-            elementId: agentInstance.elementId,
-            position: AGENT_SHINE,
-            payload: {
-              agentInstanceKey: agentInstance.agentInstanceKey,
-            } satisfies AgentShinePayload,
-          },
-        ];
-      },
-    );
-    return {agentOverlays, elementsWithAgent};
-  }, [agentInstancesData]);
-
-  const waitingStateOverlays = useMemo(() => {
-    return allWaitingStateOverlays.filter(
-      (overlay) => !elementsWithAgent.has(overlay.elementId),
-    );
-  }, [allWaitingStateOverlays, elementsWithAgent]);
-
-  const selectedElementIds = useMemo(() => {
-    return selectedAnchorElementId
-      ? [selectedAnchorElementId]
-      : selectedElementId
-        ? [selectedElementId]
-        : undefined;
-  }, [selectedElementId, selectedAnchorElementId]);
 
   const highlightedSequenceFlows = useMemo(() => {
     const compensationAssociationIds = Object.values(
@@ -288,7 +105,6 @@ const TopPanel: React.FC = observer(() => {
     )
       .filter(isCompensationAssociation)
       .filter(({targetRef}) => {
-        // check if the target element for the association was executed
         return executedElements?.find(({elementId, completed}) => {
           return targetRef?.id === elementId && completed > 0;
         });
@@ -305,45 +121,13 @@ const TopPanel: React.FC = observer(() => {
     return executedElements?.map(({elementId}) => elementId);
   }, [executedElements]);
 
-  const modificationBadgesPerElement = computed(() =>
-    Object.entries(modificationsByElement).reduce<
-      {
-        elementId: string;
-        type: string;
-        payload: ModificationBadgePayload;
-        position: OverlayPosition;
-      }[]
-    >((badges, [elementId, tokens]) => {
-      return [
-        ...badges,
-        {
-          elementId,
-          type: OVERLAY_TYPE_MODIFICATIONS_BADGE,
-          position: MODIFICATIONS,
-          payload: {
-            newTokenCount: tokens.newTokens,
-            cancelledTokenCount: tokens.visibleCancelledTokens,
-          },
-        },
-      ];
-    }, []),
-  );
-
-  const stateOverlays = diagramOverlaysStore.state.overlays.filter(
-    ({type}) => type === OVERLAY_TYPE_STATE,
-  );
-  const modificationBadgeOverlays = diagramOverlaysStore.state.overlays.filter(
-    ({type}) => type === OVERLAY_TYPE_MODIFICATIONS_BADGE,
-  );
-  const waitingOverlays = diagramOverlaysStore.state.overlays.filter(
-    ({type}) => type === OVERLAY_TYPE_WAITING_STATE,
-  );
-  const agentStatusOverlays = diagramOverlaysStore.state.overlays.filter(
-    ({type}) => type === OVERLAY_TYPE_AGENT_STATUS,
-  );
-  const agentShineOverlays = diagramOverlaysStore.state.overlays.filter(
-    ({type}) => type === OVERLAY_TYPE_AGENT_SHINE,
-  );
+  const selectedElementIds = useMemo(() => {
+    return selectedAnchorElementId
+      ? [selectedAnchorElementId]
+      : selectedElementId
+        ? [selectedElementId]
+        : undefined;
+  }, [selectedElementId, selectedAnchorElementId]);
 
   const modifiableElements = useModifiableElements();
 
@@ -485,18 +269,7 @@ const TopPanel: React.FC = observer(() => {
                     }
                   }
                 }}
-                overlaysData={
-                  isModificationModeEnabled
-                    ? [
-                        ...(elementStateOverlays ?? []),
-                        ...modificationBadgesPerElement.get(),
-                      ]
-                    : [
-                        ...(elementStateOverlays ?? []),
-                        ...agentOverlays,
-                        ...waitingStateOverlays,
-                      ]
-                }
+                overlaysData={overlaysData}
                 selectedElementOverlay={
                   isModificationModeEnabled && <ModificationDropdown />
                 }
@@ -519,74 +292,7 @@ const TopPanel: React.FC = observer(() => {
                   }
                 }}
               >
-                {stateOverlays.map((overlay) => {
-                  const payload = overlay.payload as {
-                    elementState: ElementState | 'completedEndEvents';
-                    count: number;
-                  };
-
-                  return (
-                    <StateOverlay
-                      key={`${overlay.elementId}-${payload.elementState}`}
-                      state={payload.elementState}
-                      count={payload.count}
-                      container={overlay.container}
-                      isFaded={hasPendingCancelOrMoveModification({
-                        elementId: overlay.elementId,
-                        elementInstanceKey: undefined,
-                        modificationsByElement: modificationsByElement,
-                      })}
-                      title={
-                        payload.elementState === 'completed'
-                          ? 'Execution Count'
-                          : undefined
-                      }
-                    />
-                  );
-                })}
-                {modificationBadgeOverlays?.map((overlay) => {
-                  const payload = overlay.payload as ModificationBadgePayload;
-
-                  return (
-                    <ModificationBadgeOverlay
-                      key={overlay.elementId}
-                      container={overlay.container}
-                      newTokenCount={payload.newTokenCount}
-                      cancelledTokenCount={payload.cancelledTokenCount}
-                    />
-                  );
-                })}
-                {waitingOverlays?.map((overlay) => {
-                  const payload = overlay.payload as {label: string};
-
-                  return (
-                    <WaitingStateOverlay
-                      key={`waiting-${overlay.elementId}`}
-                      container={overlay.container}
-                      label={payload.label}
-                    />
-                  );
-                })}
-                {agentStatusOverlays.map((overlay) => {
-                  const payload = overlay.payload as AgentStatusPayload;
-                  return (
-                    <AgentStatusOverlay
-                      key={`${payload.agentInstanceKey}-status`}
-                      container={overlay.container}
-                      status={payload.status}
-                    />
-                  );
-                })}
-                {agentShineOverlays.map((overlay) => {
-                  const payload = overlay.payload as AgentShinePayload;
-                  return (
-                    <AgentShineOverlay
-                      key={`${payload.agentInstanceKey}-shine`}
-                      container={overlay.container}
-                      elementId={overlay.elementId}
-                    />
-                  );
-                })}
+                <DiagramOverlays />
               </Diagram>
             )}
         </DiagramShell>

--- a/operate/client/src/App/ProcessInstance/TopPanel/useDiagramOverlaysData.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/useDiagramOverlaysData.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMemo} from 'react';
+import {computed} from 'mobx';
+import {type OverlayPosition} from 'bpmn-js/lib/NavigatedViewer';
+import {
+  CANCELED_BADGE,
+  MODIFICATIONS,
+  ACTIVE_BADGE,
+  INCIDENTS_BADGE,
+  COMPLETED_BADGE,
+  COMPLETED_END_EVENT_BADGE,
+  SUBPROCESS_WITH_INCIDENTS,
+  WAITING_BADGE,
+  AGENT_STATUS_TAG,
+  AGENT_SHINE,
+} from 'modules/bpmn-js/badgePositions';
+import {modificationsStore} from 'modules/stores/modifications';
+import {executionCountToggleStore} from 'modules/stores/executionCountToggle';
+import {useProcessInstancePageParams} from '../useProcessInstancePageParams';
+import {useElementStatistics} from 'modules/queries/elementInstancesStatistics/useElementStatistics';
+import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
+import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
+import {useElementInstanceInspection} from 'modules/queries/elementInstanceInspection/useElementInstanceInspection';
+import {useProcessInstanceAgentInstances} from 'modules/queries/agentInstances/useProcessInstanceAgentInstances';
+import {useModificationsByElement} from 'modules/hooks/modifications';
+import {getSubprocessOverlayFromIncidentElements} from 'modules/utils/elements';
+import {getWaitStateLabel} from 'modules/utils/waitStates';
+import {
+  OVERLAY_TYPE_STATE,
+  OVERLAY_TYPE_MODIFICATIONS_BADGE,
+  OVERLAY_TYPE_WAITING_STATE,
+  OVERLAY_TYPE_AGENT_STATUS,
+  OVERLAY_TYPE_AGENT_SHINE,
+  type AgentShinePayload,
+  type AgentStatusPayload,
+  type ModificationBadgePayload,
+  type OverlayData,
+} from 'modules/bpmn-js/overlayTypes';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+const overlayPositions = {
+  active: ACTIVE_BADGE,
+  incidents: INCIDENTS_BADGE,
+  canceled: CANCELED_BADGE,
+  completed: COMPLETED_BADGE,
+  completedEndEvents: COMPLETED_END_EVENT_BADGE,
+  subprocessWithIncidents: SUBPROCESS_WITH_INCIDENTS,
+} as const;
+
+function useDiagramOverlaysData(): OverlayData[] {
+  const clientConfig = getClientConfig();
+  const {processInstanceId = ''} = useProcessInstancePageParams();
+  const {data: statistics} = useElementStatistics();
+  const {data: businessObjects} = useBusinessObjects();
+  const {isExecutionCountVisible} = executionCountToggleStore.state;
+  const {data: processInstance} = useProcessInstance();
+  const {data: inspectionData} = useElementInstanceInspection({
+    processInstanceKey: processInstanceId,
+    enabled:
+      clientConfig.waitStatesEnabled && processInstance?.state === 'ACTIVE',
+  });
+  const {data: agentInstancesData} = useProcessInstanceAgentInstances();
+  const modificationsByElement = useModificationsByElement();
+  const {isModificationModeEnabled} = modificationsStore;
+
+  const elementStateOverlays = useMemo(() => {
+    const elementIdsWithIncidents = statistics
+      ?.filter(({elementState}) => elementState === 'incidents')
+      ?.map((element) => element.id);
+
+    const selectableElementsWithIncidents = elementIdsWithIncidents?.map(
+      (elementId) => businessObjects?.[elementId],
+    );
+
+    const subprocessOverlays = getSubprocessOverlayFromIncidentElements(
+      selectableElementsWithIncidents,
+    );
+
+    const allElementStateOverlays = [
+      ...(statistics?.map(({elementState, count, id: elementId}) => ({
+        payload: {elementState: elementState, count},
+        type: OVERLAY_TYPE_STATE,
+        elementId,
+        position: overlayPositions[elementState],
+      })) || []),
+      ...subprocessOverlays,
+    ];
+
+    const notCompletedElementStateOverlays = allElementStateOverlays?.filter(
+      (stateOverlay) => stateOverlay.payload.elementState !== 'completed',
+    );
+
+    return isExecutionCountVisible
+      ? allElementStateOverlays
+      : notCompletedElementStateOverlays;
+  }, [statistics, businessObjects, isExecutionCountVisible]);
+
+  const allWaitingStateOverlays = useMemo(() => {
+    if (!inspectionData?.items?.length) {
+      return [];
+    }
+
+    const waitStatesByElement = new Map<string, typeof inspectionData.items>();
+    for (const item of inspectionData.items) {
+      const existing = waitStatesByElement.get(item.elementId) ?? [];
+      existing.push(item);
+      waitStatesByElement.set(item.elementId, existing);
+    }
+
+    const overlays: Array<{
+      elementId: string;
+      type: string;
+      position: typeof WAITING_BADGE;
+      payload: {label: string};
+    }> = [];
+
+    for (const [elementId, waitStates] of waitStatesByElement) {
+      const label = getWaitStateLabel(waitStates);
+      if (label) {
+        overlays.push({
+          elementId,
+          type: OVERLAY_TYPE_WAITING_STATE,
+          position: WAITING_BADGE,
+          payload: {label},
+        });
+      }
+    }
+
+    return overlays;
+  }, [inspectionData]);
+
+  const {agentOverlays, elementsWithAgent} = useMemo(() => {
+    if (!agentInstancesData?.items?.length) {
+      return {agentOverlays: [], elementsWithAgent: new Set<string>()};
+    }
+
+    const elementsWithAgent = new Set<string>();
+
+    const agentOverlays = agentInstancesData.items.flatMap<OverlayData>(
+      (agentInstance) => {
+        // We expect only one active agent instance per element. But there *can* be multiple.
+        // For now, only add an overlay to an element for first matching agent instance.
+        if (elementsWithAgent.has(agentInstance.elementId)) {
+          return [];
+        }
+
+        elementsWithAgent.add(agentInstance.elementId);
+        return [
+          {
+            type: OVERLAY_TYPE_AGENT_STATUS,
+            elementId: agentInstance.elementId,
+            position: AGENT_STATUS_TAG,
+            payload: {
+              status: agentInstance.status,
+              agentInstanceKey: agentInstance.agentInstanceKey,
+            } satisfies AgentStatusPayload,
+          },
+          {
+            type: OVERLAY_TYPE_AGENT_SHINE,
+            elementId: agentInstance.elementId,
+            position: AGENT_SHINE,
+            payload: {
+              agentInstanceKey: agentInstance.agentInstanceKey,
+            } satisfies AgentShinePayload,
+          },
+        ];
+      },
+    );
+    return {agentOverlays, elementsWithAgent};
+  }, [agentInstancesData]);
+
+  const waitingStateOverlays = useMemo(() => {
+    return allWaitingStateOverlays.filter(
+      (overlay) => !elementsWithAgent.has(overlay.elementId),
+    );
+  }, [allWaitingStateOverlays, elementsWithAgent]);
+
+  const modificationBadgesPerElement = computed(() =>
+    Object.entries(modificationsByElement).reduce<
+      {
+        elementId: string;
+        type: string;
+        payload: ModificationBadgePayload;
+        position: OverlayPosition;
+      }[]
+    >((badges, [elementId, tokens]) => {
+      return [
+        ...badges,
+        {
+          elementId,
+          type: OVERLAY_TYPE_MODIFICATIONS_BADGE,
+          position: MODIFICATIONS,
+          payload: {
+            newTokenCount: tokens.newTokens,
+            cancelledTokenCount: tokens.visibleCancelledTokens,
+          },
+        },
+      ];
+    }, []),
+  );
+
+  if (isModificationModeEnabled) {
+    return [
+      ...(elementStateOverlays ?? []),
+      ...modificationBadgesPerElement.get(),
+    ];
+  }
+
+  return [
+    ...(elementStateOverlays ?? []),
+    ...agentOverlays,
+    ...waitingStateOverlays,
+  ];
+}
+
+export {useDiagramOverlaysData};

--- a/operate/client/src/modules/bpmn-js/overlayTypes.ts
+++ b/operate/client/src/modules/bpmn-js/overlayTypes.ts
@@ -28,8 +28,8 @@ type StatisticsPayload = {
 };
 
 type ModificationBadgePayload = {
-  newTokenCount?: number;
-  cancelledTokenCount?: number;
+  newTokenCount: number;
+  cancelledTokenCount: number;
 };
 
 type WaitingStatePayload = {
@@ -44,6 +44,12 @@ type AgentStatusPayload = {
 type AgentShinePayload = {
   agentInstanceKey: string;
 };
+
+const OVERLAY_TYPE_STATE = 'elementState';
+const OVERLAY_TYPE_MODIFICATIONS_BADGE = 'modificationsBadge';
+const OVERLAY_TYPE_WAITING_STATE = 'waitingState';
+const OVERLAY_TYPE_AGENT_STATUS = 'agentStatus';
+const OVERLAY_TYPE_AGENT_SHINE = 'agentShine';
 
 const isStatisticsPayload = (
   payload: unknown,
@@ -95,6 +101,11 @@ const isAgentShinePayload = (
 };
 
 export {
+  OVERLAY_TYPE_STATE,
+  OVERLAY_TYPE_MODIFICATIONS_BADGE,
+  OVERLAY_TYPE_WAITING_STATE,
+  OVERLAY_TYPE_AGENT_STATUS,
+  OVERLAY_TYPE_AGENT_SHINE,
   isStatisticsPayload,
   isModificationBadgePayload,
   isWaitingStatePayload,
@@ -104,6 +115,7 @@ export {
 export type {
   ElementState,
   OverlayData,
+  ModificationBadgePayload,
   WaitingStatePayload,
   AgentStatusPayload,
   AgentShinePayload,


### PR DESCRIPTION
## Description

This PR addresses the review comment https://github.com/camunda/camunda/pull/55012#discussion_r3396907083. The logic is split form the `TopPanel` component into a separate hook for aggregating the overlays and a component for rendering.

Only change I made on top of Claude's refactoring is using the `overlayTypes.ts` predicates instead of type-casting in `DiagramOverlays`. The predicates where mostly unused before.

I did some brief testing and everything still seems to work.