### PR TITLE
[Backport stable/8.9] ci: submit job-level owner to CI Analytics for push and schedule workflows

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -76,6 +76,9 @@
 /qa/acceptance-tests/src/test/java/io/camunda/it/client/     @camunda/camundaex
 /qa/acceptance-tests/src/test/java/io/camunda/it/spring/     @camunda/camundaex
 
+# CI
+/.github/workflows/camunda-spring-boot-starter-compatibility-test* @camunda/camundaex
+
 ################################
 ## @camunda/connectors-agentic-ai
 ################################
@@ -381,3 +384,13 @@
 /.github/workflows/release-branch-notifications.yml @camunda/monorepo-devops-team
 /.github/workflows/add-release-comments-to-issues.yml @camunda/monorepo-devops-team
 /.github/workflows/update-identity.yml @camunda/monorepo-devops-team
+
+################################
+## Late overrides
+################################
+
+# Codeowners is last-match-wins. Add specific overrides here when a broader
+# earlier rule (e.g. `/.github/workflows/zeebe*`) needs to be reverted to a
+# different team for a particular file.
+/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml @camunda/qa-engineering
+/.github/workflows/zeebe-release-stable-dry-run.yml @camunda/monorepo-devops-team

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status.'
     required: false
   user_description:
-    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status.'
+    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status. When empty, falls back to the TEST_OWNER environment variable.'
     required: false
   job_name:
     description: 'Optional string, the job whose status is being observed; defaults to $GITHUB_JOB when omitted'
@@ -102,5 +102,5 @@ runs:
         build_status: "${{ inputs.build_status }}"
         build_duration_millis: "${{ steps.get-build-duration-millis.outputs.result }}"
         user_reason: "${{ inputs.user_reason }}"
-        user_description: "${{ inputs.user_description }}"
+        user_description: "${{ inputs.user_description != '' && inputs.user_description || env.TEST_OWNER }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"

--- a/.github/workflows/add-release-comments-to-issues.yml
+++ b/.github/workflows/add-release-comments-to-issues.yml
@@ -42,6 +42,7 @@ on:
         default: false
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 permissions: {}
@@ -57,7 +58,6 @@ jobs:
       run:
         shell: bash
     env:
-      TEST_OWNER: Engineering Operations
       TEST_PRODUCT: Orchestration Cluster
       TEST_TYPE: CI Helper
     steps:

--- a/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  TEST_OWNER: '@camunda/qa-engineering'
+
 jobs:
   request-validation-tests:
     name: V2 Stateless Tests (${{ matrix.branch }})
