### PR TITLE
fix: return null listenerEventType for non-listener job wait states

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/elementinstancewaitstate/SearchElementInstanceWaitStatesTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstancewaitstate/SearchElementInstanceWaitStatesTest.java
@@ -171,7 +171,7 @@ public class SearchElementInstanceWaitStatesTest extends ClientRestTest {
     jobDetails.setJobKey("999");
     jobDetails.setJobType("payment");
     jobDetails.setJobKind(JobKindEnum.BPMN_ELEMENT);
-    jobDetails.setListenerEventType(JobListenerEventTypeEnum.UNSPECIFIED);
+    jobDetails.setListenerEventType(null);
     jobDetails.setRetries(3);
 
     final io.camunda.client.protocol.rest.ElementInstanceWaitStateResult item =
@@ -208,8 +208,47 @@ public class SearchElementInstanceWaitStatesTest extends ClientRestTest {
     assertThat(details.getJobKey()).isEqualTo("999");
     assertThat(details.getJobType()).isEqualTo("payment");
     assertThat(details.getJobKind()).isEqualTo(JobKind.BPMN_ELEMENT);
-    assertThat(details.getListenerEventType()).isEqualTo(ListenerEventType.UNSPECIFIED);
+    assertThat(details.getListenerEventType()).isNull();
     assertThat(details.getRetries()).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldMapListenerJobResponseFields() {
+    // given — an EXECUTION_LISTENER job with START listenerEventType
+    final io.camunda.client.protocol.rest.JobWaitStateDetails jobDetails =
+        new io.camunda.client.protocol.rest.JobWaitStateDetails();
+    jobDetails.setWaitStateType("JOB");
+    jobDetails.setJobKey("888");
+    jobDetails.setJobType("exec-listener");
+    jobDetails.setJobKind(JobKindEnum.EXECUTION_LISTENER);
+    jobDetails.setListenerEventType(JobListenerEventTypeEnum.START);
+    jobDetails.setRetries(3);
+
+    final io.camunda.client.protocol.rest.ElementInstanceWaitStateResult item =
+        new io.camunda.client.protocol.rest.ElementInstanceWaitStateResult();
+    item.setProcessInstanceKey("200");
+    item.setRootProcessInstanceKey("100");
+    item.setElementInstanceKey("300");
+    item.setElementId("sub-el");
+    item.setTenantId("<default>");
+    item.setBpmnProcessId("el-process");
+    item.setDetails(jobDetails);
+
+    final ElementInstanceWaitStateQueryResult response = buildEmptyResponse();
+    response.addItemsItem(item);
+    gatewayService.onSearchElementInstanceWaitStatesRequest(response);
+
+    // when
+    final SearchResponse<io.camunda.client.api.search.response.ElementInstanceWaitStateResult>
+        result = client.newElementInstanceWaitStateSearchRequest().send().join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    final io.camunda.client.api.search.response.ElementInstanceWaitStateResult mapped =
+        result.items().get(0);
+    final JobWaitStateDetails details = (JobWaitStateDetails) mapped.getDetails();
+    assertThat(details.getJobKind()).isEqualTo(JobKind.EXECUTION_LISTENER);
+    assertThat(details.getListenerEventType()).isEqualTo(ListenerEventType.START);
   }
 
   @Test

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -694,6 +694,7 @@ public final class SearchQueryResponseMapper {
                       .jobKind(JobKindEnum.fromValue(jobKind.name()))
                       .listenerEventType(
                           listenerEventType == null
+                                  || listenerEventType == JobEntity.ListenerEventType.UNSPECIFIED
                               ? null
                               : JobListenerEventTypeEnum.fromValue(listenerEventType.name()))
                       .retries(retries)

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -16,6 +16,7 @@ import io.camunda.gateway.protocol.model.IncidentErrorTypeEnum;
 import io.camunda.gateway.protocol.model.IncidentStateEnum;
 import io.camunda.gateway.protocol.model.JobListenerEventTypeEnum;
 import io.camunda.gateway.protocol.model.JobSearchQueryResult;
+import io.camunda.gateway.protocol.model.JobWaitStateDetails;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
@@ -49,6 +50,8 @@ import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.UserTaskEntity.UserTaskState;
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.user.CamundaUserDTO;
 import java.time.OffsetDateTime;
@@ -974,5 +977,37 @@ class SearchQueryResponseMapperTest {
           .isNotNull()
           .isEqualTo(JobListenerEventTypeEnum.fromValue(type.name()));
     }
+  }
+
+  @Test
+  void shouldMapUnspecifiedListenerEventTypeToNullInWaitStateJobDetails() {
+    // given
+    final var jobDetails =
+        new WaitStateJobDetails(
+            111L, // jobKey
+            "service-task-job", // jobType
+            JobKind.BPMN_ELEMENT, // jobKind
+            ListenerEventType.UNSPECIFIED, // listenerEventType — sentinel for non-listener jobs
+            3); // retries
+    final var entity =
+        new WaitStateEntity.Builder()
+            .processInstanceKey(789L)
+            .elementInstanceKey(111L)
+            .elementId("serviceTask")
+            .elementType(FlowNodeType.SERVICE_TASK)
+            .rootProcessInstanceKey(999L)
+            .bpmnProcessId("process1")
+            .details(jobDetails)
+            .tenantId("default")
+            .build();
+
+    // when
+    final var result =
+        SearchQueryResponseMapper.toElementInstanceWaitStateQueryResult(
+            new SearchQueryResult<>(1, false, List.of(entity), null, null));
+
+    // then
+    final var responseDetails = (JobWaitStateDetails) result.getItems().getFirst().getDetails();
+    assertThat(responseDetails.getListenerEventType()).isNull();
   }
 }

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -160,6 +160,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
       <version>78.3</version>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateJobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateJobIT.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.search.enums.JobKind;
+import io.camunda.client.api.search.enums.ListenerEventType;
 import io.camunda.client.api.search.enums.WaitStateElementType;
 import io.camunda.client.api.search.enums.WaitStateType;
 import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
@@ -31,6 +32,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.util.List;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -158,63 +160,87 @@ public class WaitStateJobIT {
             WaitStateElementType.PROCESS);
   }
 
