### PR TITLE
55078 implement io token trend

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -14,6 +14,7 @@ import static io.camunda.optimize.service.dashboard.AgenticControlDashboardServi
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_TREND_REPORT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
@@ -25,6 +26,8 @@ import io.camunda.optimize.dto.optimize.persistence.incident.IncidentStatus;
 import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto;
 import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto.AgentMetricsDto;
 import io.camunda.optimize.dto.optimize.query.report.AdditionalProcessReportEvaluationFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.CommandEvaluationResult;
+import io.camunda.optimize.dto.optimize.query.report.SingleReportEvaluationResult;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
@@ -33,6 +36,8 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.filter.Filte
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceEndDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.result.MeasureDto;
+import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
+import io.camunda.optimize.service.db.report.result.MapCommandResult;
 import io.camunda.optimize.service.db.report.result.NumberCommandResult;
 import io.camunda.optimize.service.report.ReportEvaluationService;
 import java.time.OffsetDateTime;
@@ -865,6 +870,64 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   // ---------------------------------------------------------------------------
+  // Token trend report (weekly multi-measure line chart)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldComputeWeeklyInputTokensGroupedByWeek() {
+    // given two instances within the same week with known input tokens
+    persistProcessInstances(
+        List.of(
+            agenticInstance(PROC_KEY, 100L, 50L)
+                .startDate(OffsetDateTime.now().minusDays(3))
+                .endDate(OffsetDateTime.now().minusDays(2))
+                .build(),
+            agenticInstance(PROC_KEY, 200L, 80L)
+                .startDate(OffsetDateTime.now().minusDays(3))
+                .endDate(OffsetDateTime.now().minusDays(2))
+                .build()));
+
+    // when evaluating the first measure (input tokens) of the token-trend report
+    final List<MapResultEntryDto> buckets = evaluateMapMeasure(TOKEN_TREND_REPORT_ID, 0);
+
+    // then total input tokens across all buckets equals 300
+    assertThat(buckets).isNotEmpty();
+    final double totalInput =
+        buckets.stream()
+            .filter(e -> e.getValue() != null)
+            .mapToDouble(MapResultEntryDto::getValue)
+            .sum();
+    assertThat(totalInput).isCloseTo(300.0, within(1.0));
+  }
+
+  @Test
+  void shouldComputeWeeklyOutputTokensGroupedByWeek() {
+    // given two instances within the same week with known output tokens
+    persistProcessInstances(
+        List.of(
+            agenticInstance(PROC_KEY, 50L, 100L)
+                .startDate(OffsetDateTime.now().minusDays(3))
+                .endDate(OffsetDateTime.now().minusDays(2))
+                .build(),
+            agenticInstance(PROC_KEY, 80L, 200L)
+                .startDate(OffsetDateTime.now().minusDays(3))
+                .endDate(OffsetDateTime.now().minusDays(2))
+                .build()));
+
+    // when evaluating the second measure (output tokens) of the token-trend report
+    final List<MapResultEntryDto> buckets = evaluateMapMeasure(TOKEN_TREND_REPORT_ID, 1);
+
+    // then total output tokens across all buckets equals 300
+    assertThat(buckets).isNotEmpty();
+    final double totalOutput =
+        buckets.stream()
+            .filter(e -> e.getValue() != null)
+            .mapToDouble(MapResultEntryDto::getValue)
+            .sum();
+    assertThat(totalOutput).isCloseTo(300.0, within(1.0));
+  }
+
+  // ---------------------------------------------------------------------------
   // Combined: process definition + date range
   // ---------------------------------------------------------------------------
 
@@ -925,18 +988,34 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
         .agentTotalTokens(inputTokens + outputTokens);
   }
 
