### PR TITLE
test: write tasks fetching unit tests

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/user-tasks.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/user-tasks.ts
@@ -38,7 +38,10 @@ function createUserTask(overrides?: Partial<UserTask>): UserTask {
 	};
 }
 
-function createQueryUserTasksResponse(overrides?: {items?: UserTask[]}): QueryUserTasksResponseBody {
+function createQueryUserTasksResponse(overrides?: {
+	items?: UserTask[];
+	page?: Partial<QueryUserTasksResponseBody['page']>;
+}): QueryUserTasksResponseBody {
 	const items = overrides?.items ?? [];
 	return {
 		items,
@@ -47,6 +50,7 @@ function createQueryUserTasksResponse(overrides?: {items?: UserTask[]}): QueryUs
 			startCursor: null,
 			endCursor: null,
 			hasMoreTotalItems: false,
+			...overrides?.page,
 		},
 	};
 }

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
@@ -11,7 +11,7 @@ import {createEndpointMock} from './mock-endpoint';
 
 const mockQueryUserTasksEndpoint = createEndpointMock({
 	endpoint: endpoints.queryUserTasks.getUrl(),
-	method: endpoints.queryUserTasks.method,
+	method: endpoints.queryUserTasks.method as 'POST',
 });
 
 const mockGetProcessDefinitionInstanceStatisticsEndpoint = createEndpointMock({

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/AssigneeTag.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/AssigneeTag.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render} from 'vitest-browser-react';
+import {it} from '#/vitest-modules/test-extend';
+import {describe, expect} from 'vitest';
+import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
+import {AssigneeTag} from './AssigneeTag';
+
+const currentUser = createCurrentUser({username: 'demo'});
+
+describe('<AssigneeTag />', () => {
+	it('should display "Unassigned" ', async () => {
+		const screen = await render(<AssigneeTag currentUser={currentUser} assignee={null} />);
+
+		await expect.element(screen.getByText('Unassigned')).toBeVisible();
+
+		await screen.rerender(<AssigneeTag currentUser={currentUser} assignee={undefined} />);
+
+		await expect.element(screen.getByText('Unassigned')).toBeVisible();
+	});
+
+	it('should display "Me"', async () => {
+		const screen = await render(<AssigneeTag currentUser={currentUser} assignee="demo" isShortFormat />);
+
+		await expect.element(screen.getByText('Me')).toBeVisible();
+	});
+
+	it('should display "Assigned to me"', async () => {
+		const screen = await render(<AssigneeTag currentUser={currentUser} assignee="demo" isShortFormat={false} />);
+
+		await expect.element(screen.getByText('Assigned to me')).toBeVisible();
+	});
+
+	it('should display the assignee username', async () => {
+		const screen = await render(<AssigneeTag currentUser={currentUser} assignee="john.doe" isShortFormat />);
+
+		await expect.element(screen.getByText('john.doe')).toBeVisible();
+	});
+
+	it('should display "Assigned to john.doe"', async () => {
+		const screen = await render(<AssigneeTag currentUser={currentUser} assignee="john.doe" isShortFormat={false} />);
+
+		await expect.element(screen.getByText('Assigned to john.doe')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/AvailableTasks.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/AvailableTasks.test.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {it} from '#/vitest-modules/test-extend';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
+import {describe, expect, vi} from 'vitest';
+import {userEvent} from 'vitest/browser';
+import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
+import {AvailableTasks} from './AvailableTasks';
+import {createUserTask} from '#/shared-test-modules/api-mocks/user-tasks';
+
+const currentUser = createCurrentUser({username: 'demo'});
+
+const noop = vi.fn().mockResolvedValue([]);
+
+function createTasks(count: number) {
+	return Array.from({length: count}, (_, i) => createUserTask({userTaskKey: String(i), name: `Task ${i}`}));
+}
+
+describe('<AvailableTasks />', () => {
+	it('should render the list of tasks', async () => {
+		const tasks = [
+			createUserTask({userTaskKey: '1', name: 'First Task'}),
+			createUserTask({userTaskKey: '2', name: 'Second Task'}),
+		];
+
+		const screen = await renderWithRouter(
+			() => (
+				<AvailableTasks
+					tasks={tasks}
+					currentUser={currentUser}
+					hasNextPage={false}
+					hasPreviousPage={false}
+					onScrollDown={noop}
+					onScrollUp={noop}
+				/>
+			),
+			{path: '/tasklist/$id', initialEntry: '/tasklist/1'},
+		);
+
+		await expect.element(screen.getByText('First Task')).toBeVisible();
+		await expect.element(screen.getByText('Second Task')).toBeVisible();
+	});
+
+	it('should render the empty state', async () => {
+		const screen = await renderWithRouter(
+			() => (
+				<AvailableTasks
+					tasks={[]}
+					currentUser={currentUser}
+					hasNextPage={false}
+					hasPreviousPage={false}
+					onScrollDown={noop}
+					onScrollUp={noop}
+				/>
+			),
+			{path: '/', initialEntry: '/'},
+		);
+
+		await expect.element(screen.getByText('No tasks found')).toBeVisible();
+	});
+
+	it('should call onScrollDown', async () => {
+		const tasks = createTasks(20);
+		const onScrollDown = vi.fn().mockResolvedValue([]);
+		const onScrollUp = vi.fn().mockResolvedValue([]);
+
+		const screen = await renderWithRouter(
+			() => (
+				<div style={{height: '100px'}}>
+					<AvailableTasks
+						tasks={tasks}
+						currentUser={currentUser}
+						hasNextPage={true}
+						hasPreviousPage={false}
+						onScrollDown={onScrollDown}
+						onScrollUp={onScrollUp}
+					/>
+				</div>
+			),
+			{path: '/tasklist/$id', initialEntry: '/tasklist/1'},
+		);
+
+		await userEvent.wheel(screen.getByTestId('scrollable-list'), {delta: {y: 10000}});
+
+		expect(onScrollDown).toHaveBeenCalled();
+		expect(onScrollUp).not.toHaveBeenCalled();
+	});
+
+	it('should not call onScrollDown when there is no next page', async () => {
+		const tasks = createTasks(20);
+		const onScrollDown = vi.fn().mockResolvedValue([]);
+		const onScrollUp = vi.fn().mockResolvedValue([]);
+
+		const screen = await renderWithRouter(
+			() => (
+				<div style={{height: '100px'}}>
+					<AvailableTasks
+						tasks={tasks}
+						currentUser={currentUser}
+						hasNextPage={false}
+						hasPreviousPage={false}
+						onScrollDown={onScrollDown}
+						onScrollUp={onScrollUp}
+					/>
+				</div>
+			),
+			{path: '/tasklist/$id', initialEntry: '/tasklist/1'},
+		);
+
+		await userEvent.wheel(screen.getByTestId('scrollable-list'), {delta: {y: 10000}});
+
+		expect(onScrollDown).not.toHaveBeenCalled();
+	});
+
+	it('should call onScrollUp', async () => {
+		const tasks = createTasks(20);
+		const onScrollDown = vi.fn().mockResolvedValue([]);
+		const onScrollUp = vi.fn().mockResolvedValue([]);
+
+		const screen = await renderWithRouter(
+			() => (
+				<div style={{height: '100px'}}>
+					<AvailableTasks
+						tasks={tasks}
+						currentUser={currentUser}
+						hasNextPage={false}
+						hasPreviousPage={true}
+						onScrollDown={onScrollDown}
+						onScrollUp={onScrollUp}
+					/>
+				</div>
+			),
+			{path: '/tasklist/$id', initialEntry: '/tasklist/1'},
+		);
+
+		const scrollableList = screen.getByTestId('scrollable-list');
+
+		await userEvent.wheel(scrollableList, {delta: {y: 200}});
+		await userEvent.wheel(scrollableList, {delta: {y: -10000}});
+
+		expect(onScrollUp).toHaveBeenCalled();
+		expect(onScrollDown).not.toHaveBeenCalled();
+	});
+
+	it('should not call onScrollUp', async () => {
+		const tasks = createTasks(20);
+		const onScrollDown = vi.fn().mockResolvedValue([]);
+		const onScrollUp = vi.fn().mockResolvedValue([]);
+
+		const screen = await renderWithRouter(
+			() => (
+				<div style={{height: '100px'}}>
+					<AvailableTasks
+						tasks={tasks}
+						currentUser={currentUser}
+						hasNextPage={false}
+						hasPreviousPage={false}
+						onScrollDown={onScrollDown}
+						onScrollUp={onScrollUp}
+					/>
+				</div>
+			),
+			{path: '/tasklist/$id', initialEntry: '/tasklist/1'},
+		);
+
+		const scrollableList = screen.getByTestId('scrollable-list');
+		await userEvent.wheel(scrollableList, {delta: {y: 200}});
+		await userEvent.wheel(scrollableList, {delta: {y: -10000}});
+
+		expect(onScrollUp).not.toHaveBeenCalled();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/DateLabel.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/DateLabel.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render} from 'vitest-browser-react';
+import {userEvent} from 'vitest/browser';
+import {it} from '#/vitest-modules/test-extend';
+import {describe, expect} from 'vitest';
+import {DateLabel} from './DateLabel';
+
+const todayDate = {
+	date: new Date(2024, 0, 12, 10, 30, 0),
+	relative: {resolution: 'days' as const, text: 'Today', speech: 'today at 10:30'},
+	absolute: {text: '12 Jan 2024'},
+};
+
+const weekDate = {
+	date: new Date(2024, 0, 8, 12, 0, 0),
+	relative: {resolution: 'week' as const, text: 'Monday', speech: 'Monday'},
+	absolute: {text: '8 Jan 2024'},
+};
+
+const monthsDate = {
+	date: new Date(2024, 0, 6, 12, 0, 0),
+	relative: {resolution: 'months' as const, text: '6 Jan', speech: '6th of January'},
+	absolute: {text: '6 Jan 2024'},
+};
+
+const yearsDate = {
+	date: new Date(2023, 11, 31, 12, 0, 0),
+	relative: {resolution: 'years' as const, text: '31 Dec 2023', speech: '31st of December, 2023'},
+	absolute: {text: '31 Dec 2023'},
+};
+
+describe('<DateLabel />', () => {
+	it('should render the relative date text', async () => {
+		const screen = await render(<DateLabel date={monthsDate} relativeLabel="Created" absoluteLabel="Created on" />);
+
+		await expect.element(screen.getByText('6 Jan', {exact: true})).toBeVisible();
+	});
+
+	it.for([
+		{name: 'week', fixture: weekDate, expectedTitle: 'Created on Monday'},
+		{name: 'months', fixture: monthsDate, expectedTitle: 'Created on 6th of January'},
+		{name: 'years', fixture: yearsDate, expectedTitle: 'Created on 31st of December, 2023'},
+	])('should use absoluteLabel + speech as the title for "$name" resolution', async ({fixture, expectedTitle}) => {
+		const screen = await render(<DateLabel date={fixture} relativeLabel="Created" absoluteLabel="Created on" />);
+
+		await expect.element(screen.getByTitle(expectedTitle)).toBeVisible();
+	});
+
+	it('should use relativeLabel + speech as the title for non-week/month/year resolutions', async () => {
+		const screen = await render(<DateLabel date={todayDate} relativeLabel="Created" absoluteLabel="Created on" />);
+
+		await expect.element(screen.getByTitle('Created today at 10:30')).toBeVisible();
+	});
+
+	it('should show popover with absolute date on hover and hide it on unhover', async () => {
+		const screen = await render(<DateLabel date={monthsDate} relativeLabel="Created" absoluteLabel="Created on" />);
+
+		await expect.element(screen.getByText('Created on')).not.toBeVisible();
+		await expect.element(screen.getByText('6 Jan 2024')).not.toBeVisible();
+
+		await userEvent.hover(screen.getByTitle('Created on 6th of January'));
+
+		await expect.element(screen.getByText('Created on')).toBeVisible();
+		await expect.element(screen.getByText('6 Jan 2024')).toBeVisible();
+
+		await userEvent.unhover(screen.getByTitle('Created on 6th of January'));
+
+		await expect.element(screen.getByText('Created on')).not.toBeVisible();
+		await expect.element(screen.getByText('6 Jan 2024')).not.toBeVisible();
+	});
+
+	it('should render an icon alongside the relative date text when provided', async () => {
+		const screen = await render(
+			<DateLabel
+				date={monthsDate}
+				relativeLabel="Created"
+				absoluteLabel="Created on"
+				icon={<span data-testid="calendar-icon">icon</span>}
+			/>,
+		);
+
+		await expect.element(screen.getByTestId('calendar-icon')).toBeVisible();
+		await expect.element(screen.getByTitle('Created on 6th of January')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/LabelWithPopover.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/LabelWithPopover.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render} from 'vitest-browser-react';
+import {userEvent} from 'vitest/browser';
+import {it} from '#/vitest-modules/test-extend';
+import {describe, expect} from 'vitest';
+import {LabelWithPopover} from './LabelWithPopover';
+
+describe('<LabelWithPopover />', () => {
+	it('should render label', async () => {
+		const screen = await render(
+			<LabelWithPopover title="hover title" popoverContent={<span>Popover content</span>} align="top-start">
+				Label text
+			</LabelWithPopover>,
+		);
+
+		await expect.element(screen.getByText('Label text')).toBeVisible();
+	});
+
+	it('should have the title attribute on the label', async () => {
+		const screen = await render(
+			<LabelWithPopover title="hover title" popoverContent={<span>Details</span>} align="top-start">
+				Label text
+			</LabelWithPopover>,
+		);
+
+		await expect.element(screen.getByTitle('hover title')).toBeVisible();
+	});
+
+	it('should show popover content on mouse enter', async () => {
+		const screen = await render(
+			<LabelWithPopover title="hover title" popoverContent={<span>Popover details</span>} align="top-start">
+				Label text
+			</LabelWithPopover>,
+		);
+
+		await userEvent.hover(screen.getByTitle('hover title'));
+
+		await expect.element(screen.getByText('Popover details')).toBeVisible();
+	});
+
+	it('should hide popover content on mouse leave', async () => {
+		const screen = await render(
+			<LabelWithPopover title="hover title" popoverContent={<span>Popover details</span>} align="top-start">
+				Label text
+			</LabelWithPopover>,
+		);
+
+		await userEvent.hover(screen.getByTitle('hover title'));
+		await expect.element(screen.getByText('Popover details')).toBeVisible();
+
+		await userEvent.unhover(screen.getByTitle('hover title'));
+
+		await expect.element(screen.getByText('Popover details')).not.toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/PriorityLabel.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/PriorityLabel.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render} from 'vitest-browser-react';
+import {userEvent} from 'vitest/browser';
+import {it} from '#/vitest-modules/test-extend';
+import {describe, expect} from 'vitest';
+import {PriorityLabel} from './PriorityLabel';
+
+describe('<PriorityLabel />', () => {
+	it('should render "Critical" short label for priority > 75', async () => {
+		const screen = await render(<PriorityLabel priority={80} />);
+
+		await expect.element(screen.getByText('Critical', {exact: true})).toBeVisible();
+	});
+
+	it('should render "High" short label for priority 51-75', async () => {
+		const screen = await render(<PriorityLabel priority={60} />);
+
+		await expect.element(screen.getByText('High', {exact: true})).toBeVisible();
+	});
+
+	it('should render "Medium" short label for priority 26-50', async () => {
+		const screen = await render(<PriorityLabel priority={30} />);
+
+		await expect.element(screen.getByText('Medium', {exact: true})).toBeVisible();
+	});
+
+	it('should render "Low" short label for priority 0-25', async () => {
+		const screen = await render(<PriorityLabel priority={10} />);
+
+		await expect.element(screen.getByText('Low', {exact: true})).toBeVisible();
+	});
+
+	it('should show "Priority: Critical" as the title attribute for critical priority', async () => {
+		const screen = await render(<PriorityLabel priority={80} />);
+
+		await expect.element(screen.getByTitle('Priority: Critical')).toBeVisible();
+	});
+
+	it('should show the long "Priority: High" label as popover content on hover', async () => {
+		const screen = await render(<PriorityLabel priority={60} />);
+
+		await userEvent.hover(screen.getByTitle('Priority: High'));
+
+		await expect.element(screen.getByText('Priority: High')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/Task.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/Task.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {it} from '#/vitest-modules/test-extend';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
+import {describe, expect} from 'vitest';
+import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
+import {Task} from './Task';
+
+const currentUser = createCurrentUser({username: 'demo'});
+
+const baseProps = {
+	taskId: 'task-42',
+	displayName: 'Review invoice',
+	processDisplayName: 'Invoice process',
+	assignee: null,
+	creationDate: '2024-01-06T12:00:00.000Z',
+	followUpDate: null,
+	dueDate: null,
+	completionDate: null,
+	priority: 50,
+	currentUser,
+};
+
+describe('<Task />', () => {
+	it('should render the task display name and process name', async () => {
+		const screen = await renderWithRouter(() => <Task {...baseProps} />, {
+			path: '/tasklist/$id',
+			initialEntry: '/tasklist/other-task',
+		});
+
+		await expect.element(screen.getByText('Review invoice')).toBeVisible();
+		await expect.element(screen.getByText('Invoice process')).toBeVisible();
+	});
+
+	it('should render a link with an accessible label for an unassigned task', async () => {
+		const screen = await renderWithRouter(() => <Task {...baseProps} assignee={null} />, {
+			path: '/tasklist/$id',
+			initialEntry: '/tasklist/other-task',
+		});
+
+		await expect.element(screen.getByRole('link', {name: 'Unassigned task: Review invoice'})).toBeVisible();
+	});
+
+	it('should render an "assigned to me" label', async () => {
+		const screen = await renderWithRouter(() => <Task {...baseProps} assignee={currentUser.username} />, {
+			path: '/tasklist/$id',
+			initialEntry: '/tasklist/other-task',
+		});
+
+		await expect.element(screen.getByRole('link', {name: 'Task assigned to me: Review invoice'})).toBeVisible();
+	});
+
+	it('should render an "assigned task" label', async () => {
+		const screen = await renderWithRouter(() => <Task {...baseProps} assignee="john.doe" />, {
+			path: '/tasklist/$id',
+			initialEntry: '/tasklist/other-task',
+		});
+
+		await expect.element(screen.getByRole('link', {name: 'Assigned task: Review invoice'})).toBeVisible();
+	});
+
+	it('should render the priority label', async () => {
+		const screen = await renderWithRouter(() => <Task {...baseProps} priority={80} />, {
+			path: '/tasklist/$id',
+			initialEntry: '/tasklist/other-task',
+		});
+
+		await expect.element(screen.getByText('Critical', {exact: true})).toBeVisible();
+	});
+
+	it('should not render the priority label', async () => {
+		const screen = await renderWithRouter(() => <Task {...baseProps} priority={null} />, {
+			path: '/tasklist/$id',
+			initialEntry: '/tasklist/other-task',
+		});
+
+		await expect.element(screen.getByText('Critical')).not.toBeInTheDocument();
+		await expect.element(screen.getByText('High')).not.toBeInTheDocument();
+		await expect.element(screen.getByText('Medium')).not.toBeInTheDocument();
+		await expect.element(screen.getByText('Low')).not.toBeInTheDocument();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/getNavLinkLabel.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/getNavLinkLabel.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect} from 'vitest';
+import {it} from '#/vitest-modules/test-extend';
+import {getNavLinkLabel} from './getNavLinkLabel';
+
+describe('getNavLinkLabel', () => {
+	it('should return the "assigned to me" label', () => {
+		const result = getNavLinkLabel({
+			displayName: 'Review invoice',
+			assigneeId: 'demo',
+			currentUsername: 'demo',
+		});
+
+		expect(result).toBe('Task assigned to me: Review invoice');
+	});
+
+	it('should return the "assigned task" label', () => {
+		const result = getNavLinkLabel({
+			displayName: 'Review invoice',
+			assigneeId: 'other-user',
+			currentUsername: 'demo',
+		});
+
+		expect(result).toBe('Assigned task: Review invoice');
+	});
+
+	it('should return the "unassigned task" label for a null assignee', () => {
+		const result = getNavLinkLabel({
+			displayName: 'Review invoice',
+			assigneeId: null,
+			currentUsername: 'demo',
+		});
+
+		expect(result).toBe('Unassigned task: Review invoice');
+	});
+
+	it('should return the "unassigned task" label for an undefined assignee', () => {
+		const result = getNavLinkLabel({
+			displayName: 'Review invoice',
+			assigneeId: undefined,
+			currentUsername: 'demo',
+		});
+
+		expect(result).toBe('Unassigned task: Review invoice');
+	});
+
+	it('should include the task display name in every label variant', () => {
+		const name = 'Approve purchase order';
+
+		expect(getNavLinkLabel({displayName: name, assigneeId: 'demo', currentUsername: 'demo'})).toContain(name);
+		expect(getNavLinkLabel({displayName: name, assigneeId: 'other', currentUsername: 'demo'})).toContain(name);
+		expect(getNavLinkLabel({displayName: name, assigneeId: null, currentUsername: 'demo'})).toContain(name);
+		expect(getNavLinkLabel({displayName: name, assigneeId: undefined, currentUsername: 'demo'})).toContain(name);
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/getPriorityLabel.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/getPriorityLabel.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect} from 'vitest';
+import {it} from '#/vitest-modules/test-extend';
+import {getPriorityLabel} from './getPriorityLabel';
+
+describe('getPriorityLabel', () => {
+	it('should return key "critical" for priority > 75', () => {
+		expect(getPriorityLabel(100).key).toBe('critical');
+		expect(getPriorityLabel(80).key).toBe('critical');
+		expect(getPriorityLabel(76).key).toBe('critical');
+	});
+
+	it('should return key "high" for priority 51-75', () => {
+		expect(getPriorityLabel(75).key).toBe('high');
+		expect(getPriorityLabel(60).key).toBe('high');
+		expect(getPriorityLabel(51).key).toBe('high');
+	});
+
+	it('should return key "medium" for priority 26-50', () => {
+		expect(getPriorityLabel(50).key).toBe('medium');
+		expect(getPriorityLabel(30).key).toBe('medium');
+		expect(getPriorityLabel(26).key).toBe('medium');
+	});
+
+	it('should return key "low" for priority 0-25', () => {
+		expect(getPriorityLabel(25).key).toBe('low');
+		expect(getPriorityLabel(20).key).toBe('low');
+		expect(getPriorityLabel(0).key).toBe('low');
+	});
+
+	it('should return the correct short label for each bucket', () => {
+		expect(getPriorityLabel(80).short).toBe('Critical');
+		expect(getPriorityLabel(60).short).toBe('High');
+		expect(getPriorityLabel(30).short).toBe('Medium');
+		expect(getPriorityLabel(20).short).toBe('Low');
+	});
+
+	it('should return the correct long label for each bucket', () => {
+		expect(getPriorityLabel(80).long).toBe('Priority: Critical');
+		expect(getPriorityLabel(60).long).toBe('Priority: High');
+		expect(getPriorityLabel(30).long).toBe('Priority: Medium');
+		expect(getPriorityLabel(20).long).toBe('Priority: Low');
+	});
+
+	it('should handle exact boundary values correctly', () => {
+		expect(getPriorityLabel(75).key).toBe('high');
+		expect(getPriorityLabel(50).key).toBe('medium');
+		expect(getPriorityLabel(25).key).toBe('low');
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/getSecondaryDate.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/getSecondaryDate.test.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect, beforeEach, afterEach, vi} from 'vitest';
+import {it} from '#/vitest-modules/test-extend';
+import {getSecondaryDate} from './getSecondaryDate';
+
+const FAKE_NOW = new Date(2024, 0, 10, 12, 0, 0, 0);
+
+function makeDate(date: Date) {
+	return {
+		date,
+		relative: {resolution: 'months' as const, text: '10 Jan', speech: '10th of January'},
+		absolute: {text: '10 Jan 2024'},
+	};
+}
+
+const pastDate = makeDate(new Date(2024, 0, 9, 12, 0, 0, 0));
+const futureDate = makeDate(new Date(2024, 0, 11, 12, 0, 0, 0));
+const futureDateLater = makeDate(new Date(2024, 0, 12, 12, 0, 0, 0));
+
+describe('getSecondaryDate', () => {
+	beforeEach(() => {
+		vi.useFakeTimers({toFake: ['Date']});
+		vi.setSystemTime(FAKE_NOW);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should return the completion date on "creation" sort when the task is completed', () => {
+		const result = getSecondaryDate({
+			sortBy: 'creation',
+			completionDate: pastDate,
+			dueDate: null,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({completionDate: pastDate});
+	});
+
+	it('should return the follow-up date on "creation" sort when it is before the due date and task is not overdue', () => {
+		const result = getSecondaryDate({
+			sortBy: 'creation',
+			completionDate: null,
+			dueDate: futureDateLater,
+			followUpDate: futureDate,
+		});
+
+		expect(result).toEqual({followUpDate: futureDate});
+	});
+
+	it('should return the overdue date on "creation" sort when the due date is in the past', () => {
+		const result = getSecondaryDate({
+			sortBy: 'creation',
+			completionDate: null,
+			dueDate: pastDate,
+			followUpDate: futureDate,
+		});
+
+		expect(result).toEqual({overDueDate: pastDate});
+	});
+
+	it('should return the due date on "creation" sort when the follow-up is not before the due date', () => {
+		const result = getSecondaryDate({
+			sortBy: 'creation',
+			completionDate: null,
+			dueDate: futureDate,
+			followUpDate: futureDateLater,
+		});
+
+		expect(result).toEqual({dueDate: futureDate});
+	});
+
+	it('should return the overdue date on "creation" sort when the due date is overdue and there is no follow-up', () => {
+		const result = getSecondaryDate({
+			sortBy: 'creation',
+			completionDate: null,
+			dueDate: pastDate,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({overDueDate: pastDate});
+	});
+
+	it('should return the due date on "creation" sort when the due date is in the future and no follow-up', () => {
+		const result = getSecondaryDate({
+			sortBy: 'creation',
+			completionDate: null,
+			dueDate: futureDate,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({dueDate: futureDate});
+	});
+
+	it('should return an empty object on "creation" sort when no dates are available', () => {
+		const result = getSecondaryDate({
+			sortBy: 'creation',
+			completionDate: null,
+			dueDate: null,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({});
+	});
+
+	it('should return the completion date on "completion" sort when present', () => {
+		const result = getSecondaryDate({
+			sortBy: 'completion',
+			completionDate: pastDate,
+			dueDate: futureDate,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({completionDate: pastDate});
+	});
+
+	it('should return the due date on "completion" sort when there is no completion date', () => {
+		const result = getSecondaryDate({
+			sortBy: 'completion',
+			completionDate: null,
+			dueDate: futureDate,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({dueDate: futureDate});
+	});
+
+	it('should return the follow-up date on "follow-up" sort when present', () => {
+		const result = getSecondaryDate({
+			sortBy: 'follow-up',
+			completionDate: null,
+			dueDate: futureDate,
+			followUpDate: pastDate,
+		});
+
+		expect(result).toEqual({followUpDate: pastDate});
+	});
+
+	it('should return the due date on "follow-up" sort when there is no follow-up date', () => {
+		const result = getSecondaryDate({
+			sortBy: 'follow-up',
+			completionDate: null,
+			dueDate: futureDate,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({dueDate: futureDate});
+	});
+
+	it('should return the due date on "due" sort when the due date is in the future', () => {
+		const result = getSecondaryDate({
+			sortBy: 'due',
+			completionDate: null,
+			dueDate: futureDate,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({dueDate: futureDate});
+	});
+
+	it('should return the overdue date on "due" sort when the due date is in the past', () => {
+		const result = getSecondaryDate({
+			sortBy: 'due',
+			completionDate: null,
+			dueDate: pastDate,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({overDueDate: pastDate});
+	});
+
+	it('should return the due date on "priority" sort when the due date is in the future', () => {
+		const result = getSecondaryDate({
+			sortBy: 'priority',
+			completionDate: null,
+			dueDate: futureDate,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({dueDate: futureDate});
+	});
+
+	it('should return the overdue date on "priority" sort when the due date is in the past', () => {
+		const result = getSecondaryDate({
+			sortBy: 'priority',
+			completionDate: null,
+			dueDate: pastDate,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({overDueDate: pastDate});
+	});
+
+	it('should return an empty object on "priority" sort when no dates are present', () => {
+		const result = getSecondaryDate({
+			sortBy: 'priority',
+			completionDate: null,
+			dueDate: null,
+			followUpDate: null,
+		});
+
+		expect(result).toEqual({});
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/dates/formatDateRelative.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/dates/formatDateRelative.test.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect, beforeEach, afterEach, vi} from 'vitest';
+import {it} from '#/vitest-modules/test-extend';
+import {formatISODate, formatISODateTime} from './formatDateRelative';
+
+const FAKE_NOW = new Date(2024, 0, 10, 12, 0, 0, 0);
+
+const t = (year: number, month: number, day: number, hour = 12, minute = 0) =>
+	new Date(year, month - 1, day, hour, minute, 0, 0).toISOString();
+
+describe('formatDateRelative', () => {
+	beforeEach(() => {
+		vi.useFakeTimers({toFake: ['Date']});
+		vi.setSystemTime(FAKE_NOW);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should return null for null input to formatISODate', () => {
+		expect(formatISODate(null)).toBeNull();
+	});
+
+	it('should return null for undefined input to formatISODate', () => {
+		expect(formatISODate(undefined)).toBeNull();
+	});
+
+	it('should return null for an invalid ISO string in formatISODate', () => {
+		expect(formatISODate('not-a-date')).toBeNull();
+	});
+
+	it('should format "Now"', () => {
+		const result = formatISODate(FAKE_NOW.toISOString());
+
+		expect(result?.relative.resolution).toBe('now');
+		expect(result?.relative.text).toBe('Now');
+		expect(result?.relative.speech).toBe('Now');
+	});
+
+	it('should format "1 minute ago"', () => {
+		const result = formatISODate(t(2024, 1, 10, 11, 59));
+
+		expect(result?.relative.resolution).toBe('minutes');
+		expect(result?.relative.text).toBe('1 minute ago');
+	});
+
+	it('should format "10 minutes ago"', () => {
+		const result = formatISODate(t(2024, 1, 10, 11, 50));
+
+		expect(result?.relative.resolution).toBe('minutes');
+		expect(result?.relative.text).toBe('10 minutes ago');
+	});
+
+	it('should format "In 1 minute"', () => {
+		const result = formatISODate(t(2024, 1, 10, 12, 1));
+
+		expect(result?.relative.resolution).toBe('minutes');
+		expect(result?.relative.text).toBe('In 1 minute');
+	});
+
+	it('should format "In 10 minutes"', () => {
+		const result = formatISODate(t(2024, 1, 10, 12, 10));
+
+		expect(result?.relative.resolution).toBe('minutes');
+		expect(result?.relative.text).toBe('In 10 minutes');
+	});
+
+	it('should format "Today"', () => {
+		const result = formatISODate(t(2024, 1, 10, 9, 0));
+
+		expect(result?.relative.resolution).toBe('days');
+		expect(result?.relative.text).toBe('Today');
+	});
+
+	it('should format "Tomorrow"', () => {
+		const result = formatISODate(t(2024, 1, 11, 12, 0));
+
+		expect(result?.relative.resolution).toBe('days');
+		expect(result?.relative.text).toBe('Tomorrow');
+	});
+
+	it('should format "Yesterday"', () => {
+		const result = formatISODate(t(2024, 1, 9, 12, 0));
+
+		expect(result?.relative.resolution).toBe('days');
+		expect(result?.relative.text).toBe('Yesterday');
+	});
+
+	it('should format a weekday name within the same week', () => {
+		const result = formatISODate(t(2024, 1, 8, 12, 0));
+
+		expect(result?.relative.resolution).toBe('week');
+		expect(result?.relative.text).toBe('Monday');
+		expect(result?.relative.speech).toBe('Monday');
+	});
+
+	it('should format "6 Jan" within the same year', () => {
+		const result = formatISODate(t(2024, 1, 6, 12, 0));
+
+		expect(result?.relative.resolution).toBe('months');
+		expect(result?.relative.text).toBe('6 Jan');
+		expect(result?.relative.speech).toBe('6th of January');
+	});
+
+	it('should format "31 Dec 2023" for a different year', () => {
+		const result = formatISODate(t(2023, 12, 31, 12, 0));
+
+		expect(result?.relative.resolution).toBe('years');
+		expect(result?.relative.text).toBe('31 Dec 2023');
+		expect(result?.relative.speech).toBe('31st of December, 2023');
+	});
+
+	it('should include the absolute date in day-month-year format', () => {
+		expect(formatISODate(FAKE_NOW.toISOString())?.absolute.text).toBe('10 Jan 2024');
+		expect(formatISODate(t(2024, 1, 10, 11, 59))?.absolute.text).toBe('10 Jan 2024');
+		expect(formatISODate(t(2023, 12, 31, 12, 0))?.absolute.text).toBe('31 Dec 2023');
+	});
+
+	it('should return null for null input to formatISODateTime', () => {
+		expect(formatISODateTime(null)).toBeNull();
+	});
+
+	it('should format "Now" without a time suffix', () => {
+		const result = formatISODateTime(FAKE_NOW.toISOString());
+
+		expect(result?.relative.resolution).toBe('now');
+		expect(result?.relative.text).toBe('Now');
+	});
+
+	it('should format "1 minute ago" without a time suffix', () => {
+		const result = formatISODateTime(t(2024, 1, 10, 11, 59));
+
+		expect(result?.relative.resolution).toBe('minutes');
+		expect(result?.relative.text).toBe('1 minute ago');
+	});
+
+	it('should format "Today" with a time suffix', () => {
+		const result = formatISODateTime(t(2024, 1, 10, 9, 0));
+
+		expect(result?.relative.resolution).toBe('days');
+		expect(result?.relative.text).toMatch(/^Today,/);
+		expect(result?.relative.speech).toMatch(/^Today at/);
+	});
+
+	it('should format "Tomorrow" with a time suffix', () => {
+		const result = formatISODateTime(t(2024, 1, 11, 12, 0));
+
+		expect(result?.relative.resolution).toBe('days');
+		expect(result?.relative.text).toMatch(/^Tomorrow,/);
+		expect(result?.relative.speech).toMatch(/^Tomorrow at/);
+	});
+
+	it('should format "Yesterday" with a time suffix', () => {
+		const result = formatISODateTime(t(2024, 1, 9, 12, 0));
+
+		expect(result?.relative.resolution).toBe('days');
+		expect(result?.relative.text).toMatch(/^Yesterday,/);
+		expect(result?.relative.speech).toMatch(/^Yesterday at/);
+	});
+
+	it('should format "6 Jan" with a time suffix', () => {
+		const result = formatISODateTime(t(2024, 1, 6, 12, 0));
+
+		expect(result?.relative.resolution).toBe('months');
+		expect(result?.relative.text).toMatch(/^6 Jan,/);
+		expect(result?.relative.speech).toMatch(/^6th of January at/);
+	});
+
+	it('should format "31 Dec 2023" with a time suffix', () => {
+		const result = formatISODateTime(t(2023, 12, 31, 12, 0));
+
+		expect(result?.relative.resolution).toBe('years');
+		expect(result?.relative.text).toMatch(/^31 Dec 2023,/);
+		expect(result?.relative.speech).toMatch(/^31st of December, 2023 at/);
+	});
+
+	it('should include the absolute date with a time suffix', () => {
+		const result = formatISODateTime(FAKE_NOW.toISOString());
+
+		expect(result?.absolute.text).toMatch(/^10 Jan 2024,/);
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/pages/NoTaskSelectedPage.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/pages/NoTaskSelectedPage.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render} from 'vitest-browser-react';
+import {it} from '#/vitest-modules/test-extend';
+import {describe, expect, beforeEach, afterEach} from 'vitest';
+import {storeStateLocally, clearStateLocally} from '#/shared/browser-storage/local-storage';
+import {NoTaskSelectedPage} from './NoTaskSelectedPage';
+
+describe('<NoTaskSelectedPage />', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		clearStateLocally('hasCompletedTask');
+	});
+
+	it('should show the welcome header for a new user', async () => {
+		const screen = await render(<NoTaskSelectedPage hasNoTasks={false} />);
+
+		await expect.element(screen.getByRole('heading', {name: 'Welcome to Tasklist'})).toBeVisible();
+	});
+
+	it('should show the tutorial paragraph for a new user', async () => {
+		const screen = await render(<NoTaskSelectedPage hasNoTasks={false} />);
+
+		await expect.element(screen.getByTestId('tutorial-paragraph')).toBeVisible();
+	});
+
+	it('should show the task-available prompt for a new user when there are tasks', async () => {
+		const screen = await render(<NoTaskSelectedPage hasNoTasks={false} />);
+
+		await expect.element(screen.getByText('Select a task to view its details.')).toBeVisible();
+	});
+
+	it('should not show the task-available prompt for a new user when there are no tasks', async () => {
+		const screen = await render(<NoTaskSelectedPage hasNoTasks={true} />);
+
+		await expect.element(screen.getByText('Select a task to view its details.')).not.toBeInTheDocument();
+	});
+
+	it('should show the pick-a-task prompt for a returning user', async () => {
+		storeStateLocally('hasCompletedTask', true);
+
+		const screen = await render(<NoTaskSelectedPage hasNoTasks={false} />);
+
+		await expect.element(screen.getByRole('heading', {name: 'Pick a task to work on'})).toBeVisible();
+	});
+
+	it('should not show the welcome header for a returning user', async () => {
+		storeStateLocally('hasCompletedTask', true);
+
+		const screen = await render(<NoTaskSelectedPage hasNoTasks={false} />);
+
+		await expect.element(screen.getByRole('heading', {name: 'Welcome to Tasklist'})).not.toBeInTheDocument();
+	});
+
+	it('should render nothing for a returning user when there are no tasks', async () => {
+		storeStateLocally('hasCompletedTask', true);
+
+		const screen = await render(<NoTaskSelectedPage hasNoTasks={true} />);
+
+		await expect.element(screen.getByRole('heading', {name: 'Pick a task to work on'})).not.toBeInTheDocument();
+		await expect.element(screen.getByRole('heading', {name: 'Welcome to Tasklist'})).not.toBeInTheDocument();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/tasklist-index.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/tasklist-index.test.ts
@@ -8,6 +8,7 @@
 
 import {test, expect} from '#/pw-modules/test-extend';
 import {HttpResponse} from 'msw';
+import {z} from 'zod';
 import {
 	mockCurrentUserEndpoint,
 	mockLicenseEndpoint,
@@ -17,12 +18,40 @@ import {
 import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
 import {createLicense} from '#/shared-test-modules/api-mocks/license';
 import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
-import {createQueryUserTasksResponse} from '#/shared-test-modules/api-mocks/user-tasks';
+import {createQueryUserTasksResponse, createUserTask} from '#/shared-test-modules/api-mocks/user-tasks';
+
+const currentUser = createCurrentUser();
+
+function createTasksPageRequestSchema(from: number) {
+	return z.object({
+		filter: z.object({
+			state: z.object({
+				$in: z.tuple([
+					z.literal('CREATED'),
+					z.literal('ASSIGNING'),
+					z.literal('UPDATING'),
+					z.literal('COMPLETING'),
+					z.literal('CANCELING'),
+				]),
+			}),
+		}),
+		sort: z.tuple([
+			z.object({
+				field: z.literal('creationDate'),
+				order: z.literal('desc'),
+			}),
+		]),
+		page: z.object({
+			limit: z.literal(50),
+			from: z.literal(from),
+		}),
+	});
+}
 
 test.beforeEach(({network}) => {
 	network.use(
 		mockCurrentUserEndpoint({
-			successResponse: HttpResponse.json(createCurrentUser()),
+			successResponse: HttpResponse.json(currentUser),
 		}),
 		mockSystemConfigurationEndpoint({
 			successResponse: HttpResponse.json(createSystemConfiguration({components: {active: ['tasklist']}})),
@@ -52,5 +81,94 @@ test.describe('Tasklist index page', () => {
 		await tasklistIndexPage.processesNavItem.click();
 
 		await expect(page).toHaveURL('/tasklist/processes');
+	});
+});
+
+test.describe('Tasks panel', () => {
+	test('should render tasks', async ({network, tasklistIndexPage}) => {
+		const firstPageTasks = [
+			createUserTask({userTaskKey: '1', name: 'Approve purchase order'}),
+			createUserTask({userTaskKey: '2', name: 'Review contract'}),
+		];
+
+		network.use(
+			mockQueryUserTasksEndpoint({
+				schema: createTasksPageRequestSchema(0),
+				successResponse: HttpResponse.json(createQueryUserTasksResponse({items: firstPageTasks})),
+				failureResponse: new HttpResponse(null, {status: 400}),
+			}),
+		);
+
+		await tasklistIndexPage.goto();
+
+		await expect(tasklistIndexPage.taskItem('Approve purchase order')).toBeVisible();
+		await expect(tasklistIndexPage.taskItem('Review contract')).toBeVisible();
+	});
+
+	test('should show the empty state', async ({network, tasklistIndexPage}) => {
+		network.use(
+			mockQueryUserTasksEndpoint({
+				successResponse: HttpResponse.json(createQueryUserTasksResponse({items: []})),
+			}),
+		);
+
+		await tasklistIndexPage.goto();
+
+		await expect(tasklistIndexPage.noTasksMessage).toBeVisible();
+	});
+
+	test('should navigate to the task details', async ({network, page, tasklistIndexPage}) => {
+		network.use(
+			mockQueryUserTasksEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryUserTasksResponse({
+						items: [createUserTask({userTaskKey: '2251799813685281', name: 'Sign document'})],
+					}),
+				),
+			}),
+		);
+
+		await tasklistIndexPage.goto();
+		await tasklistIndexPage.taskItem('Sign document').click();
+
+		await expect(page).toHaveURL('/tasklist/2251799813685281');
+	});
+
+	test('should paginate when scrolling to the bottom', async ({network, tasklistIndexPage}) => {
+		const firstPageTasks = Array.from({length: 50}, (_, i) =>
+			createUserTask({userTaskKey: String(i + 1), name: `Task ${i + 1}`}),
+		);
+		const secondPageTasks = [createUserTask({userTaskKey: '51', name: 'Task from second page'})];
+
+		network.use(
+			mockQueryUserTasksEndpoint({
+				schema: createTasksPageRequestSchema(0),
+				successResponse: HttpResponse.json(
+					createQueryUserTasksResponse({items: firstPageTasks, page: {totalItems: 51}}),
+				),
+				failureResponse: new HttpResponse(null, {status: 400}),
+			}),
+		);
+
+		await tasklistIndexPage.goto();
+
+		await expect(tasklistIndexPage.taskItem('Task 50')).toBeVisible();
+
+		network.use(
+			mockQueryUserTasksEndpoint({
+				schema: createTasksPageRequestSchema(50),
+				successResponse: HttpResponse.json(
+					createQueryUserTasksResponse({
+						items: secondPageTasks,
+						page: {totalItems: 51},
+					}),
+				),
+				failureResponse: new HttpResponse(null, {status: 400}),
+			}),
+		);
+
+		await tasklistIndexPage.taskItem('Task 50').scrollIntoViewIfNeeded();
+
+		await expect(tasklistIndexPage.taskItem('Task from second page')).toBeVisible();
 	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/TasklistIndex.page.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/TasklistIndex.page.ts
@@ -33,6 +33,14 @@ class TasklistIndexPage extends BasePage {
 	get processesNavItem() {
 		return this.page.getByRole('link', {name: 'Processes'});
 	}
+
+	taskItem(name: string) {
+		return this.page.getByRole('link', {name: new RegExp(`task.*:.*${name}`, 'i')});
+	}
+
+	get noTasksMessage() {
+		return this.page.getByText('No tasks found');
+	}
 }
 
 export {TasklistIndexPage};


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds tests for the PR merged earlier (https://github.com/camunda/camunda/pull/55205) which migrated the tasks panel data fetching to the unified webapp

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53937
