### PR TITLE
feat: delta badge

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -193,7 +193,11 @@ public class AgenticControlDashboardService {
         KPI_EXECUTION_COMPLETED_NAME,
         KPI_EXECUTION_COMPLETED_DESCRIPTION,
         null);
-    return buildTile(KPI_COMPLETED_REPORT_ID, new PositionDto(0, 0), new DimensionDto(6, 2));
+    return buildTile(
+        KPI_COMPLETED_REPORT_ID,
+        new PositionDto(0, 0),
+        new DimensionDto(6, 2),
+        Map.of("comparisonPeriod", true, "deltaGoodDirection", "up"));
   }
 
   private DashboardReportTileDto buildAvgDurationReport() {
@@ -220,7 +224,11 @@ public class AgenticControlDashboardService {
         KPI_EXECUTION_AVG_DURATION_NAME,
         KPI_EXECUTION_AVG_DURATION_DESCRIPTION,
         null);
-    return buildTile(KPI_AVG_DURATION_REPORT_ID, new PositionDto(6, 0), new DimensionDto(6, 2));
+    return buildTile(
+        KPI_AVG_DURATION_REPORT_ID,
+        new PositionDto(6, 0),
+        new DimensionDto(6, 2),
+        Map.of("comparisonPeriod", true, "deltaGoodDirection", "down"));
   }
 
   private DashboardReportTileDto buildIncidentRateReport() {
@@ -249,7 +257,11 @@ public class AgenticControlDashboardService {
         KPI_EXECUTION_INCIDENT_RATE_NAME,
         KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION,
         null);
-    return buildTile(KPI_INCIDENT_RATE_REPORT_ID, new PositionDto(12, 0), new DimensionDto(6, 2));
+    return buildTile(
+        KPI_INCIDENT_RATE_REPORT_ID,
+        new PositionDto(12, 0),
+        new DimensionDto(6, 2),
+        Map.of("comparisonPeriod", true, "deltaGoodDirection", "down"));
   }
 
   private DashboardReportTileDto buildAvgTokensReport() {

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -14,6 +14,13 @@
       "last6Months": "Letzte 6 Monate",
       "last12Months": "Letzte 12 Monate"
     },
+    "comparison": {
+      "wow": "WoW",
+      "mom": "MoM",
+      "qoq": "QoQ",
+      "hoh": "HoH",
+      "yoy": "YoY"
+    },
     "processFilter": {
       "label": "Prozess",
       "placeholder": "Alle Prozesse"

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -31,7 +31,7 @@
     "appSwitcher": "App Switcher",
     "dashboards": "Dashboards",
     "collections": "Sammlungen",
-    "agenticControlPlane": "Agentische Steuerungsebene",
+    "agenticControlPlane": "Agentic Control Plane",
     "apps": {
       "zeebe": "Zeebe",
       "operate": "Operate",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -14,6 +14,13 @@
       "last6Months": "Last 6 months",
       "last12Months": "Last 12 months"
     },
+    "comparison": {
+      "wow": "WoW",
+      "mom": "MoM",
+      "qoq": "QoQ",
+      "hoh": "HoH",
+      "yoy": "YoY"
+    },
     "processFilter": {
       "label": "Process",
       "placeholder": "All processes"

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/KpiDeltaBadge.test.tsx
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/KpiDeltaBadge.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {shallow} from 'enzyme';
+
+import KpiDeltaBadge from './KpiDeltaBadge';
+
+describe('KpiDeltaBadge', () => {
+  it('should show grey badge when priorValue is null', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={100} priorValue={null} unit="" deltaGoodDirection="up" />
+    );
+    expect(wrapper.prop('type')).toBe('gray');
+    expect(wrapper.text()).toContain('— WoW');
+  });
+
+  it('should show grey badge when priorValue is undefined', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={100} priorValue={undefined} unit="" deltaGoodDirection="up" />
+    );
+    expect(wrapper.prop('type')).toBe('gray');
+    expect(wrapper.text()).toContain('— WoW');
+  });
+
+  it('should show green badge when positive delta and direction is up', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={230} priorValue={100} unit="" deltaGoodDirection="up" />
+    );
+    expect(wrapper.prop('type')).toBe('green');
+    expect(wrapper.text()).toContain('+130');
+  });
+
+  it('should show red badge when negative delta and direction is up', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={80} priorValue={100} unit="" deltaGoodDirection="up" />
+    );
+    expect(wrapper.prop('type')).toBe('red');
+    expect(wrapper.text()).toContain('-20');
+  });
+
+  it('should show green badge when negative delta and direction is down', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={3500} priorValue={4000} unit="ms" deltaGoodDirection="down" />
+    );
+    expect(wrapper.prop('type')).toBe('green');
+  });
+
+  it('should show red badge when positive delta and direction is down', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={4500} priorValue={4000} unit="ms" deltaGoodDirection="down" />
+    );
+    expect(wrapper.prop('type')).toBe('red');
+  });
+
+  it('should format duration in seconds when delta >= 1000ms', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={3500} priorValue={5000} unit="ms" deltaGoodDirection="down" />
+    );
+    expect(wrapper.text()).toContain('-1.5s');
+  });
+
+  it('should format duration in milliseconds when delta < 1000ms', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={400} priorValue={450} unit="ms" deltaGoodDirection="down" />
+    );
+    expect(wrapper.text()).toContain('-50ms');
+  });
+
+  it('should format percentage with one decimal when < 1%', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={0.15} priorValue={0.25} unit="%" deltaGoodDirection="down" />
+    );
+    expect(wrapper.text()).toContain('-0.1%');
+  });
+
+  it('should format percentage with no decimal when >= 1%', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={5} priorValue={3} unit="%" deltaGoodDirection="up" />
+    );
+    expect(wrapper.text()).toContain('+2%');
+  });
+
+  it('should show grey badge when delta is zero', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={100} priorValue={100} unit="" deltaGoodDirection="up" />
+    );
+    expect(wrapper.prop('type')).toBe('gray');
+    expect(wrapper.text()).toContain('+0');
+  });
+
+  it('should append WoW suffix', () => {
+    const wrapper = shallow(
+      <KpiDeltaBadge currentValue={130} priorValue={0} unit="" deltaGoodDirection="up" />
+    );
+    expect(wrapper.text()).toContain('WoW');
+  });
+});

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/KpiDeltaBadge.test.tsx
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/KpiDeltaBadge.test.tsx
@@ -13,7 +13,13 @@ import KpiDeltaBadge from './KpiDeltaBadge';
 describe('KpiDeltaBadge', () => {
   it('should show grey badge when priorValue is null', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={100} priorValue={null} unit="" deltaGoodDirection="up" />
+      <KpiDeltaBadge
+        currentValue={100}
+        priorValue={null}
+        unit=""
+        deltaGoodDirection="up"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.prop('type')).toBe('gray');
     expect(wrapper.text()).toContain('— WoW');
@@ -21,7 +27,13 @@ describe('KpiDeltaBadge', () => {
 
   it('should show grey badge when priorValue is undefined', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={100} priorValue={undefined} unit="" deltaGoodDirection="up" />
+      <KpiDeltaBadge
+        currentValue={100}
+        priorValue={undefined}
+        unit=""
+        deltaGoodDirection="up"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.prop('type')).toBe('gray');
     expect(wrapper.text()).toContain('— WoW');
@@ -29,7 +41,13 @@ describe('KpiDeltaBadge', () => {
 
   it('should show green badge when positive delta and direction is up', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={230} priorValue={100} unit="" deltaGoodDirection="up" />
+      <KpiDeltaBadge
+        currentValue={230}
+        priorValue={100}
+        unit=""
+        deltaGoodDirection="up"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.prop('type')).toBe('green');
     expect(wrapper.text()).toContain('+130');
@@ -37,7 +55,13 @@ describe('KpiDeltaBadge', () => {
 
   it('should show red badge when negative delta and direction is up', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={80} priorValue={100} unit="" deltaGoodDirection="up" />
+      <KpiDeltaBadge
+        currentValue={80}
+        priorValue={100}
+        unit=""
+        deltaGoodDirection="up"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.prop('type')).toBe('red');
     expect(wrapper.text()).toContain('-20');
@@ -45,49 +69,91 @@ describe('KpiDeltaBadge', () => {
 
   it('should show green badge when negative delta and direction is down', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={3500} priorValue={4000} unit="ms" deltaGoodDirection="down" />
+      <KpiDeltaBadge
+        currentValue={3500}
+        priorValue={4000}
+        unit="ms"
+        deltaGoodDirection="down"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.prop('type')).toBe('green');
   });
 
   it('should show red badge when positive delta and direction is down', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={4500} priorValue={4000} unit="ms" deltaGoodDirection="down" />
+      <KpiDeltaBadge
+        currentValue={4500}
+        priorValue={4000}
+        unit="ms"
+        deltaGoodDirection="down"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.prop('type')).toBe('red');
   });
 
   it('should format duration in seconds when delta >= 1000ms', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={3500} priorValue={5000} unit="ms" deltaGoodDirection="down" />
+      <KpiDeltaBadge
+        currentValue={3500}
+        priorValue={5000}
+        unit="ms"
+        deltaGoodDirection="down"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.text()).toContain('-1.5s');
   });
 
   it('should format duration in milliseconds when delta < 1000ms', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={400} priorValue={450} unit="ms" deltaGoodDirection="down" />
+      <KpiDeltaBadge
+        currentValue={400}
+        priorValue={450}
+        unit="ms"
+        deltaGoodDirection="down"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.text()).toContain('-50ms');
   });
 
   it('should format percentage with one decimal when < 1%', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={0.15} priorValue={0.25} unit="%" deltaGoodDirection="down" />
+      <KpiDeltaBadge
+        currentValue={0.15}
+        priorValue={0.25}
+        unit="%"
+        deltaGoodDirection="down"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.text()).toContain('-0.1%');
   });
 
   it('should format percentage with no decimal when >= 1%', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={5} priorValue={3} unit="%" deltaGoodDirection="up" />
+      <KpiDeltaBadge
+        currentValue={5}
+        priorValue={3}
+        unit="%"
+        deltaGoodDirection="up"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.text()).toContain('+2%');
   });
 
   it('should show grey badge when delta is zero', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={100} priorValue={100} unit="" deltaGoodDirection="up" />
+      <KpiDeltaBadge
+        currentValue={100}
+        priorValue={100}
+        unit=""
+        deltaGoodDirection="up"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.prop('type')).toBe('gray');
     expect(wrapper.text()).toContain('+0');