@@ -46,7 +49,7 @@ jobs:
             tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo "Failed")
             operate_status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
             identity_status=$(curl -s -m 5 http://localhost:8080/identity || echo "Failed")
-            
+
             if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" && "$identity_status" != "Failed" ]]; then
               echo "Services are ready!"
               ready=true

--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -1,6 +1,6 @@
 # description: Daily compatibility tests for Camunda components across versions
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/camundaex
 name: Camunda Compatibility Tests
 
 on:
@@ -31,6 +31,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/camundaex'
   FLAKY_TEST_RERUN_COUNT: '3'
 
 jobs:

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -20,6 +20,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
 jobs:
   benchmark-data:
     name: Collect benchmark data

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/camunda-load-test-ttl-cleanup.yml
+++ b/.github/workflows/camunda-load-test-ttl-cleanup.yml
@@ -13,6 +13,7 @@ on:
         required: false
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -19,6 +19,9 @@ on:
     # Runs at 01:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
     - cron: '0 1 * * 1-5'
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   setup:
     name: Resolve release branch

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -1,6 +1,6 @@
 # description: Daily compatibility tests for Camunda Spring Boot Starter across server versions
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/camundaex
 name: Camunda Spring Boot Starter Compatibility Tests
 
 on:
@@ -31,6 +31,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/camundaex'
   FLAKY_TEST_RERUN_COUNT: '3'
 
 jobs:

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -19,6 +19,10 @@ on:
     # Runs at 1am every monday https://crontab.guru/#0_1_*_*_1
     - cron: 0 1 * * 1
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
+
 jobs:
   test-data:
     name: Collect test data

--- a/.github/workflows/check-licenses-active-issues.yml
+++ b/.github/workflows/check-licenses-active-issues.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -20,6 +20,7 @@ on:
     - synchronize
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/check-outdated-prs.yml
+++ b/.github/workflows/check-outdated-prs.yml
@@ -26,6 +26,9 @@ permissions:
   pull-requests: write
   contents: read
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   get-prs:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   check-all-pr-conflicts:
     if: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -62,6 +62,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
 
@@ -157,7 +158,6 @@ jobs:
           job_name: "${{ inputs.test-type }}/${{ inputs.database-type }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -34,6 +34,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Operate
 
@@ -51,12 +52,15 @@ jobs:
         include:
           - suite: DataLayer
             suiteName: Data Layer
+            owner: '@camunda/data-layer'
           - suite: CoreFeatures
             suiteName: Core Features
+            owner: '@camunda/core-features'
     with:
       componentName: "Operate"
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
+      owner: ${{ matrix.owner }}
 
   # Checks to see if Operate can properly build itself and a docker image
   build-operate-backend:
@@ -67,7 +71,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-      TEST_OWNER: Core Features
       TEST_TYPE: Build
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -103,7 +106,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-unit-tests:
     if: inputs.runFeTests
@@ -118,7 +120,6 @@ jobs:
         shardTotal: [4]
     env:
       TEST_TYPE: Unit
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: operate/client
@@ -165,7 +166,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Unit
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: operate/client
@@ -196,7 +196,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Operate
     defaults:
       run:
@@ -222,7 +221,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   # Front End Code linting
   operate-fe-eslint:
@@ -233,7 +231,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Operate
     defaults:
       run:
@@ -259,7 +256,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-fe-sbom-snyk:
     if: inputs.runFeTests
@@ -269,7 +265,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: operate/client
@@ -305,7 +300,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   # description: This workflow runs a11y accessibility tests on Operate
   operate-fe-a11y-tests:
@@ -316,7 +310,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.58.2
       options: --user 1001:1000
@@ -354,7 +347,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-fe-visual-regression-tests:
     if: inputs.runFeTests
@@ -369,7 +361,6 @@ jobs:
         shardTotal: [4]
     env:
       TEST_TYPE: visual-regression
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.58.2
       options: --user 1001:1000
@@ -409,7 +400,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-fe-visual-regression-merge:
     if: ${{ !cancelled() && inputs.runFeTests }}
@@ -420,7 +410,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: operate/client
@@ -459,7 +448,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: screenshot-update
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.58.2
       options: --user 1001:1000
@@ -496,7 +484,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   run-backup-restore-tests:
     if: inputs.runBeTests
@@ -506,7 +493,7 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       DOCKER_IMAGE_TAG: current-test
-      TEST_OWNER: Data Layer
+      TEST_OWNER: '@camunda/data-layer'
       TEST_TYPE: Integration
     services:
       registry:
@@ -561,7 +548,6 @@ jobs:
           job_name: "operate-ci/backup-restore"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-data-layer"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -34,6 +34,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Optimize
 
@@ -51,12 +52,15 @@ jobs:
         include:
           - suite: DataLayer
             suiteName: Data Layer
+            owner: '@camunda/data-layer'
           - suite: CoreFeatures
             suiteName: Core Features
+            owner: '@camunda/core-features'
     with:
       componentName: "Optimize"
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
+      owner: ${{ matrix.owner }}
 
   optimize-it-elasticsearch:
     name: "Integration / Elasticsearch ITs"
@@ -65,7 +69,6 @@ jobs:
     timeout-minutes: 45
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: IT
     strategy:
       fail-fast: false
@@ -149,7 +152,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   optimize-it-opensearch:
     name: "Integration / OpenSearch ITs"
@@ -158,7 +160,6 @@ jobs:
     timeout-minutes: 60
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: IT
     strategy:
       fail-fast: false
@@ -242,7 +243,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   optimize-frontend-unit-tests:
     name: "Unit - Front End"
@@ -255,7 +255,6 @@ jobs:
         working-directory: optimize/client
     env:
       LIMITS_CPU: 4
-      TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -296,7 +295,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   optimize-frontend-sbom-snyk:
     name: "Tool / Front End - Snyk SBOM"
@@ -308,7 +306,6 @@ jobs:
       run:
         working-directory: optimize/client
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Tool
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -353,7 +350,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   hadolint:
     if: inputs.runBeTests
@@ -362,7 +358,6 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     timeout-minutes: 4
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Tool
     strategy:
       fail-fast: false
@@ -390,7 +385,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
   optimize-e2e-smoke:
     name: "E2E / Self-Managed (Smoke)"
     if: inputs.runFeTests
@@ -399,7 +393,6 @@ jobs:
     permissions: { }
     env:
       TEST_TYPE: E2E
-      TEST_OWNER: Core Features
 
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -550,7 +543,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   e2e-cloud-test:
     name: "E2E Cloud"
@@ -559,7 +551,6 @@ jobs:
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: E2E
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -665,4 +656,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -34,6 +34,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Tasklist
 
@@ -51,12 +52,15 @@ jobs:
         include:
           - suite: DataLayer
             suiteName: Data Layer
+            owner: '@camunda/data-layer'
           - suite: CoreFeatures
             suiteName: Core Features
+            owner: '@camunda/core-features'
     with:
       componentName: "Tasklist"
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
+      owner: ${{ matrix.owner }}
 
   fe-type-check:
     if: inputs.runFeTests
@@ -66,7 +70,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Tasklist
     defaults:
       run:
@@ -92,7 +95,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-eslint:
     if: inputs.runFeTests
@@ -102,7 +104,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Tasklist
     defaults:
       run:
@@ -128,7 +129,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-stylelint:
     if: inputs.runFeTests
@@ -138,7 +138,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: tasklist/client
@@ -163,7 +162,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-tests:
     if: inputs.runFeTests
@@ -173,7 +171,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Unit
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: tasklist/client
@@ -198,7 +195,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-sbom-snyk:
     if: inputs.runFeTests
@@ -208,7 +204,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: tasklist/client
@@ -244,7 +239,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-visual-regression-tests:
     if: inputs.runFeTests
@@ -254,7 +248,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.58.2
       options: --user 1001:1000
@@ -292,7 +285,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-a11y-tests:
     if: inputs.runFeTests
@@ -302,7 +294,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.58.2
       options: --user 1001:1000
@@ -340,7 +331,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   run-backup-restore-tests:
     if: inputs.runBeTests
@@ -352,7 +342,7 @@ jobs:
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
       TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
       TEST_TYPE: Integration
-      TEST_OWNER: Data Layer
+      TEST_OWNER: '@camunda/data-layer'
     strategy:
       fail-fast: false
       matrix:
@@ -420,12 +410,10 @@ jobs:
           job_name: "tasklist-ci/backup-restore-${{ matrix.database }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-data-layer"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
 
   integration-tests:
     if: inputs.runBeTests
@@ -436,7 +424,6 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Integration
-      TEST_OWNER: Core Features
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
       TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
     services:
@@ -497,4 +484,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -20,10 +20,14 @@ on:
         description: "Well formatted name of the suite under test. ie, 'Data Layer' or 'Core Features'"
         required: true
         type: string
+      owner:
+        description: "Canonical GitHub team handle owning the suite under test, e.g. '@camunda/data-layer'"
+        required: true
+        type: string
 
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
-  TEST_OWNER: Core Features
+  TEST_OWNER: ${{ inputs.owner }}
   TEST_TYPE: Unit
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
 
@@ -89,7 +93,6 @@ jobs:
           job_name: "${{inputs.componentName}}-unit-tests/${{inputs.suite}}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "${{inputs.suiteName}}"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -26,6 +26,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/zeebe-distributed-platform'
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Zeebe
@@ -38,7 +39,6 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runner }}
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Smoke
     strategy:
       fail-fast: false