-  @ParameterizedTest(name = "{1} / {3}")
+  @ParameterizedTest(name = "{1} / {3} / listenerEventType={4}")
   @MethodSource("elementTypeTestCases")
   void shouldFilterByElementType(
       final WaitStateElementType elementType,
       final String expectedElementId,
       final String expectedJobType,
       final JobKind expectedJobKind,
+      final @Nullable ListenerEventType expectedListenerEventType,
       final int expectedRetries) {
     assertSingleJobWaitState(
-        elementType, expectedElementId, expectedJobType, expectedJobKind, expectedRetries);
+        elementType,
+        expectedElementId,
+        expectedJobType,
+        expectedJobKind,
+        expectedListenerEventType,
+        expectedRetries);
   }
 
   static Stream<Arguments> elementTypeTestCases() {
     return Stream.of(
         Arguments.of(
-            WaitStateElementType.SERVICE_TASK, SERVICE_TASK, "svc", JobKind.BPMN_ELEMENT, 3),
-        Arguments.of(WaitStateElementType.SEND_TASK, SEND_TASK, "snd", JobKind.BPMN_ELEMENT, 3),
-        Arguments.of(WaitStateElementType.SCRIPT_TASK, SCRIPT_TASK, "scr", JobKind.BPMN_ELEMENT, 3),
+            WaitStateElementType.SERVICE_TASK, SERVICE_TASK, "svc", JobKind.BPMN_ELEMENT, null, 3),
+        Arguments.of(
+            WaitStateElementType.SEND_TASK, SEND_TASK, "snd", JobKind.BPMN_ELEMENT, null, 3),
+        Arguments.of(
+            WaitStateElementType.SCRIPT_TASK, SCRIPT_TASK, "scr", JobKind.BPMN_ELEMENT, null, 3),
         Arguments.of(
             WaitStateElementType.BUSINESS_RULE_TASK,
             BUSINESS_RULE_TASK,
             "biz",
             JobKind.BPMN_ELEMENT,
+            null,
             3),
         Arguments.of(
             WaitStateElementType.SUB_PROCESS,
             SUBPROCESS_EL,
             "sub-listener",
             JobKind.EXECUTION_LISTENER,
+            ListenerEventType.START,
             3),
         Arguments.of(
             WaitStateElementType.USER_TASK,
             USER_TASK_TL,
             "task-listener",
             JobKind.TASK_LISTENER,
+            ListenerEventType.CREATING,
             3),
         Arguments.of(
             WaitStateElementType.USER_TASK,
             JOB_USER_TASK,
             "io.camunda.zeebe:userTask",
             JobKind.BPMN_ELEMENT,
+            null,
             1),
         Arguments.of(
             WaitStateElementType.INTERMEDIATE_THROW_EVENT,
             INT_MSG_THROW,
             "int-msg-svc",
             JobKind.BPMN_ELEMENT,
+            null,
             3),
         Arguments.of(
-            WaitStateElementType.END_EVENT, END_MSG_EVENT, "end-msg-svc", JobKind.BPMN_ELEMENT, 3),
+            WaitStateElementType.END_EVENT,
+            END_MSG_EVENT,
+            "end-msg-svc",
+            JobKind.BPMN_ELEMENT,
+            null,
+            3),
         Arguments.of(
-            WaitStateElementType.SUB_PROCESS, AHSP, "ahsp-job", JobKind.AD_HOC_SUB_PROCESS, 3),
+            WaitStateElementType.SUB_PROCESS,
+            AHSP,
+            "ahsp-job",
+            JobKind.AD_HOC_SUB_PROCESS,
+            null,
+            3),
         Arguments.of(
             WaitStateElementType.PROCESS,
             PROCESS_LISTENER_PROCESS_ID,
             "process-listener",
             JobKind.EXECUTION_LISTENER,
+            ListenerEventType.START,
             3));
   }
 