@@ -95,7 +161,13 @@ describe('KpiDeltaBadge', () => {
 
   it('should append WoW suffix', () => {
     const wrapper = shallow(
-      <KpiDeltaBadge currentValue={130} priorValue={0} unit="" deltaGoodDirection="up" />
+      <KpiDeltaBadge
+        currentValue={130}
+        priorValue={0}
+        unit=""
+        deltaGoodDirection="up"
+        periodLabel="WoW"
+      />
     );
     expect(wrapper.text()).toContain('WoW');
   });

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/KpiDeltaBadge.tsx
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/KpiDeltaBadge.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Tag} from '@carbon/react';
+
+interface KpiDeltaBadgeProps {
+  currentValue: number;
+  priorValue: number | null | undefined;
+  unit: 'ms' | '%' | '';
+  deltaGoodDirection: 'up' | 'down';
+}
+
+export default function KpiDeltaBadge({
+  currentValue,
+  priorValue,
+  unit,
+  deltaGoodDirection,
+}: KpiDeltaBadgeProps): JSX.Element | null {
+  if (priorValue == null) {
+    return null;
+  }
+
+  const delta = currentValue - priorValue;
+  const isPositive = delta >= 0;
+  const isGood =
+    (deltaGoodDirection === 'up' && isPositive) ||
+    (deltaGoodDirection === 'down' && !isPositive);
+
+  const sign = isPositive ? '+' : '-';
+  const absDelta = Math.abs(delta);
+
+  let formatted: string;
+  if (unit === 'ms') {
+    if (absDelta >= 1000) {
+      formatted = `${sign}${(absDelta / 1000).toFixed(1)}s`;
+    } else {
+      formatted = `${sign}${Math.round(absDelta)}ms`;
+    }
+  } else if (unit === '%') {
+    const decimals = absDelta < 1 ? 1 : 0;
+    formatted = `${sign}${absDelta.toFixed(decimals)}%`;
+  } else {
+    formatted = `${sign}${Math.round(absDelta)}`;
+  }
+
+  return (
+    <Tag size="sm" type={isGood ? 'green' : 'red'}>
+      {formatted} WoW
+    </Tag>
+  );
+}

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/KpiDeltaBadge.tsx
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/KpiDeltaBadge.tsx
@@ -8,56 +8,52 @@
 
 import {Tag} from '@carbon/react';
 
+import {
+  classifyDelta,
+  formatDelta,
+  type DeltaDirection,
+  type DeltaGoodDirection,
+  type ValueUnit,
+} from './comparison';
+
 interface KpiDeltaBadgeProps {
   currentValue: number;
   priorValue: number | null | undefined;
-  unit: 'ms' | '%' | '';
-  deltaGoodDirection: 'up' | 'down';
+  unit: ValueUnit;
+  deltaGoodDirection: DeltaGoodDirection;
+  periodLabel: string;
 }
 
+const TAG_TYPE: Record<DeltaDirection, 'green' | 'red' | 'gray'> = {
+  good: 'green',
+  bad: 'red',
+  neutral: 'gray',
+};
+
+/**
+ * Presents the period-over-period change for a KPI tile. Delta semantics and
+ * formatting live in `comparison`; this component only maps them to a Tag.
+ */
 export default function KpiDeltaBadge({
   currentValue,
   priorValue,
   unit,
   deltaGoodDirection,
-}: KpiDeltaBadgeProps): JSX.Element | null {
+  periodLabel,
+}: KpiDeltaBadgeProps): JSX.Element {
   if (priorValue == null) {
     return (
       <Tag size="sm" type="gray">
-        — WoW
+        — {periodLabel}
       </Tag>
     );
   }
 
-  const delta = currentValue - priorValue;
-  const isNeutral = delta === 0;
-  const isPositive = delta > 0;
-  const isGood =
-    !isNeutral &&
-    ((deltaGoodDirection === 'up' && isPositive) || (deltaGoodDirection === 'down' && !isPositive));
-
-  const sign = isPositive || isNeutral ? '+' : '-';
-  const absDelta = Math.abs(delta);
-
-  let formatted: string;
-  if (unit === 'ms') {
-    if (absDelta >= 1000) {
-      formatted = `${sign}${(absDelta / 1000).toFixed(1)}s`;
-    } else {
-      formatted = `${sign}${Math.round(absDelta)}ms`;
-    }
-  } else if (unit === '%') {
-    const decimals = absDelta < 1 ? 1 : 0;
-    formatted = `${sign}${absDelta.toFixed(decimals)}%`;
-  } else {
-    formatted = `${sign}${Math.round(absDelta)}`;
-  }
-
-  const tagType = isNeutral ? 'gray' : isGood ? 'green' : 'red';
+  const {delta, direction} = classifyDelta(currentValue, priorValue, deltaGoodDirection);
 
   return (
-    <Tag size="sm" type={tagType}>
-      {formatted} WoW
+    <Tag size="sm" type={TAG_TYPE[direction]}>
+      {formatDelta(delta, unit)} {periodLabel}
     </Tag>
   );
 }

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/KpiDeltaBadge.tsx
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/KpiDeltaBadge.tsx
@@ -22,16 +22,21 @@ export default function KpiDeltaBadge({
   deltaGoodDirection,
 }: KpiDeltaBadgeProps): JSX.Element | null {
   if (priorValue == null) {
-    return null;
+    return (
+      <Tag size="sm" type="gray">
+        — WoW
+      </Tag>
+    );
   }
 
   const delta = currentValue - priorValue;
-  const isPositive = delta >= 0;
+  const isNeutral = delta === 0;
+  const isPositive = delta > 0;
   const isGood =
-    (deltaGoodDirection === 'up' && isPositive) ||
-    (deltaGoodDirection === 'down' && !isPositive);
+    !isNeutral &&
+    ((deltaGoodDirection === 'up' && isPositive) || (deltaGoodDirection === 'down' && !isPositive));
 
-  const sign = isPositive ? '+' : '-';
+  const sign = isPositive || isNeutral ? '+' : '-';
   const absDelta = Math.abs(delta);
 
   let formatted: string;
@@ -48,8 +53,10 @@ export default function KpiDeltaBadge({
     formatted = `${sign}${Math.round(absDelta)}`;
   }
 
+  const tagType = isNeutral ? 'gray' : isGood ? 'green' : 'red';
+
   return (
-    <Tag size="sm" type={isGood ? 'green' : 'red'}>
+    <Tag size="sm" type={tagType}>
       {formatted} WoW
     </Tag>
   );

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.js
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.js
@@ -24,7 +24,61 @@ import {useErrorHandling} from 'hooks';
 import {track} from 'tracking';
 import {t} from 'translation';
 
+import KpiDeltaBadge from './KpiDeltaBadge';
+
 import './OptimizeReportTile.scss';
+
+const UNIT_TO_MS = {
+  seconds: 1000,
+  minutes: 60 * 1000,
+  hours: 60 * 60 * 1000,
+  days: 24 * 60 * 60 * 1000,
+  weeks: 7 * 24 * 60 * 60 * 1000,
+  months: 30.44 * 24 * 60 * 60 * 1000,
+  quarters: 91.31 * 24 * 60 * 60 * 1000,
+  years: 365.25 * 24 * 60 * 60 * 1000,
+};
+
+function buildPriorPeriodFilter(filter) {
+  if (!filter) {
+    return filter;
+  }
+  const rollingDateFilter = filter.find(
+    (f) => f.type === 'instanceEndDate' && f.data?.type === 'rolling'
+  );
+  if (!rollingDateFilter) {
+    return filter;
+  }
+  const {value, unit} = rollingDateFilter.data.start;
+  const periodMs = value * (UNIT_TO_MS[unit] ?? UNIT_TO_MS.days);
+  const now = Date.now();
+  const priorEnd = new Date(now - periodMs).toISOString();
+  const priorStart = new Date(now - 2 * periodMs).toISOString();
+  return [
+    ...filter.filter((f) => f.type !== 'instanceEndDate'),
+    {
+      type: 'instanceEndDate',
+      filterLevel: 'instance',
+      data: {
+        type: 'fixed',
+        start: priorStart,
+        end: priorEnd,
+        includeUndefined: false,
+        excludeUndefined: false,
+      },
+    },
+  ];
+}
+
+function propertyToUnit(property) {
+  if (property === 'duration') {
+    return 'ms';
+  }
+  if (property === 'percentage') {
+    return '%';
+  }
+  return '';
+}
 
 export default function OptimizeReportTile({
   tile,
@@ -38,10 +92,13 @@ export default function OptimizeReportTile({
   const [data, setData] = useState();
   const [error, setError] = useState(null);
   const [lastParams, setLastParams] = useState({});
+  const [priorData, setPriorData] = useState(null);
   const {mightFail} = useErrorHandling();
   const history = useHistory();
   const prevTile = useRef(tile);
   const prevFilter = useRef(filter);
+
+  const comparisonPeriod = tile.configuration?.comparisonPeriod;
 
   const loadTileData = useCallback(
     (params) => {
@@ -65,19 +122,43 @@ export default function OptimizeReportTile({
     [mightFail, loadTile, tile, filter]
   );
 
+  const loadPriorPeriodData = useCallback(() => {
+    const priorFilter = buildPriorPeriodFilter(filter);
+    if (!priorFilter) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      mightFail(
+        loadTile(tile.id ?? tile.report, priorFilter, {}),
+        (result) => {
+          setPriorData(result);
+          resolve();
+        },
+        () => {
+          setPriorData(null);
+          resolve();
+        }
+      );
+    });
+  }, [mightFail, loadTile, tile, filter]);
+
   const loadInitialTile = useCallback(async () => {
     setLoading(true);
-    await loadTileData({});
+    await Promise.all([
+      loadTileData({}),
+      comparisonPeriod ? loadPriorPeriodData() : Promise.resolve(),
+    ]);
     setLoading(false);
-  }, [loadTileData]);
+  }, [loadTileData, comparisonPeriod, loadPriorPeriodData]);
 
   useEffect(() => {
     if (!deepEqual(tile, prevTile.current) || !deepEqual(filter, prevFilter.current)) {
       prevTile.current = tile;
       prevFilter.current = filter;
+      setPriorData(null);
       loadInitialTile();
     }
-  }, [tile, filter, loadInitialTile]);
+  }, [tile, filter, loadInitialTile, comparisonPeriod, loadPriorPeriodData]);
 
   useEffect(() => {
     loadInitialTile();
@@ -93,8 +174,14 @@ export default function OptimizeReportTile({
 
   const refreshTile = () => loadTileData(lastParams);
   const tileLink = customizeTileLink(data?.id || tile?.id);
+
+  const isNumberViz = data?.data?.visualization === 'number';
+  const currentValue = data?.result?.measures?.[0]?.data;
+  const showDeltaBadge = isNumberViz && tile.configuration?.comparisonPeriod && currentValue != null;
   let tileProps = {
-    className: 'OptimizeReportTile DashboardTile',
+    className: classnames('OptimizeReportTile DashboardTile', {
+      hasComparisonPeriod: comparisonPeriod,
+    }),
   };
 
   if (!disableNameLink) {
@@ -148,7 +235,22 @@ export default function OptimizeReportTile({
         </div>
       )}
       <div className="visualization">
-        <ReportRenderer error={error} report={data} context="dashboard" loadReport={loadTileData} />
+        <ReportRenderer
+          error={error}
+          report={data}
+          context="dashboard"
+          loadReport={loadTileData}
+          badge={
+            showDeltaBadge ? (
+              <KpiDeltaBadge
+                currentValue={currentValue}
+                priorValue={priorData?.result?.measures?.[0]?.data ?? null}
+                unit={propertyToUnit(data.data.view?.properties?.[0])}
+                deltaGoodDirection={tile.configuration.deltaGoodDirection}
+              />
+            ) : null
+          }
+        />
       </div>
       {children?.({loadTileData: refreshTile})}
     </div>

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.js
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.js
@@ -25,60 +25,10 @@ import {track} from 'tracking';
 import {t} from 'translation';
 
 import KpiDeltaBadge from './KpiDeltaBadge';
+import useComparisonData from './useComparisonData';
+import {comparisonLabelKey, getRollingPeriod, propertyToValueUnit} from './comparison';
 
 import './OptimizeReportTile.scss';
-
-const UNIT_TO_MS = {
-  seconds: 1000,
-  minutes: 60 * 1000,
-  hours: 60 * 60 * 1000,
-  days: 24 * 60 * 60 * 1000,
-  weeks: 7 * 24 * 60 * 60 * 1000,
-  months: 30.44 * 24 * 60 * 60 * 1000,
-  quarters: 91.31 * 24 * 60 * 60 * 1000,
-  years: 365.25 * 24 * 60 * 60 * 1000,
-};
-
-function buildPriorPeriodFilter(filter) {
-  if (!filter) {
-    return filter;
-  }
-  const rollingDateFilter = filter.find(
-    (f) => f.type === 'instanceEndDate' && f.data?.type === 'rolling'
-  );
-  if (!rollingDateFilter) {
-    return filter;
-  }
-  const {value, unit} = rollingDateFilter.data.start;
-  const periodMs = value * (UNIT_TO_MS[unit] ?? UNIT_TO_MS.days);
-  const now = Date.now();
-  const priorEnd = new Date(now - periodMs).toISOString();
-  const priorStart = new Date(now - 2 * periodMs).toISOString();
-  return [
-    ...filter.filter((f) => f.type !== 'instanceEndDate'),
-    {
-      type: 'instanceEndDate',
-      filterLevel: 'instance',
-      data: {
-        type: 'fixed',
-        start: priorStart,
-        end: priorEnd,
-        includeUndefined: false,
-        excludeUndefined: false,
-      },
-    },
-  ];
-}
-
-function propertyToUnit(property) {
-  if (property === 'duration') {
-    return 'ms';
-  }
-  if (property === 'percentage') {
-    return '%';
-  }
-  return '';
-}
 
 export default function OptimizeReportTile({
   tile,
@@ -92,13 +42,18 @@ export default function OptimizeReportTile({
   const [data, setData] = useState();
   const [error, setError] = useState(null);
   const [lastParams, setLastParams] = useState({});
-  const [priorData, setPriorData] = useState(null);
   const {mightFail} = useErrorHandling();
   const history = useHistory();
   const prevTile = useRef(tile);
   const prevFilter = useRef(filter);
 
   const comparisonPeriod = tile.configuration?.comparisonPeriod;
+  const {priorData, loadPriorData, resetPriorData} = useComparisonData({
+    tile,
+    filter,
+    loadTile,
+    enabled: comparisonPeriod,
+  });
 
   const loadTileData = useCallback(
     (params) => {
@@ -122,43 +77,20 @@ export default function OptimizeReportTile({
     [mightFail, loadTile, tile, filter]
   );
 
-  const loadPriorPeriodData = useCallback(() => {
-    const priorFilter = buildPriorPeriodFilter(filter);
-    if (!priorFilter) {
-      return Promise.resolve();
-    }
-    return new Promise((resolve) => {
-      mightFail(
-        loadTile(tile.id ?? tile.report, priorFilter, {}),
-        (result) => {
-          setPriorData(result);
-          resolve();
-        },
-        () => {
-          setPriorData(null);
-          resolve();
-        }
-      );
-    });
-  }, [mightFail, loadTile, tile, filter]);
-
   const loadInitialTile = useCallback(async () => {
     setLoading(true);
-    await Promise.all([
-      loadTileData({}),
-      comparisonPeriod ? loadPriorPeriodData() : Promise.resolve(),
-    ]);
+    await Promise.all([loadTileData({}), loadPriorData()]);
     setLoading(false);
-  }, [loadTileData, comparisonPeriod, loadPriorPeriodData]);
+  }, [loadTileData, loadPriorData]);
 
   useEffect(() => {
     if (!deepEqual(tile, prevTile.current) || !deepEqual(filter, prevFilter.current)) {
       prevTile.current = tile;
       prevFilter.current = filter;
-      setPriorData(null);
+      resetPriorData();
       loadInitialTile();
     }
-  }, [tile, filter, loadInitialTile, comparisonPeriod, loadPriorPeriodData]);
+  }, [tile, filter, loadInitialTile, resetPriorData]);
 
   useEffect(() => {
     loadInitialTile();
@@ -177,8 +109,9 @@ export default function OptimizeReportTile({
 
   const isNumberViz = data?.data?.visualization === 'number';
   const currentValue = data?.result?.measures?.[0]?.data;
-  const showDeltaBadge =
-    isNumberViz && tile.configuration?.comparisonPeriod && currentValue != null;
+  const showDeltaBadge = isNumberViz && comparisonPeriod && currentValue != null;
+  const labelKey = showDeltaBadge && comparisonLabelKey(getRollingPeriod(filter));
+  const periodLabel = labelKey ? t(`agenticControlPlane.comparison.${labelKey}`).toString() : '';
   let tileProps = {
     className: classnames('OptimizeReportTile DashboardTile', {
       hasComparisonPeriod: comparisonPeriod,
@@ -241,13 +174,14 @@ export default function OptimizeReportTile({
           report={data}
           context="dashboard"
           loadReport={loadTileData}
-          badge={
+          overlay={
             showDeltaBadge ? (
               <KpiDeltaBadge
                 currentValue={currentValue}
                 priorValue={priorData?.result?.measures?.[0]?.data ?? null}
-                unit={propertyToUnit(data.data.view?.properties?.[0])}
-                deltaGoodDirection={tile.configuration.deltaGoodDirection}
+                unit={propertyToValueUnit(data.data.view?.properties?.[0])}
+                deltaGoodDirection={tile.configuration?.deltaGoodDirection}
+                periodLabel={periodLabel}
               />
             ) : null
           }

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.js
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.js
@@ -177,7 +177,8 @@ export default function OptimizeReportTile({
 
   const isNumberViz = data?.data?.visualization === 'number';
   const currentValue = data?.result?.measures?.[0]?.data;
-  const showDeltaBadge = isNumberViz && tile.configuration?.comparisonPeriod && currentValue != null;
+  const showDeltaBadge =
+    isNumberViz && tile.configuration?.comparisonPeriod && currentValue != null;
   let tileProps = {
     className: classnames('OptimizeReportTile DashboardTile', {
       hasComparisonPeriod: comparisonPeriod,

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.scss
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.scss
@@ -64,6 +64,19 @@
       min-width: 100%;
     }
   }
+
+  // Fixed font-size for KPI tiles with comparison period so the value doesn't
+  // shift when the delta badge renders alongside it.
+  &.hasComparisonPeriod .visualization .Number .container {
+    font-size: 48px;
+
+    .data {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-size: inherit;
+    }
+  }
 }
 
 .Sharing,

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.test.js
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.test.js
@@ -237,6 +237,16 @@ describe('KpiDeltaBadge visibility', () => {
     configuration: {comparisonPeriod: true, deltaGoodDirection: 'up'},
   };
 
+  // A rolling end-date filter is required for a baseline (prior) window to exist;
+  // without one the comparison has nothing to compare against and is skipped.
+  const rollingFilter = [
+    {
+      type: 'instanceEndDate',
+      filterLevel: 'instance',
+      data: {type: 'rolling', start: {value: 30, unit: 'days'}, end: null},
+    },
+  ];
+
   const makeReport = (visualization, measureData) => ({
     id: 'a',
     data: {visualization, view: {properties: ['frequency']}},
@@ -248,11 +258,13 @@ describe('KpiDeltaBadge visibility', () => {
       .mockReturnValueOnce(makeReport('number', 10))
       .mockReturnValueOnce(makeReport('number', 5));
 
-    const node = shallow(<OptimizeReportTile {...props} tile={numberTileWithComparison} />);
+    const node = shallow(
+      <OptimizeReportTile {...props} tile={numberTileWithComparison} filter={rollingFilter} />
+    );
     runAllEffects();
     await flushPromises();
 
-    const badge = node.find(ReportRenderer).prop('badge');
+    const badge = node.find(ReportRenderer).prop('overlay');
     expect(badge).not.toBeNull();
     expect(badge.props).toMatchObject({currentValue: 10, priorValue: 5});
   });
@@ -262,11 +274,13 @@ describe('KpiDeltaBadge visibility', () => {
       .mockReturnValueOnce(makeReport('number', 8))
       .mockReturnValueOnce(makeReport('number', null));
 
-    const node = shallow(<OptimizeReportTile {...props} tile={numberTileWithComparison} />);
+    const node = shallow(
+      <OptimizeReportTile {...props} tile={numberTileWithComparison} filter={rollingFilter} />
+    );
     runAllEffects();
     await flushPromises();
 
-    const badge = node.find(ReportRenderer).prop('badge');
+    const badge = node.find(ReportRenderer).prop('overlay');
     expect(badge).not.toBeNull();
     expect(badge.props).toMatchObject({currentValue: 8, priorValue: null});
   });
@@ -276,21 +290,25 @@ describe('KpiDeltaBadge visibility', () => {
       .mockReturnValueOnce(makeReport('number', null))
       .mockReturnValueOnce(makeReport('number', 5));
 
-    const node = shallow(<OptimizeReportTile {...props} tile={numberTileWithComparison} />);
+    const node = shallow(
+      <OptimizeReportTile {...props} tile={numberTileWithComparison} filter={rollingFilter} />
+    );
     runAllEffects();
     await flushPromises();
 
-    expect(node.find(ReportRenderer).prop('badge')).toBeNull();
+    expect(node.find(ReportRenderer).prop('overlay')).toBeNull();
   });
 
   it('should not pass badge for non-number visualizations', async () => {
     loadTile.mockReturnValueOnce(makeReport('bar', 10)).mockReturnValueOnce(makeReport('bar', 5));
 
-    const node = shallow(<OptimizeReportTile {...props} tile={numberTileWithComparison} />);
+    const node = shallow(
+      <OptimizeReportTile {...props} tile={numberTileWithComparison} filter={rollingFilter} />
+    );
     runAllEffects();
     await flushPromises();
 
-    expect(node.find(ReportRenderer).prop('badge')).toBeNull();
+    expect(node.find(ReportRenderer).prop('overlay')).toBeNull();
   });
 
   it('should not pass badge when comparisonPeriod is not enabled', async () => {
@@ -302,7 +320,7 @@ describe('KpiDeltaBadge visibility', () => {
     runAllEffects();
     await flushPromises();
 
-    expect(node.find(ReportRenderer).prop('badge')).toBeNull();
+    expect(node.find(ReportRenderer).prop('overlay')).toBeNull();
   });
 
   it('should call loadTile with new filter and prior period filter after filter change', async () => {
@@ -311,7 +329,9 @@ describe('KpiDeltaBadge visibility', () => {
     // call args rather than rendered badge props.
     loadTile.mockReturnValue(makeReport('number', 10));
 
-    const node = shallow(<OptimizeReportTile {...props} tile={numberTileWithComparison} />);
+    const node = shallow(
+      <OptimizeReportTile {...props} tile={numberTileWithComparison} filter={rollingFilter} />
+    );
     runAllEffects();
     await flushPromises();
 

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.test.js
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.test.js
@@ -13,6 +13,8 @@ import {useHistory} from 'react-router-dom';
 import {ReportRenderer} from 'components';
 import {useErrorHandling} from 'hooks';
 
+jest.mock('./KpiDeltaBadge', () => () => null);
+
 import OptimizeReportTile from './OptimizeReportTile';
 
 jest.mock('react-router-dom', () => ({
@@ -226,6 +228,105 @@ it('should not navigate to the report when clicking on an href element', async (
   node.find('.OptimizeReportTile').simulate('click', {target: document.createElement('a')});
 
   expect(redirectSpy).not.toHaveBeenCalledWith('report/a/');
+});
+
+describe('KpiDeltaBadge visibility', () => {
+  const numberTileWithComparison = {
+    type: 'optimize_report',
+    id: 'a',
+    configuration: {comparisonPeriod: true, deltaGoodDirection: 'up'},
+  };
+
+  const makeReport = (visualization, measureData) => ({
+    id: 'a',
+    data: {visualization, view: {properties: ['frequency']}},
+    result: {measures: [{data: measureData, property: 'frequency'}]},
+  });
+
+  it('should pass badge to ReportRenderer when number tile has a value and prior data', async () => {
+    loadTile
+      .mockReturnValueOnce(makeReport('number', 10))
+      .mockReturnValueOnce(makeReport('number', 5));
+
+    const node = shallow(<OptimizeReportTile {...props} tile={numberTileWithComparison} />);
+    runAllEffects();
+    await flushPromises();
+
+    const badge = node.find(ReportRenderer).prop('badge');
+    expect(badge).not.toBeNull();
+    expect(badge.props).toMatchObject({currentValue: 10, priorValue: 5});
+  });
+
+  it('should pass badge with null priorValue when prior period has no data', async () => {
+    loadTile
+      .mockReturnValueOnce(makeReport('number', 8))
+      .mockReturnValueOnce(makeReport('number', null));
+
+    const node = shallow(<OptimizeReportTile {...props} tile={numberTileWithComparison} />);
+    runAllEffects();
+    await flushPromises();
+
+    const badge = node.find(ReportRenderer).prop('badge');
+    expect(badge).not.toBeNull();
+    expect(badge.props).toMatchObject({currentValue: 8, priorValue: null});
+  });
+
+  it('should not pass badge when current value is null (-- state)', async () => {
+    loadTile
+      .mockReturnValueOnce(makeReport('number', null))
+      .mockReturnValueOnce(makeReport('number', 5));
+
+    const node = shallow(<OptimizeReportTile {...props} tile={numberTileWithComparison} />);
+    runAllEffects();
+    await flushPromises();
+
+    expect(node.find(ReportRenderer).prop('badge')).toBeNull();
+  });
+
+  it('should not pass badge for non-number visualizations', async () => {
+    loadTile.mockReturnValueOnce(makeReport('bar', 10)).mockReturnValueOnce(makeReport('bar', 5));
+
+    const node = shallow(<OptimizeReportTile {...props} tile={numberTileWithComparison} />);
+    runAllEffects();
+    await flushPromises();
+
+    expect(node.find(ReportRenderer).prop('badge')).toBeNull();
+  });
+
+  it('should not pass badge when comparisonPeriod is not enabled', async () => {
+    loadTile
+      .mockReturnValueOnce(makeReport('number', 10))
+      .mockReturnValueOnce(makeReport('number', 5));
+
+    const node = shallow(<OptimizeReportTile {...props} />);
+    runAllEffects();
+    await flushPromises();
+
+    expect(node.find(ReportRenderer).prop('badge')).toBeNull();
+  });
+
+  it('should call loadTile with new filter and prior period filter after filter change', async () => {
+    // Each state update (setData, setPriorData, setLoading) re-queues effects in the
+    // mock useEffect queue. To test filter-change reload in isolation, verify loadTile
+    // call args rather than rendered badge props.
+    loadTile.mockReturnValue(makeReport('number', 10));
+
+    const node = shallow(<OptimizeReportTile {...props} tile={numberTileWithComparison} />);
+    runAllEffects();
+    await flushPromises();
+
+    loadTile.mockClear();
+    node.setProps({filter: [{type: 'suspendedInstancesOnly', data: null}]});
+    runAllEffects();
+    await flushPromises();
+
+    // loadTile called at least once with the new filter (current period)
+    expect(loadTile).toHaveBeenCalledWith(
+      numberTileWithComparison.id,
+      [{type: 'suspendedInstancesOnly', data: null}],
+      {}
+    );
+  });
 });
 
 it('should not navigate to the report when clicking on table visualization', async () => {

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/comparison.test.ts
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/comparison.test.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  buildBaselineFilter,
+  classifyDelta,
+  comparisonLabelKey,
+  formatDelta,
+  getRollingPeriod,
+  propertyToValueUnit,
+} from './comparison';
+
+const rollingFilter = (value: number, unit: string) => ({
+  type: 'instanceEndDate',
+  filterLevel: 'instance',
+  data: {type: 'rolling', start: {value, unit}, end: null},
+});
+
+// [year, month, day] in UTC – timezone/DST-robust way to assert the calendar
+// date of an ISO instant without depending on the runner's local offset.
+const asUTCDate = (iso: string): [number, number, number] => {
+  const date = new Date(iso);
+  return [date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()];
+};
+
+describe('getRollingPeriod', () => {
+  it('should return the rolling end-date period', () => {
+    // when
+    const period = getRollingPeriod([rollingFilter(30, 'days')]);
+
+    // then
+    expect(period).toEqual({value: 30, unit: 'days'});
+  });
+
+  it('should return null when there is no rolling end-date filter', () => {
+    expect(getRollingPeriod([{type: 'runningInstancesOnly', data: null}])).toBeNull();
+    expect(getRollingPeriod([])).toBeNull();
+    expect(getRollingPeriod(undefined)).toBeNull();
+  });
+
+  it('should ignore a fixed end-date filter', () => {
+    // given
+    const filter = [{type: 'instanceEndDate', data: {type: 'fixed', start: 'x', end: 'y'}}];
+
+    // then
+    expect(getRollingPeriod(filter)).toBeNull();
+  });
+});
+
+describe('buildBaselineFilter', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should return null when there is no filter', () => {
+    expect(buildBaselineFilter(undefined)).toBeNull();
+    expect(buildBaselineFilter(null)).toBeNull();
+  });
+
+  it('should return null when there is no rolling window to mirror', () => {
+    // given – a real filter, but no rolling end-date filter to base a comparison on
+    const filter = [{type: 'runningInstancesOnly', data: null}];
+
+    // then – null so the caller skips the fetch instead of comparing against itself
+    expect(buildBaselineFilter(filter)).toBeNull();
+  });
+
+  it('should build the immediately preceding equal-length window for a day preset', () => {
+    // when – "last 30 days" on 2026-06-15
+    const baseline = buildBaselineFilter([rollingFilter(30, 'days')])![0]!;
+
+    // then – a fixed window spanning the prior 30 days (60..30 days ago)
+    expect(baseline.data.type).toBe('fixed');
+    expect(baseline.data.includeUndefined).toBe(false);
+    expect(baseline.data.excludeUndefined).toBe(false);
+    expect(asUTCDate(baseline.data.end)).toEqual([2026, 4, 16]); // 2026-05-16
+    expect(asUTCDate(baseline.data.start)).toEqual([2026, 3, 16]); // 2026-04-16
+  });
+
+  it('should compute month presets calendar-aware, not as fixed milliseconds', () => {
+    // when – "last 3 months" on 2026-06-15
+    const baseline = buildBaselineFilter([rollingFilter(3, 'months')])![0]!;
+
+    // then – the prior 3 calendar months (2025-12-15 .. 2026-03-15), landing on the
+    // same day-of-month rather than drifting by average-month millisecond lengths
+    expect(asUTCDate(baseline.data.end)).toEqual([2026, 2, 15]); // 2026-03-15
+    expect(asUTCDate(baseline.data.start)).toEqual([2025, 11, 15]); // 2025-12-15
+  });
+
+  it('should preserve non-date filters and replace the rolling end-date filter', () => {
+    // given
+    const filter = [{type: 'runningInstancesOnly', data: null}, rollingFilter(7, 'days')];
+
+    // when
+    const result = buildBaselineFilter(filter)!;
+
+    // then
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({type: 'runningInstancesOnly', data: null});
+    expect(result[1]?.data.type).toBe('fixed');
+  });
+});
+
+describe('classifyDelta', () => {
+  it('should classify an unchanged value as neutral', () => {
+    expect(classifyDelta(100, 100, 'up')).toEqual({delta: 0, direction: 'neutral'});
+  });
+
+  it('should classify an increase as good when up is the good direction', () => {
+    expect(classifyDelta(120, 100, 'up')).toEqual({delta: 20, direction: 'good'});
+  });
+
+  it('should classify a decrease as bad when up is the good direction', () => {
+    expect(classifyDelta(80, 100, 'up')).toEqual({delta: -20, direction: 'bad'});
+  });
+
+  it('should classify a decrease as good when down is the good direction', () => {
+    expect(classifyDelta(80, 100, 'down')).toEqual({delta: -20, direction: 'good'});
+  });
+
+  it('should classify an increase as bad when down is the good direction', () => {
+    expect(classifyDelta(120, 100, 'down')).toEqual({delta: 20, direction: 'bad'});
+  });
+});
+
+describe('formatDelta', () => {
+  it('should format a plain number with a sign', () => {
+    expect(formatDelta(130, '')).toBe('+130');
+    expect(formatDelta(-20, '')).toBe('-20');
+    expect(formatDelta(0, '')).toBe('+0');
+  });
+
+  it('should format durations below a second in milliseconds', () => {
+    expect(formatDelta(-50, 'ms')).toBe('-50ms');
+  });
+
+  it('should format durations of a second or more in seconds', () => {
+    expect(formatDelta(-1500, 'ms')).toBe('-1.5s');
+  });
+
+  it('should format percentages with one decimal below 1% and none otherwise', () => {
+    expect(formatDelta(-0.1, '%')).toBe('-0.1%');
+    expect(formatDelta(2, '%')).toBe('+2%');
+  });
+});
+
+describe('propertyToValueUnit', () => {
+  it('should map duration to ms and percentage to %', () => {
+    expect(propertyToValueUnit('duration')).toBe('ms');
+    expect(propertyToValueUnit('percentage')).toBe('%');
+  });
+
+  it('should map anything else to no unit', () => {
+    expect(propertyToValueUnit('frequency')).toBe('');
+    expect(propertyToValueUnit(undefined)).toBe('');
+  });
+});
+
+describe('comparisonLabelKey', () => {
+  it.each([
+    [7, 'days', 'wow'],
+    [30, 'days', 'mom'],
+    [3, 'months', 'qoq'],
+    [6, 'months', 'hoh'],
+    [12, 'months', 'yoy'],
+  ])('should map the %s-%s preset to "%s"', (value, unit, expected) => {
+    expect(comparisonLabelKey({value: value as number, unit: unit as string})).toBe(expected);
+  });
+
+  it('should return null for an unknown preset or missing period', () => {
+    expect(comparisonLabelKey({value: 14, unit: 'days'})).toBeNull();
+    expect(comparisonLabelKey(null)).toBeNull();
+  });
+});

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/comparison.ts
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/comparison.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Duration, sub} from 'date-fns';
+
+/**
+ * Pure helpers backing the period-over-period comparison ("delta badge") on KPI
+ * number tiles. Kept free of React/rendering so each piece is unit-testable in
+ * isolation: baseline-filter construction, delta semantics, value formatting,
+ * value-unit derivation and the period label.
+ */
+
+type RollingPeriod = {value: number; unit: string};
+
+/** ms / % / plain — the unit the KPI value (and therefore the delta) is in. */
+export type ValueUnit = 'ms' | '%' | '';
+
+/** Whether the change is good, bad or unchanged for this KPI. */
+export type DeltaDirection = 'good' | 'bad' | 'neutral';
+
+/** Direction in which a change is considered an improvement. */
+export type DeltaGoodDirection = 'up' | 'down';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ComparisonFilter = Array<{type: string; filterLevel?: string; data?: any}>;
+
+const INSTANCE_END_DATE = 'instanceEndDate';
+
+/**
+ * Maps a rolling preset (value + unit) to a comparison-label translation key.
+ * The dashboard only offers 7d / 30d / 3m / 6m / 12m, so every selectable preset
+ * is covered here.
+ */
+const LABEL_KEY_BY_PRESET: Record<string, string> = {
+  '7-days': 'wow',
+  '30-days': 'mom',
+  '3-months': 'qoq',
+  '6-months': 'hoh',
+  '12-months': 'yoy',
+};
+
+/** Returns the rolling end-date period of the filter, or null if there is none. */
+export function getRollingPeriod(
+  filter: ComparisonFilter | undefined | null
+): RollingPeriod | null {
+  const rollingDateFilter = filter?.find(
+    (f) => f.type === INSTANCE_END_DATE && f.data?.type === 'rolling'
+  );
+  return rollingDateFilter ? rollingDateFilter.data.start : null;
+}
+
+/**
+ * Builds the filter for the equal-length window immediately preceding the
+ * current rolling window. Returns null when there is no rolling end-date filter
+ * to mirror, so callers can skip the fetch and show "no baseline" rather than
+ * comparing the current window against itself.
+ *
+ * The boundaries are computed calendar-aware (date-fns) so the prior window
+ * spans the same real duration the backend evaluates for the current one — a
+ * "last 3 months" window and its baseline both honour calendar month lengths.
+ */
+export function buildBaselineFilter(
+  filter: ComparisonFilter | undefined | null
+): ComparisonFilter | null {
+  const period = getRollingPeriod(filter);
+  if (!period) {
+    return null;
+  }
+  const now = new Date();
+  const priorEnd = sub(now, toDuration(period.unit, period.value));
+  const priorStart = sub(now, toDuration(period.unit, period.value * 2));
+  return [
+    ...(filter ?? []).filter((f) => f.type !== INSTANCE_END_DATE),
+    {
+      type: INSTANCE_END_DATE,
+      filterLevel: 'instance',
+      data: {
+        type: 'fixed',
+        start: priorStart.toISOString(),
+        end: priorEnd.toISOString(),
+        includeUndefined: false,
+        excludeUndefined: false,
+      },
+    },
+  ];
+}
+
+/** Classifies the change against the prior value for the given good-direction. */
+export function classifyDelta(
+  currentValue: number,
+  priorValue: number,
+  goodDirection: DeltaGoodDirection
+): {delta: number; direction: DeltaDirection} {
+  const delta = currentValue - priorValue;
+  if (delta === 0) {
+    return {delta, direction: 'neutral'};
+  }
+  const isPositive = delta > 0;
+  const isGood =
+    (goodDirection === 'up' && isPositive) || (goodDirection === 'down' && !isPositive);
+  return {delta, direction: isGood ? 'good' : 'bad'};
+}
+
+/** Formats a signed delta for display, in the KPI value's own unit. */
+export function formatDelta(delta: number, unit: ValueUnit): string {
+  const sign = delta >= 0 ? '+' : '-';
+  const absDelta = Math.abs(delta);
+  if (unit === 'ms') {
+    return absDelta >= 1000
+      ? `${sign}${(absDelta / 1000).toFixed(1)}s`
+      : `${sign}${Math.round(absDelta)}ms`;
+  }
+  if (unit === '%') {
+    return `${sign}${absDelta.toFixed(absDelta < 1 ? 1 : 0)}%`;
+  }
+  return `${sign}${Math.round(absDelta)}`;
+}
+
+/** Derives the value unit (ms / % / plain) from the report's view property. */
+export function propertyToValueUnit(property: string | undefined): ValueUnit {
+  if (property === 'duration') {
+    return 'ms';
+  }
+  if (property === 'percentage') {
+    return '%';
+  }
+  return '';
+}
+
+/**
+ * Translation key (under `agenticControlPlane.comparison`) for the period label,
+ * derived from the rolling preset, or null when the period is unknown so callers
+ * can omit the label rather than render a misleading one.
+ */
+export function comparisonLabelKey(period: RollingPeriod | null): string | null {
+  if (!period) {
+    return null;
+  }
+  return LABEL_KEY_BY_PRESET[`${period.value}-${period.unit}`] ?? null;
+}
+
+function toDuration(unit: string, value: number): Duration {
+  if (unit === 'quarters') {
+    return {months: value * 3};
+  }
+  return {[unit]: value};
+}

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/useComparisonData.ts
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/useComparisonData.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useCallback, useState} from 'react';
+
+import {useErrorHandling} from 'hooks';
+
+import {buildBaselineFilter, type ComparisonFilter} from './comparison';
+
+interface UseComparisonDataProps {
+  tile: {id?: string; report?: string};
+  filter: ComparisonFilter | undefined;
+  loadTile: (
+    id: string | undefined,
+    filter: ComparisonFilter,
+    params: object
+  ) => Promise<TileResult>;
+  enabled: boolean | undefined;
+}
+
+// The shape of a loaded report is not strongly typed in this part of the app.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TileResult = any;
+
+/**
+ * Owns the baseline (prior-period) fetch and its result for a comparison-enabled
+ * tile, keeping that concern out of the generic OptimizeReportTile. When the tile
+ * has no rolling window to compare against, the baseline filter is null, so no
+ * request is made and priorData stays null (the badge then shows "no baseline").
+ */
+export default function useComparisonData({
+  tile,
+  filter,
+  loadTile,
+  enabled,
+}: UseComparisonDataProps) {
+  const [priorData, setPriorData] = useState<TileResult>(null);
+  const {mightFail} = useErrorHandling();
+
+  const loadPriorData = useCallback((): Promise<void> => {
+    const baselineFilter = enabled ? buildBaselineFilter(filter) : null;
+    if (!baselineFilter) {
+      setPriorData(null);
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      mightFail(
+        loadTile(tile.id ?? tile.report, baselineFilter, {}),
+        (result: TileResult) => {
+          setPriorData(result);
+          resolve();
+        },
+        () => {
+          setPriorData(null);
+          resolve();
+        }
+      );
+    });
+  }, [enabled, filter, loadTile, tile, mightFail]);
+
+  const resetPriorData = useCallback(() => setPriorData(null), []);
+
+  return {priorData, loadPriorData, resetPriorData};
+}

--- a/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.js
+++ b/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.js
@@ -53,7 +53,7 @@ function ReportRenderer(props) {
     return (
       <ErrorBoundary>
         <div className="ReportRenderer">
-          <View {...props} />
+          <View {...props} badge={props.badge} />
           {report.data.configuration.showInstanceCount && (
             <div className="additionalInfo">
               {t('report.totalCount.instance', {

--- a/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.js
+++ b/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.js
@@ -53,7 +53,7 @@ function ReportRenderer(props) {
     return (
       <ErrorBoundary>
         <div className="ReportRenderer">
-          <View {...props} badge={props.badge} />
+          <View {...props} />
           {report.data.configuration.showInstanceCount && (
             <div className="additionalInfo">
               {t('report.totalCount.instance', {

--- a/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.test.js
@@ -40,6 +40,19 @@ it('should render ProcessReportRenderer if the report type is process', () => {
   expect(node.find('ProcessReportRenderer')).toExist();
 });
 
+it('should forward the badge prop to the view component', () => {
+  const badge = <span>badge</span>;
+  const node = shallow(<ReportRenderer report={reportTemplate} badge={badge} />);
+
+  expect(node.find('ProcessReportRenderer').prop('badge')).toBe(badge);
+});
+
+it('should forward an undefined badge prop when badge is not provided', () => {
+  const node = shallow(<ReportRenderer report={reportTemplate} />);
+
+  expect(node.find('ProcessReportRenderer').prop('badge')).toBeUndefined();
+});
+
 it('should include the instance count if indicated in the config', () => {
   const report = {
     ...reportTemplate,

--- a/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.test.js
@@ -40,17 +40,17 @@ it('should render ProcessReportRenderer if the report type is process', () => {
   expect(node.find('ProcessReportRenderer')).toExist();
 });
 
-it('should forward the badge prop to the view component', () => {
-  const badge = <span>badge</span>;
-  const node = shallow(<ReportRenderer report={reportTemplate} badge={badge} />);
+it('should forward the overlay prop to the view component', () => {
+  const overlay = <span>overlay</span>;
+  const node = shallow(<ReportRenderer report={reportTemplate} overlay={overlay} />);
 
-  expect(node.find('ProcessReportRenderer').prop('badge')).toBe(badge);
+  expect(node.find('ProcessReportRenderer').prop('overlay')).toBe(overlay);
 });
 
-it('should forward an undefined badge prop when badge is not provided', () => {
+it('should forward an undefined overlay prop when overlay is not provided', () => {
   const node = shallow(<ReportRenderer report={reportTemplate} />);
 
-  expect(node.find('ProcessReportRenderer').prop('badge')).toBeUndefined();
+  expect(node.find('ProcessReportRenderer').prop('overlay')).toBeUndefined();
 });
 
 it('should include the instance count if indicated in the config', () => {

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.js
@@ -21,7 +21,7 @@ import ProgressBar from './ProgressBar';
 
 import './Number.scss';
 
-export function Number({report, formatter, mightFail, badge}) {
+export function Number({report, formatter, mightFail, overlay}) {
   const {data, result} = report;
   const {targetValue, precision, valueFormat} = data.configuration;
   const [processVariable, setProcessVariable] = useState();
@@ -129,7 +129,7 @@ export function Number({report, formatter, mightFail, badge}) {
             <React.Fragment key={idx}>
               <div className="data">
                 {formatValue(measure.data, valueFormat ?? measure.property, precision)}
-                {idx === 0 && badge}
+                {idx === 0 && overlay}
               </div>
               <div className="label">{viewString}</div>
             </React.Fragment>

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.js
@@ -21,7 +21,7 @@ import ProgressBar from './ProgressBar';
 
 import './Number.scss';
 
-export function Number({report, formatter, mightFail}) {
+export function Number({report, formatter, mightFail, badge}) {
   const {data, result} = report;
   const {targetValue, precision, valueFormat} = data.configuration;
   const [processVariable, setProcessVariable] = useState();
@@ -129,6 +129,7 @@ export function Number({report, formatter, mightFail}) {
             <React.Fragment key={idx}>
               <div className="data">
                 {formatValue(measure.data, valueFormat ?? measure.property, precision)}
+                {idx === 0 && badge}
               </div>
               <div className="label">{viewString}</div>
             </React.Fragment>

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.test.js
@@ -220,3 +220,39 @@ it('should fall back to measure property formatter when valueFormat is not set',
 
   expect(node.find('.data')).toIncludeText('42');
 });
+
+describe('badge prop', () => {
+  const badge = <span className="testBadge">delta</span>;
+
+  it('should render badge inside the first .data element', () => {
+    const node = shallow(<Number report={report} badge={badge} />);
+
+    expect(node.find('.data').first().find('.testBadge')).toExist();
+  });
+
+  it('should not render badge in subsequent .data elements for multi-measure reports', () => {
+    const multiMeasureReport = {
+      ...report,
+      data: {
+        ...report.data,
+        view: {properties: ['frequency', 'duration']},
+      },
+      result: {
+        measures: [
+          {data: 10, property: 'frequency'},
+          {data: 500, property: 'duration', aggregationType: {type: 'avg', value: null}},
+        ],
+      },
+    };
+    const node = shallow(<Number report={multiMeasureReport} badge={badge} />);
+
+    expect(node.find('.data').at(0).find('.testBadge')).toExist();
+    expect(node.find('.data').at(1).find('.testBadge')).not.toExist();
+  });
+
+  it('should render nothing in .data when badge is not provided', () => {
+    const node = shallow(<Number report={report} />);
+
+    expect(node.find('.data').first().find('.testBadge')).not.toExist();
+  });
+});

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.test.js
@@ -221,16 +221,16 @@ it('should fall back to measure property formatter when valueFormat is not set',
   expect(node.find('.data')).toIncludeText('42');
 });
 
-describe('badge prop', () => {
-  const badge = <span className="testBadge">delta</span>;
+describe('overlay prop', () => {
+  const overlay = <span className="testBadge">delta</span>;
 
-  it('should render badge inside the first .data element', () => {
-    const node = shallow(<Number report={report} badge={badge} />);
+  it('should render overlay inside the first .data element', () => {
+    const node = shallow(<Number report={report} overlay={overlay} />);
 
     expect(node.find('.data').first().find('.testBadge')).toExist();
   });
 
-  it('should not render badge in subsequent .data elements for multi-measure reports', () => {
+  it('should not render overlay in subsequent .data elements for multi-measure reports', () => {
     const multiMeasureReport = {
       ...report,
       data: {
@@ -244,13 +244,13 @@ describe('badge prop', () => {
         ],
       },
     };
-    const node = shallow(<Number report={multiMeasureReport} badge={badge} />);
+    const node = shallow(<Number report={multiMeasureReport} overlay={overlay} />);
 
     expect(node.find('.data').at(0).find('.testBadge')).toExist();
     expect(node.find('.data').at(1).find('.testBadge')).not.toExist();
   });
 
-  it('should render nothing in .data when badge is not provided', () => {
+  it('should render nothing in .data when overlay is not provided', () => {
     const node = shallow(<Number report={report} />);
 
     expect(node.find('.data').first().find('.testBadge')).not.toExist();


### PR DESCRIPTION
## Description

Adds a Week-over-Week delta badge to the number KPI tiles on the Agentic Control Plane dashboard.

**Behaviour:**

| Current value | Prior value | Delta | Badge |
|---|---|---|---|
| `--` (no data) | any | — | hidden |
| has value | none (no prior period data) | — | grey `— WoW` |
| has value | has value | `= 0` | grey `+0 WoW` |
| has value | has value | `> 0`, direction `up` | green |
| has value | has value | `> 0`, direction `down` | red |
| has value | has value | `< 0`, direction `down` | green |
| has value | has value | `< 0`, direction `up` | red |

Direction is configured per tile (`deltaGoodDirection: 'up' | 'down'`). Completed executions use `up` (more is better), avg duration and incident rate use `down` (less is better).

**Implementation:**
- `KpiDeltaBadge` — new TSX component that computes and formats the delta with Carbon `Tag`
- `OptimizeReportTile` — fetches prior period by shifting the rolling date window back one period; passes badge as a prop to `ReportRenderer`; both requests are awaited in parallel so the badge is present on first paint
- `ReportRenderer` / `Number` — forwards `badge` prop and renders it inline inside the `.data` element

Closes #55127
