### PR TITLE
Add createAgentHistoryItem command to the Java Client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -35,6 +35,7 @@ import io.camunda.client.api.command.CancelBatchOperationStep1;
 import io.camunda.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.client.api.command.CorrelateMessageCommandStep1;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1;
 import io.camunda.client.api.command.CreateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
 import io.camunda.client.api.command.CreateBatchOperationCommandStep1;
@@ -3477,6 +3478,27 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for creating an agent instance
    */
   CreateAgentInstanceCommandStep1 newCreateAgentInstanceCommand();
+
+  /**
+   * Creates a command to append a conversation history item to an agent instance.
+   *
+   * <pre>
+   *   CreateAgentHistoryItemResponse response = camundaClient
+   *       .newCreateAgentHistoryItemCommand(agentInstanceKey)
+   *       .elementInstanceKey(elementInstanceKey)
+   *       .jobKey(jobKey)
+   *       .jobLease(jobLease)
+   *       .role(AgentHistoryRole.ASSISTANT)
+   *       .content(contentList)
+   *       .producedAt(OffsetDateTime.now())
+   *       .send()
+   *       .join();
+   * </pre>
+   *
+   * @param agentInstanceKey the key of the agent instance
+   * @return a builder for creating an agent history item
+   */
+  CreateAgentHistoryItemCommandStep1 newCreateAgentHistoryItemCommand(long agentInstanceKey);
 
   /**
    * Creates a command to update an existing agent instance.

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentHistoryItemCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentHistoryItemCommandStep1.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.CreateAgentHistoryItemResponse;
+import io.camunda.client.api.response.DocumentReferenceResponse;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a request to append a conversation history item to an agent instance.
+ *
+ * <p>Usage example:
+ *
+ * <pre>
+ *   CreateAgentHistoryItemResponse response = camundaClient
+ *       .newCreateAgentHistoryItemCommand(agentInstanceKey)
+ *       .elementInstanceKey(2251799813685248L)
+ *       .jobKey(2251799813685249L)
+ *       .role(AgentHistoryRole.USER)
+ *       .content(List.of(AgentHistoryContent.text("Hello!")))
+ *       .producedAt(OffsetDateTime.now())
+ *       .send()
+ *       .join();
+ * </pre>
+ */
+public interface CreateAgentHistoryItemCommandStep1 {
+
+  /**
+   * Sets the element instance key of the element instance this history item belongs to.
+   *
+   * @param elementInstanceKey the key of the element instance. Must be greater than 0.
+   * @return this builder for method chaining
+   */
+  CreateAgentHistoryItemCommandStep2 elementInstanceKey(long elementInstanceKey);
+
+  interface CreateAgentHistoryItemCommandStep2 {
+
+    /**
+     * Sets the job key of the currently active job during which this item was produced.
+     *
+     * @param jobKey the key of the active job. Must be greater than 0.
+     * @return this builder for method chaining
+     */
+    CreateAgentHistoryItemCommandStep3 jobKey(long jobKey);
+  }
+
+  interface CreateAgentHistoryItemCommandStep3 {
+
+    /**
+     * Sets the role of this history item in the conversation.
+     *
+     * @param role the conversation role. Must not be null.
+     * @return this builder for method chaining
+     */
+    CreateAgentHistoryItemCommandStep4 role(AgentHistoryRole role);
+  }
+
+  interface CreateAgentHistoryItemCommandStep4 {
+
+    /**
+     * Sets the content blocks of this history item.
+     *
+     * @param content the list of content blocks. Must not be null.
+     * @return this builder for method chaining
+     */
+    CreateAgentHistoryItemCommandStep5 content(List<AgentHistoryContent> content);
+  }
+
+  interface CreateAgentHistoryItemCommandStep5 {
+
+    /**
+     * Sets the connector-side timestamp when this message was produced.
+     *
+     * @param producedAt the production timestamp. Must not be null.
+     * @return this builder for method chaining
+     */
+    CreateAgentHistoryItemFinalCommandStep producedAt(OffsetDateTime producedAt);
+  }
+
+  interface CreateAgentHistoryItemFinalCommandStep
+      extends FinalCommandStep<CreateAgentHistoryItemResponse> {
+
+    /**
+     * Sets the opaque job lease token received from the job activation response.
+     *
+     * <p>Job leasing is not yet enforced (#55033); this field is optional until support is added.
+     *
+     * @param jobLease the lease token. Must not be null or empty.
+     * @return this builder for method chaining
+     */
+    CreateAgentHistoryItemFinalCommandStep jobLease(String jobLease);
+
+    /**
+     * Sets the sequential iteration number this item belongs to.
+     *
+     * @param iteration the iteration number.
+     * @return this builder for method chaining
+     */
+    CreateAgentHistoryItemFinalCommandStep iteration(int iteration);
+
+    /**
+     * Sets the tool calls associated with this history item.
+     *
+     * @param toolCalls the list of tool calls. May be null.
+     * @return this builder for method chaining
+     */
+    CreateAgentHistoryItemFinalCommandStep toolCalls(List<AgentHistoryToolCall> toolCalls);
+
+    /**
+     * Sets per-call token and latency metrics. Present on ASSISTANT items only.
+     *
+     * @param metrics the metrics. May be null.
+     * @return this builder for method chaining
+     */
+    CreateAgentHistoryItemFinalCommandStep metrics(AgentHistoryMetrics metrics);
+  }
+
+  /** Role of a history item in the agent conversation. */
+  enum AgentHistoryRole {
+    USER,
+    ASSISTANT,
+    TOOL_RESULT
+  }
+
+  /**
+   * Factory for content blocks passed to {@link CreateAgentHistoryItemCommandStep4#content}. Use
+   * these instead of the generated protocol classes to avoid explicit casts.
+   *
+   * <p>Example:
+   *
+   * <pre>
+   *   .content(List.of(
+   *       AgentHistoryContent.text("I can help."),
+   *       AgentHistoryContent.object(Map.of("key", "value")),
+   *       AgentHistoryContent.document(documentReferenceResponse)
+   *   ))
+   * </pre>
+   */
+  interface AgentHistoryContent {
+
+    /**
+     * Creates a plain-text content block.
+     *
+     * @param text the text. Must not be null.
+     * @return an {@link AgentHistoryContent} of type TEXT
+     */
+    static AgentHistoryContent text(final String text) {
+      if (text == null) {
+        throw new IllegalArgumentException("text must not be null");
+      }
+      return new TextContent(text);
+    }
+
+    /**
+     * Creates an arbitrary-object content block.
+     *
+     * @param object the key-value map. Must not be null.
+     * @return an {@link AgentHistoryContent} of type OBJECT
+     */
+    static AgentHistoryContent object(final Map<String, Object> object) {
+      if (object == null) {
+        throw new IllegalArgumentException("object must not be null");
+      }
+      return new ObjectContent(object);
+    }
+
+    /**
+     * Creates a document-reference content block from a {@link DocumentReferenceResponse} returned
+     * by other document APIs (e.g. upload or create-link).
+     *
+     * @param documentReference the document reference. Must not be null.
+     * @return a {@link DocumentContent} of type DOCUMENT
+     */
+    static DocumentContent document(final DocumentReferenceResponse documentReference) {
+      if (documentReference == null) {
+        throw new IllegalArgumentException("documentReference must not be null");
+      }
+      return new DocumentContent(documentReference);
+    }
+
+    /** Plain-text content block. */
+    final class TextContent implements AgentHistoryContent {
+      private final String text;
+
+      TextContent(final String text) {
+        this.text = text;
+      }
+
+      public String getText() {
+        return text;
+      }
+    }
+
+    /** Arbitrary-object content block. */
+    final class ObjectContent implements AgentHistoryContent {
+      private final Map<String, Object> object;
+
+      ObjectContent(final Map<String, Object> object) {
+        this.object = object;
+      }
+
+      public Map<String, Object> getObject() {
+        return object;
+      }
+    }
+
+    /** Document-reference content block. Use {@link AgentHistoryContent#document} to create. */
+    final class DocumentContent implements AgentHistoryContent {
+      private final DocumentReferenceResponse documentReference;
+
+      DocumentContent(final DocumentReferenceResponse documentReference) {
+        this.documentReference = documentReference;
+      }
+
+      public DocumentReferenceResponse getDocumentReference() {
+        return documentReference;
+      }
+    }
+  }
+
+  /** Per-call token and latency metrics for an ASSISTANT history item. */
+  final class AgentHistoryMetrics {
+    private Long inputTokens;
+    private Long outputTokens;
+    private Long durationMs;
+
+    public AgentHistoryMetrics inputTokens(final long inputTokens) {
+      this.inputTokens = inputTokens;
+      return this;
+    }
+
+    public AgentHistoryMetrics outputTokens(final long outputTokens) {
+      this.outputTokens = outputTokens;
+      return this;
+    }
+
+    public AgentHistoryMetrics durationMs(final long durationMs) {
+      this.durationMs = durationMs;
+      return this;
+    }
+
+    public Long getInputTokens() {
+      return inputTokens;
+    }
+
+    public Long getOutputTokens() {
+      return outputTokens;
+    }
+
+    public Long getDurationMs() {
+      return durationMs;
+    }
+  }
+
+  /** A tool call associated with an ASSISTANT history item. */
+  final class AgentHistoryToolCall {
+    private String toolCallId;
+    private String toolName;
+    private String elementId;
+    private Map<String, Object> arguments;
+
+    public AgentHistoryToolCall toolCallId(final String toolCallId) {
+      this.toolCallId = toolCallId;
+      return this;
+    }
+
+    public AgentHistoryToolCall toolName(final String toolName) {
+      this.toolName = toolName;
+      return this;
+    }
+
+    public AgentHistoryToolCall elementId(final String elementId) {
+      this.elementId = elementId;
+      return this;
+    }
+
+    public AgentHistoryToolCall arguments(final Map<String, Object> arguments) {
+      this.arguments = arguments;
+      return this;
+    }
+
+    public String getToolCallId() {
+      return toolCallId;
+    }
+
+    public String getToolName() {
+      return toolName;
+    }
+
+    public String getElementId() {
+      return elementId;
+    }
+
+    public Map<String, Object> getArguments() {
+      return arguments;
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateAgentHistoryItemResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateAgentHistoryItemResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface CreateAgentHistoryItemResponse {
+
+  /**
+   * @return the system-generated key for the created agent history item
+   */
+  long getHistoryItemKey();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -43,6 +43,7 @@ import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.client.api.command.CorrelateMessageCommandStep1;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1;
 import io.camunda.client.api.command.CreateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
 import io.camunda.client.api.command.CreateBatchOperationCommandStep1;
@@ -230,6 +231,7 @@ import io.camunda.client.impl.command.CancelBatchOperationCommandImpl;
 import io.camunda.client.impl.command.CancelProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.CompleteUserTaskCommandImpl;
 import io.camunda.client.impl.command.CorrelateMessageCommandImpl;
+import io.camunda.client.impl.command.CreateAgentHistoryItemCommandImpl;
 import io.camunda.client.impl.command.CreateAgentInstanceCommandImpl;
 import io.camunda.client.impl.command.CreateAuthorizationCommandImpl;
 import io.camunda.client.impl.command.CreateBatchOperationCommandImpl.CreateBatchOperationCommandStep1Impl;
@@ -1723,6 +1725,12 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public ResourceContentGetRequest newResourceContentBinaryGetRequest(final long resourceKey) {
     return new ResourceContentBinaryGetRequestImpl(httpClient, resourceKey);
+  }
+
+  @Override
+  public CreateAgentHistoryItemCommandStep1 newCreateAgentHistoryItemCommand(
+      final long agentInstanceKey) {
+    return new CreateAgentHistoryItemCommandImpl(httpClient, jsonMapper, agentInstanceKey);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
@@ -113,8 +113,8 @@ public class CreateAgentHistoryItemCommandImpl
       }
       if (item instanceof TextContent) {
         final String text = ((TextContent) item).getText();
-        if (text == null) {
-          throw new IllegalArgumentException("text content value must not be null");
+        if (text == null || text.trim().isEmpty()) {
+          throw new IllegalArgumentException("text content value must not be null or blank");
         }
         protocolContent.add(new AgentInstanceTextContent().text(text));
       } else if (item instanceof ObjectContent) {
@@ -236,12 +236,6 @@ public class CreateAgentHistoryItemCommandImpl
   public CreateAgentHistoryItemFinalCommandStep metrics(final AgentHistoryMetrics metrics) {
     if (metrics == null) {
       return this;
-    }
-    if (metrics.getInputTokens() == null
-        || metrics.getOutputTokens() == null
-        || metrics.getDurationMs() == null) {
-      throw new IllegalArgumentException(
-          "metrics requires all fields: inputTokens, outputTokens, durationMs");
     }
     request.metrics(
         new AgentInstanceHistoryItemMetrics()

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent.DocumentContent;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent.ObjectContent;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent.TextContent;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryMetrics;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryToolCall;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemCommandStep2;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemCommandStep3;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemCommandStep4;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemCommandStep5;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemFinalCommandStep;
+import io.camunda.client.api.response.CreateAgentHistoryItemResponse;
+import io.camunda.client.api.response.DocumentMetadata;
+import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.CreateAgentHistoryItemResponseImpl;
+import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemCreationResult;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetrics;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemRequest;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
+import io.camunda.client.protocol.rest.AgentInstanceMessageContent;
+import io.camunda.client.protocol.rest.AgentInstanceObjectContent;
+import io.camunda.client.protocol.rest.AgentInstanceTextContent;
+import io.camunda.client.protocol.rest.AgentInstanceToolCall;
+import io.camunda.client.protocol.rest.DocumentMetadataResponse;
+import io.camunda.client.protocol.rest.DocumentReference;
+import io.camunda.client.protocol.rest.DocumentReference.CamundaDocumentTypeEnum;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class CreateAgentHistoryItemCommandImpl
+    implements CreateAgentHistoryItemCommandStep1,
+        CreateAgentHistoryItemCommandStep2,
+        CreateAgentHistoryItemCommandStep3,
+        CreateAgentHistoryItemCommandStep4,
+        CreateAgentHistoryItemCommandStep5,
+        CreateAgentHistoryItemFinalCommandStep {
+
+  private final AgentInstanceHistoryItemRequest request;
+  private final long agentInstanceKey;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public CreateAgentHistoryItemCommandImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final long agentInstanceKey) {
+    ArgumentUtil.ensureGreaterThan("agentInstanceKey", agentInstanceKey, 0);
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    this.agentInstanceKey = agentInstanceKey;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new AgentInstanceHistoryItemRequest();
+  }
+
+  @Override
+  public CreateAgentHistoryItemCommandStep2 elementInstanceKey(final long elementInstanceKey) {
+    ArgumentUtil.ensureGreaterThan("elementInstanceKey", elementInstanceKey, 0);
+    request.elementInstanceKey(String.valueOf(elementInstanceKey));
+    return this;
+  }
+
+  @Override
+  public CreateAgentHistoryItemCommandStep3 jobKey(final long jobKey) {
+    ArgumentUtil.ensureGreaterThan("jobKey", jobKey, 0);
+    request.jobKey(String.valueOf(jobKey));
+    return this;
+  }
+
+  @Override
+  public CreateAgentHistoryItemCommandStep4 role(final AgentHistoryRole role) {
+    ArgumentUtil.ensureNotNull("role", role);
+    request.role(AgentInstanceHistoryRoleEnum.fromValue(role.name()));
+    return this;
+  }
+
+  @Override
+  public CreateAgentHistoryItemCommandStep5 content(final List<AgentHistoryContent> content) {
+    ArgumentUtil.ensureNotNull("content", content);
+    if (content.isEmpty()) {
+      throw new IllegalArgumentException("content must not be empty");
+    }
+    final List<AgentInstanceMessageContent> protocolContent = new ArrayList<>(content.size());
+    for (final AgentHistoryContent item : content) {
+      if (item == null) {
+        throw new IllegalArgumentException("content must not contain null elements");
+      }
+      if (item instanceof TextContent) {
+        final String text = ((TextContent) item).getText();
+        if (text == null) {
+          throw new IllegalArgumentException("text content value must not be null");
+        }
+        protocolContent.add(new AgentInstanceTextContent().text(text));
+      } else if (item instanceof ObjectContent) {
+        final Object obj = ((ObjectContent) item).getObject();
+        if (obj == null) {
+          throw new IllegalArgumentException("object content value must not be null");
+        }
+        protocolContent.add(
+            new AgentInstanceObjectContent()._object(((ObjectContent) item).getObject()));
+      } else if (item instanceof DocumentContent) {
+        protocolContent.add(toProtocolDocumentContent((DocumentContent) item));
+      } else {
+        throw new IllegalArgumentException("Unsupported AgentHistoryContent type: " + item);
+      }
+    }
+    request.content(protocolContent);
+    return this;
+  }
+
+  private AgentInstanceDocumentContent toProtocolDocumentContent(final DocumentContent item) {
+    final DocumentReferenceResponse ref = item.getDocumentReference();
+    final DocumentReference protocolRef =
+        new DocumentReference()
+            .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
+            .documentId(ref.getDocumentId())
+            .storeId(ref.getStoreId());
+    if (ref.getContentHash() != null) {
+      protocolRef.contentHash(ref.getContentHash());
+    }
+    final DocumentMetadata metadata = ref.getMetadata();
+    if (metadata != null) {
+      protocolRef.metadata(toProtocolDocumentMetadata(metadata));
+    }
+    return new AgentInstanceDocumentContent().documentReference(protocolRef);
+  }
+
+  private DocumentMetadataResponse toProtocolDocumentMetadata(final DocumentMetadata metadata) {
+    final DocumentMetadataResponse protocolMeta = new DocumentMetadataResponse();
+    if (metadata.getFileName() != null) {
+      protocolMeta.fileName(metadata.getFileName());
+    }
+    if (metadata.getContentType() != null) {
+      protocolMeta.contentType(metadata.getContentType());
+    }
+    if (metadata.getSize() != null) {
+      protocolMeta.size(metadata.getSize());
+    }
+    if (metadata.getExpiresAt() != null) {
+      protocolMeta.expiresAt(metadata.getExpiresAt().toString());
+    }
+    if (metadata.getProcessDefinitionId() != null) {
+      protocolMeta.processDefinitionId(metadata.getProcessDefinitionId());
+    }
+    if (metadata.getProcessInstanceKey() != null) {
+      protocolMeta.processInstanceKey(String.valueOf(metadata.getProcessInstanceKey()));
+    }
+    if (metadata.getCustomProperties() != null && !metadata.getCustomProperties().isEmpty()) {
+      protocolMeta.customProperties(metadata.getCustomProperties());
+    }
+    return protocolMeta;
+  }
+
+  @Override
+  public CreateAgentHistoryItemFinalCommandStep producedAt(final OffsetDateTime producedAt) {
+    ArgumentUtil.ensureNotNull("producedAt", producedAt);
+    request.producedAt(producedAt.toString());
+    return this;
+  }
+
+  @Override
+  public CreateAgentHistoryItemFinalCommandStep jobLease(final String jobLease) {
+    ArgumentUtil.ensureNotNull("jobLease", jobLease);
+    if (jobLease.trim().isEmpty()) {
+      throw new IllegalArgumentException("jobLease must not be blank");
+    }
+    request.jobLease(jobLease);
+    return this;
+  }
+
+  @Override
+  public CreateAgentHistoryItemFinalCommandStep iteration(final int iteration) {
+    ArgumentUtil.ensureGreaterThan("iteration", iteration, 0);
+    request.iteration(iteration);
+    return this;
+  }
+
+  @Override
+  public CreateAgentHistoryItemFinalCommandStep toolCalls(
+      final List<AgentHistoryToolCall> toolCalls) {
+    if (toolCalls == null) {
+      return this;
+    }
+    final List<AgentInstanceToolCall> protocolToolCalls = new ArrayList<>(toolCalls.size());
+    for (final AgentHistoryToolCall tc : toolCalls) {
+      if (tc == null) {
+        throw new IllegalArgumentException("toolCalls must not contain null elements");
+      }
+      if (tc.getToolCallId() == null || tc.getToolCallId().trim().isEmpty()) {
+        throw new IllegalArgumentException("toolCallId must not be null or blank");
+      }
+      if (tc.getToolName() == null || tc.getToolName().trim().isEmpty()) {
+        throw new IllegalArgumentException("toolName must not be null or blank");
+      }
+      protocolToolCalls.add(
+          new AgentInstanceToolCall()
+              .toolCallId(tc.getToolCallId())
+              .toolName(tc.getToolName())
+              .elementId(tc.getElementId())
+              .arguments(tc.getArguments()));
+    }
+    request.toolCalls(protocolToolCalls);
+    return this;
+  }
+
+  @Override
+  public CreateAgentHistoryItemFinalCommandStep metrics(final AgentHistoryMetrics metrics) {
+    if (metrics == null) {
+      return this;
+    }
+    if (metrics.getInputTokens() == null
+        || metrics.getOutputTokens() == null
+        || metrics.getDurationMs() == null) {
+      throw new IllegalArgumentException(
+          "metrics requires all fields: inputTokens, outputTokens, durationMs");
+    }
+    request.metrics(
+        new AgentInstanceHistoryItemMetrics()
+            .inputTokens(metrics.getInputTokens())
+            .outputTokens(metrics.getOutputTokens())
+            .durationMs(metrics.getDurationMs()));
+    return this;
+  }
+
+  @Override
+  public CreateAgentHistoryItemFinalCommandStep requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<CreateAgentHistoryItemResponse> send() {
+    final HttpCamundaFuture<CreateAgentHistoryItemResponse> result = new HttpCamundaFuture<>();
+    final CreateAgentHistoryItemResponseImpl response = new CreateAgentHistoryItemResponseImpl();
+    httpClient.post(
+        "/agent-instances/" + agentInstanceKey + "/history",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        AgentInstanceHistoryItemCreationResult.class,
+        response::setResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
@@ -136,6 +136,9 @@ public class CreateAgentHistoryItemCommandImpl
 
   private AgentInstanceDocumentContent toProtocolDocumentContent(final DocumentContent item) {
     final DocumentReferenceResponse ref = item.getDocumentReference();
+    if (ref.getDocumentId() == null || ref.getDocumentId().trim().isEmpty()) {
+      throw new IllegalArgumentException("documentReference.documentId must not be null or blank");
+    }
     final DocumentReference protocolRef =
         new DocumentReference()
             .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateAgentHistoryItemResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateAgentHistoryItemResponseImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.CreateAgentHistoryItemResponse;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemCreationResult;
+
+public class CreateAgentHistoryItemResponseImpl implements CreateAgentHistoryItemResponse {
+
+  private long historyItemKey;
+
+  public CreateAgentHistoryItemResponseImpl setResponse(
+      final AgentInstanceHistoryItemCreationResult result) {
+    historyItemKey = Long.parseLong(result.getHistoryItemKey());
+    return this;
+  }
+
+  @Override
+  public long getHistoryItemKey() {
+    return historyItemKey;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DocumentReferenceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DocumentReferenceResponseImpl.java
@@ -46,7 +46,10 @@ public class DocumentReferenceResponseImpl implements DocumentReferenceResponse 
     storeId = documentReference.getStoreId();
     contentHash = documentReference.getContentHash();
 
-    metadata = new DocumentMetadataImpl(documentReference.getMetadata());
+    metadata =
+        documentReference.getMetadata() != null
+            ? new DocumentMetadataImpl(documentReference.getMetadata())
+            : null;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
@@ -309,6 +309,25 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
         .hasMessageContaining("documentReference must not be null");
   }
 
+  @Test
+  void shouldRejectNullDocumentId() {
+    final DocumentReferenceResponseImpl doc =
+        new DocumentReferenceResponseImpl(
+            new DocumentReference()
+                .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
+                .storeId("store-1")); // documentId not set → null
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .role(AgentHistoryRole.USER)
+                    .content(Collections.singletonList(AgentHistoryContent.document(doc))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("documentId must not be null or blank");
+  }
+
   // ── Argument validation: metrics (all fields required) ───────────────────
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
@@ -203,7 +203,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .elementInstanceKey(ELEMENT_INSTANCE_KEY)
                     .jobKey(JOB_KEY)
                     .role(null))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("role must not be null");
   }
 
   @Test
@@ -216,7 +217,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .jobKey(JOB_KEY)
                     .role(AgentHistoryRole.USER)
                     .content(null))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("content must not be null");
   }
 
   @Test
@@ -230,7 +232,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .role(AgentHistoryRole.USER)
                     .content(Collections.singletonList(AgentHistoryContent.text("hello")))
                     .producedAt(null))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("producedAt must not be null");
   }
 
   // ── Argument validation: jobLease (optional, but non-blank when set) ──────
@@ -248,7 +251,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .content(Collections.singletonList(AgentHistoryContent.text("hello")))
                     .producedAt(PRODUCED_AT)
                     .jobLease(jobLease))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("jobLease must not be blank");
   }
 
   // ── Argument validation: content (empty list) ─────────────────────────────

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
@@ -267,6 +267,21 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
         .hasMessageContaining("content must not be empty");
   }
 
+  @ParameterizedTest(name = "blank text [{0}] should be rejected")
+  @ValueSource(strings = {"", " ", "\t"})
+  void shouldRejectBlankTextContent(final String text) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .role(AgentHistoryRole.USER)
+                    .content(Collections.singletonList(AgentHistoryContent.text(text))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("text content value must not be null or blank");
+  }
+
   // ── Argument validation: iteration ───────────────────────────────────────
 
   @ParameterizedTest(name = "iteration={0} should be rejected")
@@ -326,24 +341,6 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .content(Collections.singletonList(AgentHistoryContent.document(doc))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("documentId must not be null or blank");
-  }
-
-  // ── Argument validation: metrics (all fields required) ───────────────────
-
-  @Test
-  void shouldRejectPartialMetrics() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
-                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
-                    .jobKey(JOB_KEY)
-                    .role(AgentHistoryRole.USER)
-                    .content(Collections.singletonList(AgentHistoryContent.text("hello")))
-                    .producedAt(PRODUCED_AT)
-                    .metrics(new AgentHistoryMetrics().inputTokens(100L).outputTokens(50L)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("metrics requires all fields");
   }
 
   // ── Argument validation: toolCalls ───────────────────────────────────────

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryMetrics;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
+import io.camunda.client.api.response.CreateAgentHistoryItemResponse;
+import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
+import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemCreationResult;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemRequest;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
+import io.camunda.client.protocol.rest.DocumentMetadataResponse;
+import io.camunda.client.protocol.rest.DocumentReference;
+import io.camunda.client.protocol.rest.DocumentReference.CamundaDocumentTypeEnum;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CreateAgentHistoryItemCommandTest extends ClientRestTest {
+
+  private static final long AGENT_INSTANCE_KEY = 2251799813685248L;
+  private static final long ELEMENT_INSTANCE_KEY = 2251799813685249L;
+  private static final long JOB_KEY = 2251799813685250L;
+  private static final OffsetDateTime PRODUCED_AT = OffsetDateTime.parse("2025-06-01T12:00:00Z");
+
+  // ── Happy-path: request routing ───────────────────────────────────────────
+
+  @Test
+  void shouldSendPostToCorrectUrl() {
+    // given
+    gatewayService.onCreateAgentHistoryItemRequest(
+        AGENT_INSTANCE_KEY, new AgentInstanceHistoryItemCreationResult().historyItemKey("1"));
+
+    // when
+    client
+        .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .jobKey(JOB_KEY)
+        .role(AgentHistoryRole.USER)
+        .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+        .producedAt(PRODUCED_AT)
+        .execute();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(request.getUrl())
+        .isEqualTo("/v2/agent-instances/" + AGENT_INSTANCE_KEY + "/history");
+  }
+
+  @Test
+  void shouldSendRequiredFieldsInRequestBody() {
+    // given
+    gatewayService.onCreateAgentHistoryItemRequest(
+        AGENT_INSTANCE_KEY, new AgentInstanceHistoryItemCreationResult().historyItemKey("1"));
+
+    // when
+    client
+        .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .jobKey(JOB_KEY)
+        .role(AgentHistoryRole.ASSISTANT)
+        .content(Collections.singletonList(AgentHistoryContent.text("I can help.")))
+        .producedAt(PRODUCED_AT)
+        .execute();
+
+    // then
+    final AgentInstanceHistoryItemRequest body =
+        gatewayService.getLastRequest(AgentInstanceHistoryItemRequest.class);
+    assertThat(body.getElementInstanceKey()).isEqualTo(String.valueOf(ELEMENT_INSTANCE_KEY));
+    assertThat(body.getJobKey()).isEqualTo(String.valueOf(JOB_KEY));
+    assertThat(body.getJobLease()).isNull();
+    assertThat(body.getRole()).isEqualTo(AgentInstanceHistoryRoleEnum.ASSISTANT);
+    assertThat(body.getContent()).hasSize(1);
+    assertThat(body.getProducedAt()).isEqualTo(PRODUCED_AT.toString());
+    assertThat(body.getIteration()).isNull();
+    assertThat(body.getToolCalls()).isNull();
+    assertThat(body.getMetrics()).isNull();
+  }
+
+  @Test
+  void shouldSendOptionalFieldsInRequestBody() {
+    // given
+    gatewayService.onCreateAgentHistoryItemRequest(
+        AGENT_INSTANCE_KEY, new AgentInstanceHistoryItemCreationResult().historyItemKey("2"));
+
+    // when
+    client
+        .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .jobKey(JOB_KEY)
+        .role(AgentHistoryRole.USER)
+        .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+        .producedAt(PRODUCED_AT)
+        .jobLease("lease-token")
+        .iteration(3)
+        .metrics(new AgentHistoryMetrics().inputTokens(100L).outputTokens(50L).durationMs(200L))
+        .execute();
+
+    // then
+    final AgentInstanceHistoryItemRequest body =
+        gatewayService.getLastRequest(AgentInstanceHistoryItemRequest.class);
+    assertThat(body.getJobLease()).isEqualTo("lease-token");
+    assertThat(body.getIteration()).isEqualTo(3);
+    assertThat(body.getMetrics().getInputTokens()).isEqualTo(100L);
+    assertThat(body.getMetrics().getOutputTokens()).isEqualTo(50L);
+    assertThat(body.getMetrics().getDurationMs()).isEqualTo(200L);
+  }
+
+  @Test
+  void shouldParseHistoryItemKeyFromResponse() {
+    // given
+    gatewayService.onCreateAgentHistoryItemRequest(
+        AGENT_INSTANCE_KEY,
+        new AgentInstanceHistoryItemCreationResult().historyItemKey("9876543210"));
+
+    // when
+    final CreateAgentHistoryItemResponse response =
+        client
+            .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+            .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+            .jobKey(JOB_KEY)
+            .role(AgentHistoryRole.USER)
+            .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+            .producedAt(PRODUCED_AT)
+            .execute();
+
+    // then
+    assertThat(response.getHistoryItemKey()).isEqualTo(9876543210L);
+  }
+
+  // ── Argument validation: agentInstanceKey ────────────────────────────────
+
+  @ParameterizedTest(name = "agentInstanceKey={0} should be rejected")
+  @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+  void shouldRejectNonPositiveAgentInstanceKey(final long invalidKey) {
+    assertThatThrownBy(() -> client.newCreateAgentHistoryItemCommand(invalidKey))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("agentInstanceKey must be greater than 0");
+  }
+
+  // ── Argument validation: elementInstanceKey ───────────────────────────────
+
+  @ParameterizedTest(name = "elementInstanceKey={0} should be rejected")
+  @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+  void shouldRejectNonPositiveElementInstanceKey(final long invalidKey) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(invalidKey))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("elementInstanceKey must be greater than 0");
+  }
+
+  // ── Argument validation: jobKey ───────────────────────────────────────────
+
+  @ParameterizedTest(name = "jobKey={0} should be rejected")
+  @ValueSource(longs = {0L, -1L, Long.MIN_VALUE})
+  void shouldRejectNonPositiveJobKey(final long invalidKey) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(invalidKey))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("jobKey must be greater than 0");
+  }
+
+  // ── Argument validation: required fields ─────────────────────────────────
+
+  @Test
+  void shouldRejectNullRole() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .role(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectNullContent() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .role(AgentHistoryRole.USER)
+                    .content(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectNullProducedAt() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .role(AgentHistoryRole.USER)
+                    .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+                    .producedAt(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  // ── Argument validation: jobLease (optional, but non-blank when set) ──────
+
+  @ParameterizedTest(name = "jobLease=''{0}'' should be rejected")
+  @ValueSource(strings = {"", " "})
+  void shouldRejectBlankJobLease(final String jobLease) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .role(AgentHistoryRole.USER)
+                    .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+                    .producedAt(PRODUCED_AT)
+                    .jobLease(jobLease))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  // ── Argument validation: content (empty list) ─────────────────────────────
+
+  @Test
+  void shouldRejectEmptyContentList() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .role(AgentHistoryRole.USER)
+                    .content(Collections.emptyList()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("content must not be empty");
+  }
+
+  // ── Argument validation: iteration ───────────────────────────────────────
+
+  @ParameterizedTest(name = "iteration={0} should be rejected")
+  @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
+  void shouldRejectNonPositiveIteration(final int iteration) {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .role(AgentHistoryRole.USER)
+                    .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+                    .producedAt(PRODUCED_AT)
+                    .iteration(iteration))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("iteration must be greater than 0");
+  }
+
+  // ── Argument validation: content factory null guards ─────────────────────
+
+  @Test
+  void shouldRejectNullTextArg() {
+    assertThatThrownBy(() -> AgentHistoryContent.text(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("text must not be null");
+  }
+
+  @Test
+  void shouldRejectNullObjectArg() {
+    assertThatThrownBy(() -> AgentHistoryContent.object(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("object must not be null");
+  }
+
+  @Test
+  void shouldRejectNullDocumentReferenceArg() {
+    assertThatThrownBy(() -> AgentHistoryContent.document(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("documentReference must not be null");
+  }
+
+  // ── Argument validation: metrics (all fields required) ───────────────────
+
+  @Test
+  void shouldRejectPartialMetrics() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .role(AgentHistoryRole.USER)
+                    .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+                    .producedAt(PRODUCED_AT)
+                    .metrics(new AgentHistoryMetrics().inputTokens(100L).outputTokens(50L)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("metrics requires all fields");
+  }
+
+  // ── Argument validation: toolCalls ───────────────────────────────────────
+
+  @Test
+  void shouldRejectNullToolCallEntry() {
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+                    .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+                    .jobKey(JOB_KEY)
+                    .role(AgentHistoryRole.USER)
+                    .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+                    .producedAt(PRODUCED_AT)
+                    .toolCalls(Collections.singletonList(null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("toolCalls must not contain null elements");
+  }
+
+  // ── Happy-path: document content ─────────────────────────────────────────
+
+  @Test
+  void shouldSendDocumentContentInRequestBody() {
+    // given
+    gatewayService.onCreateAgentHistoryItemRequest(
+        AGENT_INSTANCE_KEY, new AgentInstanceHistoryItemCreationResult().historyItemKey("3"));
+    final DocumentReferenceResponseImpl doc =
+        new DocumentReferenceResponseImpl(
+            new DocumentReference()
+                .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
+                .documentId("doc-abc")
+                .storeId("store-1"));
+
+    // when
+    client
+        .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .jobKey(JOB_KEY)
+        .role(AgentHistoryRole.USER)
+        .content(Collections.singletonList(AgentHistoryContent.document(doc)))
+        .producedAt(PRODUCED_AT)
+        .execute();
+
+    // then
+    final AgentInstanceHistoryItemRequest body =
+        gatewayService.getLastRequest(AgentInstanceHistoryItemRequest.class);
+    assertThat(body.getContent()).hasSize(1);
+    assertThat(body.getContent().get(0)).isInstanceOf(AgentInstanceDocumentContent.class);
+    final AgentInstanceDocumentContent docContent =
+        (AgentInstanceDocumentContent) body.getContent().get(0);
+    assertThat(docContent.getDocumentReference().getCamundaDocumentType())
+        .isEqualTo(CamundaDocumentTypeEnum.CAMUNDA);
+    assertThat(docContent.getDocumentReference().getDocumentId()).isEqualTo("doc-abc");
+    assertThat(docContent.getDocumentReference().getStoreId()).isEqualTo("store-1");
+    assertThat(docContent.getDocumentReference().getMetadata()).isNull();
+  }
+
+  @Test
+  void shouldSendDocumentContentWithMetadataInRequestBody() {
+    // given
+    gatewayService.onCreateAgentHistoryItemRequest(
+        AGENT_INSTANCE_KEY, new AgentInstanceHistoryItemCreationResult().historyItemKey("4"));
+    final DocumentMetadataResponse meta =
+        new DocumentMetadataResponse()
+            .fileName("report.pdf")
+            .contentType("application/pdf")
+            .size(1024L)
+            .expiresAt(PRODUCED_AT.toString())
+            .processDefinitionId("proc-1")
+            .processInstanceKey("42");
+    final DocumentReferenceResponseImpl doc =
+        new DocumentReferenceResponseImpl(
+            new DocumentReference()
+                .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
+                .documentId("doc-xyz")
+                .storeId("store-2")
+                .contentHash("sha256:abc")
+                .metadata(meta));
+
+    // when
+    client
+        .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
+        .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .jobKey(JOB_KEY)
+        .role(AgentHistoryRole.USER)
+        .content(Collections.singletonList(AgentHistoryContent.document(doc)))
+        .producedAt(PRODUCED_AT)
+        .execute();
+
+    // then
+    final AgentInstanceHistoryItemRequest body =
+        gatewayService.getLastRequest(AgentInstanceHistoryItemRequest.class);
+    final AgentInstanceDocumentContent docContent =
+        (AgentInstanceDocumentContent) body.getContent().get(0);
+    assertThat(docContent.getDocumentReference().getCamundaDocumentType())
+        .isEqualTo(CamundaDocumentTypeEnum.CAMUNDA);
+    assertThat(docContent.getDocumentReference().getDocumentId()).isEqualTo("doc-xyz");
+    assertThat(docContent.getDocumentReference().getStoreId()).isEqualTo("store-2");
+    assertThat(docContent.getDocumentReference().getContentHash()).isEqualTo("sha256:abc");
+    final DocumentMetadataResponse mappedMeta = docContent.getDocumentReference().getMetadata();
+    assertThat(mappedMeta).isNotNull();
+    assertThat(mappedMeta.getFileName()).isEqualTo("report.pdf");
+    assertThat(mappedMeta.getContentType()).isEqualTo("application/pdf");
+    assertThat(mappedMeta.getSize()).isEqualTo(1024L);
+    assertThat(mappedMeta.getExpiresAt()).isEqualTo(PRODUCED_AT.toString());
+    assertThat(mappedMeta.getProcessDefinitionId()).isEqualTo("proc-1");
+    assertThat(mappedMeta.getProcessInstanceKey()).isEqualTo("42");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -23,6 +23,8 @@ public class RestGatewayPaths {
   private static final String URL_AUTHORIZATIONS = REST_API_PATH + "/authorizations";
   private static final String URL_AGENT_INSTANCES = REST_API_PATH + "/agent-instances";
   private static final String URL_AGENT_INSTANCE = REST_API_PATH + "/agent-instances/%s";
+  private static final String URL_AGENT_HISTORY_ITEM =
+      REST_API_PATH + "/agent-instances/%s/history";
   private static final String URL_AGENT_INSTANCES_SEARCH =
       REST_API_PATH + "/agent-instances/search";
   private static final String URL_BATCH_OPERATION = REST_API_PATH + "/batch-operations/%s";
@@ -502,6 +504,10 @@ public class RestGatewayPaths {
 
   public static String getAgentInstanceUrl(final long agentInstanceKey) {
     return String.format(URL_AGENT_INSTANCE, agentInstanceKey);
+  }
+
+  public static String getAgentHistoryItemUrl(final long agentInstanceKey) {
+    return String.format(URL_AGENT_HISTORY_ITEM, agentInstanceKey);
   }
 
   public static String getAgentInstancesSearchUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.protocol.rest.AgentInstanceCreationResult;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemCreationResult;
 import io.camunda.client.protocol.rest.AgentInstanceResult;
 import io.camunda.client.protocol.rest.AgentInstanceSearchQueryResult;
 import io.camunda.client.protocol.rest.AuditLogResult;
@@ -370,6 +371,11 @@ public class RestGatewayService {
 
   public void onCreateAgentInstanceRequest(final AgentInstanceCreationResult response) {
     registerPost(RestGatewayPaths.getAgentInstancesUrl(), response);
+  }
+
+  public void onCreateAgentHistoryItemRequest(
+      final long agentInstanceKey, final AgentInstanceHistoryItemCreationResult response) {
+    registerPost(RestGatewayPaths.getAgentHistoryItemUrl(agentInstanceKey), response);
   }
 
   public void onUpdateAgentInstanceRequest(final long agentInstanceKey) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -18,6 +18,7 @@ import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static io.camunda.it.util.TestHelper.waitForJobs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,6 +29,7 @@ import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHis
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.client.api.search.response.Job;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
@@ -105,18 +107,22 @@ class AgentInstanceAuthorizationIT {
   private static long agentInstanceKey3;
   private static long elementInstanceKey1;
   private static long elementInstanceKey3;
+  private static long jobKey1;
+  private static long jobKey3;
 
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
     final var result1 = createAgentInstance(adminClient, PROCESS_ID_1);
     agentInstanceKey1 = result1.agentInstanceKey();
     elementInstanceKey1 = result1.elementInstanceKey();
+    jobKey1 = result1.jobKey();
 
     agentInstanceKey2 = createAgentInstance(adminClient, PROCESS_ID_2).agentInstanceKey();
     final var result3 = createAgentInstance(adminClient, PROCESS_ID_3);
 
     agentInstanceKey3 = result3.agentInstanceKey();
     elementInstanceKey3 = result3.elementInstanceKey();
+    jobKey3 = result3.jobKey();
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey1);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey2);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey3);
@@ -285,7 +291,7 @@ class AgentInstanceAuthorizationIT {
             camundaClient
                 .newCreateAgentHistoryItemCommand(agentInstanceKey1)
                 .elementInstanceKey(elementInstanceKey1)
-                .jobKey(elementInstanceKey1)
+                .jobKey(jobKey1)
                 .role(AgentHistoryRole.USER)
                 .content(List.of(AgentHistoryContent.text("hello")))
                 .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
@@ -308,7 +314,7 @@ class AgentInstanceAuthorizationIT {
                 camundaClient
                     .newCreateAgentHistoryItemCommand(agentInstanceKey3)
                     .elementInstanceKey(elementInstanceKey3)
-                    .jobKey(elementInstanceKey3)
+                    .jobKey(jobKey3)
                     .role(AgentHistoryRole.USER)
                     .content(List.of(AgentHistoryContent.text("hello")))
                     .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
@@ -356,8 +362,19 @@ class AgentInstanceAuthorizationIT {
             .execute()
             .getAgentInstanceKey();
 
-    return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey);
+    final long jobKey =
+        waitForJobs(adminClient, List.of(processInstanceKey)).stream()
+            .filter(j -> JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX.equals(j.getType()))
+            .findFirst()
+            .map(Job::getJobKey)
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        "No agent job found for process instance " + processInstanceKey));
+
+    return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey, jobKey);
   }
 
-  private record AgentInstanceCreationResult(long agentInstanceKey, long elementInstanceKey) {}
+  private record AgentInstanceCreationResult(
+      long agentInstanceKey, long elementInstanceKey, long jobKey) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -20,9 +20,12 @@ import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.AgentInstance;
 import io.camunda.qa.util.auth.Authenticated;
@@ -34,6 +37,7 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.OffsetDateTime;
 import java.util.List;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeAll;
@@ -268,6 +272,49 @@ class AgentInstanceAuthorizationIT {
                     .newUpdateAgentInstanceCommand(agentInstanceKey3)
                     .elementInstanceKey(elementInstanceKey3)
                     .execute());
+  }
+
+  // ── createHistoryItem ─────────────────────────────────────────────────────
+
+  @Test
+  void createHistoryItemShouldReturn403WhenUnauthorized(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given — user1 has READ_PROCESS_INSTANCE on PROCESS_ID_1 but not UPDATE_PROCESS_INSTANCE
+    final ThrowingCallable execute =
+        () ->
+            camundaClient
+                .newCreateAgentHistoryItemCommand(agentInstanceKey1)
+                .elementInstanceKey(elementInstanceKey1)
+                .jobKey(elementInstanceKey1)
+                .role(AgentHistoryRole.USER)
+                .content(List.of(AgentHistoryContent.text("hello")))
+                .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
+                .execute();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(execute).actual();
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail()).contains("'UPDATE_PROCESS_INSTANCE'");
+  }
+
+  @Test
+  void createHistoryItemShouldPassAuthorizationForAuthorizedUser(
+      @Authenticated(USER3) final CamundaClient camundaClient) {
+    // given — user3 has UPDATE_PROCESS_INSTANCE on PROCESS_ID_3; there is no active job, so the
+    // engine rejects with 404 after authorization, not 403
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newCreateAgentHistoryItemCommand(agentInstanceKey3)
+                    .elementInstanceKey(elementInstanceKey3)
+                    .jobKey(elementInstanceKey3)
+                    .role(AgentHistoryRole.USER)
+                    .content(List.of(AgentHistoryContent.text("hello")))
+                    .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
+                    .execute())
+        .isInstanceOf(ProblemException.class)
+        .satisfies(ex -> assertThat(((ProblemException) ex).code()).isNotEqualTo(403));
   }
 
   // ── helpers ───────────────────────────────────────────────────────────────

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -10,6 +10,7 @@ package io.camunda.it.tenancy;
 import static io.camunda.it.util.TestHelper.deployProcessForTenantAndWaitForIt;
 import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static io.camunda.it.util.TestHelper.waitForJobs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -17,6 +18,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.Job;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
@@ -65,6 +67,7 @@ public class AgentInstanceTenancyIT {
   private static long agentInstanceKeyA;
   private static long agentInstanceKeyB;
   private static long elementInstanceKeyB;
+  private static long jobKeyB;
 
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
@@ -90,6 +93,7 @@ public class AgentInstanceTenancyIT {
     final var resultB = createAgentInstanceWithResult(adminClient, TENANT_B);
     agentInstanceKeyB = resultB.agentInstanceKey();
     elementInstanceKeyB = resultB.elementInstanceKey();
+    jobKeyB = resultB.jobKey();
 
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyA);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyB);
@@ -227,7 +231,7 @@ public class AgentInstanceTenancyIT {
                     camundaClient
                         .newCreateAgentHistoryItemCommand(agentInstanceKeyB)
                         .elementInstanceKey(elementInstanceKeyB)
-                        .jobKey(elementInstanceKeyB)
+                        .jobKey(jobKeyB)
                         .role(AgentHistoryRole.USER)
                         .content(List.of(AgentHistoryContent.text("hello")))
                         .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
@@ -296,8 +300,19 @@ public class AgentInstanceTenancyIT {
             .execute()
             .getAgentInstanceKey();
 
-    return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey);
+    final long jobKey =
+        waitForJobs(client, List.of(processInstanceKey)).stream()
+            .filter(j -> JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX.equals(j.getType()))
+            .findFirst()
+            .map(Job::getJobKey)
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        "No agent job found for process instance " + processInstanceKey));
+
+    return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey, jobKey);
   }
 
-  private record AgentInstanceCreationResult(long agentInstanceKey, long elementInstanceKey) {}
+  private record AgentInstanceCreationResult(
+      long agentInstanceKey, long elementInstanceKey, long jobKey) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -14,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.TestUser;
@@ -24,6 +26,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -205,6 +208,33 @@ public class AgentInstanceTenancyIT {
             .actual();
 
     // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+  }
+
+  // ── createHistoryItem ─────────────────────────────────────────────────────
+
+  @Test
+  void createHistoryItemShouldReturn404ForCrossTenantRequest(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // given — user1 belongs to TENANT_A only; agentInstanceKeyB is in TENANT_B
+    final var exception =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newCreateAgentHistoryItemCommand(agentInstanceKeyB)
+                        .elementInstanceKey(elementInstanceKeyB)
+                        .jobKey(elementInstanceKeyB)
+                        .role(AgentHistoryRole.USER)
+                        .content(List.of(AgentHistoryContent.text("hello")))
+                        .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
+                        .execute())
+            .actual();
+
+    // then — tenant boundary surfaced as 404, not 403
     assertThat(exception.getMessage()).startsWith("Failed with code 404");
     assertThat(exception.details()).isNotNull();
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentHistoryItemTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentHistoryItemTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.client.command;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
+import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public final class CreateAgentHistoryItemTest {
+
+  @TestZeebe
+  private static final TestStandaloneBroker ZEEBE =
+      new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+
+  @AutoClose CamundaClient client;
+  ZeebeResourcesHelper resourcesHelper;
+
+  @BeforeEach
+  public void init() {
+    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+  }
+
+  @Test
+  public void shouldReturnUnavailableWhenAgentInstanceKeyEncodesNonExistentPartition() {
+    // given
+    // Keys encode the target partition in their upper 13 bits; a key for a non-existent partition
+    // yields 503 UNAVAILABLE (PartitionNotFoundException).
+    final long agentInstanceKey = Protocol.encodePartitionId(999, 1);
+
+    // when
+    final var responseFuture =
+        client
+            .newCreateAgentHistoryItemCommand(agentInstanceKey)
+            .elementInstanceKey(Protocol.encodePartitionId(999, 2))
+            .jobKey(Protocol.encodePartitionId(999, 3))
+            .role(AgentHistoryRole.USER)
+            .content(List.of(AgentHistoryContent.text("hello")))
+            .producedAt(OffsetDateTime.now())
+            .send();
+
+    // then
+    assertThatThrownBy(responseFuture::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAVAILABLE")
+        .hasMessageContaining("status: 503")
+        .hasMessageContaining("Expected to handle request, but request could not be delivered");
+  }
+
+  @Test
+  public void shouldReturnNotFoundWhenAgentInstanceDoesNotExistOnExistingPartition() {
+    // given
+    final int partition = resourcesHelper.getPartitions().getFirst();
+    final long nonExistingKey = Protocol.encodePartitionId(partition, 2);
+
+    // when
+    final var responseFuture =
+        client
+            .newCreateAgentHistoryItemCommand(nonExistingKey)
+            .elementInstanceKey(Protocol.encodePartitionId(partition, 3))
+            .jobKey(Protocol.encodePartitionId(partition, 4))
+            .role(AgentHistoryRole.USER)
+            .content(List.of(AgentHistoryContent.text("hello")))
+            .producedAt(OffsetDateTime.now())
+            .send();
+
+    // then
+    assertThatThrownBy(responseFuture::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: NOT_FOUND")
+        .hasMessageContaining("status: 404")
+        .hasMessageContaining(
+            "Expected to create agent history entry for agent instance with key '%d', but no such agent instance was found."
+                .formatted(nonExistingKey));
+  }
+}


### PR DESCRIPTION
## Description

### Summary

Adds `CamundaClient#newCreateAgentHistoryItemCommand(long agentInstanceKey)` to the Java client. Part of issue #51522.

This PR is stacked on top of #55234 (which implements the REST endpoint).

### What this PR does

- **`CreateAgentHistoryItemCommandStep1`** — step-builder interface that enforces required fields at compile time: `elementInstanceKey → jobKey → role → content → producedAt`. Optional fields (`jobLease`, `iteration`, `toolCalls`, `metrics`) are exposed on the final step. `jobLease` is optional pending #55033.
- **`CreateAgentHistoryItemCommandImpl`** — implementation; routes `POST /v2/agent-instances/{agentInstanceKey}/history`; validates all required and optional arguments.
- **`CreateAgentHistoryItemResponse` / `CreateAgentHistoryItemResponseImpl`** — response type returning `historyItemKey`.
- **`CamundaClient` / `CamundaClientImpl`** — wires `newCreateAgentHistoryItemCommand(long)`.
- **Tests** — unit tests (`CreateAgentHistoryItemCommandTest`), integration tests (`CreateAgentHistoryItemTest`), and additions to `AgentInstanceAuthorizationIT` and `AgentInstanceTenancyIT`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55032