### PR TITLE
feat: seed failure rate by version report on agentic control dashboard

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.dashboard;
 
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.DURATION_STABILITY_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_AVG_TOKENS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID;
@@ -1079,6 +1080,159 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   // ---------------------------------------------------------------------------
+  // Failure rate by process version
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldComputeFailureRatePerProcessVersion() {
+    // given version 1: 2 completed agentic instances, 1 with a resolved incident → 50%
+    final ProcessInstanceDto v1WithIncident =
+        resolvedIncident(agenticInstance(PROC_KEY, "1", 100L, 50L));
+    final ProcessInstanceDto v1Clean = agenticInstance(PROC_KEY, "1", 100L, 50L).build();
+    // version 2: 4 completed agentic instances, 1 with a resolved incident → 25%
+    final ProcessInstanceDto v2WithIncident =
+        resolvedIncident(agenticInstance(PROC_KEY, "2", 100L, 50L));
+    final List<ProcessInstanceDto> v2Clean =
+        repeat(3, () -> agenticInstance(PROC_KEY, "2", 100L, 50L).build());
+
+    persistProcessInstances(
+        Stream.concat(Stream.of(v1WithIncident, v1Clean, v2WithIncident), v2Clean.stream())
+            .toList());
+
+    // when
+    final List<MapResultEntryDto> buckets =
+        evaluateMapData(FAILURE_RATE_BY_VERSION_REPORT_ID, noExtraFilters());
+
+    // then
+    assertThat(rateForVersion(buckets, "1")).isEqualTo(50.0);
+    assertThat(rateForVersion(buckets, "2")).isEqualTo(25.0);
+  }
+
+  @Test
+  void shouldScopeDenominatorPerVersionBucket() {
+    // given version 1: 1 completed agentic with incident, 1 completed agentic clean → 50%
+    final ProcessInstanceDto withIncident =
+        resolvedIncident(agenticInstance(PROC_KEY, "1", 100L, 50L));
+    final ProcessInstanceDto clean = agenticInstance(PROC_KEY, "1", 100L, 50L).build();
+    // running agentic instances on the same version — must be excluded from the denominator
+    final List<ProcessInstanceDto> running =
+        repeat(
+            5,
+            () ->
+                agenticInstance(PROC_KEY, "1", 100L, 50L)
+                    .state(ProcessInstanceConstants.ACTIVE_STATE)
+                    .endDate(null)
+                    .duration(null)
+                    .build());
+    // completed non-agentic instances on the same version — must be excluded from the denominator
+    final List<ProcessInstanceDto> nonAgentic =
+        repeat(8, () -> completedInstance(PROC_KEY).processDefinitionVersion("1").build());
+
+    persistProcessInstances(
+        Stream.of(List.of(withIncident, clean), running, nonAgentic)
+            .flatMap(List::stream)
+            .toList());
+
+    // when
+    final List<MapResultEntryDto> buckets =
+        evaluateMapData(FAILURE_RATE_BY_VERSION_REPORT_ID, noExtraFilters());
+
+    // then denominator = 2 completed agentic instances (not 15); numerator = 1 → 50%
+    assertThat(rateForVersion(buckets, "1")).isEqualTo(50.0);
+  }
+
+  @Test
+  void shouldScopeFailureRatePerVersionByDateFilter() {
+    // given version 1 in window: 1 with incident, 1 clean → 50%
+    final ProcessInstanceDto recentWithIncident =
+        resolvedIncident(
+            agenticInstance(PROC_KEY, "1", 100L, 50L)
+                .startDate(OffsetDateTime.now().minusHours(3))
+                .endDate(OffsetDateTime.now().minusHours(2)));
+    final ProcessInstanceDto recentClean =
+        agenticInstance(PROC_KEY, "1", 100L, 50L)
+            .startDate(OffsetDateTime.now().minusHours(3))
+            .endDate(OffsetDateTime.now().minusHours(2))
+            .build();
+    // version 1 out of window: 10 with incidents — must not affect the bucket
+    final List<ProcessInstanceDto> oldWithIncidents =
+        repeat(
+            10,
+            () ->
+                resolvedIncident(
+                    agenticInstance(PROC_KEY, "1", 100L, 50L)
+                        .startDate(OffsetDateTime.now().minusDays(10))
+                        .endDate(OffsetDateTime.now().minusDays(9))));
+
+    persistProcessInstances(
+        Stream.concat(Stream.of(recentWithIncident, recentClean), oldWithIncidents.stream())
+            .toList());
+
+    // when
+    final List<MapResultEntryDto> buckets =
+        evaluateMapData(FAILURE_RATE_BY_VERSION_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS));
+
+    // then only the 2 in-window instances count → 1/2 = 50%
+    assertThat(rateForVersion(buckets, "1")).isEqualTo(50.0);
+  }
+
+  @Test
+  void shouldReturnOnlyScopedProcessVersionsWhenDefinitionFilterApplied() {
+    final String procKeyA = "proc-fr-a";
+    final String procKeyB = "proc-fr-b";
+
+    // procKeyA version 1: 2 instances, 1 with incident → 50%
+    final ProcessInstanceDto aV1WithIncident =
+        resolvedIncident(agenticInstance(procKeyA, "1", 100L, 50L));
+    final ProcessInstanceDto aV1Clean = agenticInstance(procKeyA, "1", 100L, 50L).build();
+    // procKeyA version 2: 4 instances, 1 with incident → 25%
+    final ProcessInstanceDto aV2WithIncident =
+        resolvedIncident(agenticInstance(procKeyA, "2", 100L, 50L));
+    final List<ProcessInstanceDto> aV2Clean =
+        repeat(3, () -> agenticInstance(procKeyA, "2", 100L, 50L).build());
+    // procKeyB version 1: 5 instances all with incidents — must not inflate procKeyA's version 1
+    final List<ProcessInstanceDto> bV1WithIncidents =
+        repeat(5, () -> resolvedIncident(agenticInstance(procKeyB, "1", 100L, 50L)));
+
+    persistProcessInstances(
+        Stream.of(List.of(aV1WithIncident, aV1Clean, aV2WithIncident), aV2Clean, bV1WithIncidents)
+            .flatMap(List::stream)
+            .toList());
+
+    // when
+    final List<MapResultEntryDto> buckets =
+        evaluateMapData(
+            FAILURE_RATE_BY_VERSION_REPORT_ID,
+            withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA))));
+
+    // then scope to procKeyA → only its versions appear, each with its own scoped rate
+    assertThat(buckets).extracting(MapResultEntryDto::getKey).containsExactlyInAnyOrder("1", "2");
+    assertThat(rateForVersion(buckets, "1")).isEqualTo(50.0);
+    assertThat(rateForVersion(buckets, "2")).isEqualTo(25.0);
+  }
+
+  @Test
+  void shouldReturnNoErrorWhenNoCompletedAgenticInstancesMatch() {
+    // given only running agentic and completed non-agentic instances — nothing to group
+    final ProcessInstanceDto running =
+        agenticInstance(PROC_KEY, "1", 100L, 50L)
+            .state(ProcessInstanceConstants.ACTIVE_STATE)
+            .endDate(null)
+            .duration(null)
+            .build();
+    final ProcessInstanceDto nonAgentic = completedInstance(PROC_KEY).build();
+
+    persistProcessInstances(List.of(running, nonAgentic));
+
+    // when
+    final List<MapResultEntryDto> buckets =
+        evaluateMapData(FAILURE_RATE_BY_VERSION_REPORT_ID, noExtraFilters());
+
+    // then evaluation succeeds with empty buckets (no NaN, no exception)
+    assertThat(buckets).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 
@@ -1124,6 +1278,53 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   private ProcessInstanceDto.ProcessInstanceDtoBuilder agenticInstanceWithDuration(
       final String processDefinitionKey, final long duration) {
     return agenticInstanceWithTokens(processDefinitionKey, 0L, 0L).duration(duration);
+  }
+
+  /**
+   * Builds a completed agentic {@link ProcessInstanceDto} pinned to a specific process definition
+   * version, so reports grouped by version see distinct buckets.
+   */
+  private ProcessInstanceDto.ProcessInstanceDtoBuilder agenticInstance(
+      final String processDefinitionKey,
+      final String processDefinitionVersion,
+      final long inputTokens,
+      final long outputTokens) {
+    return agenticInstanceWithTokens(processDefinitionKey, inputTokens, outputTokens)
+        .processDefinitionVersion(processDefinitionVersion)
+        .processDefinitionId(processDefinitionKey + ":" + processDefinitionVersion + ":1");
+  }
+
+  private List<ProcessInstanceDto> repeat(
+      final int count, final java.util.function.Supplier<ProcessInstanceDto> supplier) {
+    return java.util.stream.IntStream.range(0, count).mapToObj(i -> supplier.get()).toList();
+  }
+
+  private ProcessInstanceDto resolvedIncident(
+      final ProcessInstanceDto.ProcessInstanceDtoBuilder builder) {
+    final String instanceId = UUID.randomUUID().toString();
+    return builder
+        .processInstanceId(instanceId)
+        .incidents(
+            List.of(
+                IncidentDto.builder()
+                    .incidentStatus(IncidentStatus.RESOLVED)
+                    .processInstanceId(instanceId)
+                    .build()))
+        .build();
+  }
+
+  private List<MapResultEntryDto> evaluateMapData(
+      final String reportId, final AdditionalProcessReportEvaluationFilterDto filterDto) {
+    return evaluateMap(reportId, filterDto).getFirstMeasureData();
+  }
+
+  private Double rateForVersion(
+      final List<MapResultEntryDto> buckets, final String processDefinitionVersion) {
+    return buckets.stream()
+        .filter(entry -> processDefinitionVersion.equals(entry.getKey()))
+        .map(MapResultEntryDto::getValue)
+        .findFirst()
+        .orElse(null);
   }
 
   private Double evaluateNumber(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -317,7 +317,7 @@ public class AgenticControlDashboardService {
 
     return buildTile(
         TOKEN_TREND_REPORT_ID,
-        new PositionDto(0, 6),
+        new PositionDto(0, 4),
         new DimensionDto(9, 4),
         Map.of("section", "token", "footnote", KPI_TOKEN_TREND_FOOTNOTE_KEY));
   }
@@ -359,7 +359,7 @@ public class AgenticControlDashboardService {
         KPI_DURATION_P50_REPORT_ID,
         KPI_DURATION_P50_NAME,
         KPI_DURATION_P50_DESCRIPTION,
-        new PositionDto(0, 4));
+        new PositionDto(0, 10));
   }
 
   private DashboardReportTileDto buildP95DurationReport() {
@@ -368,7 +368,7 @@ public class AgenticControlDashboardService {
         KPI_DURATION_P95_REPORT_ID,
         KPI_DURATION_P95_NAME,
         KPI_DURATION_P95_DESCRIPTION,
-        new PositionDto(9, 4));
+        new PositionDto(9, 10));
   }
 
   private DashboardReportTileDto buildDurationPercentileReport(
@@ -440,7 +440,7 @@ public class AgenticControlDashboardService {
         null);
     return buildTile(
         DURATION_STABILITY_REPORT_ID,
-        new PositionDto(0, 6),
+        new PositionDto(0, 12),
         new DimensionDto(18, 2),
         Map.of("section", "duration"));
   }
