### PR TITLE
[Backport stable/8.8] ci: submit job-level owner to CI Analytics for push and schedule workflows

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status.'
     required: false
   user_description:
-    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status.'
+    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status. When empty, falls back to the TEST_OWNER environment variable.'
     required: false
   job_name:
     description: 'Optional string, the job whose status is being observed; defaults to $GITHUB_JOB when omitted'
@@ -102,5 +102,5 @@ runs:
         build_status: "${{ inputs.build_status }}"
         build_duration_millis: "${{ steps.get-build-duration-millis.outputs.result }}"
         user_reason: "${{ inputs.user_reason }}"
-        user_description: "${{ inputs.user_description }}"
+        user_description: "${{ inputs.user_description != '' && inputs.user_description || env.TEST_OWNER }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"

--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -1,6 +1,6 @@
 # description: Daily compatibility tests for Camunda components across versions
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/camundaex
 name: Camunda Compatibility Tests
 
 on:
@@ -31,6 +31,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/camundaex'
   FLAKY_TEST_RERUN_COUNT: '3'
 
 jobs:

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -20,6 +20,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
 jobs:
   benchmark-data:
     name: Collect benchmark data

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/camunda-load-test-ttl-cleanup.yml
+++ b/.github/workflows/camunda-load-test-ttl-cleanup.yml
@@ -13,6 +13,7 @@ on:
         required: false
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -15,6 +15,9 @@ on:
     # Runs at 01:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
     - cron: '0 1 * * 1-5'
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   setup:
     name: Resolve release branch

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -1,6 +1,6 @@
 # description: Daily compatibility tests for Camunda Spring Boot Starter across server versions
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/camundaex
 name: Camunda Spring Boot Starter Compatibility Tests
 
 on:
@@ -31,6 +31,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/camundaex'
   FLAKY_TEST_RERUN_COUNT: '3'
 
 jobs:

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -19,6 +19,9 @@ on:
     # Runs at 1am every monday https://crontab.guru/#0_1_*_*_1
     - cron: 0 1 * * 1
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
 jobs:
   test-data:
     name: Collect test data

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -20,6 +20,7 @@ on:
     - synchronize
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   check-all-pr-conflicts:
     if: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -34,6 +34,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Operate
 
@@ -51,12 +52,15 @@ jobs:
         include:
           - suite: DataLayer
             suiteName: Data Layer
+            owner: '@camunda/data-layer'
           - suite: CoreFeatures
             suiteName: Core Features
+            owner: '@camunda/core-features'
     with:
       componentName: "Operate"
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
+      owner: ${{ matrix.owner }}
 
 
   # Checks to see if Operate can properly build itself and a docker image
@@ -68,7 +72,6 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-      TEST_OWNER: Core Features
       TEST_TYPE: Build
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -104,7 +107,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-unit-tests:
     if: inputs.runFeTests
@@ -114,7 +116,6 @@ jobs:
     permissions: { } # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Unit
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: operate/client
@@ -149,7 +150,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Operate
     defaults:
       run:
@@ -175,7 +175,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   # Front End Code linting
   operate-fe-eslint:
@@ -186,7 +185,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Operate
     defaults:
       run:
@@ -212,7 +210,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-fe-sbom-snyk:
     if: inputs.runFeTests
@@ -222,7 +219,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: operate/client
@@ -258,7 +254,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   # description: This workflow runs a11y accessibility tests on Operate
   operate-fe-a11y-tests:
@@ -269,7 +264,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.54.2
       options: --user 1001:1000
@@ -307,7 +301,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-fe-visual-regression-tests:
     if: inputs.runFeTests
@@ -317,7 +310,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.54.2
       options: --user 1001:1000
@@ -355,7 +347,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   operate-update-screenshots:
     if: inputs.runFeTests
@@ -365,7 +356,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: screenshot-update
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.54.2
       options: --user 1001:1000
@@ -402,7 +392,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   run-importer-tests:
     if: inputs.runBeTests
@@ -411,7 +400,7 @@ jobs:
     timeout-minutes: 10
     env:
       TEST_TYPE: Integration
