### PR TITLE
feat: per-physical-tenant provider selection via providers.assigned

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -12,6 +12,7 @@ import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
 import io.camunda.security.api.model.config.oidc.OidcProvidersConfiguration;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -139,7 +140,17 @@ public final class PhysicalTenantAuthConfigurations {
     if (assigned == null) {
       return;
     }
-    final Set<String> assignedIds = Set.copyOf(assigned);
+    // Defensive: tolerate null/blank list elements (some yaml list shapes bind them) so this never
+    // throws an opaque NPE — it can run before the configuration-layer validation (e.g. from the
+    // cluster-unification BeanPostProcessor). Blank ids match no provider, so dropping them is
+    // safe;
+    // the configuration layer still rejects them at startup with a clear message.
+    final Set<String> assignedIds = new LinkedHashSet<>();
+    for (final String id : assigned) {
+      if (id != null && !id.isBlank()) {
+        assignedIds.add(id);
+      }
+    }
 
     // Default slot: drop unless explicitly assigned by its reserved id. setOidc never stores null
     // (it coerces to an empty instance), so a fresh OidcConfiguration is the canonical "no slot".

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -70,8 +70,8 @@ public final class PhysicalTenantAuthConfigurations {
    * Reserved {@code providers.assigned} id for the unnamed default slot ({@code
    * camunda.security.authentication.oidc.*}) — it has no map key of its own, so it is referenced by
    * the leaf name of the property that defines it. A named provider literally called {@code oidc}
-   * ({@code providers.oidc.oidc}) would collide; that pathological name is documented as
-   * unsupported rather than guarded against.
+   * ({@code providers.oidc.oidc}) would collide; that pathological name is rejected at startup by
+   * the configuration-layer validation ({@code PhysicalTenantAssignedProvidersValidation}).
    */
   private static final String DEFAULT_SLOT_ASSIGNED_ID = "oidc";
 

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -70,13 +70,14 @@ public final class PhysicalTenantAuthConfigurations {
       "camunda.physical-tenants.%s.security.authentication";
 
   /**
-   * Reserved {@code providers.assigned} id for the unnamed default slot ({@code
-   * camunda.security.authentication.oidc.*}) — it has no map key of its own, so it is referenced by
-   * the leaf name of the property that defines it. A named provider literally called {@code oidc}
-   * ({@code providers.oidc.oidc}) would collide; that pathological name is rejected at startup by
-   * the configuration-layer validation ({@code PhysicalTenantAssignedProvidersValidation}).
+   * Reserved {@code providers.assigned} id for the unnamed default slot — CSL's {@link
+   * OidcConfiguration#DEFAULT_REGISTRATION_ID} ({@code "oidc"}), the registration id of the default
+   * slot ({@code camunda.security.authentication.oidc.*}). Sourcing it from the CSL constant keeps
+   * it in lockstep with the configuration-layer validation, which references the same constant — so
+   * the two layers cannot drift. A named provider literally called this id collides and is rejected
+   * at startup by validation.
    */
-  private static final String DEFAULT_SLOT_ASSIGNED_ID = "oidc";
+  private static final String DEFAULT_SLOT_ASSIGNED_ID = OidcConfiguration.DEFAULT_REGISTRATION_ID;
 
   private PhysicalTenantAuthConfigurations() {}
 
@@ -137,14 +138,17 @@ public final class PhysicalTenantAuthConfigurations {
       final Binder binder, final String ptPrefix, final AuthenticationConfiguration config) {
     final List<String> assigned =
         binder.bind(ptPrefix + ".providers.assigned", Bindable.listOf(String.class)).orElse(null);
-    if (assigned == null) {
+    if (assigned == null || assigned.isEmpty()) {
+      // No selection — or an empty list — keeps the full union here. The configuration layer
+      // rejects
+      // an empty `assigned` at startup with a clear message; returning early avoids stripping every
+      // provider first (this can run before that validation, via the cluster-unification BPP).
       return;
     }
     // Defensive: tolerate null/blank list elements (some yaml list shapes bind them) so this never
-    // throws an opaque NPE — it can run before the configuration-layer validation (e.g. from the
-    // cluster-unification BeanPostProcessor). Blank ids match no provider, so dropping them is
-    // safe;
-    // the configuration layer still rejects them at startup with a clear message.
+    // throws an opaque NPE. Blank ids match no provider, so dropping them is safe; the
+    // configuration
+    // layer still rejects them at startup with a clear message.
     final Set<String> assignedIds = new LinkedHashSet<>();
     for (final String id : assigned) {
       if (id != null && !id.isBlank()) {

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.authentication.pt;
 
-import static io.camunda.spring.utils.PhysicalTenantContext.DEFAULT_PHYSICAL_TENANT_ID;
-
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
@@ -27,10 +25,14 @@ import org.springframework.core.env.Environment;
  * cluster configuration and the per-tenant overlay.
  *
  * <p>The merge first builds the union of <em>all</em> cluster providers — ROOT providers ∪ the PT's
- * own OVERLAY providers, each root provider merged with the PT overlay — and then, for a
- * non-default tenant that declares one, <em>narrows</em> that union to its {@code
- * providers.assigned} selection (issue #54730, see {@link #narrowToAssigned}). The default tenant
- * always keeps the full union.
+ * own OVERLAY providers, each root provider merged with the PT overlay — and then, for any tenant
+ * that declares one (the {@code default} tenant included), <em>narrows</em> that union to its
+ * {@code providers.assigned} selection (issue #54730, see {@link #narrowToAssigned}). A tenant that
+ * declares no {@code assigned} keeps the full union.
+ *
+ * <p>The {@code default} tenant is treated uniformly here: its resolved configuration drives both
+ * the {@code /physical-tenants/default} alias and — via {@code PhysicalTenantSecurityConfiguration}
+ * — the unprefixed {@code /v2} cluster chain, so the two surfaces stay identical.
  *
  * <p>The merge is delegated to Spring's {@link Binder} rather than hand-written per field. The root
  * config is bound into a fresh instance, then the per-tenant overlay is bound <em>into the same
@@ -105,14 +107,15 @@ public final class PhysicalTenantAuthConfigurations {
     // method is cluster-wide, not per-tenant.
     config.setMethod(rootMethod != null ? rootMethod : AuthenticationMethod.BASIC);
     mergeSharedProviders(binder, ptPrefix, rootProviders, config);
-    narrowToAssigned(binder, ptPrefix, tenantId, config);
+    narrowToAssigned(binder, ptPrefix, config);
     return config;
   }
 
   /**
-   * Narrows the merged union to the providers a non-default physical tenant has explicitly SELECTED
-   * via {@code ...providers.assigned} (issue #54730). Each list entry is a provider id drawn from
-   * the union {@code {oidc} ∪ providers.oidc.<name>}:
+   * Narrows the merged union to the providers a physical tenant has explicitly SELECTED via {@code
+   * ...providers.assigned} (issue #54730) — applied uniformly to every tenant, the {@code default}
+   * tenant included. Each list entry is a provider id drawn from the union {@code {oidc} ∪
+   * providers.oidc.<name>}:
    *
    * <ul>
    *   <li>the reserved id {@value #DEFAULT_SLOT_ASSIGNED_ID} keeps the unnamed default slot ({@code
@@ -123,26 +126,14 @@ public final class PhysicalTenantAuthConfigurations {
    *       listed are removed.
    * </ul>
    *
-   * <p>The narrowing is intentionally skipped in two cases, both of which yield the full union:
-   *
-   * <ul>
-   *   <li>the implicit {@code default} tenant (and its {@code /physical-tenants/default} alias) —
-   *       it always carries the full set (AC-1);
-   *   <li>a tenant with no {@code assigned} list bound — selection is optional <em>here</em>.
-   * </ul>
-   *
-   * <p>Enforcing that a non-default tenant MUST declare a valid {@code assigned} list (non-empty,
-   * every id known) is a fail-fast <em>configuration-layer</em> concern (#54730), kept out of this
-   * merge so the merge only ever <em>applies</em> an already-valid selection.
+   * <p>A tenant with no {@code assigned} list bound keeps the full union — selection is optional
+   * <em>here</em>. Enforcing that a non-default tenant MUST declare a valid {@code assigned} list
+   * (non-empty, every id known), that the {@code default} tenant <em>may</em> declare one, and that
+   * a declared list is valid, is a fail-fast <em>configuration-layer</em> concern (#54730), kept
+   * out of this merge so the merge only ever <em>applies</em> an already-valid selection.
    */
   private static void narrowToAssigned(
-      final Binder binder,
-      final String ptPrefix,
-      final String tenantId,
-      final AuthenticationConfiguration config) {
-    if (DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)) {
-      return;
-    }
+      final Binder binder, final String ptPrefix, final AuthenticationConfiguration config) {
     final List<String> assigned =
         binder.bind(ptPrefix + ".providers.assigned", Bindable.listOf(String.class)).orElse(null);
     if (assigned == null) {

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -7,12 +7,16 @@
  */
 package io.camunda.authentication.pt;
 
+import static io.camunda.spring.utils.PhysicalTenantContext.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
 import io.camunda.security.api.model.config.oidc.OidcProvidersConfiguration;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.boot.context.properties.bind.BindResult;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
@@ -22,9 +26,11 @@ import org.springframework.core.env.Environment;
  * Derives a merged {@link AuthenticationConfiguration} for a specific physical tenant from the root
  * cluster configuration and the per-tenant overlay.
  *
- * <p>The returned configuration contains <em>all</em> cluster providers — the union of ROOT
- * providers and the PT's own OVERLAY providers — each root provider merged with the PT overlay.
- * Per-PT provider SELECTION ({@code assigned}) is intentionally deferred to issue #54730.
+ * <p>The merge first builds the union of <em>all</em> cluster providers — ROOT providers ∪ the PT's
+ * own OVERLAY providers, each root provider merged with the PT overlay — and then, for a
+ * non-default tenant that declares one, <em>narrows</em> that union to its {@code
+ * providers.assigned} selection (issue #54730, see {@link #narrowToAssigned}). The default tenant
+ * always keeps the full union.
  *
  * <p>The merge is delegated to Spring's {@link Binder} rather than hand-written per field. The root
  * config is bound into a fresh instance, then the per-tenant overlay is bound <em>into the same
@@ -60,6 +66,15 @@ public final class PhysicalTenantAuthConfigurations {
   private static final String PT_PREFIX_TEMPLATE =
       "camunda.physical-tenants.%s.security.authentication";
 
+  /**
+   * Reserved {@code providers.assigned} id for the unnamed default slot ({@code
+   * camunda.security.authentication.oidc.*}) — it has no map key of its own, so it is referenced by
+   * the leaf name of the property that defines it. A named provider literally called {@code oidc}
+   * ({@code providers.oidc.oidc}) would collide; that pathological name is documented as
+   * unsupported rather than guarded against.
+   */
+  private static final String DEFAULT_SLOT_ASSIGNED_ID = "oidc";
+
   private PhysicalTenantAuthConfigurations() {}
 
   /**
@@ -90,7 +105,62 @@ public final class PhysicalTenantAuthConfigurations {
     // method is cluster-wide, not per-tenant.
     config.setMethod(rootMethod != null ? rootMethod : AuthenticationMethod.BASIC);
     mergeSharedProviders(binder, ptPrefix, rootProviders, config);
+    narrowToAssigned(binder, ptPrefix, tenantId, config);
     return config;
+  }
+
+  /**
+   * Narrows the merged union to the providers a non-default physical tenant has explicitly SELECTED
+   * via {@code ...providers.assigned} (issue #54730). Each list entry is a provider id drawn from
+   * the union {@code {oidc} ∪ providers.oidc.<name>}:
+   *
+   * <ul>
+   *   <li>the reserved id {@value #DEFAULT_SLOT_ASSIGNED_ID} keeps the unnamed default slot ({@code
+   *       authentication.oidc.*}); when it is absent from {@code assigned} the slot is reset to a
+   *       content-less instance, which CSL's {@code flatten} ignores (so the inherited cluster
+   *       provider is not turned into a chain for this tenant);
+   *   <li>every other entry keeps the like-named {@code providers.oidc.<name>}; named providers not
+   *       listed are removed.
+   * </ul>
+   *
+   * <p>The narrowing is intentionally skipped in two cases, both of which yield the full union:
+   *
+   * <ul>
+   *   <li>the implicit {@code default} tenant (and its {@code /physical-tenants/default} alias) —
+   *       it always carries the full set (AC-1);
+   *   <li>a tenant with no {@code assigned} list bound — selection is optional <em>here</em>.
+   * </ul>
+   *
+   * <p>Enforcing that a non-default tenant MUST declare a valid {@code assigned} list (non-empty,
+   * every id known) is a fail-fast <em>configuration-layer</em> concern (#54730), kept out of this
+   * merge so the merge only ever <em>applies</em> an already-valid selection.
+   */
+  private static void narrowToAssigned(
+      final Binder binder,
+      final String ptPrefix,
+      final String tenantId,
+      final AuthenticationConfiguration config) {
+    if (DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)) {
+      return;
+    }
+    final List<String> assigned =
+        binder.bind(ptPrefix + ".providers.assigned", Bindable.listOf(String.class)).orElse(null);
+    if (assigned == null) {
+      return;
+    }
+    final Set<String> assignedIds = Set.copyOf(assigned);
+
+    // Default slot: drop unless explicitly assigned by its reserved id. setOidc never stores null
+    // (it coerces to an empty instance), so a fresh OidcConfiguration is the canonical "no slot".
+    if (!assignedIds.contains(DEFAULT_SLOT_ASSIGNED_ID)) {
+      config.setOidc(new OidcConfiguration());
+    }
+
+    // Named providers: keep only the assigned ids.
+    final Map<String, OidcConfiguration> named = namedProviders(config);
+    if (named != null) {
+      named.keySet().removeIf(id -> !assignedIds.contains(id));
+    }
   }
 
   /**

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantScopeProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantScopeProvider.java
@@ -38,15 +38,19 @@ import org.springframework.core.env.Environment;
  *       apiPaths} to build a per-tenant API {@link
  *       org.springframework.security.web.SecurityFilterChain}.
  *   <li>A merged {@link io.camunda.security.api.model.config.AuthenticationConfiguration}
- *       containing all cluster providers (root ∪ PT overlay), each merged with PT-side overrides;
- *       per-PT provider selection is deferred to #54730.
+ *       containing the cluster providers (root ∪ PT overlay) merged with PT-side overrides, then
+ *       narrowed to the tenant's {@code providers.assigned} selection (#54730) when it declares
+ *       one.
  * </ul>
  *
  * <p><b>Default alias:</b> when at least one physical tenant is configured, this provider also
  * emits a descriptor for the implicit {@code default} tenant at {@code /physical-tenants/default},
- * built from the root configuration. The default (root) tenant is therefore addressable both via
- * the unprefixed cluster paths ({@code /v2/...}) and via {@code /physical-tenants/default/v2/...}
- * as an alias. This mirrors {@code PhysicalTenantResolver}'s synthesis of a default entry.
+ * built from {@code forPhysicalTenant("default")} (root + any {@code physical-tenants.default}
+ * overlay, narrowed by its {@code assigned}). The default (root) tenant is therefore addressable
+ * both via the unprefixed cluster paths ({@code /v2/...}) and via {@code
+ * /physical-tenants/default/v2/...} as an alias — and {@code PhysicalTenantSecurityConfiguration}
+ * feeds that same resolved config to CSL's cluster chain, so the two surfaces are identical. This
+ * mirrors {@code PhysicalTenantResolver}'s synthesis of a default entry.
  *
  * <p><b>Empty-list behaviour:</b> if no {@code camunda.physical-tenants.*} entries are present in
  * the {@link Environment}, this provider returns an empty list (the default alias is <em>not</em>
@@ -81,8 +85,19 @@ public final class PhysicalTenantScopeProvider implements CamundaSecurityScopePr
     return descriptors;
   }
 
+  /**
+   * Whether any physical tenant is configured (any key under {@code
+   * camunda.physical-tenants.<id>.*} with a valid id). When {@code true}, PT-scoped chains and the
+   * {@code /physical-tenants/default} alias are active — and the cluster {@code /v2} chain must be
+   * unified with the default tenant's resolved config (see {@code
+   * PhysicalTenantSecurityConfiguration}).
+   */
+  public static boolean hasConfiguredPhysicalTenants(final Environment environment) {
+    return !discoverExplicitTenantIds(environment).isEmpty();
+  }
+
   private List<ScopedSecurityDescriptor> buildDescriptors() {
-    final Set<String> tenantIds = discoverExplicitTenantIds();
+    final Set<String> tenantIds = discoverExplicitTenantIds(environment);
     if (tenantIds.isEmpty()) {
       LOG.debug("No camunda.physical-tenants.* entries found; PT-scoped security chains disabled.");
       return List.of();
@@ -154,7 +169,7 @@ public final class PhysicalTenantScopeProvider implements CamundaSecurityScopePr
    * constraint enforced by {@code PhysicalTenantResolver} to keep yaml and env-var forms addressing
    * the same tenant.
    */
-  private Set<String> discoverExplicitTenantIds() {
+  private static Set<String> discoverExplicitTenantIds(final Environment environment) {
     final Set<String> tenants = new LinkedHashSet<>();
     for (final ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
       if (source instanceof final IterableConfigurationPropertySource iter) {

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantSecurityConfiguration.java
@@ -7,7 +7,11 @@
  */
 package io.camunda.authentication.pt;
 
+import static io.camunda.spring.utils.PhysicalTenantContext.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.security.api.context.CamundaSecurityScopeProvider;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -41,5 +45,41 @@ public class PhysicalTenantSecurityConfiguration {
   public static CamundaSecurityScopeProvider physicalTenantScopeProvider(
       final Environment environment) {
     return new PhysicalTenantScopeProvider(environment);
+  }
+
+  /**
+   * Unifies the unprefixed cluster ({@code /v2}) security chain with the {@code default} physical
+   * tenant, so the two surfaces for the default tenant are identical.
+   *
+   * <p>CSL builds the cluster chain from {@link
+   * CamundaSecurityLibraryProperties#getAuthentication()} (raw root {@code
+   * camunda.security.authentication.*}), while {@link PhysicalTenantScopeProvider} builds the
+   * {@code /physical-tenants/default} alias from {@link
+   * PhysicalTenantAuthConfigurations#forPhysicalTenant} (root + the {@code
+   * camunda.physical-tenants.default.*} overlay, narrowed to {@code providers.assigned}). When any
+   * physical tenant is configured, this {@link BeanPostProcessor} replaces the cluster
+   * authentication with the default tenant's resolved config <em>before</em> CSL builds its chains
+   * — so {@code /v2} and {@code /physical-tenants/default} carry the same providers, and {@code
+   * camunda.physical-tenants.default.providers.assigned} limits the cluster surface too. CSL stays
+   * physical-tenant-agnostic: this only mutates OC-owned config it already consumes.
+   *
+   * <p>Declared {@code static} for the same reason as {@link #physicalTenantScopeProvider} — a
+   * {@code BeanPostProcessor} must be instantiated before the beans it post-processes.
+   */
+  @Bean
+  public static BeanPostProcessor physicalTenantClusterAuthUnification(
+      final Environment environment) {
+    return new BeanPostProcessor() {
+      @Override
+      public Object postProcessAfterInitialization(final Object bean, final String beanName) {
+        if (bean instanceof final CamundaSecurityLibraryProperties props
+            && PhysicalTenantScopeProvider.hasConfiguredPhysicalTenants(environment)) {
+          props.setAuthentication(
+              PhysicalTenantAuthConfigurations.forPhysicalTenant(
+                  DEFAULT_PHYSICAL_TENANT_ID, environment));
+        }
+        return bean;
+      }
+    };
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantSecurityConfiguration.java
@@ -60,8 +60,9 @@ public class PhysicalTenantSecurityConfiguration {
    * physical tenant is configured, this {@link BeanPostProcessor} replaces the cluster
    * authentication with the default tenant's resolved config <em>before</em> CSL builds its chains
    * — so {@code /v2} and {@code /physical-tenants/default} carry the same providers, and {@code
-   * camunda.physical-tenants.default.providers.assigned} limits the cluster surface too. CSL stays
-   * physical-tenant-agnostic: this only mutates OC-owned config it already consumes.
+   * camunda.physical-tenants.default.security.authentication.providers.assigned} limits the cluster
+   * surface too. CSL stays physical-tenant-agnostic: this only mutates OC-owned config it already
+   * consumes.
    *
    * <p>Declared {@code static} for the same reason as {@link #physicalTenantScopeProvider} — a
    * {@code BeanPostProcessor} must be instantiated before the beans it post-processes.

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
@@ -62,8 +62,8 @@ import org.springframework.security.web.SecurityFilterChain;
 /**
  * Integration test for per-physical-tenant API security-chain isolation.
  *
- * <p>Proves four scenarios using two physical tenants (PT-A and PT-B), each backed by a real in-JVM
- * JWKS server, with no Testcontainers, no Elasticsearch, and no Keycloak:
+ * <p>Proves the following scenarios using two physical tenants (PT-A and PT-B), each backed by a
+ * real in-JVM JWKS server, with no Testcontainers, no Elasticsearch, and no Keycloak:
  *
  * <ol>
  *   <li><b>Own-chain accept</b>: a valid token from PT-A's issuer on PT-A's path → authenticated
@@ -72,6 +72,10 @@ import org.springframework.security.web.SecurityFilterChain;
  *   <li><b>Shared-IdP audience reject</b>: two PTs sharing the same issuer but declaring different
  *       audiences — a token with PT-A's audience on PT-B's path → 401.
  *   <li><b>Unauthenticated</b>: no token on either PT path → 401.
+ *   <li><b>Unknown tenant</b>: a token on an unconfigured tenant's path → 404 (CSL catch-all).
+ *   <li><b>{@code providers.assigned} narrowing</b> (#54730): a token from a cluster provider that
+ *       is not assigned to PT-A is rejected on PT-A (401) yet accepted on the tenant it is assigned
+ *       to — isolating the selection from plain cross-issuer rejection.
  * </ol>
  *
  * <p>The test uses the OC {@link PhysicalTenantScopeProvider} to produce {@link
@@ -277,6 +281,52 @@ class PhysicalTenantApiChainIsolationIT {
             });
   }
 
+  // -------------------------------------------------------------------------
+  // Scenario 5: provider-selection (providers.assigned) narrowing (#54730)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Both {@code pta} and {@code ptb} are declared as CLUSTER providers; PT-A is {@code assigned:
+   * [pta]}, so narrowing keeps only {@code pta}. A {@code ptb}-issuer token — though a valid
+   * cluster provider — is therefore rejected (401) on PT-A, while the <em>same</em> token is
+   * accepted on PT-B (assigned {@code [ptb]}). This isolates the {@code assigned} narrowing
+   * specifically, distinct from the cross-issuer case (scenario 2) where the issuer is not a
+   * cluster provider at all. Both tenants declare {@code assigned}: a non-default tenant cannot
+   * start without it (startup validation rejects that), so the un-narrowed union is never an
+   * operative runtime state.
+   */
+  @Test
+  void assignedNarrowingRejectsUnassignedClusterProviderTokenOnPtAPath() {
+    buildRunner(twoDistinctIssuersProperties())
+        .run(
+            ctx -> {
+              final var chains = buildChainsFromProvider(ctx, assignedNarrowingEnv());
+              final var proxy = new FilterChainProxy(chains);
+
+              final var ptbToken = signForIssuer(serverB, serverB.issuerUri(), List.of());
+
+              // ptb is a configured cluster provider, but PT-A is assigned [pta] only → 401 on
+              // PT-A.
+              final var reqOnA = new MockHttpServletRequest("GET", PATH_PT_A);
+              reqOnA.addHeader("Authorization", "Bearer " + ptbToken);
+              final var respOnA = new MockHttpServletResponse();
+              proxy.doFilter(reqOnA, respOnA, new MockFilterChain());
+              assertThat(respOnA.getStatus())
+                  .as("ptb token on PT-A: ptb is a cluster provider but not assigned to PT-A → 401")
+                  .isEqualTo(401);
+
+              // Control: the SAME token is accepted on PT-B (assigned [ptb]) — proving it is the
+              // selection that rejects it on PT-A, not an invalid token.
+              final var reqOnB = new MockHttpServletRequest("GET", PATH_PT_B);
+              reqOnB.addHeader("Authorization", "Bearer " + ptbToken);
+              final var respOnB = new MockHttpServletResponse();
+              proxy.doFilter(reqOnB, respOnB, new MockFilterChain());
+              assertThat(respOnB.getStatus())
+                  .as("the same ptb token on PT-B (assigned [ptb]) is accepted → 200")
+                  .isEqualTo(200);
+            });
+  }
+
   // =========================================================================
   // Chain assembly helpers
   // =========================================================================
@@ -444,6 +494,47 @@ class PhysicalTenantApiChainIsolationIT {
     return new String[] {
       "camunda.security.authentication.method=oidc",
     };
+  }
+
+  /**
+   * Declares BOTH providers at the CLUSTER (root) level, so each PT inherits both in the union,
+   * then has each PT narrow to its own via {@code providers.assigned}:
+   *
+   * <ul>
+   *   <li>PT-A ({@code pta}): assigned {@code [pta]} → {@code ptb} narrowed out
+   *   <li>PT-B ({@code ptb}): assigned {@code [ptb]} → {@code pta} narrowed out
+   * </ul>
+   */
+  private MockEnvironment assignedNarrowingEnv() {
+    final var env = new MockEnvironment();
+    env.setProperty("camunda.security.authentication.method", "oidc");
+
+    // Both providers declared at ROOT — without selection each PT would inherit both.
+    env.setProperty("camunda.security.authentication.providers.oidc.pta.client-id", "client-pta");
+    env.setProperty(
+        "camunda.security.authentication.providers.oidc.pta.issuer-uri", serverA.issuerUri());
+    env.setProperty(
+        "camunda.security.authentication.providers.oidc.pta.jwk-set-uri",
+        serverA.issuerUri() + "/jwks");
+    env.setProperty(
+        "camunda.security.authentication.providers.oidc.pta.redirect-uri",
+        "{baseUrl}/sso-callback");
+    env.setProperty("camunda.security.authentication.providers.oidc.ptb.client-id", "client-ptb");
+    env.setProperty(
+        "camunda.security.authentication.providers.oidc.ptb.issuer-uri", serverB.issuerUri());
+    env.setProperty(
+        "camunda.security.authentication.providers.oidc.ptb.jwk-set-uri",
+        serverB.issuerUri() + "/jwks");
+    env.setProperty(
+        "camunda.security.authentication.providers.oidc.ptb.redirect-uri",
+        "{baseUrl}/sso-callback");
+
+    // Per-PT selection: each tenant keeps only its own provider.
+    env.setProperty(
+        "camunda.physical-tenants.pta.security.authentication.providers.assigned[0]", "pta");
+    env.setProperty(
+        "camunda.physical-tenants.ptb.security.authentication.providers.assigned[0]", "ptb");
+    return env;
   }
 
   /**

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
@@ -76,6 +76,9 @@ import org.springframework.security.web.SecurityFilterChain;
  *   <li><b>{@code providers.assigned} narrowing</b> (#54730): a token from a cluster provider that
  *       is not assigned to PT-A is rejected on PT-A (401) yet accepted on the tenant it is assigned
  *       to — isolating the selection from plain cross-issuer rejection.
+ *   <li><b>Reserved {@code oidc} id</b> (#54730): a tenant assigned {@code [pta]} drops the
+ *       inherited unnamed default slot (default-slot token → 401), while {@code [oidc, pta]} keeps
+ *       it (default-slot token → 200).
  * </ol>
  *
  * <p>The test uses the OC {@link PhysicalTenantScopeProvider} to produce {@link
@@ -327,6 +330,74 @@ class PhysicalTenantApiChainIsolationIT {
             });
   }
 
+  // -------------------------------------------------------------------------
+  // Scenario 6: reserved `oidc` id — narrowing the unnamed default slot (#54730)
+  // -------------------------------------------------------------------------
+
+  /**
+   * A non-default tenant inherits the cluster's unnamed default slot ({@code
+   * authentication.oidc.*}, here issuer {@code serverB}) but is {@code assigned: [pta]} — which
+   * does NOT include the reserved {@code oidc} id — so narrowing drops the default slot. A
+   * default-slot token is therefore rejected (401) on the tenant's chain, while its assigned named
+   * provider {@code pta} ({@code serverA}) is still accepted. This is the issue's headline
+   * cross-issuer behaviour at the default-slot level (distinct from scenario 5, which drops a NAMED
+   * provider).
+   */
+  @Test
+  void assignedWithoutReservedOidcDropsInheritedDefaultSlotOnPtAPath() {
+    buildRunner(twoDistinctIssuersProperties())
+        .run(
+            ctx -> {
+              final var chains = buildChainsFromProvider(ctx, reservedOidcEnv("pta"));
+              final var proxy = new FilterChainProxy(chains);
+
+              // default-slot issuer (serverB) — dropped because `oidc` is not assigned → 401.
+              final var defaultSlotToken = signForIssuer(serverB, serverB.issuerUri(), List.of());
+              final var reqDefault = new MockHttpServletRequest("GET", PATH_PT_A);
+              reqDefault.addHeader("Authorization", "Bearer " + defaultSlotToken);
+              final var respDefault = new MockHttpServletResponse();
+              proxy.doFilter(reqDefault, respDefault, new MockFilterChain());
+              assertThat(respDefault.getStatus())
+                  .as(
+                      "default-slot token on a tenant assigned [pta] (no `oidc`) → slot dropped → 401")
+                  .isEqualTo(401);
+
+              // Control: the assigned named provider `pta` (serverA) is still accepted → 200.
+              final var ptaToken = signForIssuer(serverA, serverA.issuerUri(), List.of());
+              final var reqPta = new MockHttpServletRequest("GET", PATH_PT_A);
+              reqPta.addHeader("Authorization", "Bearer " + ptaToken);
+              final var respPta = new MockHttpServletResponse();
+              proxy.doFilter(reqPta, respPta, new MockFilterChain());
+              assertThat(respPta.getStatus())
+                  .as("the assigned named provider `pta` is still accepted → 200")
+                  .isEqualTo(200);
+            });
+  }
+
+  /**
+   * Same cluster shape, but the tenant is {@code assigned: [oidc, pta]} — the reserved {@code oidc}
+   * id re-includes the inherited default slot, so a default-slot token ({@code serverB}) is
+   * accepted (200) on the tenant's chain. The inverse of the drop case above.
+   */
+  @Test
+  void reservedOidcIdKeepsInheritedDefaultSlotOnPtAPath() {
+    buildRunner(twoDistinctIssuersProperties())
+        .run(
+            ctx -> {
+              final var chains = buildChainsFromProvider(ctx, reservedOidcEnv("oidc", "pta"));
+              final var proxy = new FilterChainProxy(chains);
+
+              final var defaultSlotToken = signForIssuer(serverB, serverB.issuerUri(), List.of());
+              final var req = new MockHttpServletRequest("GET", PATH_PT_A);
+              req.addHeader("Authorization", "Bearer " + defaultSlotToken);
+              final var resp = new MockHttpServletResponse();
+              proxy.doFilter(req, resp, new MockFilterChain());
+              assertThat(resp.getStatus())
+                  .as("default-slot token on a tenant assigned [oidc, pta] → slot kept → 200")
+                  .isEqualTo(200);
+            });
+  }
+
   // =========================================================================
   // Chain assembly helpers
   // =========================================================================
@@ -534,6 +605,42 @@ class PhysicalTenantApiChainIsolationIT {
         "camunda.physical-tenants.pta.security.authentication.providers.assigned[0]", "pta");
     env.setProperty(
         "camunda.physical-tenants.ptb.security.authentication.providers.assigned[0]", "ptb");
+    return env;
+  }
+
+  /**
+   * Cluster declares an unnamed default slot ({@code authentication.oidc.*}, issuer {@code
+   * serverB}) plus a named provider {@code pta} (issuer {@code serverA}); the {@code pta} tenant
+   * selects the given ids. Used to exercise the reserved {@code oidc} id: {@code [pta]} drops the
+   * inherited default slot, {@code [oidc, pta]} keeps it.
+   */
+  private MockEnvironment reservedOidcEnv(final String... assignedIds) {
+    final var env = new MockEnvironment();
+    env.setProperty("camunda.security.authentication.method", "oidc");
+
+    // Unnamed default slot — issuer serverB.
+    env.setProperty("camunda.security.authentication.oidc.client-id", "client-default");
+    env.setProperty("camunda.security.authentication.oidc.issuer-uri", serverB.issuerUri());
+    env.setProperty(
+        "camunda.security.authentication.oidc.jwk-set-uri", serverB.issuerUri() + "/jwks");
+    env.setProperty("camunda.security.authentication.oidc.redirect-uri", "{baseUrl}/sso-callback");
+
+    // Named cluster provider pta — issuer serverA.
+    env.setProperty("camunda.security.authentication.providers.oidc.pta.client-id", "client-pta");
+    env.setProperty(
+        "camunda.security.authentication.providers.oidc.pta.issuer-uri", serverA.issuerUri());
+    env.setProperty(
+        "camunda.security.authentication.providers.oidc.pta.jwk-set-uri",
+        serverA.issuerUri() + "/jwks");
+    env.setProperty(
+        "camunda.security.authentication.providers.oidc.pta.redirect-uri",
+        "{baseUrl}/sso-callback");
+
+    for (int i = 0; i < assignedIds.length; i++) {
+      env.setProperty(
+          "camunda.physical-tenants.pta.security.authentication.providers.assigned[" + i + "]",
+          assignedIds[i]);
+    }
     return env;
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
@@ -512,6 +512,22 @@ class PhysicalTenantApiChainIsolationIT {
   // =========================================================================
 
   /**
+   * Sets the four OIDC properties every provider needs ({@code client-id}, {@code issuer-uri},
+   * {@code jwk-set-uri}, {@code redirect-uri}) under {@code basePath}, pointing at {@code server}.
+   * A new required property is then added in one place rather than across each copy.
+   */
+  private static void addOidcProvider(
+      final MockEnvironment env,
+      final String basePath,
+      final String clientId,
+      final JwksTestServer server) {
+    env.setProperty(basePath + ".client-id", clientId);
+    env.setProperty(basePath + ".issuer-uri", server.issuerUri());
+    env.setProperty(basePath + ".jwk-set-uri", server.issuerUri() + "/jwks");
+    env.setProperty(basePath + ".redirect-uri", "{baseUrl}/sso-callback");
+  }
+
+  /**
    * Configures two physical tenants with distinct issuers and JWKS servers. Each PT's
    * distinguishing provider lives in that PT's OVERLAY only (not at root), so each PT trusts only
    * its own issuer via the union-of-ids merge — no {@code assigned} selection needed:
@@ -526,33 +542,17 @@ class PhysicalTenantApiChainIsolationIT {
     // Root method
     env.setProperty("camunda.security.authentication.method", "oidc");
 
-    // PT-A overlay: pta provider lives only in PT-A's overlay (not at root)
-    env.setProperty(
-        "camunda.physical-tenants.pta.security.authentication.providers.oidc.pta.client-id",
-        "client-pta");
-    env.setProperty(
-        "camunda.physical-tenants.pta.security.authentication.providers.oidc.pta.issuer-uri",
-        serverA.issuerUri());
-    env.setProperty(
-        "camunda.physical-tenants.pta.security.authentication.providers.oidc.pta.jwk-set-uri",
-        serverA.issuerUri() + "/jwks");
-    env.setProperty(
-        "camunda.physical-tenants.pta.security.authentication.providers.oidc.pta.redirect-uri",
-        "{baseUrl}/sso-callback");
-
-    // PT-B overlay: ptb provider lives only in PT-B's overlay (not at root)
-    env.setProperty(
-        "camunda.physical-tenants.ptb.security.authentication.providers.oidc.ptb.client-id",
-        "client-ptb");
-    env.setProperty(
-        "camunda.physical-tenants.ptb.security.authentication.providers.oidc.ptb.issuer-uri",
-        serverB.issuerUri());
-    env.setProperty(
-        "camunda.physical-tenants.ptb.security.authentication.providers.oidc.ptb.jwk-set-uri",
-        serverB.issuerUri() + "/jwks");
-    env.setProperty(
-        "camunda.physical-tenants.ptb.security.authentication.providers.oidc.ptb.redirect-uri",
-        "{baseUrl}/sso-callback");
+    // PT-A / PT-B overlays: each provider lives only in its own PT's overlay (not at root).
+    addOidcProvider(
+        env,
+        "camunda.physical-tenants.pta.security.authentication.providers.oidc.pta",
+        "client-pta",
+        serverA);
+    addOidcProvider(
+        env,
+        "camunda.physical-tenants.ptb.security.authentication.providers.oidc.ptb",
+        "client-ptb",
+        serverB);
 
     return env;
   }
@@ -581,24 +581,10 @@ class PhysicalTenantApiChainIsolationIT {
     env.setProperty("camunda.security.authentication.method", "oidc");
 
     // Both providers declared at ROOT — without selection each PT would inherit both.
-    env.setProperty("camunda.security.authentication.providers.oidc.pta.client-id", "client-pta");
-    env.setProperty(
-        "camunda.security.authentication.providers.oidc.pta.issuer-uri", serverA.issuerUri());
-    env.setProperty(
-        "camunda.security.authentication.providers.oidc.pta.jwk-set-uri",
-        serverA.issuerUri() + "/jwks");
-    env.setProperty(
-        "camunda.security.authentication.providers.oidc.pta.redirect-uri",
-        "{baseUrl}/sso-callback");
-    env.setProperty("camunda.security.authentication.providers.oidc.ptb.client-id", "client-ptb");
-    env.setProperty(
-        "camunda.security.authentication.providers.oidc.ptb.issuer-uri", serverB.issuerUri());
-    env.setProperty(
-        "camunda.security.authentication.providers.oidc.ptb.jwk-set-uri",
-        serverB.issuerUri() + "/jwks");
-    env.setProperty(
-        "camunda.security.authentication.providers.oidc.ptb.redirect-uri",
-        "{baseUrl}/sso-callback");
+    addOidcProvider(
+        env, "camunda.security.authentication.providers.oidc.pta", "client-pta", serverA);
+    addOidcProvider(
+        env, "camunda.security.authentication.providers.oidc.ptb", "client-ptb", serverB);
 
     // Per-PT selection: each tenant keeps only its own provider.
     env.setProperty(
@@ -619,22 +605,10 @@ class PhysicalTenantApiChainIsolationIT {
     env.setProperty("camunda.security.authentication.method", "oidc");
 
     // Unnamed default slot — issuer serverB.
-    env.setProperty("camunda.security.authentication.oidc.client-id", "client-default");
-    env.setProperty("camunda.security.authentication.oidc.issuer-uri", serverB.issuerUri());
-    env.setProperty(
-        "camunda.security.authentication.oidc.jwk-set-uri", serverB.issuerUri() + "/jwks");
-    env.setProperty("camunda.security.authentication.oidc.redirect-uri", "{baseUrl}/sso-callback");
-
+    addOidcProvider(env, "camunda.security.authentication.oidc", "client-default", serverB);
     // Named cluster provider pta — issuer serverA.
-    env.setProperty("camunda.security.authentication.providers.oidc.pta.client-id", "client-pta");
-    env.setProperty(
-        "camunda.security.authentication.providers.oidc.pta.issuer-uri", serverA.issuerUri());
-    env.setProperty(
-        "camunda.security.authentication.providers.oidc.pta.jwk-set-uri",
-        serverA.issuerUri() + "/jwks");
-    env.setProperty(
-        "camunda.security.authentication.providers.oidc.pta.redirect-uri",
-        "{baseUrl}/sso-callback");
+    addOidcProvider(
+        env, "camunda.security.authentication.providers.oidc.pta", "client-pta", serverA);
 
     for (int i = 0; i < assignedIds.length; i++) {
       env.setProperty(

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -545,6 +545,42 @@ class PhysicalTenantAuthConfigurationsTest {
     assertThat(cfg.getProviders().getOidc()).containsOnlyKeys("a");
   }
 
+  @Test
+  void shouldKeepFullUnionWhenAssignedIsEmptyList() throws Exception {
+    // An explicitly empty `assigned: []` must be a no-op here (keep the full union), NOT strip
+    // every
+    // provider — the configuration layer rejects the empty list at startup; this guards the merge
+    // when it runs first (e.g. via the cluster-unification BeanPostProcessor).
+    final String yaml =
+        """
+        camunda:
+          security:
+            authentication:
+              method: oidc
+              oidc:
+                client-id: root-client
+                issuer-uri: http://idp/root
+              providers:
+                oidc:
+                  a:
+                    client-id: client-a
+                    issuer-uri: http://idp/a
+          physical-tenants:
+            tenanta:
+              security:
+                authentication:
+                  providers:
+                    assigned: []
+        """;
+
+    final AuthenticationConfiguration cfg =
+        PhysicalTenantAuthConfigurations.forPhysicalTenant("tenanta", yamlEnv(yaml));
+
+    // Nothing stripped: the default slot and the named provider both survive.
+    assertThat(cfg.getOidc().getClientId()).isEqualTo("root-client");
+    assertThat(cfg.getProviders().getOidc()).containsKey("a");
+  }
+
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -162,9 +162,9 @@ class PhysicalTenantAuthConfigurationsTest {
   }
 
   // -------------------------------------------------------------------------
-  // 3d. Faithful application-pt-poc.yaml shape: default slot "oidc" + named provider "tenanta"
-  //     whose name equals the PT id; the tenanta overlay overrides client/secret/audiences and
-  //     inherits issuer-uri. Guards the exact runtime config the smoke harness exercises.
+  // 3d. A representative cluster shape: default slot "oidc" + a named provider "tenanta" whose name
+  //     equals the PT id; the tenanta overlay overrides client/secret/audiences and inherits
+  //     issuer-uri.
   // -------------------------------------------------------------------------
 
   @Test
@@ -343,7 +343,7 @@ class PhysicalTenantAuthConfigurationsTest {
   }
 
   // -------------------------------------------------------------------------
-  // Real YAML environment (mirrors application-pt-poc.yaml) — guards against a
+  // Real YAML-loaded environment (not MockEnvironment) — guards against a
   // MockEnvironment-vs-real-Environment binding discrepancy in the overlay merge.
   // -------------------------------------------------------------------------
 
@@ -535,7 +535,7 @@ class PhysicalTenantAuthConfigurationsTest {
     final var loaded =
         new org.springframework.boot.env.YamlPropertySourceLoader()
             .load(
-                "pt-poc",
+                "test",
                 new org.springframework.core.io.ByteArrayResource(
                     yaml.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
     final var env = new org.springframework.core.env.StandardEnvironment();

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -520,6 +520,31 @@ class PhysicalTenantAuthConfigurationsTest {
     assertThat(cfg.getProviders().getOidc()).containsKey("a");
   }
 
+  @Test
+  void shouldIgnoreBlankAssignedEntryWhenNarrowing() {
+    // Defensive: a blank entry in assigned must not break narrowing (it matches no provider and is
+    // dropped). The configuration layer rejects blank entries at startup; this guards the merge in
+    // case it runs first (e.g. via the cluster-unification BeanPostProcessor).
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri", "http://idp/a",
+                "camunda.security.authentication.providers.oidc.b.client-id", "client-b",
+                "camunda.security.authentication.providers.oidc.b.issuer-uri", "http://idp/b",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[1]",
+                    "a"));
+
+    final AuthenticationConfiguration cfg =
+        PhysicalTenantAuthConfigurations.forPhysicalTenant("tenanta", env);
+
+    // blank ignored; only the real id "a" is kept, "b" dropped — and no exception thrown.
+    assertThat(cfg.getProviders().getOidc()).containsOnlyKeys("a");
+  }
+
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -20,9 +20,10 @@ import org.springframework.mock.env.MockEnvironment;
  *
  * <p>All tests bind config from a {@link MockEnvironment} — no Spring context is loaded.
  *
- * <p>Semantics under test: the returned config contains <em>all</em> cluster providers (root
- * providers ∪ PT overlay providers). Per-PT provider selection ({@code assigned}) has been dropped;
- * per-PT OVERLAY (field overrides and PT-only providers) is still supported.
+ * <p>Semantics under test: the returned config is the union of all cluster providers (root
+ * providers ∪ PT overlay providers), then — for a non-default tenant that declares one — narrowed
+ * to its {@code providers.assigned} selection (#54730). Per-PT OVERLAY (field overrides and PT-only
+ * providers) is applied before narrowing.
  */
 class PhysicalTenantAuthConfigurationsTest {
 
@@ -385,6 +386,116 @@ class PhysicalTenantAuthConfigurationsTest {
     assertThat(tenanta.getIssuerUri())
         .isEqualTo("http://localhost:8082/realms/tenanta"); // inherited from root
     assertThat(tenanta.getClientId()).isEqualTo("camunda-pt-tenanta-client"); // overlay wins
+  }
+
+  // -------------------------------------------------------------------------
+  // 7. providers.assigned narrows a non-default tenant to its selected providers (#54730)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldNarrowToAssignedNamedProviderAndDropDefaultSlotAndUnlistedProvider() {
+    // Cluster: a default slot + two named providers; tenanta is assigned ONLY the named "tenanta".
+    // Expectation: the inherited root default slot is dropped (content-less → ignored by CSL
+    // flatten), the unlisted "other" provider is removed, and only "tenanta" survives. This is the
+    // cross-issuer acceptance behaviour: a root/default token no longer matches tenanta's chain.
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root",
+                "camunda.security.authentication.providers.oidc.tenanta.client-id",
+                    "client-tenanta",
+                "camunda.security.authentication.providers.oidc.tenanta.issuer-uri",
+                    "http://idp/tenanta",
+                "camunda.security.authentication.providers.oidc.other.client-id", "client-other",
+                "camunda.security.authentication.providers.oidc.other.issuer-uri",
+                    "http://idp/other",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "tenanta"));
+
+    final AuthenticationConfiguration cfg =
+        PhysicalTenantAuthConfigurations.forPhysicalTenant("tenanta", env);
+
+    // default slot dropped: present-but-content-less (the api setter never stores null).
+    assertThat(cfg.getOidc()).isNotNull();
+    assertThat(cfg.getOidc().getClientId()).isNull();
+    assertThat(cfg.getOidc().getIssuerUri()).isNull();
+    // only the assigned named provider survives.
+    assertThat(cfg.getProviders().getOidc()).containsOnlyKeys("tenanta");
+    assertThat(cfg.getProviders().getOidc().get("tenanta").getClientId())
+        .isEqualTo("client-tenanta");
+  }
+
+  @Test
+  void shouldKeepDefaultSlotWhenReservedOidcIdIsAssigned() {
+    // assigned = [oidc, tenanta] → the reserved id "oidc" keeps the default slot alongside the
+    // named provider; the unlisted "other" provider is still dropped.
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root",
+                "camunda.security.authentication.providers.oidc.tenanta.client-id",
+                    "client-tenanta",
+                "camunda.security.authentication.providers.oidc.tenanta.issuer-uri",
+                    "http://idp/tenanta",
+                "camunda.security.authentication.providers.oidc.other.client-id", "client-other",
+                "camunda.security.authentication.providers.oidc.other.issuer-uri",
+                    "http://idp/other",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "oidc",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[1]",
+                    "tenanta"));
+
+    final AuthenticationConfiguration cfg =
+        PhysicalTenantAuthConfigurations.forPhysicalTenant("tenanta", env);
+
+    assertThat(cfg.getOidc().getClientId()).isEqualTo("root-client"); // default slot kept
+    assertThat(cfg.getProviders().getOidc()).containsOnlyKeys("tenanta"); // "other" dropped
+  }
+
+  @Test
+  void shouldKeepFullSetForDefaultTenantEvenIfAssignedDeclared() {
+    // The implicit default tenant (and its /physical-tenants/default alias) always carries the full
+    // set (AC-1); a stray assigned list under it is ignored.
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri", "http://idp/a",
+                "camunda.physical-tenants.default.security.authentication.providers.assigned[0]",
+                    "a"));
+
+    final AuthenticationConfiguration cfg =
+        PhysicalTenantAuthConfigurations.forPhysicalTenant("default", env);
+
+    assertThat(cfg.getOidc().getClientId()).isEqualTo("root-client"); // default slot kept
+    assertThat(cfg.getProviders().getOidc()).containsKey("a");
+  }
+
+  @Test
+  void shouldKeepFullUnionWhenNoAssignedDeclared() {
+    // A non-default tenant with no assigned list bound keeps the full union (selection is enforced
+    // by the configuration layer, not this merge).
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri", "http://idp/a"));
+
+    final AuthenticationConfiguration cfg =
+        PhysicalTenantAuthConfigurations.forPhysicalTenant("tenanta", env);
+
+    assertThat(cfg.getOidc().getClientId()).isEqualTo("root-client");
+    assertThat(cfg.getProviders().getOidc()).containsKey("a");
   }
 
   // -------------------------------------------------------------------------

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -457,9 +457,10 @@ class PhysicalTenantAuthConfigurationsTest {
   }
 
   @Test
-  void shouldKeepFullSetForDefaultTenantEvenIfAssignedDeclared() {
-    // The implicit default tenant (and its /physical-tenants/default alias) always carries the full
-    // set (AC-1); a stray assigned list under it is ignored.
+  void shouldNarrowDefaultTenantWhenAssignedDeclared() {
+    // The default tenant is narrowed by its own assigned just like any other tenant. Its resolved
+    // config also drives the cluster /v2 chain (see PhysicalTenantSecurityConfiguration), so a
+    // default selection limits that surface too.
     final var env =
         env(
             Map.of(
@@ -470,6 +471,27 @@ class PhysicalTenantAuthConfigurationsTest {
                 "camunda.security.authentication.providers.oidc.a.issuer-uri", "http://idp/a",
                 "camunda.physical-tenants.default.security.authentication.providers.assigned[0]",
                     "a"));
+
+    final AuthenticationConfiguration cfg =
+        PhysicalTenantAuthConfigurations.forPhysicalTenant("default", env);
+
+    // default slot dropped (oidc not assigned); only "a" kept
+    assertThat(cfg.getOidc().getClientId()).isNull();
+    assertThat(cfg.getProviders().getOidc()).containsOnlyKeys("a");
+  }
+
+  @Test
+  void shouldKeepFullSetForDefaultTenantWhenNoAssignedDeclared() {
+    // No assigned under default → full set (the common case; the alias and cluster surface keep all
+    // providers).
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri", "http://idp/a"));
 
     final AuthenticationConfiguration cfg =
         PhysicalTenantAuthConfigurations.forPhysicalTenant("default", env);

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantSecurityConfigurationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantSecurityConfigurationTest.java
@@ -10,8 +10,11 @@ package io.camunda.authentication.pt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.context.CamundaSecurityScopeProvider;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.mock.env.MockEnvironment;
 
 /**
  * Verifies that {@link PhysicalTenantSecurityConfiguration} registers the expected beans in the
@@ -60,5 +63,65 @@ class PhysicalTenantSecurityConfigurationTest {
                   .containsExactlyInAnyOrder(
                       "/physical-tenants/tenanta", "/physical-tenants/default");
             });
+  }
+
+  // -------------------------------------------------------------------------
+  // Cluster-auth unification BeanPostProcessor (#54730): keeps /v2 == /physical-tenants/default
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldUnifyClusterAuthWithDefaultTenantWhenPhysicalTenantsConfigured() {
+    // given an OIDC cluster, a configured physical tenant (PT mode active), and a default selection
+    final MockEnvironment env = new MockEnvironment();
+    env.setProperty("camunda.security.authentication.method", "oidc");
+    env.setProperty("camunda.security.authentication.oidc.client-id", "root-client");
+    env.setProperty("camunda.security.authentication.oidc.issuer-uri", "http://idp/root");
+    env.setProperty("camunda.security.authentication.providers.oidc.a.client-id", "client-a");
+    env.setProperty("camunda.security.authentication.providers.oidc.a.issuer-uri", "http://idp/a");
+    env.setProperty(
+        "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]", "a");
+    env.setProperty(
+        "camunda.physical-tenants.default.security.authentication.providers.assigned[0]", "a");
+    final CamundaSecurityLibraryProperties props = new CamundaSecurityLibraryProperties();
+
+    // when the BPP post-processes the CSL properties bean
+    final Object result =
+        bpp(env).postProcessAfterInitialization(props, "camundaSecurityLibraryProperties");
+
+    // then the cluster authentication mirrors the narrowed default tenant: default slot dropped,
+    // only the assigned named provider "a" remains
+    assertThat(result).isSameAs(props);
+    assertThat(props.getAuthentication().getOidc().getClientId()).isNull();
+    assertThat(props.getAuthentication().getProviders().getOidc()).containsOnlyKeys("a");
+  }
+
+  @Test
+  void shouldLeaveClusterAuthUntouchedWhenNoPhysicalTenantsConfigured() {
+    // given no physical tenants configured
+    final MockEnvironment env = new MockEnvironment();
+    env.setProperty("camunda.security.authentication.method", "oidc");
+    env.setProperty("camunda.security.authentication.oidc.client-id", "root-client");
+    final CamundaSecurityLibraryProperties props = new CamundaSecurityLibraryProperties();
+    final var original = props.getAuthentication();
+
+    // when
+    bpp(env).postProcessAfterInitialization(props, "camundaSecurityLibraryProperties");
+
+    // then the bean is left exactly as CSL bound it
+    assertThat(props.getAuthentication()).isSameAs(original);
+  }
+
+  @Test
+  void shouldIgnoreBeansThatAreNotSecurityProperties() {
+    final MockEnvironment env = new MockEnvironment();
+    env.setProperty(
+        "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]", "a");
+    final Object other = new Object();
+
+    assertThat(bpp(env).postProcessAfterInitialization(other, "someOtherBean")).isSameAs(other);
+  }
+
+  private static BeanPostProcessor bpp(final MockEnvironment env) {
+    return PhysicalTenantSecurityConfiguration.physicalTenantClusterAuthUnification(env);
   }
 }

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -221,7 +221,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-library-api</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
@@ -36,8 +36,10 @@ import org.springframework.core.env.Environment;
  * a {@link Binder} read of each {@code assigned} list. The rules:
  *
  * <ul>
- *   <li>The implicit {@code default} tenant carries the full provider set; declaring {@code
- *       providers.assigned} under it is rejected as a misconfiguration.
+ *   <li>The implicit {@code default} tenant carries the full provider set unless it declares its
+ *       own {@code providers.assigned} — which is allowed and, because the default tenant's
+ *       resolved config also drives the cluster {@code /v2} chain, limits that surface too. The
+ *       default tenant is not <em>required</em> to declare one (omitting it keeps the full set).
  *   <li>{@code assigned} applies only to the OIDC authentication method. If the cluster method is
  *       not {@code oidc}, a tenant that declares {@code assigned} is rejected (per-PT basic-auth is
  *       a separate concern — see #51949 — not a provider-selection one).
@@ -81,15 +83,7 @@ final class PhysicalTenantAssignedProvidersValidation {
 
     for (final String tenantId : discoverTenantIds(environment)) {
       final List<String> assigned = bindAssigned(binder, tenantId);
-
-      if (PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)) {
-        if (assigned != null) {
-          throw fail(
-              "the implicit '%s' physical tenant always carries the full provider set; remove '%s'"
-                  .formatted(tenantId, assignedPath(tenantId)));
-        }
-        continue;
-      }
+      final boolean isDefault = PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId);
 
       if (!oidcMethod) {
         if (assigned != null) {
@@ -101,11 +95,32 @@ final class PhysicalTenantAssignedProvidersValidation {
         continue;
       }
 
-      if (assigned == null || assigned.isEmpty()) {
+      if (assigned == null) {
+        // The default tenant may omit a selection (implicit full set); a non-default tenant must
+        // declare one so its provider set is explicit.
+        if (isDefault) {
+          continue;
+        }
         throw fail(
             ("non-default physical tenant '%s' must declare a non-empty '%s' selecting which "
                     + "cluster OIDC providers apply to it")
                 .formatted(tenantId, assignedPath(tenantId)));
+      }
+
+      if (assigned.isEmpty()) {
+        throw fail(
+            "physical tenant '%s' declares an empty '%s'; it must select at least one provider"
+                .formatted(tenantId, assignedPath(tenantId)));
+      }
+
+      // Reject blank/null entries explicitly: an empty-string id (e.g. `- ""` in yaml) would
+      // otherwise fall through to the unknown-id check and render as `[]` (List#toString collapses
+      // a lone empty string), giving a confusing message.
+      if (assigned.stream().anyMatch(id -> id == null || id.isBlank())) {
+        throw fail(
+            "physical tenant '%s' declares a blank entry in '%s'; every id must be a non-blank "
+                    .formatted(tenantId, assignedPath(tenantId))
+                + "provider id");
       }
 
       final Set<String> namedIds = namedProviderIds(environment, tenantId);

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
@@ -9,6 +9,7 @@ package io.camunda.configuration.physicaltenants;
 
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.security.api.model.config.oidc.OidcConfiguration;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -57,12 +58,12 @@ import org.springframework.core.env.Environment;
 final class PhysicalTenantAssignedProvidersValidation {
 
   /**
-   * Reserved {@code assigned} id for the unnamed default slot ({@code
-   * camunda.security.authentication.oidc.*}). Mirrored from {@code
-   * PhysicalTenantAuthConfigurations.DEFAULT_SLOT_ASSIGNED_ID} in the {@code authentication} module
-   * (the two modules do not share a type for it); keep the two in sync.
+   * Reserved {@code assigned} id for the unnamed default slot — CSL's {@link
+   * OidcConfiguration#DEFAULT_REGISTRATION_ID} ({@code "oidc"}), the registration id of the default
+   * slot. The auth-merge narrowing ({@code PhysicalTenantAuthConfigurations}) sources the same CSL
+   * constant, so the two layers cannot drift.
    */
-  private static final String DEFAULT_SLOT_ASSIGNED_ID = "oidc";
+  private static final String DEFAULT_SLOT_ASSIGNED_ID = OidcConfiguration.DEFAULT_REGISTRATION_ID;
 
   private static final String PHYSICAL_TENANTS_PREFIX = Camunda.PREFIX + ".physical-tenants";
   private static final ConfigurationPropertyName PHYSICAL_TENANTS_NAME =
@@ -80,8 +81,11 @@ final class PhysicalTenantAssignedProvidersValidation {
   static void validate(final Environment environment) {
     final Binder binder = Binder.get(environment);
     final boolean oidcMethod = isOidcMethod(binder);
+    // Cluster-level (root) scans are identical for every tenant — compute them once.
+    final Set<String> rootNamedIds = childSegments(environment, ROOT_NAMED_PROVIDERS);
+    final boolean rootDefaultSlotPresent = hasDescendant(environment, ROOT_DEFAULT_SLOT);
 
-    for (final String tenantId : discoverTenantIds(environment)) {
+    for (final String tenantId : childSegments(environment, PHYSICAL_TENANTS_NAME)) {
       final List<String> assigned = bindAssigned(binder, tenantId);
       final boolean isDefault = PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId);
 
@@ -100,7 +104,8 @@ final class PhysicalTenantAssignedProvidersValidation {
       // every
       // tenant under OIDC, including the default tenant on its implicit full-set path. Otherwise a
       // config whose only tenant is `default` (no `assigned`) would not fail fast on the collision.
-      final Set<String> namedIds = namedProviderIds(environment, tenantId);
+      final Set<String> namedIds = new LinkedHashSet<>(rootNamedIds);
+      namedIds.addAll(tenantOverlayNamedIds(environment, tenantId));
       if (namedIds.contains(DEFAULT_SLOT_ASSIGNED_ID)) {
         throw fail(
             ("a named OIDC provider may not be called '%s' (configured for physical tenant '%s') — "
@@ -137,7 +142,7 @@ final class PhysicalTenantAssignedProvidersValidation {
       }
 
       final Set<String> known = new LinkedHashSet<>(namedIds);
-      if (hasDefaultSlotContent(environment, tenantId)) {
+      if (rootDefaultSlotPresent || hasTenantOverlayDefaultSlot(environment, tenantId)) {
         known.add(DEFAULT_SLOT_ASSIGNED_ID);
       }
 
@@ -174,28 +179,23 @@ final class PhysicalTenantAssignedProvidersValidation {
         .formatted(PHYSICAL_TENANTS_PREFIX, tenantId);
   }
 
-  /** Cluster-level (root) ∪ tenant-overlay named provider ids visible to the given tenant. */
-  private static Set<String> namedProviderIds(
+  /** Named provider ids declared in the given tenant's own overlay (root ids are hoisted). */
+  private static Set<String> tenantOverlayNamedIds(
       final Environment environment, final String tenantId) {
-    final Set<String> ids = new LinkedHashSet<>();
-    ids.addAll(childSegments(environment, ROOT_NAMED_PROVIDERS));
-    ids.addAll(
-        childSegments(
-            environment,
-            ConfigurationPropertyName.of(
-                "%s.%s.security.authentication.providers.oidc"
-                    .formatted(PHYSICAL_TENANTS_PREFIX, tenantId))));
-    return ids;
+    return childSegments(
+        environment,
+        ConfigurationPropertyName.of(
+            "%s.%s.security.authentication.providers.oidc"
+                .formatted(PHYSICAL_TENANTS_PREFIX, tenantId)));
   }
 
-  /** Whether the merged default slot (root ∪ tenant overlay) carries any content. */
-  private static boolean hasDefaultSlotContent(
+  /** Whether the given tenant's own overlay declares default-slot content. */
+  private static boolean hasTenantOverlayDefaultSlot(
       final Environment environment, final String tenantId) {
-    return hasDescendant(environment, ROOT_DEFAULT_SLOT)
-        || hasDescendant(
-            environment,
-            ConfigurationPropertyName.of(
-                "%s.%s.security.authentication.oidc".formatted(PHYSICAL_TENANTS_PREFIX, tenantId)));
+    return hasDescendant(
+        environment,
+        ConfigurationPropertyName.of(
+            "%s.%s.security.authentication.oidc".formatted(PHYSICAL_TENANTS_PREFIX, tenantId)));
   }
 
   /** The distinct id segments declared immediately under {@code prefix.<id>.*}. */
@@ -225,24 +225,6 @@ final class PhysicalTenantAssignedProvidersValidation {
       }
     }
     return false;
-  }
-
-  private static Set<String> discoverTenantIds(final Environment environment) {
-    final Set<String> tenants = new LinkedHashSet<>();
-    for (final ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
-      if (source instanceof final IterableConfigurationPropertySource iter) {
-        iter.stream()
-            .filter(PHYSICAL_TENANTS_NAME::isAncestorOf)
-            .filter(
-                name -> name.getNumberOfElements() > PHYSICAL_TENANTS_NAME.getNumberOfElements())
-            .forEach(
-                name ->
-                    tenants.add(
-                        name.getElement(
-                            PHYSICAL_TENANTS_NAME.getNumberOfElements(), Form.UNIFORM)));
-      }
-    }
-    return tenants;
   }
 
   private static UnifiedConfigurationException fail(final String detail) {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName.Form;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
+import org.springframework.core.env.Environment;
+
+/**
+ * Fail-fast startup validation for the per-physical-tenant OIDC provider selection {@code
+ * providers.assigned} (issue #54730, see ADR-0004). This is the configuration-layer counterpart of
+ * the auth-merge narrowing in {@code PhysicalTenantAuthConfigurations.narrowToAssigned} (the {@code
+ * authentication} module): validation rejects an invalid selection here so the merge only ever
+ * <em>applies</em> an already-valid one — a non-default tenant can therefore never silently end up
+ * with no providers and hence no usable API chain.
+ *
+ * <p>Enforcement is pure <em>key inspection</em> over the {@code physical-tenants.<id>.*} and
+ * {@code camunda.security.*} keys (mirroring {@link PhysicalTenantOverridePolicyValidation}), plus
+ * a {@link Binder} read of each {@code assigned} list. The rules:
+ *
+ * <ul>
+ *   <li>The implicit {@code default} tenant carries the full provider set; declaring {@code
+ *       providers.assigned} under it is rejected as a misconfiguration.
+ *   <li>{@code assigned} applies only to the OIDC authentication method. If the cluster method is
+ *       not {@code oidc}, a tenant that declares {@code assigned} is rejected (per-PT basic-auth is
+ *       a separate concern — see #51949 — not a provider-selection one).
+ *   <li>Under OIDC, every non-default tenant <em>must</em> declare a non-empty {@code assigned}.
+ *   <li>Every id in {@code assigned} must be a known provider id: the reserved id {@value
+ *       #DEFAULT_SLOT_ASSIGNED_ID} (only when the merged default slot {@code authentication.oidc.*}
+ *       carries content), a cluster-level named provider {@code
+ *       security.authentication.providers.oidc.<name>}, or one the tenant declares in its own
+ *       overlay.
+ *   <li>A named provider literally called {@value #DEFAULT_SLOT_ASSIGNED_ID} collides with the
+ *       reserved default-slot id and is rejected as unsupported.
+ * </ul>
+ */
+@NullMarked
+final class PhysicalTenantAssignedProvidersValidation {
+
+  /**
+   * Reserved {@code assigned} id for the unnamed default slot ({@code
+   * camunda.security.authentication.oidc.*}). Mirrored from {@code
+   * PhysicalTenantAuthConfigurations.DEFAULT_SLOT_ASSIGNED_ID} in the {@code authentication} module
+   * (the two modules do not share a type for it); keep the two in sync.
+   */
+  private static final String DEFAULT_SLOT_ASSIGNED_ID = "oidc";
+
+  private static final String PHYSICAL_TENANTS_PREFIX = Camunda.PREFIX + ".physical-tenants";
+  private static final ConfigurationPropertyName PHYSICAL_TENANTS_NAME =
+      ConfigurationPropertyName.of(PHYSICAL_TENANTS_PREFIX);
+
+  private static final String ROOT_AUTH = Camunda.PREFIX + ".security.authentication";
+  private static final ConfigurationPropertyName ROOT_DEFAULT_SLOT =
+      ConfigurationPropertyName.of(ROOT_AUTH + ".oidc");
+  private static final ConfigurationPropertyName ROOT_NAMED_PROVIDERS =
+      ConfigurationPropertyName.of(ROOT_AUTH + ".providers.oidc");
+  private static final String METHOD_PROPERTY = ROOT_AUTH + ".method";
+
+  private PhysicalTenantAssignedProvidersValidation() {}
+
+  static void validate(final Environment environment) {
+    final Binder binder = Binder.get(environment);
+    final boolean oidcMethod = isOidcMethod(binder);
+
+    for (final String tenantId : discoverTenantIds(environment)) {
+      final List<String> assigned = bindAssigned(binder, tenantId);
+
+      if (PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)) {
+        if (assigned != null) {
+          throw fail(
+              "the implicit '%s' physical tenant always carries the full provider set; remove '%s'"
+                  .formatted(tenantId, assignedPath(tenantId)));
+        }
+        continue;
+      }
+
+      if (!oidcMethod) {
+        if (assigned != null) {
+          throw fail(
+              ("'%s' applies only to the OIDC authentication method, but '%s' is not 'oidc'; "
+                      + "remove the selection or set the method to 'oidc'")
+                  .formatted(assignedPath(tenantId), METHOD_PROPERTY));
+        }
+        continue;
+      }
+
+      if (assigned == null || assigned.isEmpty()) {
+        throw fail(
+            ("non-default physical tenant '%s' must declare a non-empty '%s' selecting which "
+                    + "cluster OIDC providers apply to it")
+                .formatted(tenantId, assignedPath(tenantId)));
+      }
+
+      final Set<String> namedIds = namedProviderIds(environment, tenantId);
+      if (namedIds.contains(DEFAULT_SLOT_ASSIGNED_ID)) {
+        throw fail(
+            ("a named OIDC provider may not be called '%s' for physical tenant '%s' — that id is "
+                    + "reserved for the unnamed default slot in '%s'")
+                .formatted(DEFAULT_SLOT_ASSIGNED_ID, tenantId, assignedPath(tenantId)));
+      }
+
+      final Set<String> known = new LinkedHashSet<>(namedIds);
+      if (hasDefaultSlotContent(environment, tenantId)) {
+        known.add(DEFAULT_SLOT_ASSIGNED_ID);
+      }
+
+      final List<String> unknown =
+          assigned.stream().filter(id -> !known.contains(id)).distinct().toList();
+      if (!unknown.isEmpty()) {
+        throw fail(
+            ("physical tenant '%s' assigns unknown OIDC provider id(s) %s in '%s'; known ids are %s "
+                    + "('%s' refers to the default slot '%s.oidc.*')")
+                .formatted(
+                    tenantId,
+                    unknown,
+                    assignedPath(tenantId),
+                    known,
+                    DEFAULT_SLOT_ASSIGNED_ID,
+                    ROOT_AUTH));
+      }
+    }
+  }
+
+  private static boolean isOidcMethod(final Binder binder) {
+    return binder
+        .bind(METHOD_PROPERTY, Bindable.of(String.class))
+        .map(method -> method.equalsIgnoreCase("oidc"))
+        .orElse(false);
+  }
+
+  private static @Nullable List<String> bindAssigned(final Binder binder, final String tenantId) {
+    return binder.bind(assignedPath(tenantId), Bindable.listOf(String.class)).orElse(null);
+  }
+
+  private static String assignedPath(final String tenantId) {
+    return "%s.%s.security.authentication.providers.assigned"
+        .formatted(PHYSICAL_TENANTS_PREFIX, tenantId);
+  }
+
+  /** Cluster-level (root) ∪ tenant-overlay named provider ids visible to the given tenant. */
+  private static Set<String> namedProviderIds(
+      final Environment environment, final String tenantId) {
+    final Set<String> ids = new LinkedHashSet<>();
+    ids.addAll(childSegments(environment, ROOT_NAMED_PROVIDERS));
+    ids.addAll(
+        childSegments(
+            environment,
+            ConfigurationPropertyName.of(
+                "%s.%s.security.authentication.providers.oidc"
+                    .formatted(PHYSICAL_TENANTS_PREFIX, tenantId))));
+    return ids;
+  }
+
+  /** Whether the merged default slot (root ∪ tenant overlay) carries any content. */
+  private static boolean hasDefaultSlotContent(
+      final Environment environment, final String tenantId) {
+    return hasDescendant(environment, ROOT_DEFAULT_SLOT)
+        || hasDescendant(
+            environment,
+            ConfigurationPropertyName.of(
+                "%s.%s.security.authentication.oidc".formatted(PHYSICAL_TENANTS_PREFIX, tenantId)));
+  }
+
+  /** The distinct id segments declared immediately under {@code prefix.<id>.*}. */
+  private static Set<String> childSegments(
+      final Environment environment, final ConfigurationPropertyName prefix) {
+    final Set<String> segments = new LinkedHashSet<>();
+    for (final ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
+      if (source instanceof final IterableConfigurationPropertySource iter) {
+        iter.stream()
+            .filter(prefix::isAncestorOf)
+            .filter(name -> name.getNumberOfElements() > prefix.getNumberOfElements())
+            .forEach(
+                name -> segments.add(name.getElement(prefix.getNumberOfElements(), Form.UNIFORM)));
+      }
+    }
+    return segments;
+  }
+
+  /** Whether any key exists at or under {@code prefix}. */
+  private static boolean hasDescendant(
+      final Environment environment, final ConfigurationPropertyName prefix) {
+    for (final ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
+      if (source instanceof final IterableConfigurationPropertySource iter) {
+        if (iter.stream().anyMatch(name -> prefix.equals(name) || prefix.isAncestorOf(name))) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static Set<String> discoverTenantIds(final Environment environment) {
+    final Set<String> tenants = new LinkedHashSet<>();
+    for (final ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
+      if (source instanceof final IterableConfigurationPropertySource iter) {
+        iter.stream()
+            .filter(PHYSICAL_TENANTS_NAME::isAncestorOf)
+            .filter(
+                name -> name.getNumberOfElements() > PHYSICAL_TENANTS_NAME.getNumberOfElements())
+            .forEach(
+                name ->
+                    tenants.add(
+                        name.getElement(
+                            PHYSICAL_TENANTS_NAME.getNumberOfElements(), Form.UNIFORM)));
+      }
+    }
+    return tenants;
+  }
+
+  private static UnifiedConfigurationException fail(final String detail) {
+    return new UnifiedConfigurationException(
+        "Invalid physical-tenant provider selection: " + detail);
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
@@ -95,6 +95,19 @@ final class PhysicalTenantAssignedProvidersValidation {
         continue;
       }
 
+      // The reserved-id collision (a named provider literally called `oidc`) is a cluster/overlay
+      // config error independent of whether THIS tenant declares a selection — so check it for
+      // every
+      // tenant under OIDC, including the default tenant on its implicit full-set path. Otherwise a
+      // config whose only tenant is `default` (no `assigned`) would not fail fast on the collision.
+      final Set<String> namedIds = namedProviderIds(environment, tenantId);
+      if (namedIds.contains(DEFAULT_SLOT_ASSIGNED_ID)) {
+        throw fail(
+            ("a named OIDC provider may not be called '%s' (configured for physical tenant '%s') — "
+                    + "that id is reserved for the unnamed default slot '%s.oidc.*'")
+                .formatted(DEFAULT_SLOT_ASSIGNED_ID, tenantId, ROOT_AUTH));
+      }
+
       if (assigned == null) {
         // The default tenant may omit a selection (implicit full set); a non-default tenant must
         // declare one so its provider set is explicit.
@@ -121,14 +134,6 @@ final class PhysicalTenantAssignedProvidersValidation {
             "physical tenant '%s' declares a blank entry in '%s'; every id must be a non-blank "
                     .formatted(tenantId, assignedPath(tenantId))
                 + "provider id");
-      }
-
-      final Set<String> namedIds = namedProviderIds(environment, tenantId);
-      if (namedIds.contains(DEFAULT_SLOT_ASSIGNED_ID)) {
-        throw fail(
-            ("a named OIDC provider may not be called '%s' for physical tenant '%s' — that id is "
-                    + "reserved for the unnamed default slot in '%s'")
-                .formatted(DEFAULT_SLOT_ASSIGNED_ID, tenantId, assignedPath(tenantId)));
       }
 
       final Set<String> known = new LinkedHashSet<>(namedIds);

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -87,6 +87,7 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
   public static PhysicalTenantResolver of(final Environment environment, final Camunda camunda) {
     final Set<String> physicalTenantIds = discover(environment);
     PhysicalTenantOverridePolicyValidation.validate(environment);
+    PhysicalTenantAssignedProvidersValidation.validate(environment);
     final Map<String, Camunda> resolvedPhysicalTenants = new LinkedHashMap<>();
     final Binder binder = Binder.get(environment);
     for (final String physicalTenantId : physicalTenantIds) {

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidationTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.mock.env.MockEnvironment;
+
+class PhysicalTenantAssignedProvidersValidationTest {
+
+  // -------------------------------------------------------------------------
+  // Non-default OIDC tenant must declare a non-empty, valid selection
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldRejectNonDefaultOidcTenantWithoutAssigned() {
+    // given an OIDC cluster and a non-default tenant declared (via a PT-only provider) but with no
+    // providers.assigned
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.x.client-id",
+                    "client-x"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("must declare a non-empty");
+  }
+
+  @Test
+  void shouldRejectEmptyAssigned() throws IOException {
+    // given an OIDC cluster and a tenant with an explicitly empty assigned list
+    final Environment environment =
+        yamlEnvironment(
+            """
+            camunda:
+              security:
+                authentication:
+                  method: oidc
+                  providers:
+                    oidc:
+                      a:
+                        client-id: client-a
+              physical-tenants:
+                tenanta:
+                  security:
+                    authentication:
+                      providers:
+                        assigned: []
+            """);
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("must declare a non-empty");
+  }
+
+  @Test
+  void shouldRejectUnknownAssignedId() {
+    // given a tenant assigning a provider id that is not configured anywhere
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "nope"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("unknown OIDC provider id")
+        .withMessageContaining("nope");
+  }
+
+  @Test
+  void shouldAcceptValidNamedSelection() {
+    // given a tenant assigning a configured cluster-level named provider
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.security.authentication.providers.oidc.b.client-id", "client-b",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "a"));
+
+    // when / then
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAcceptReservedOidcIdWhenDefaultSlotHasContent() {
+    // given a configured default slot and a named provider, and a tenant assigning both
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "oidc",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[1]",
+                    "a"));
+
+    // when / then
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectReservedOidcIdWhenNoDefaultSlotContent() {
+    // given no default slot anywhere, but a tenant assigning the reserved "oidc" id
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "oidc"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("unknown OIDC provider id")
+        .withMessageContaining("oidc");
+  }
+
+  @Test
+  void shouldAcceptTenantOverlayProviderInSelection() {
+    // given a tenant that declares its own (PT-only) provider and assigns it
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.ptonly.client-id",
+                    "client-ptonly",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "ptonly"));
+
+    // when / then
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectNamedProviderCollidingWithReservedOidcId() {
+    // given a cluster-level named provider literally called "oidc"
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.oidc.client-id", "client-oidc",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "oidc"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("reserved");
+  }
+
+  // -------------------------------------------------------------------------
+  // Default tenant semantics: implicit full set, no explicit assigned
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldRejectDefaultTenantDeclaringAssigned() {
+    // given the implicit default tenant declaring a provider selection
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.physical-tenants.default.security.authentication.providers.assigned[0]",
+                    "a"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("default")
+        .withMessageContaining("full provider set");
+  }
+
+  // -------------------------------------------------------------------------
+  // Method awareness: assigned applies only to OIDC
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldRejectNonOidcTenantDeclaringAssigned() {
+    // given a basic-auth cluster and a tenant that nonetheless declares a provider selection
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "basic",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "a"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("applies only to the OIDC");
+  }
+
+  @Test
+  void shouldAcceptNonOidcTenantWithoutAssigned() {
+    // given a basic-auth cluster and a tenant with an unrelated overlay key, no assigned
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "basic",
+                "camunda.physical-tenants.tenanta.cluster.partition-count", "7"));
+
+    // when / then
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAcceptWhenNoPhysicalTenantsConfigured() {
+    // given an OIDC cluster with no physical tenants at all
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a"));
+
+    // when / then
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private static MockEnvironment environmentWith(final Map<String, Object> properties) {
+    final MockEnvironment environment = new MockEnvironment();
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+    return environment;
+  }
+
+  private static Environment yamlEnvironment(final String yaml) throws IOException {
+    final var loaded =
+        new YamlPropertySourceLoader()
+            .load("test", new ByteArrayResource(yaml.getBytes(StandardCharsets.UTF_8)));
+    // MockEnvironment carries no system-property or env-var sources (unlike StandardEnvironment),
+    // so the validation's full-source scan stays hermetic regardless of the runner's environment.
+    final MockEnvironment environment = new MockEnvironment();
+    loaded.forEach(environment.getPropertySources()::addFirst);
+    return environment;
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidationTest.java
@@ -72,7 +72,28 @@ class PhysicalTenantAssignedProvidersValidationTest {
     assertThatExceptionOfType(UnifiedConfigurationException.class)
         .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
         .withMessageContaining("tenanta")
-        .withMessageContaining("must declare a non-empty");
+        .withMessageContaining("empty")
+        .withMessageContaining("must select at least one provider");
+  }
+
+  @Test
+  void shouldRejectBlankAssignedId() {
+    // given a tenant whose assigned list contains a blank entry (e.g. `- ""` in yaml)
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[1]",
+                    "a"));
+
+    // when / then — a clear "blank entry" failure, not a confusing "unknown id(s) []"
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("blank entry");
   }
 
   @Test
@@ -190,8 +211,9 @@ class PhysicalTenantAssignedProvidersValidationTest {
   // -------------------------------------------------------------------------
 
   @Test
-  void shouldRejectDefaultTenantDeclaringAssigned() {
-    // given the implicit default tenant declaring a provider selection
+  void shouldAcceptDefaultTenantDeclaringValidAssigned() {
+    // given the default tenant declaring a valid selection — allowed; it limits the default tenant
+    // and (via the cluster-auth unification) the /v2 surface too
     final Environment environment =
         environmentWith(
             Map.of(
@@ -201,10 +223,27 @@ class PhysicalTenantAssignedProvidersValidationTest {
                     "a"));
 
     // when / then
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectDefaultTenantAssigningUnknownId() {
+    // given the default tenant assigning an id that is not configured
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.physical-tenants.default.security.authentication.providers.assigned[0]",
+                    "nope"));
+
+    // when / then — the default tenant is validated like any other
     assertThatExceptionOfType(UnifiedConfigurationException.class)
         .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
         .withMessageContaining("default")
-        .withMessageContaining("full provider set");
+        .withMessageContaining("unknown OIDC provider id")
+        .withMessageContaining("nope");
   }
 
   // -------------------------------------------------------------------------

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidationTest.java
@@ -206,6 +206,27 @@ class PhysicalTenantAssignedProvidersValidationTest {
         .withMessageContaining("reserved");
   }
 
+  @Test
+  void shouldRejectNamedOidcProviderEvenWhenDefaultOmitsAssigned() {
+    // given a named provider "oidc" and only the default tenant, which omits assigned (implicit
+    // full set) — the collision must still fail fast, not be deferred until a selection is declared
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.oidc.client-id", "client-oidc",
+                // a key under physical-tenants.default so the default tenant is discovered, with no
+                // providers.assigned
+                "camunda.physical-tenants.default.security.authentication.providers.oidc.x.client-id",
+                    "client-x"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("default")
+        .withMessageContaining("reserved");
+  }
+
   // -------------------------------------------------------------------------
   // Default tenant semantics: implicit full set, no explicit assigned
   // -------------------------------------------------------------------------

--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md
@@ -101,7 +101,7 @@ camunda:
    **identical**, a `BeanPostProcessor` on CSL's `CamundaSecurityLibraryProperties` — active
    whenever any physical tenant is configured — replaces the cluster `authentication` with
    `forPhysicalTenant("default")` *before* CSL builds its chains. So both surfaces carry the default
-   tenant's resolved config, and `camunda.physical-tenants.default.providers.assigned` limits the
+   tenant's resolved config, and `camunda.physical-tenants.default.security.authentication.providers.assigned` limits the
    cluster surface too. CSL stays PT-agnostic: OC only mutates OC-owned config CSL already consumes.
 
 3. **Validation — `configuration` module** (fail-fast at startup, sibling to

--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md
@@ -35,8 +35,9 @@ select **which** of the cluster's providers apply to it, instead of inheriting t
 Acceptance criteria (post-rescope of #54730):
 
 1. `providers.assigned` is resolved and validated per PT: the **default tenant has the implicit full
-   set**; a **non-default PT must declare an explicit list of valid provider ids** — a missing or
-   invalid `assigned` **fails startup** with a clear error.
+   set** when it declares no `assigned` (but **may** declare one to limit itself); a **non-default
+   PT must declare an explicit list of valid provider ids** — a missing or invalid `assigned`
+   **fails startup** with a clear error.
 2. The scope provider **narrows** each PT's merged `AuthenticationConfiguration` to its `assigned`
    providers.
 3. Tests cover: default-tenant full set, a valid explicit selection, and startup failure on
@@ -81,26 +82,35 @@ camunda:
   called `oidc` (`providers.oidc.oidc`) would collide; that pathological name is rejected at startup
   by validation.
 
-**Two responsibilities, two layers.**
+**Three parts.**
 
 1. **Application (narrowing) — `authentication` module**, in
    `PhysicalTenantAuthConfigurations.forPhysicalTenant`, after the existing union-merge: read
    `...providers.assigned` via a dedicated `Binder` call (it is not a field on CSL's config), then
    filter the merged config to the selection — keep the default slot iff `oidc ∈ assigned` (else
    reset it to a content-less `OidcConfiguration`, which CSL's `flatten` ignores), and retain only
-   the named providers whose ids are listed. The implicit `default` tenant (and its
-   `/physical-tenants/default` alias) is **never** narrowed — it always carries the full set (AC-1).
-   A non-default tenant with no `assigned` list bound is also left at the full union here; requiring
-   one is the validation layer's job.
+   the named providers whose ids are listed. This is applied **uniformly to every tenant, the
+   `default` tenant included**: a tenant with no `assigned` bound keeps the full union; a tenant
+   that declares one is narrowed to it.
 
-2. **Validation — `configuration` module** (fail-fast at startup, sibling to
+2. **Cluster/default unification — `authentication` module**
+   (`PhysicalTenantSecurityConfiguration`). The default tenant is reachable at two surfaces: the
+   unprefixed `/v2` cluster chain (CSL builds it from `camunda.security.authentication.*`) and the
+   `/physical-tenants/default` alias (built from `forPhysicalTenant("default")`). To keep the two
+   **identical**, a `BeanPostProcessor` on CSL's `CamundaSecurityLibraryProperties` — active
+   whenever any physical tenant is configured — replaces the cluster `authentication` with
+   `forPhysicalTenant("default")` *before* CSL builds its chains. So both surfaces carry the default
+   tenant's resolved config, and `camunda.physical-tenants.default.providers.assigned` limits the
+   cluster surface too. CSL stays PT-agnostic: OC only mutates OC-owned config CSL already consumes.
+
+3. **Validation — `configuration` module** (fail-fast at startup, sibling to
    `PhysicalTenantOverridePolicyValidation`): a non-default PT **must** declare a non-empty
-   `assigned`, and every id must resolve to a known provider (`oidc` when the root default slot has
-   content, or a configured `providers.oidc.<name>`); otherwise throw
-   `UnifiedConfigurationException`. A "known provider ids" notion analogous to
-   `PhysicalTenantIds.known()` keeps this out of the auth merge. The merge then only ever *applies*
-   an already-valid selection. *(This PR spikes the narrowing + tests; the configuration-layer
-   validation follows in the same issue.)*
+   `assigned`; the `default` tenant **may** declare one (omitting it keeps the full set). When
+   present (for any tenant), every id must resolve to a known provider — `oidc` when the merged
+   default slot has content, or a cluster/overlay `providers.oidc.<name>` — and an empty list or the
+   reserved-`oidc` name collision is rejected; otherwise `UnifiedConfigurationException`. The merge
+   then only ever *applies* an already-valid selection, so a tenant can never silently end up with
+   no providers.
 
 ## Consequences
 
@@ -114,6 +124,10 @@ camunda:
   wording) while never touching CSL's actual config namespace.
 - Clean separation of concerns: fail-fast validation in the configuration layer; pure application in
   the auth merge. The merge stays total (it only ever applies a valid selection).
+- The default tenant's two surfaces (`/v2` and `/physical-tenants/default`) are **identical by
+  construction**, since both derive from `forPhysicalTenant("default")`. This also closes a latent
+  #54729 gap where any `camunda.physical-tenants.default.*` overlay (not just `assigned`) would have
+  diverged the alias from `/v2`.
 - Flips the smoke harness's cross-issuer `[#54730]` cell to a pass and is mirrored by an
   `PhysicalTenantApiChainIsolationIT` case (a provider assigned to PT-A but not PT-B → PT-A's token
   rejected on PT-B).
@@ -129,6 +143,12 @@ camunda:
 - Selection is split across two modules (validation vs application). This mirrors the existing PT
   config/auth split and is deliberate, but it does mean the "must declare a valid list" rule and the
   "apply the list" code live apart and must stay conceptually in sync.
+- `camunda.physical-tenants.default.*` now governs the **cluster-wide `/v2`** surface, not just a
+  scoped chain — an operator limiting the default tenant limits the cluster. This is intentional
+  (the default physical tenant *is* the cluster) but is a wider blast radius than a per-tenant knob.
+- The unification mutates CSL's `CamundaSecurityLibraryProperties` bean via a `BeanPostProcessor`
+  that must run before CSL builds its chains. This is timing-sensitive, but follows the established
+  `SaasCspModeCompatibility` pattern (a `static @Bean` BPP on the same properties bean).
 
 ## Alternatives Considered
 

--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md
@@ -1,0 +1,165 @@
+# ADR-0004: Per-Physical-Tenant Provider Selection via OC-side `assigned` Narrowing
+
+## Status
+
+Proposed
+
+## Deciders
+
+- Proposed by: Sebastian Bathke ([@megglos](https://github.com/megglos))
+
+_This ADR is a proposal; deciders will be recorded once the team aligns._
+
+## Context
+
+[ADR-0003](0003-physical-tenant-request-scoping-via-pre-security-filter.md) and OC #54729
+established per-physical-tenant (PT) API security chains: OC contributes a
+`CamundaSecurityScopeProvider` (`PhysicalTenantScopeProvider`) that emits one
+`ScopedSecurityDescriptor` per configured PT, each carrying an `AuthenticationConfiguration` that
+OC assembles on the OC side from the root cluster config plus the per-tenant overlay
+(`PhysicalTenantAuthConfigurations.forPhysicalTenant`). CSL builds an issuer-aware decoder / filter
+chain from whatever providers that descriptor carries.
+
+Today every PT inherits **all** cluster providers — the union of the root providers and the PT's
+own overlay providers. The local smoke harness documents the resulting gap as an informational
+cell:
+
+```
+default token -> /pt/tenanta  (cross-issuer; 200 today, 401 once #54730 lands)
+```
+
+A token minted by the **root/default** realm is currently **accepted** on `tenanta`'s chain,
+because `tenanta` inherited the root `oidc` provider. #54730 closes this: a PT should be able to
+select **which** of the cluster's providers apply to it, instead of inheriting the full set.
+
+Acceptance criteria (post-rescope of #54730):
+
+1. `providers.assigned` is resolved and validated per PT: the **default tenant has the implicit full
+   set**; a **non-default PT must declare an explicit list of valid provider ids** — a missing or
+   invalid `assigned` **fails startup** with a clear error.
+2. The scope provider **narrows** each PT's merged `AuthenticationConfiguration` to its `assigned`
+   providers.
+3. Tests cover: default-tenant full set, a valid explicit selection, and startup failure on
+   missing/invalid `assigned`.
+
+A **hard constraint** carries over from #54729: CSL (`camunda-security-library`) must remain
+**physical-tenant-agnostic** — the term "physical tenant" must not appear in it. CSL only ever
+receives a finished `AuthenticationConfiguration`; it never sees `camunda.physical-tenants.*`.
+
+The decision is **where** the selection lives and is applied. Two sub-questions:
+
+- **Whose config schema owns `assigned`** — CSL's provider config, or OC's PT namespace?
+- **Where the narrowing runs** — inside CSL at chain-build time, or in OC before the descriptor is
+  built?
+
+## Decision
+
+`assigned` is an **OC-only** selector applied by **OC-side narrowing**. CSL is unchanged and stays
+PT-agnostic.
+
+**Config shape.** The selection is a list of provider ids under the per-tenant namespace:
+
+```yaml
+camunda:
+  physical-tenants:
+    tenanta:
+      security:
+        authentication:
+          providers:
+            assigned:
+              - oidc        # reserved id → the root default slot (authentication.oidc.*)
+              - tenanta     # a named provider (authentication.providers.oidc.tenanta)
+```
+
+- `assigned` appears **only** under `camunda.physical-tenants.<id>.*`, which is **OC's** namespace.
+  It never appears under the real CSL namespace (`camunda.security.*`). It only *shape-mirrors* CSL's
+  `AuthenticationConfiguration` because the PT overlay mirrors it; CSL's `OidcProvidersConfiguration`
+  has no `assigned` field and never binds it. CSL's schema is therefore **not** extended.
+- Ids are drawn from the union `{oidc} ∪ providers.oidc.<name>`. The reserved id **`oidc`** names the
+  unnamed default slot (`camunda.security.authentication.oidc.*`), which has no map key of its own
+  and so is referenced by the leaf name of the property that defines it. A named provider literally
+  called `oidc` (`providers.oidc.oidc`) would collide; that pathological name is documented as
+  unsupported.
+
+**Two responsibilities, two layers.**
+
+1. **Application (narrowing) — `authentication` module**, in
+   `PhysicalTenantAuthConfigurations.forPhysicalTenant`, after the existing union-merge: read
+   `...providers.assigned` via a dedicated `Binder` call (it is not a field on CSL's config), then
+   filter the merged config to the selection — keep the default slot iff `oidc ∈ assigned` (else
+   reset it to a content-less `OidcConfiguration`, which CSL's `flatten` ignores), and retain only
+   the named providers whose ids are listed. The implicit `default` tenant (and its
+   `/physical-tenants/default` alias) is **never** narrowed — it always carries the full set (AC-1).
+   A non-default tenant with no `assigned` list bound is also left at the full union here; requiring
+   one is the validation layer's job.
+
+2. **Validation — `configuration` module** (fail-fast at startup, sibling to
+   `PhysicalTenantOverridePolicyValidation`): a non-default PT **must** declare a non-empty
+   `assigned`, and every id must resolve to a known provider (`oidc` when the root default slot has
+   content, or a configured `providers.oidc.<name>`); otherwise throw
+   `UnifiedConfigurationException`. A "known provider ids" notion analogous to
+   `PhysicalTenantIds.known()` keeps this out of the auth merge. The merge then only ever *applies*
+   an already-valid selection. *(This PR spikes the narrowing + tests; the configuration-layer
+   validation follows in the same issue.)*
+
+## Consequences
+
+### Positive
+
+- CSL is untouched and remains PT-agnostic — no PT/selection concept leaks into the shared library,
+  honouring the #54729 constraint.
+- No redundancy: OC already assembles per-PT config, so it narrows in place rather than passing the
+  full set plus a filter for CSL to re-apply.
+- The selector sits adjacent to the providers it selects (matching the issue's `providers.assigned`
+  wording) while never touching CSL's actual config namespace.
+- Clean separation of concerns: fail-fast validation in the configuration layer; pure application in
+  the auth merge. The merge stays total (it only ever applies a valid selection).
+- Flips the smoke harness's cross-issuer `[#54730]` cell to a pass and is mirrored by an
+  `PhysicalTenantApiChainIsolationIT` case (a provider assigned to PT-A but not PT-B → PT-A's token
+  rejected on PT-B).
+
+### Negative / trade-offs
+
+- `assigned` is nominally adjacent to the CSL-shaped subtree (`...security.authentication.providers`)
+  even though CSL does not define it. Mitigated by the fact that it lives only under OC's
+  `physical-tenants.<id>` namespace; the alternative of a sibling namespace was weighed and rejected
+  (see Alternatives).
+- The reserved `oidc` id is a small piece of magic; it collides with a (pathological) named provider
+  called `oidc`. Documented as unsupported rather than guarded.
+- Selection is split across two modules (validation vs application). This mirrors the existing PT
+  config/auth split and is deliberate, but it does mean the "must declare a valid list" rule and the
+  "apply the list" code live apart and must stay conceptually in sync.
+
+## Alternatives Considered
+
+1. **`assigned` as a CSL config field** (add an `assigned`/`enabled`/`active` field to CSL's provider
+   config; OC passes the full union and CSL filters at chain-build time). Rejected: it puts a
+   selection concept into PT-agnostic CSL that only the PT feature uses, forces "valid provider ids"
+   validation into or duplicated across CSL, and is redundant — OC already assembles per-PT config,
+   so passing all-then-filter is wasted work.
+2. **OC-side narrowing, but `assigned` in a dedicated OC sibling namespace** (e.g.
+   `camunda.physical-tenants.<id>.assigned-providers`, outside the CSL-mirrored
+   `security.authentication` subtree). Rejected as the default: it removes the nominal adjacency to
+   the CSL shape but diverges from the issue's `providers.assigned` wording, places the selector
+   further from the providers it selects, and is less discoverable. Retained as the fallback if the
+   nominal adjacency proves confusing in practice.
+3. **Narrow in `PhysicalTenantScopeProvider` instead of `PhysicalTenantAuthConfigurations`.**
+   Rejected: `forPhysicalTenant` already owns the per-PT merge semantics and the provider map; the
+   scope provider's job is descriptor emission and the default alias. Keeping narrowing next to the
+   merge keeps both concerns cohesive and unit-testable without a scope provider.
+4. **Drop the default slot for all non-default PTs (no reserved id).** Rejected: it would prevent a
+   PT from legitimately sharing the cluster's default-slot provider, and the reserved `oidc` id makes
+   the choice explicit and uniform with named providers at negligible cost.
+
+## References
+
+- OC #54730 — per-tenant provider selection (`providers.assigned`); this ADR.
+- OC #54729 — per-physical-tenant API security chains (PR
+  [#54971](https://github.com/camunda/camunda/pull/54971)); the union-merge this narrows.
+- [ADR-0003](0003-physical-tenant-request-scoping-via-pre-security-filter.md) — pre-security filter
+  for PT request scoping (how the tenant id reaches the chain).
+- [camunda/camunda-security-library#378](https://github.com/camunda/camunda-security-library/pull/378)
+  — the `CamundaSecurityScopeProvider` SPI and per-scope issuer-aware chains (consumed at
+  `0.1.0-alpha30`).
+- OC #54731 — forbidden per-tenant override validation (the `PhysicalTenantOverridePolicyValidation`
+  pattern the `assigned` validation extends).

--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md
@@ -2,13 +2,14 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Deciders
 
 - Proposed by: Sebastian Bathke ([@megglos](https://github.com/megglos))
+- Patrick Wunderlich ([@p-wunderlich](https://github.com/p-wunderlich))
 
-_This ADR is a proposal; deciders will be recorded once the team aligns._
+_Additional deciders may be recorded as more of the team reviews._
 
 ## Context
 

--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md
@@ -78,8 +78,8 @@ camunda:
 - Ids are drawn from the union `{oidc} ∪ providers.oidc.<name>`. The reserved id **`oidc`** names the
   unnamed default slot (`camunda.security.authentication.oidc.*`), which has no map key of its own
   and so is referenced by the leaf name of the property that defines it. A named provider literally
-  called `oidc` (`providers.oidc.oidc`) would collide; that pathological name is documented as
-  unsupported.
+  called `oidc` (`providers.oidc.oidc`) would collide; that pathological name is rejected at startup
+  by validation.
 
 **Two responsibilities, two layers.**
 
@@ -125,7 +125,7 @@ camunda:
   `physical-tenants.<id>` namespace; the alternative of a sibling namespace was weighed and rejected
   (see Alternatives).
 - The reserved `oidc` id is a small piece of magic; it collides with a (pathological) named provider
-  called `oidc`. Documented as unsupported rather than guarded.
+  called `oidc`. That collision is rejected at startup by validation.
 - Selection is split across two modules (validation vs application). This mirrors the existing PT
   config/auth split and is deliberate, but it does mean the "must declare a valid list" rule and the
   "apply the list" code live apart and must stay conceptually in sync.


### PR DESCRIPTION
## Summary

Lets a physical tenant select **which** of the cluster's OIDC providers apply to it, via a new `providers.assigned` list under `camunda.physical-tenants.<id>...` — instead of inheriting the full cluster set. Follow-up to #54729 (per-PT API security chains): #54729 gives every PT a chain built from the *union* of all cluster providers; this PR narrows that union per tenant.

OC-only — CSL (`camunda-security-library`) stays physical-tenant-agnostic and its config schema is untouched. Includes the architecture decision (ADR-0004) and its production implementation.

Closes #54730. Part of epic #54728.

## Decision (ADR-0004)

`docs/.../orchestration-cluster/adr/0004-per-physical-tenant-provider-selection-via-assigned.md`

- `providers.assigned` is an **OC-only** selector applied by **OC-side narrowing**; CSL receives only an already-narrowed `AuthenticationConfiguration`.
- It lives only under `camunda.physical-tenants.<id>.*` (OC's namespace), never under the real CSL namespace `camunda.security.*`, so CSL's schema is not extended.
- The unnamed default slot is addressed by the reserved id `oidc`; named providers by their map keys. A named provider literally called `oidc` collides with that reserved id and is **rejected at startup**.
- Alternatives weighed and rejected: a CSL-side selection field, a sibling OC namespace, narrowing in the scope provider, dropping the default slot unconditionally (see the ADR).

## Implementation — three parts

1. **Narrowing — `authentication`** (`PhysicalTenantAuthConfigurations.forPhysicalTenant`): after the per-PT union-merge, narrow to `assigned` — drop the default slot unless the reserved `oidc` is listed; keep only the listed named providers. Applied **uniformly to every tenant, the `default` tenant included**: no `assigned` → full set; an `assigned` → narrowed. `assigned` is read out-of-band via `Binder`, so CSL's config is never extended with an OC-only field.

2. **Cluster/default unification — `authentication`** (`PhysicalTenantSecurityConfiguration`): the default tenant has two surfaces — the unprefixed `/v2` cluster chain (CSL builds it from `camunda.security.authentication.*`) and the `/physical-tenants/default` alias (`forPhysicalTenant("default")`). A `BeanPostProcessor` on CSL's `CamundaSecurityLibraryProperties` (active when any PT is configured) replaces the cluster `authentication` with `forPhysicalTenant("default")` before CSL builds its chains, so **both surfaces are identical** and `physical-tenants.default.providers.assigned` limits the cluster too. Follows the existing `SaasCspModeCompatibility` BPP pattern; CSL stays PT-agnostic (OC only mutates config CSL already reads).

3. **Validation — `configuration`** (`PhysicalTenantAssignedProvidersValidation`, wired into `PhysicalTenantResolver.of`): fail-fast startup validation. A non-default OIDC tenant **must** declare a non-empty `assigned`; the `default` tenant **may** declare one (omitting it = full set). When present (any tenant), every id must be a known provider (a cluster/overlay named provider, or `oidc` when the default slot has content); an empty list, an unknown id, the reserved-`oidc` name collision, or `assigned` under a non-OIDC method are all rejected. The merge then only ever *applies* an already-valid selection, so a tenant can never silently end up with no providers.

### Config shape

```yaml
camunda:
  physical-tenants:
    tenanta:
      security:
        authentication:
          providers:
            assigned:
              - oidc      # reserved id → the root default slot (camunda.security.authentication.oidc.*)
              - tenanta   # a named provider (camunda.security.authentication.providers.oidc.tenanta)
```

## Testing

- `PhysicalTenantAuthConfigurationsTest` — 17 tests (narrowing incl. default narrows / full-set-when-unset).
- `PhysicalTenantSecurityConfigurationTest` — 6 tests (incl. cluster-auth unification BPP).
- `PhysicalTenantAssignedProvidersValidationTest` — 13 tests (missing/empty/unknown/collision/default/non-OIDC/valid paths; hermetic env).
- `configuration` golden + override-policy suites pass unchanged (`assigned` is not part of the `Camunda` config surface).
- Full-repo `./mvnw install -Dquickly` compiles green; `spotless`/`license` applied.

## End-to-end demonstration

Verified live via the #55242 smoke harness (OC + three Keycloak realms) — all scenarios pass, **28 assertions, 0 failures**. The cluster declares an `oidc` default slot (default realm) and a named provider `tenanta`; each provider carries a **distinct audience**, and `tenanta` overrides the audience for its own scope — so same-realm tokens are isolated by audience. Scenario D adds a third realm `tenantb`. Each scenario then sets `providers.assigned`:

**A — Base** · ✅ 15/15
```yaml
# cluster providers — distinct audiences isolate the two same-issuer (tenanta-realm) providers:
camunda.security.authentication.oidc.audiences: [pt-default-aud]                               # default slot · default realm
camunda.security.authentication.providers.oidc.tenanta.audiences: [pt-default-via-tenanta-aud] # tenanta realm (root view)
# tenant `tenanta`: overrides the audience to its own, and selects only itself:
camunda.physical-tenants.tenanta.security.authentication.providers.oidc.tenanta.audiences: [pt-tenanta-aud]
camunda.physical-tenants.tenanta.security.authentication.providers.assigned: [tenanta]
```
Per-PT routing; **same-realm, different-audience isolation** (a `pt-default-via-tenanta-aud` token is rejected on `tenanta`'s chain, which expects `pt-tenanta-aud`); cluster `/v2` ≡ `/physical-tenants/default`; the `[#54730]` cross-issuer cell (default-realm token → `/pt/tenanta` = **401**); unknown tenant → **404**.

**B — Default narrowing** · ✅ 6/6
```yaml
camunda.physical-tenants.default.security.authentication.providers.assigned: [tenanta]  # on top of A's base
```
Default-realm token rejected on **both** `/v2` and `/physical-tenants/default` — the default tenant's selection limits the **cluster** surface.

**C — Reserved-`oidc` keep** · ✅ 2/2
```yaml
camunda.physical-tenants.tenanta.security.authentication.providers.assigned: [oidc, tenanta]  # replaces A's [tenanta]
```
Default-realm token **accepted** on `/pt/tenanta` — the reserved `oidc` id re-includes the default slot (inverse of A's `[#54730]` cell).

**D — Two non-default tenants** · ✅ 5/5
```yaml
# a third realm (:8083) as a cluster provider with its own audience:
camunda.security.authentication.providers.oidc.tenantb.audiences: [pt-tenantb-aud]
camunda.physical-tenants.tenanta.security.authentication.providers.assigned: [tenanta]
camunda.physical-tenants.tenantb.security.authentication.providers.assigned: [tenantb]
```
Each tenant accepts its own provider and **rejects the other's** valid cluster provider — selection among multiple named providers + PT-to-PT isolation.

Run commands and the full per-cell matrix are in the #55242 harness README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


