### PR TITLE
feat: add tool calls and document references to conversation history

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -29,7 +29,11 @@ function createWrapper() {
   return ({children}: {children: ReactNode}) => {
     const router = createMemoryRouter(
       [{path: Paths.processInstance(undefined, true), element: children}],
-      {initialEntries: [Paths.processInstanceDetails({isRelative: true})]},
+      {
+        initialEntries: [
+          Paths.processInstanceDetails({processInstanceId: AGENT_INSTANCE_KEY}),
+        ],
+      },
     );
     return (
       <QueryClientProvider client={queryClient}>
@@ -130,7 +134,122 @@ describe('<ConversationHistory />', () => {
     expect(screen.getByText('Tool output here')).toBeInTheDocument();
   });
 
-  it('should render enabled tool call buttons when the tool link to an element', async () => {
+  it('should render conversation items with formatted object content', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '1',
+          role: 'TOOL_RESULT',
+          content: [
+            {
+              contentType: 'OBJECT',
+              object: {message: 'Tool output here', hello: 'world'},
+            },
+          ],
+        }),
+      ]),
+    );
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    const toolResultMessage = within(
+      screen.getByTestId('conversation-message-1'),
+    );
+    expect(
+      toolResultMessage.getByRole('heading', {name: 'Tool Result'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '{\n  "message": "Tool output here",\n  "hello": "world"\n}',
+        {
+          normalizer: (text) => text,
+        },
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render document references', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '1',
+          role: 'USER',
+          content: [
+            {contentType: 'TEXT', text: 'Here are the documents.'},
+            {
+              contentType: 'DOCUMENT',
+              documentReference: {
+                'camunda.document.type': 'camunda',
+                contentHash: 'abc123',
+                documentId: 'doc-1',
+                storeId: 'default',
+                metadata: {
+                  contentType: 'text/plain',
+                  fileName: 'report.txt',
+                  size: 1234,
+                  expiresAt: null,
+                  processDefinitionId: null,
+                  processInstanceKey: null,
+                  customProperties: {},
+                },
+              },
+            },
+            {
+              contentType: 'DOCUMENT',
+              documentReference: {
+                'camunda.document.type': 'camunda',
+                contentHash: 'def456',
+                documentId: 'doc-2',
+                storeId: 'default',
+                metadata: {
+                  contentType: 'image/png',
+                  fileName: 'screenshot.png',
+                  size: 5678,
+                  expiresAt: null,
+                  processDefinitionId: null,
+                  processInstanceKey: null,
+                  customProperties: {},
+                },
+              },
+            },
+          ],
+        }),
+      ]),
+    );
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    const message = within(screen.getByTestId('conversation-message-1'));
+    expect(message.getByText('Here are the documents.')).toBeInTheDocument();
+    expect(
+      message.getByRole('button', {name: 'report.txt'}),
+    ).toBeInTheDocument();
+    expect(
+      message.getByRole('button', {name: 'screenshot.png'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should render tool calls and enable them when a tool links to an element', async () => {
     mockSearchAgentInstanceHistory().withSuccess(
       searchResult([
         mockAgentInstanceHistoryItem({
@@ -174,49 +293,5 @@ describe('<ConversationHistory />', () => {
     expect(
       assistantMessage.getByRole('button', {name: 'search'}),
     ).toBeDisabled();
-  });
-
-  it('should render conversation items with formatted object content', async () => {
-    mockSearchAgentInstanceHistory().withSuccess(
-      searchResult([
-        mockAgentInstanceHistoryItem({
-          historyItemKey: '1',
-          role: 'TOOL_RESULT',
-          content: [
-            {
-              contentType: 'OBJECT',
-              object: {message: 'Tool output here', hello: 'world'},
-            },
-          ],
-        }),
-      ]),
-    );
-
-    render(
-      <ConversationHistory
-        agentInstanceKey={AGENT_INSTANCE_KEY}
-        enablePeriodicRefetch={false}
-      />,
-      {wrapper: createWrapper()},
-    );
-
-    await waitForElementToBeRemoved(
-      screen.queryByTestId('conversation-history-skeleton'),
-    );
-
-    const toolResultMessage = within(
-      screen.getByTestId('conversation-message-1'),
-    );
-    expect(
-      toolResultMessage.getByRole('heading', {name: 'Tool Result'}),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        '{\n  "message": "Tool output here",\n  "hello": "world"\n}',
-        {
-          normalizer: (text) => text,
-        },
-      ),
-    ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -289,9 +289,13 @@ describe('<ConversationHistory />', () => {
     const assistantMessage = within(
       screen.getByTestId('conversation-message-1'),
     );
-    expect(assistantMessage.getByRole('button', {name: 'greet'})).toBeEnabled();
     expect(
-      assistantMessage.getByRole('button', {name: 'search'}),
+      assistantMessage.getByRole('button', {
+        name: '"greet" tool call. Click to open details.',
+      }),
+    ).toBeEnabled();
+    expect(
+      assistantMessage.getByRole('button', {name: '"search" tool call.'}),
     ).toBeDisabled();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -12,7 +12,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from 'modules/testing-library';
-import {createMemoryRouter, RouterProvider} from 'react-router-dom';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import type {ReactNode} from 'react';
@@ -27,17 +27,13 @@ const AGENT_INSTANCE_KEY = '2251799813851828';
 function createWrapper() {
   const queryClient = getMockQueryClient();
   return ({children}: {children: ReactNode}) => {
-    const router = createMemoryRouter(
-      [{path: Paths.processInstance(undefined, true), element: children}],
-      {
-        initialEntries: [
-          Paths.processInstanceDetails({processInstanceId: AGENT_INSTANCE_KEY}),
-        ],
-      },
-    );
     return (
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+          </Routes>
+        </MemoryRouter>
       </QueryClientProvider>
     );
   };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -12,6 +12,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from 'modules/testing-library';
+import {createMemoryRouter, RouterProvider} from 'react-router-dom';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import type {ReactNode} from 'react';
@@ -19,14 +20,23 @@ import {mockSearchAgentInstanceHistory} from 'modules/mocks/api/v2/agentInstance
 import {ConversationHistory} from './index';
 import {searchResult} from 'modules/testUtils';
 import {mockAgentInstanceHistoryItem} from 'modules/mocks/mockAgentInstanceHistoryItem';
+import {Paths} from 'modules/Routes';
 
 const AGENT_INSTANCE_KEY = '2251799813851828';
 
 function createWrapper() {
   const queryClient = getMockQueryClient();
-  return ({children}: {children: ReactNode}) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
+  return ({children}: {children: ReactNode}) => {
+    const router = createMemoryRouter(
+      [{path: Paths.processInstance(undefined, true), element: children}],
+      {initialEntries: [Paths.processInstanceDetails({isRelative: true})]},
+    );
+    return (
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    );
+  };
 }
 
 describe('<ConversationHistory />', () => {
@@ -118,6 +128,52 @@ describe('<ConversationHistory />', () => {
       toolResultMessage.getByRole('heading', {name: 'Tool Result'}),
     ).toBeInTheDocument();
     expect(screen.getByText('Tool output here')).toBeInTheDocument();
+  });
+
+  it('should render enabled tool call buttons when the tool link to an element', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '1',
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'Calling tools now.'}],
+          toolCalls: [
+            {
+              toolCallId: 'tc-1',
+              toolName: 'greet',
+              elementId: 'greet-element',
+              arguments: {},
+            },
+            {
+              toolCallId: 'tc-2',
+              toolName: 'search',
+              elementId: null,
+              arguments: {},
+            },
+          ],
+        }),
+      ]),
+    );
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    const assistantMessage = within(
+      screen.getByTestId('conversation-message-1'),
+    );
+    expect(assistantMessage.getByRole('button', {name: 'greet'})).toBeEnabled();
+    expect(
+      assistantMessage.getByRole('button', {name: 'search'}),
+    ).toBeDisabled();
   });
 
   it('should render conversation items with formatted object content', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -8,6 +8,7 @@
 
 import {SkeletonText} from '@carbon/react';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
 import {ConversationContainer, ErrorHint} from './styled';
 
@@ -20,6 +21,7 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   agentInstanceKey,
   enablePeriodicRefetch,
 }) => {
+  const {selectElement} = useProcessInstanceElementSelection();
   const {data, status} = useAgentInstanceHistory(agentInstanceKey, {
     enablePeriodicRefetch,
   });
@@ -48,6 +50,12 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
           historyItemKey={item.historyItemKey}
           actor={item.role}
           content={item.content}
+          toolCalls={item.toolCalls}
+          onToolCallClick={(toolCall) => {
+            if (toolCall.elementId) {
+              selectElement({elementId: toolCall.elementId});
+            }
+          }}
         />
       ))}
     </ConversationContainer>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -52,7 +52,7 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
           content={item.content}
           toolCalls={item.toolCalls}
           onToolCallClick={(toolCall) => {
-            if (toolCall.elementId) {
+            if (toolCall.elementId !== null) {
               selectElement({elementId: toolCall.elementId});
             }
           }}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -21,14 +21,18 @@ import {
   TextContent,
   MessageActions,
   ObjectContent,
+  AttachmentsContainer,
+  AttachmentsLabel,
+  AttachmentButton,
 } from './styled';
 import {MarkdownMessage} from './MarkdownMessage';
 import {RichTextEditorModal} from 'modules/components/RichTextEditorModal';
 
 type Actor = AgentInstanceHistoryRole | 'SYSTEM';
 type ContentItem = AgentInstanceHistoryItem['content'][number];
+type ToolCall = AgentInstanceHistoryItem['toolCalls'][number];
 
-const editorModalTitleByActor: Record<Actor, string> = {
+const readableTitleByActor: Record<Actor, string> = {
   SYSTEM: 'System prompt',
   USER: 'User message',
   ASSISTANT: 'Assistant message',
@@ -46,12 +50,16 @@ type ConversationMessageProps = {
   actor: Actor;
   content: ContentItem[];
   historyItemKey?: string;
+  toolCalls?: ToolCall[];
+  onToolCallClick?: (toolCall: ToolCall) => void;
 };
 
 const ConversationMessage: React.FC<ConversationMessageProps> = ({
   actor,
   content,
   historyItemKey,
+  toolCalls = [],
+  onToolCallClick,
 }) => {
   const [messageDetails, dispatch] = useReducer(
     messageDetailsReducer,
@@ -62,6 +70,7 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
     <Container
       $actor={actor}
       data-testid={`conversation-message${historyItemKey ? `-${historyItemKey}` : ''}`}
+      aria-label={readableTitleByActor[actor]}
     >
       <ActorLabel>{labelByActor[actor]}</ActorLabel>
       {content.map((entry, index) => {
@@ -100,6 +109,20 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
           }
         }
       })}
+      {toolCalls.length > 0 && (
+        <AttachmentsContainer>
+          <AttachmentsLabel>Tool calls</AttachmentsLabel>
+          {toolCalls.map((tc) => (
+            <AttachmentButton
+              key={tc.toolCallId}
+              disabled={tc.elementId === null}
+              onClick={() => onToolCallClick?.(tc)}
+            >
+              {tc.toolName}
+            </AttachmentButton>
+          ))}
+        </AttachmentsContainer>
+      )}
       <RichTextEditorModal
         title={messageDetails.title}
         readOnly
@@ -169,14 +192,14 @@ function messageDetailsReducer(
         state: 'visible',
         language: 'markdown',
         content: action.text,
-        title: editorModalTitleByActor[action.actor],
+        title: readableTitleByActor[action.actor],
       };
     case 'show-object':
       return {
         state: 'visible',
         language: 'json',
         content: action.value,
-        title: editorModalTitleByActor[action.actor],
+        title: readableTitleByActor[action.actor],
       };
     case 'hide':
       return initialMessageDetailsState;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -127,15 +127,22 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
       {toolCalls.length > 0 && (
         <AttachmentsContainer>
           <AttachmentsLabel>Tool calls</AttachmentsLabel>
-          {toolCalls.map((tc) => (
-            <AttachmentButton
-              key={tc.toolCallId}
-              disabled={tc.elementId === null}
-              onClick={() => onToolCallClick?.(tc)}
-            >
-              {tc.toolName}
-            </AttachmentButton>
-          ))}
+          {toolCalls.map((tc) => {
+            const isDisabled = tc.elementId === null;
+            const label = isDisabled
+              ? `"${tc.toolName}" tool call.`
+              : `"${tc.toolName}" tool call. Click to open details.`;
+            return (
+              <AttachmentButton
+                key={tc.toolCallId}
+                aria-label={label}
+                disabled={isDisabled}
+                onClick={() => onToolCallClick?.(tc)}
+              >
+                {tc.toolName}
+              </AttachmentButton>
+            );
+          })}
         </AttachmentsContainer>
       )}
       <RichTextEditorModal

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -8,7 +8,7 @@
 
 import {useReducer} from 'react';
 import {Button} from '@carbon/react';
-import {Maximize} from '@carbon/react/icons';
+import {Document, Maximize} from '@carbon/react/icons';
 import type {
   AgentInstanceHistoryItem,
   AgentInstanceHistoryRole,
@@ -66,6 +66,10 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
     initialMessageDetailsState,
   );
 
+  const documentEntries = content.filter(
+    (entry) => entry.contentType === 'DOCUMENT',
+  );
+
   return (
     <Container
       $actor={actor}
@@ -109,6 +113,17 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
           }
         }
       })}
+      {documentEntries.length > 0 && (
+        <AttachmentsContainer>
+          <AttachmentsLabel>Documents</AttachmentsLabel>
+          {documentEntries.map(({documentReference}) => (
+            <AttachmentButton key={documentReference.documentId} disabled>
+              <Document size={12} />
+              {documentReference.metadata.fileName}
+            </AttachmentButton>
+          ))}
+        </AttachmentsContainer>
+      )}
       {toolCalls.length > 0 && (
         <AttachmentsContainer>
           <AttachmentsLabel>Tool calls</AttachmentsLabel>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
@@ -18,7 +18,7 @@ const accentColorByActor: Record<ActorType, string> = {
   TOOL_RESULT: 'var(--cds-status-gray)',
 };
 
-const Container = styled.div<{$actor: ActorType}>`
+const Container = styled.article<{$actor: ActorType}>`
   display: flex;
   flex-direction: column;
   gap: var(--cds-spacing-02);
@@ -30,7 +30,7 @@ const Container = styled.div<{$actor: ActorType}>`
 
 const ActorLabel = styled.h5`
   font-size: var(--cds-label-01-font-size);
-  font-weight: var(--cds-label-01-font-weight);
+  font-weight: var(--cds-heading-compact-01-font-weight);
   line-height: var(--cds-label-01-line-height);
   letter-spacing: var(--cds-label-01-letter-spacing);
   color: var(--cds-text-secondary);
@@ -81,6 +81,45 @@ const ObjectContent = styled.pre`
   word-break: break-word;
 `;
 
+const AttachmentsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-block-start: var(--cds-spacing-04);
+  gap: var(--cds-spacing-02);
+`;
+
+const AttachmentsLabel = styled.h6`
+  font-size: var(--cds-label-01-font-size);
+  font-weight: var(--cds-label-01-font-weight);
+  line-height: var(--cds-label-01-line-height);
+  letter-spacing: var(--cds-label-01-letter-spacing);
+  color: var(--cds-text-secondary);
+`;
+
+const AttachmentButton = styled.button`
+  appearance: none;
+  background-color: transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cds-spacing-02);
+  padding: var(--cds-spacing-01) var(--cds-spacing-03);
+  border-radius: 100px; // pill shape
+  font-size: var(--cds-label-01-font-size);
+  font-weight: var(--cds-label-01-font-weight);
+  line-height: var(--cds-label-01-line-height);
+  letter-spacing: var(--cds-label-01-letter-spacing);
+  color: var(--cds-link-primary);
+  border: 1px solid var(--cds-border-subtle-01);
+  whitespace: nowrap;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    color: var(--cds-text-primary);
+  }
+`;
+
 export {
   Container,
   MessageBlock,
@@ -88,4 +127,7 @@ export {
   TextContent,
   ObjectContent,
   MessageActions,
+  AttachmentsContainer,
+  AttachmentsLabel,
+  AttachmentButton,
 };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
@@ -114,6 +114,10 @@ const AttachmentButton = styled.button`
   whitespace: nowrap;
   cursor: pointer;
 
+  & > svg {
+    color: var(--cds-icon-secondary);
+  }
+
   &:disabled {
     cursor: not-allowed;
     color: var(--cds-text-primary);

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
@@ -111,7 +111,7 @@ const AttachmentButton = styled.button`
   letter-spacing: var(--cds-label-01-letter-spacing);
   color: var(--cds-link-primary);
   border: 1px solid var(--cds-border-subtle-01);
-  whitespace: nowrap;
+  white-space: nowrap;
   cursor: pointer;
 
   & > svg {


### PR DESCRIPTION
## Description

This PR renders tool calls and document references in the `ConversationMessage` component. They are added as an `Attachment` concept, i.e. `AttachmentLabel` and `AttachmentButton`, to have reusable components between them.

Right now, documents are not interactive and will be extended with functionality in a follow-up PR. 

Tool calls link to their `elementId` if one exists (disabled otherwise).

<img width="914" height="375" alt="Screenshot 2026-06-15 at 16 52 40" src="https://github.com/user-attachments/assets/d2e7498f-1ac9-4443-948a-c9a96c0d546f" />

## Related issues

relates #51928
