### PR TITLE
ci: extend canonical TEST_OWNER coverage to non-push/schedule workflows

### DIFF
--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -39,6 +39,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -21,6 +21,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
   # renovate: datasource=node-version depName=node
   NODE_VERSION: '24.16.0'
 

--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -20,6 +20,9 @@ concurrency:
 permissions:
   contents: read # for git clone
 
+env:
+  TEST_OWNER: '@camunda/identity'
+
 jobs:
   read-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -77,6 +77,9 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   scan:
     name: Snyk Scan


### PR DESCRIPTION
## Description

Follow-up to [#55040](https://github.com/camunda/camunda/pull/55040). Post-merge BigQuery analysis of `ci-30-162810.prod_ci_analytics.build_status_v2` showed that on `refs/heads/main`, `user_description` is now ~100% canonical `@camunda/...` handles, with the remaining handful of NULL rows all attributable to a few non-push/schedule workflows that have `observe-build-status` calls but no workflow-level `env: TEST_OWNER:`.

This PR closes that gap by adding the env var to each, sourced from `.codeowners` (verified with `codeowners-cli owner <path>`).

### Files

| Workflow | Handle |
|---|---|
| `zeebe-snyk.yml` (the `scan` job, called transitively from `ci-zeebe.yml`) | `@camunda/core-features` |
| `identity-e2e-tests.yml` | `@camunda/identity` |
| `docs-preview.yml` | `@camunda/monorepo-devops-team` |
| `camunda-pr-load-test.yaml` | `@camunda/reliability-testing` |

### Excluded

- `tasklist-e2e-tests.yml` is a legacy workflow (`name: "[Legacy] Tasklist / E2E Tests"`) — out of scope.
- `ci-operate.yml`'s `integration-tests` NULL rows turned out to come from stable branches (workflow file differs there), not main — covered by the stable backport PRs.
- `check-licenses.yml` already had `TEST_OWNER: '@camunda/monorepo-devops-team'` at workflow level — no change needed.

### Verification

Hourly trend on `refs/heads/main`, push/schedule triggers only, since #55040 merged:

| Hour (UTC) | Canonical | NULL | % canonical |
|---|---|---|---|
| 09:00 | 46 | 18 | 71.9% |
| 10:00 | 1752 | 393 | 81.7% |
| … | … | … | … |
| 15:00 | 92 | 0 | **100%** |

The 12 NULLs on main during the window all came from the `scan` job in `zeebe-snyk.yml`, which this PR fixes.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Contributes to #52873. Follow-up to #55040.