### PR TITLE
Implement agent history creation endpoint

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -19,6 +19,7 @@ import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.service.AdHocSubProcessActivityServices;
+import io.camunda.service.AgentHistoryServices;
 import io.camunda.service.AgentInstanceServices;
 import io.camunda.service.ApiServicesExecutorProvider;
 import io.camunda.service.AuditLogServices;
@@ -219,6 +220,10 @@ public class CamundaServicesConfiguration {
                   .adHocSubProcessActivityServices(
                       tenantId,
                       new AdHocSubProcessActivityServices(
+                          brokerClient, securityContextProvider, executor, converter))
+                  .agentHistoryServices(
+                      tenantId,
+                      new AgentHistoryServices(
                           brokerClient, securityContextProvider, executor, converter))
                   .agentInstanceServices(
                       tenantId,

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -24,12 +24,14 @@ import io.camunda.gateway.protocol.model.AgentInstanceToolCall;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateStatusEnum;
 import io.camunda.gateway.protocol.model.AgentTool;
+import io.camunda.gateway.protocol.model.DocumentMetadataResponse;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
+import io.camunda.zeebe.protocol.impl.record.value.document.DocumentReferenceMetadata;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
@@ -195,6 +197,10 @@ public class AgentInstanceMapper {
             .setDocumentId(ref.getDocumentId() != null ? ref.getDocumentId() : "")
             .setStoreId(ref.getStoreId() != null ? ref.getStoreId() : "")
             .setContentHash(ref.getContentHash() != null ? ref.getContentHash() : "");
+        final var meta = ref.getMetadata();
+        if (meta != null) {
+          fillDocumentReferenceMetadata(meta, result.getDocumentReference().getMetadata());
+        }
       }
     } else if (content instanceof final AgentInstanceObjectContent obj) {
       result.setContentType(AgentHistoryContentType.OBJECT);
@@ -220,6 +226,26 @@ public class AgentInstanceMapper {
 
   private DirectBuffer toMsgPackBuffer(final Map<String, Object> map) {
     return BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(map));
+  }
+
+  private void fillDocumentReferenceMetadata(
+      final DocumentMetadataResponse meta, final DocumentReferenceMetadata recordMeta) {
+    recordMeta
+        .setContentType(meta.getContentType() != null ? meta.getContentType() : "")
+        .setFileName(meta.getFileName() != null ? meta.getFileName() : "")
+        .setSize(meta.getSize() != null ? meta.getSize() : -1L);
+    if (meta.getExpiresAt() != null) {
+      recordMeta.setExpiresAt(OffsetDateTime.parse(meta.getExpiresAt()).toInstant().toEpochMilli());
+    }
+    if (meta.getProcessDefinitionId() != null) {
+      recordMeta.setProcessDefinitionId(meta.getProcessDefinitionId());
+    }
+    if (meta.getProcessInstanceKey() != null) {
+      recordMeta.setProcessInstanceKey(Long.parseLong(meta.getProcessInstanceKey()));
+    }
+    if (meta.getCustomProperties() != null && !meta.getCustomProperties().isEmpty()) {
+      recordMeta.setCustomProperties(meta.getCustomProperties());
+    }
   }
 
   // Note: even if limits are marked @NotNull in AgentInstanceCreationRequest,

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -12,16 +12,34 @@ import io.camunda.gateway.mapping.http.util.KeyUtil;
 import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationResult;
+import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemCreationResult;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
 import io.camunda.gateway.protocol.model.AgentInstanceLimits;
+import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
+import io.camunda.gateway.protocol.model.AgentInstanceObjectContent;
+import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
+import io.camunda.gateway.protocol.model.AgentInstanceToolCall;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateStatusEnum;
 import io.camunda.gateway.protocol.model.AgentTool;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.http.ProblemDetail;
 
@@ -105,6 +123,103 @@ public class AgentInstanceMapper {
     return AgentInstanceCreationResult.Builder.create()
         .agentInstanceKey(KeyUtil.keyToString(record.getAgentInstanceKey()))
         .build();
+  }
+
+  public Either<ProblemDetail, AgentHistoryRecord> toCreateAgentHistoryRecord(
+      final String agentInstanceKey, final AgentInstanceHistoryItemRequest request) {
+    return RequestMapper.getResult(
+        requestValidator.validateHistoryItemRequest(agentInstanceKey, request),
+        () -> {
+          final var record = new AgentHistoryRecord();
+
+          record.setAgentInstanceKey(Long.parseLong(agentInstanceKey));
+          record.setElementInstanceKey(Long.parseLong(request.getElementInstanceKey()));
+          record.setJobKey(Long.parseLong(request.getJobKey()));
+          record.setJobLease(request.getJobLease());
+          record.setRole(mapHistoryRole(request.getRole()));
+          record.setProducedAt(
+              OffsetDateTime.parse(request.getProducedAt()).toInstant().toEpochMilli());
+
+          if (request.getIteration() != null) {
+            record.setIteration(request.getIteration());
+          }
+
+          for (final AgentInstanceMessageContent content : request.getContent()) {
+            record.addContent(mapContent(content));
+          }
+
+          if (request.getToolCalls() != null) {
+            for (final AgentInstanceToolCall toolCall : request.getToolCalls()) {
+              record.addToolCall(mapToolCall(toolCall));
+            }
+          }
+
+          if (request.getMetrics() != null) {
+            final var metrics = request.getMetrics();
+            record
+                .getMetrics()
+                .setInputTokens(metrics.getInputTokens() != null ? metrics.getInputTokens() : 0L)
+                .setOutputTokens(metrics.getOutputTokens() != null ? metrics.getOutputTokens() : 0L)
+                .setDurationMs(metrics.getDurationMs() != null ? metrics.getDurationMs() : 0L);
+          }
+
+          return record;
+        });
+  }
+
+  public AgentInstanceHistoryItemCreationResult toAgentHistoryItemCreationResult(
+      final AgentHistoryRecord record) {
+    return AgentInstanceHistoryItemCreationResult.Builder.create()
+        .historyItemKey(KeyUtil.keyToString(record.getAgentHistoryKey()))
+        .build();
+  }
+
+  private AgentHistoryRole mapHistoryRole(final AgentInstanceHistoryRoleEnum role) {
+    return switch (role) {
+      case USER -> AgentHistoryRole.USER;
+      case ASSISTANT -> AgentHistoryRole.ASSISTANT;
+      case TOOL_RESULT -> AgentHistoryRole.TOOL_RESULT;
+    };
+  }
+
+  private AgentHistoryMessageContent mapContent(final AgentInstanceMessageContent content) {
+    final var result = new AgentHistoryMessageContent();
+    if (content instanceof final AgentInstanceTextContent text) {
+      result.setContentType(AgentHistoryContentType.TEXT).setText(text.getText());
+    } else if (content instanceof final AgentInstanceDocumentContent doc) {
+      result.setContentType(AgentHistoryContentType.DOCUMENT);
+      final var ref = doc.getDocumentReference();
+      if (ref != null) {
+        result
+            .getDocumentReference()
+            .setDocumentId(ref.getDocumentId() != null ? ref.getDocumentId() : "")
+            .setStoreId(ref.getStoreId() != null ? ref.getStoreId() : "")
+            .setContentHash(ref.getContentHash() != null ? ref.getContentHash() : "");
+      }
+    } else if (content instanceof final AgentInstanceObjectContent obj) {
+      result.setContentType(AgentHistoryContentType.OBJECT);
+      if (obj.getObject() != null) {
+        result.setObject(toMsgPackBuffer(obj.getObject()));
+      }
+    }
+    return result;
+  }
+
+  private AgentHistoryEmbeddedToolCall mapToolCall(final AgentInstanceToolCall toolCall) {
+    final var result = new AgentHistoryEmbeddedToolCall();
+    result.setToolCallId(toolCall.getToolCallId());
+    result.setToolName(toolCall.getToolName());
+    if (toolCall.getElementId() != null) {
+      result.setElementId(toolCall.getElementId());
+    }
+    if (toolCall.getArguments() != null) {
+      result.setArguments(toMsgPackBuffer(toolCall.getArguments()));
+    }
+    return result;
+  }
+
+  private DirectBuffer toMsgPackBuffer(final Map<String, Object> map) {
+    return BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(map));
   }
 
   // Note: even if limits are marked @NotNull in AgentInstanceCreationRequest,

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -137,7 +137,7 @@ public class AgentInstanceMapper {
           record.setAgentInstanceKey(Long.parseLong(agentInstanceKey));
           record.setElementInstanceKey(Long.parseLong(request.getElementInstanceKey()));
           record.setJobKey(Long.parseLong(request.getJobKey()));
-          record.setJobLease(request.getJobLease());
+          record.setJobLease(request.getJobLease() != null ? request.getJobLease() : "");
           record.setRole(mapHistoryRole(request.getRole()));
           record.setProducedAt(
               OffsetDateTime.parse(request.getProducedAt()).toInstant().toEpochMilli());
@@ -187,7 +187,9 @@ public class AgentInstanceMapper {
   private AgentHistoryMessageContent mapContent(final AgentInstanceMessageContent content) {
     final var result = new AgentHistoryMessageContent();
     if (content instanceof final AgentInstanceTextContent text) {
-      result.setContentType(AgentHistoryContentType.TEXT).setText(text.getText());
+      result
+          .setContentType(AgentHistoryContentType.TEXT)
+          .setText(text.getText() != null ? text.getText() : "");
     } else if (content instanceof final AgentInstanceDocumentContent doc) {
       result.setContentType(AgentHistoryContentType.DOCUMENT);
       final var ref = doc.getDocumentReference();
@@ -213,8 +215,8 @@ public class AgentInstanceMapper {
 
   private AgentHistoryEmbeddedToolCall mapToolCall(final AgentInstanceToolCall toolCall) {
     final var result = new AgentHistoryEmbeddedToolCall();
-    result.setToolCallId(toolCall.getToolCallId());
-    result.setToolName(toolCall.getToolName());
+    result.setToolCallId(toolCall.getToolCallId() != null ? toolCall.getToolCallId() : "");
+    result.setToolName(toolCall.getToolName() != null ? toolCall.getToolName() : "");
     if (toolCall.getElementId() != null) {
       result.setElementId(toolCall.getElementId());
     }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -236,13 +236,13 @@ public class AgentInstanceMapper {
         .setContentType(meta.getContentType() != null ? meta.getContentType() : "")
         .setFileName(meta.getFileName() != null ? meta.getFileName() : "")
         .setSize(meta.getSize() != null ? meta.getSize() : -1L);
-    if (meta.getExpiresAt() != null) {
+    if (meta.getExpiresAt() != null && !meta.getExpiresAt().isBlank()) {
       recordMeta.setExpiresAt(OffsetDateTime.parse(meta.getExpiresAt()).toInstant().toEpochMilli());
     }
     if (meta.getProcessDefinitionId() != null) {
       recordMeta.setProcessDefinitionId(meta.getProcessDefinitionId());
     }
-    if (meta.getProcessInstanceKey() != null) {
+    if (meta.getProcessInstanceKey() != null && !meta.getProcessInstanceKey().isBlank()) {
       recordMeta.setProcessInstanceKey(Long.parseLong(meta.getProcessInstanceKey()));
     }
     if (meta.getCustomProperties() != null && !meta.getCustomProperties().isEmpty()) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -180,6 +180,12 @@ public class AgentInstanceRequestValidator {
           ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("content[" + index + "].documentReference"));
       return;
     }
+    if (ref.getDocumentId() == null || ref.getDocumentId().isBlank()) {
+      violations.add(
+          ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(
+              "content[" + index + "].documentReference.documentId"));
+      return;
+    }
     if (ref.getMetadata() == null) {
       return;
     }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -10,10 +10,12 @@ package io.camunda.gateway.mapping.http.validator;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateDate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validatePositiveKeyFormat;
 
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
 import java.util.ArrayList;
@@ -101,10 +103,19 @@ public class AgentInstanceRequestValidator {
 
           if (request.getContent() == null || request.getContent().isEmpty()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("content"));
+          } else {
+            for (int i = 0; i < request.getContent().size(); i++) {
+              final var content = request.getContent().get(i);
+              if (content instanceof final AgentInstanceDocumentContent doc) {
+                validateDocumentContentItem(i, doc, violations);
+              }
+            }
           }
 
           if (request.getProducedAt() == null || request.getProducedAt().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("producedAt"));
+          } else {
+            validateDate(request.getProducedAt(), "producedAt", violations);
           }
 
           return violations;
@@ -147,6 +158,19 @@ public class AgentInstanceRequestValidator {
 
           return violations;
         });
+  }
+
+  private void validateDocumentContentItem(
+      final int index, final AgentInstanceDocumentContent doc, final List<String> violations) {
+    final var ref = doc.getDocumentReference();
+    if (ref == null || ref.getMetadata() == null) {
+      return;
+    }
+    final var expiresAt = ref.getMetadata().getExpiresAt();
+    if (expiresAt != null && !expiresAt.isBlank()) {
+      validateDate(
+          expiresAt, "content[" + index + "].documentReference.metadata.expiresAt", violations);
+    }
   }
 
   private List<String> validateLimit(final String limitName, final Number limit) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -14,6 +14,7 @@ import static io.camunda.gateway.mapping.http.validator.RequestValidator.validat
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validatePositiveKeyFormat;
 
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,6 +62,49 @@ public class AgentInstanceRequestValidator {
             violations.addAll(validateLimit("limits.maxTokens", limits.getMaxTokens()));
             violations.addAll(validateLimit("limits.maxModelCalls", limits.getMaxModelCalls()));
             violations.addAll(validateLimit("limits.maxToolCalls", limits.getMaxToolCalls()));
+          }
+
+          return violations;
+        });
+  }
+
+  @SuppressWarnings("ConstantValue")
+  public Optional<ProblemDetail> validateHistoryItemRequest(
+      final String agentInstanceKey, final AgentInstanceHistoryItemRequest request) {
+    return validate(
+        () -> {
+          final List<String> violations = new ArrayList<>();
+
+          validatePositiveKeyFormat(agentInstanceKey, "agentInstanceKey", violations);
+
+          if (request.getElementInstanceKey() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elementInstanceKey"));
+          } else {
+            validatePositiveKeyFormat(
+                request.getElementInstanceKey(), "elementInstanceKey", violations);
+          }
+
+          if (request.getJobKey() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobKey"));
+          } else {
+            validatePositiveKeyFormat(request.getJobKey(), "jobKey", violations);
+          }
+
+          // TODO: validate jobLease once job leasing is implemented (#55033)
+          // if (request.getJobLease() == null || request.getJobLease().isBlank()) {
+          //   violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobLease"));
+          // }
+
+          if (request.getRole() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("role"));
+          }
+
+          if (request.getContent() == null || request.getContent().isEmpty()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("content"));
+          }
+
+          if (request.getProducedAt() == null || request.getProducedAt().isBlank()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("producedAt"));
           }
 
           return violations;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -17,6 +17,8 @@ import static io.camunda.gateway.mapping.http.validator.RequestValidator.validat
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceObjectContent;
+import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -106,8 +108,18 @@ public class AgentInstanceRequestValidator {
           } else {
             for (int i = 0; i < request.getContent().size(); i++) {
               final var content = request.getContent().get(i);
-              if (content instanceof final AgentInstanceDocumentContent doc) {
+              if (content instanceof final AgentInstanceTextContent text) {
+                if (text.getText() == null || text.getText().isBlank()) {
+                  violations.add(
+                      ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("content[" + i + "].text"));
+                }
+              } else if (content instanceof final AgentInstanceDocumentContent doc) {
                 validateDocumentContentItem(i, doc, violations);
+              } else if (content instanceof final AgentInstanceObjectContent obj) {
+                if (obj.getObject() == null) {
+                  violations.add(
+                      ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("content[" + i + "].object"));
+                }
               }
             }
           }
@@ -163,7 +175,12 @@ public class AgentInstanceRequestValidator {
   private void validateDocumentContentItem(
       final int index, final AgentInstanceDocumentContent doc, final List<String> violations) {
     final var ref = doc.getDocumentReference();
-    if (ref == null || ref.getMetadata() == null) {
+    if (ref == null) {
+      violations.add(
+          ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("content[" + index + "].documentReference"));
+      return;
+    }
+    if (ref.getMetadata() == null) {
       return;
     }
     final var expiresAt = ref.getMetadata().getExpiresAt();

--- a/service/src/main/java/io/camunda/service/AgentHistoryServices.java
+++ b/service/src/main/java/io/camunda/service/AgentHistoryServices.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateAgentHistoryRequest;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import java.util.concurrent.CompletableFuture;
+
+public final class AgentHistoryServices extends ApiServices<AgentHistoryServices> {
+
+  public AgentHistoryServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  public CompletableFuture<AgentHistoryRecord> createAgentHistoryItem(
+      final AgentHistoryRecord record, final CamundaAuthentication authentication) {
+    return sendBrokerRequest(new BrokerCreateAgentHistoryRequest(record), authentication);
+  }
+}

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.service.registry;
 
 import io.camunda.service.AdHocSubProcessActivityServices;
+import io.camunda.service.AgentHistoryServices;
 import io.camunda.service.AgentInstanceServices;
 import io.camunda.service.AuditLogServices;
 import io.camunda.service.AuthorizationServices;
@@ -52,6 +53,7 @@ import java.util.function.Consumer;
  */
 public record DefaultServiceRegistry(
     Map<String, AdHocSubProcessActivityServices> adHocSubProcessActivityByTenant,
+    Map<String, AgentHistoryServices> agentHistoryByTenant,
     Map<String, AgentInstanceServices> agentInstanceByTenant,
     Map<String, AuditLogServices> auditLogByTenant,
     Map<String, AuthorizationServices> authorizationByTenant,
@@ -99,6 +101,11 @@ public record DefaultServiceRegistry(
   public AdHocSubProcessActivityServices adHocSubProcessActivityServices(
       final String physicalTenantId) {
     return byTenant(adHocSubProcessActivityByTenant, physicalTenantId);
+  }
+
+  @Override
+  public AgentHistoryServices agentHistoryServices(final String physicalTenantId) {
+    return byTenant(agentHistoryByTenant, physicalTenantId);
   }
 
   @Override
@@ -303,6 +310,7 @@ public record DefaultServiceRegistry(
 
     private final Map<String, AdHocSubProcessActivityServices> adHocSubProcessActivityByTenant =
         new HashMap<>();
+    private final Map<String, AgentHistoryServices> agentHistoryByTenant = new HashMap<>();
     private final Map<String, AgentInstanceServices> agentInstanceByTenant = new HashMap<>();
     private final Map<String, AuditLogServices> auditLogByTenant = new HashMap<>();
     private final Map<String, AuthorizationServices> authorizationByTenant = new HashMap<>();
@@ -344,6 +352,11 @@ public record DefaultServiceRegistry(
     public Builder adHocSubProcessActivityServices(
         final String tenantId, final AdHocSubProcessActivityServices service) {
       adHocSubProcessActivityByTenant.put(tenantId, service);
+      return this;
+    }
+
+    public Builder agentHistoryServices(final String tenantId, final AgentHistoryServices service) {
+      agentHistoryByTenant.put(tenantId, service);
       return this;
     }
 
@@ -527,6 +540,7 @@ public record DefaultServiceRegistry(
     public DefaultServiceRegistry build() {
       return new DefaultServiceRegistry(
           Map.copyOf(adHocSubProcessActivityByTenant),
+          Map.copyOf(agentHistoryByTenant),
           Map.copyOf(agentInstanceByTenant),
           Map.copyOf(auditLogByTenant),
           Map.copyOf(authorizationByTenant),

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.service.registry;
 
 import io.camunda.service.AdHocSubProcessActivityServices;
+import io.camunda.service.AgentHistoryServices;
 import io.camunda.service.AgentInstanceServices;
 import io.camunda.service.AuditLogServices;
 import io.camunda.service.AuthorizationServices;
@@ -54,6 +55,8 @@ public interface ServiceRegistry {
   // -- tenant-scoped --
 
   AdHocSubProcessActivityServices adHocSubProcessActivityServices(String physicalTenantId);
+
+  AgentHistoryServices agentHistoryServices(String physicalTenantId);
 
   AgentInstanceServices agentInstanceServices(String physicalTenantId);
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
@@ -14,6 +14,7 @@ import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceResult;
 import io.camunda.gateway.protocol.model.AgentInstanceSearchQuery;
 import io.camunda.gateway.protocol.model.AgentInstanceSearchQueryResult;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.HttpStatus;
@@ -75,6 +77,18 @@ public class AgentInstanceController {
             record -> update(physicalTenantId, record));
   }
 
+  @CamundaPostMapping(path = "/{agentInstanceKey}/history")
+  public CompletableFuture<ResponseEntity<Object>> createAgentInstanceHistoryItem(
+      @PhysicalTenantId final String physicalTenantId,
+      @PathVariable final String agentInstanceKey,
+      @RequestBody final AgentInstanceHistoryItemRequest request) {
+    return mapper
+        .toCreateAgentHistoryRecord(agentInstanceKey, request)
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            record -> createHistoryItem(physicalTenantId, record));
+  }
+
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{agentInstanceKey}")
   public ResponseEntity<AgentInstanceResult> getAgentInstance(
@@ -116,6 +130,16 @@ public class AgentInstanceController {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () -> agentInstanceServices.updateAgentInstance(record, authentication));
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> createHistoryItem(
+      final String physicalTenantId, final AgentHistoryRecord record) {
+    final var agentHistoryServices = serviceRegistry.agentHistoryServices(physicalTenantId);
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethod(
+        () -> agentHistoryServices.createAgentHistoryItem(record, authentication),
+        mapper::toAgentHistoryItemCreationResult,
+        HttpStatus.CREATED);
   }
 
   private ResponseEntity<AgentInstanceSearchQueryResult> search(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -1153,7 +1153,55 @@ class AgentInstanceControllerTest extends RestControllerTest {
                     """
                         .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
             "The provided content[0].documentReference.metadata.expiresAt 'not-a-date'"
-                + " cannot be parsed as a date according to RFC 3339, section 5.6."));
+                + " cannot be parsed as a date according to RFC 3339, section 5.6."),
+        Arguments.of(
+            named(
+                "TEXT content missing text field",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobKey": "%d",
+                      "role": "ASSISTANT",
+                      "content": [{ "contentType": "TEXT" }],
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+            "No content[0].text provided."),
+        Arguments.of(
+            named(
+                "DOCUMENT content missing documentReference",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobKey": "%d",
+                      "role": "USER",
+                      "content": [{ "contentType": "DOCUMENT" }],
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+            "No content[0].documentReference provided."),
+        Arguments.of(
+            named(
+                "OBJECT content missing object field",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobKey": "%d",
+                      "role": "ASSISTANT",
+                      "content": [{ "contentType": "OBJECT" }],
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+            "No content[0].object provided."));
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -1201,7 +1201,23 @@ class AgentInstanceControllerTest extends RestControllerTest {
                     }
                     """
                         .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
-            "No content[0].object provided."));
+            "No content[0].object provided."),
+        Arguments.of(
+            named(
+                "DOCUMENT content with missing documentId",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobKey": "%d",
+                      "role": "USER",
+                      "content": [{ "contentType": "DOCUMENT", "documentReference": {} }],
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+            "No content[0].documentReference.documentId provided."));
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -16,9 +16,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.AgentHistoryServices;
 import io.camunda.service.AgentInstanceServices;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -38,14 +40,18 @@ class AgentInstanceControllerTest extends RestControllerTest {
   private static final String AGENT_INSTANCES_URL = "/v2/agent-instances";
   private static final long ELEMENT_INSTANCE_KEY = 2251799813685248L;
   private static final long AGENT_INSTANCE_KEY = 9007199254741017L;
+  private static final long JOB_KEY = 2251799813685249L;
+  private static final long HISTORY_ITEM_KEY = 9007199254741018L;
 
   @MockitoBean private AgentInstanceServices agentInstanceServices;
+  @MockitoBean private AgentHistoryServices agentHistoryServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean private ServiceRegistry serviceRegistry;
 
   @BeforeEach
   void setUp() {
     when(serviceRegistry.agentInstanceServices(any())).thenReturn(agentInstanceServices);
+    when(serviceRegistry.agentHistoryServices(any())).thenReturn(agentHistoryServices);
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
   }
@@ -727,5 +733,328 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .is5xxServerError();
   }
 
+  // --------------------------------- history item tests -----------------------------------------
+
+  @Test
+  void shouldCreateAgentHistoryItemWithTextContent() {
+    // given
+    final var responseRecord = new AgentHistoryRecord();
+    responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
+    when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(responseRecord));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "jobKey": "%d",
+          "jobLease": "lease-abc",
+          "role": "ASSISTANT",
+          "content": [
+            { "contentType": "TEXT", "text": "I will process the invoice." }
+          ],
+          "producedAt": "2025-06-01T12:00:00Z"
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody()
+        .json(
+            """
+            { "historyItemKey": "%d" }
+            """
+                .formatted(HISTORY_ITEM_KEY),
+            JsonCompareMode.STRICT);
+
+    verify(agentHistoryServices)
+        .createAgentHistoryItem(
+            assertArg(
+                record -> {
+                  assertThat(record.getAgentInstanceKey()).isEqualTo(AGENT_INSTANCE_KEY);
+                  assertThat(record.getElementInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
+                  assertThat(record.getJobKey()).isEqualTo(JOB_KEY);
+                  assertThat(record.getJobLease()).isEqualTo("lease-abc");
+                  assertThat(record.getRole().name()).isEqualTo("ASSISTANT");
+                  assertThat(record.getContent()).hasSize(1);
+                  assertThat(record.getContent().get(0).getText())
+                      .isEqualTo("I will process the invoice.");
+                }),
+            any());
+  }
+
+  @Test
+  void shouldCreateAgentHistoryItemWithAllFields() {
+    // given
+    final var responseRecord = new AgentHistoryRecord();
+    responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
+    when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(responseRecord));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "jobKey": "%d",
+          "jobLease": "lease-abc",
+          "role": "USER",
+          "iteration": 2,
+          "content": [
+            { "contentType": "TEXT", "text": "What is in the invoice?" },
+            { "contentType": "OBJECT", "object": { "key": "value" } }
+          ],
+          "toolCalls": [
+            { "toolCallId": "tc-001", "toolName": "extract_data", "elementId": "extract-task" }
+          ],
+          "metrics": {
+            "inputTokens": 512,
+            "outputTokens": 128,
+            "durationMs": 1500
+          },
+          "producedAt": "2025-06-01T12:00:00Z"
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isCreated();
+
+    verify(agentHistoryServices)
+        .createAgentHistoryItem(
+            assertArg(
+                record -> {
+                  assertThat(record.getIteration()).isEqualTo(2);
+                  assertThat(record.getContent()).hasSize(2);
+                  assertThat(record.getToolCalls()).hasSize(1);
+                  assertThat(record.getToolCalls().get(0).getToolCallId()).isEqualTo("tc-001");
+                  assertThat(record.getToolCalls().get(0).getToolName()).isEqualTo("extract_data");
+                  assertThat(record.getMetrics().getInputTokens()).isEqualTo(512L);
+                  assertThat(record.getMetrics().getOutputTokens()).isEqualTo(128L);
+                  assertThat(record.getMetrics().getDurationMs()).isEqualTo(1500L);
+                }),
+            any());
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("invalidHistoryItemRequests")
+  void shouldRejectInvalidHistoryItemRequest(
+      final HistoryItemRequest request, final String expectedDetail) {
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL + "/%s/history".formatted(request.agentInstanceKeyPath()))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request.requestBody())
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "%s",
+              "instance": "/v2/agent-instances/%s/history"
+            }
+            """
+                .formatted(expectedDetail, request.agentInstanceKeyPath()),
+            JsonCompareMode.STRICT);
+
+    verifyNoInteractions(agentHistoryServices);
+  }
+
+  static Stream<Arguments> invalidHistoryItemRequests() {
+    final String validKey = String.valueOf(AGENT_INSTANCE_KEY);
+    final String validBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "jobKey": "%d",
+          "jobLease": "lease-abc",
+          "role": "ASSISTANT",
+          "content": [{ "contentType": "TEXT", "text": "hello" }],
+          "producedAt": "2025-06-01T12:00:00Z"
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
+
+    return Stream.of(
+        Arguments.of(
+            named("zero agentInstanceKey", new HistoryItemRequest("0", validBody)),
+            "The value for agentInstanceKey is '0' but must be > 0."),
+        Arguments.of(
+            named("non-numeric agentInstanceKey", new HistoryItemRequest("not-a-key", validBody)),
+            "The provided agentInstanceKey 'not-a-key' is not a valid key."
+                + " Expected a numeric value."
+                + " Did you pass an entity id instead of an entity key?."),
+        Arguments.of(
+            named(
+                "missing elementInstanceKey",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "jobKey": "%d",
+                      "jobLease": "lease-abc",
+                      "role": "ASSISTANT",
+                      "content": [{ "contentType": "TEXT", "text": "hello" }],
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(JOB_KEY))),
+            "No elementInstanceKey provided."),
+        Arguments.of(
+            named(
+                "zero elementInstanceKey",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "0",
+                      "jobKey": "%d",
+                      "jobLease": "lease-abc",
+                      "role": "ASSISTANT",
+                      "content": [{ "contentType": "TEXT", "text": "hello" }],
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(JOB_KEY))),
+            "The value for elementInstanceKey is '0' but must be > 0."),
+        Arguments.of(
+            named(
+                "missing jobKey",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobLease": "lease-abc",
+                      "role": "ASSISTANT",
+                      "content": [{ "contentType": "TEXT", "text": "hello" }],
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY))),
+            "No jobKey provided."),
+        Arguments.of(
+            named(
+                "missing role",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobKey": "%d",
+                      "jobLease": "lease-abc",
+                      "content": [{ "contentType": "TEXT", "text": "hello" }],
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+            "No role provided."),
+        Arguments.of(
+            named(
+                "missing content",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobKey": "%d",
+                      "jobLease": "lease-abc",
+                      "role": "ASSISTANT",
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+            "No content provided."),
+        Arguments.of(
+            named(
+                "empty content list",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobKey": "%d",
+                      "jobLease": "lease-abc",
+                      "role": "ASSISTANT",
+                      "content": [],
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+            "No content provided."),
+        Arguments.of(
+            named(
+                "missing producedAt",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobKey": "%d",
+                      "jobLease": "lease-abc",
+                      "role": "ASSISTANT",
+                      "content": [{ "contentType": "TEXT", "text": "hello" }]
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+            "No producedAt provided."));
+  }
+
+  @Test
+  void shouldReturn5xxOnHistoryItemServiceError() {
+    // given
+    when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker unavailable")));
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "elementInstanceKey": "%d",
+              "jobKey": "%d",
+              "jobLease": "lease-abc",
+              "role": "ASSISTANT",
+              "content": [{ "contentType": "TEXT", "text": "hello" }],
+              "producedAt": "2025-06-01T12:00:00Z"
+            }
+            """
+                .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))
+        .exchange()
+        .expectStatus()
+        .is5xxServerError();
+  }
+
   private record UpdateRequest(long agentInstanceKey, String requestBody) {}
+
+  private record HistoryItemRequest(String agentInstanceKeyPath, String requestBody) {}
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -1101,7 +1101,59 @@ class AgentInstanceControllerTest extends RestControllerTest {
                     }
                     """
                         .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
-            "No producedAt provided."));
+            "No producedAt provided."),
+        Arguments.of(
+            named(
+                "invalid producedAt format",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobKey": "%d",
+                      "jobLease": "lease-abc",
+                      "role": "ASSISTANT",
+                      "content": [{ "contentType": "TEXT", "text": "hello" }],
+                      "producedAt": "not-a-date"
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+            "The provided producedAt 'not-a-date' cannot be parsed as a date"
+                + " according to RFC 3339, section 5.6."),
+        Arguments.of(
+            named(
+                "invalid document metadata expiresAt format",
+                new HistoryItemRequest(
+                    validKey,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "jobKey": "%d",
+                      "jobLease": "lease-abc",
+                      "role": "USER",
+                      "content": [
+                        {
+                          "contentType": "DOCUMENT",
+                          "documentReference": {
+                            "camunda.document.type": "camunda",
+                            "storeId": "store-1",
+                            "documentId": "doc-abc",
+                            "metadata": {
+                              "contentType": "application/pdf",
+                              "fileName": "invoice.pdf",
+                              "size": 1024,
+                              "expiresAt": "not-a-date",
+                              "customProperties": {}
+                            }
+                          }
+                        }
+                      ],
+                      "producedAt": "2025-06-01T12:00:00Z"
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY))),
+            "The provided content[0].documentReference.metadata.expiresAt 'not-a-date'"
+                + " cannot be parsed as a date according to RFC 3339, section 5.6."));
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -22,6 +22,8 @@ import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
+import java.time.OffsetDateTime;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -848,6 +850,83 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getMetrics().getInputTokens()).isEqualTo(512L);
                   assertThat(record.getMetrics().getOutputTokens()).isEqualTo(128L);
                   assertThat(record.getMetrics().getDurationMs()).isEqualTo(1500L);
+                }),
+            any());
+  }
+
+  @Test
+  void shouldCreateAgentHistoryItemWithDocumentContent() {
+    // given
+    final var responseRecord = new AgentHistoryRecord();
+    responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
+    when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(responseRecord));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "jobKey": "%d",
+          "jobLease": "lease-abc",
+          "role": "USER",
+          "content": [
+            {
+              "contentType": "DOCUMENT",
+              "documentReference": {
+                "camunda.document.type": "camunda",
+                "storeId": "store-1",
+                "documentId": "doc-abc",
+                "contentHash": "sha256:deadbeef",
+                "metadata": {
+                  "contentType": "application/pdf",
+                  "fileName": "invoice.pdf",
+                  "expiresAt": "2025-12-31T23:59:59Z",
+                  "size": 12345,
+                  "processDefinitionId": "invoice-process",
+                  "processInstanceKey": "%d",
+                  "customProperties": {"source": "email"}
+                }
+              }
+            }
+          ],
+          "producedAt": "2025-06-01T12:00:00Z"
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY, ELEMENT_INSTANCE_KEY);
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isCreated();
+
+    verify(agentHistoryServices)
+        .createAgentHistoryItem(
+            assertArg(
+                record -> {
+                  assertThat(record.getContent()).hasSize(1);
+                  final var docContent = record.getContent().get(0);
+                  assertThat(docContent.getContentType())
+                      .isEqualTo(AgentHistoryContentType.DOCUMENT);
+                  final var docRef = docContent.getDocumentReference();
+                  assertThat(docRef.getDocumentId()).isEqualTo("doc-abc");
+                  assertThat(docRef.getStoreId()).isEqualTo("store-1");
+                  assertThat(docRef.getContentHash()).isEqualTo("sha256:deadbeef");
+                  final var meta = docRef.getMetadata();
+                  assertThat(meta.getContentType()).isEqualTo("application/pdf");
+                  assertThat(meta.getFileName()).isEqualTo("invoice.pdf");
+                  assertThat(meta.getExpiresAt())
+                      .isEqualTo(
+                          OffsetDateTime.parse("2025-12-31T23:59:59Z").toInstant().toEpochMilli());
+                  assertThat(meta.getSize()).isEqualTo(12345L);
+                  assertThat(meta.getProcessDefinitionId()).isEqualTo("invoice-process");
+                  assertThat(meta.getProcessInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
+                  assertThat(meta.getCustomProperties()).containsEntry("source", "email");
                 }),
             any());
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateAgentHistoryRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateAgentHistoryRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerCreateAgentHistoryRequest extends BrokerExecuteCommand<AgentHistoryRecord> {
+
+  private final AgentHistoryRecord requestDto;
+
+  public BrokerCreateAgentHistoryRequest(final AgentHistoryRecord record) {
+    super(ValueType.AGENT_HISTORY, AgentHistoryIntent.CREATE);
+    requestDto = record;
+    // Route to the partition that owns the agent instance, decoded from the key.
+    request.setPartitionId(Protocol.decodePartitionId(record.getAgentInstanceKey()));
+  }
+
+  @Override
+  public AgentHistoryRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected AgentHistoryRecord toResponseDto(final DirectBuffer buffer) {
+    final AgentHistoryRecord responseDto = new AgentHistoryRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateAgentHistoryRequestTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateAgentHistoryRequestTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import org.junit.jupiter.api.Test;
+
+final class BrokerCreateAgentHistoryRequestTest {
+
+  private static final long AGENT_INSTANCE_KEY = 9007199254741017L;
+
+  @Test
+  void shouldUseAgentHistoryValueType() {
+    final var request = new BrokerCreateAgentHistoryRequest(record(AGENT_INSTANCE_KEY));
+    assertThat(request.getValueType()).isEqualTo(ValueType.AGENT_HISTORY);
+  }
+
+  @Test
+  void shouldUseCreateIntent() {
+    final var request = new BrokerCreateAgentHistoryRequest(record(AGENT_INSTANCE_KEY));
+    assertThat(request.getIntent()).isEqualTo(AgentHistoryIntent.CREATE);
+  }
+
+  @Test
+  void shouldRouteToPartitionDecodedFromAgentInstanceKey() {
+    final var request = new BrokerCreateAgentHistoryRequest(record(AGENT_INSTANCE_KEY));
+    assertThat(request.getPartitionId()).isEqualTo(Protocol.decodePartitionId(AGENT_INSTANCE_KEY));
+  }
+
+  @Test
+  void shouldReturnEmptyDispatchStrategy() {
+    final var request = new BrokerCreateAgentHistoryRequest(record(AGENT_INSTANCE_KEY));
+    assertThat(request.requestDispatchStrategy()).isEmpty();
+  }
+
+  private static AgentHistoryRecord record(final long agentInstanceKey) {
+    final var record = new AgentHistoryRecord();
+    record.setAgentInstanceKey(agentInstanceKey);
+    return record;
+  }
+}


### PR DESCRIPTION
## Description

### Summary

Implements the service layer and REST controller for the agent history creation endpoint defined in the OpenAPI spec. Part of issue #51522.

### What this PR does

- **`BrokerCreateAgentHistoryRequest`** — routes `AGENT_HISTORY:CREATE` to the partition decoded from `agentInstanceKey` (path parameter, always present).
- **`AgentHistoryServices`** — command-only service (no search client); sends the broker request and returns the response record.
- **`ServiceRegistry` / `DefaultServiceRegistry`** — registers `AgentHistoryServices` per physical tenant alongside other per-tenant services.
- **`CamundaServicesConfiguration`** — wires one `AgentHistoryServices` instance per tenant in the Spring context.
- **`AgentInstanceRequestValidator`** — validates all required fields: `agentInstanceKey` (positive key format), `elementInstanceKey` (required, positive key), `jobKey` (required, positive key), `role` (required), `content` (required, non-empty), `producedAt` (required, RFC 3339 format). `jobLease` validation is commented out pending #55033. Document metadata `expiresAt` is also validated as RFC 3339 if present.
- **`AgentInstanceMapper`** — maps `AgentInstanceHistoryItemRequest` → `AgentHistoryRecord` (handles polymorphic content types TEXT/DOCUMENT/OBJECT via `instanceof` dispatch, toolCalls, metrics). DOCUMENT content maps all 7 `DocumentReferenceMetadata` fields. All `StringProperty` setters are guarded against null. Maps `AgentHistoryRecord` → `AgentInstanceHistoryItemCreationResult` (reads `record.getAgentHistoryKey()` and exposes it as the REST-level `historyItemKey` field).
- **`AgentInstanceController`** — new `POST /{agentInstanceKey}/history` endpoint; validates + maps + calls service; returns **201 Created** with `{ "historyItemKey": "<key>" }`.

## Key design decisions

### Partition routing
Routes on `agentInstanceKey` (path parameter, always present). Both keys encode the owning partition (Zeebe key structure), but `agentInstanceKey` is the stable, always-available routing key for this endpoint. `elementInstanceKey` is not guaranteed to be on the same partition as the agent instance.

### `Either<ProblemDetail, AgentHistoryRecord>` pattern
The mapper returns `Either<ProblemDetail, AgentHistoryRecord>`. The controller folds on it: left → `RestErrorMapper::mapProblemToCompletedResponse`, right → service call. This avoids a try/catch in the controller and keeps validation co-located with mapping.

### AgentHistoryServices has no search client
`AgentHistoryServices extends ApiServices<AgentHistoryServices>` (not `SearchApiServices`) because history creation is write-only. No search dependency is injected.

### Content type polymorphism
`AgentInstanceMessageContent` is a Jackson-polymorphic interface discriminated by `contentType` (TEXT/DOCUMENT/OBJECT). Mapping uses `instanceof` pattern matching; all three variants are handled. DOCUMENT content maps all document reference fields including the full `DocumentReferenceMetadata` sub-object (7 fields, with type conversions for `expiresAt` and `processInstanceKey`). OBJECT content uses `MsgPackConverter.convertToMsgPack()` + `BufferUtil.wrapArray()` to serialize the arbitrary map to msgpack.

### `producedAt` validation
The OpenAPI field is `string` (RFC 3339). Validated in the request validator via `RequestValidator.validateDate()` — invalid format returns 400 with a structured error. The mapper then parses it with `OffsetDateTime.parse(s).toInstant().toEpochMilli()`.

### `agentHistoryKey` vs `historyItemKey`
The internal Zeebe protocol record uses `agentHistoryKey` (renamed in the dependency branch). The external REST API (`AgentInstanceHistoryItemCreationResult`) retains `historyItemKey` — the OpenAPI spec was not changed. The mapper bridges the two names.

## Changed files

| File | Change |
|------|--------|
| `zeebe/gateway/…/BrokerCreateAgentHistoryRequest.java` | New — broker request class |
| `service/…/AgentHistoryServices.java` | New — command-only service |
| `service/…/ServiceRegistry.java` | Add `agentHistoryServices(String)` accessor |
| `service/…/DefaultServiceRegistry.java` | Add record component + builder wiring |
| `dist/…/CamundaServicesConfiguration.java` | Wire `AgentHistoryServices` per tenant |
| `gateways/…/AgentInstanceRequestValidator.java` | Add `validateHistoryItemRequest(…)` with RFC 3339 validation for `producedAt` and document metadata `expiresAt` |
| `gateways/…/AgentInstanceMapper.java` | Add `toCreateAgentHistoryRecord(…)` + `toAgentHistoryItemCreationResult(…)`; map full `DocumentReferenceMetadata`; null-safe `StringProperty` setters |
| `zeebe/gateway-rest/…/AgentInstanceController.java` | Add POST `/{agentInstanceKey}/history` |
| `zeebe/gateway/…/BrokerCreateAgentHistoryRequestTest.java` | New — unit tests |
| `zeebe/gateway-rest/…/AgentInstanceControllerTest.java` | Add history endpoint tests including DOCUMENT content path and date validation cases |

## Tests

### `BrokerCreateAgentHistoryRequestTest`
- Correct `ValueType` (`AGENT_HISTORY`) and `Intent` (`CREATE`)
- Partition decoded from `agentInstanceKey`
- Empty dispatch strategy (partition is set directly, not hash-based)

### `AgentInstanceControllerTest` additions
- Happy path: minimal TEXT content → 201 + `historyItemKey`
- Happy path: full request with TEXT + OBJECT content, toolCalls, metrics → verifies all record fields
- Happy path: DOCUMENT content → verifies all document reference fields including full `DocumentReferenceMetadata`
- Parameterized validation: zero/non-numeric `agentInstanceKey` (path), missing/zero `elementInstanceKey`, missing `jobKey`, missing `role`, missing/empty `content`, missing `producedAt`, invalid `producedAt` RFC 3339 format, invalid document metadata `expiresAt` RFC 3339 format (`jobLease` not validated yet — #55033)
- Service error → 5xx

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55030