-      TEST_OWNER: Data Layer
+      TEST_OWNER: '@camunda/data-layer'
     permissions: {} # GITHUB_TOKEN unused in this job
     steps:
       - name: Check out repository code
@@ -438,7 +427,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-data-layer"
 
   run-backup-restore-tests:
     if: inputs.runBeTests
@@ -448,7 +436,7 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
       DOCKER_IMAGE_TAG: current-test
-      TEST_OWNER: Data Layer
+      TEST_OWNER: '@camunda/data-layer'
       TEST_TYPE: Integration
     services:
       registry:
@@ -503,7 +491,6 @@ jobs:
           job_name: "operate-ci/backup-restore"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-data-layer"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -34,6 +34,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Optimize
 
@@ -51,12 +52,15 @@ jobs:
         include:
           - suite: DataLayer
             suiteName: Data Layer
+            owner: '@camunda/data-layer'
           - suite: CoreFeatures
             suiteName: Core Features
+            owner: '@camunda/core-features'
     with:
       componentName: "Optimize"
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
+      owner: ${{ matrix.owner }}
 
   optimize-it-elasticsearch:
     name: "Integration / Elasticsearch ITs"
@@ -65,7 +69,6 @@ jobs:
     timeout-minutes: 45
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: IT
     strategy:
       fail-fast: false
@@ -149,7 +152,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   optimize-it-opensearch:
     name: "Integration / OpenSearch ITs"
@@ -158,7 +160,6 @@ jobs:
     timeout-minutes: 60
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: IT
     strategy:
       fail-fast: false
@@ -242,7 +243,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   optimize-frontend-unit-tests:
     name: "Unit - Front End"
@@ -255,7 +255,6 @@ jobs:
         working-directory: optimize/client
     env:
       LIMITS_CPU: 4
-      TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -296,7 +295,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   optimize-frontend-sbom-snyk:
     name: "Tool / Front End - Snyk SBOM"
@@ -308,7 +306,6 @@ jobs:
       run:
         working-directory: optimize/client
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Tool
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -353,7 +350,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   hadolint:
     if: inputs.runBeTests
@@ -362,7 +358,6 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     timeout-minutes: 4
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Tool
     strategy:
       fail-fast: false
@@ -390,7 +385,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
   optimize-e2e-smoke:
     name: "E2E / Self-Managed (Smoke)"
     if: inputs.runFeTests
@@ -399,7 +393,6 @@ jobs:
     permissions: { }
     env:
       TEST_TYPE: E2E
-      TEST_OWNER: Core Features
 
     steps:
       - name: Checkout code
@@ -493,7 +486,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   e2e-cloud-test:
     name: "E2E Cloud"
@@ -502,7 +494,6 @@ jobs:
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: E2E
     steps:
       - name: Checkout code
@@ -607,4 +598,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -34,6 +34,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Tasklist
 
@@ -51,12 +52,15 @@ jobs:
         include:
           - suite: DataLayer
             suiteName: Data Layer
+            owner: '@camunda/data-layer'
           - suite: CoreFeatures
             suiteName: Core Features
+            owner: '@camunda/core-features'
     with:
       componentName: "Tasklist"
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
+      owner: ${{ matrix.owner }}
 
   fe-type-check:
     if: inputs.runFeTests
@@ -66,7 +70,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Tasklist
     defaults:
       run:
@@ -92,7 +95,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-eslint:
     if: inputs.runFeTests
@@ -102,7 +104,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
       TEST_PRODUCT: Tasklist
     defaults:
       run:
@@ -128,7 +129,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-stylelint:
     if: inputs.runFeTests
@@ -138,7 +138,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: tasklist/client
@@ -163,7 +162,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-tests:
     if: inputs.runFeTests
@@ -173,7 +171,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Unit
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: tasklist/client
@@ -198,7 +195,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-sbom-snyk:
     if: inputs.runFeTests
@@ -208,7 +204,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     defaults:
       run:
         working-directory: tasklist/client
@@ -244,7 +239,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-visual-regression-tests:
     if: inputs.runFeTests
@@ -254,7 +248,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.53.2
       options: --user 1001:1000
@@ -292,7 +285,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   fe-a11y-tests:
     if: inputs.runFeTests
