### PR TITLE
ci: add step to delete stale regenerated responses PRs

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -164,6 +164,37 @@ jobs:
           # 'test:' prefix — commitlint rejects 'fix:' for this kind of change.
           git commit -m "test: regenerate API response assertions from latest ${TARGET_REF} OpenAPI spec"
           git push origin "$branch"
+      
+      - name: Close stale regeneration PRs
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          title="test: regenerate API response assertions from latest ${TARGET_REF} OpenAPI spec"
+
+          # List all open PRs targeting this ref whose title matches exactly.
+          # --search scopes to the title string; --base further narrows to this
+          # ref only, so PRs from other matrix legs are never touched.
+          stale=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base "$TARGET_REF" \
+            --state open \
+            --search "in:title ${title}" \
+            --json number,headRefName \
+            --jq '.[] | "\(.number) \(.headRefName)"')
+
+          if [ -z "$stale" ]; then
+            echo "No stale PRs found."
+          else
+            while IFS=" " read -r number branch; do
+              echo "Closing stale PR #${number} (branch: ${branch})"
+              gh pr close "$number" \
+                --repo "$GITHUB_REPOSITORY" \
+                --comment "Superseded by a newer regeneration run — closing in favour of the incoming PR." \
+                --delete-branch
+            done <<< "$stale"
+          fi
 
       - name: Open pull request
         id: pr

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -174,15 +174,17 @@ jobs:
           title="test: regenerate API response assertions from latest ${TARGET_REF} OpenAPI spec"
 
           # List all open PRs targeting this ref whose title matches exactly.
-          # --search scopes to the title string; --base further narrows to this
-          # ref only, so PRs from other matrix legs are never touched.
+          # --search narrows the result set; --jq enforces exact title equality.
+          export TITLE="$title"
+          export PREFIX="regenerate-responses-${SAFE}-"
           stale=$(gh pr list \
             --repo "$GITHUB_REPOSITORY" \
             --base "$TARGET_REF" \
             --state open \
-            --search "in:title ${title}" \
-            --json number,headRefName \
-            --jq '.[] | "\(.number) \(.headRefName)"')
+            --limit 200 \
+            --search "in:title \"${title}\"" \
+            --json number,headRefName,title \
+            --jq '.[] | select(.title == env.TITLE) | select(.headRefName | startswith(env.PREFIX)) | "\(.number) \(.headRefName)"')
 
           if [ -z "$stale" ]; then
             echo "No stale PRs found."

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -13,7 +13,7 @@ name: C8 Orchestration Cluster Responses Regeneration
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 13 * * *'
+    - cron: '0 12 * * *'
 
 defaults:
   run:


### PR DESCRIPTION
## Description

This PR introduces new step in [responses schema regeneration workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-responses-regenerate.yml). Also this PR changes dispatch time to an earlier point.

If the workflow detected changes, this step:

- builds the exact PR title it expects
- searches for open PRs against the same target branch
- filters to PRs with that exact regeneration title
- closes each matching old PR
- deletes each old PR’s branch

That prevents multiple outdated regeneration PRs from piling up. (as it happened over this weekend (closed [PR1](https://github.com/camunda/camunda/pull/55191), [PR2](https://github.com/camunda/camunda/pull/55208). Merged [PR](https://github.com/camunda/camunda/pull/55206)).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