@@ -121,7 +121,6 @@ jobs:
           job_name: "smoke-tests/${{ matrix.os }}-${{ matrix.arch }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-distributed-systems"
           detailed_junit_tests: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}  # feature only supported on Linux for now
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -133,7 +132,6 @@ jobs:
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -180,7 +178,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-distributed-systems"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -193,7 +190,7 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"
-      TEST_OWNER: Core Features
+      TEST_OWNER: '@camunda/core-features'
       TEST_TYPE: Performance
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -251,7 +248,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-core-features"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -264,7 +260,6 @@ jobs:
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -315,7 +310,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-distributed-systems"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -335,7 +329,6 @@ jobs:
           - 5000:5000
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/zeebe
-      TEST_OWNER: Core Features
       TEST_TYPE: Build
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -395,7 +388,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-distributed-systems"
 
   test-summary:
     # Used by the merge queue to check all tests, including the unit test matrix.
@@ -475,7 +467,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "team-distributed-systems"
 
   # Dynamically generate the concurrency group for load test image deployment
   utils-get-concurrency-group-for-load-test:
@@ -499,6 +490,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     env:
+      TEST_OWNER: '@camunda/reliability-testing'
       IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
       IMAGE_TAG: ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
     steps:
@@ -525,7 +517,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-reliability-testing"
 
   deploy-snyk-projects:
     name: Deploy Snyk development projects
