### PR TITLE
fix: declare zeebe-client-java as direct dep

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -256,7 +256,7 @@ jobs:
           additional_flags: "--profile self-managed"
 
       - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+        run: ./mvnw -T1C clean install -DskipTests -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
@@ -383,7 +383,7 @@ jobs:
           directory: ./optimize/client
           node-version: ${{ steps.pom-info.outputs.x_version_node }}
       - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+        run: ./mvnw -T1C clean install -DskipTests -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
       - name: Start backend

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -89,6 +89,19 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!--
+      Direct declaration so that `-am` includes clients/java-deprecated in the local build graph.
+      Without this, zeebe-client-java is only reached transitively via zeebe-test-container (a test dep),
+      which is an external artifact. Maven's -am walk stops at external artifacts, so the module is never
+      built locally and the SNAPSHOT lookup against Nexus fails on release merge-back PRs.
+    -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
@@ -822,6 +835,7 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <ignoredUnusedDeclaredDependency>io.camunda:zeebe-protocol-jackson:jar</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>io.camunda:zeebe-client-java:jar</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.junit.platform:junit-platform-suite</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>

--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -160,7 +160,7 @@ async function setupEnvironment() {
 function buildBackend() {
   return new Promise((resolve, reject) => {
     buildBackendProcess = spawnWithArgs(
-      'mvn -f optimize/pom.xml clean install -T1C -DskipTests -Dskip.docker -pl backend -am',
+      'mvn -f optimize/pom.xml clean install -T1C -DskipTests -Dskip.docker -pl backend,upgrade -am',
       {
         cwd: _resolve(__dirname, '..', '..', '..'),
         shell: true,
@@ -226,7 +226,7 @@ function setVersionInfo() {
         const properties = data.project.properties;
         elasticSearchVersion = properties['elasticsearch.test.version'];
         opensearchVersion = properties['opensearch.test.version'];
-        zeebeVersion = properties['zeebe.version'];
+        zeebeVersion = properties['zeebe.backend.version'];
         identityVersion = properties['identity.version'];
         resolve();
       });

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -48,6 +48,8 @@
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
     <zeebe.version>8.8.28-SNAPSHOT</zeebe.version>
+    <!-- This is used for spinning up Zeebe containers for e2e -->
+    <zeebe.backend.version>8.8.10</zeebe.backend.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Without a direct declaration, zeebe-client-java is only reached transitively via zeebe-test-container (external artifact). Maven's -am walk stops at external artifacts, so the SNAPSHOT lookup against Nexus fails on release merge-back PRs. Also suppress it in ignoredUnusedDeclaredDependencies to satisfy dependency analysis.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
