### PR TITLE
fix: authenticate GitHub API requests in zeebe-version-compatibility workflow

### DIFF
--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   actions: read # Required to get the previous report
+  contents: read # Required for authenticated GitHub API calls in RollingUpdateTest (releases, tags)
 
 jobs:
   released-versions:

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -83,6 +83,7 @@ jobs:
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_INDEX: ${{ strategy.job-index }}
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_TOTAL: ${{ strategy.job-total }}
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_REPORT: ${{ github.workspace }}/zeebe-version-compatibility
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./.github/actions/collect-test-artifacts
         if: always()
         with:
@@ -148,6 +149,7 @@ jobs:
           verify
         env:
           ZEEBE_CI_CHECK_CURRENT_VERSION_COMPATIBILITY: true
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./.github/actions/collect-test-artifacts
         if: always()
         with:


### PR DESCRIPTION
## Summary

- Adds `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the **Test rolling update** step in the `released-versions` job
- Adds the same to the **Test snapshot** step in the `current-snapshot` job

Both steps run `io.camunda.zeebe.test.RollingUpdateTest`, which calls `VersionCompatibilityMatrix.createAuthenticatedRequest`. Without a token, requests go out unauthenticated and hit GitHub's public rate limit on shared runners.

Closes incident: https://camunda.slack.com/archives/C0B9QQEC9QU

Failing job example: https://github.com/camunda/camunda/actions/runs/27260772693/job/80505668078#step:9:370

## Test plan

- [ ] Trigger the `zeebe-version-compatibility` workflow manually after merge and confirm no rate-limit errors in the `Test rolling update` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)