@@ -473,7 +473,7 @@ public class AgenticControlDashboardService {
         null);
     return buildTile(
         FAILURE_RATE_BY_VERSION_REPORT_ID,
-        new PositionDto(0, 6),
+        new PositionDto(0, 8),
         new DimensionDto(18, 2),
         Map.of("visibleInL1Only", true, "section", "reliabilityAndToolCalls"));
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -32,6 +32,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.util.ProcessFilterBuilder;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.EndDateGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.NoneGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionVersionGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.value.DateGroupByValueDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
@@ -85,6 +86,9 @@ public class AgenticControlDashboardService {
   public static final String KPI_DURATION_P50_DESCRIPTION = "agenticKpiDurationP50Description";
   public static final String KPI_DURATION_P95_NAME = "agenticKpiDurationP95Name";
   public static final String KPI_DURATION_P95_DESCRIPTION = "agenticKpiDurationP95Description";
+  public static final String FAILURE_RATE_BY_VERSION_NAME = "agenticFailureRateByVersionName";
+  public static final String FAILURE_RATE_BY_VERSION_DESCRIPTION =
+      "agenticFailureRateByVersionDescription";
 
   public static final String DURATION_STABILITY_NAME = "agenticDurationStabilityName";
   public static final String DURATION_STABILITY_DESCRIPTION = "agenticDurationStabilityDescription";
@@ -114,6 +118,9 @@ public class AgenticControlDashboardService {
       UUID.nameUUIDFromBytes("agentic-duration-p50".getBytes(StandardCharsets.UTF_8)).toString();
   public static final String KPI_DURATION_P95_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-duration-p95".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String FAILURE_RATE_BY_VERSION_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-failure-rate-by-version".getBytes(StandardCharsets.UTF_8))
+          .toString();
 
   private static final long INSTANCE_END_DATE_ROLLING_DAYS = 30L;
 
@@ -158,6 +165,7 @@ public class AgenticControlDashboardService {
     tiles.add(buildTokenTrendReport());
     tiles.add(buildP50DurationReport());
     tiles.add(buildP95DurationReport());
+    tiles.add(buildFailureRateByVersionReport());
 
     // Always upsert the dashboard too — tile list can grow across versions and the cold-start
     // guard would leave an existing deployment stuck on the old layout.
@@ -435,6 +443,39 @@ public class AgenticControlDashboardService {
         new PositionDto(0, 6),
         new DimensionDto(18, 2),
         Map.of("section", "duration"));
+  }
+
+  private DashboardReportTileDto buildFailureRateByVersionReport() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.PERCENTAGE))
+            .groupBy(new ProcessDefinitionVersionGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.BAR)
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .withResolvedIncident()
+                    .add()
+                    .buildList())
+            .agenticControlReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        FAILURE_RATE_BY_VERSION_REPORT_ID,
+        null,
+        reportData,
+        FAILURE_RATE_BY_VERSION_NAME,
+        FAILURE_RATE_BY_VERSION_DESCRIPTION,
+        null);
+    return buildTile(
+        FAILURE_RATE_BY_VERSION_REPORT_ID,
+        new PositionDto(0, 6),
+        new DimensionDto(18, 2),
+        Map.of("visibleInL1Only", true, "section", "reliabilityAndToolCalls"));
   }
 
   private DashboardDefinitionRestDto buildAgentDashboard(final List<DashboardReportTileDto> tiles) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByInterpreterES.java
@@ -34,4 +34,18 @@ public interface ProcessGroupByInterpreterES
       final Query baseQuery) {
     return Optional.empty();
   }
+
+  /**
+   * Declares the instance index field on which unfiltered per-group baseline counts should be
+   * aggregated for this group-by, or empty if the group-by does not need per-group baselines (the
+   * report-level baseline count is used instead). The execution plan interpreter performs the
+   * actual aggregation, keeping the database client out of the group-by layer. Defaults to empty.
+   *
+   * @param context command execution context
+   * @return the field to aggregate per-group baseline counts on, if applicable
+   */
+  default Optional<String> getBaselineCountAggregationField(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    return Optional.empty();
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByInterpreterFacadeES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByInterpreterFacadeES.java
@@ -71,4 +71,10 @@ public class ProcessGroupByInterpreterFacadeES
       final Query baseQuery) {
     return interpreter(context.getPlan().getGroupBy()).getMinMaxStats(context, baseQuery);
   }