@@ -562,6 +553,8 @@ jobs:
     permissions:
       checks: read
       pull-requests: write
+    env:
+      TEST_OWNER: '@camunda/monorepo-devops-team'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Generate GitHub token
@@ -594,4 +587,3 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "General"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
@@ -458,7 +459,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -474,6 +474,7 @@ jobs:
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     env:
+      TEST_OWNER: ${{ matrix.owner }}
       TEST_TYPE: "Unit"
       TEST_PRODUCT: "Zeebe"
     strategy:
@@ -482,24 +483,31 @@ jobs:
         include:
           - component: General
             suite: CoreFeatures
+            owner: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_CORE_FEATURES_MODULES }}
           - component: Protocol
             suite: CoreFeatures
+            owner: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_PROTOCOL_MODULES }}
           - component: Gateway
             suite: CoreFeatures
+            owner: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_GATEWAY_MODULES }}
           - component: Exporter
             suite: DataLayer
+            owner: '@camunda/data-layer'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_EXPORTER_MODULES }}
           - component: Backup
             suite: DistributedPlatform
+            owner: '@camunda/zeebe-distributed-platform'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_BACKUP_MODULES }}
           - component:  Distributed
             suite: DistributedPlatform
+            owner: '@camunda/zeebe-distributed-platform'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_DISTRIBUTED_MODULES }}
           - component: Client
             suite: CamundaEx
+            owner: '@camunda/camundaex'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_CLIENT_MODULES }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -507,7 +515,7 @@ jobs:
       - name: Print metadata
         uses: ./.github/actions/print-metadata
         with:
-          test_owner: "${{ matrix.suite }}"
+          test_owner: "${{ matrix.owner }}"
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: ut-zeebe
@@ -567,7 +575,6 @@ jobs:
           job_name: "zeebe-unit-tests/${{ matrix.component }}-${{matrix.suite}}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "${{matrix.suite}}"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -699,7 +706,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -726,7 +732,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "QA"
+            owner: '@camunda/qa-engineering'
             module: "QA"
           - group: zeebe-ds-modules
             name: "Zeebe Distributed Platform Modules"
@@ -736,7 +742,7 @@ jobs:
             runs-on: gcp-perf-core-16-longrunning
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "Distributed Platform"
+            owner: '@camunda/zeebe-distributed-platform'
             module: "Zeebe"
           - group: zeebe-engine-modules
             name: "Zeebe Engine Modules"
@@ -746,7 +752,7 @@ jobs:
             runs-on: gcp-perf-core-16-longrunning
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "Core Features"
+            owner: '@camunda/core-features'
             module: "Zeebe"
           - group: zeebe-exporter-modules
             name: "Zeebe Exporter Modules"
