### PR TITLE
Use thread-safe map for importer empty batch counts

### DIFF
--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/RecordsReaderHolder.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/RecordsReaderHolder.java
@@ -16,11 +16,11 @@ import io.camunda.operate.zeebe.PartitionHolder;
 import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
@@ -44,7 +44,8 @@ public class RecordsReaderHolder {
 
   @Autowired private OperateProperties operateProperties;
 
-  private final Map<RecordsReader, Integer> countEmptyBatchesAfterImportingDone = new HashMap<>();
+  private final Map<RecordsReader, Integer> countEmptyBatchesAfterImportingDone =
+      new ConcurrentHashMap<>();
 
   public Set<RecordsReader> getAllRecordsReaders() {
     if (CollectionUtil.isNotEmpty(recordsReaders)) {

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/elasticsearch/ElasticsearchRecordsReader.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/elasticsearch/ElasticsearchRecordsReader.java
@@ -28,6 +28,7 @@ import io.camunda.operate.zeebe.ImportValueType;
 import io.camunda.operate.zeebeimport.*;
 import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.entities.ImportPositionEntity;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.time.Duration;
@@ -81,6 +82,8 @@ public class ElasticsearchRecordsReader implements RecordsReader {
   private static final String READ_BATCH_ERROR_MESSAGE =
       "Exception occurred for alias [%s], while obtaining next Zeebe records batch: %s";
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchRecordsReader.class);
+  private static final ThrottledLogger THROTTLED_LOGGER =
+      new ThrottledLogger(LOGGER, Duration.ofSeconds(60L));
 
   /** Partition id. */
   private final int partitionId;
@@ -158,6 +161,14 @@ public class ElasticsearchRecordsReader implements RecordsReader {
               importValueType.getAliasTemplate(), partitionId);
 
       importPositionHolder.recordLatestLoadedPosition(latestPosition);
+
+      LOGGER.info(
+          "Importing partition {} for value type {} starting from position {} using prefix: {}",
+          partitionId,
+          importValueType,
+          latestPosition.getPosition(),
+          operateProperties.getZeebeElasticsearch().getPrefix());
+
     } catch (final IOException e) {
       LOGGER.error(
           "Failed to write initial import position index document for value type [{}] and partition [{}]",
@@ -605,6 +616,8 @@ public class ElasticsearchRecordsReader implements RecordsReader {
   private void markRecordReaderCompletedIfMinimumEmptyBatchesReceived() {
     if (isPartitionCompletedImporting(partitionId)) {
       recordsReaderHolder.incrementEmptyBatches(partitionId, importValueType);
+    } else {
+      THROTTLED_LOGGER.warn("Partition {} has not completed import yet", partitionId);
     }
 
     if (recordsReaderHolder.isRecordReaderCompletedImporting(partitionId, importValueType)) {
@@ -618,6 +631,9 @@ public class ElasticsearchRecordsReader implements RecordsReader {
             partitionId,
             e);
       }
+    } else {
+      THROTTLED_LOGGER.warn(
+          "Not marking partition: {} value type: {} as completed", partitionId, importValueType);
     }
   }
 

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/opensearch/OpensearchRecordsReader.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/opensearch/OpensearchRecordsReader.java
@@ -43,6 +43,7 @@ import io.camunda.operate.zeebeimport.RecordsReader;
 import io.camunda.operate.zeebeimport.RecordsReaderHolder;
 import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.entities.ImportPositionEntity;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -83,6 +84,8 @@ public class OpensearchRecordsReader implements RecordsReader {
   private static final String READ_BATCH_ERROR_MESSAGE =
       "Exception occurred for alias [%s], while obtaining next Zeebe records batch: %s";
   private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchRecordsReader.class);
+  private static final ThrottledLogger THROTTLED_LOGGER =
+      new ThrottledLogger(LOGGER, Duration.ofSeconds(60L));
 
   /** Partition id. */
   private final int partitionId;
@@ -157,6 +160,14 @@ public class OpensearchRecordsReader implements RecordsReader {
               importValueType.getAliasTemplate(), partitionId);
 
       importPositionHolder.recordLatestLoadedPosition(latestPosition);
+
+      LOGGER.info(
+          "Importing partition {} for value type {} starting from position {} using prefix: {}",
+          partitionId,
+          importValueType,
+          latestPosition.getPosition(),
+          operateProperties.getZeebeOpensearch().getPrefix());
+
     } catch (final IOException e) {
       LOGGER.error(
           "Failed to write initial import position index document for value type [{}] and partition [{}]",
@@ -567,6 +578,8 @@ public class OpensearchRecordsReader implements RecordsReader {
   private void markRecordReaderCompletedIfMinimumEmptyBatchesReceived() {
     if (isPartitionCompletedImporting(partitionId)) {
       recordsReaderHolder.incrementEmptyBatches(partitionId, importValueType);
+    } else {
+      THROTTLED_LOGGER.warn("Partition {} has not completed import yet", partitionId);
     }
 
     if (recordsReaderHolder.isRecordReaderCompletedImporting(partitionId, importValueType)) {
@@ -580,6 +593,9 @@ public class OpensearchRecordsReader implements RecordsReader {
             partitionId,
             e);
       }
+    } else {
+      THROTTLED_LOGGER.warn(
+          "Not marking partition: {} value type: {} as completed", partitionId, importValueType);
     }
   }
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderHolder.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderHolder.java
@@ -15,7 +15,6 @@ import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +39,8 @@ public class RecordsReaderHolder {
 
   private final Set<Integer> partitionsCompletedImporting = ConcurrentHashMap.newKeySet();
 
-  private final Map<RecordsReader, Integer> countEmptyBatchesAfterImportingDone = new HashMap<>();
+  private final Map<RecordsReader, Integer> countEmptyBatchesAfterImportingDone =
+      new ConcurrentHashMap<>();
 
   @Autowired private BeanFactory beanFactory;
 


### PR DESCRIPTION
Use `ConcurrentHashMap` instead of `HashMap` as we are reading + updating in multiple threads.  Prior to this we might have lost updates to the map, which would mean the import would fail to mark some partitions + record types as complete.

Pretty similar problem to https://github.com/camunda/camunda/pull/42749

I think maybe in practice this was sort of working, as we pre-initialise the `HashMap` in the main thread, but there's no reason we should not use a `ConcurrentHashMap`.

Also added a little extra logging to help us in the future.

closes #55244