### PR TITLE
fix: use only latest client patch in compatibility test matrices

### DIFF
--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -149,9 +149,12 @@ jobs:
 
           echo "next-snapshot=$NEXT_SNAPSHOT" >> "$GITHUB_OUTPUT"
 
-          # Create CLIENT_LIST: on stable branches, only same-minor versions (no snapshot)
+          # Create CLIENT_LIST: on stable branches, only the latest patch for the stable minor
+          # Patch versions don't change the client API, so only the latest patch matters
+          # for forward compatibility testing (keeps the matrix small and bounded)
           CLIENT_LIST=""
           CLIENT_COUNT=0
+          LATEST_CLIENT_TAG=""
           if [[ -n "$FILTERED_TAGS" ]]; then
             for tag in $FILTERED_TAGS; do
               if [[ -n "$STABLE_VERSION" ]]; then
@@ -163,10 +166,20 @@ jobs:
                     continue
                   fi
                 fi
+                # Tags are sorted by version (sort -V), so the last match is the latest
+                LATEST_CLIENT_TAG="$tag"
+              else
+                CLIENT_LIST+="$tag"$'\n'
+                CLIENT_COUNT=$((CLIENT_COUNT + 1))
               fi
-              CLIENT_LIST+="$tag"$'\n'
-              CLIENT_COUNT=$((CLIENT_COUNT + 1))
             done
+          fi
+
+          # On stable branches, use only the latest patch version
+          if [[ -n "$STABLE_VERSION" ]] && [[ -n "$LATEST_CLIENT_TAG" ]]; then
+            CLIENT_LIST="$LATEST_CLIENT_TAG"$'\n'
+            CLIENT_COUNT=1
+            echo "Using latest client patch: $LATEST_CLIENT_TAG (skipped older patches)"
           fi
 
           if [[ "$IS_MAIN" == "true" ]]; then

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -149,9 +149,12 @@ jobs:
 
           echo "next-snapshot=$NEXT_SNAPSHOT" >> "$GITHUB_OUTPUT"
 
-          # Create CLIENT_LIST: on stable branches, only same major.minor versions (no snapshot)
+          # Create CLIENT_LIST: on stable branches, only the latest patch for the stable minor
+          # Patch versions don't change the client API, so only the latest patch matters
+          # for forward compatibility testing (keeps the matrix small and bounded)
           CLIENT_LIST=""
           CLIENT_COUNT=0
+          LATEST_CLIENT_TAG=""
           if [[ -n "$FILTERED_TAGS" ]]; then
             for tag in $FILTERED_TAGS; do
               if [[ -n "$STABLE_VERSION" ]]; then
@@ -159,10 +162,20 @@ jobs:
                 if [[ ! "$tag" =~ ^${STABLE_MAJOR}\.${STABLE_MINOR}\. ]]; then
                   continue
                 fi
+                # Tags are sorted by version (sort -V), so the last match is the latest
+                LATEST_CLIENT_TAG="$tag"
+              else
+                CLIENT_LIST+="$tag"$'\n'
+                CLIENT_COUNT=$((CLIENT_COUNT + 1))
               fi
-              CLIENT_LIST+="$tag"$'\n'
-              CLIENT_COUNT=$((CLIENT_COUNT + 1))
             done
+          fi
+
+          # On stable branches, use only the latest patch version
+          if [[ -n "$STABLE_VERSION" ]] && [[ -n "$LATEST_CLIENT_TAG" ]]; then
+            CLIENT_LIST="$LATEST_CLIENT_TAG"$'\n'
+            CLIENT_COUNT=1
+            echo "Using latest client patch: $LATEST_CLIENT_TAG (skipped older patches)"
           fi
 
           if [[ "$IS_MAIN" == "true" ]]; then


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The compatibility test workflows generated a matrix entry for every patch version of the client (e.g., 8.8.0 through 8.8.27), producing 280 combinations on stable/8.8. With the cache only covering 21 entries and SNAPSHOT combos never cached, 259 jobs were enqueued — exceeding GitHub Actions' 256 matrix job limit and causing the entire run to fail silently (no test jobs created).

Patch versions within a minor don't change the client API, so only the latest patch is needed for forward compatibility testing. This reduces the matrix from 28×10=280 to 1×10=10 on stable/8.8, well within limits and growing only with new server releases.

## Related issues

client failures in https://app.slack.com/client/T0PM0P1SA/C0A2AGG2Q2E