@@ -756,7 +762,7 @@ jobs:
             runs-on: gcp-perf-core-16-longrunning
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "DataLayer"
+            owner: '@camunda/data-layer'
             module: "Zeebe"
           - group: schema-manager
             name: "Schema Manager"
@@ -766,7 +772,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "Data Layer"
+            owner: '@camunda/data-layer'
             module: "Schema Manager"
           - group: zeebe-engine-integration
             name: "Zeebe Engine QA"
@@ -774,7 +780,7 @@ jobs:
             maven-build-threads: 1
             maven-test-fork-count: 10
             runs-on: gcp-perf-core-16-default
-            owner: "Core Features"
+            owner: '@camunda/core-features'
             module: "Zeebe"
             test-filter: "io.camunda.zeebe.it.engine.**,!**/*$*.java"
           - group: zeebe-ds-integration
@@ -785,7 +791,7 @@ jobs:
             runs-on: gcp-perf-core-16-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "Distributed Platform"
+            owner: '@camunda/zeebe-distributed-platform'
             module: "Zeebe"
             test-filter: "io.camunda.zeebe.it.cluster.**,!io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest,!**/*$*.java"
           - group: zeebe-ds-integration-scaleup
@@ -794,7 +800,7 @@ jobs:
             maven-build-threads: 1
             maven-test-fork-count: 1
             runs-on: gcp-perf-core-8-default
-            owner: "Distributed Platform"
+            owner: '@camunda/zeebe-distributed-platform'
             module: "Zeebe"
             test-filter: "io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest"
           - group: zeebe-shared-integration
@@ -805,7 +811,7 @@ jobs:
             runs-on: gcp-perf-core-16-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "General"
+            owner: '@camunda/monorepo-devops-team'
             module: "Zeebe"
             test-filter: "!io.camunda.zeebe.it.engine.**,!io.camunda.zeebe.it.cluster.**,!**/*$*.java"
           - group: qa-update
@@ -816,7 +822,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "Core Features"
+            owner: '@camunda/core-features'
             module: "Zeebe"
           - group: qa-camunda-process-test
             name: "Camunda Process"
@@ -826,7 +832,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "CamundaEx"
+            owner: '@camunda/camundaex'
             module: "Testing"
           - group: qa-testcontainers
             name: "Testcontainers Tests"
@@ -836,9 +842,10 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "Distributed Platform"
+            owner: '@camunda/zeebe-distributed-platform'
             module: "Zeebe"
     env:
+      TEST_OWNER: ${{ matrix.owner }}
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist:current-test
@@ -961,7 +968,6 @@ jobs:
           job_name: "integration-tests/${{ matrix.group }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ matrix.owner }}
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -975,7 +981,6 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     env:
-      TEST_OWNER: General
       TEST_PRODUCT: Camunda
       TEST_TYPE: Unit
     outputs:
@@ -1029,7 +1034,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -1154,7 +1158,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
 
   detect-new-flaky-tests:
@@ -1348,6 +1351,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
+    env:
+      TEST_OWNER: '@camunda/identity'
     defaults:
       run:
         working-directory: identity/client
@@ -1380,7 +1385,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "Identity"
 
   tasklist-ci:
     if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
@@ -1484,7 +1488,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
 
   openapi-lint:
     name: "Lint / C8 REST OpenAPI"
@@ -1534,7 +1537,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
 
   renovatelint:
     if: needs.detect-changes.outputs.renovate-config-changes == 'true'
@@ -1708,7 +1710,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
 
   # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
   utils-get-snapshot-docker-tag:
@@ -1787,7 +1788,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
 
   utils-get-concurrency-group-for-optimize-docker-snapshot:
     needs: [ check-results ]
@@ -1809,6 +1809,8 @@ jobs:
     concurrency:
       group: ${{ needs.utils-get-concurrency-group-for-optimize-docker-snapshot.outputs.concurrency_group_name }}
       cancel-in-progress: false
+    env:
+      TEST_OWNER: '@camunda/core-features'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1851,4 +1853,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -45,6 +45,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  TEST_OWNER: '@camunda/distribution'
   GHA_BEST_PRACTICES_LINTER: enabled
   HARBOR_REGISTRY: registry.camunda.cloud
   HARBOR_REPOSITORY: registry.camunda.cloud/team-camunda/camunda

