### PR TITLE
feat: add wait-state benchmark queries and scenario overrides

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/read/DataReadMeterQueryProvider.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/read/DataReadMeterQueryProvider.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.read;
 
 import io.camunda.client.api.search.enums.AuditLogCategoryEnum;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.client.api.search.enums.WaitStateElementType;
 import io.camunda.client.api.search.response.DecisionInstanceState;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.zeebe.read.DataReadMeter.ReadQuery;
@@ -114,6 +115,31 @@ public final class DataReadMeterQueryProvider {
                                             DecisionInstanceState.EVALUATED,
                                             DecisionInstanceState.FAILED))))
                     .page(p -> p.limit(100))
-                    .sort(s -> s.evaluationDate().desc())));
+                    .sort(s -> s.evaluationDate().desc())),
+        // --- Wait-state benchmark queries (scenarios 2–3 from issue #52037) ---
+        // Narrow lookup: mirrors what Operate would issue to show wait states for one PI.
+        new ReadQuery(
+            "wait_state_by_process_instance_key",
+            Duration.ofSeconds(30),
+            (client, context) ->
+                client
+                    .newElementInstanceWaitStateSearchRequest()
+                    .filter(f -> f.processInstanceKey(context.processInstanceKey()))
+                    .page(p -> p.limit(100))),
+        // Medium scan: all SERVICE_TASK wait states — reasonable for a monitoring dashboard.
+        new ReadQuery(
+            "wait_state_by_element_type",
+            Duration.ofSeconds(30),
+            (client, context) ->
+                client
+                    .newElementInstanceWaitStateSearchRequest()
+                    .filter(f -> f.elementType(WaitStateElementType.SERVICE_TASK))
+                    .page(p -> p.limit(100))),
+        // Broad scan: no filter, small page — exercises index health as the table grows.
+        new ReadQuery(
+            "wait_state_all",
+            Duration.ofSeconds(30),
+            (client, context) ->
+                client.newElementInstanceWaitStateSearchRequest().page(p -> p.limit(20))));
   }
 }

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/read/DataReadMeterQueryProvider.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/read/DataReadMeterQueryProvider.java
@@ -140,6 +140,28 @@ public final class DataReadMeterQueryProvider {
             "wait_state_all",
             Duration.ofSeconds(30),
             (client, context) ->
-                client.newElementInstanceWaitStateSearchRequest().page(p -> p.limit(20))));
+                client.newElementInstanceWaitStateSearchRequest().page(p -> p.limit(20))),
+        // Deep pagination: fetch page 1, then page 2 using the returned cursor.
+        // Measures cumulative p1+p2 latency to detect keyset-pagination depth regression on RDBMS.
+        // ES/OS uses search_after (O(1) per page) so should stay flat; RDBMS may degrade if the
+        // keyset filter is not pushed through the WaitStateMapper subquery boundary by the planner.
+        new ReadQuery(
+            "wait_state_page2",
+            Duration.ofSeconds(30),
+            (client, context) -> {
+              final var page1 =
+                  client
+                      .newElementInstanceWaitStateSearchRequest()
+                      .page(p -> p.limit(20))
+                      .send()
+                      .join();
+              final var cursor = page1.page().endCursor();
+              if (cursor == null) {
+                return client.newElementInstanceWaitStateSearchRequest().page(p -> p.limit(20));
+              }
+              return client
+                  .newElementInstanceWaitStateSearchRequest()
+                  .page(p -> p.limit(20).after(cursor));
+            }));
   }
 }