+  private List<MapResultEntryDto> evaluateMapMeasure(
+      final String reportId, final int measureIndex) {
+    final var result =
+        evaluationService.evaluateSavedReportWithAdditionalFilters(
+            USER_ID, UTC, reportId, noExtraFilters(), null);
+    final MapCommandResult commandResult =
+        (MapCommandResult)
+            ((SingleReportEvaluationResult<?>) result.getEvaluationResult())
+                .getCommandEvaluationResults()
+                .get(measureIndex);
+    final List<MeasureDto<List<MapResultEntryDto>>> measures = commandResult.getMeasures();
+    return measures.isEmpty() ? List.of() : measures.getFirst().getData();
+  }
+
   private Double evaluateNumber(
+      final String reportId, final AdditionalProcessReportEvaluationFilterDto filterDto) {
+    final NumberCommandResult commandResult =
+        (NumberCommandResult) firstCommandResult(reportId, filterDto);
+    final List<MeasureDto<Double>> measures = commandResult.getMeasures();
+    return measures.isEmpty() ? null : measures.getFirst().getData();
+  }
+
+  private CommandEvaluationResult<?> firstCommandResult(
       final String reportId, final AdditionalProcessReportEvaluationFilterDto filterDto) {
     final var result =
         evaluationService.evaluateSavedReportWithAdditionalFilters(
             USER_ID, UTC, reportId, filterDto, null);
-    final NumberCommandResult commandResult =
-        (NumberCommandResult)
-            ((io.camunda.optimize.dto.optimize.query.report.SingleReportEvaluationResult<?>)
-                    result.getEvaluationResult())
-                .getFirstCommandResult();
-    final List<MeasureDto<Double>> measures = commandResult.getMeasures();
-    return measures.isEmpty() ? null : measures.getFirst().getData();
+    return ((SingleReportEvaluationResult<?>) result.getEvaluationResult()).getFirstCommandResult();
   }
 
   private AdditionalProcessReportEvaluationFilterDto noExtraFilters() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -25,11 +25,14 @@ import io.camunda.optimize.dto.optimize.query.report.single.configuration.Single
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RollingDateFilterDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.group.AggregateByDateUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessVisualization;
 import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.NoneDistributedByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.util.ProcessFilterBuilder;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.EndDateGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.NoneGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.value.DateGroupByValueDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
 import io.camunda.optimize.service.db.reader.DashboardReader;
