### PR TITLE
test: per-physical-tenant API smoke & demo harness (demo — do not merge)

### DIFF
--- a/dist/src/main/resources/application-pt-poc-basic.yaml
+++ b/dist/src/main/resources/application-pt-poc-basic.yaml
@@ -1,0 +1,78 @@
+# Physical-tenant BASIC-auth PoC config (INTERIM — drop before review).
+#
+# Activated via the `pt-poc-basic` profile (see spring.profiles.group.pt-poc-basic in
+# application.properties). Unlike application-pt-poc.yaml (OIDC + two Keycloak realms), this needs
+# no external IdP: basic-auth users are seeded per physical tenant via camunda.security.initialization.
+#
+# Basic-auth user resolution is per physical tenant — BasicAuthUserDetailsAdapter looks the user up
+# via serviceRegistry.userServices(<ptId>). alice is seeded (below) into the default/root store and
+# resolves on /v2/... and /physical-tenants/default/...; the tenanta chain resolves against a
+# SEPARATE store, so alice is rejected there (per-tenant routing isolation).
+#
+# SCOPE NOTE: this single-engine harness provisions only the default store (index-prefix
+# ptbasicdefault). It does NOT provision a separate engine/store per physical tenant, so the
+# tenanta block below (index-prefix + bob) is NOT actually seeded — no ptbasictenanta-* indices are
+# created. Per-PT engine/store provisioning is separate from this PR's API-security-chain scope; the
+# tenanta config is kept to document intent and will seed bob once provisioning lands.
+camunda:
+  data:
+    secondary-storage:
+      type: elasticsearch
+      elasticsearch:
+        url: http://localhost:9200
+        number-of-replicas: 0
+        create-schema: true
+        # Default/root tenant store. Distinct from the OIDC harness prefixes so the two harnesses
+        # can share one ES node without their indices colliding.
+        index-prefix: ptbasicdefault
+  security:
+    authorizations:
+      enabled: true
+    authentication:
+      method: basic
+    # Default/root tenant users live in the ptbasicdefault store. alice is the default admin.
+    # NOTE: users are created in secondary storage via the broker exporter, so they only become
+    # resolvable once the exporter is healthy and the initialization data has been exported — wait
+    # for that (a few seconds after "Tomcat started") before running the smoke.
+    initialization:
+      users:
+        - username: alice
+          password: alice
+          name: Alice Default
+          email: alice@default
+      defaultRoles:
+        admin:
+          users:
+            - alice
+  physical-tenants:
+    tenanta:
+      data:
+        secondary-storage:
+          elasticsearch:
+            # tenanta's own store — bob lives here, not in the default store.
+            index-prefix: ptbasictenanta
+      security:
+        initialization:
+          users:
+            - username: bob
+              password: bob
+              name: Bob Tenanta
+              email: bob@tenanta
+          defaultRoles:
+            admin:
+              users:
+                - bob
+
+server:
+  port: 8080
+
+logging:
+  file:
+    name: /tmp/oc-basic.log
+  level:
+    io.camunda.authentication.pt: DEBUG
+    io.camunda.security: INFO
+    org.springframework.security: INFO
+    # DEBUG to surface the exact index/property the CamundaExporter's schema-readiness check flags
+    # as a mapping diff — the cause of repeated "Schema is not ready for use" on the broker exporter.
+    io.camunda.search.schema: DEBUG

--- a/dist/src/main/resources/application-pt-poc.yaml
+++ b/dist/src/main/resources/application-pt-poc.yaml
@@ -1,0 +1,114 @@
+camunda:
+  data:
+    secondary-storage:
+      # type defaults to elasticsearch in code; declared explicitly for clarity.
+      type: elasticsearch
+      elasticsearch:
+        # Local single-node dev ES — no auth, no TLS.
+        url: http://localhost:9200
+        # Single-node cluster: replicas must be 0 or indices go yellow/unassigned.
+        number-of-replicas: 0
+        create-schema: true
+        # Give the root/default tenant its own index prefix so its indices don't
+        # collide with tenanta's when the exporter writes to the same ES node.
+        index-prefix: ptdefault
+  security:
+    # Authorizations enabled, with alice and bob granted the admin role via the initialization
+    # block below. Their usernames resolve from the OIDC `preferred_username` claim (see
+    # `username-claim` on the providers) — the default `sub` claim would be the Keycloak UUID.
+    # NOTE: authorization grants are read from secondary storage (ES); they only take effect once
+    # the broker exporter is healthy and the initialization data has been exported.
+    authorizations:
+      enabled: true
+    initialization:
+      defaultRoles:
+        admin:
+          users:
+            - alice
+            - bob
+    authentication:
+      method: oidc
+      # Root declares two OIDC providers:
+      #   - "oidc" (the flat default slot): the default Keycloak realm on :8081
+      #   - "tenanta" (named slot): the tenanta Keycloak realm on :8082, viewed as default's
+      #     secondary provider. Root "tenanta" uses the DEFAULT tenant's client at that realm
+      #     (camunda-pt-default-via-tenanta-client / audience pt-default-via-tenanta-aud).
+      #     The tenanta PT overrides clientId/secret/audiences below to its own client.
+      #
+      # Because CSL's per-scope token validator now reads the scope's own provider config
+      # (audiences included), audience isolation works automatically from these declarations:
+      # default PT accepts pt-default-via-tenanta-aud; tenanta PT accepts pt-tenanta-aud.
+      # Both share issuer http://localhost:8082/realms/tenanta — audience is what isolates them.
+      oidc:                # default slot — registration id "oidc"
+        # Resolve the username from preferred_username (e.g. "alice") rather than the default
+        # `sub` (a Keycloak UUID), so the admin-role grant in initialization matches.
+        username-claim: preferred_username
+        client-id: camunda-pt-default-client
+        client-secret: default-secret
+        issuer-uri: http://localhost:8081/realms/default
+        audiences: [pt-default-aud]
+        # CSL builds full ClientRegistrations (authorization_code grant), which require a
+        # non-empty redirect-uri even though the API smoke only exercises bearer auth.
+        redirect-uri: "{baseUrl}/sso-callback"
+      providers:
+        oidc:
+          tenanta:
+            # Root "tenanta" provider: the default tenant's view of the tenanta IdP.
+            # Uses default's own client at the tenanta Keycloak realm and default's audience.
+            # The tenanta PT overrides clientId/secret/audiences from its physical-tenants
+            # overlay below.
+            # Resolve "bob" from preferred_username rather than the default `sub` UUID.
+            username-claim: preferred_username
+            client-id: camunda-pt-default-via-tenanta-client
+            client-secret: default-via-tenanta-secret
+            issuer-uri: http://localhost:8082/realms/tenanta
+            audiences: [pt-default-via-tenanta-aud]
+            redirect-uri: "{baseUrl}/sso-callback"
+  physical-tenants:
+    default:
+      security:
+        authentication:
+          # With `assigned` removed, the default PT now receives all cluster providers plus its
+          # own overlay. Both root providers (`oidc` and `tenanta`) are included automatically;
+          # isolation comes from audience values declared in each provider's configuration.
+          providers: {}
+    tenanta:
+      data:
+        secondary-storage:
+          elasticsearch:
+            # tenanta uses a distinct prefix to isolate its indices from default's.
+            index-prefix: pttenanta
+      security:
+        authentication:
+          providers:
+            # tenanta PT overlay: overrides the `tenanta` provider's client/secret/audiences.
+            # With `assigned` removed, the tenanta PT receives all root providers plus this
+            # overlay. The overlay ensures tenanta uses its own client and audience at the
+            # tenanta Keycloak realm; issuerUri inherits from root.
+            oidc:
+              tenanta:
+                # PT-side override: tenanta tenant uses its OWN client at the tenanta
+                # Keycloak realm (camunda-pt-tenanta-client) and audience pt-tenanta-aud.
+                # issuerUri inherits from root (http://localhost:8082/realms/tenanta).
+                client-id: camunda-pt-tenanta-client
+                client-secret: tenanta-secret
+                audiences: [pt-tenanta-aud]
+
+server:
+  port: 8080
+
+logging:
+  file:
+    name: /tmp/oc.log
+  level:
+    io.camunda.authentication.pt: DEBUG
+    # DEBUG to diagnose per-scope audience isolation: io.camunda.security surfaces CSL's per-scope
+    # JwtDecoder/validator construction, and org.springframework.security logs which SecurityFilterChain
+    # matches each request ("Securing GET /physical-tenants/tenanta/..."), so we can tell whether the
+    # per-scope chain or the cluster chain handled a tenant-prefixed request.
+    io.camunda.security: DEBUG
+    org.springframework.security: DEBUG
+    # DEBUG to surface the exact index/property the CamundaExporter's schema-readiness check
+    # (validateIndexMappings) flags as a mapping diff — the cause of repeated
+    # "Schema is not ready for use" on the broker exporter.
+    io.camunda.search.schema: DEBUG

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -1,6 +1,23 @@
 # General Spring configuration; enable graceful shutdown with a timeout per phase
 server.shutdown=graceful
 