@@ -302,7 +294,6 @@ jobs:
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
-      TEST_OWNER: Core Features
     container:
       image: mcr.microsoft.com/playwright:v1.53.2
       options: --user 1001:1000
@@ -340,7 +331,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"
 
   run-backup-restore-tests:
     if: inputs.runBeTests
@@ -351,7 +341,7 @@ jobs:
     env:
       DOCKER_IMAGE_TAG: current-test
       TEST_TYPE: Integration
-      TEST_OWNER: Data Layer
+      TEST_OWNER: '@camunda/data-layer'
     strategy:
       fail-fast: false
       matrix:
@@ -409,12 +399,10 @@ jobs:
           job_name: "tasklist-ci/backup-restore-${{ matrix.database }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-data-layer"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
 
   integration-tests:
     if: inputs.runBeTests
@@ -425,7 +413,7 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Integration
-      TEST_OWNER: Core Features
+      TEST_OWNER: '@camunda/core-features'
     services:
       registry:
         image: registry:3
@@ -474,4 +462,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -20,10 +20,14 @@ on:
         description: "Well formatted name of the suite under test. ie, 'Data Layer' or 'Core Features'"
         required: true
         type: string
+      owner:
+        description: "Canonical GitHub team handle owning the suite under test, e.g. '@camunda/data-layer'"
+        required: true
+        type: string
 
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
-  TEST_OWNER: Core Features
+  TEST_OWNER: ${{ inputs.owner }}
   TEST_TYPE: Unit
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
 
@@ -90,7 +94,6 @@ jobs:
           job_name: "${{inputs.componentName}}-unit-tests/${{inputs.suite}}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "${{inputs.suiteName}}"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -26,6 +26,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/zeebe-distributed-platform'
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Zeebe
@@ -38,7 +39,7 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runner }}
     env:
-      TEST_OWNER: Core Features
+      TEST_OWNER: '@camunda/reliability-testing'
       TEST_TYPE: Smoke
     strategy:
       fail-fast: false
@@ -116,7 +117,6 @@ jobs:
           job_name: "smoke-tests/${{ matrix.os }}-${{ matrix.arch }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-reliability-testing"
           detailed_junit_tests: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}  # feature only supported on Linux for now
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -128,7 +128,6 @@ jobs:
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -175,7 +174,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-distributed-systems"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -188,7 +186,7 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"
-      TEST_OWNER: Core Features
+      TEST_OWNER: '@camunda/core-features'
       TEST_TYPE: Performance
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -246,7 +244,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-core-features"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -259,7 +256,6 @@ jobs:
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -310,7 +306,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-distributed-systems"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -330,7 +325,6 @@ jobs:
           - 5000:5000
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/zeebe
-      TEST_OWNER: Core Features
       TEST_TYPE: Build
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -389,7 +383,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-distributed-systems"
 
   test-summary:
     # Used by the merge queue to check all tests, including the unit test matrix.
@@ -469,7 +462,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "team-distributed-systems"
 
   # Dynamically generate the concurrency group for load test image deployment
   utils-get-concurrency-group-for-load-test:
@@ -493,6 +485,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     env:
+      TEST_OWNER: '@camunda/reliability-testing'
       IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
       IMAGE_TAG: ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
     steps:
@@ -520,7 +513,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-reliability-testing"
 
   deploy-snyk-projects:
     name: Deploy Snyk development projects
@@ -557,6 +549,8 @@ jobs:
     permissions:
       checks: read
       pull-requests: write
+    env:
+      TEST_OWNER: '@camunda/monorepo-devops-team'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Generate GitHub token
@@ -589,4 +583,3 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "General"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1051,7 +1051,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: '@camunda/core-features'
+            owner: '@camunda/camundaex'
             module: "Testing"
     env:
       TEST_OWNER: ${{ matrix.owner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
@@ -475,7 +476,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -489,6 +489,7 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     env:
+      TEST_OWNER: ${{ matrix.owner }}
       TEST_TYPE: "Unit"
       TEST_PRODUCT: "Zeebe"
     strategy:
@@ -497,24 +498,31 @@ jobs:
         include:
           - component: General
             suite: CoreFeatures
+            owner: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_CORE_FEATURES_MODULES }}
           - component: Protocol
             suite: CoreFeatures