--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -22,6 +22,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   # renovate: datasource=node-version depName=node
   NODE_VERSION: '24.13.1'
 

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -21,6 +21,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   cleanup-orphaned-previews:
     name: Cleanup Orphaned Documentation Previews

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   submit-maven-snapshot:
     name: "Security / Submit Maven Dependency Snapshot"

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -1,5 +1,5 @@
 # type: Project Management
-# owner: Engineering Ops
+# owner: @camunda/monorepo-devops-team
 name: "Opened Issue Labeler"
 on:
   issues:

--- a/.github/workflows/optimize-ci-data-upgrade-nightly.yml
+++ b/.github/workflows/optimize-ci-data-upgrade-nightly.yml
@@ -21,6 +21,9 @@ permissions:
   checks: write
   pull-requests: write
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   detect-changes:
     name: Get changed directories

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -18,6 +18,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 permissions:
@@ -34,7 +35,6 @@ jobs:
     timeout-minutes: 120
     env:
       TEST_TYPE: E2E
-      TEST_OWNER: Core Features
 
     steps:
       - name: Checkout code
@@ -140,4 +140,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -35,6 +35,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GH_TOKEN: ${{ github.token }} # needs to be available for the gh CLI tool
 
 jobs:

--- a/.github/workflows/preview-env-clean.yml
+++ b/.github/workflows/preview-env-clean.yml
@@ -23,6 +23,9 @@ on:
         required: true
   workflow_dispatch:
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   preview-env-clean:
     concurrency:

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -25,6 +25,9 @@ on:
         type: boolean
         default: false
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   deploy-8-8:
     name: Deploy 8.8 Preview Environment

--- a/.github/workflows/publish-zod-schemas.yml
+++ b/.github/workflows/publish-zod-schemas.yml
@@ -21,6 +21,7 @@ on:
       - 'client-components/packages/camunda-api-zod-schemas/**'
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
@@ -36,7 +37,6 @@ jobs:
         working-directory: client-components
         shell: bash
     env:
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Camunda
       TEST_TYPE: Build
     steps:

--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - release-*
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   validate-event:
     name: Validate GitHub event for release branch activity

--- a/.github/workflows/renovate-daily.yml
+++ b/.github/workflows/renovate-daily.yml
@@ -15,6 +15,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/renovate-weekly.yml
+++ b/.github/workflows/renovate-weekly.yml
@@ -14,6 +14,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -15,6 +15,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch: { }
   workflow_call: { }
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   integration-tests:
     name: Tasklist Docker tests
@@ -73,4 +76,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
@@ -13,6 +13,7 @@ on:
     - cron: "0 4 * * Mon-Fri"
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 defaults:
@@ -121,7 +122,6 @@ jobs:
           job_name: "integration-tests/camunda-qa-acceptance-tests"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: General
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -26,6 +26,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   cleanup-opensearch-indices:
     name: "[PRE] Cleanup old AWS OpenSearch indices. OS ver.${{ matrix.os_version }}"
@@ -66,7 +69,6 @@ jobs:
         with:
           job_name: "cleanup-opensearch-indices/${{ matrix.os_version }}"
           build_status: ${{ job.status }}
-          user_description: "General"
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -97,7 +99,7 @@ jobs:
             maven-test-fork-count: 7
             maven-test-profiles: multi-db-test-client
             runs-on: aws-core-8-default
-            owner: "General"
+            owner: '@camunda/monorepo-devops-team'
           - group: camunda-qa-acceptance-tests-non-client
             name: "Camunda QA Module Non-Client Tests"
             maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
@@ -105,7 +107,7 @@ jobs:
             maven-test-fork-count: 7
             maven-test-profiles: multi-db-test-non-client
             runs-on: aws-core-8-default
-            owner: "General"
+            owner: '@camunda/monorepo-devops-team'
           - group: search-client-opensearch
             name: "Search Client OpenSearch ITs"
             maven-modules: "'io.camunda:camunda-search-client-connect,io.camunda:camunda-search-client-opensearch'"