@@ -480,6 +506,7 @@ public class WaitStateJobIT {
       final String expectedElementId,
       final String expectedJobType,
       final JobKind expectedJobKind,
+      final @Nullable ListenerEventType expectedListenerEventType,
       final int expectedRetries) {
     // when
     final var result =
@@ -499,6 +526,7 @@ public class WaitStateJobIT {
     assertThat(jobDetails.getWaitStateType()).isEqualTo(WaitStateType.JOB);
     assertThat(jobDetails.getJobType()).isEqualTo(expectedJobType);
     assertThat(jobDetails.getJobKind()).isEqualTo(expectedJobKind);
+    assertThat(jobDetails.getListenerEventType()).isEqualTo(expectedListenerEventType);
     assertThat(jobDetails.getRetries()).isEqualTo(expectedRetries);
     assertThat(jobDetails.getJobKey()).isNotNull();
   }

--- a/zeebe/exporter-common/pom.xml
+++ b/zeebe/exporter-common/pom.xml
@@ -63,6 +63,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
 
     <!-- testing -->
     <dependency>

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformer.java
@@ -13,7 +13,10 @@ import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformerConfig;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import org.jspecify.annotations.Nullable;
 
 public class JobBasedWaitStateTransformer implements WaitStateTransformer<JobRecordValue> {
 
@@ -32,7 +35,18 @@ public class JobBasedWaitStateTransformer implements WaitStateTransformer<JobRec
                 record.getKey(),
                 value.getType(),
                 value.getJobKind(),
-                value.getJobListenerEventType(),
+                listenerEventType(value),
                 value.getRetries()));
