### PR TITLE
feat: register AGENT_HISTORY index templates in the engine-side ES/OS exporters

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -126,6 +126,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
       case GLOBAL_LISTENER_BATCH -> index.globalListenerBatch;
       case GLOBAL_LISTENER -> index.globalListener;
       case AGENT_INSTANCE -> index.agentInstance;
+      case AGENT_HISTORY -> index.agentHistory;
       default -> false;
     };
   }
@@ -260,6 +261,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     public boolean globalListener = true;
 
     public boolean agentInstance = true;
+    public boolean agentHistory = true;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -214,6 +214,9 @@ public class ElasticsearchExporterSchemaManager {
       if (index.agentInstance) {
         createValueIndexTemplate(ValueType.AGENT_INSTANCE, version);
       }
+      if (index.agentHistory) {
+        createValueIndexTemplate(ValueType.AGENT_HISTORY, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
@@ -7,7 +7,7 @@
   "version": 1,
   "template": {
     "settings": {
-      "number_of_shards": 3,
+      "number_of_shards": 1,
       "number_of_replicas": 0,
       "index.queries.cache.enabled": false
     },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
@@ -1,0 +1,82 @@
+{
+  "index_patterns": [
+    "zeebe-record_agent-history_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 3,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-agent-history": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "agentHistoryKey": {
+              "type": "long"
+            },
+            "agentInstanceKey": {
+              "type": "long"
+            },
+            "elementInstanceKey": {
+              "type": "long"
+            },
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
+            },
+            "processDefinitionKey": {
+              "type": "long"
+            },
+            "tenantId": {
+              "type": "keyword"
+            },
+            "jobKey": {
+              "type": "long"
+            },
+            "jobLease": {
+              "type": "keyword"
+            },
+            "iteration": {
+              "type": "integer"
+            },
+            "role": {
+              "type": "keyword"
+            },
+            "producedAt": {
+              "type": "long"
+            },
+            "content": {
+              "enabled": false
+            },
+            "toolCalls": {
+              "enabled": false
+            },
+            "metrics": {
+              "properties": {
+                "inputTokens": {
+                  "type": "long"
+                },
+                "outputTokens": {
+                  "type": "long"
+                },
+                "durationMs": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
@@ -7,7 +7,7 @@
   "version": 1,
   "template": {
     "settings": {
-      "number_of_shards": 3,
+      "number_of_shards": 1,
       "number_of_replicas": 0,
       "index.queries.cache.enabled": false
     },

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -85,6 +85,7 @@ final class TestSupport {
       case GLOBAL_LISTENER_BATCH -> config.globalListenerBatch = value;
       case GLOBAL_LISTENER -> config.globalListener = value;
       case AGENT_INSTANCE -> config.agentInstance = value;
+      case AGENT_HISTORY -> config.agentHistory = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -145,8 +146,7 @@ final class TestSupport {
             ValueType.CONDITIONAL_EVALUATION,
             ValueType.EXPRESSION,
             ValueType.JOB_METRICS_BATCH,
-            ValueType.RESOURCE_REEXPORT,
-            ValueType.AGENT_HISTORY);
+            ValueType.RESOURCE_REEXPORT);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -171,6 +171,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
       case GLOBAL_LISTENER_BATCH -> index.globalListenerBatch;
       case GLOBAL_LISTENER -> index.globalListener;
       case AGENT_INSTANCE -> index.agentInstance;
+      case AGENT_HISTORY -> index.agentHistory;
       default -> false;
     };
   }
@@ -289,6 +290,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     public boolean globalListener = true;
 
     public boolean agentInstance = true;
+    public boolean agentHistory = true;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
@@ -188,6 +188,9 @@ public class OpensearchExporterSchemaManager {
       if (index.agentInstance) {
         createValueIndexTemplate(ValueType.AGENT_INSTANCE, version);
       }
+      if (index.agentHistory) {
+        createValueIndexTemplate(ValueType.AGENT_HISTORY, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
@@ -1,0 +1,88 @@
+{
+  "index_patterns": [
+    "zeebe-record_agent-history_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "number_of_shards": "3",
+        "number_of_replicas": "0",
+        "queries": {
+          "cache": {
+            "enabled": false
+          }
+        }
+      }
+    },
+    "aliases": {
+      "zeebe-record-agent-history": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "agentHistoryKey": {
+              "type": "long"
+            },
+            "agentInstanceKey": {
+              "type": "long"
+            },
+            "elementInstanceKey": {
+              "type": "long"
+            },
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
+            },
+            "processDefinitionKey": {
+              "type": "long"
+            },
+            "tenantId": {
+              "type": "keyword"
+            },
+            "jobKey": {
+              "type": "long"
+            },
+            "jobLease": {
+              "type": "keyword"
+            },
+            "iteration": {
+              "type": "integer"
+            },
+            "role": {
+              "type": "keyword"
+            },
+            "producedAt": {
+              "type": "long"
+            },
+            "content": {
+              "enabled": false
+            },
+            "toolCalls": {
+              "enabled": false
+            },
+            "metrics": {
+              "properties": {
+                "inputTokens": {
+                  "type": "long"
+                },
+                "outputTokens": {
+                  "type": "long"
+                },
+                "durationMs": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "index": {
-        "number_of_shards": "3",
+        "number_of_shards": "1",
         "number_of_replicas": "0",
         "queries": {
           "cache": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "index": {
-        "number_of_shards": "3",
+        "number_of_shards": "1",
         "number_of_replicas": "0",
         "queries": {
           "cache": {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -86,6 +86,7 @@ final class TestSupport {
       case GLOBAL_LISTENER_BATCH -> config.globalListenerBatch = value;
       case GLOBAL_LISTENER -> config.globalListener = value;
       case AGENT_INSTANCE -> config.agentInstance = value;
+      case AGENT_HISTORY -> config.agentHistory = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -146,8 +147,7 @@ final class TestSupport {
             ValueType.CONDITIONAL_EVALUATION,
             ValueType.EXPRESSION,
             ValueType.JOB_METRICS_BATCH,
-            ValueType.RESOURCE_REEXPORT,
-            ValueType.AGENT_HISTORY);
+            ValueType.RESOURCE_REEXPORT);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 


### PR DESCRIPTION
## Description

The engine-side Elasticsearch and OpenSearch exporters write every Zeebe record to secondary storage through a template-based index system. Before a record type can be indexed, a matching template must be registered at exporter startup — otherwise ES/OS either rejects the document (when `dynamic: strict` is active) or maps it into an unstructured catch-all index that is difficult to query.

`AGENT_HISTORY` records were added to the Zeebe protocol to surface per-iteration conversation turns produced by the AI Agent Connector during job execution. Each record carries the message role, content items (text, document references, structured objects), embedded tool calls, and LLM token metrics. Without the corresponding index templates, every `AGENT_HISTORY` event record is silently lost at the exporter boundary — it never reaches secondary ES/OS storage.

This PR registers `AGENT_HISTORY` in both engine-side exporters: adds the JSON template resources, wires the `agentHistory` configuration flag, hooks into the schema manager, and removes the `TestSupport` exclusion so the existing parameterised template round-trip tests cover this record type.

### Index template design

**`content` and `toolCalls` mapped with `enabled: false`**
Both arrays contain `Map<String,Object>` sub-fields (`content[].object`, `toolCalls[].arguments`, and `documentReference.metadata.customProperties`) whose keys are entirely determined at runtime by the AI connector. With `dynamic: strict` active on the `value` wrapper, any undeclared key causes ES/OS to reject the document outright. Mapping the entire `content` and `toolCalls` sub-objects with `enabled: false` disables field indexing for those sub-trees while keeping the raw data in `_source`, following the same pattern used for `variables` and `customHeaders` in the job and user-task templates. An alternative of declaring each sub-field individually with `index: false` was considered but rejected as brittle: any future sub-field addition would require a coordinated template update.

**`metrics` sub-fields mapped as explicit `long`s**
`inputTokens`, `outputTokens`, and `durationMs` are simple scalars with no dynamic sub-structure. Keeping them indexed allows range queries and aggregations for cost and latency monitoring directly against the Zeebe-side index.

**`producedAt` mapped as `long` (epoch-millis)**
`AgentHistoryRecord.producedAtProp` is a `LongProperty` that serialises as a raw integer. Mapping it as `date` would require an explicit `epoch_millis` format hint and could silently misparse the value in older ES/OS versions. Using `long` is unambiguous and is consistent with `creationTimestamp` in the user-task template.

**`agentHistory = true` default**
Matches the `agentInstance = true` default. `AGENT_HISTORY` records are first-class observability data — making them opt-in by default would silently break the monitoring and Query API layers for most deployments.

**ES and OS templates share identical mappings**
The two template files differ only in their `settings` block format: ES uses flat property names (`number_of_shards: 1`), OS uses nested format with string values
(`index.number_of_shards: "1"`). This is the established convention across all template pairs in the project.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55263