@@ -113,7 +115,7 @@ jobs:
             maven-test-fork-count: 7
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
-            owner: "Core Features"
+            owner: '@camunda/core-features'
           - group: camunda-exporter
             name: "Camunda Exporter ITs"
             maven-modules: "'io.camunda:camunda-exporter'"
@@ -121,7 +123,7 @@ jobs:
             maven-test-fork-count: 7
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
-            owner: "Data Layer"
+            owner: '@camunda/data-layer'
           - group: zeebe-opensearch-exporter
             name: "Zeebe OpenSearch Exporter ITs"
             maven-modules: "'io.camunda:zeebe-opensearch-exporter'"
@@ -129,7 +131,7 @@ jobs:
             maven-test-fork-count: 7
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
-            owner: "Data Layer"
+            owner: '@camunda/data-layer'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup AWS OpenSearch

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -20,6 +20,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   # This URL is used as the business key for the various QA workflows
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/zeebe-rdbms-integration-tests.yml
+++ b/.github/workflows/zeebe-rdbms-integration-tests.yml
@@ -20,6 +20,7 @@ on:
     - cron: "0 5 * * Mon-Fri"
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 defaults:

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -10,6 +10,9 @@ on:
     # Runs at 02:00 every week day; see this link for more: https://crontab.guru/#0_2_*_*_1-5
     - cron: '0 2 * * 1-5'
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   dry-run-release-88:
     name: "Release from stable/8.8"

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -15,6 +15,9 @@ concurrency:
 permissions:
   actions: read # Required to get the previous report
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   released-versions:
     name: Released Versions

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -10,6 +10,9 @@ on:
     # Run at 7:00 on every monday
     - cron: "0 7 * * 1"
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   # This job will figure out the last supported versions based on the latest tags.
   #

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -199,15 +199,27 @@ Related resources:
 
 ### Ownership
 
-Each CI test file has an owning team. The owning team can be found either through the `CODEOWNERS` file or on the metadata in the file itself. The `CODEOWNERS` file is organized and broken down by team, any additions to the file should follow that convention. The metadata on a GHA workflow file is used by a scraping tool so that it is easy to gather information about the current state of CI. You can look at the metadata for a quick overview of the owning team, where the tests live, how the test is called, and a description of what the file is actually testing
+Each CI test file has an owning team. The owning team can be found in `.codeowners` (lookup via `codeowners-cli owner <path>`) with the same value also in the metadata in the GHA workflow YAML file itself. `.codeowners` is the source-of-truth, the metadata is for human overview only:
+
+You can look at the metadata for a quick overview of the owning team, where the tests live, how the test is called, and a description of what the file is actually testing
+
+The owning team is the general point of contact for any questions or problems with the GHA workflow. Unless overwritten on the GHA job-level, the owning team will also own all job failures and their medic can be contacted to resolve those.
 
 Metadata follows this structure and is placed at the beginning of a GHA workflow file
 
 ```
 # <Description of what the GHA is running and what is being tested>
 # test location: <The filepath of the tests being run>
-# owner: <The name of the owning team>
+# owner: <The GitHub handle of the owning team>
 ```
