### PR TITLE
ci: wire base-ref and snapshot-workflow into pr-vuln-check gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1751,14 +1751,17 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      actions: read  # required to list snapshot-workflow runs for base resolution (Workstream D)
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check for vulnerable dependencies
-        uses: camunda/infra-global-github-actions/dependency-vuln-check@50f8493e449f1abc6956f158185e58d1d261aa1f # main
+        uses: camunda/infra-global-github-actions/dependency-vuln-check@f1e0bd49b88f17b2caeba3dbc7bebf9abfc1ef33 # main — bump to post-merge SHA after infra-global-github-actions#715 merges
         with:
           base-sha: ${{ github.event.pull_request.base.sha }}
           head-sha: ${{ github.event.pull_request.head.sha }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          snapshot-workflow: maven-dependency-snapshot.yml
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1756,7 +1756,7 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check for vulnerable dependencies
-        uses: camunda/infra-global-github-actions/dependency-vuln-check@f1e0bd49b88f17b2caeba3dbc7bebf9abfc1ef33 # main — bump to post-merge SHA after infra-global-github-actions#715 merges
+        uses: camunda/infra-global-github-actions/dependency-vuln-check@5d109398b8e6b977dfac8e4ab463bba3e798f462 # main
         with:
           base-sha: ${{ github.event.pull_request.base.sha }}
           head-sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

The gate currently trusts the raw `base.sha` from the PR event payload. The snapshot workflow (`maven-dependency-snapshot.yml`) is path-filtered, so a code-only base commit has no snapshot — the base side of the dependency diff is empty, and the *entire* head dep tree is flagged as newly added. This produced false positives like #54971.

The fix (implemented in camunda/infra-global-github-actions#715) resolves `base.sha` to the most recent snapshotted ancestor commit before running the diff. This PR wires in the new required inputs on the consumer side.

## Changes

- **`actions: read`** permission added — required to list `maven-dependency-snapshot.yml` runs for ancestor resolution
- **`base-ref`** input passed — tells the action which branch to scan for snapshot runs
- **`snapshot-workflow`** input passed — `maven-dependency-snapshot.yml`
- **SHA bumped** to `5d109398b8e6b977dfac8e4ab463bba3e798f462` (merge commit of camunda/infra-global-github-actions#715)

## Test plan

- [x] Merge camunda/infra-global-github-actions#715
- [x] Update pinned SHA to post-merge `main` SHA (`5d109398b8e6b977dfac8e4ab463bba3e798f462`)
- [ ] Verify `pr-vuln-check` passes on a dep-changing PR with a code-only base commit (the previously failing case)
- [ ] Verify no regression on a dep-changing PR with a normal snapshot on the base commit

Part of #29729.