+            owner: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_PROTOCOL_MODULES }}
           - component: Gateway
             suite: CoreFeatures
+            owner: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_GATEWAY_MODULES }}
           - component: Exporter
             suite: DataLayer
+            owner: '@camunda/data-layer'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_EXPORTER_MODULES }}
           - component: Backup
             suite: DistributedPlatform
+            owner: '@camunda/zeebe-distributed-platform'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_BACKUP_MODULES }}
           - component:  Distributed
             suite: DistributedPlatform
+            owner: '@camunda/zeebe-distributed-platform'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_DISTRIBUTED_MODULES }}
           - component: Client
             suite: CamundaEx
+            owner: '@camunda/camundaex'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_CLIENT_MODULES }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
@@ -522,7 +530,7 @@ jobs:
       - name: Print metadata
         uses: ./.github/actions/print-metadata
         with:
-          test_owner: "${{ matrix.suite }}"
+          test_owner: "${{ matrix.owner }}"
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: ut-zeebe
@@ -570,7 +578,6 @@ jobs:
           job_name: "zeebe-unit-tests/${{ matrix.component }}-${{matrix.suite}}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "${{matrix.suite}}"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -673,7 +680,6 @@ jobs:
           job_name: "elasticsearch-integration-tests/${{ matrix.module.maven_module }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -782,7 +788,6 @@ jobs:
           job_name: "opensearch-integration-tests/${{ matrix.module.maven_module }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -850,7 +855,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -911,7 +915,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -936,7 +939,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            owner: "QA"
+            owner: '@camunda/qa-engineering'
             module: "QA"
           - group: zeebe-ds-modules
             name: "Zeebe Distributed Platform Modules"
@@ -946,7 +949,7 @@ jobs:
             runs-on: gcp-perf-core-16-longrunning
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            owner: "Distributed Platform"
+            owner: '@camunda/zeebe-distributed-platform'
             module: "Zeebe"
           - group: zeebe-engine-modules
             name: "Zeebe Engine Modules"
@@ -956,7 +959,7 @@ jobs:
             runs-on: gcp-perf-core-16-longrunning
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "Core Features"
+            owner: '@camunda/core-features'
             module: "Zeebe"
           - group: zeebe-exporter-modules
             name: "Zeebe Exporter Modules"
@@ -966,7 +969,7 @@ jobs:
             runs-on: gcp-perf-core-16-longrunning
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            owner: "DataLayer"
+            owner: '@camunda/data-layer'
             module: "Zeebe"
           - group: schema-manager
             name: "Schema Manager"
@@ -976,7 +979,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "Data Layer"
+            owner: '@camunda/data-layer'
             module: "Schema Manager"
           - group: zeebe-engine-integration
             name: "Zeebe Engine QA"
@@ -986,7 +989,7 @@ jobs:
             runs-on: gcp-perf-core-16-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            owner: "Core Features"
+            owner: '@camunda/core-features'
             module: "Zeebe"
             test-filter: "io.camunda.zeebe.it.engine.**,!**/*$*.java"
           - group: zeebe-ds-integration
@@ -997,7 +1000,7 @@ jobs:
             runs-on: gcp-perf-core-16-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            owner: "Distributed Platform"
+            owner: '@camunda/zeebe-distributed-platform'
             module: "Zeebe"
             test-filter: "io.camunda.zeebe.it.cluster.**,!io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest,!**/*$*.java"
           - group: zeebe-ds-integration-scaleup
@@ -1006,7 +1009,7 @@ jobs:
             maven-build-threads: 1
             maven-test-fork-count: 1
             runs-on: gcp-perf-core-8-default
-            owner: "Distributed Platform"
+            owner: '@camunda/zeebe-distributed-platform'
             module: "Zeebe"
             test-filter: "io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest"
           - group: zeebe-shared-integration
@@ -1017,7 +1020,7 @@ jobs:
             runs-on: gcp-perf-core-16-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            owner: "General"
+            owner: '@camunda/monorepo-devops-team'
             module: "Zeebe"
             test-filter: "!io.camunda.zeebe.it.engine.**,!io.camunda.zeebe.it.cluster.**"
           - group: qa-migration-integration