+# Physical-tenant PoC profile group (INTERIM — drop before review).
+# Activating "pt-poc" pulls in consolidated-auth (host security graph), broker (embedded Zeebe
+# broker), and the identity/tasklist/operate webapp profiles (so the web UIs are served; the
+# frontend assets are built by pt-poc-oc.sh step 1 with -Dskip.fe.build=false). ES secondary
+# storage is configured directly via camunda.data.secondary-storage
+# in application-pt-poc.yaml — that unified config provisions the single `camundaexporter` and
+# the search clients, and sets secondary-storage.type=elasticsearch which is what activates
+# PhysicalTenantSearchClientReadersConfiguration (@ConditionalOnSecondaryStorageType).
+#
+# Do NOT add the `elasticsearch` spring profile here: application-elasticsearch.yaml ALSO declares
+# an explicit camunda.data.exporters.camundaExporter, which collides with the secondary-storage-
+# provisioned `camundaexporter` (two exporters of the same class race on the schema → the exporter
+# flaps "Schema is not ready" and nothing is exported — e.g. authorization/role indices stay empty).
+# Profile-include is declared here (not in application-pt-poc.yaml) because Spring
+# Boot 2.4+ rejects spring.profiles.include inside profile-specific config files.
+spring.profiles.group.pt-poc=consolidated-auth,broker,identity,tasklist,operate
+
 # Jackson 2 compatibility mode for Spring Boot 4.0
 # See: https://docs.spring.io/spring-boot/4.0-SNAPSHOT/reference/features/json.html#features.json.jackson2
 spring.http.converters.preferred-json-mapper=jackson2

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -18,6 +18,11 @@ server.shutdown=graceful
 # Boot 2.4+ rejects spring.profiles.include inside profile-specific config files.
 spring.profiles.group.pt-poc=consolidated-auth,broker,identity,tasklist,operate
 
+# Basic-auth variant of the PoC (INTERIM — drop before review): same profile members, but activates
+# application-pt-poc-basic.yaml (method=basic, users seeded per tenant via initialization) instead
+# of the OIDC application-pt-poc.yaml. Booted by pt-poc-oc-basic.sh.
+spring.profiles.group.pt-poc-basic=consolidated-auth,broker,identity,tasklist,operate
+
 # Jackson 2 compatibility mode for Spring Boot 4.0
 # See: https://docs.spring.io/spring-boot/4.0-SNAPSHOT/reference/features/json.html#features.json.jackson2
 spring.http.converters.preferred-json-mapper=jackson2

