### PR TITLE
fix: declare direct zeebe-client-java dep in optimize-backend to fix merge-back CI

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -476,7 +476,7 @@ jobs:
           additional_flags: "--profile self-managed"
 
       - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+        run: ./mvnw -T1C clean install -DskipTests -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
@@ -627,7 +627,7 @@ jobs:
           directory: ./optimize/client
           node-version: ${{ steps.pom-info.outputs.x_version_node }}
       - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+        run: ./mvnw -T1C clean install -DskipTests -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
       - name: Start backend

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -89,6 +89,19 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!--
+      Direct declaration so that `-am` includes clients/java-deprecated in the local build graph.
+      Without this, zeebe-client-java is only reached transitively via zeebe-test-container (a test dep),
+      which is an external artifact. Maven's -am walk stops at external artifacts, so the module is never
+      built locally and the SNAPSHOT lookup against Nexus fails on release merge-back PRs.
+    -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
@@ -801,6 +814,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>io.camunda:zeebe-client-java:jar</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>io.camunda:zeebe-protocol-jackson:jar</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.junit.platform:junit-platform-suite</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-jackson2</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION

## Description

<!-- Describe the goal and purpose of this PR. -->
Adds zeebe-client-java as a direct test-scoped dependency so Maven's -am flag includes clients/java-deprecated in the local build graph. Without this, the module is only reachable transitively via the external zeebe-test-container artifact, which -am doesn't descend into, causing SNAPSHOT resolution failures against Nexus during release merge-back PRs.

1. Direct test dependency on `io.camunda:zeebe-client-java` added under the Zeebe dependencies section (`optimize/backend/pom.xml:100`). Version is managed by the BOM (`${project.version}`), scope is `test`.
2. Enforcer suppression added to `ignoredUnusedDeclaredDependencies` (pom.xml:817) so `maven-dependency-plugin:analyze` won't fail on the unused-but-intentional declaration.

  Why this works: Maven's -am flag walks the reactor module graph only through direct dependencies. `zeebe-test-container` is an external artifact (not a reactor module), so Maven never descends into it to discover `zeebe-client-java`.
  By declaring `zeebe-client-java` directly, -am sees it as a reactor module and builds it locally — no Nexus lookup needed, so the merge-back window failure is gone.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