+  }
+
+  private static @Nullable JobListenerEventType listenerEventType(final JobRecordValue value) {
+    return isListenerJob(value.getJobKind()) ? value.getJobListenerEventType() : null;
+  }
+
+  private static boolean isListenerJob(final JobKind jobKind) {
+    return switch (jobKind) {
+      case EXECUTION_LISTENER, TASK_LISTENER -> true;
+      case BPMN_ELEMENT, AD_HOC_SUB_PROCESS -> false;
+    };
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobWaitStateDetails.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobWaitStateDetails.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.common.waitstate.transformers;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Wait-state details for job-based element waits (service tasks, send tasks, script tasks,
@@ -19,6 +20,9 @@ public record JobWaitStateDetails(
     long jobKey,
     String jobType,
     JobKind jobKind,
-    JobListenerEventType listenerEventType,
+    /**
+     * Non-null only for {@link JobKind#EXECUTION_LISTENER} and {@link JobKind#TASK_LISTENER} jobs.
+     */
+    @Nullable JobListenerEventType listenerEventType,
     int retries)
     implements WaitStateDetails {}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntryTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntryTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobKind;
-import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -29,9 +28,7 @@ class WaitStateEntryTest {
   @Test
   void shouldExposeAllFieldsViaAccessors() {
     // given
-    final var details =
-        new JobWaitStateDetails(
-            42L, "payment", JobKind.BPMN_ELEMENT, JobListenerEventType.UNSPECIFIED, 3);
+    final var details = new JobWaitStateDetails(42L, "payment", JobKind.BPMN_ELEMENT, null, 3);
     final var entry =
         new WaitStateEntry()
             .setRootProcessInstanceKey(100L)

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformerTest.java
@@ -36,7 +36,6 @@ class JobBasedWaitStateTransformerTest {
             .from(factory.generateObject(JobRecordValue.class))
             .withType("payment-service")
             .withJobKind(JobKind.BPMN_ELEMENT)
-            .withJobListenerEventType(JobListenerEventType.UNSPECIFIED)
             .withRetries(3)
             .withElementType(BpmnElementType.SERVICE_TASK)
             .withElementId("task-payment")
@@ -76,7 +75,7 @@ class JobBasedWaitStateTransformerTest {
     assertThat(details.jobKey()).isEqualTo(999L);
     assertThat(details.jobType()).isEqualTo("payment-service");
     assertThat(details.jobKind()).isEqualTo(JobKind.BPMN_ELEMENT);
-    assertThat(details.listenerEventType()).isEqualTo(JobListenerEventType.UNSPECIFIED);
+    assertThat(details.listenerEventType()).isNull();
     assertThat(details.retries()).isEqualTo(3);
   }
 
@@ -95,6 +94,114 @@ class JobBasedWaitStateTransformerTest {
     assertThat(transformer.supports(record)).isTrue();
     assertThat(transformer.triggersAdd(record)).isTrue();
     assertThat(transformer.triggersRemoval(record)).isFalse();
+  }
+
+  @Test
+  void shouldRetainListenerEventTypeForExecutionListenerJob() {
+    // given
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("exec-listener")
+            .withJobKind(JobKind.EXECUTION_LISTENER)
+            .withJobListenerEventType(JobListenerEventType.START)
+            .withRetries(3)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("exec-el")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withKey(999L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(JobIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then
+    final var details = (JobWaitStateDetails) entry.getDetails();
+    assertThat(details.jobKind()).isEqualTo(JobKind.EXECUTION_LISTENER);
+    assertThat(details.listenerEventType()).isEqualTo(JobListenerEventType.START);
+  }
+
+  @Test
+  void shouldRetainListenerEventTypeForTaskListenerJob() {
+    // given
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("task-listener")
+            .withJobKind(JobKind.TASK_LISTENER)
+            .withJobListenerEventType(JobListenerEventType.CREATING)
+            .withRetries(3)
+            .withElementType(BpmnElementType.USER_TASK)
+            .withElementId("user-task-tl")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withKey(999L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(JobIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then
+    final var details = (JobWaitStateDetails) entry.getDetails();
+    assertThat(details.jobKind()).isEqualTo(JobKind.TASK_LISTENER);
+    assertThat(details.listenerEventType()).isEqualTo(JobListenerEventType.CREATING);
+  }
+
+  @Test
+  void shouldEmitNullListenerEventTypeForAdHocSubProcess() {
+    // given
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("ahsp-job")
+            .withJobKind(JobKind.AD_HOC_SUB_PROCESS)
+            .withJobListenerEventType(JobListenerEventType.UNSPECIFIED)
+            .withRetries(3)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .withElementId("ahsp")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withKey(999L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(JobIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then
+    final var details = (JobWaitStateDetails) entry.getDetails();
+    assertThat(details.jobKind()).isEqualTo(JobKind.AD_HOC_SUB_PROCESS);
+    assertThat(details.listenerEventType()).isNull();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
@@ -149,8 +149,7 @@ class JobWaitStateHandlerTest {
     assertThat(details.get("jobKey").longValue()).isEqualTo(JOB_KEY);
     assertThat(details.get("jobType").textValue()).isEqualTo("payment-service");
     assertThat(details.get("jobKind").textValue()).isEqualTo(JobKind.BPMN_ELEMENT.name());
-    assertThat(details.get("listenerEventType").textValue())
-        .isEqualTo(JobListenerEventType.UNSPECIFIED.name());
+    assertThat(details.get("listenerEventType").isNull()).isTrue();
     assertThat(details.get("retries").intValue()).isEqualTo(3);
   }
 


### PR DESCRIPTION
## Summary

- `JobBasedWaitStateTransformer` now emits `null` for `listenerEventType` when `jobKind` is `BPMN_ELEMENT` or `AD_HOC_SUB_PROCESS`; only `EXECUTION_LISTENER` and `TASK_LISTENER` jobs forward the actual event type
- `SearchQueryResponseMapper` additionally treats stored `UNSPECIFIED` values as `null` so old Elasticsearch records also return a consistent `null` via the REST API
- `@Nullable` annotations added to the record field and Java client interface method; `isListenerJob` uses an exhaustive switch to catch future `JobKind` additions at compile time

Closes #55097

## Test Plan

- [ ] `JobBasedWaitStateTransformerTest` — updated assertion for BPMN_ELEMENT (`null`), two new tests for EXECUTION_LISTENER (`START`) and TASK_LISTENER (`CREATING`), one new test for AD_HOC_SUB_PROCESS (`null`)
- [ ] `SearchQueryResponseMapperTest` — new test `shouldMapUnspecifiedListenerEventTypeToNullInWaitStateJobDetails` verifies old `UNSPECIFIED` records return `null`
- [ ] `SearchElementInstanceWaitStatesTest` — BPMN_ELEMENT mock now sends `null`; new test for EXECUTION_LISTENER listener path
- [ ] `WaitStateJobIT` — `shouldFilterByElementType` now asserts `listenerEventType` for all 11 wait-state element types