--- a/dist/src/test/resources/pt-poc/default-realm.json
+++ b/dist/src/test/resources/pt-poc/default-realm.json
@@ -1,0 +1,49 @@
+{
+  "realm": "default",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "clients": [
+    {
+      "clientId": "camunda-pt-default-client",
+      "enabled": true,
+      "secret": "default-secret",
+      "publicClient": false,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": true,
+      "serviceAccountsEnabled": true,
+      "redirectUris": [
+        "http://localhost:8080/physical-tenant/default/login/oauth2/code/*",
+        "http://localhost:8080/login/oauth2/code/*",
+        "http://localhost:8080/sso-callback"
+      ],
+      "webOrigins": ["http://localhost:8080"],
+      "protocolMappers": [
+        {
+          "name": "audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "pt-default-aud",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "lightweight.claim": "false",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "alice",
+      "enabled": true,
+      "email": "alice@default",
+      "emailVerified": true,
+      "firstName": "Alice",
+      "lastName": "Default",
+      "credentials": [{"type": "password", "value": "alice", "temporary": false}]
+    }
+  ]
+}

--- a/dist/src/test/resources/pt-poc/tenanta-realm.json
+++ b/dist/src/test/resources/pt-poc/tenanta-realm.json
@@ -1,0 +1,78 @@
+{
+  "realm": "tenanta",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "clients": [
+    {
+      "clientId": "camunda-pt-tenanta-client",
+      "enabled": true,
+      "secret": "tenanta-secret",
+      "publicClient": false,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": true,
+      "serviceAccountsEnabled": true,
+      "redirectUris": [
+        "http://localhost:8080/physical-tenant/tenanta/login/oauth2/code/*",
+        "http://localhost:8080/sso-callback"
+      ],
+      "webOrigins": ["http://localhost:8080"],
+      "protocolMappers": [
+        {
+          "name": "audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "pt-tenanta-aud",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "lightweight.claim": "false",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "camunda-pt-default-via-tenanta-client",
+      "enabled": true,
+      "secret": "default-via-tenanta-secret",
+      "publicClient": false,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": true,
+      "serviceAccountsEnabled": true,
+      "redirectUris": [
+        "http://localhost:8080/physical-tenant/default/login/oauth2/code/*",
+        "http://localhost:8080/login/oauth2/code/*",
+        "http://localhost:8080/sso-callback"
+      ],
+      "webOrigins": ["http://localhost:8080"],
+      "protocolMappers": [
+        {
+          "name": "audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "pt-default-via-tenanta-aud",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "lightweight.claim": "false",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "bob",
+      "enabled": true,
+      "email": "bob@tenanta",
+      "emailVerified": true,
+      "firstName": "Bob",
+      "lastName": "Tenanta",
+      "credentials": [{"type": "password", "value": "bob", "temporary": false}]
+    }
+  ]
+}

--- a/pt-poc-README.md
+++ b/pt-poc-README.md
@@ -108,4 +108,34 @@ but carrying `aud=pt-default-via-tenanta-aud` (default's audience, not tenanta's
 | `dist/src/test/resources/pt-poc/default-realm.json` | Keycloak realm export — default realm |
 | `dist/src/test/resources/pt-poc/tenanta-realm.json` | Keycloak realm export — tenanta realm |
 | `dist/src/main/resources/application-pt-poc.yaml` | PT provider config + trimmed diagnostics |
-| `dist/src/main/resources/application.properties` | `spring.profiles.group.pt-poc=...` entry |
+| `dist/src/main/resources/application.properties` | `spring.profiles.group.pt-poc{,-basic}=...` entries |
+
+## BASIC-auth variant
+
+A parallel harness validates the same per-tenant chains under `method=basic` (no Keycloak). Users
+are seeded per tenant via `camunda.security.initialization`, and isolation is by per-tenant user
+store: `alice` lives only in the default store, `bob` only in the tenanta store.
+
+```bash
+# Terminal 1: Elasticsearch only (no IdP needed)
+#   reuse pt-poc-idp.sh's ES, or run your own on :9200
+# Terminal 2:
+./pt-poc-oc-basic.sh      # boots OC under the pt-poc-basic profile (application-pt-poc-basic.yaml)
+# Terminal 3 (after the broker exporter has seeded the initialization users):
+./pt-poc-basic-smoke.sh
+```
+
+Matrix: `alice` (default store) is accepted on `/v2` and `/pt/default`, 401 with a wrong/unknown
+password, and — the per-tenant routing isolation — **rejected on `/pt/tenanta`** because that chain
+resolves against a separate store (`userServices("tenanta")`).
+
+> **Scope:** seeding a *non-default* tenant's user store (`bob` on `/pt/tenanta`) needs per-PT
+> engine/store provisioning, which is separate from this PR's API-security-chain scope. This
+> single-engine harness only provisions the default store, so `bob` is never seeded — that cell is
+> informational (401 today, 200 once provisioning lands).
+
+| Path | Purpose |
+|---|---|
+| `pt-poc-oc-basic.sh` | Rebuilds + boots OC under the `pt-poc-basic` profile |
+| `pt-poc-basic-smoke.sh` | Runs the basic-auth per-tenant user-isolation matrix |
+| `dist/src/main/resources/application-pt-poc-basic.yaml` | `method=basic` + per-tenant initialization users |

--- a/pt-poc-README.md
+++ b/pt-poc-README.md
@@ -1,0 +1,111 @@
+# Physical-Tenant API Smoke Harness
+
+> **INTERIM — drop before review.**
+> This harness is local scaffolding to exercise the per-physical-tenant API security chains
+> implemented in `authentication/src/main/java/io/camunda/authentication/pt/`. It is NOT part
+> of the production deliverable and MUST be removed in a dedicated drop commit before the PR
+> is marked review-ready.
+
+## What it demonstrates
+
+Per-PT **API** chain isolation via the CSL `CamundaSecurityScopeProvider` (`PhysicalTenantScopeProvider`):
+
+- Two physical tenants (`default`, `tenanta`) are declared in `application-pt-poc.yaml`.
+- `PhysicalTenantScopeProvider` emits one `ScopedSecurityDescriptor` per tenant; CSL builds one
+  `SecurityFilterChain` per descriptor, matching the tenant-first path prefix
+  `/physical-tenants/<id>/v2/...`.
+- A token minted for tenant A's Keycloak client is accepted on tenant A's chain and rejected (401)
+  on tenant B's chain — the chain's JWT decoder is configured with only that tenant's issuer and
+  audiences, so cross-tenant tokens fail validation.
+- Audience-based isolation: when the same Keycloak realm serves multiple tenants, each tenant gets
+  its own client and audience claim. A token carrying the wrong audience is rejected even when the
+  issuer matches.
+
+## Architecture alignment
+
+| Config key | Value | Effect |
+|---|---|---|
+| `camunda.physical-tenants.default.security.authentication.providers.assigned` | `[oidc, tenanta]` | default PT uses two providers |
+| `camunda.physical-tenants.tenanta.security.authentication.providers.assigned` | `[tenanta]` | tenanta PT uses one provider with its own clientId/audience override |
+| `camunda.security.authorizations.enabled` | `false` | authorizations disabled (orthogonal to chain isolation) |
+
+The `pt-poc` profile group (`spring.profiles.group.pt-poc=consolidated-auth,elasticsearch,broker`)
+activates the host security graph, Elasticsearch secondary storage, and the embedded Zeebe broker.
+Elasticsearch is required because `PhysicalTenantSearchClientReadersConfiguration` (which creates
+per-PT search clients) is `@ConditionalOnSecondaryStorageType(elasticsearch, opensearch)` — with
+rdbms the multi-PT readers do not activate and OC fails to start with more than one physical tenant.
+
+## Prerequisites
+
+- Docker with at least 4 GB memory available (ES needs ~1 GB heap; Keycloak adds ~500 MB each)
+  - First run pulls `quay.io/keycloak/keycloak:26.2` (~500 MB) and
+    `docker.elastic.co/elasticsearch/elasticsearch:8.19.13` (~1.5 GB)
+- Java 21 on `PATH`
+- `./mvnw` (repo Maven wrapper)
+- `curl`, `jq`, and `python3` (used by the ES health-check in `pt-poc-idp.sh`)
+- Free ports: 8080 (OC), 8081 (Keycloak default realm), 8082 (Keycloak tenanta realm),
+  9200 (Elasticsearch), 9600 (OC management)
+
+## Running
+
+Three terminals. Run steps in order — each step depends on the previous.
+
+### Terminal 1 — Keycloak + Elasticsearch
+
+```bash
+./pt-poc-idp.sh
+```
+
+Boots one Elasticsearch container (`:9200`) and two Keycloak containers (`:8081`, `:8082`) via
+`docker run`. Wait for `=== PT-PoC local IdPs + ES ready ===`.
+Press Ctrl-C to stop all three containers.
+
+### Terminal 2 — OC
+
+```bash
+./pt-poc-oc.sh
+```
+
+Rebuilds dist + upstream modules then boots OC under `--spring.profiles.active=pt-poc`.
+Wait for `Tomcat started on port 8080`. Logs tee to `/tmp/oc.log`. Press Ctrl-C to stop.
+
+### Terminal 3 — smoke
+
+```bash
+./pt-poc-api-smoke.sh
+```
+
+Runs 12 assertion cells against `GET /physical-tenants/<id>/v2/authentication/me` and
+`GET /v2/authentication/me`. Exits 0 (all PASS) or 1 (at least one FAIL).
+
+## Smoke matrix
+
+| # | Token | Path | Expected |
+|---|---|---|---|
+| 1 | default | `/physical-tenants/default/v2/authentication/me` | NOT 401 (own chain) |
+| 2 | tenanta | `/physical-tenants/tenanta/v2/authentication/me` | NOT 401 (own chain) |
+| 3 | default | `/physical-tenants/tenanta/v2/authentication/me` | 401 (cross-tenant) |
+| 4 | tenanta | `/physical-tenants/default/v2/authentication/me` | 401 (cross-tenant) |
+| 5 | none | `/physical-tenants/default/v2/authentication/me` | 401 (unauthenticated) |
+| 6 | none | `/physical-tenants/tenanta/v2/authentication/me` | 401 (unauthenticated) |
+| 7 | dvta | `/physical-tenants/default/v2/authentication/me` | NOT 401 (default's aud) |
+| 8 | dvta | `/physical-tenants/tenanta/v2/authentication/me` | 401 (wrong aud) |
+| 9 | default | `/v2/authentication/me` | NOT 401 (cluster path) |
+| 10 | tenanta | `/v2/authentication/me` | NOT 401 (cluster path) |
+| 11 | none | `/v2/authentication/me` | 401 (unauthenticated) |
+| 12 | dvta | `/v2/authentication/me` | NOT 401 (cluster path) |
+
+**dvta** = `camunda-pt-default-via-tenanta-client` token — issued by the tenanta Keycloak realm
+but carrying `aud=pt-default-via-tenanta-aud` (default's audience, not tenanta's).
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `pt-poc-idp.sh` | Boots ES (`:9200`) and two Keycloak containers (default on :8081, tenanta on :8082) |
+| `pt-poc-oc.sh` | Rebuilds + boots OC under the pt-poc profile |
+| `pt-poc-api-smoke.sh` | Runs the 12-cell API isolation matrix |
+| `dist/src/test/resources/pt-poc/default-realm.json` | Keycloak realm export — default realm |
+| `dist/src/test/resources/pt-poc/tenanta-realm.json` | Keycloak realm export — tenanta realm |
+| `dist/src/main/resources/application-pt-poc.yaml` | PT provider config + trimmed diagnostics |
+| `dist/src/main/resources/application.properties` | `spring.profiles.group.pt-poc=...` entry |

--- a/pt-poc-api-smoke.sh
+++ b/pt-poc-api-smoke.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# INTERIM — drop before review. Part of the local PT API smoke harness.
+#
+# API isolation smoke matrix for the physical-tenant security chains.
+#
+# Demonstrates the isolation this PR actually delivers under the current (post-`assigned`-removal)
+# model, where every physical tenant inherits ALL cluster providers (root ∪ its own overlay):
+#
+#   - A non-default tenant (e.g. `tenanta`) gets a dedicated API chain at the tenant-first path
+#     /physical-tenants/<id>/v2/...  built from its ScopedSecurityDescriptor.
+#   - The implicit `default` tenant is the ROOT: it is served at the unprefixed /v2/... cluster path
+#     AND, as an alias, at /physical-tenants/default/v2/... — PhysicalTenantScopeProvider emits a
+#     default-alias descriptor (built from the root config) whenever PT scoping is active. Both
+#     surfaces accept the same (root) providers/audiences.
+#   - Per-scope AUDIENCE validation isolates tenants that share one IdP issuer: tenanta's overlay
+#     overrides its provider audience to pt-tenanta-aud, so a same-issuer token with a different
+#     audience is rejected by tenanta's chain even though the issuer matches.
+#
+# The probe endpoint is GET .../v2/authentication/me (AuthenticationController, a
+# @CamundaRestController — registered under the PT prefix by
+# PhysicalTenantRequestMappingHandlerMapping for scoped tenants, and at /v2 for the cluster).
+#
+# NOT asserted here (deferred): per-tenant ISSUER isolation — rejecting a *different cluster
+# provider's* token on a tenant's chain (e.g. the root default-realm token on /pt/tenanta). That
+# requires per-tenant provider SELECTION (`providers.assigned`), which is deferred to #54730. With
+# all-providers, tenanta inherits the root default `oidc` provider, so it accepts that token. The
+# two cells below marked [#54730] print the current behaviour for visibility but do not pass/fail.
+#
+# Requires: ./pt-poc-idp.sh and ./pt-poc-oc.sh running.
+# Dependencies: curl, jq.
+
+set -u
+
+OC="http://localhost:8080"
+KC_DEFAULT="http://localhost:8081/realms/default/protocol/openid-connect/token"
+KC_TENANTA="http://localhost:8082/realms/tenanta/protocol/openid-connect/token"
+
+PROBE_PATH_TEMPLATE="/physical-tenants/%s/v2/authentication/me"
+PROBE_CLUSTER="/v2/authentication/me"
+
+PASS=0
+FAIL=0
+
+token() {
+  local url="$1" client_id="$2" client_secret="$3" user="$4" pass="$5"
+  curl -fsS -X POST "$url" \
+    -d "grant_type=password" \
+    -d "client_id=$client_id" \
+    -d "client_secret=$client_secret" \
+    -d "username=$user" \
+    -d "password=$pass" \
+    | jq -r .access_token
+}
+
+_status() {
+  local tok="$1" path="$2"
+  if [[ -n "$tok" ]]; then
+    curl -sS -o /tmp/pt-poc-api-body -w "%{http_code}" -H "Authorization: Bearer $tok" "$OC$path"
+  else
+    curl -sS -o /tmp/pt-poc-api-body -w "%{http_code}" "$OC$path"
+  fi
+}
+
+# check_not_401: token was accepted by the chain (200, or even 403 from authz — anything but 401).
+check_not_401() {
+  local label="$1" tok="$2" path="$3" status
+  status=$(_status "$tok" "$path")
+  printf "%-72s %s  " "$label" "$status"
+  if [[ "$status" != "401" ]]; then
+    echo "PASS (not 401)"; PASS=$((PASS + 1))
+  else
+    echo "FAIL (got 401 — token rejected by chain)"; cat /tmp/pt-poc-api-body 2>/dev/null && echo
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# check_401: chain rejected the token (or no token) with 401.
+check_401() {
+  local label="$1" tok="$2" path="$3" status
+  status=$(_status "$tok" "$path")
+  printf "%-72s %s  " "$label" "$status"
+  if [[ "$status" == "401" ]]; then
+    echo "PASS (401 as expected)"; PASS=$((PASS + 1))
+  else
+    echo "FAIL (expected 401, got $status)"; cat /tmp/pt-poc-api-body 2>/dev/null && echo
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# info: print current behaviour without pass/fail (for documented, deferred behaviour).
+info() {
+  local label="$1" tok="$2" path="$3" status
+  status=$(_status "$tok" "$path")
+  printf "%-72s %s  INFO\n" "$label" "$status"
+}
+
+echo "=== Acquiring tokens ==="
+DEF=$(token "$KC_DEFAULT" camunda-pt-default-client default-secret alice alice)
+TA=$(token "$KC_TENANTA" camunda-pt-tenanta-client tenanta-secret bob bob)
+# DVTA: a token from the SHARED tenanta realm (same issuer :8082 as TA) but a different
+# client/audience (pt-default-via-tenanta-aud vs pt-tenanta-aud) — drives the audience-isolation cell.
+DVTA=$(token "$KC_TENANTA" camunda-pt-default-via-tenanta-client default-via-tenanta-secret bob bob)
+echo "  default token (alice, :8081, aud=pt-default-aud):                ${DEF:0:32}..."
+echo "  tenanta token (bob,   :8082, aud=pt-tenanta-aud):                ${TA:0:32}..."
+echo "  default-via-tenanta   (bob,   :8082, aud=pt-default-via-tenanta-aud): ${DVTA:0:32}..."
+echo
+
+echo "=== Scoped tenant chain — /physical-tenants/tenanta/v2/... ==="
+check_not_401 "tenanta token -> /pt/tenanta  (own chain accepts)"               "$TA"   "$(printf "$PROBE_PATH_TEMPLATE" tenanta)"
+check_401     "no token      -> /pt/tenanta  (unauthenticated rejected)"         ""      "$(printf "$PROBE_PATH_TEMPLATE" tenanta)"
+check_401     "dvta token    -> /pt/tenanta  (AUDIENCE ISOLATION, shared issuer)" "$DVTA" "$(printf "$PROBE_PATH_TEMPLATE" tenanta)"
+echo "    ^ KEY CELL: same issuer (:8082) as tenanta, but aud=pt-default-via-tenanta-aud != the"
+echo "      tenanta chain's pt-tenanta-aud, so CSL's per-scope audience validator rejects it."
+echo
+
+echo "=== Cluster / root-tenant surface — unprefixed /v2/... (the 'default' tenant) ==="
+check_not_401 "default token -> /v2  (root-tenant surface accepts default realm)" "$DEF"  "$PROBE_CLUSTER"
+check_401     "no token      -> /v2  (unauthenticated rejected)"                   ""      "$PROBE_CLUSTER"
+check_401     "tenanta token -> /v2  (scope-private client not in cluster providers)" "$TA" "$PROBE_CLUSTER"
+check_not_401 "dvta token    -> /v2  (accepted via root tenanta provider)"          "$DVTA" "$PROBE_CLUSTER"
+echo
+
+echo "=== Default-tenant alias — /physical-tenants/default/v2/... (mirrors the cluster surface) ==="
+check_not_401 "default token -> /pt/default  (alias accepts default realm)"          "$DEF"  "$(printf "$PROBE_PATH_TEMPLATE" default)"
+check_401     "no token      -> /pt/default  (unauthenticated rejected)"              ""      "$(printf "$PROBE_PATH_TEMPLATE" default)"
+check_401     "tenanta token -> /pt/default  (scope-private client not in root providers)" "$TA" "$(printf "$PROBE_PATH_TEMPLATE" default)"
+check_not_401 "dvta token    -> /pt/default  (accepted via root tenanta provider)"   "$DVTA" "$(printf "$PROBE_PATH_TEMPLATE" default)"
+echo
+
+echo "=== Deferred to #54730 (per-tenant ISSUER selection via providers.assigned) — informational ==="
+echo "    With all-providers, tenanta inherits the root default 'oidc' provider, so it accepts the"
+echo "    default-realm token (cross-issuer); this becomes a 401 once #54730's provider selection lands."
+info "default token -> /pt/tenanta  (cross-issuer; 200 today, 401 once #54730 lands)" "$DEF" "$(printf "$PROBE_PATH_TEMPLATE" tenanta)"
+echo
+
+rm -f /tmp/pt-poc-api-body
+
+echo "=== Results: $PASS passed, $FAIL failed (informational cells excluded) ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/pt-poc-basic-smoke.sh
+++ b/pt-poc-basic-smoke.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# INTERIM — drop before review. Part of the local PT smoke harness (BASIC-auth variant).
+#
+# Basic-auth smoke for the physical-tenant security chains. The cluster-wide auth method is `basic`,
+# so every chain (cluster, per-tenant, default alias) uses HTTP Basic, and a user is resolved per
+# request via BasicAuthUserDetailsAdapter -> userServices(<ptId>) — a per-tenant user store.
+#
+# What this PR delivers (and this smoke proves):
+#   - basic auth on the cluster /v2 surface and the /physical-tenants/default alias, backed by the
+#     default user store (alice); wrong/unknown credentials -> 401.
+#   - per-tenant ROUTING isolation: the /physical-tenants/tenanta chain resolves against a SEPARATE
+#     store, so alice (a default-store user) is rejected there.
+#
+# Out of scope here: provisioning a non-default tenant's user store. Seeding bob into the tenanta
+# store needs per-PT engine/store provisioning (a separate piece of the physical-tenants work); in
+# this single-engine harness only the default store (ptbasicdefault-* indices) exists, so bob is
+# never seeded and the "bob accepted on /pt/tenanta" cell is informational (401 today).
+#
+# The probe endpoint is GET .../v2/authentication/me (registered under the PT prefix by
+# PhysicalTenantRequestMappingHandlerMapping for scoped tenants, and at /v2 for the cluster).
+#
+# Requires: ./pt-poc-oc-basic.sh running, and the broker exporter to have seeded the initialization
+# users into ES (wait a few seconds after "Tomcat started"). Dependencies: curl.
+
+set -u
+
+OC="http://localhost:8080"
+PROBE_PATH_TEMPLATE="/physical-tenants/%s/v2/authentication/me"
+PROBE_CLUSTER="/v2/authentication/me"
+
+PASS=0
+FAIL=0
+
+_status() {
+  local creds="$1" path="$2"
+  if [[ -n "$creds" ]]; then
+    curl -sS -o /tmp/pt-poc-basic-body -w "%{http_code}" -u "$creds" "$OC$path"
+  else
+    curl -sS -o /tmp/pt-poc-basic-body -w "%{http_code}" "$OC$path"
+  fi
+}
+
+# check_not_401: credentials accepted by the chain (200, or even 403 from authz — anything but 401).
+check_not_401() {
+  local label="$1" creds="$2" path="$3" status
+  status=$(_status "$creds" "$path")
+  printf "%-72s %s  " "$label" "$status"
+  if [[ "$status" != "401" ]]; then
+    echo "PASS (not 401)"; PASS=$((PASS + 1))
+  else
+    echo "FAIL (got 401 — credentials rejected by chain)"; cat /tmp/pt-poc-basic-body 2>/dev/null && echo
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# check_401: chain rejected the credentials (or absence thereof) with 401.
+check_401() {
+  local label="$1" creds="$2" path="$3" status
+  status=$(_status "$creds" "$path")
+  printf "%-72s %s  " "$label" "$status"
+  if [[ "$status" == "401" ]]; then
+    echo "PASS (401 as expected)"; PASS=$((PASS + 1))
+  else
+    echo "FAIL (expected 401, got $status)"; cat /tmp/pt-poc-basic-body 2>/dev/null && echo
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# info: print current behaviour without pass/fail (for documented, deferred behaviour).
+info() {
+  local label="$1" creds="$2" path="$3" status
+  status=$(_status "$creds" "$path")
+  printf "%-72s %s  INFO\n" "$label" "$status"
+}
+
+echo "=== Scoped tenant chain — /physical-tenants/tenanta/v2/... (separate per-tenant store) ==="
+check_401     "no creds    -> /pt/tenanta  (unauthenticated rejected)"               ""            "$(printf "$PROBE_PATH_TEMPLATE" tenanta)"
+check_401     "alice:alice -> /pt/tenanta  (ISOLATION: default-store user rejected)" "alice:alice" "$(printf "$PROBE_PATH_TEMPLATE" tenanta)"
+echo "    ^ proves the tenanta chain resolves against a SEPARATE store via userServices(tenanta) —"
+echo "      a default-store user (alice) is not accepted here."
+echo
+
+echo "=== Informational — accepting a user on a non-default tenant needs per-PT store provisioning ==="
+echo "    Only the default store (ptbasicdefault-* indices) exists in this single-engine harness; the"
+echo "    tenanta store is not provisioned, so bob (declared under physical-tenants.tenanta.*.init)"
+echo "    is never seeded. This is separate from the API-security-chain scope of this PR."
+info "bob:bob     -> /pt/tenanta  (401 today; 200 once the tenanta store is provisioned)" "bob:bob" "$(printf "$PROBE_PATH_TEMPLATE" tenanta)"
+echo
+
+echo "=== Cluster / default surface — unprefixed /v2/... (default store: alice) ==="
+check_not_401 "alice:alice -> /v2  (default store accepts)"                         "alice:alice" "$PROBE_CLUSTER"
+check_401     "no creds    -> /v2  (unauthenticated rejected)"                      ""            "$PROBE_CLUSTER"
+check_401     "bob:bob     -> /v2  (USER ISOLATION: not in default store)"          "bob:bob"     "$PROBE_CLUSTER"
+check_401     "alice:wrong -> /v2  (wrong password rejected)"                       "alice:wrong" "$PROBE_CLUSTER"
+echo
+
+echo "=== Default-tenant alias — /physical-tenants/default/v2/... (default store) ==="
+check_not_401 "alice:alice -> /pt/default  (alias accepts default store)"           "alice:alice" "$(printf "$PROBE_PATH_TEMPLATE" default)"
+check_401     "no creds    -> /pt/default  (unauthenticated rejected)"              ""            "$(printf "$PROBE_PATH_TEMPLATE" default)"
+check_401     "bob:bob     -> /pt/default  (USER ISOLATION: not in default store)" "bob:bob"     "$(printf "$PROBE_PATH_TEMPLATE" default)"
+echo
+
+rm -f /tmp/pt-poc-basic-body
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/pt-poc-idp.sh
+++ b/pt-poc-idp.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# INTERIM — drop before review. Part of the local PT API smoke harness.
+#
+# Boots two Keycloak realms and one Elasticsearch node for the physical-tenant API smoke
+# harness:
+#   - "default" realm on :8081  (issuer: http://localhost:8081/realms/default)
+#   - "tenanta" realm on :8082  (issuer: http://localhost:8082/realms/tenanta)
+#   - Elasticsearch on :9200    (single-node, no auth, no TLS)
+#
+# Elasticsearch is required because PhysicalTenantSearchClientReadersConfiguration is
+# @ConditionalOnSecondaryStorageType(elasticsearch, opensearch) — with rdbms as secondary
+# storage the multi-PT search readers do not activate and OC fails to start with more than
+# one physical tenant ("Unknown physical tenant: 'tenanta'. Known tenants: [default]").
+#
+# Requires Docker (with enough memory for ES — at least 4 GB recommended).
+# First invocation pulls the Keycloak and ES images; subsequent runs start in ~20s.
+# Leave this running while ./pt-poc-oc.sh and ./pt-poc-api-smoke.sh are active.
+# Press Ctrl-C to stop all containers.
+#
+# Usage:
+#   ./pt-poc-idp.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REALM_DIR="$SCRIPT_DIR/dist/src/test/resources/pt-poc"
+
+KC_IMAGE="quay.io/keycloak/keycloak:26.2"
+KC_OPTS="start-dev --health-enabled=true"
+ES_IMAGE="docker.elastic.co/elasticsearch/elasticsearch:8.19.13"
+
+cleanup() {
+  echo
+  echo "Stopping containers..."
+  docker rm -f pt-poc-kc-default pt-poc-kc-tenanta pt-poc-es 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Remove any leftover containers from a previous run
+docker rm -f pt-poc-kc-default pt-poc-kc-tenanta pt-poc-es 2>/dev/null || true
+
+echo "Starting Elasticsearch (port 9200)..."
+# Disable the disk-based shard allocation decider. On Colima/Docker-Desktop the ES container
+# sees the (small, often nearly-full) VM disk, so the flood-stage watermark trips and ES marks
+# all indices read-only — a false positive for this local smoke harness. Disabling the decider
+# avoids the spurious read-only block; this is a throwaway single-node dev node, never production.
+docker run -d \
+  --name pt-poc-es \
+  -p 9200:9200 \
+  -e discovery.type=single-node \
+  -e xpack.security.enabled=false \
+  -e "cluster.routing.allocation.disk.threshold_enabled=false" \
+  -e "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
+  "$ES_IMAGE"
+
+echo "Starting default realm (port 8081)..."
+docker run -d \
+  --name pt-poc-kc-default \
+  -p 8081:8080 \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  -v "$REALM_DIR/default-realm.json:/opt/keycloak/data/import/default-realm.json:ro" \
+  "$KC_IMAGE" \
+  start-dev --import-realm --health-enabled=true
+
+echo "Starting tenanta realm (port 8082)..."
+docker run -d \
+  --name pt-poc-kc-tenanta \
+  -p 8082:8080 \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  -v "$REALM_DIR/tenanta-realm.json:/opt/keycloak/data/import/tenanta-realm.json:ro" \
+  "$KC_IMAGE" \
+  start-dev --import-realm --health-enabled=true
+
+echo "Waiting for Elasticsearch to become ready..."
+for i in $(seq 1 60); do
+  STATUS=$(curl -fsS "http://localhost:9200/_cluster/health" 2>/dev/null \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))" 2>/dev/null || true)
+  if [ "$STATUS" = "green" ] || [ "$STATUS" = "yellow" ]; then
+    echo "  pt-poc-es ready (cluster status: $STATUS)"
+    # Safety net (in addition to the disk.threshold_enabled=false start-up setting): disable the
+    # disk decider via the cluster settings API and clear any flood-stage read-only block, in case
+    # the Colima/Docker VM disk already tripped the watermark on a reused volume. Idempotent.
+    curl -fsS -X PUT "http://localhost:9200/_cluster/settings" \
+      -H 'Content-Type: application/json' \
+      -d '{"persistent":{"cluster.routing.allocation.disk.threshold_enabled":false}}' \
+      >/dev/null 2>&1 || true
+    curl -fsS -X PUT "http://localhost:9200/_all/_settings" \
+      -H 'Content-Type: application/json' \
+      -d '{"index.blocks.read_only_allow_delete":null}' >/dev/null 2>&1 || true
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "  ERROR: pt-poc-es did not become ready within 120s" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "Waiting for Keycloak realms to become ready..."
+# Keycloak 26 serves /health on the management port (9000), not the app port, so we
+# probe the realm's OIDC discovery document on the app port instead — this confirms both
+# that Keycloak is up AND that the realm imported successfully.
+for entry in "pt-poc-kc-default:8081:default" "pt-poc-kc-tenanta:8082:tenanta"; do
+  IFS=: read -r container port realm <<<"$entry"
+  for i in $(seq 1 60); do
+    if curl -fsS "http://localhost:$port/realms/$realm/.well-known/openid-configuration" >/dev/null 2>&1; then
+      echo "  $container ready (realm '$realm' on port $port)"
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      echo "  ERROR: $container did not become ready within 120s" >&2
+      exit 1
+    fi
+    sleep 2
+  done
+done
+
+echo
+echo "=== PT-PoC local IdPs + ES ready ==="
+echo "Elasticsearch:    http://localhost:9200"
+echo "default issuer:   http://localhost:8081/realms/default"
+echo "tenanta issuer:   http://localhost:8082/realms/tenanta"
+echo
+echo "Clients:"
+echo "  camunda-pt-default-client / default-secret          (default realm)"
+echo "  camunda-pt-tenanta-client / tenanta-secret          (tenanta realm)"
+echo "  camunda-pt-default-via-tenanta-client / default-via-tenanta-secret  (tenanta realm)"
+echo
+echo "Users:"
+echo "  alice / alice  (default realm)"
+echo "  bob   / bob    (tenanta realm)"
+echo
+echo "Press Ctrl-C to stop."
+# Block until the containers stop (or Ctrl-C). Notes:
+#  - A bare `wait` returns immediately: `docker run -d` containers are not shell jobs.
+#  - Blocking on `docker wait` in the FOREGROUND would defer the INT/TERM trap until that
+#    command returns, so Ctrl-C wouldn't clean up promptly.
+# Running `docker wait` in the background and blocking on the `wait` BUILTIN fixes both:
+# the builtin is interruptible by the trap, so Ctrl-C tears the containers down at once.
+docker wait pt-poc-kc-default pt-poc-kc-tenanta pt-poc-es >/dev/null 2>&1 &
+wait $! || true

--- a/pt-poc-oc-basic.sh
+++ b/pt-poc-oc-basic.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# INTERIM — drop before review. Part of the local PT smoke harness (BASIC-auth variant).
+#
+# Boots the OC under the pt-poc-basic profile, which expands (via spring.profiles.group.pt-poc-basic
+# in application.properties) into the same members as the OIDC harness — consolidated-auth, broker,
+# identity, tasklist, operate — but activates application-pt-poc-basic.yaml (method=basic, users
+# seeded per tenant via camunda.security.initialization). No external IdP is needed for basic auth.
+#
+# Prerequisite: Elasticsearch on localhost:9200 (users are stored in secondary storage). No
+# ./pt-poc-idp.sh needed.
+#
+# Usage:
+#   ./pt-poc-oc-basic.sh
+#
+# Once Tomcat reports "Tomcat started on port 8080", wait a few seconds for the broker exporter to
+# seed the initialization users into ES, then run ./pt-poc-basic-smoke.sh. Logs stream to the
+# terminal and tee to /tmp/oc-basic.log. Press Ctrl-C to stop.
+#
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Truncate the log up front so stale output from a previous session doesn't linger.
+rm -f /tmp/oc-basic.log
+
+# Always start the broker from clean state (see pt-poc-oc.sh for the rationale): a leftover/stale
+# exporter entry otherwise opens with the wrong config and gets stuck on "Schema is not ready".
+echo "Clearing broker data (dist/data)..."
+rm -rf dist/data
+
+# Step 1: build dist + all upstream modules. See pt-poc-oc.sh for why -Dmaven.build.cache.enabled
+# =false and `clean` are required (avoid stale resources/classes) and why -Dskip.fe.build=false is
+# needed (webapp frontends). The first build is slow (npm); subsequent runs reuse the cached jars.
+./mvnw clean install -pl dist -am -DskipTests -DskipChecks -Dskip.fe.build=false -Dmaven.build.cache.enabled=false -T1C
+
+# Step 2: boot OC under the pt-poc-basic profile.
+exec ./mvnw -pl dist spring-boot:run \
+  -DskipChecks \
+  -Dspring-boot.run.profiles=pt-poc-basic 2>&1 | tee /tmp/oc-basic.log

--- a/pt-poc-oc.sh
+++ b/pt-poc-oc.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# INTERIM — drop before review. Part of the local PT API smoke harness.
+#
+# Boots the OC under the pt-poc profile, which expands (via spring.profiles.group.pt-poc
+# in application.properties) into: consolidated-auth, elasticsearch, broker.
+#
+#   - consolidated-auth: activates the host security graph and AuthenticationConfiguration
+#   - elasticsearch:     ES secondary storage on localhost:9200 (required for multi-PT
+#                        PhysicalTenantSearchClientReadersConfiguration to activate)
+#   - broker:            embedded Zeebe broker (needed for /v2/authentication/me to respond)
+#
+# The per-tenant SecurityFilterChain wiring activates automatically once
+# camunda.physical-tenants.* entries are present in application-pt-poc.yaml.
+#
+# Prerequisite: run ./pt-poc-idp.sh in a separate terminal first.
+#
+# Usage:
+#   ./pt-poc-oc.sh
+#
+# Once Tomcat reports "Tomcat started on port 8080", run ./pt-poc-api-smoke.sh.
+# Press Ctrl-C to stop. Logs stream to the terminal and tee to /tmp/oc.log.
+#
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Truncate the log up front so stale output from a previous session doesn't linger.
+rm -f /tmp/oc.log
+
+# Always start the broker from clean state. The persisted topology (dist/data/.topology.meta)
+# and RocksDB survive across runs; a leftover/duplicate exporter entry (e.g. a stale
+# "camundaexporter" alongside "camundaExporter") then opens with the wrong config and the
+# exporter is stuck retrying "Schema is not ready for use". Wiping dist/data rebuilds the
+# topology from the current config every run. Local dev data only — safe to delete.
+echo "Clearing broker data (dist/data)..."
+rm -rf dist/data
+
+# Step 1: build dist + all upstream modules so spring-boot:run picks up fresh classes,
+# INCLUDING the webapp frontends (Operate/Tasklist UI). We skip tests and checks for speed but
+# force the frontend build with -Dskip.fe.build=false. NOTE: do NOT pass -Dquickly here — the
+# parent pom sets `skip.fe.build = ${quickly}`, so -Dquickly would skip the npm build and the UI
+# would 404 (e.g. /operate/forbidden). The first build is slow (npm); once the webapp jars are in
+# ~/.m2 you can re-comment this line to make subsequent runs fast.
+#
+# -Dmaven.build.cache.enabled=false is REQUIRED: the build cache can restore a stale dist
+# target/classes (e.g. an application.properties without our spring.profiles.group.pt-poc line),
+# so the profile group silently fails to expand and consolidated-auth/operate/etc. never activate
+# — every endpoint then 404s. Disabling the cache forces resources to be re-copied each run.
+# `clean` guarantees the authentication module (and all reactor modules) recompile from source —
+# belt-and-braces against any stale per-tenant auth-config classes from an earlier build.
+./mvnw clean install -pl dist -am -DskipTests -DskipChecks -Dskip.fe.build=false -Dmaven.build.cache.enabled=false -T1C
+
+# Step 2: boot OC under the pt-poc profile.
+exec ./mvnw -pl dist spring-boot:run \
+  -DskipChecks \
+  -Dspring-boot.run.profiles=pt-poc 2>&1 | tee /tmp/oc.log


### PR DESCRIPTION
## ⚠️ Demo / do-not-merge

Manual smoke + demo harness for the **per-physical-tenant API security chains** feature shipped in #54971 (now on `main`). Kept as a **draft**: it is scaffolding for local verification and demos, not production code. CI is expected to be red — the `dist` resource changes are demo profiles, not intended to merge.

## What's in here

**Run scripts (repo root)**
- `pt-poc-README.md` — how to run the harness end to end
- `pt-poc-oc.sh` / `pt-poc-oc-basic.sh` — boot a local OC with the PT demo profile (OIDC / basic auth)
- `pt-poc-idp.sh` — boot a local Keycloak with the demo realms
- `pt-poc-api-smoke.sh` — OIDC API smoke matrix (per-tenant audience isolation, unknown-tenant → 404)
- `pt-poc-basic-smoke.sh` — basic-auth API smoke matrix

**Demo config (`dist/src/main/resources`, `dist/src/test/resources/pt-poc`)**
- `application-pt-poc.yaml` / `application-pt-poc-basic.yaml` — demo profiles wiring two physical tenants (`default`, `tenanta`)
- `default-realm.json` / `tenanta-realm.json` — Keycloak realms per tenant (distinct audiences)

## What it demonstrates
- Per-physical-tenant API chains route `/physical-tenants/<id>/v2/**` to the tenant's own auth config
- Cross-tenant audience isolation (a token minted for tenant A is rejected on tenant B)
- Unknown/unconfigured tenant falls through to CSL's catch-all `/**` `denyAll` chain → **404**