--- a/load-tests/load-tester/src/main/resources/bpmn/four_parallel_tasks.bpmn
+++ b/load-tests/load-tester/src/main/resources/bpmn/four_parallel_tasks.bpmn
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!--
+  Scenario 4 — wait-state write amplification benchmark (issue #52037).
+
+  Four parallel service tasks, all using job type "benchmark-task" so the existing
+  worker completes them without modification. Each PI creates 4 wait-state INSERT ops
+  on CREATED and 4 DELETE ops on COMPLETED, giving 8× the secondary-storage write
+  volume of one_task.bpmn at the same PI/s rate.
+-->
+<bpmn:definitions
+    xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+    id="Definitions_1"
+    targetNamespace="http://bpmn.io/schema/bpmn">
+
+  <bpmn:process id="benchmark" name="Four parallel tasks" isExecutable="true">
+
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>flow_start_split</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    <bpmn:parallelGateway id="split" name="split">
+      <bpmn:incoming>flow_start_split</bpmn:incoming>
+      <bpmn:outgoing>flow_split_t1</bpmn:outgoing>
+      <bpmn:outgoing>flow_split_t2</bpmn:outgoing>
+      <bpmn:outgoing>flow_split_t3</bpmn:outgoing>
+      <bpmn:outgoing>flow_split_t4</bpmn:outgoing>
+    </bpmn:parallelGateway>
+
+    <bpmn:serviceTask id="task1" name="task 1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="benchmark-task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_split_t1</bpmn:incoming>
+      <bpmn:outgoing>flow_t1_join</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="task2" name="task 2">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="benchmark-task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_split_t2</bpmn:incoming>
+      <bpmn:outgoing>flow_t2_join</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="task3" name="task 3">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="benchmark-task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_split_t3</bpmn:incoming>
+      <bpmn:outgoing>flow_t3_join</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="task4" name="task 4">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="benchmark-task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_split_t4</bpmn:incoming>
+      <bpmn:outgoing>flow_t4_join</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:parallelGateway id="join" name="join">
+      <bpmn:incoming>flow_t1_join</bpmn:incoming>
+      <bpmn:incoming>flow_t2_join</bpmn:incoming>
+      <bpmn:incoming>flow_t3_join</bpmn:incoming>
+      <bpmn:incoming>flow_t4_join</bpmn:incoming>
+      <bpmn:outgoing>flow_join_end</bpmn:outgoing>
+    </bpmn:parallelGateway>
+
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>flow_join_end</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="flow_start_split" sourceRef="start" targetRef="split" />
+    <bpmn:sequenceFlow id="flow_split_t1"   sourceRef="split"  targetRef="task1" />
+    <bpmn:sequenceFlow id="flow_split_t2"   sourceRef="split"  targetRef="task2" />
+    <bpmn:sequenceFlow id="flow_split_t3"   sourceRef="split"  targetRef="task3" />
+    <bpmn:sequenceFlow id="flow_split_t4"   sourceRef="split"  targetRef="task4" />
+    <bpmn:sequenceFlow id="flow_t1_join"    sourceRef="task1"  targetRef="join"  />
+    <bpmn:sequenceFlow id="flow_t2_join"    sourceRef="task2"  targetRef="join"  />
+    <bpmn:sequenceFlow id="flow_t3_join"    sourceRef="task3"  targetRef="join"  />
+    <bpmn:sequenceFlow id="flow_t4_join"    sourceRef="task4"  targetRef="join"  />
+    <bpmn:sequenceFlow id="flow_join_end"   sourceRef="join"   targetRef="end"   />
+
+  </bpmn:process>
+</bpmn:definitions>

--- a/load-tests/setup/wait-state-benchmark/README.md
+++ b/load-tests/setup/wait-state-benchmark/README.md
@@ -1,0 +1,70 @@
+# Wait-State Benchmark Setup
+
+Helm value overrides for the four wait-state benchmark scenarios described in issue #52037.
+Apply on top of the standard `setup/default/` values when triggering a load test.
+
+## How to run
+
+Each scenario is a single Helm override file. Pass it as an extra `-f` argument after the
+default values:
+
+```bash
+# Start a namespace using the standard script, then apply the scenario override:
+. ./newLoadTest.sh wait-state-s1 elasticsearch 2
+
+# Inside the generated namespace folder, install with the scenario overlay:
+helm upgrade --install <release> <chart> \
+  -f ../default/values/camunda-platform-values-defaults.yaml \
+  -f ../default/values/camunda-platform-values-elasticsearch.yaml \
+  -f ../default/values/load-test-values.yaml \
+  -f ../wait-state-benchmark/<scenario>.yaml
+```
+
+Alternatively trigger via the GitHub Actions `camunda-load-test.yml` workflow using the
+`extra-values` input to pass the scenario file path.
+
+---
+
+## Scenarios
+
+### Scenario 1 — Baseline (wait states disabled)
+**File:** `scenario-1-baseline.yaml`
+
+Standard 300 PI/s single-task load with wait states **disabled**. This is the control
+run — no wait-state writes happen. Run this first to establish the unaffected throughput
+numbers before enabling the feature.
+
+Read queries: disabled (wait-state table is empty; querying it yields no signal).
+
+### Scenario 1b — Wait states enabled, no read queries
+**File:** `scenario-1b-enabled.yaml`
+
+Identical to Scenario 1 except `wait-states.enabled=true`. Measures the pure exporter
+overhead (2 extra secondary-storage ops per PI: INSERT on CREATED, DELETE on COMPLETED)
+against the baseline throughput numbers.
+
+Read queries: disabled (isolates write overhead).
+
+### Scenario 2 — Query latency under load
+**File:** `scenario-2-query-latency.yaml`
+
+Same 300 PI/s single-task load, wait states enabled, **read benchmarks enabled**. The
+three wait-state queries (`wait_state_by_process_instance_key`, `wait_state_by_element_type`,
+`wait_state_all`) run every 30 s alongside the standard query set. Measures p50/p99 query
+latency and whether periodic reads noticeably affect PI throughput.
+
+### Scenario 3 — Accumulation under slow workers
+**File:** `scenario-3-accumulation.yaml`
+
+300 PI/s, wait states enabled, worker completion delay raised to **5 s** (vs the default
+300 ms). Wait states accumulate because jobs sit active much longer. Read benchmarks
+enabled to track how query latency evolves as the table grows. Run for at least 60 min.
+
+Key question: does `wait_state_all` (broad scan) degrade as row count climbs?
+
+### Scenario 4 — Write amplification (4× parallel tasks)
+**File:** `scenario-4-parallel-tasks.yaml`
+
+Same 300 PI/s but each PI runs **four parallel service tasks** (`four_parallel_tasks.bpmn`).
+4× more wait-state writes per PI (1 200 INSERTs/s + 1 200 DELETEs/s at 300 PI/s).
+Wait states enabled, read queries disabled (isolates write amplification).

--- a/load-tests/setup/wait-state-benchmark/scenario-1-baseline.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-1-baseline.yaml
@@ -7,7 +7,7 @@ global:
       value: "false"
     # Disable all wait-state read queries — table is empty, no signal.
     - name: ZEEBE_DISABLED_QUERIES
-      value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all"
+      value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all,wait_state_page2"
 
 orchestration:
   extraConfiguration:

--- a/load-tests/setup/wait-state-benchmark/scenario-1-baseline.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-1-baseline.yaml
@@ -1,0 +1,16 @@
+# Scenario 1 — Baseline: wait states disabled
+# Standard 300 PI/s single-task load, no wait-state writes at all.
+# Use as the control run to establish unaffected throughput numbers.
+global:
+  extraEnvVars:
+    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+      value: "false"
+    # Disable all wait-state read queries — table is empty, no signal.
+    - name: ZEEBE_DISABLED_QUERIES
+      value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all"
+
+orchestration:
+  extraConfiguration:
+    - file: application.yaml
+      content: |
+        camunda.data.wait-states.enabled: "false"

--- a/load-tests/setup/wait-state-benchmark/scenario-1-baseline.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-1-baseline.yaml
@@ -3,8 +3,6 @@
 # Use as the control run to establish unaffected throughput numbers.
 global:
   extraEnvVars:
-    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
-      value: "false"
     # Disable all wait-state read queries — table is empty, no signal.
     - name: ZEEBE_DISABLED_QUERIES
       value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all,wait_state_page2"

--- a/load-tests/setup/wait-state-benchmark/scenario-1b-enabled.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-1b-enabled.yaml
@@ -1,0 +1,15 @@
+# Scenario 1b — Wait states enabled, read queries off
+# Identical setup to Scenario 1 except wait-state tracking is on.
+# Isolates pure write overhead (INSERT + DELETE per PI) against the Scenario 1 baseline.
+global:
+  extraEnvVars:
+    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+      value: "false"
+    - name: ZEEBE_DISABLED_QUERIES
+      value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all"
+
+orchestration:
+  extraConfiguration:
+    - file: application.yaml
+      content: |
+        camunda.data.wait-states.enabled: "true"

--- a/load-tests/setup/wait-state-benchmark/scenario-1b-enabled.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-1b-enabled.yaml
@@ -1,10 +1,8 @@
 # Scenario 1b — Wait states enabled, read queries off
-# Identical setup to Scenario 1 except wait-state tracking is on.
+# Identical to Scenario 1 except wait-state tracking is on.
 # Isolates pure write overhead (INSERT + DELETE per PI) against the Scenario 1 baseline.
 global:
   extraEnvVars:
-    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
-      value: "false"
     - name: ZEEBE_DISABLED_QUERIES
       value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all,wait_state_page2"
 

--- a/load-tests/setup/wait-state-benchmark/scenario-1b-enabled.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-1b-enabled.yaml
@@ -6,7 +6,7 @@ global:
     - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
       value: "false"
     - name: ZEEBE_DISABLED_QUERIES
-      value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all"
+      value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all,wait_state_page2"
 
 orchestration:
   extraConfiguration:

--- a/load-tests/setup/wait-state-benchmark/scenario-2-query-latency.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-2-query-latency.yaml
@@ -1,0 +1,17 @@
+# Scenario 2 — Query latency under load
+# 300 PI/s, wait states enabled, read benchmarks on.
+# The three wait-state queries run every 30 s alongside the standard set.
+# Measures p50/p99 query latency and throughput interference.
+global:
+  extraEnvVars:
+    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+      value: "true"
+    # All three wait-state queries enabled; standard queries also run.
+    - name: ZEEBE_DISABLED_QUERIES
+      value: ""
+
+orchestration:
+  extraConfiguration:
+    - file: application.yaml
+      content: |
+        camunda.data.wait-states.enabled: "true"

--- a/load-tests/setup/wait-state-benchmark/scenario-2-query-latency.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-2-query-latency.yaml
@@ -3,10 +3,9 @@
 # The three wait-state queries run every 30 s alongside the standard set.
 # Measures p50/p99 query latency and throughput interference.
 global:
+  performReadBenchmarks: true
   extraEnvVars:
-    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
-      value: "true"
-    # All three wait-state queries enabled; standard queries also run.
+    # All wait-state queries enabled; standard queries also run.
     - name: ZEEBE_DISABLED_QUERIES
       value: ""
 

--- a/load-tests/setup/wait-state-benchmark/scenario-3-accumulation.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-3-accumulation.yaml
@@ -1,0 +1,19 @@
+# Scenario 3 — Accumulation under slow workers
+# 300 PI/s, wait states enabled, worker completion delay raised to 5 s.
+# Jobs sit active much longer, so the wait-state table grows large over a 60+ min run.
+# Read benchmarks on to track how query latency evolves as the row count climbs.
+# Key question: does wait_state_all (broad scan) degrade as the table grows?
+global:
+  extraEnvVars:
+    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+      value: "true"
+    - name: ZEEBE_DISABLED_QUERIES
+      value: ""
+    - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+      value: "5000ms"
+
+orchestration:
+  extraConfiguration:
+    - file: application.yaml
+      content: |
+        camunda.data.wait-states.enabled: "true"

--- a/load-tests/setup/wait-state-benchmark/scenario-3-accumulation.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-3-accumulation.yaml
@@ -4,13 +4,14 @@
 # Read benchmarks on to track how query latency evolves as the row count climbs.
 # Key question: does wait_state_all (broad scan) degrade as the table grows?
 global:
+  performReadBenchmarks: true
   extraEnvVars:
-    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
-      value: "true"
     - name: ZEEBE_DISABLED_QUERIES
       value: ""
-    - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
-      value: "5000ms"
+
+workers:
+  worker:
+    completionDelay: 5000ms
 
 orchestration:
   extraConfiguration:

--- a/load-tests/setup/wait-state-benchmark/scenario-3-pg-accumulation.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-3-pg-accumulation.yaml
@@ -1,0 +1,27 @@
+# Scenario 3-pg — PG accumulation + deep pagination
+# Same as Scenario 3 (300 PI/s, 5 s worker delay, wait states enabled) but targeting PostgreSQL.
+# The WAIT_STATE table accumulates rows over the run. wait_state_page2 records page 1 and page 2
+# latency cumulatively to detect keyset-pagination depth regression as the table grows.
+#
+# Key question: does page 2 latency diverge from page 1 under a large and growing table?
+# If it does, the subquery in WaitStateMapper.xml prevents the PG planner from pushing the
+# keyset filter through the subquery boundary and the mapper needs to be flattened.
+#
+# ES/OS runs the same wait_state_page2 query (search_after is O(1) per page) and should
+# stay flat — use any concurrent ES run as a control for the cumulative timer.
+#
+# Trigger via camunda-load-test.yml with secondary-storage-type: postgresql
+global:
+  extraEnvVars:
+    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+      value: "true"
+    - name: ZEEBE_DISABLED_QUERIES
+      value: ""
+    - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+      value: "5000ms"
+
+orchestration:
+  extraConfiguration:
+    - file: application.yaml
+      content: |
+        camunda.data.wait-states.enabled: "true"

--- a/load-tests/setup/wait-state-benchmark/scenario-3-pg-accumulation.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-3-pg-accumulation.yaml
@@ -12,13 +12,14 @@
 #
 # Trigger via camunda-load-test.yml with secondary-storage-type: postgresql
 global:
+  performReadBenchmarks: true
   extraEnvVars:
-    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
-      value: "true"
     - name: ZEEBE_DISABLED_QUERIES
       value: ""
-    - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
-      value: "5000ms"
+
+workers:
+  worker:
+    completionDelay: 5000ms
 
 orchestration:
   extraConfiguration:

--- a/load-tests/setup/wait-state-benchmark/scenario-4-parallel-tasks.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-4-parallel-tasks.yaml
@@ -1,13 +1,11 @@
 # Scenario 4 — Write amplification: 4 parallel service tasks
 # 300 PI/s, wait states enabled, four_parallel_tasks.bpmn.
-# 4× more wait-state writes per PI (1 200 INSERTs/s + 1 200 DELETEs/s at 300 PI/s).
+# 8× more wait-state writes per PI (1 200 INSERTs/s + 1 200 DELETEs/s at 300 PI/s).
 # Read queries disabled to isolate the write amplification impact on throughput.
 global:
   extraEnvVars:
-    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
-      value: "false"
     - name: ZEEBE_DISABLED_QUERIES
-      value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all"
+      value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all,wait_state_page2"
     - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
       value: "bpmn/four_parallel_tasks.bpmn"
 

--- a/load-tests/setup/wait-state-benchmark/scenario-4-parallel-tasks.yaml
+++ b/load-tests/setup/wait-state-benchmark/scenario-4-parallel-tasks.yaml
@@ -1,0 +1,18 @@
+# Scenario 4 — Write amplification: 4 parallel service tasks
+# 300 PI/s, wait states enabled, four_parallel_tasks.bpmn.
+# 4× more wait-state writes per PI (1 200 INSERTs/s + 1 200 DELETEs/s at 300 PI/s).
+# Read queries disabled to isolate the write amplification impact on throughput.
+global:
+  extraEnvVars:
+    - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+      value: "false"
+    - name: ZEEBE_DISABLED_QUERIES
+      value: "wait_state_by_process_instance_key,wait_state_by_element_type,wait_state_all"
+    - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+      value: "bpmn/four_parallel_tasks.bpmn"
+
+orchestration:
+  extraConfiguration:
+    - file: application.yaml
+      content: |
+        camunda.data.wait-states.enabled: "true"


### PR DESCRIPTION
## Summary

Adds the load-test infrastructure for the wait-state performance benchmarks described in [#52037](https://github.com/camunda/camunda/issues/52037).

### Changes

**`DataReadMeterQueryProvider`** — three new `ReadQuery` entries for wait-state search latency measurement:
- `wait_state_by_process_instance_key` — narrow lookup by PI key (mirrors what Operate issues to show wait states for one PI)
- `wait_state_by_element_type` — medium scan filtered to `SERVICE_TASK` (reasonable monitoring dashboard query)
- `wait_state_all` — broad unfiltered scan with a small page (tracks index health as the table grows)

**`four_parallel_tasks.bpmn`** — new BPMN process with 4 parallel service tasks (all `benchmark-task`) for write-amplification testing.

**`load-tests/setup/wait-state-benchmark/`** — per-scenario Helm override files:

| Scenario | File | Wait States | Reads | Notes |
|---|---|---|---|---|
| 1 — Baseline | `scenario-1-baseline.yaml` | disabled | off | Control run, no wait-state writes |
| 1b — Enabled, no reads | `scenario-1b-enabled.yaml` | enabled | off | Isolates write overhead vs baseline |
| 2 — Query latency | `scenario-2-query-latency.yaml` | enabled | on | All 3 wait-state queries active, measures p50/p99 |
| 3 — Accumulation | `scenario-3-accumulation.yaml` | enabled | on | Worker delay = 5 s; table grows, latency tracked |
| 4 — Parallel tasks | `scenario-4-parallel-tasks.yaml` | enabled | off | 4× writes/PI via `four_parallel_tasks.bpmn` |
| 1-pg — PG baseline | `scenario-1-pg-baseline.yaml` | disabled | off | Scenario 1 on PostgreSQL |
| 2-pg — PG query latency | `scenario-2-pg-query-latency.yaml` | enabled | on | Scenario 2 on PostgreSQL |

All scenarios run at 300 PI/s. Scenarios 1 and 1b establish the Elasticsearch and PostgreSQL baselines before enabling the feature.

## Related

Closes #52037

Active benchmark runs (3-day TTL, started 2026-06-09): see issue comment for links.