### PR TITLE
[Backport stable/8.7] ci: submit job-level owner to CI Analytics for push and schedule workflows

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status.'
     required: false
   user_description:
-    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status.'
+    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status. When empty, falls back to the TEST_OWNER environment variable.'
     required: false
   job_name:
     description: 'Optional string, the job whose status is being observed; defaults to $GITHUB_JOB when omitted'
@@ -102,5 +102,5 @@ runs:
         build_status: "${{ inputs.build_status }}"
         build_duration_millis: "${{ steps.get-build-duration-millis.outputs.result }}"
         user_reason: "${{ inputs.user_reason }}"
-        user_description: "${{ inputs.user_description }}"
+        user_description: "${{ inputs.user_description != '' && inputs.user_description || env.TEST_OWNER }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -20,6 +20,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
 jobs:
   benchmark-data:
     name: Collect benchmark data

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/camunda-load-test-ttl-cleanup.yml
+++ b/.github/workflows/camunda-load-test-ttl-cleanup.yml
@@ -13,6 +13,7 @@ on:
         required: false
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -14,6 +14,9 @@ on:
     # Runs at 01:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
     - cron: '0 1 * * 1-5'
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   setup:
     name: Resolve release branch
@@ -101,7 +104,7 @@ jobs:
     steps:
       - id: slack-notify-failure
         name: Send failure slack notification
-        uses: slackapi/slack-github-action@v1.27.1
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
         if: ${{ always() && needs.dry-run-release.result != 'success' }}
         with:
           # For posting a rich message using Block Kit
@@ -126,7 +129,7 @@ jobs:
             }
       - id: slack-notify-success
         name: Send success slack notification
-        uses: slackapi/slack-github-action@v1.27.1
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
         if: ${{ always() && needs.dry-run-release.result == 'success' }}
         with:
           # For posting a rich message using Block Kit

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -19,6 +19,9 @@ on:
     # Runs at 1am every monday https://crontab.guru/#0_1_*_*_1
     - cron: 0 1 * * 1
 
+env:
+  TEST_OWNER: '@camunda/reliability-testing'
+
 jobs:
   test-data:
     name: Collect test data

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -14,6 +14,7 @@ on:
     - '*'
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   check-all-pr-conflicts:
     if: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
@@ -329,7 +330,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -353,31 +353,37 @@ jobs:
             maven-build-threads: 2
             maven-test-fork-count: 7
             runs-on: gcp-perf-core-8-default
+            owner: '@camunda/qa-engineering'
           - group: modules
             name: "Zeebe Module Integration Tests"
             maven-modules: "'!qa/integration-tests,!qa/update-tests' -f zeebe"
             maven-build-threads: 2
             maven-test-fork-count: 7
             runs-on: gcp-perf-core-8-longrunning
+            owner: '@camunda/monorepo-devops-team'
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
             maven-modules: "zeebe/qa/integration-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
             runs-on: gcp-perf-core-16-default
+            owner: '@camunda/monorepo-devops-team'
           - group: qa-update
             name: "Zeebe QA - Update Tests"
             maven-modules: "zeebe/qa/update-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
             runs-on: gcp-perf-core-8-default
+            owner: '@camunda/core-features'
           - group: qa-camunda-process-test
             name: "Camunda Process Test"
             maven-modules: "testing/camunda-process-test-java,testing/camunda-process-test-spring"
             maven-build-threads: 1
             maven-test-fork-count: 10
             runs-on: gcp-perf-core-8-default
+            owner: '@camunda/camundaex'
     env:
+      TEST_OWNER: ${{ matrix.owner }}
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist:current-test
@@ -456,7 +462,6 @@ jobs:
           job_name: "integration-tests/${{ matrix.group }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -470,7 +475,6 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     env:
-      TEST_OWNER: General
       TEST_PRODUCT: Camunda
       TEST_TYPE: Unit
     outputs:
@@ -524,7 +528,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -39,6 +39,7 @@ on:
       - checks_requested
 
 env:
+  TEST_OWNER: '@camunda/distribution'
   GHA_BEST_PRACTICES_LINTER: enabled
   HARBOR_REGISTRY: registry.camunda.cloud
   HARBOR_ZEEBE_REPOSITORY: registry.camunda.cloud/team-camunda/zeebe

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   submit-maven-snapshot:
     name: "Security / Submit Maven Dependency Snapshot"

--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - release-*
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   validate-event:
     name: Validate GitHub event for release branch activity

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch: { }
   workflow_call: { }
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   integration-tests:
     name: Tasklist Docker tests

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -21,6 +21,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/zeebe-distributed-platform'
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
@@ -104,8 +105,7 @@ jobs:
           job_name: "smoke-tests/${{ matrix.os }}-${{ matrix.arch }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
-          detailed_junit_tests: true
+          detailed_junit_tests: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}  # feature only supported on Linux for now
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -157,7 +157,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -223,7 +222,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -281,7 +279,6 @@ jobs:
         with:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
           detailed_junit_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -433,7 +430,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          user_description: "team-distributed-systems"
 
   deploy-snyk-projects:
     name: Deploy Snyk development projects
@@ -470,6 +466,8 @@ jobs:
     permissions:
       checks: read
       pull-requests: write
+    env:
+      TEST_OWNER: '@camunda/monorepo-devops-team'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Generate GitHub token

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -12,6 +12,7 @@ on:
     - cron: '0 1 * * 1-5'
 
 env:
+  TEST_OWNER: '@camunda/core-features'
   # This URL is used as the business key for the various QA workflows
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -8,6 +8,9 @@ on:
     # Runs at 02:00 every week day; see this link for more: https://crontab.guru/#0_2_*_*_1-5
     - cron: '0 2 * * 1-5'
 
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+
 jobs:
   dry-run-release-85:
     name: "Release from stable/8.5"

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -11,6 +11,9 @@ concurrency:
 permissions:
   actions: read # Required to get the previous report
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   released-versions:
     name: Released Versions

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -11,6 +11,9 @@ on:
     # Run at 7:00 on every monday
     - cron: '0 7 * * 1'
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   # This job will figure out the last supported versions based on the latest tags.
   #

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -202,15 +202,27 @@ Related resources:
 
 ### Ownership
 
-Each CI test file has an owning team. The owning team can be found either through the `CODEOWNERS` file or on the metadata in the file itself. The `CODEOWNERS` file is organized and broken down by team, any additions to the file should follow that convention. The metadata on a GHA workflow file is used by a scraping tool so that it is easy to gather information about the current state of CI. You can look at the metadata for a quick overview of the owning team, where the tests live, how the test is called, and a description of what the file is actually testing
+Each CI test file has an owning team. The owning team can be found in `.codeowners` (lookup via `codeowners-cli owner <path>`) with the same value also in the metadata in the GHA workflow YAML file itself. `.codeowners` is the source-of-truth, the metadata is for human overview only:
+
+You can look at the metadata for a quick overview of the owning team, where the tests live, how the test is called, and a description of what the file is actually testing
+
+The owning team is the general point of contact for any questions or problems with the GHA workflow. Unless overwritten on the GHA job-level, the owning team will also own all job failures and their medic can be contacted to resolve those.
 
 Metadata follows this structure and is placed at the beginning of a GHA workflow file
 
 ```
 # <Description of what the GHA is running and what is being tested>
 # test location: <The filepath of the tests being run>
-# owner: <The name of the owning team>
+# owner: <The GitHub handle of the owning team>
 ```
+
+#### Automatic Alert Attribution
+
+For programmatic alert routing and medic assignment on CI incidents, each workflow also propagates the canonical GitHub team handle to [CI Analytics](#ci-health-metrics) via a workflow-level `env: TEST_OWNER:` block.
+
+The [`observe-build-status` action](#metrics-collection) reads this env var as the default for the `user_description` field it submits to CI Analytics. This can be overwritten on the job-level with more specific `env: TEST_OWNER:` blocks.
+
+See [Metrics Collection](#metrics-collection) for the concrete `env:` snippet, including how to override per-job and how to wire matrix-driven values.
 
 ### Legacy CI
 
@@ -354,6 +366,31 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+```
+
+To attribute CI Analytics rows to an owning team, set a canonical handle as a workflow-level env var. This is read by `observe-build-status` as the default for its `user_description` input, so no inline argument is needed at the call site:
+
+```yaml
+# owner: @camunda/core-features
+env:
+  TEST_OWNER: '@camunda/core-features'
+```
+
+The handle must match with `.codeowners` (verify with `codeowners-cli owner <path>`). Override per job for outliers if necessary, including matrix-driven values:
+
+```yaml
+jobs:
+  per-suite-tests:
+    strategy:
+      matrix:
+        include:
+          - suite: CoreFeatures
+            owner: '@camunda/core-features'
+          - suite: DataLayer
+            owner: '@camunda/data-layer'
+    env:
+      TEST_OWNER: ${{ matrix.owner }}
+    # ...
 ```
 
 Related resources:


### PR DESCRIPTION
## Description

Backport of [#55040](https://github.com/camunda/camunda/pull/55040) to \`stable/8.7\`. Submits canonical \`@camunda/...\` team handles to CI Analytics from every push/schedule workflow on this branch, so failures route to the responsible team's medic.

### Adaptations for stable/8.7

\`stable/8.7\` has the most divergence from \`main\` of the three target branches. Applied via \`git cherry-pick -m 1 e1594074d86\` then resolved:

- **Dropped 43 workflow + doc files** that exist on \`main\` but not on \`stable/8.7\` (including \`.codeowners\`, the entire \`c8-orchestration-cluster-*-nightly-*\` family, multiple \`*-compatibility-test*\` files, several reusable workflows, etc.). \`stable/8.7\` uses \`CODEOWNERS\` (uppercase) instead of \`.codeowners\` — no rules were introduced.
- **\`ci.yml\`** — kept stable/8.7's structure entirely for three large divergent sections (Java unit tests vs setup-tests + integration-tests matrix; identity-frontend-tests job; timeouts/Node versions). Dropped 2 buggy inline \`user_description: \${{ steps.analyze-test-run.outputs.flakyTests }}\` blocks (these were submitting the list of flaky tests as the description — clearly a stable bug).
- **\`zeebe-ci.yml\`** — renamed from \`ci-zeebe.yml\` on main; git rename detection applied the workflow-level \`TEST_OWNER: '@camunda/zeebe-distributed-platform'\` correctly. Dropped 4 buggy inline \`user_description: \${{ steps.analyze-test-run.outputs.flakyTests }}\` blocks and kept incoming's \`detailed_junit_tests: \${{ matrix.os != 'macos' && matrix.os != 'windows' }}\` matrix-aware expression for smoke-tests.
- **\`camunda-weekly-load-tests.yml\`** — added \`env: TEST_OWNER: '@camunda/reliability-testing'\` only; did not import unrelated additions (\`defaults.run.shell\`, unused \`IMAGE_REPOSITORY\` env).
- **\`tasklist-docker-tests.yml\`** — removed on main, still present on stable/8.7; applied the workflow-level TEST_OWNER pattern in a separate commit.

### Verification

- 0 inline \`user_description\` values left non-canonical
- 0 \`TEST_OWNER\` env values left non-canonical (all are \`@camunda/...\` handles, matrix expressions, or input refs)
- YAML parses cleanly for every modified workflow

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary — this is the backport.
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Contributes to #52873. Backport of #55040.