+
+  @Override
+  public Optional<String> getBaselineCountAggregationField(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    return interpreter(context.getPlan().getGroupBy()).getBaselineCountAggregationField(context);
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterES.java
@@ -18,6 +18,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch.core.search.ResponseBody;
 import co.elastic.clients.util.NamedValue;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
@@ -30,6 +31,7 @@ import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCon
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -58,6 +60,17 @@ public class ProcessGroupByProcessDefinitionVersionInterpreterES
   @Override
   public Set<ProcessGroupBy> getSupportedGroupBys() {
     return Set.of(PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION);
+  }
+
+  @Override
+  public Optional<String> getBaselineCountAggregationField(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    // Percentage reports are relative to the unfiltered instance count. When grouped by version,
+    // that denominator must be computed per version, so we aggregate baseline counts on the
+    // version field. Other views use the report-level baseline count.
+    return context.getReportData().getViewProperties().contains(ViewProperty.PERCENTAGE)
+        ? Optional.of(PROCESS_DEFINITION_VERSION)
+        : Optional.empty();
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterES.java
@@ -89,14 +89,26 @@ public class ProcessGroupByProcessDefinitionVersionInterpreterES
     final StringTermsAggregate processDefinitionVersionAggregation =
         response.aggregations().get(PROCESS_DEFINITION_VERSION_AGGREGATION).sterms();
     final List<GroupByResult> groupedData = new ArrayList<>();
-    for (final StringTermsBucket processDefinitionVersionBucket :
-        processDefinitionVersionAggregation.buckets().array()) {
-      final String processDefinitionVersion = processDefinitionVersionBucket.key().stringValue();
-      final List<CompositeCommandResult.DistributedByResult> distributedByResult =
-          distributedByInterpreter.retrieveResult(
-              response, processDefinitionVersionBucket.aggregations(), context);
-      groupedData.add(
-          GroupByResult.createGroupByResult(processDefinitionVersion, distributedByResult));
+    // Save the global baseline count so we can restore it after the loop; the per-bucket override
+    // is only relevant inside the view interpreter and must not leak into the report-level count.
+    final long globalBaselineCount = context.getUnfilteredTotalInstanceCount();
+    final Map<String, Long> perGroupCounts = context.getUnfilteredInstanceCountsByGroupKey();
+    try {
+      for (final StringTermsBucket processDefinitionVersionBucket :
+          processDefinitionVersionAggregation.buckets().array()) {
+        final String processDefinitionVersion = processDefinitionVersionBucket.key().stringValue();
+        if (!perGroupCounts.isEmpty()) {
+          context.setUnfilteredTotalInstanceCount(
+              perGroupCounts.getOrDefault(processDefinitionVersion, 0L));
+        }
+        final List<CompositeCommandResult.DistributedByResult> distributedByResult =
+            distributedByInterpreter.retrieveResult(
+                response, processDefinitionVersionBucket.aggregations(), context);
+        groupedData.add(
+            GroupByResult.createGroupByResult(processDefinitionVersion, distributedByResult));
+      }
+    } finally {
+      context.setUnfilteredTotalInstanceCount(globalBaselineCount);
     }
     compositeCommandResult.setGroups(groupedData);
     compositeCommandResult.setGroupByKeyOfNumericType(true);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/AbstractExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/AbstractExecutionPlanInterpreterES.java
@@ -110,6 +110,11 @@ public abstract class AbstractExecutionPlanInterpreterES<
   protected abstract BoolQuery.Builder setupUnfilteredBaseQueryBuilder(
       final ExecutionContext<DATA, PLAN> reportData);
 
+  // Hook for subclasses to populate per-group baseline counts (e.g. per process definition version)
+  // when the report uses a grouped percentage view. Default implementation is a no-op.
+  protected void populatePerGroupBaselineCounts(
+      final ExecutionContext<DATA, PLAN> context, final String[] indices) throws IOException {}
+
   private OptimizeSearchRequestBuilderES createBaseQuerySearchRequest(
       final ExecutionContext<DATA, PLAN> executionContext, final String... indexes) {
     final Supplier<BoolQuery.Builder> baseQueryBuilderSupplier =
@@ -162,6 +167,7 @@ public abstract class AbstractExecutionPlanInterpreterES<
     final BoolQuery.Builder countQueryBuilder = setupUnfilteredBaseQueryBuilder(executionContext);
     executionContext.setUnfilteredTotalInstanceCount(
         getEsClient().count(indices, countQueryBuilder));
+    populatePerGroupBaselineCounts(executionContext, indices);
     return response;
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/AbstractExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/AbstractExecutionPlanInterpreterES.java
@@ -110,10 +110,12 @@ public abstract class AbstractExecutionPlanInterpreterES<
   protected abstract BoolQuery.Builder setupUnfilteredBaseQueryBuilder(
       final ExecutionContext<DATA, PLAN> reportData);
 
-  // Hook for subclasses to populate per-group baseline counts (e.g. per process definition version)
-  // when the report uses a grouped percentage view. Default implementation is a no-op.
-  protected void populatePerGroupBaselineCounts(
-      final ExecutionContext<DATA, PLAN> context, final String[] indices) throws IOException {}
+  // Hook for subclasses to provide per-group baseline counts (e.g. per process definition version)
+  // when the report uses a grouped percentage view. Default implementation contributes no counts.
+  protected Map<String, Long> retrievePerGroupBaselineCounts(
+      final ExecutionContext<DATA, PLAN> context, final String[] indices) {
+    return Map.of();
+  }
 
   private OptimizeSearchRequestBuilderES createBaseQuerySearchRequest(
       final ExecutionContext<DATA, PLAN> executionContext, final String... indexes) {
@@ -167,7 +169,8 @@ public abstract class AbstractExecutionPlanInterpreterES<
     final BoolQuery.Builder countQueryBuilder = setupUnfilteredBaseQueryBuilder(executionContext);
     executionContext.setUnfilteredTotalInstanceCount(
         getEsClient().count(indices, countQueryBuilder));
-    populatePerGroupBaselineCounts(executionContext, indices);
+    executionContext.setUnfilteredInstanceCountsByGroupKey(
+        retrievePerGroupBaselineCounts(executionContext, indices));
     return response;
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterES.java
@@ -9,20 +9,21 @@ package io.camunda.optimize.service.db.es.report.interpreter.plan.process;
 
 import static io.camunda.optimize.dto.optimize.ReportConstants.APPLIED_TO_ALL_DEFINITIONS;
 import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_INSTANCE_MULTI_ALIAS;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
+import static java.util.stream.Collectors.toMap;
 
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import co.elastic.clients.util.NamedValue;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
-import io.camunda.optimize.dto.optimize.query.report.single.process.filter.CompletedInstancesOnlyFilterDto;
-import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FilterApplicationLevel;
-import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeEndDateFilterDto;
-import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FlowNodeStartDateFilterDto;
-import io.camunda.optimize.dto.optimize.query.report.single.process.filter.HasAgentInstancesFilterDto;
-import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceEndDateFilterDto;
-import io.camunda.optimize.dto.optimize.query.report.single.process.filter.InstanceStartDateFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
 import io.camunda.optimize.service.db.es.builders.OptimizeBoolQueryBuilderES;
+import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
 import io.camunda.optimize.service.db.es.filter.ProcessQueryFilterEnhancerES;
 import io.camunda.optimize.service.db.es.report.interpreter.groupby.process.ProcessGroupByInterpreterES;
 import io.camunda.optimize.service.db.es.report.interpreter.plan.AbstractExecutionPlanInterpreterES;
@@ -33,6 +34,8 @@ import io.camunda.optimize.service.db.report.MinMaxStatDto;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.util.DefinitionQueryUtilES;
 import io.camunda.optimize.service.util.InstanceIndexUtil;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -43,30 +46,14 @@ import java.util.stream.Stream;
 public abstract class AbstractProcessExecutionPlanInterpreterES
     extends AbstractExecutionPlanInterpreterES<ProcessReportDataDto, ProcessExecutionPlan>
     implements ProcessExecutionPlanInterpreterES {
-  // Instance date filters should also reduce the total count (baseline) considered for report
-  // evaluation
-  private static final List<Class<? extends ProcessFilterDto<?>>> FILTERS_AFFECTING_BASELINE =
-      List.of(
-          InstanceStartDateFilterDto.class,
-          InstanceEndDateFilterDto.class,
-          FlowNodeStartDateFilterDto.class,
-          FlowNodeEndDateFilterDto.class);
 
-  // For agentic reports the baseline must also be scoped to completed agentic instances so that the
-  // percentage denominator matches the same population as the numerator filter set.
-  private static final List<Class<? extends ProcessFilterDto<?>>>
-      FILTERS_AFFECTING_AGENTIC_BASELINE =
-          List.of(
-              InstanceStartDateFilterDto.class,
-              InstanceEndDateFilterDto.class,
-              FlowNodeStartDateFilterDto.class,
-              FlowNodeEndDateFilterDto.class,
-              CompletedInstancesOnlyFilterDto.class,
-              HasAgentInstancesFilterDto.class);
+  private static final String VERSION_BASELINE_AGGREGATION = "versionBaselineAgg";
 
   protected abstract ProcessDefinitionReader getProcessDefinitionReader();
 
   protected abstract ProcessQueryFilterEnhancerES getQueryFilterEnhancer();
+
+  protected abstract ConfigurationService getConfigurationService();
 
   @Override
   public Optional<MinMaxStatDto> getGroupByMinMaxStats(
@@ -104,25 +91,8 @@ public abstract class AbstractProcessExecutionPlanInterpreterES
   @Override
   protected BoolQuery.Builder setupUnfilteredBaseQueryBuilder(
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
-    // Instance level date filters are also applied to the baseline so are included here.
-    // For agentic reports the baseline is further scoped to completed agentic instances so that the
-    // percentage denominator matches the correct population.
-    final List<Class<? extends ProcessFilterDto<?>>> effectiveBaselineFilters =
-        context.getReportData().isAgenticControlReport()
-            ? FILTERS_AFFECTING_AGENTIC_BASELINE
-            : FILTERS_AFFECTING_BASELINE;
     final Map<String, List<ProcessFilterDto<?>>> instanceLevelDateFiltersByDefinitionKey =
-        context.getReportData().groupFiltersByDefinitionIdentifier().entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry ->
-                        entry.getValue().stream()
-                            .filter(
-                                filter ->
-                                    filter.getFilterLevel() == FilterApplicationLevel.INSTANCE)
-                            .filter(filter -> effectiveBaselineFilters.contains(filter.getClass()))
-                            .collect(Collectors.toList())));
+        buildBaselineFiltersByDefinition(context);
     final BoolQuery.Builder multiDefinitionFilterQuery =
         buildDefinitionBaseQueryForFilters(context, instanceLevelDateFiltersByDefinitionKey);
 
@@ -133,6 +103,46 @@ public abstract class AbstractProcessExecutionPlanInterpreterES
                 APPLIED_TO_ALL_DEFINITIONS, Collections.emptyList()),
             context.getFilterContext());
     return multiDefinitionFilterQuery;
+  }
+
+  @Override
+  protected void populatePerGroupBaselineCounts(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
+      final String[] indices)
+      throws IOException {
+    if (context.getPlan() == PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION) {
+      final BoolQuery.Builder baselineQuery = setupUnfilteredBaseQueryBuilder(context);
+      final ResponseBody<?> response =
+          getEsClient()
+              .search(
+                  OptimizeSearchRequestBuilderES.of(
+                      r ->
+                          r.optimizeIndex(getEsClient(), indices)
+                              .query(q -> q.bool(baselineQuery.build()))
+                              .size(0)
+                              .aggregations(
+                                  VERSION_BASELINE_AGGREGATION,
+                                  a ->
+                                      a.terms(
+                                          t ->
+                                              t.field(PROCESS_DEFINITION_VERSION)
+                                                  .size(
+                                                      getConfigurationService()
+                                                          .getElasticSearchConfiguration()
+                                                          .getAggregationBucketLimit())
+                                                  .order(NamedValue.of("_key", SortOrder.Asc))))),
+                  Object.class);
+      final Map<String, Long> perVersionCounts =
+          response
+              .aggregations()
+              .get(VERSION_BASELINE_AGGREGATION)
+              .sterms()
+              .buckets()
+              .array()
+              .stream()
+              .collect(toMap(b -> b.key().stringValue(), StringTermsBucket::docCount));
+      context.setUnfilteredInstanceCountsByGroupKey(perVersionCounts);
+    }
   }
 
   private BoolQuery.Builder buildDefinitionBaseQueryForFilters(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterES.java
@@ -9,21 +9,13 @@ package io.camunda.optimize.service.db.es.report.interpreter.plan.process;
 
 import static io.camunda.optimize.dto.optimize.ReportConstants.APPLIED_TO_ALL_DEFINITIONS;
 import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_INSTANCE_MULTI_ALIAS;
-import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION;
-import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
-import static java.util.stream.Collectors.toMap;
 
-import co.elastic.clients.elasticsearch._types.SortOrder;
-import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.elasticsearch.core.search.ResponseBody;
-import co.elastic.clients.util.NamedValue;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
 import io.camunda.optimize.service.db.es.builders.OptimizeBoolQueryBuilderES;
-import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
 import io.camunda.optimize.service.db.es.filter.ProcessQueryFilterEnhancerES;
 import io.camunda.optimize.service.db.es.report.interpreter.groupby.process.ProcessGroupByInterpreterES;
 import io.camunda.optimize.service.db.es.report.interpreter.plan.AbstractExecutionPlanInterpreterES;
@@ -34,8 +26,6 @@ import io.camunda.optimize.service.db.report.MinMaxStatDto;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.util.DefinitionQueryUtilES;
 import io.camunda.optimize.service.util.InstanceIndexUtil;
-import io.camunda.optimize.service.util.configuration.ConfigurationService;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -47,13 +37,9 @@ public abstract class AbstractProcessExecutionPlanInterpreterES
     extends AbstractExecutionPlanInterpreterES<ProcessReportDataDto, ProcessExecutionPlan>
     implements ProcessExecutionPlanInterpreterES {
 
-  private static final String VERSION_BASELINE_AGGREGATION = "versionBaselineAgg";
-
   protected abstract ProcessDefinitionReader getProcessDefinitionReader();
 
   protected abstract ProcessQueryFilterEnhancerES getQueryFilterEnhancer();
-
-  protected abstract ConfigurationService getConfigurationService();
 
   @Override
   public Optional<MinMaxStatDto> getGroupByMinMaxStats(
@@ -103,46 +89,6 @@ public abstract class AbstractProcessExecutionPlanInterpreterES
                 APPLIED_TO_ALL_DEFINITIONS, Collections.emptyList()),
             context.getFilterContext());
     return multiDefinitionFilterQuery;
-  }
-
-  @Override
-  protected void populatePerGroupBaselineCounts(
-      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
-      final String[] indices)
-      throws IOException {
-    if (context.getPlan() == PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION) {
-      final BoolQuery.Builder baselineQuery = setupUnfilteredBaseQueryBuilder(context);
-      final ResponseBody<?> response =
-          getEsClient()
-              .search(
-                  OptimizeSearchRequestBuilderES.of(
-                      r ->
-                          r.optimizeIndex(getEsClient(), indices)
-                              .query(q -> q.bool(baselineQuery.build()))
-                              .size(0)
-                              .aggregations(
-                                  VERSION_BASELINE_AGGREGATION,
-                                  a ->
-                                      a.terms(
-                                          t ->
-                                              t.field(PROCESS_DEFINITION_VERSION)
-                                                  .size(
-                                                      getConfigurationService()
-                                                          .getElasticSearchConfiguration()
-                                                          .getAggregationBucketLimit())
-                                                  .order(NamedValue.of("_key", SortOrder.Asc))))),
-                  Object.class);
-      final Map<String, Long> perVersionCounts =
-          response
-              .aggregations()
-              .get(VERSION_BASELINE_AGGREGATION)
-              .sterms()
-              .buckets()
-              .array()
-              .stream()
-              .collect(toMap(b -> b.key().stringValue(), StringTermsBucket::docCount));
-      context.setUnfilteredInstanceCountsByGroupKey(perVersionCounts);
-    }
   }
 
   private BoolQuery.Builder buildDefinitionBaseQueryForFilters(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterES.java
@@ -7,14 +7,31 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.plan.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.VERSION_BASELINE_AGGREGATION;
+import static java.util.stream.Collectors.toMap;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import co.elastic.clients.util.NamedValue;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
 import io.camunda.optimize.service.db.es.filter.ProcessQueryFilterEnhancerES;
+import io.camunda.optimize.service.db.es.report.interpreter.groupby.process.ProcessGroupByInterpreterES;
 import io.camunda.optimize.service.db.es.report.interpreter.groupby.process.ProcessGroupByInterpreterFacadeES;
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.interpreter.plan.process.GenericProcessExecutionPlanInterpreter;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -71,5 +88,55 @@ public class GenericProcessExecutionPlanInterpreterES
 
   public ConfigurationService getConfigurationService() {
     return this.configurationService;
+  }
+
+  @Override
+  protected Map<String, Long> retrievePerGroupBaselineCounts(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
+      final String[] indices) {
+    if (!(getGroupByInterpreter()
+        instanceof final ProcessGroupByInterpreterES groupByInterpreter)) {
+      return Map.of();
+    }
+    final Optional<String> baselineField =
+        groupByInterpreter.getBaselineCountAggregationField(context);
+    if (baselineField.isEmpty()) {
+      return Map.of();
+    }
+    final String field = baselineField.get();
+    final BoolQuery.Builder baselineQuery = setupUnfilteredBaseQueryBuilder(context);
+    final ResponseBody<?> response;
+    try {
+      response =
+          getEsClient()
+              .search(
+                  OptimizeSearchRequestBuilderES.of(
+                      r ->
+                          r.optimizeIndex(getEsClient(), indices)
+                              .query(q -> q.bool(baselineQuery.build()))
+                              .size(0)
+                              .aggregations(
+                                  VERSION_BASELINE_AGGREGATION,
+                                  a ->
+                                      a.terms(
+                                          t ->
+                                              t.field(field)
+                                                  .size(
+                                                      getConfigurationService()
+                                                          .getElasticSearchConfiguration()
+                                                          .getAggregationBucketLimit())
+                                                  .order(NamedValue.of("_key", SortOrder.Asc))))),
+                  Object.class);
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException("Could not retrieve per-version baseline counts", e);
+    }
+    return response
+        .aggregations()
+        .get(VERSION_BASELINE_AGGREGATION)
+        .sterms()
+        .buckets()
+        .array()
+        .stream()
+        .collect(toMap(b -> b.key().stringValue(), StringTermsBucket::docCount));
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterES.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.service.db.es.report.interpreter.groupby.process.Proc
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.report.interpreter.plan.process.GenericProcessExecutionPlanInterpreter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
@@ -31,18 +32,21 @@ public class GenericProcessExecutionPlanInterpreterES
   private final ProcessQueryFilterEnhancerES queryFilterEnhancer;
   private final ProcessGroupByInterpreterFacadeES groupByInterpreter;
   private final ProcessViewInterpreterFacadeES viewInterpreter;
+  private final ConfigurationService configurationService;
 
   public GenericProcessExecutionPlanInterpreterES(
       final ProcessDefinitionReader processDefinitionReader,
       final OptimizeElasticsearchClient esClient,
       final ProcessQueryFilterEnhancerES queryFilterEnhancer,
       final ProcessGroupByInterpreterFacadeES groupByInterpreter,
-      final ProcessViewInterpreterFacadeES viewInterpreter) {
+      final ProcessViewInterpreterFacadeES viewInterpreter,
+      final ConfigurationService configurationService) {
     this.processDefinitionReader = processDefinitionReader;
     this.esClient = esClient;
     this.queryFilterEnhancer = queryFilterEnhancer;
     this.groupByInterpreter = groupByInterpreter;
     this.viewInterpreter = viewInterpreter;
+    this.configurationService = configurationService;
   }
 
   public ProcessDefinitionReader getProcessDefinitionReader() {
@@ -63,5 +67,9 @@ public class GenericProcessExecutionPlanInterpreterES
 
   public ProcessViewInterpreterFacadeES getViewInterpreter() {
     return this.viewInterpreter;
+  }
+
+  public ConfigurationService getConfigurationService() {
+    return this.configurationService;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterES.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.interpreter.plan.process.RawProcessInstanceDataGroupByNoneExecutionPlanInterpreter;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.util.Set;
 import org.springframework.context.annotation.Conditional;
@@ -35,18 +36,21 @@ public class RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterES
   private final OptimizeElasticsearchClient esClient;
   private final ProcessDefinitionReader processDefinitionReader;
   private final ProcessQueryFilterEnhancerES queryFilterEnhancer;
+  private final ConfigurationService configurationService;
 
   public RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterES(
       final ProcessGroupByInterpreterFacadeES groupByInterpreter,
       final ProcessViewInterpreterFacadeES viewInterpreter,
       final OptimizeElasticsearchClient esClient,
       final ProcessDefinitionReader processDefinitionReader,
-      final ProcessQueryFilterEnhancerES queryFilterEnhancer) {
+      final ProcessQueryFilterEnhancerES queryFilterEnhancer,
+      final ConfigurationService configurationService) {
     this.groupByInterpreter = groupByInterpreter;
     this.viewInterpreter = viewInterpreter;
     this.esClient = esClient;
     this.processDefinitionReader = processDefinitionReader;
     this.queryFilterEnhancer = queryFilterEnhancer;
+    this.configurationService = configurationService;
   }
 
   @Override
@@ -80,5 +84,9 @@ public class RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterES
 
   public ProcessQueryFilterEnhancerES getQueryFilterEnhancer() {
     return this.queryFilterEnhancer;
+  }
+
+  public ConfigurationService getConfigurationService() {
+    return this.configurationService;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterES.java
@@ -19,7 +19,6 @@ import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.interpreter.plan.process.RawProcessInstanceDataGroupByNoneExecutionPlanInterpreter;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
-import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.util.Set;
 import org.springframework.context.annotation.Conditional;
@@ -36,21 +35,18 @@ public class RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterES
   private final OptimizeElasticsearchClient esClient;
   private final ProcessDefinitionReader processDefinitionReader;
   private final ProcessQueryFilterEnhancerES queryFilterEnhancer;
-  private final ConfigurationService configurationService;
 
   public RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterES(
       final ProcessGroupByInterpreterFacadeES groupByInterpreter,
       final ProcessViewInterpreterFacadeES viewInterpreter,
       final OptimizeElasticsearchClient esClient,
       final ProcessDefinitionReader processDefinitionReader,
-      final ProcessQueryFilterEnhancerES queryFilterEnhancer,
-      final ConfigurationService configurationService) {
+      final ProcessQueryFilterEnhancerES queryFilterEnhancer) {
     this.groupByInterpreter = groupByInterpreter;
     this.viewInterpreter = viewInterpreter;
     this.esClient = esClient;
     this.processDefinitionReader = processDefinitionReader;
     this.queryFilterEnhancer = queryFilterEnhancer;
-    this.configurationService = configurationService;
   }
 
   @Override
@@ -84,9 +80,5 @@ public class RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterES
 
   public ProcessQueryFilterEnhancerES getQueryFilterEnhancer() {
     return this.queryFilterEnhancer;
-  }
-
-  public ConfigurationService getConfigurationService() {
-    return this.configurationService;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByInterpreterFacadeOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByInterpreterFacadeOS.java
@@ -79,4 +79,10 @@ public class ProcessGroupByInterpreterFacadeOS
       final Query baseQuery) {
     return interpreter(context.getPlan().getGroupBy()).getMinMaxStats(context, baseQuery);
   }
+
+  @Override
+  public Optional<String> getBaselineCountAggregationField(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    return interpreter(context.getPlan().getGroupBy()).getBaselineCountAggregationField(context);
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByInterpreterOS.java
@@ -34,4 +34,18 @@ public interface ProcessGroupByInterpreterOS
       final Query baseQuery) {
     return Optional.empty();
   }
+
+  /**
+   * Declares the instance index field on which unfiltered per-group baseline counts should be
+   * aggregated for this group-by, or empty if the group-by does not need per-group baselines (the
+   * report-level baseline count is used instead). The execution plan interpreter performs the
+   * actual aggregation, keeping the database client out of the group-by layer. Defaults to empty.
+   *
+   * @param context command execution context
+   * @return the field to aggregate per-group baseline counts on, if applicable
+   */
+  default Optional<String> getBaselineCountAggregationField(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    return Optional.empty();
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOS.java
@@ -13,6 +13,7 @@ import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.
 import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
 
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
 import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
@@ -26,6 +27,7 @@ import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondit
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
@@ -60,6 +62,17 @@ public class ProcessGroupByProcessDefinitionVersionInterpreterOS
   @Override
   public Set<ProcessGroupBy> getSupportedGroupBys() {
     return Set.of(PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION);
+  }
+
+  @Override
+  public Optional<String> getBaselineCountAggregationField(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    // Percentage reports are relative to the unfiltered instance count. When grouped by version,
+    // that denominator must be computed per version, so we aggregate baseline counts on the
+    // version field. Other views use the report-level baseline count.
+    return context.getReportData().getViewProperties().contains(ViewProperty.PERCENTAGE)
+        ? Optional.of(PROCESS_DEFINITION_VERSION)
+        : Optional.empty();
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOS.java
@@ -83,14 +83,26 @@ public class ProcessGroupByProcessDefinitionVersionInterpreterOS
     final StringTermsAggregate processDefinitionVersionAggregation =
         response.aggregations().get(PROCESS_DEFINITION_VERSION_AGGREGATION).sterms();
     final List<GroupByResult> groupedData = new ArrayList<>();
-    for (final StringTermsBucket processDefinitionVersionBucket :
-        processDefinitionVersionAggregation.buckets().array()) {
-      final String processDefinitionVersion = processDefinitionVersionBucket.key();
-      final List<CompositeCommandResult.DistributedByResult> distributedByResult =
-          distributedByInterpreter.retrieveResult(
-              response, processDefinitionVersionBucket.aggregations(), context);
-      groupedData.add(
-          GroupByResult.createGroupByResult(processDefinitionVersion, distributedByResult));
+    // Save the global baseline count so we can restore it after the loop; the per-bucket override
+    // is only relevant inside the view interpreter and must not leak into the report-level count.
+    final long globalBaselineCount = context.getUnfilteredTotalInstanceCount();
+    final Map<String, Long> perGroupCounts = context.getUnfilteredInstanceCountsByGroupKey();
+    try {
+      for (final StringTermsBucket processDefinitionVersionBucket :
+          processDefinitionVersionAggregation.buckets().array()) {
+        final String processDefinitionVersion = processDefinitionVersionBucket.key();
+        if (!perGroupCounts.isEmpty()) {
+          context.setUnfilteredTotalInstanceCount(
+              perGroupCounts.getOrDefault(processDefinitionVersion, 0L));
+        }
+        final List<CompositeCommandResult.DistributedByResult> distributedByResult =
+            distributedByInterpreter.retrieveResult(
+                response, processDefinitionVersionBucket.aggregations(), context);
+        groupedData.add(
+            GroupByResult.createGroupByResult(processDefinitionVersion, distributedByResult));
+      }
+    } finally {
+      context.setUnfilteredTotalInstanceCount(globalBaselineCount);
     }
     compositeCommandResult.setGroups(groupedData);
     compositeCommandResult.setGroupByKeyOfNumericType(true);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/AbstractExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/AbstractExecutionPlanInterpreterOS.java
@@ -102,6 +102,11 @@ public abstract class AbstractExecutionPlanInterpreterOS<
   protected abstract BoolQuery.Builder unfilteredBaseQueryBuilder(
       final ExecutionContext<DATA, PLAN> reportData);
 
+  // Hook for subclasses to populate per-group baseline counts (e.g. per process definition version)
+  // when the report uses a grouped percentage view. Default implementation is a no-op.
+  protected void populatePerGroupBaselineCounts(
+      final ExecutionContext<DATA, PLAN> context, final String[] indices) throws IOException {}
+
   private SearchRequest.Builder createBaseQuerySearchRequest(
       final ExecutionContext<DATA, PLAN> executionContext) {
     final Query query =
@@ -137,6 +142,7 @@ public abstract class AbstractExecutionPlanInterpreterOS<
     final String[] indices = getIndexNames(executionContext);
     final Query countQuery = unfilteredBaseQueryBuilder(executionContext).build().toQuery();
     executionContext.setUnfilteredTotalInstanceCount(getOsClient().count(indices, countQuery));
+    populatePerGroupBaselineCounts(executionContext, indices);
     return response;
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/AbstractExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/AbstractExecutionPlanInterpreterOS.java
@@ -27,6 +27,7 @@ import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -102,10 +103,12 @@ public abstract class AbstractExecutionPlanInterpreterOS<
   protected abstract BoolQuery.Builder unfilteredBaseQueryBuilder(
       final ExecutionContext<DATA, PLAN> reportData);
 
-  // Hook for subclasses to populate per-group baseline counts (e.g. per process definition version)
-  // when the report uses a grouped percentage view. Default implementation is a no-op.
-  protected void populatePerGroupBaselineCounts(
-      final ExecutionContext<DATA, PLAN> context, final String[] indices) throws IOException {}
+  // Hook for subclasses to provide per-group baseline counts (e.g. per process definition version)
+  // when the report uses a grouped percentage view. Default implementation contributes no counts.
+  protected Map<String, Long> retrievePerGroupBaselineCounts(
+      final ExecutionContext<DATA, PLAN> context, final String[] indices) {
+    return Map.of();
+  }
 
   private SearchRequest.Builder createBaseQuerySearchRequest(
       final ExecutionContext<DATA, PLAN> executionContext) {
@@ -142,7 +145,8 @@ public abstract class AbstractExecutionPlanInterpreterOS<
     final String[] indices = getIndexNames(executionContext);
     final Query countQuery = unfilteredBaseQueryBuilder(executionContext).build().toQuery();
     executionContext.setUnfilteredTotalInstanceCount(getOsClient().count(indices, countQuery));
-    populatePerGroupBaselineCounts(executionContext, indices);
+    executionContext.setUnfilteredInstanceCountsByGroupKey(
+        retrievePerGroupBaselineCounts(executionContext, indices));
     return response;
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterOS.java
@@ -11,9 +11,6 @@ import static io.camunda.optimize.dto.optimize.ReportConstants.APPLIED_TO_ALL_DE
 import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_INSTANCE_MULTI_ALIAS;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.matchAll;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.not;
-import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION;
-import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
-import static java.util.stream.Collectors.toMap;
 
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
@@ -29,31 +26,21 @@ import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.MinMaxStatDto;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.util.InstanceIndexUtil;
-import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.opensearch.client.opensearch._types.SortOrder;
-import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
-import org.opensearch.client.opensearch.core.SearchRequest;
-import org.opensearch.client.opensearch.core.SearchResponse;
 
 public abstract class AbstractProcessExecutionPlanInterpreterOS
     extends AbstractExecutionPlanInterpreterOS<ProcessReportDataDto, ProcessExecutionPlan>
     implements ProcessExecutionPlanInterpreterOS {
 
-  private static final String VERSION_BASELINE_AGGREGATION = "versionBaselineAgg";
-
   protected abstract ProcessDefinitionReader getProcessDefinitionReader();
 
   protected abstract ProcessQueryFilterEnhancerOS getQueryFilterEnhancer();
-
-  protected abstract ConfigurationService getConfigurationService();
 
   @Override
   public Optional<MinMaxStatDto> getGroupByMinMaxStats(
@@ -95,40 +82,6 @@ public abstract class AbstractProcessExecutionPlanInterpreterOS
   @Override
   protected String[] getMultiIndexAlias() {
     return new String[] {PROCESS_INSTANCE_MULTI_ALIAS};
-  }
-
-  @Override
-  protected void populatePerGroupBaselineCounts(
-      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
-      final String[] indices) {
-    if (context.getPlan() == PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION) {
-      final BoolQuery.Builder baselineQuery = unfilteredBaseQueryBuilder(context);
-      final SearchRequest.Builder requestBuilder =
-          new SearchRequest.Builder()
-              .index(Arrays.asList(indices))
-              .query(baselineQuery.build().toQuery())
-              .size(0)
-              .aggregations(
-                  VERSION_BASELINE_AGGREGATION,
-                  a ->
-                      a.terms(
-                          t ->
-                              t.field(PROCESS_DEFINITION_VERSION)
-                                  .size(
-                                      getConfigurationService()
-                                          .getOpenSearchConfiguration()
-                                          .getAggregationBucketLimit())
-                                  .order(Map.of("_key", SortOrder.Asc))));
-      final SearchResponse<?> response =
-          getOsClient()
-              .searchWithFixedAggregations(
-                  requestBuilder, Object.class, "Could not retrieve per-version baseline counts");
-      final StringTermsAggregate versionsAgg =
-          response.aggregations().get(VERSION_BASELINE_AGGREGATION).sterms();
-      final Map<String, Long> perVersionCounts =
-          versionsAgg.buckets().array().stream().collect(toMap(b -> b.key(), b -> b.docCount()));
-      context.setUnfilteredInstanceCountsByGroupKey(perVersionCounts);
-    }
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/AbstractProcessExecutionPlanInterpreterOS.java
@@ -11,6 +11,9 @@ import static io.camunda.optimize.dto.optimize.ReportConstants.APPLIED_TO_ALL_DE
 import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_INSTANCE_MULTI_ALIAS;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.matchAll;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.not;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
+import static java.util.stream.Collectors.toMap;
 
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
@@ -26,20 +29,31 @@ import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.MinMaxStatDto;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.util.InstanceIndexUtil;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
 
 public abstract class AbstractProcessExecutionPlanInterpreterOS
     extends AbstractExecutionPlanInterpreterOS<ProcessReportDataDto, ProcessExecutionPlan>
     implements ProcessExecutionPlanInterpreterOS {
+
+  private static final String VERSION_BASELINE_AGGREGATION = "versionBaselineAgg";
+
   protected abstract ProcessDefinitionReader getProcessDefinitionReader();
 
   protected abstract ProcessQueryFilterEnhancerOS getQueryFilterEnhancer();
+
+  protected abstract ConfigurationService getConfigurationService();
 
   @Override
   public Optional<MinMaxStatDto> getGroupByMinMaxStats(
@@ -84,18 +98,51 @@ public abstract class AbstractProcessExecutionPlanInterpreterOS
   }
 
   @Override
+  protected void populatePerGroupBaselineCounts(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
+      final String[] indices) {
+    if (context.getPlan() == PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION) {
+      final BoolQuery.Builder baselineQuery = unfilteredBaseQueryBuilder(context);
+      final SearchRequest.Builder requestBuilder =
+          new SearchRequest.Builder()
+              .index(Arrays.asList(indices))
+              .query(baselineQuery.build().toQuery())
+              .size(0)
+              .aggregations(
+                  VERSION_BASELINE_AGGREGATION,
+                  a ->
+                      a.terms(
+                          t ->
+                              t.field(PROCESS_DEFINITION_VERSION)
+                                  .size(
+                                      getConfigurationService()
+                                          .getOpenSearchConfiguration()
+                                          .getAggregationBucketLimit())
+                                  .order(Map.of("_key", SortOrder.Asc))));
+      final SearchResponse<?> response =
+          getOsClient()
+              .searchWithFixedAggregations(
+                  requestBuilder, Object.class, "Could not retrieve per-version baseline counts");
+      final StringTermsAggregate versionsAgg =
+          response.aggregations().get(VERSION_BASELINE_AGGREGATION).sterms();
+      final Map<String, Long> perVersionCounts =
+          versionsAgg.buckets().array().stream().collect(toMap(b -> b.key(), b -> b.docCount()));
+      context.setUnfilteredInstanceCountsByGroupKey(perVersionCounts);
+    }
+  }
+
+  @Override
   protected BoolQuery.Builder unfilteredBaseQueryBuilder(
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
-    // Instance level date filters are also applied to the baseline so are included here
-    final Map<String, List<ProcessFilterDto<?>>> instanceLevelDateFiltersByDefinitionKey =
-        getInstanceLevelDateFiltersByDefinitionKey(context);
+    final Map<String, List<ProcessFilterDto<?>>> instanceLevelFiltersByDefinitionKey =
+        buildBaselineFiltersByDefinition(context);
     final List<ProcessFilterDto<?>> filters =
-        instanceLevelDateFiltersByDefinitionKey.getOrDefault(
+        instanceLevelFiltersByDefinitionKey.getOrDefault(
             APPLIED_TO_ALL_DEFINITIONS, Collections.emptyList());
     final List<Query> filterQueries =
         getQueryFilterEnhancer().filterQueries(filters, context.getFilterContext());
     return buildDefinitionBaseQueryForFilters(
-        context, instanceLevelDateFiltersByDefinitionKey, filterQueries);
+        context, instanceLevelFiltersByDefinitionKey, filterQueries);
   }
 
   private BoolQuery.Builder buildDefinitionBaseQueryForFilters(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterOS.java
@@ -7,14 +7,29 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.plan.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.VERSION_BASELINE_AGGREGATION;
+import static java.util.stream.Collectors.toMap;
+
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.report.filter.ProcessQueryFilterEnhancerOS;
 import io.camunda.optimize.service.db.os.report.interpreter.groupby.process.ProcessGroupByInterpreterFacadeOS;
+import io.camunda.optimize.service.db.os.report.interpreter.groupby.process.ProcessGroupByInterpreterOS;
 import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.interpreter.plan.process.GenericProcessExecutionPlanInterpreter;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -71,5 +86,45 @@ public class GenericProcessExecutionPlanInterpreterOS
 
   public ConfigurationService getConfigurationService() {
     return this.configurationService;
+  }
+
+  @Override
+  protected Map<String, Long> retrievePerGroupBaselineCounts(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
+      final String[] indices) {
+    if (!(getGroupByInterpreter()
+        instanceof final ProcessGroupByInterpreterOS groupByInterpreter)) {
+      return Map.of();
+    }
+    final Optional<String> baselineField =
+        groupByInterpreter.getBaselineCountAggregationField(context);
+    if (baselineField.isEmpty()) {
+      return Map.of();
+    }
+    final String field = baselineField.get();
+    final BoolQuery.Builder baselineQuery = unfilteredBaseQueryBuilder(context);
+    final SearchRequest.Builder requestBuilder =
+        new SearchRequest.Builder()
+            .index(Arrays.asList(indices))
+            .query(baselineQuery.build().toQuery())
+            .size(0)
+            .aggregations(
+                VERSION_BASELINE_AGGREGATION,
+                a ->
+                    a.terms(
+                        t ->
+                            t.field(field)
+                                .size(
+                                    getConfigurationService()
+                                        .getOpenSearchConfiguration()
+                                        .getAggregationBucketLimit())
+                                .order(Map.of("_key", SortOrder.Asc))));
+    final SearchResponse<?> response =
+        getOsClient()
+            .searchWithFixedAggregations(
+                requestBuilder, Object.class, "Could not retrieve per-version baseline counts");
+    final StringTermsAggregate versionsAgg =
+        response.aggregations().get(VERSION_BASELINE_AGGREGATION).sterms();
+    return versionsAgg.buckets().array().stream().collect(toMap(b -> b.key(), b -> b.docCount()));
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterOS.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.service.db.os.report.interpreter.groupby.process.Proc
 import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.report.interpreter.plan.process.GenericProcessExecutionPlanInterpreter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
@@ -31,18 +32,21 @@ public class GenericProcessExecutionPlanInterpreterOS
   private final ProcessQueryFilterEnhancerOS queryFilterEnhancer;
   private final ProcessGroupByInterpreterFacadeOS groupByInterpreter;
   private final ProcessViewInterpreterFacadeOS viewInterpreter;
+  private final ConfigurationService configurationService;
 
   public GenericProcessExecutionPlanInterpreterOS(
       final ProcessDefinitionReader processDefinitionReader,
       final OptimizeOpenSearchClient osClient,
       final ProcessQueryFilterEnhancerOS queryFilterEnhancer,
       final ProcessGroupByInterpreterFacadeOS groupByInterpreter,
-      final ProcessViewInterpreterFacadeOS viewInterpreter) {
+      final ProcessViewInterpreterFacadeOS viewInterpreter,
+      final ConfigurationService configurationService) {
     this.processDefinitionReader = processDefinitionReader;
     this.osClient = osClient;
     this.queryFilterEnhancer = queryFilterEnhancer;
     this.groupByInterpreter = groupByInterpreter;
     this.viewInterpreter = viewInterpreter;
+    this.configurationService = configurationService;
   }
 
   public ProcessDefinitionReader getProcessDefinitionReader() {
@@ -63,5 +67,9 @@ public class GenericProcessExecutionPlanInterpreterOS
 
   public ProcessViewInterpreterFacadeOS getViewInterpreter() {
     return this.viewInterpreter;
+  }
+
+  public ConfigurationService getConfigurationService() {
+    return this.configurationService;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterOS.java
@@ -19,7 +19,6 @@ import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.interpreter.plan.process.RawProcessInstanceDataGroupByNoneExecutionPlanInterpreter;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
-import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
 import java.util.Set;
 import org.springframework.context.annotation.Conditional;
@@ -36,21 +35,18 @@ public class RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterOS
   private final OptimizeOpenSearchClient osClient;
   private final ProcessDefinitionReader processDefinitionReader;
   private final ProcessQueryFilterEnhancerOS queryFilterEnhancer;
-  private final ConfigurationService configurationService;
 
   public RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterOS(
       final ProcessGroupByInterpreterFacadeOS groupByInterpreter,
       final ProcessViewInterpreterFacadeOS viewInterpreter,
       final OptimizeOpenSearchClient osClient,
       final ProcessDefinitionReader processDefinitionReader,
-      final ProcessQueryFilterEnhancerOS queryFilterEnhancer,
-      final ConfigurationService configurationService) {
+      final ProcessQueryFilterEnhancerOS queryFilterEnhancer) {
     this.groupByInterpreter = groupByInterpreter;
     this.viewInterpreter = viewInterpreter;
     this.osClient = osClient;
     this.processDefinitionReader = processDefinitionReader;
     this.queryFilterEnhancer = queryFilterEnhancer;
-    this.configurationService = configurationService;
   }
 
   @Override
@@ -84,9 +80,5 @@ public class RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterOS
 
   public ProcessQueryFilterEnhancerOS getQueryFilterEnhancer() {
     return this.queryFilterEnhancer;
-  }
-
-  public ConfigurationService getConfigurationService() {
-    return this.configurationService;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterOS.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.interpreter.plan.process.RawProcessInstanceDataGroupByNoneExecutionPlanInterpreter;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
 import java.util.Set;
 import org.springframework.context.annotation.Conditional;
@@ -35,18 +36,21 @@ public class RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterOS
   private final OptimizeOpenSearchClient osClient;
   private final ProcessDefinitionReader processDefinitionReader;
   private final ProcessQueryFilterEnhancerOS queryFilterEnhancer;
+  private final ConfigurationService configurationService;
 
   public RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterOS(
       final ProcessGroupByInterpreterFacadeOS groupByInterpreter,
       final ProcessViewInterpreterFacadeOS viewInterpreter,
       final OptimizeOpenSearchClient osClient,
       final ProcessDefinitionReader processDefinitionReader,
-      final ProcessQueryFilterEnhancerOS queryFilterEnhancer) {
+      final ProcessQueryFilterEnhancerOS queryFilterEnhancer,
+      final ConfigurationService configurationService) {
     this.groupByInterpreter = groupByInterpreter;
     this.viewInterpreter = viewInterpreter;
     this.osClient = osClient;
     this.processDefinitionReader = processDefinitionReader;
     this.queryFilterEnhancer = queryFilterEnhancer;
+    this.configurationService = configurationService;
   }
 
   @Override
@@ -80,5 +84,9 @@ public class RawProcessInstanceDataGroupByNoneExecutionPlanInterpreterOS
 
   public ProcessQueryFilterEnhancerOS getQueryFilterEnhancer() {
     return this.queryFilterEnhancer;
+  }
+
+  public ConfigurationService getConfigurationService() {
+    return this.configurationService;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ExecutionContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ExecutionContext.java
@@ -57,6 +57,9 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
   // for these nodes are calculated up front and removed during result retrieval
   private Set<String> hiddenFlowNodeIds = new HashSet<>();
 
+  // Per-group-key baseline counts for grouped percentage reports; empty means use the global count
+  private Map<String, Long> unfilteredInstanceCountsByGroupKey = new HashMap<>();
+
   private FilterContext filterContext;
 
   private boolean multiIndexAlias = false;
@@ -145,6 +148,10 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
     return this.hiddenFlowNodeIds;
   }
 
+  public Map<String, Long> getUnfilteredInstanceCountsByGroupKey() {
+    return this.unfilteredInstanceCountsByGroupKey;
+  }
+
   public FilterContext getFilterContext() {
     return this.filterContext;
   }
@@ -198,6 +205,11 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
     this.hiddenFlowNodeIds = hiddenFlowNodeIds;
   }
 
+  public void setUnfilteredInstanceCountsByGroupKey(
+      final Map<String, Long> unfilteredInstanceCountsByGroupKey) {
+    this.unfilteredInstanceCountsByGroupKey = unfilteredInstanceCountsByGroupKey;
+  }
+
   public void setFilterContext(final FilterContext filterContext) {
     this.filterContext = filterContext;
   }
@@ -224,7 +236,8 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
         && Objects.equals(allDistributedByKeysAndLabels, that.allDistributedByKeysAndLabels)
         && Objects.equals(allVariablesNames, that.allVariablesNames)
         && Objects.equals(hiddenFlowNodeIds, that.hiddenFlowNodeIds)
-        && Objects.equals(unfilteredInstanceCountsByGroupKey, that.unfilteredInstanceCountsByGroupKey)
+        && Objects.equals(
+            unfilteredInstanceCountsByGroupKey, that.unfilteredInstanceCountsByGroupKey)
         && Objects.equals(filterContext, that.filterContext);
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ExecutionContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ExecutionContext.java
@@ -224,6 +224,7 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
         && Objects.equals(allDistributedByKeysAndLabels, that.allDistributedByKeysAndLabels)
         && Objects.equals(allVariablesNames, that.allVariablesNames)
         && Objects.equals(hiddenFlowNodeIds, that.hiddenFlowNodeIds)
+        && Objects.equals(unfilteredInstanceCountsByGroupKey, that.unfilteredInstanceCountsByGroupKey)
         && Objects.equals(filterContext, that.filterContext);
   }
 
@@ -241,6 +242,7 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
         allDistributedByKeysAndLabels,
         allVariablesNames,
         hiddenFlowNodeIds,
+        unfilteredInstanceCountsByGroupKey,
         filterContext,
         multiIndexAlias);
   }
@@ -272,6 +274,8 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
         + this.getAllVariablesNames()
         + ", hiddenFlowNodeIds="
         + this.getHiddenFlowNodeIds()
+        + ", unfilteredInstanceCountsByGroupKey="
+        + this.getUnfilteredInstanceCountsByGroupKey()
         + ", filterContext="
         + this.getFilterContext()
         + ", multiIndexAlias="

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/plan/process/ProcessExecutionPlanInterpreter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/plan/process/ProcessExecutionPlanInterpreter.java
@@ -48,7 +48,7 @@ public interface ProcessExecutionPlanInterpreter
           CompletedInstancesOnlyFilterDto.class,
           HasAgentInstancesFilterDto.class);
 
-  default Map<String, List<ProcessFilterDto<?>>> getInstanceLevelDateFiltersByDefinitionKey(
+  default Map<String, List<ProcessFilterDto<?>>> buildBaselineFiltersByDefinition(
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
     final List<Class<? extends ProcessFilterDto<?>>> effectiveBaselineFilters =
         context.getReportData().isAgenticControlReport()
@@ -63,6 +63,6 @@ public interface ProcessExecutionPlanInterpreter
                         .filter(
                             filter -> filter.getFilterLevel() == FilterApplicationLevel.INSTANCE)
                         .filter(filter -> effectiveBaselineFilters.contains(filter.getClass()))
-                        .toList()));
+                        .collect(Collectors.toList())));
   }
 }

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -6,7 +6,7 @@
     "description": "Überwachen Sie die Einführung, das Verhalten und die Zuverlässigkeit von KI-Agenten sowie den Token-Verbrauch prozessübergreifend.",
     "dateRange": "Zeitraum",
     "tokenUsage": "Token-Nutzung",
-    "reliabilityAndToolCalls": "Zuverlässigkeit & Tool Aufrufe",
+    "reliabilityAndToolCalls": "Zuverlässigkeit & Tool-Aufrufe",
     "duration": "Dauer",
     "presets": {
       "last7Days": "Letzte 7 Tage",

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -6,6 +6,7 @@
     "description": "Überwachen Sie die Einführung, das Verhalten und die Zuverlässigkeit von KI-Agenten sowie den Token-Verbrauch prozessübergreifend.",
     "dateRange": "Zeitraum",
     "tokenUsage": "Token-Nutzung",
+    "reliabilityAndToolCalls": "Zuverlässigkeit & Tool Aufrufe",
     "duration": "Dauer",
     "presets": {
       "last7Days": "Letzte 7 Tage",
@@ -1565,7 +1566,9 @@
       "agenticKpiDurationP50Name": "P50-Ausführungsdauer",
       "agenticKpiDurationP50Description": "Median (P50) der Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum.",
       "agenticKpiDurationP95Name": "P95-Ausführungsdauer",
-      "agenticKpiDurationP95Description": "95. Perzentil der Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum."
+      "agenticKpiDurationP95Description": "95. Perzentil der Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum.",
+      "agenticFailureRateByVersionName": "Vorfallsrate nach Prozessversion",
+      "agenticFailureRateByVersionDescription": "Prozentsatz der abgeschlossenen agentischen Prozessinstanzen mit einem gelösten Vorfall, aufgeschlüsselt nach Prozessdefinitionsversion."
     }
   },
   "managementDashboard": {

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -6,6 +6,7 @@
     "description": "Monitor AI agent adoption, token spend, behavior, and reliability across your processes.",
     "dateRange": "Date range",
     "tokenUsage": "Token usage",
+    "reliabilityAndToolCalls": "Reliability & Tool Calls",
     "duration": "Duration",
     "presets": {
       "last7Days": "Last 7 days",
@@ -1565,7 +1566,9 @@
       "agenticKpiDurationP50Name": "P50 execution duration",
       "agenticKpiDurationP50Description": "Median (P50) execution duration of completed agentic process instances in the selected period.",
       "agenticKpiDurationP95Name": "P95 execution duration",
-      "agenticKpiDurationP95Description": "95th percentile execution duration of completed agentic process instances in the selected period."
+      "agenticKpiDurationP95Description": "95th percentile execution duration of completed agentic process instances in the selected period.",
+      "agenticFailureRateByVersionName": "Failure rate by process version",
+      "agenticFailureRateByVersionDescription": "Percentage of completed agentic process instances that encountered a resolved incident, broken down by process definition version."
     }
   },
   "managementDashboard": {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -418,7 +418,7 @@ public class AgenticControlDashboardServiceTest {
             .orElseThrow();
 
     assertThat(stabilityTile.getPosition().getX()).isEqualTo(0);
-    assertThat(stabilityTile.getPosition().getY()).isEqualTo(6);
+    assertThat(stabilityTile.getPosition().getY()).isEqualTo(12);
     assertThat(stabilityTile.getDimensions().getWidth()).isEqualTo(18);
     assertThat(stabilityTile.getDimensions().getHeight()).isEqualTo(2);
     assertThat(stabilityTile.getConfiguration()).isEqualTo(Map.of("section", "duration"));

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -41,6 +41,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessVisua
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.CompletedInstancesOnlyFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.HasAgentInstancesFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.EndDateGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionVersionGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
 import io.camunda.optimize.service.db.reader.DashboardReader;
 import io.camunda.optimize.service.db.writer.DashboardWriter;
@@ -89,7 +90,7 @@ public class AgenticControlDashboardServiceTest {
     assertThat(saved.isAgenticControlDashboard()).isTrue();
     assertThat(saved.isManagementDashboard()).isFalse();
     assertThat(saved.getCollectionId()).isNull();
-    assertThat(saved.getTiles()).hasSize(9);
+    assertThat(saved.getTiles()).hasSize(10);
   }
 
   @Test
@@ -172,7 +173,8 @@ public class AgenticControlDashboardServiceTest {
             AgenticControlDashboardService.DURATION_STABILITY_REPORT_ID,
             AgenticControlDashboardService.TOKEN_TREND_REPORT_ID,
             AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID,
-            AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID);
+            AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID,
+            AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_REPORT_ID);
   }
 
   @Test
@@ -233,7 +235,7 @@ public class AgenticControlDashboardServiceTest {
     underTest.reconcile();
 
     // then reports are upserted and dashboard tiles are updated, but dashboard is not recreated
-    verify(reportWriter, times(9))
+    verify(reportWriter, times(10))
         .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
     verify(dashboardWriter, never()).saveDashboard(any());
     verify(dashboardWriter).updateDashboard(any(), any());
@@ -330,7 +332,9 @@ public class AgenticControlDashboardServiceTest {
               AgenticControlDashboardService.KPI_DURATION_P95_NAME,
               AgenticControlDashboardService.KPI_DURATION_P95_DESCRIPTION,
               AgenticControlDashboardService.DURATION_STABILITY_NAME,
-              AgenticControlDashboardService.DURATION_STABILITY_DESCRIPTION);
+              AgenticControlDashboardService.DURATION_STABILITY_DESCRIPTION,
+              AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_NAME,
+              AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_DESCRIPTION);
     }
   }
 
@@ -540,6 +544,56 @@ public class AgenticControlDashboardServiceTest {
             any(),
             any());
     verify(dashboardWriter, never()).saveDashboard(any());
+  }
+
+  @Test
+  void shouldSeedFailureRateByVersionReportWithGroupedBarShape() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+    final ArgumentCaptor<ProcessReportDataDto> dataCaptor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+
+    // when
+    underTest.reconcile();
+
+    // then the report is upserted with the correct deterministic ID and localization keys
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_REPORT_ID),
+            isNull(),
+            dataCaptor.capture(),
+            eq(AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_NAME),
+            eq(AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_DESCRIPTION),
+            isNull());
+
+    final ProcessReportDataDto reportData = dataCaptor.getValue();
+    assertThat(reportData.getView().getEntity()).isEqualTo(ProcessViewEntity.PROCESS_INSTANCE);
+    assertThat(reportData.getView().getProperties()).contains(ViewProperty.PERCENTAGE);
+    assertThat(reportData.getGroupBy()).isInstanceOf(ProcessDefinitionVersionGroupByDto.class);
+    assertThat(reportData.getVisualization()).isEqualTo(ProcessVisualization.BAR);
+    assertThat(reportData.isAgenticControlReport()).isTrue();
+  }
+
+  @Test
+  void shouldMarkFailureRateByVersionTileAsL1Only() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then the tile carries the L1-only visibility flag so the frontend hides it in the L0 view
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    final DashboardReportTileDto failureRateTile =
+        saved.getTiles().stream()
+            .filter(
+                tile ->
+                    AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_REPORT_ID.equals(
+                        tile.getId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(failureRateTile.getConfiguration())
+        .isEqualTo(Map.of("section", "reliabilityAndToolCalls", "visibleInL1Only", true));
   }
 
   @SuppressWarnings("unchecked")

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterESTest.java
@@ -69,6 +69,27 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void shouldAggregateBaselineCountsOnVersionFieldForPercentageView() {
+    final ProcessReportDataDto reportData = mock(ProcessReportDataDto.class);
+    when(reportData.getViewProperties()).thenReturn(List.of(ViewProperty.PERCENTAGE));
+    when(context.getReportData()).thenReturn(reportData);
+
+    assertThat(underTest.getBaselineCountAggregationField(context))
+        .contains(PROCESS_DEFINITION_VERSION);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldNotProvideBaselineCountFieldForNonPercentageView() {
+    final ProcessReportDataDto reportData = mock(ProcessReportDataDto.class);
+    when(reportData.getViewProperties()).thenReturn(List.of(ViewProperty.FREQUENCY));
+    when(context.getReportData()).thenReturn(reportData);
+
+    assertThat(underTest.getBaselineCountAggregationField(context)).isEmpty();
+  }
+
+  @Test
   void shouldBuildTermsAggregationOnVersionFieldSortedByKeyAscending() {
     when(configurationService.getElasticSearchConfiguration())
         .thenReturn(elasticSearchConfiguration);

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterESTest.java
@@ -10,7 +10,9 @@ package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,6 +37,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -149,6 +152,29 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
     underTest.addQueryResult(result, response, context);
 
     assertThat(result.isGroupByKeyOfNumericType()).isTrue();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldRestoreGlobalBaselineCountWhenDistributedByRetrievalFails() {
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations())
+        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate("1")));
+    when(context.getUnfilteredTotalInstanceCount()).thenReturn(10L);
+    when(context.getUnfilteredInstanceCountsByGroupKey()).thenReturn(Map.of("1", 3L));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any()))
+        .thenThrow(new RuntimeException("boom"));
+
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+
+    assertThatThrownBy(() -> underTest.addQueryResult(result, response, context))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("boom");
+
+    final InOrder inOrder = inOrder(context);
+    inOrder.verify(context).setUnfilteredTotalInstanceCount(3L);
+    inOrder.verify(context).setUnfilteredTotalInstanceCount(10L);
   }
 
   private static Aggregate stringTermsAggregate(final String... keys) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOSTest.java
@@ -66,6 +66,27 @@ class ProcessGroupByProcessDefinitionVersionInterpreterOSTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void shouldAggregateBaselineCountsOnVersionFieldForPercentageView() {
+    final ProcessReportDataDto reportData = mock(ProcessReportDataDto.class);
+    when(reportData.getViewProperties()).thenReturn(List.of(ViewProperty.PERCENTAGE));
+    when(context.getReportData()).thenReturn(reportData);
+
+    assertThat(underTest.getBaselineCountAggregationField(context))
+        .contains(PROCESS_DEFINITION_VERSION);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldNotProvideBaselineCountFieldForNonPercentageView() {
+    final ProcessReportDataDto reportData = mock(ProcessReportDataDto.class);
+    when(reportData.getViewProperties()).thenReturn(List.of(ViewProperty.FREQUENCY));
+    when(context.getReportData()).thenReturn(reportData);
+
+    assertThat(underTest.getBaselineCountAggregationField(context)).isEmpty();
+  }
+
+  @Test
   void shouldBuildTermsAggregationOnVersionFieldSortedByKeyAscending() {
     when(configurationService.getOpenSearchConfiguration()).thenReturn(openSearchConfiguration);
     when(openSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
@@ -119,6 +119,11 @@ export function AgenticControlPlane() {
       titleKey: 'agenticControlPlane.tokenUsage',
       loadTile: scopedEvaluateTokenTrendReport,
     },
+    {
+      key: 'reliabilityAndToolCalls',
+      titleKey: 'agenticControlPlane.reliabilityAndToolCalls',
+      loadTile: scopedEvaluateReport,
+    },
     {key: 'duration', titleKey: 'agenticControlPlane.duration', loadTile: scopedEvaluateReport},
   ];
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
@@ -79,6 +79,7 @@ public final class DatabaseConstants {
   public static final String INGESTED_DATA_SOURCE = "ingested";
   // Aggregation constants
   public static final String FREQUENCY_AGGREGATION = "_frequency";
+  public static final String VERSION_BASELINE_AGGREGATION = "versionBaselineAgg";
   // Units
   public static final String GB_UNIT = "gb";
 


### PR DESCRIPTION
Adds a new "Failure Rate by Version" tile to the agentic control plane dashboard, grouped by process definition version, showing the percentage of completed agentic instances with resolved incidents per version.

## Description

- Seeds a new `buildFailureRateByVersionReport` in `AgenticControlDashboardService` using `PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION` plan with `CompletedInstancesOnly`, `HasAgentInstances`, and `WithResolvedIncident` filters.
- Adds per-group baseline count support to `AbstractProcessExecutionPlanInterpreterES` and `AbstractProcessExecutionPlanInterpreterOS`: a pre-query fetches instance counts per process definition version and stores them in `ExecutionContext.unfilteredInstanceCountsByGroupKey` so each version bucket uses the correct denominator.
- Uses the per-version baseline in `ProcessGroupByProcessDefinitionVersionInterpreterES/OS` to override the global unfiltered count when computing percentages.
- The baseline terms aggregation is ordered by `_key asc` in both ES and OS to stay consistent with the group-by aggregation bucket ordering, preventing denominator mismatches when the bucket limit is reached.
- The OS `unfilteredBaseQueryBuilder` now explicitly checks `isAgenticControlReport()` and applies `FILTERS_AFFECTING_AGENTIC_BASELINE` (including `CompletedInstancesOnly` and `HasAgentInstances`) vs `FILTERS_AFFECTING_BASELINE` for regular reports — aligned with the ES `setupUnfilteredBaseQueryBuilder` pattern.
- The global baseline count is always restored after per-bucket processing in both ES and OS group-by interpreters (try/finally) to prevent leakage on exceptions.
- `ExecutionContext` `equals`/`hashCode`/`toString` updated to include `unfilteredInstanceCountsByGroupKey`.

## Related issues

related to #55294 

## Checklist

- [ ] I have self-reviewed this PR to the best of my abilities
- [ ] I have written unit and/or integration tests for my changes
- [ ] I have tested my changes locally or in a development environment
- [ ] I have updated related documentation if applicable