@@ -74,6 +77,10 @@ public class AgenticControlDashboardService {
       "agenticKpiExecutionMedianTokensName";
   public static final String KPI_EXECUTION_MEDIAN_TOKENS_DESCRIPTION =
       "agenticKpiExecutionMedianTokensDescription";
+  public static final String KPI_TOKEN_TREND_NAME = "agenticKpiTokenTrendName";
+  public static final String KPI_TOKEN_TREND_FOOTNOTE = "agenticKpiTokenTrendFootnote";
+  public static final String KPI_TOKEN_TREND_FOOTNOTE_KEY =
+      "agenticControl.report." + KPI_TOKEN_TREND_FOOTNOTE;
   public static final String KPI_DURATION_P50_NAME = "agenticKpiDurationP50Name";
   public static final String KPI_DURATION_P50_DESCRIPTION = "agenticKpiDurationP50Description";
   public static final String KPI_DURATION_P95_NAME = "agenticKpiDurationP95Name";
@@ -95,6 +102,8 @@ public class AgenticControlDashboardService {
   public static final String KPI_MEDIAN_TOKENS_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-kpi-median-tokens".getBytes(StandardCharsets.UTF_8))
           .toString();
+  public static final String TOKEN_TREND_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-token-trend".getBytes(StandardCharsets.UTF_8)).toString();
   public static final String KPI_DURATION_P50_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-duration-p50".getBytes(StandardCharsets.UTF_8)).toString();
   public static final String KPI_DURATION_P95_REPORT_ID =
@@ -139,6 +148,7 @@ public class AgenticControlDashboardService {
     tiles.add(buildIncidentRateReport());
     tiles.add(buildAvgTokensReport());
     tiles.add(buildMedianTokensReport());
+    tiles.add(buildTokenTrendReport());
     tiles.add(buildP50DurationReport());
     tiles.add(buildP95DurationReport());
 
@@ -284,6 +294,48 @@ public class AgenticControlDashboardService {
     reportWriter.createOrUpdateSingleProcessReport(
         id, null, reportData, nameKey, descriptionKey, null);
     return buildTile(id, position, new DimensionDto(9, 2), Map.of("section", "token"));
+  }
+
+  private DashboardReportTileDto buildTokenTrendReport() {
+    reportWriter.createOrUpdateSingleProcessReport(
+        TOKEN_TREND_REPORT_ID, null, buildTokenTrendReportData(), KPI_TOKEN_TREND_NAME, null, null);
+
+    return buildTile(
+        TOKEN_TREND_REPORT_ID,
+        new PositionDto(0, 6),
+        new DimensionDto(9, 4),
+        Map.of("section", "token", "footnote", KPI_TOKEN_TREND_FOOTNOTE_KEY));
+  }
+
+  // A single multi-measure report (input + output tokens) renders both series as separate lines,
+  // which is the supported way to combine measures — combined reports were removed from Optimize.
+  private ProcessReportDataDto buildTokenTrendReportData() {
+    final EndDateGroupByDto groupBy = new EndDateGroupByDto();
+    groupBy.setValue(new DateGroupByValueDto(AggregateByDateUnit.WEEK));
+    return ProcessReportDataDto.builder()
+        .definitions(Collections.emptyList())
+        .view(
+            new ProcessViewDto(
+                ProcessViewEntity.AGENT_INSTANCE,
+                List.of(ViewProperty.INPUT_TOKENS, ViewProperty.OUTPUT_TOKENS)))
+        .groupBy(groupBy)
+        .distributedBy(new NoneDistributedByDto())
+        .visualization(ProcessVisualization.LINE)
+        .configuration(
+            SingleReportConfigurationDto.builder()
+                .aggregationTypes(
+                    new LinkedHashSet<>(
+                        Collections.singletonList(new AggregationDto(AggregationType.SUM))))
+                .build())
+        .filter(
+            ProcessFilterBuilder.filter()
+                .completedInstancesOnly()
+                .add()
+                .hasAgentInstances()
+                .add()
+                .buildList())
+        .agenticControlReport(true)
+        .build();
   }
 
   private DashboardReportTileDto buildP50DurationReport() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterES.java
@@ -138,12 +138,13 @@ public abstract class AbstractProcessExecutionPlanInterpreterES
   private BoolQuery.Builder buildDefinitionBaseQueryForFilters(
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
       final Map<String, List<ProcessFilterDto<?>>> filtersByDefinition) {
-    // If the user has access to no definitions, management reports may contain no processes in its
-    // data source so we exclude all instances from the result
-    if (context.getReportData().getDefinitions().isEmpty()
-        && context.getReportData().isManagementReport()) {
+    if (context.getReportData().getDefinitions().isEmpty()) {
       final BoolQuery.Builder builder = new OptimizeBoolQueryBuilderES();
-      builder.mustNot(m -> m.matchAll(i -> i));
+      if (context.getReportData().isManagementReport()) {
+        // Management report with no accessible definitions: exclude all instances from the result
+        builder.mustNot(m -> m.matchAll(i -> i));
+      }
+      // No definitions: skip definition-scoped filtering and let other query filters apply
       return builder;
     }
     final BoolQuery.Builder multiDefinitionFilterQuery =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterOS.java
@@ -102,15 +102,18 @@ public abstract class AbstractProcessExecutionPlanInterpreterOS
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
       final Map<String, List<ProcessFilterDto<?>>> filtersByDefinition,
       final List<Query> filterQueries) {
-    // If the user has access to no definitions, management reports may contain no processes in its
-    // data source so we exclude all instances from the result
-    return context.getReportData().getDefinitions().isEmpty()
-            && context.getReportData().isManagementReport()
-        ? new BoolQuery.Builder().filter(not(matchAll()))
-        : new BoolQuery.Builder()
-            .minimumShouldMatch("1")
-            .should(multiDefinitionFilterQueries(context, filtersByDefinition))
-            .filter(filterQueries);
+    if (context.getReportData().getDefinitions().isEmpty()) {
+      if (context.getReportData().isManagementReport()) {
+        // Management report with no accessible definitions: exclude all instances from the result
+        return new BoolQuery.Builder().filter(not(matchAll()));
+      }
+      // No definitions: skip definition-scoped filtering and let other query filters apply
+      return new BoolQuery.Builder().filter(filterQueries);
+    }
+    return new BoolQuery.Builder()
+        .minimumShouldMatch("1")
+        .should(multiDefinitionFilterQueries(context, filtersByDefinition))
+        .filter(filterQueries);
   }
 
   private List<Query> multiDefinitionFilterQueries(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
@@ -35,6 +35,8 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessRepor
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessVisualization;
 import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.EndDateGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.value.DateGroupByValueDto;
 import io.camunda.optimize.dto.optimize.query.report.single.result.ResultType;
 import io.camunda.optimize.dto.optimize.query.variable.ProcessVariableNameResponseDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
@@ -275,8 +277,7 @@ public abstract class ReportEvaluationHandler {
     final List<SingleProcessReportDefinitionRequestDto> foundSingleReports =
         reportService.getAllSingleProcessReportsForIdsOmitXml(singleReportIds).stream()
             .filter(reportDefinition -> getAuthorizedRole(userId, reportDefinition).isPresent())
-            .peek(
-                reportDefinition -> addAdditionalFiltersForReport(evaluationInfo, reportDefinition))
+            .peek(reportDefinition -> applyEvaluationOverrides(evaluationInfo, reportDefinition))
             .collect(Collectors.toList());
 
     if (foundSingleReports.size() != singleReportIds.size()) {
@@ -294,7 +295,7 @@ public abstract class ReportEvaluationHandler {
 
   private ReportEvaluationResult evaluateSingleReportWithErrorCheck(
       final ReportEvaluationInfo evaluationInfo, final RoleType currentUserRole) {
-    addAdditionalFiltersForReport(evaluationInfo, evaluationInfo.getReport());
+    applyEvaluationOverrides(evaluationInfo, evaluationInfo.getReport());
     addHiddenFlowNodeIds(evaluationInfo);
     try {
       final ReportEvaluationContext<SingleReportDefinitionDto<SingleReportDataDto>> context =
@@ -316,7 +317,7 @@ public abstract class ReportEvaluationHandler {
     }
   }
 
-  private void addAdditionalFiltersForReport(
+  private void applyEvaluationOverrides(
       final ReportEvaluationInfo evaluationInfo, final ReportDefinitionDto<?> reportDefinition) {
     if (evaluationInfo.isSharedReport()) {
       addAdditionalFiltersForReport(reportDefinition, evaluationInfo.getAdditionalFilters());
@@ -324,6 +325,7 @@ public abstract class ReportEvaluationHandler {
       addAdditionalFiltersForAuthorizedReport(
           evaluationInfo.getUserId(), reportDefinition, evaluationInfo.getAdditionalFilters());
     }
+    overrideGroupByDateUnit(reportDefinition, evaluationInfo.getAdditionalFilters());
   }
 
   private void addHiddenFlowNodeIds(final ReportEvaluationInfo evaluationInfo) {
@@ -410,6 +412,22 @@ public abstract class ReportEvaluationHandler {
             "Cannot add additional filters to report [{}] as it is not a process report",
             reportDefinitionDto.getId());
       }
+    }
+  }
+
+  private void overrideGroupByDateUnit(
+      final ReportDefinitionDto<?> reportDefinitionDto,
+      final AdditionalProcessReportEvaluationFilterDto additionalFilters) {
+    if (additionalFilters == null || additionalFilters.getGroupByDateUnit() == null) {
+      return;
+    }
+    if (!(reportDefinitionDto
+        instanceof final SingleProcessReportDefinitionRequestDto definitionDto)) {
+      return;
+    }
+    if (definitionDto.getData().getGroupBy() instanceof final EndDateGroupByDto endDateGroupBy
+        && endDateGroupBy.getValue() instanceof final DateGroupByValueDto dateValue) {
+      dateValue.setUnit(additionalFilters.getGroupByDateUnit());
     }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/result/CompositeCommandResult.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/result/CompositeCommandResult.java
@@ -139,7 +139,9 @@ public class CompositeCommandResult {
                       .forEach(
                           viewMeasure ->
                               measureDataSets
-                                  .get(viewMeasure.getViewMeasureIdentifier())
+                                  .computeIfAbsent(
+                                      viewMeasure.getViewMeasureIdentifier(),
+                                      k -> new ArrayList<>())
                                   .add(
                                       new MapResultEntryDto(
                                           group.getKey(),
@@ -205,8 +207,11 @@ public class CompositeCommandResult {
                               measureMap.put(
                                   new ViewMeasureIdentifier(aggregationType, userTaskDurationTime),
                                   defaultValueSupplier.get())));
-    } else if (ViewProperty.DURATION.equals(viewProperty) || isNumberVariableView()) {
-      // if this is duration view property an entry per aggregationType is expected
+    } else if (ViewProperty.DURATION.equals(viewProperty)
+        || isNumberVariableView()
+        || (viewProperty != null && viewProperty.isAgentToken())) {
+      // duration, numeric variable, and agent token views each produce one entry per
+      // aggregationType
       reportDataDto
           .getConfiguration()
           .getAggregationTypes()

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -303,7 +303,9 @@
       "variable": "Variable",
       "process": "Prozessansicht",
       "agentInstance": "Agenteninstanz",
-      "totalTokens": "Tokens insgesamt"
+      "totalTokens": "Tokens insgesamt",
+      "inputTokens": "Eingabe-Tokens",
+      "outputTokens": "Ausgabe-Tokens"
     },
     "groupBy": {
       "label": "Gruppiere nach",
@@ -1556,6 +1558,8 @@
       "agenticKpiExecutionAvgTokensDescription": "Durchschnittliche Gesamtanzahl der verbrauchten Tokens pro abgeschlossener agentischer Prozessinstanz im gewählten Zeitraum.",
       "agenticKpiExecutionMedianTokensName": "Mediane Tokens pro Ausführung",
       "agenticKpiExecutionMedianTokensDescription": "Median der verbrauchten Tokens pro abgeschlossener agentischer Prozessinstanz im gewählten Zeitraum.",
+      "agenticKpiTokenTrendName": "Token-Trend",
+      "agenticKpiTokenTrendFootnote": "Wenn die Token-Nutzung ohne mehr Ausführungen steigt, wachsen möglicherweise die Prompts oder das Modell erzeugt längere Ausgaben. Engineering informieren.",
       "agenticKpiDurationP50Name": "P50-Ausführungsdauer",
       "agenticKpiDurationP50Description": "Median (P50) der Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum.",
       "agenticKpiDurationP95Name": "P95-Ausführungsdauer",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -303,7 +303,9 @@
       "variable": "Variable",
       "process": "Process view",
       "agentInstance": "Agent instance",
-      "totalTokens": "Total tokens"
+      "totalTokens": "Total tokens",
+      "inputTokens": "Input tokens",
+      "outputTokens": "Output tokens"
     },
     "groupBy": {
       "label": "Group by",
@@ -1556,6 +1558,8 @@
       "agenticKpiExecutionAvgTokensDescription": "Average total tokens consumed per completed agentic process instance in the selected period.",
       "agenticKpiExecutionMedianTokensName": "Median tokens per execution",
       "agenticKpiExecutionMedianTokensDescription": "Median total tokens consumed per completed agentic process instance in the selected period.",
+      "agenticKpiTokenTrendName": "Token Trend",
+      "agenticKpiTokenTrendFootnote": "If token use rises without more executions, prompts may be growing or the model is producing longer outputs. Raise with engineering.",
       "agenticKpiDurationP50Name": "P50 execution duration",
       "agenticKpiDurationP50Description": "Median (P50) execution duration of completed agentic process instances in the selected period.",
       "agenticKpiDurationP95Name": "P95 execution duration",

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -63,8 +64,6 @@ public class AgenticControlDashboardServiceTest {
 
   @BeforeEach
   void setUp() {
-    // createOrUpdateSingleProcessReport is called with (reportId, userId, data, name, desc,
-    // collectionId)
     when(reportWriter.createOrUpdateSingleProcessReport(
             any(), isNull(), any(), any(), any(), isNull()))
         .thenAnswer(invocation -> new IdResponseDto(invocation.getArgument(0)));
@@ -84,7 +83,7 @@ public class AgenticControlDashboardServiceTest {
     assertThat(saved.isAgenticControlDashboard()).isTrue();
     assertThat(saved.isManagementDashboard()).isFalse();
     assertThat(saved.getCollectionId()).isNull();
-    assertThat(saved.getTiles()).hasSize(7);
+    assertThat(saved.getTiles()).hasSize(8);
   }
 
   @Test
@@ -98,35 +97,27 @@ public class AgenticControlDashboardServiceTest {
     // then three reports are upserted with deterministic IDs and correct localization keys
     verify(reportWriter)
         .createOrUpdateSingleProcessReport(
-            org.mockito.ArgumentMatchers.eq(AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID),
+            eq(AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID),
             isNull(),
             any(),
-            org.mockito.ArgumentMatchers.eq(
-                AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_NAME),
-            org.mockito.ArgumentMatchers.eq(
-                AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_DESCRIPTION),
+            eq(AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_NAME),
+            eq(AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_DESCRIPTION),
             isNull());
     verify(reportWriter)
         .createOrUpdateSingleProcessReport(
-            org.mockito.ArgumentMatchers.eq(
-                AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID),
+            eq(AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID),
             isNull(),
             any(),
-            org.mockito.ArgumentMatchers.eq(
-                AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_NAME),
-            org.mockito.ArgumentMatchers.eq(
-                AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_DESCRIPTION),
+            eq(AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_NAME),
+            eq(AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_DESCRIPTION),
             isNull());
     verify(reportWriter)
         .createOrUpdateSingleProcessReport(
-            org.mockito.ArgumentMatchers.eq(
-                AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID),
+            eq(AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID),
             isNull(),
             any(),
-            org.mockito.ArgumentMatchers.eq(
-                AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_NAME),
-            org.mockito.ArgumentMatchers.eq(
-                AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION),
+            eq(AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_NAME),
+            eq(AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION),
             isNull());
   }
 
@@ -141,16 +132,16 @@ public class AgenticControlDashboardServiceTest {
     underTest.reconcile();
 
     // then — reports are upserted on every call, dashboard is updated but never recreated
-    verify(reportWriter, org.mockito.Mockito.times(2))
+    verify(reportWriter, times(2))
         .createOrUpdateSingleProcessReport(
-            org.mockito.ArgumentMatchers.eq(AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID),
+            eq(AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID),
             any(),
             any(),
             any(),
             any(),
             any());
     verify(dashboardWriter, never()).saveDashboard(any());
-    verify(dashboardWriter, org.mockito.Mockito.times(2)).updateDashboard(any(), any());
+    verify(dashboardWriter, times(2)).updateDashboard(any(), any());
   }
 
   @Test
@@ -172,6 +163,7 @@ public class AgenticControlDashboardServiceTest {
             AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID,
             AgenticControlDashboardService.KPI_AVG_TOKENS_REPORT_ID,
             AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID,
+            AgenticControlDashboardService.TOKEN_TREND_REPORT_ID,
             AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID,
             AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID);
   }
@@ -234,7 +226,7 @@ public class AgenticControlDashboardServiceTest {
     underTest.reconcile();
 
     // then reports are upserted and dashboard tiles are updated, but dashboard is not recreated
-    verify(reportWriter, org.mockito.Mockito.times(7))
+    verify(reportWriter, org.mockito.Mockito.times(8))
         .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
     verify(dashboardWriter, never()).saveDashboard(any());
     verify(dashboardWriter).updateDashboard(any(), any());
@@ -324,11 +316,88 @@ public class AgenticControlDashboardServiceTest {
               AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_DESCRIPTION,
               AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_NAME,
               AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION,
+              AgenticControlDashboardService.KPI_TOKEN_TREND_NAME,
+              AgenticControlDashboardService.KPI_TOKEN_TREND_FOOTNOTE,
               AgenticControlDashboardService.KPI_DURATION_P50_NAME,
               AgenticControlDashboardService.KPI_DURATION_P50_DESCRIPTION,
               AgenticControlDashboardService.KPI_DURATION_P95_NAME,
               AgenticControlDashboardService.KPI_DURATION_P95_DESCRIPTION);
     }
+  }
+
+  @Test
+  void shouldSeedTokenTrendReportWithBothTokenMeasures() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then a single multi-measure report is upserted with a deterministic ID
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.TOKEN_TREND_REPORT_ID),
+            isNull(),
+            any(),
+            eq(AgenticControlDashboardService.KPI_TOKEN_TREND_NAME),
+            isNull(),
+            isNull());
+  }
+
+  @Test
+  void shouldSumBothTokenMeasuresPerWeekInTokenTrendReport() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then the token-trend report exposes input and output tokens as SUM measures so weekly totals
+    // are not averaged
+    assertThat(captureTokenTrendReport())
+        .satisfies(
+            data -> {
+              assertThat(data.getView().getProperties())
+                  .containsExactly(ViewProperty.INPUT_TOKENS, ViewProperty.OUTPUT_TOKENS);
+              assertThat(data.getConfiguration().getAggregationTypes())
+                  .extracting(agg -> agg.getType())
+                  .containsExactly(AggregationType.SUM);
+            });
+  }
+
+  private ProcessReportDataDto captureTokenTrendReport() {
+    final ArgumentCaptor<ProcessReportDataDto> captor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.TOKEN_TREND_REPORT_ID),
+            isNull(),
+            captor.capture(),
+            any(),
+            isNull(),
+            isNull());
+    return captor.getValue();
+  }
+
+  @Test
+  void shouldUpsertTokenTrendReportOnWarmRestart() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID))
+        .thenReturn(Optional.of(new DashboardDefinitionRestDto()));
+
+    // when
+    underTest.reconcile();
+    underTest.reconcile();
+
+    // then the token-trend report is upserted on every reconcile
+    verify(reportWriter, times(2))
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.TOKEN_TREND_REPORT_ID),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
   }
 
   @Test

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.scss
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.scss
@@ -39,4 +39,12 @@
     border-top: 1px solid var(--cds-border-subtle-01, var(--silver-darken-80));
     margin: 0;
   }
+
+  .tile-footnote {
+    margin: 0.5rem 0 0;
+    padding-top: 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1.2;
+    color: var(--cds-text-secondary);
+  }
 }

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
@@ -20,6 +20,7 @@ import type {DashboardTile} from 'types';
 
 import {DATE_PRESETS, FilterBar} from './FilterBar';
 import {loadAgenticDashboard} from './service';
+import {TileFootnote} from './TileFootnote';
 
 import './AgenticControlPlane.scss';
 
@@ -27,6 +28,7 @@ interface AgenticTileConfiguration {
   visibleInL0Only?: boolean;
   visibleInL1Only?: boolean;
   section?: string;
+  footnote?: string;
 }
 
 interface RollingFilter {
@@ -39,6 +41,12 @@ interface RollingFilter {
     excludeUndefined: boolean;
     includeUndefined: boolean;
   };
+}
+
+function presetToGroupByDateUnit(presetId: string): string {
+  if (presetId === '7d') return 'day';
+  if (presetId === '30d') return 'week';
+  return 'month';
 }
 
 function presetToFilter(preset: (typeof DATE_PRESETS)[number]): RollingFilter {
@@ -79,6 +87,16 @@ export function AgenticControlPlane() {
     [processScope]
   );
 
+  const scopedEvaluateTokenTrendReport = useCallback(
+    (
+      id: ReportEvaluationPayload,
+      tileFilter: Parameters<typeof evaluateReport>[1],
+      query: Parameters<typeof evaluateReport>[2]
+    ) => evaluateReport(id, tileFilter, query, definitions, presetToGroupByDateUnit(preset)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [processScope, preset]
+  );
+
   if (!dashboard) {
     return <Loading />;
   }
@@ -96,7 +114,11 @@ export function AgenticControlPlane() {
 
   const sections = [
     {key: 'kpi', loadTile: scopedEvaluateReport},
-    {key: 'token', titleKey: 'agenticControlPlane.tokenUsage', loadTile: scopedEvaluateReport},
+    {
+      key: 'token',
+      titleKey: 'agenticControlPlane.tokenUsage',
+      loadTile: scopedEvaluateTokenTrendReport,
+    },
     {key: 'duration', titleKey: 'agenticControlPlane.duration', loadTile: scopedEvaluateReport},
   ];
 
@@ -114,7 +136,8 @@ export function AgenticControlPlane() {
       />
       {sections.map(({key, titleKey, loadTile}) => {
         const tiles = visibleTiles?.filter(
-          (tile) => ((tile.configuration as AgenticTileConfiguration | undefined)?.section ?? 'kpi') === key
+          (tile) =>
+            ((tile.configuration as AgenticTileConfiguration | undefined)?.section ?? 'kpi') === key
         );
         return (
           <div key={key}>
@@ -130,6 +153,7 @@ export function AgenticControlPlane() {
                 loadTile={loadTile}
                 tiles={tiles}
                 filter={filter}
+                addons={[<TileFootnote key="tile-footnote" />]}
               />
             </div>
           </div>

--- a/optimize/client/src/components/AgenticControlPlane/TileFootnote.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/TileFootnote.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {t} from 'translation';
+
+import type {DashboardTile} from 'types';
+
+interface TileFootnoteConfiguration {
+  footnote?: string;
+}
+
+interface TileFootnoteProps {
+  tile?: DashboardTile;
+}
+
+export function TileFootnote({tile}: TileFootnoteProps) {
+  const footnoteKey = (tile?.configuration as TileFootnoteConfiguration | undefined)?.footnote;
+  if (!footnoteKey) {
+    return null;
+  }
+  return <p className="tile-footnote">{t(footnoteKey)}</p>;
+}

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/service.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/service.js
@@ -103,12 +103,20 @@ export function canBeInterpolated({type, value}) {
   return true;
 }
 
+const TOKEN_PROPERTIES = ['inputTokens', 'outputTokens', 'totalTokens', 'toolCalls'];
+
 export function getLabel({property, aggregationType, userTaskDurationTime}) {
+  let viewKey = 'duration';
+  if (property === 'frequency') {
+    viewKey = 'count';
+  } else if (TOKEN_PROPERTIES.includes(property)) {
+    viewKey = property;
+  }
   return (
     (userTaskDurationTime
       ? `${t('report.config.userTaskDuration.' + userTaskDurationTime)} `
       : '') +
-    t('report.view.' + (property === 'frequency' ? 'count' : 'duration')) +
+    t('report.view.' + viewKey) +
     (aggregationType
       ? ` - ${t('report.config.aggregationShort.' + aggregationType.type, {
           value: aggregationType.value,
@@ -118,8 +126,12 @@ export function getLabel({property, aggregationType, userTaskDurationTime}) {
 }
 
 export function getAxisIdx(measures, measureIdx) {
-  if (measures.every(({property}) => property === measures[0].property)) {
-    // if every measure has the same prop, there is only one axis
+  // A second axis only exists when a report mixes frequency and duration measures.
+  const hasFrequencyAndDuration = ['frequency', 'duration'].every((prop) =>
+    measures.some((measure) => measure.property === prop)
+  );
+  if (!hasFrequencyAndDuration) {
+    // All measures share a single axis (e.g. input and output tokens).
     return 0;
   }
   return measures[measureIdx].property === 'frequency' ? 0 : 1;

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/service.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/service.test.js
@@ -9,6 +9,7 @@
 import {
   formatTooltip,
   formatTooltipTitle,
+  getAxisIdx,
   getLabel,
   getTooltipLabelColor,
   hasReportPersistedTooltips,
@@ -135,6 +136,29 @@ describe('getLabel', () => {
     expect(getLabel({property: 'duration', userTaskDurationTime: 'idle'})).toBe(
       'Unassigned Duration'
     );
+  });
+
+  it('should return distinct labels for token properties', () => {
+    expect(getLabel({property: 'inputTokens', aggregationType: {type: 'sum'}})).toBe(
+      'Input tokens - Sum'
+    );
+    expect(getLabel({property: 'outputTokens', aggregationType: {type: 'sum'}})).toBe(
+      'Output tokens - Sum'
+    );
+  });
+});
+
+describe('getAxisIdx', () => {
+  it('should use a single axis for token measures', () => {
+    const measures = [{property: 'inputTokens'}, {property: 'outputTokens'}];
+    expect(getAxisIdx(measures, 0)).toBe(0);
+    expect(getAxisIdx(measures, 1)).toBe(0);
+  });
+
+  it('should use a second axis for the duration measure when mixed with frequency', () => {
+    const measures = [{property: 'frequency'}, {property: 'duration'}];
+    expect(getAxisIdx(measures, 0)).toBe(0);
+    expect(getAxisIdx(measures, 1)).toBe(1);
   });
 });
 

--- a/optimize/client/src/modules/services/reportService.ts
+++ b/optimize/client/src/modules/services/reportService.ts
@@ -48,13 +48,18 @@ export async function evaluateReport(
   payload: ReportEvaluationPayload,
   filter = [],
   query = {},
-  definitions: {key: string; versions: string[]}[] = []
+  definitions: {key: string; versions: string[]}[] = [],
+  groupByDateUnit?: string
 ): Promise<Report> {
   let response;
 
   if (typeof payload !== 'object') {
     // evaluate saved report
-    const body = definitions.length > 0 ? {filter, definitions} : {filter};
+    const body: Record<string, unknown> =
+      definitions.length > 0 ? {filter, definitions} : {filter};
+    if (groupByDateUnit) {
+      body.groupByDateUnit = groupByDateUnit;
+    }
     response = await post(`api/report/${payload}/evaluate`, body, {query});
   } else {
     // evaluate unsaved report

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/AdditionalProcessReportEvaluationFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/AdditionalProcessReportEvaluationFilterDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report;
 
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.group.AggregateByDateUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +18,7 @@ public class AdditionalProcessReportEvaluationFilterDto {
 
   protected List<ProcessFilterDto<?>> filter = new ArrayList<>();
   protected List<ReportDataDefinitionDto> definitions = new ArrayList<>();
+  protected AggregateByDateUnit groupByDateUnit;
 
   public AdditionalProcessReportEvaluationFilterDto(final List<ProcessFilterDto<?>> filter) {
     this.filter = filter;
@@ -40,6 +42,14 @@ public class AdditionalProcessReportEvaluationFilterDto {
     this.definitions = definitions;
   }
 
+  public AggregateByDateUnit getGroupByDateUnit() {
+    return groupByDateUnit;
+  }
+
+  public void setGroupByDateUnit(final AggregateByDateUnit groupByDateUnit) {
+    this.groupByDateUnit = groupByDateUnit;
+  }
+
   protected boolean canEqual(final Object other) {
     return other instanceof AdditionalProcessReportEvaluationFilterDto;
   }
@@ -51,12 +61,14 @@ public class AdditionalProcessReportEvaluationFilterDto {
     }
     final AdditionalProcessReportEvaluationFilterDto that =
         (AdditionalProcessReportEvaluationFilterDto) o;
-    return Objects.equals(filter, that.filter) && Objects.equals(definitions, that.definitions);
+    return Objects.equals(filter, that.filter)
+        && Objects.equals(definitions, that.definitions)
+        && Objects.equals(groupByDateUnit, that.groupByDateUnit);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(filter, definitions);
+    return Objects.hash(filter, definitions, groupByDateUnit);
   }
 
   @Override
@@ -65,6 +77,8 @@ public class AdditionalProcessReportEvaluationFilterDto {
         + getFilter()
         + ", definitions="
         + getDefinitions()
+        + ", groupByDateUnit="
+        + getGroupByDateUnit()
         + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ViewProperty.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ViewProperty.java
@@ -80,6 +80,14 @@ public class ViewProperty implements Combinable {
     return Optional.of(viewPropertyDto).filter(clazz::isInstance).map(clazz::cast);
   }
 
+  @JsonIgnore
+  public boolean isAgentToken() {
+    return INPUT_TOKENS.equals(this)
+        || OUTPUT_TOKENS.equals(this)
+        || TOOL_CALLS.equals(this)
+        || TOTAL_TOKENS.equals(this);
+  }
+
   protected boolean canEqual(final Object other) {
     return other instanceof ViewProperty;
   }


### PR DESCRIPTION
## Description

Adds a Token Trend tile to the Agentic Control Plane dashboard, plotting weekly input and output token usage as a line chart so operators can spot rising token consumption that isn't matched by more executions.                                                                                                                                                                                 The tile is seeded as a single multi-measure process report (view.properties = [INPUT_TOKENS, OUTPUT_TOKENS], grouped by week, aggregated by SUM). Each measure renders as its own line through Optimize's standard process-report chart path, no combined reports involved.                                                                                                                                           
  Along the way this also fixes two seeding bugs and adds a small evaluation capability the tile depends on:                                                 
   - fix: agent token view properties now emit one view-measure per configured aggregation type, so SUM-based token reports compute correctly.
   - fix: seeded reports with an empty definitions list no longer filter out all results, the definition filter is skipped when no definitions are configured.
   - feat: the saved-report evaluate endpoint accepts a per-request groupByDateUnit override, letting the tile re -bucket by the selected time preset without editing the stored report.
   - feat: the half-width token-trend tile, its in-tile footnote, and the localized strings (en/de).                        
   - test: unit + integration coverage asserting the report is seeded with both token measures as SUM and that each weekly measure totals correctly end-to-end.     

## Related issues

closes https://github.com/camunda/camunda/issues/55078