+
+#### Automatic Alert Attribution
+
+For programmatic alert routing and medic assignment on CI incidents, each workflow also propagates the canonical GitHub team handle to [CI Analytics](#ci-health-metrics) via a workflow-level `env: TEST_OWNER:` block.
+
+The [`observe-build-status` action](#metrics-collection) reads this env var as the default for the `user_description` field it submits to CI Analytics. This can be overwritten on the job-level with more specific `env: TEST_OWNER:` blocks.
+
+See [Metrics Collection](#metrics-collection) for the concrete `env:` snippet, including how to override per-job and how to wire matrix-driven values.
 
 ### Legacy CI
 
@@ -351,6 +363,31 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+```
+
+To attribute CI Analytics rows to an owning team, set a canonical handle as a workflow-level env var. This is read by `observe-build-status` as the default for its `user_description` input, so no inline argument is needed at the call site:
+
+```yaml
+# owner: @camunda/core-features
+env:
+  TEST_OWNER: '@camunda/core-features'
+```
+
+The handle must match with `.codeowners` (verify with `codeowners-cli owner <path>`). Override per job for outliers if necessary, including matrix-driven values:
+
+```yaml
+jobs:
+  per-suite-tests:
+    strategy:
+      matrix:
+        include:
+          - suite: CoreFeatures
+            owner: '@camunda/core-features'
+          - suite: DataLayer
+            owner: '@camunda/data-layer'
+    env:
+      TEST_OWNER: ${{ matrix.owner }}
+    # ...
 ```
 
 Related resources:

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -1132,7 +1132,7 @@ Failures are reported to Slack and visible in the [Actions tab](https://github.c
 **What this means for contributors:**
 
 - If you change an endpoint's response shape, remove a field, or alter error codes, the forward compatibility tests will detect it.
-- If your PR intentionally introduces a breaking change (see §2.7), coordinate with `@camunda/camunda-ex` to update the test expectations on the affected older branches _before_ merging.
+- If your PR intentionally introduces a breaking change (see §2.7), coordinate with `@camunda/camundaex` to update the test expectations on the affected older branches _before_ merging.
 
 There is also an **on-demand workflow** ([`c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml`](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml)) that builds the server _and_ runs the tests from the same branch. This is useful for verifying that a feature branch passes all API tests — both against Elasticsearch _and_ H2/RDBMS — before merging. It also detects differential behavior between storage engines.
 


### PR DESCRIPTION
## Description

Backport of [#55040](https://github.com/camunda/camunda/pull/55040) to \`stable/8.9\`. Submits canonical \`@camunda/...\` team handles to CI Analytics from every push/schedule workflow on this branch, so failures route to the responsible team's medic via [setup-medic-lookup.sh](.ci/scripts/ci/setup-medic-lookup.sh).

### Adaptations for stable/8.9

The cherry-pick was applied as a single combined diff (\`git cherry-pick -m 1 e1594074d86\`) and conflicts were resolved by:

- **Dropped 14 workflow files** that exist on \`main\` but not on \`stable/8.9\` (e.g. \`assign-urgency-to-issues-cron.yml\`, the \`c8-orchestration-cluster-*-nightly-*\` family, \`*-compatibility-test-trigger.yml\` files, \`codeowners-file-owner.yml\`, \`data-layer-nightly-tests.yml\`, \`stale-backport-tracker.yml\`, \`verify-x-added-in-version-annotations.yml\`).
- **\`.codeowners\`** — applied only the rules whose target files exist on \`stable/8.9\`. The "Late overrides" section is included with rules for files that exist here (\`c8-orchestration-cluster-request-validation-nightly.yml\`, \`zeebe-release-stable-dry-run.yml\`).
- **\`ci.yml\`** — kept the stable structure; the three large incoming sections (integration tests matrix, identity-frontend-sbom-snyk job, openapi-x-added-in-version-check job) are post-stable additions on \`main\` and are not introduced here.
- **\`ci-operate.yml\` / \`ci-tasklist.yml\`** — the \`run-backup-restore-tests\` job is still active on stable/8.9 (commented out on main as part of the V1 API cleanup for 8.10). Kept the job active and updated the vocabulary to canonical handles. Did not introduce the \`fe-prettier\` / \`operate-fe-prettier\` jobs added on main.
- **\`camunda-weekly-load-tests.yml\`** — added \`env: TEST_OWNER: '@camunda/reliability-testing'\` only; did not import unrelated additions from main (\`defaults.run.shell\`, \`IMAGE_REPOSITORY\` env not referenced in this file).
- **\`tasklist-docker-tests.yml\`** — file was removed on main but still exists on stable/8.9; applied the same workflow-level TEST_OWNER pattern in a separate commit.

### Verification

- 0 inline \`user_description\` values left non-canonical
- 0 \`TEST_OWNER\` env values left non-canonical (all are \`@camunda/...\` handles, matrix expressions, or input refs)
- YAML parses cleanly for every modified workflow

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary — this is the backport.
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Contributes to #52873. Backport of #55040.