@@ -1028,7 +1031,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            owner: "Data Layer"
+            owner: '@camunda/data-layer'
             module: "Migration"
           - group: qa-update
             name: "Zeebe QA - Update"
@@ -1038,7 +1041,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
-            owner: "Core Features"
+            owner: '@camunda/core-features'
             module: "Zeebe"
           - group: qa-camunda-process-test
             name: "Camunda Process"
@@ -1048,9 +1051,10 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "Core Features"
+            owner: '@camunda/core-features'
             module: "Testing"
     env:
+      TEST_OWNER: ${{ matrix.owner }}
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist:current-test
@@ -1159,7 +1163,6 @@ jobs:
           job_name: "integration-tests/${{ matrix.group }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ matrix.owner }}
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -1173,7 +1176,6 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     env:
-      TEST_OWNER: General
       TEST_PRODUCT: Camunda
       TEST_TYPE: Unit
     outputs:
@@ -1227,7 +1229,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -1349,7 +1350,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
 
   detect-new-flaky-tests:
@@ -1522,6 +1522,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
+    env:
+      TEST_OWNER: '@camunda/identity'
     defaults:
       run:
         working-directory: identity/client
@@ -1554,7 +1556,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "Identity"
 
   identity-frontend-sbom-snyk:
     if: needs.detect-changes.outputs.identity-frontend-tests == 'true'
@@ -1564,7 +1565,7 @@ jobs:
     timeout-minutes: 10
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
-      TEST_OWNER: Identity
+      TEST_OWNER: '@camunda/identity'
       TEST_PRODUCT: Identity
       TEST_TYPE: Tool
     defaults:
@@ -1601,7 +1602,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "Identity"
 
   tasklist-ci:
     if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
@@ -1705,7 +1705,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
 
   openapi-lint:
     name: "Lint / C8 REST OpenAPI"
@@ -1742,7 +1741,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
 
   renovatelint:
     if: needs.detect-changes.outputs.renovate-config-changes == 'true'
@@ -1918,7 +1916,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
 
   # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
   utils-get-snapshot-docker-tag:
@@ -1998,7 +1995,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "General"
 
   utils-get-concurrency-group-for-optimize-docker-snapshot:
     needs: [ check-results ]
@@ -2020,6 +2016,8 @@ jobs:
     concurrency:
       group: ${{ needs.utils-get-concurrency-group-for-optimize-docker-snapshot.outputs.concurrency_group_name }}
       cancel-in-progress: false
+    env:
+      TEST_OWNER: '@camunda/core-features'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -2062,4 +2060,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -45,6 +45,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  TEST_OWNER: '@camunda/distribution'
   GHA_BEST_PRACTICES_LINTER: enabled
   HARBOR_REGISTRY: registry.camunda.cloud
   HARBOR_REPOSITORY: registry.camunda.cloud/team-camunda/camunda

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   submit-maven-snapshot:
     name: "Security / Submit Maven Dependency Snapshot"

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -1,5 +1,5 @@
 # type: Project Management
-# owner: Engineering Ops
+# owner: @camunda/monorepo-devops-team
 name: "Opened Issue Labeler"
 on:
   issues:

--- a/.github/workflows/optimize-ci-data-upgrade-nightly.yml
+++ b/.github/workflows/optimize-ci-data-upgrade-nightly.yml
@@ -21,6 +21,9 @@ permissions:
   checks: write
   pull-requests: write
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   detect-changes:
     name: Get changed directories

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -18,6 +18,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 permissions:
@@ -34,7 +35,6 @@ jobs:
     timeout-minutes: 120
     env:
       TEST_TYPE: E2E
-      TEST_OWNER: Core Features
 
     steps:
       - name: Checkout code
@@ -140,4 +140,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -36,6 +36,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   GH_TOKEN: ${{ github.token }} # needs to be available for the gh CLI tool
 
 jobs:

--- a/.github/workflows/preview-env-clean.yml
+++ b/.github/workflows/preview-env-clean.yml
@@ -23,6 +23,9 @@ on:
         required: true
   workflow_dispatch:
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   preview-env-clean:
     concurrency:

--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - release-*
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   validate-event:
     name: Validate GitHub event for release branch activity

--- a/.github/workflows/renovate-weekly.yml
+++ b/.github/workflows/renovate-weekly.yml
@@ -14,6 +14,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -15,6 +15,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch: { }
   workflow_call: { }
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   integration-tests:
     name: Tasklist Docker tests
@@ -60,4 +63,3 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          user_description: "team-core-features"

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -22,6 +22,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   integration-tests:
     name: "[IT] ${{ matrix.name }}. OS ver.${{ matrix.os_version }}"
@@ -43,28 +46,28 @@ jobs:
             maven-build-threads: 2
             maven-test-fork-count: 7
             runs-on: aws-core-8-default
-            owner: "Data Layer"
+            owner: '@camunda/data-layer'
           - group: search-client-os
             name: "Search Client AWS OS Integration Tests"
             maven-modules: "'io.camunda:camunda-search-client-connect'"
             maven-build-threads: 2
             maven-test-fork-count: 7
             runs-on: aws-core-8-default
-            owner: "Core Features"
+            owner: '@camunda/core-features'
           - group: camunda-exporter
             name: "Camunda Exporter AWS OS Integration Tests"
             maven-modules: "'io.camunda:camunda-exporter'"
             maven-build-threads: 2
             maven-test-fork-count: 7
             runs-on: aws-core-8-default
-            owner: "Data Layer"
+            owner: '@camunda/data-layer'
           - group: camunda-qa-acceptance-tests
             name: "Camunda QA Integration Module"
             maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
             maven-build-threads: 2
             maven-test-fork-count: 2
             runs-on: aws-core-8-default
-            owner: "General"
+            owner: '@camunda/monorepo-devops-team'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Import secrets from Vault
@@ -102,7 +105,7 @@ jobs:
             exit 1
           fi
           echo "OS_URL=$OS_URL" >> "$GITHUB_ENV"
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         name: Pre-login to AWS
         with:
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -14,6 +14,7 @@ on:
     - cron: '0 1 * * 1-5'
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   # This URL is used as the business key for the various QA workflows
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -10,6 +10,9 @@ on:
     # Runs at 02:00 every week day; see this link for more: https://crontab.guru/#0_2_*_*_1-5
     - cron: '0 2 * * 1-5'
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   # Camunda Platform release
   dry-run-release-87:

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -15,6 +15,9 @@ concurrency:
 permissions:
   actions: read # Required to get the previous report
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   released-versions:
     name: Released Versions

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -10,6 +10,9 @@ on:
     # Run at 7:00 on every monday
     - cron: '0 7 * * 1'
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   # This job will figure out the last supported versions based on the latest tags.
   #

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -202,15 +202,27 @@ Related resources:
 
 ### Ownership
 
-Each CI test file has an owning team. The owning team can be found either through the `CODEOWNERS` file or on the metadata in the file itself. The `CODEOWNERS` file is organized and broken down by team, any additions to the file should follow that convention. The metadata on a GHA workflow file is used by a scraping tool so that it is easy to gather information about the current state of CI. You can look at the metadata for a quick overview of the owning team, where the tests live, how the test is called, and a description of what the file is actually testing
+Each CI test file has an owning team. The owning team can be found in `.codeowners` (lookup via `codeowners-cli owner <path>`) with the same value also in the metadata in the GHA workflow YAML file itself. `.codeowners` is the source-of-truth, the metadata is for human overview only:
+
+You can look at the metadata for a quick overview of the owning team, where the tests live, how the test is called, and a description of what the file is actually testing
+
+The owning team is the general point of contact for any questions or problems with the GHA workflow. Unless overwritten on the GHA job-level, the owning team will also own all job failures and their medic can be contacted to resolve those.
 
 Metadata follows this structure and is placed at the beginning of a GHA workflow file
 
 ```
 # <Description of what the GHA is running and what is being tested>
 # test location: <The filepath of the tests being run>
-# owner: <The name of the owning team>
+# owner: <The GitHub handle of the owning team>
 ```
