### PR TITLE
test: extend propagation wait for RDBMS create-then-get API tests (nightly main)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
@@ -20,7 +20,7 @@ import {
   validateResponseShape,
 } from '../../../../json-body-assertions';
 import {deployResourceAndGetMetadata, ResourceMetadata} from '@requestHelpers';
-import {defaultAssertionOptions} from '../../../../utils/constants';
+import {extendedAssertionOptions} from '../../../../utils/constants';
 
 function validateResourceResponse(
   body: JSONDoc,
@@ -74,7 +74,9 @@ test.describe.parallel('Resource Get API', () => {
         res,
       );
       validateResourceResponse(await res.json(), metadata);
-    }).toPass(defaultAssertionOptions);
+      // Extended timeout: on RDBMS the deployed RPA resource can take longer
+      // than the default 30s to propagate through the secondary-storage indexer.
+    }).toPass(extendedAssertionOptions);
   });
 
   // eslint-disable-next-line playwright/expect-expect

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-api.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../../utils/http';
 import {getExpectedContent} from '../../../../utils/beans/requestBeans';
 import {deployResourceAndGetMetadata} from '@requestHelpers';
-import {defaultAssertionOptions} from '../../../../utils/constants';
+import {extendedAssertionOptions} from '../../../../utils/constants';
 
 test.describe.parallel('Resource Get Content API', () => {
   test('Get Resource Content - RPA Success 200', async ({request}) => {
@@ -40,7 +40,9 @@ test.describe.parallel('Resource Get Content API', () => {
 
       await assertStatusCode(res, 200);
       expect(await res.text()).toBe(expectedContent);
-    }).toPass(defaultAssertionOptions);
+      // Extended timeout: on RDBMS the deployed RPA resource can take longer
+      // than the default 30s to propagate through the secondary-storage indexer.
+    }).toPass(extendedAssertionOptions);
   });
 
   // eslint-disable-next-line playwright/expect-expect

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
@@ -17,7 +17,10 @@ import {
   encode,
   assertEqualsForKeys,
 } from '../../../../utils/http';
-import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  defaultAssertionOptions,
+  extendedAssertionOptions,
+} from '../../../../utils/constants';
 import {validateResponse} from '../../../../json-body-assertions';
 import {
   userRequiredFields,
@@ -150,7 +153,9 @@ async function createCompletedProcessInstance(request: APIRequestContext) {
     );
     expect(completedInstance?.state).toBe('COMPLETED');
     expect(completedInstance?.endDate).toBeTruthy();
-  }).toPass(defaultAssertionOptions);
+    // Extended timeout: on RDBMS the completed process instance can take longer
+    // than the default 30s to propagate through the secondary-storage indexer.
+  }).toPass(extendedAssertionOptions);
 
   return completedInstance as {
     endDate: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
@@ -21,7 +21,7 @@ import {
   authorizedComponentRequiredFields,
 } from '../beans/requestBeans';
 import {validateResponse} from 'json-body-assertions';
-import {defaultAssertionOptions} from 'utils/constants';
+import {extendedAssertionOptions} from 'utils/constants';
 
 export interface Authorization {
   ownerId: string;
@@ -98,7 +98,10 @@ export async function grantUserResourceAuthorization(
       },
       statusRes,
     );
-  }).toPass(defaultAssertionOptions);
+    // Use an extended timeout: on RDBMS the newly created authorization can
+    // take longer than the default 30s to propagate through the
+    // secondary-storage indexer, leaving the setup step racing the export.
+  }).toPass(extendedAssertionOptions);
   return {
     authorizationKey: authBody.authorizationKey,
   };


### PR DESCRIPTION
## Root cause

On the **Postgres 18 (RDBMS)** orchestration-cluster nightly, 20 API tests failed with `expected 200, received 404` after the 30s assertion timeout. In every case the 404 came from a **setup / poll-for-created-entity** step, not the endpoint under test:

- **Job statistics (12)** + **Audit log (2)** → `grantUserResourceAuthorization` (in `beforeAll`) creates an authorization (201) then polls `GET /v2/authorizations/{key}`, which 404s (`Authorization with key '…' not found`). Because the failure is in `beforeAll`, every test in those describe blocks fails — including the `Unauthorized` / `Bad Request` cases that don't touch the authorization.
- **Usage metrics (1)** → `createCompletedProcessInstance` creates a process instance then polls `GET /v2/process-instances/{key}`, which 404s (`Process Instance with key '…' not found`).
- **Resource RPA (2)** → after deploying an `.rpa` resource, the test polls `GET /v2/resources/{key}` / `…/content`, which 404s (`Resource with key '…' not found`).

These polls used `defaultAssertionOptions` (30s). On RDBMS the secondary-storage indexer takes longer than 30s under load to make a freshly created entity retrievable — the failing runs hit the 30s ceiling almost exactly (~29s). The equivalent authorization tests that use the existing 120s `expectAuthorizationCanBeFound` helper all pass, confirming the data does propagate; 30s is simply too short. This is a test-side wait that races the export, not a product regression.

## Fix

Switch the affected propagation waits from `defaultAssertionOptions` (30s) to `extendedAssertionOptions` (90s) — the constant documented for "data that has to propagate through the secondary-storage indexer on a loaded shared cluster".

## Tests fixed

All on `tests/api/v2/`, `api`, Postgres 18:

- `job/job-statistics-by-type-api-tests.spec.ts` — success / missing-from Bad Request / Unauthorized
- `job/job-statistics-by-worker-api-tests.spec.ts` — success / no jobType Bad Request / Forbidden empty result
- `job/job-statistics-error-metrics-job-type-api-tests.spec.ts` — success / no jobType Bad Request / Forbidden empty result
- `job/job-statistics-global-api-tests.spec.ts` — success / no from Bad Request / Unauthorized
- `job/job-statistics-time-series-job-type-api-tests.spec.ts` — success / not-existing job type empty result / no resolution Success
- `audit-log/audit-log-get-api-tests.spec.ts` — Get Audit Logs - Forbidden
- `audit-log/audit-log-search-api-tests.spec.ts` — Search Audit Logs - No granted permissions
- `usage-metrics/usage-metrics-api.spec.ts` — Get Usage Metrics Success
- `resource/resource-get-api.spec.ts` — Get Resource - RPA Success 200
- `resource/resource-get-content-api.spec.ts` — Get Resource Content - RPA Success 200

## Links

- Failing nightly run (API RDBMS): https://github.com/camunda/camunda/actions/runs/27589720547
- Triage run: https://github.com/camunda/camunda/actions/runs/27596908645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/27597243436