+
+#### Automatic Alert Attribution
+
+For programmatic alert routing and medic assignment on CI incidents, each workflow also propagates the canonical GitHub team handle to [CI Analytics](#ci-health-metrics) via a workflow-level `env: TEST_OWNER:` block.
+
+The [`observe-build-status` action](#metrics-collection) reads this env var as the default for the `user_description` field it submits to CI Analytics. This can be overwritten on the job-level with more specific `env: TEST_OWNER:` blocks.
+
+See [Metrics Collection](#metrics-collection) for the concrete `env:` snippet, including how to override per-job and how to wire matrix-driven values.
 
 ### Legacy CI
 
@@ -354,6 +366,31 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+```
+
+To attribute CI Analytics rows to an owning team, set a canonical handle as a workflow-level env var. This is read by `observe-build-status` as the default for its `user_description` input, so no inline argument is needed at the call site:
+
+```yaml
+# owner: @camunda/core-features
+env:
+  TEST_OWNER: '@camunda/core-features'
+```
+
+The handle must match with `.codeowners` (verify with `codeowners-cli owner <path>`). Override per job for outliers if necessary, including matrix-driven values:
+
+```yaml
+jobs:
+  per-suite-tests:
+    strategy:
+      matrix:
+        include:
+          - suite: CoreFeatures
+            owner: '@camunda/core-features'
+          - suite: DataLayer
+            owner: '@camunda/data-layer'
+    env:
+      TEST_OWNER: ${{ matrix.owner }}
+    # ...
 ```
 
 Related resources:


### PR DESCRIPTION
## Description

Backport of [#55040](https://github.com/camunda/camunda/pull/55040) to \`stable/8.8\`. Submits canonical \`@camunda/...\` team handles to CI Analytics from every push/schedule workflow on this branch, so failures route to the responsible team's medic.

### Adaptations for stable/8.8

\`stable/8.8\` has noticeably more divergence from \`main\` than 8.9. Applied via \`git cherry-pick -m 1 e1594074d86\` then resolved:

- **Dropped 28 workflow + doc files** that exist on \`main\` but not on \`stable/8.8\`. Notably, \`.codeowners\` itself does not exist at the root of this branch — the medic lookup script still works against \`CODEOWNERS\` and via per-test-file resolution, but no \`.codeowners\` rules were introduced.
- **\`ci.yml\`** — kept the stable-only OpenAPI linter (vacuum) untouched; did not introduce the \`spectral\` rewrite or \`openapi-x-added-in-version-check\` job from main. Three jobs (\`elasticsearch-integration-tests\`, \`opensearch-integration-tests\`, RDBMS H2 tests) had inline \`user_description: "General"\` — dropped the inline so they inherit the new workflow-level \`@camunda/monorepo-devops-team\` (same effective routing).
- **\`ci-operate.yml\` / \`ci-tasklist.yml\`** — both \`run-importer-tests\` (operate) and \`run-backup-restore-tests\` (operate + tasklist) jobs are still active on stable/8.8 (commented out on main as part of the 8.10 V1 API cleanup). Kept the jobs active and updated their vocabulary to canonical handles; did not introduce \`operate-fe-prettier\`, \`fe-prettier\`, \`fe-unit-tests-merge\` etc. — those are post-stable additions on main.
- **\`ci-zeebe.yml\`** — \`smoke-tests\` had inline \`user_description: "team-reliability-testing"\`. Added a job-level \`env: TEST_OWNER: '@camunda/reliability-testing'\` override (since the workflow-level default is \`@camunda/zeebe-distributed-platform\`) and dropped the inline.
- **\`camunda-weekly-load-tests.yml\`** — added \`env: TEST_OWNER: '@camunda/reliability-testing'\` only; did not import unrelated additions (\`defaults.run.shell\`, unused \`IMAGE_REPOSITORY\` env).
- **\`tasklist-docker-tests.yml\`** — removed on main, still present on stable/8.8; applied the same workflow-level TEST_OWNER pattern in a separate commit.

### Verification

- 0 inline \`user_description\` values left non-canonical
- 0 \`TEST_OWNER\` env values left non-canonical (all are \`@camunda/...\` handles, matrix expressions, or input refs)
- YAML parses cleanly for every modified workflow

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary — this is the backport.
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Contributes to #52873. Backport of #55040.