### PR TITLE
feat: add stable-89 load test setup folder on main

### DIFF
--- a/.github/workflows/camunda-load-test-smoke-dispatch.yml
+++ b/.github/workflows/camunda-load-test-smoke-dispatch.yml
@@ -53,9 +53,9 @@ jobs:
           #
           # Commented out versions - will be added as soon as we have target version support
           #
-          # if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-89/'; then
-          #   matrix_entries+=('{"version":"stable-89","orchestration-tag":"8.9-SNAPSHOT"}')
-          # fi
+          if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-89/'; then
+            matrix_entries+=('{"version":"stable-89","orchestration-tag":"8.9-SNAPSHOT"}')
+          fi
           # if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-88/'; then
           #   matrix_entries+=('{"version":"stable-88","orchestration-tag":"8.8-SNAPSHOT"}')
           # fi

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -13,7 +13,7 @@ Options:
 All other options are forwarded to the target version's newLoadTest.sh.
 For version-specific help, run: ./newLoadTest.sh --target-version main -h
 
-Available versions: main
+Available versions: main, stable-89
 EOF
 }
 

--- a/load-tests/setup/stable-89/Makefile
+++ b/load-tests/setup/stable-89/Makefile
@@ -1,0 +1,321 @@
+namespace ?= __NAMESPACE__
+secondary_storage ?= __STORAGE_TYPE__
+helm_chart ?= camunda-platform-8.9
+enable_optimize ?= __ENABLE_OPTIMIZE__
+curl_image ?= curlimages/curl:7.87.0
+camunda_management_url ?= http://camunda:9600
+prometheus_elasticsearch_exporter_chart_version ?= 7.2.1
+# Optional: additional Helm configuration for the Camunda Platform release.
+# Use this to pass extra `--set`/`-f` flags, for example:
+#   make install additional_platform_configuration="--set zeebeGateway.env[0].name=FOO --set zeebeGateway.env[0].value=bar"
+# See the load test README for more examples and details.
+additional_platform_configuration ?=
+# Optional: additional Helm configuration for the load test release.
+# Use this to pass extra `--set`/`-f` flags when installing/upgrading the load tests.
+# See the load test README for example values and guidance.
+additional_load_test_configuration ?=
+
+helm_chart_platform := camunda-platform-helm/charts/$(helm_chart)
+helm_chart_load_tests := camunda-load-tests/camunda-load-tests
+
+# Scenario: controls the workload profile for the load test.
+# Options: latency, realistic, typical, max, archiver
+# Use named targets (make max) or pass directly: make install scenario=max
+scenario ?=
+
+ifeq ($(scenario),latency)
+_scenario_load_test_flags := --set starter.rate=1 --set workers.worker.replicas=1
+_scenario_platform_flags  :=
+else ifeq ($(scenario),realistic)
+_scenario_load_test_flags := -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
+_scenario_platform_flags  :=
+else ifeq ($(scenario),typical)
+_scenario_load_test_flags := --set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn
+_scenario_platform_flags  :=
+else ifeq ($(scenario),max)
+_scenario_load_test_flags := --set starter.rate=300
+_scenario_platform_flags  := --set-file 'orchestration.extraConfiguration[1].content=./camunda-platform-override-values.yaml'
+else ifeq ($(scenario),archiver)
+_scenario_load_test_flags := --set starter.rate=1 --set starter.rateDuration=10m --set starter.processId=multiInstanceElements --set starter.bpmnXmlPath=bpmn/multiInstanceElements.bpmn --set starter.payloadPath=bpmn/multiInstanceElementsPayload.json --set workers.worker.replicas=0
+_scenario_platform_flags  :=
+else
+_scenario_load_test_flags :=
+_scenario_platform_flags  :=
+endif
+
+# Construct platform values files based on configuration
+# Starting with the defaults, which are always applied and set common baseline configuration for all
+# set ups. The other values files are focused and only contain the necessary overrides for each storage type.
+platform_values := -f camunda-platform-values-defaults.yaml
+
+# Makefile-side load-test flags. Separate from `additional_load_test_configuration`,
+# which CI sets on the make command line and would suppress `+=` here.
+_secondary_storage_load_test_flags :=
+
+# Add secondary storage values
+ifneq ($(filter $(secondary_storage),postgresql mysql mariadb mssql oracle),)
+	platform_values += -f camunda-platform-values-rdbms.yaml
+else ifeq ($(secondary_storage),none)
+	_secondary_storage_load_test_flags += --set global.extraConfig.load-tester.monitor-data-availability=false
+endif
+platform_values += -f camunda-platform-values-$(secondary_storage).yaml
+
+# Disable Optimize if not enabled
+ifneq ($(enable_optimize),true)
+	platform_values += --set optimize.enabled=false
+
+	ifneq ($(filter $(secondary_storage),postgresql mysql mariadb mssql oracle),)
+		platform_values += --set elasticsearch.enabled=false
+	endif
+else
+	# Optimize needs Elasticsearch or OpenSearch, so enable Elasticsearch if
+	# we are not already creating a cluster for secondary storage.
+	ifeq ($(filter $(secondary_storage),elasticsearch opensearch),)
+		platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
+	endif
+endif
+
+# Platform values with stable configuration
+platform_values_stable := $(platform_values) -f values-stable.yaml
+
+ifeq ($(secondary_storage),elasticsearch)
+	install_es_prom_exporter := true
+	es_prom_exporter_es_uri := http://elastic:9200
+else ifeq ($(secondary_storage),opensearch)
+	install_es_prom_exporter := true
+	es_prom_exporter_es_uri := http://opensearch:9200
+else ifeq ($(enable_optimize),true)
+	install_es_prom_exporter := true
+	es_prom_exporter_es_uri := http://elastic:9200
+else
+	install_es_prom_exporter := false
+endif
+
+.PHONY: all
+all: install
+
+.PHONY: install
+install: check-deadline create-namespace create-credentials install-storage install-platform install-load-test install-elasticsearch-exporter
+
+.PHONY: install-stable
+install-stable: check-deadline create-namespace create-credentials install-storage install-platform-stable install-load-test install-elasticsearch-exporter
+
+# Fail fast if the namespace TTL deadline (read from resources/namespace.yaml,
+# the single source of truth) is today or in the past — the TTL cleanup
+# workflow will delete the namespace and undo the install. To extend, edit
+# `deadline-date` in resources/namespace.yaml and `make create-namespace`.
+.PHONY: check-deadline
+check-deadline:
+	@deadline_date=$$(awk -F'"' '/^[[:space:]]*deadline-date:/ {print $$2; exit}' resources/namespace.yaml); \
+	if [ -z "$$deadline_date" ]; then \
+		echo "ERROR: could not parse deadline-date from resources/namespace.yaml."; \
+		exit 1; \
+	fi; \
+	today=$$(date +%Y-%m-%d); \
+	if [ "$$today" \> "$$deadline_date" ] || [ "$$today" = "$$deadline_date" ]; then \
+		echo "ERROR: namespace deadline-date ($$deadline_date) is today or earlier (today: $$today)."; \
+		echo "       The TTL cleanup workflow will delete this namespace."; \
+		echo "       To extend, edit deadline-date in resources/namespace.yaml and run:"; \
+		echo "         make create-namespace"; \
+		exit 1; \
+	fi
+
+# Apply the rendered namespace manifest. Idempotent: the same manifest applies
+# cleanly whether the namespace exists or not, so reruns of `make install`
+# after a TTL deletion recreate the namespace with the same labels and AZ.
+.PHONY: create-namespace
+create-namespace:
+	@echo "Applying namespace manifest for $(namespace)..."
+	kubectl apply -f resources/namespace.yaml
+
+# Apply the camunda-credentials secret. Idempotent: rerunning after a TTL
+# deletion reapplies the SAME credentials, so the orchestration secret in
+# load-test-values.yaml stays in sync with the live secret.
+.PHONY: create-credentials
+create-credentials:
+	@echo "Applying camunda-credentials secret for namespace $(namespace)..."
+	kubectl apply -n $(namespace) -f resources/camunda-credentials.yaml
+
+# Install secondary storage based on configuration (PostgreSQL, MySQL, MariaDB, MSSQL, Oracle, OpenSearch)
+.PHONY: install-storage
+install-storage:
+ifeq ($(secondary_storage),postgresql)
+	@echo "Installing PostgreSQL database for namespace $(namespace)..."
+	# Install Postgres database - configuration provided via camunda-platform-values-defaults.yaml, camunda-platform-values-rdbms.yaml and camunda-platform-values-postgresql.yaml
+	helm upgrade --install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
+		--namespace $(namespace) \
+		$(platform_values)
+else ifeq ($(secondary_storage),mysql)
+	@echo "Installing MySQL database for namespace $(namespace)..."
+	# Install MySQL database - configuration provided via camunda-platform-values-defaults.yaml, camunda-platform-values-rdbms.yaml and camunda-platform-values-mysql.yaml
+	helm upgrade --install mysql oci://registry-1.docker.io/bitnamicharts/mysql \
+		--namespace $(namespace) \
+		$(platform_values)
+else ifeq ($(secondary_storage),mariadb)
+	@echo "Installing MariaDB database for namespace $(namespace)..."
+	# Install MariaDB database - configuration provided via camunda-platform-values-defaults.yaml, camunda-platform-values-rdbms.yaml and camunda-platform-values-mariadb.yaml
+	helm upgrade --install mariadb oci://registry-1.docker.io/bitnamicharts/mariadb \
+		--namespace $(namespace) \
+		$(platform_values)
+else ifeq ($(secondary_storage),mssql)
+	@echo "Installing MSSQL database for namespace $(namespace)..."
+	# Deploy MSSQL via plain Kubernetes manifests (mssql.yaml) since no good public chart is available
+	kubectl apply --namespace $(namespace) -f databases/mssql.yaml
+else ifeq ($(secondary_storage),oracle)
+	@echo "Installing Oracle database for namespace $(namespace)..."
+	# Deploy Oracle Free 23c via plain Kubernetes manifests (oracle.yaml) since no maintained public chart is available
+	kubectl apply --namespace $(namespace) -f databases/oracle.yaml
+else ifeq ($(secondary_storage),opensearch)
+	@echo "Installing OpenSearch cluster for namespace $(namespace)..."
+	helm upgrade --install opensearch opensearch/opensearch \
+		--version "2.31.0" \
+		--namespace $(namespace) \
+		$(platform_values)
+else
+	@echo "Skipping secondary storage installation (secondary_storage=$(secondary_storage))"
+endif
+
+# Install Elasticsearch Prometheus exporter if Elasticsearch/OpenSearch is deployed (secondary storage or Optimize)
+.PHONY: install-elasticsearch-exporter
+install-elasticsearch-exporter:
+ifeq ($(install_es_prom_exporter),true)
+	@echo "Installing Elasticsearch Prometheus Exporter for namespace $(namespace)..."
+	helm upgrade --install elasticsearch-exporter oci://ghcr.io/prometheus-community/charts/prometheus-elasticsearch-exporter \
+    --namespace $(namespace) \
+    --version $(prometheus_elasticsearch_exporter_chart_version) \
+    --wait --timeout 5m0s \
+    -f prometheus-elasticsearch-exporter-values.yaml \
+    --set "es.uri=$(es_prom_exporter_es_uri)"
+else
+	@echo "Skipping Elasticsearch Prometheus Exporter installation (secondary_storage=$(secondary_storage))"
+endif
+
+# Install/upgrade Camunda Platform helm chart
+.PHONY: install-platform
+install-platform: setup-leader-balancer
+	helm upgrade $(namespace) $(helm_chart_platform) \
+		--install \
+		--namespace $(namespace) \
+		--reset-then-reuse-values \
+		--render-subchart-notes \
+		$(platform_values) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration)
+
+# Install/upgrade Camunda Platform on stable VMs
+.PHONY: install-platform-stable
+install-platform-stable: setup-leader-balancer
+	helm upgrade $(namespace) $(helm_chart_platform) \
+		--install \
+		--namespace $(namespace) \
+		--reset-then-reuse-values \
+		--render-subchart-notes \
+		$(platform_values_stable) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration)
+
+# Install/upgrade load test helm chart
+.PHONY: install-load-test
+install-load-test:
+	helm upgrade $(namespace)-test $(helm_chart_load_tests) \
+		--install \
+		--namespace $(namespace) \
+		--reset-then-reuse-values \
+		--render-subchart-notes \
+		-f load-test-values.yaml \
+		$(_scenario_load_test_flags) \
+		$(_secondary_storage_load_test_flags) \
+		$(additional_load_test_configuration)
+
+# Setup leader balancing cronjob
+.PHONY: setup-leader-balancer
+setup-leader-balancer:
+	@if ! kubectl get cronjob leader-balancer --namespace $(namespace) >/dev/null 2>&1; then \
+		kubectl create cronjob leader-balancer \
+			--namespace $(namespace) \
+			--image=$(curl_image) \
+			--schedule="*/10 * * * *" \
+			-- curl -L -v -X POST $(camunda_management_url)/actuator/rebalance; \
+		echo "Leader balancer cronjob created"; \
+	else \
+		echo "Leader balancer cronjob already exists"; \
+	fi
+
+# Generates templates from the Camunda Platform helm chart
+.PHONY: template
+template:
+	helm template $(namespace) $(helm_chart_platform) \
+		$(platform_values) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration) \
+		--output-dir .
+
+.PHONY: template-stable
+template-stable:
+	helm template $(namespace) $(helm_chart_platform) \
+		$(platform_values_stable) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration) \
+		--output-dir .
+
+# Generates templates from the load test helm chart
+.PHONY: template-load-test
+template-load-test:
+	helm template $(namespace)-test $(helm_chart_load_tests) \
+		-f load-test-values.yaml \
+		$(_scenario_load_test_flags) \
+		$(_secondary_storage_load_test_flags) \
+		$(additional_load_test_configuration) \
+		--output-dir .
+
+# Print the resolved scenario flags without running any Helm commands
+.PHONY: print-scenario
+print-scenario:
+	@echo "Scenario:         $(if $(scenario),$(scenario),(none — chart defaults apply))"
+	@echo "Load test flags:  $(if $(_scenario_load_test_flags),$(_scenario_load_test_flags),(none))"
+	@echo "Platform flags:   $(if $(_scenario_platform_flags),$(_scenario_platform_flags),(none))"
+
+# Workload scenario shortcuts — each runs 'make install' with the corresponding scenario profile.
+# For stable VMs, use: make install-stable scenario=<name>
+.PHONY: latency realistic typical max archiver
+latency:
+	$(MAKE) install scenario=latency
+realistic:
+	$(MAKE) install scenario=realistic
+typical:
+	$(MAKE) install scenario=typical
+max:
+	$(MAKE) install scenario=max
+archiver:
+	$(MAKE) install scenario=archiver
+
+.PHONY: clean
+clean:
+	-helm --namespace $(namespace) uninstall $(namespace)
+	-helm --namespace $(namespace) uninstall $(namespace)-test
+	-helm --namespace $(namespace) uninstall elasticsearch-exporter
+	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/instance=$(namespace)
+	-kubectl delete -n $(namespace) pvc -l app=elasticsearch-master
+	-kubectl delete -n $(namespace) cronjob leader-balancer
+# Clean up secondary storage based on helm charts
+ifneq ($(filter $(secondary_storage),postgresql mysql mariadb),)
+	@echo "Cleaning up $(secondary_storage) database for namespace $(namespace)..."
+	-helm --namespace $(namespace) uninstall $(secondary_storage)
+	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/name=$(secondary_storage)
+# MSSQL and Oracle are deployed via plain Kubernetes manifests, so we need to delete them via kubectl
+else ifneq ($(filter $(secondary_storage),mssql oracle),)
+	@echo "Cleaning up $(secondary_storage) database for namespace $(namespace)..."
+	-kubectl delete --namespace $(namespace) -f databases/$(secondary_storage).yaml
+	# StatefulSet PVCs are not deleted automatically — remove them explicitly.
+	-kubectl delete --namespace $(namespace) pvc -l app.kubernetes.io/name=$(secondary_storage)
+else ifeq ($(secondary_storage),opensearch)
+	@echo "Cleaning up OpenSearch cluster for namespace $(namespace)..."
+	-helm --namespace $(namespace) uninstall opensearch
+	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/name=opensearch
+endif
+	@echo "Deleting namespace $(namespace) and waiting for finalization..."
+	# `--wait` (default) blocks until the namespace is fully gone. We intentionally
+	# wait so that a subsequent `make install` (or `make clean install`) doesn't
+	# race against finalizers — applying manifests into a still-terminating
+	# namespace errors out with "namespace X is being terminated".
+	-kubectl delete -f resources/namespace.yaml --ignore-not-found

--- a/load-tests/setup/stable-89/databases/mssql.yaml
+++ b/load-tests/setup/stable-89/databases/mssql.yaml
@@ -1,0 +1,148 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+# mssql.yaml — Plain Kubernetes manifests for Microsoft SQL Server 2022.
+#
+# The ClusterIP Service is named "mssql" to match the JDBC URL in
+# camunda-platform-values-mssql.yaml:
+#   jdbc:sqlserver://mssql:1433;Encrypt=false
+
+---
+# SA password – referenced by the StatefulSet container.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mssql-secret
+  labels:
+    app.kubernetes.io/name: mssql
+type: Opaque
+stringData:
+  SA_PASSWORD: "Camunda#8_demo"
+
+
+---
+# ClusterIP Service — "mssql" resolves to this service inside the namespace.
+# JDBC URL: jdbc:sqlserver://mssql:1433;Encrypt=false
+apiVersion: v1
+kind: Service
+metadata:
+  name: mssql
+  labels:
+    app.kubernetes.io/name: mssql
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mssql
+  ports:
+    - name: mssql
+      port: 1433
+      targetPort: 1433
+      protocol: TCP
+
+---
+# StatefulSet — single replica with a 128 Gi SSD PVC.
+# The volumeClaimTemplate creates a PVC named "mssql-data-mssql-0";
+# this PVC is NOT removed automatically when the StatefulSet is deleted
+# (see the clean target in the Makefile for explicit PVC cleanup).
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mssql
+  labels:
+    app.kubernetes.io/name: mssql
+spec:
+  serviceName: mssql
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mssql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mssql
+    spec:
+      # fsGroup 10001 ensures the mounted volume is writable by the mssql user
+      # inside the Microsoft SQL Server container image.
+      securityContext:
+        fsGroup: 10001
+
+      nodeSelector:
+        component: benchmark-n2-standard-8
+        topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+      tolerations:
+        - key: nodepool
+          operator: Equal
+          value: n2-standard-8
+          effect: NoSchedule
+
+      containers:
+        - name: mssql
+          image: mcr.microsoft.com/mssql/server:2022-latest
+          env:
+            - name: ACCEPT_EULA
+              value: "Y"
+            - name: MSSQL_SA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mssql-secret
+                  key: SA_PASSWORD
+          ports:
+            - name: mssql
+              containerPort: 1433
+              protocol: TCP
+          resources:
+            requests:
+              memory: 8Gi
+              cpu: "3000m"
+            limits:
+              memory: 12Gi
+              cpu: "3000m"
+          readinessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - >-
+                  /opt/mssql-tools18/bin/sqlcmd
+                  -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C
+                  -Q "SELECT 1"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - >-
+                  /opt/mssql-tools18/bin/sqlcmd
+                  -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C
+                  -Q "SELECT 1"
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: mssql-data
+              mountPath: /var/opt/mssql
+
+  # PVC template — creates "mssql-data-mssql-0" on first deployment.
+  # storageClass "ssd" provisions a 128 Gi SSD-backed volume.
+  volumeClaimTemplates:
+    - metadata:
+        name: mssql-data
+        labels:
+          app.kubernetes.io/name: mssql
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: 512Gi
+

--- a/load-tests/setup/stable-89/databases/oracle.yaml
+++ b/load-tests/setup/stable-89/databases/oracle.yaml
@@ -1,0 +1,194 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+# oracle.yaml — Plain Kubernetes manifests for Oracle Database Free 23c.
+
+# Current limitations
+# - the currently used Oracle free image only supports up to 12GB of tablespace.
+#     This currently fills up with audit logs and undo logs even with an aggressive history TTL
+#
+#
+# Uses the gvenzl/oracle-free image (same as db/docker-compose.yml) which runs
+# Oracle Database Free 23c. The plain slim variant is used instead of
+# slim-faststart because the faststart image copies a pre-built database from
+# the image layer on first start. In Kubernetes that copy fails with
+# ORA-00205 (cannot identify control file), which leaves Oracle in a half-
+# started state; the subsequent restart then sees its own lock file and fails
+# with ORA-01081. The slim image avoids this by creating the database from
+# scratch via dbca, which is slower (~20-30 min on first run) but reliable.
+# The startupProbe below gives a 30-minute window to cover that first run;
+# subsequent pod restarts reuse the PVC and start in seconds.
+# Using the default entrypoint without modification keeps behaviour identical to
+# Docker Compose, letting runOracle.sh handle startup the same way in both
+# environments.
+#
+# /dev/shm: Kubernetes pods default to 64 MB of shared memory, which is far too
+# small for Oracle's Automatic Memory Management (AMM). Oracle Free's SGA alone
+# is ~2 GB. Without a sufficiently large /dev/shm Oracle fails to allocate the
+# SGA, crashes mid-startup, and on the next attempt sees its own partially-
+# created lock file → ORA-01081. The dshm emptyDir (medium: Memory) below
+# removes this limit, mirroring what Docker (and Docker Compose) provide on a
+# typical host.
+#
+# The ClusterIP Service is named "oracle" to match the JDBC URL in
+# camunda-platform-values-oracle.yaml:
+#   jdbc:oracle:thin:@//oracle:1521/FREEPDB1
+
+---
+# Passwords — referenced by the StatefulSet container.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oracle-secret
+  labels:
+    app.kubernetes.io/name: oracle
+type: Opaque
+stringData:
+  ORACLE_PASSWORD: "sys_user_password"
+  APP_USER_PASSWORD: "camunda"
+
+
+---
+# ClusterIP Service — "oracle" resolves to this service inside the namespace.
+# JDBC URL: jdbc:oracle:thin:@//oracle:1521/FREEPDB1
+apiVersion: v1
+kind: Service
+metadata:
+  name: oracle
+  labels:
+    app.kubernetes.io/name: oracle
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: oracle
+  ports:
+    - name: oracle
+      port: 1521
+      targetPort: 1521
+      protocol: TCP
+
+---
+# StatefulSet — single replica with a 128 Gi SSD PVC.
+# The volumeClaimTemplate creates a PVC named "oracle-data-oracle-0";
+# this PVC is NOT removed automatically when the StatefulSet is deleted
+# (see the clean target in the Makefile for explicit PVC cleanup).
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: oracle
+  labels:
+    app.kubernetes.io/name: oracle
+spec:
+  serviceName: oracle
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oracle
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: oracle
+    spec:
+      # fsGroup 54321 ensures the mounted PVC is writable by the oracle user
+      # (UID/GID 54321) inside the gvenzl/oracle-free container image.
+      securityContext:
+        fsGroup: 54321
+
+      nodeSelector:
+        component: benchmark-n2-standard-8
+        topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+      tolerations:
+        - key: nodepool
+          operator: Equal
+          value: n2-standard-8
+          effect: NoSchedule
+
+      containers:
+        - name: oracle
+          image: gvenzl/oracle-free:23-slim
+          # No command override — use the image's default entrypoint (runOracle.sh)
+          # exactly as Docker Compose does.
+          env:
+            - name: ORACLE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oracle-secret
+                  key: ORACLE_PASSWORD
+            - name: APP_USER
+              value: "camunda"
+            - name: APP_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oracle-secret
+                  key: APP_USER_PASSWORD
+          ports:
+            - name: oracle
+              containerPort: 1521
+              protocol: TCP
+          resources:
+            requests:
+              memory: 8Gi
+              cpu: "3000m"
+            limits:
+              memory: 12Gi
+              cpu: "3000m"
+          # startupProbe gates liveness/readiness until Oracle is fully open.
+          # On first run the slim image creates the database from scratch (~20-30
+          # minutes). failureThreshold * periodSeconds gives a 30-minute window.
+          # Subsequent restarts reuse the PVC and finish within the initial delay.
+          startupProbe:
+            exec:
+              command:
+                - healthcheck.sh
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 60   # 60 × 30 s = 1800 s ≈ 30 minutes
+          readinessProbe:
+            exec:
+              command:
+                - healthcheck.sh
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - healthcheck.sh
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - name: oracle-data
+              mountPath: /opt/oracle/oradata
+            - name: dshm
+              mountPath: /dev/shm
+
+      # Provide Oracle with a /dev/shm large enough for its SGA.
+      # The default Kubernetes /dev/shm is 64 MB; Oracle AMM needs ~2 GB.
+      # medium: Memory makes this an in-memory tmpfs; its size is bounded by
+      # the pod's memory limit rather than needing a separate sizeLimit.
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+
+  # PVC template — creates "oracle-data-oracle-0" on first deployment.
+  # storageClass "ssd" provisions a 128 Gi SSD-backed volume.
+  volumeClaimTemplates:
+    - metadata:
+        name: oracle-data
+        labels:
+          app.kubernetes.io/name: oracle
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: 128Gi
+

--- a/load-tests/setup/stable-89/newLoadTest.sh
+++ b/load-tests/setup/stable-89/newLoadTest.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The directory where the load tests and shared utilities are located.
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Contains OS specific sed function
+. "${ROOT_DIR}/utils.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]
+
+Arguments:
+  namespace          Base namespace name. Will be prefixed with "c8-" if missing.
+  secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none. Default: elasticsearch.
+  ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
+  enable_optimize    Optional. true|false to enable Optimize. Default: true.
+  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true
+
+Options:
+  -h, --help         Show this help message.
+
+Examples:
+  ./newLoadTest.sh demo
+  ./newLoadTest.sh perf opensearch 3 false
+
+This script scaffolds the per-namespace folder including rendered Kubernetes
+manifests under resources/ (namespace + credentials). The cluster itself is
+unchanged by this script — namespace and secret are created on first
+`make install` via `kubectl apply -f resources/...`. Reruns of `make install`
+after a TTL deletion recreate both from the same baked manifests, so
+credentials stay in sync with `load-test-values.yaml`.
+EOF
+}
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ -z "$1" ]; then
+  echo "Error: Missing namespace name."
+  usage
+  exit 1
+fi
+
+### Load test helper script
+### First parameter is used as namespace name
+### For a new namespace a new folder will be created
+
+helm_chart="camunda-platform-8.9"
+namespace="$1"
+
+# Add c8- prefix if not present
+if [[ ! "$namespace" =~ ^c8- ]]; then
+  namespace="c8-$namespace"
+  echo "Namespace prefix added: $namespace"
+fi
+
+# Validate against Kubernetes DNS-1123 label rules. Previously this was
+# implicit (`kubectl create namespace` rejected bad names at cluster time);
+# now that namespace creation is deferred to `make install`, validate here so
+# we don't render a folder with random secrets just to discover the name is
+# invalid.
+if [[ ! "$namespace" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]]; then
+  echo "Error: namespace '$namespace' is not a valid Kubernetes DNS-1123 label."
+  echo "       Allowed: lowercase letters, digits, '-'. Must start and end with an alphanumeric."
+  exit 1
+fi
+if [ ${#namespace} -gt 63 ]; then
+  echo "Error: namespace '$namespace' is ${#namespace} characters; Kubernetes labels are capped at 63."
+  exit 1
+fi
+
+# Validate secondaryStorage value
+secondaryStorage="${2:-elasticsearch}"
+if [[ "$secondaryStorage" != "elasticsearch" && "$secondaryStorage" != "opensearch" && "$secondaryStorage" != "postgresql" && "$secondaryStorage" != "mysql" && "$secondaryStorage" != "mariadb" && "$secondaryStorage" != "mssql" && "$secondaryStorage" != "oracle" && "$secondaryStorage" != "none" ]]; then
+  echo "Error: Invalid secondary storage type '$secondaryStorage'"
+  echo "Allowed values are: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none"
+  exit 1
+fi
+
+# Validate TTL value
+ttl_days="${3:-1}"
+numberRegex='^[0-9]+$'
+if ! [[ $ttl_days =~ $numberRegex ]] ; then
+   echo "Error: TTL '$ttl_days' is not a number"
+   exit 1
+fi
+
+# Validate enable_optimize value
+enable_optimize="${4:-true}"
+enable_optimize=$(echo "$enable_optimize" | tr '[:upper:]' '[:lower:]')
+if [[ "$enable_optimize" != "true" && "$enable_optimize" != "false" ]]; then
+  echo "Error: Invalid enable_optimize value '$enable_optimize'"
+  echo "Allowed values are: true or false"
+  exit 1
+fi
+
+enable_single_zone="${5:-true}"
+enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
+
+# Pick a "random" zone, selected from the input value.
+function hashmod_zone() {
+    local input="${1?"Specify an initial value to compute the zone from"}"
+
+    # We can get the list of zones with already created nodes with:
+    # kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io\/zone}{"\n"}{end}' | sort | uniq -c
+    zones=(
+        europe-west1-b
+        europe-west1-c
+        europe-west1-d
+    )
+    nb_zones=${#zones[@]}
+
+    # bc only accept hexadecimal with capitalized letters
+    checksum="$(echo "$input" | md5sum | cut -c 1-32 | tr "a-z" "A-Z")"
+    hashmod="$(echo "ibase=16; $checksum % $nb_zones" | bc)"
+
+    zone="${zones[$hashmod]}"
+    echo "$zone"
+}
+
+# `hashmod_zone` is deterministic, so the zone baked into namespace.yaml and
+# the values files matches any re-applied manifest after TTL deletion.
+if [[ "$enable_single_zone" == "true" ]]; then
+  availability_zone="$(hashmod_zone "$namespace")"
+else
+  availability_zone="~"
+fi
+
+git_author=$(compute_git_author)
+
+# Compute deadline-date once at scaffold time. The Makefile's check-deadline
+# target compares this against today; if it has passed, install fails fast.
+if deadline_date=$(date -d "+${ttl_days} days" +%Y-%m-%d 2>/dev/null); then
+  : # GNU date succeeded
+elif deadline_date=$(date -v +${ttl_days}d +%Y-%m-%d 2>/dev/null); then
+  : # BSD/macOS date succeeded
+else
+  echo "Error: Could not calculate deadline date. Supported on Linux and macOS only."
+  exit 1
+fi
+
+TARGET_DIRECTORY="${ROOT_DIR}/${namespace}"
+
+# Scaffold the namespace folder with only the files this $secondaryStorage uses.
+# A namespace is bound to its storage at create time; to switch storage, create
+# a new namespace via ./newLoadTest.sh <new-name> <newStorage>.
+mkdir -p "$TARGET_DIRECTORY"
+
+# Scaffold the always-copied files into the namespace folder root: the
+# Makefile, the resources/ manifests, four storage-agnostic values files
+# (defaults + override + load-test + stable), and the matching
+# camunda-platform-values-${secondaryStorage}.yaml. Flat layout so the
+# per-namespace Makefile's -f <file>.yaml references resolve unchanged.
+cp -v  "Makefile"                                                "$TARGET_DIRECTORY/"
+cp -rv "resources/"                                              "$TARGET_DIRECTORY/"
+cp -v  "values/camunda-platform-override-values.yaml"            "$TARGET_DIRECTORY/"
+cp -v  "values/load-test-values.yaml"                            "$TARGET_DIRECTORY/"
+cp -v  "values/values-stable.yaml"                               "$TARGET_DIRECTORY/"
+cp -v  "values/camunda-platform-values-defaults.yaml"            "$TARGET_DIRECTORY/"
+cp -v  "values/camunda-platform-values-${secondaryStorage}.yaml" "$TARGET_DIRECTORY/"
+
+# Storage-specific copies. databases/ is created only for mssql/oracle.
+case "$secondaryStorage" in
+  elasticsearch|opensearch)
+    cp -v "values/prometheus-elasticsearch-exporter-values.yaml" "$TARGET_DIRECTORY/"
+    ;;
+  postgresql|mysql|mariadb)
+    cp -v "values/camunda-platform-values-rdbms.yaml"            "$TARGET_DIRECTORY/"
+    ;;
+  mssql|oracle)
+    cp -v "values/camunda-platform-values-rdbms.yaml"            "$TARGET_DIRECTORY/"
+    mkdir -p "$TARGET_DIRECTORY/databases"
+    cp -v "databases/${secondaryStorage}.yaml"                   "$TARGET_DIRECTORY/databases/"
+    ;;
+esac
+
+if [[ "$enable_optimize" == "true" ]]; then
+  # Optimize needs specifically Elasticsearch (independently from the secondary
+  # storage configuration).
+  cp -v "values/camunda-platform-values-optimize-elasticsearch.yaml" "$TARGET_DIRECTORY/"
+  cp -v "values/prometheus-elasticsearch-exporter-values.yaml" "$TARGET_DIRECTORY/"
+fi
+
+cd "$TARGET_DIRECTORY"
+
+# Bake values into the rendered Makefile. The deadline lives only in
+# resources/namespace.yaml (single source of truth) — check-deadline parses
+# it out of there so the user only edits one place to extend the TTL.
+sed_inplace "s/__NAMESPACE__/$namespace/"           Makefile
+sed_inplace "s/__STORAGE_TYPE__/$secondaryStorage/" Makefile
+sed_inplace "s/__ENABLE_OPTIMIZE__/$enable_optimize/" Makefile
+
+# Bake values into the resource manifests and the platform/load-test values.
+# Values shared with the chart (NAMESPACE, AVAILABILITY_ZONE, AUTHOR) flow into
+# the upstream yaml files via the same sed pass.
+sed_inplace "s/__NAMESPACE__/$namespace/"                       load-test-values.yaml resources/*.yaml
+sed_targets=(*.yaml resources/namespace.yaml)
+[[ -d databases ]] && sed_targets+=(databases/*.yaml)
+sed_inplace "s/__AVAILABILITY_ZONE__/$availability_zone/" "${sed_targets[@]}"
+sed_inplace "s/__AUTHOR__/$git_author/"                   "${sed_targets[@]}"
+sed_inplace "s/__DEADLINE_DATE__/$deadline_date/"                resources/namespace.yaml
+
+# When single-zone is disabled the topology annotation has no useful value;
+# strip the annotation line and the now-empty `annotations:` key so the manifest
+# stays tidy.
+if [[ "$enable_single_zone" != "true" ]]; then
+  sed_inplace "/topology.kubernetes.io\\/zone:/d" resources/namespace.yaml
+  # `sed_inplace` splits args on whitespace and the `annotations:` line pattern
+  # contains literal spaces, so call sed directly with OS-aware -i flag.
+  detect_os
+  if [ "${GO_OS}" == "darwin" ]; then
+    sed -i '' -e '/^  annotations:$/d' resources/namespace.yaml
+  else
+    sed -i    -e '/^  annotations:$/d' resources/namespace.yaml
+  fi
+fi
+
+#############################################################################################
+################################ CREDENTIALS ################################################
+#############################################################################################
+
+function get_existing_secret() {
+  jsonObject=$1
+  key=$2
+  existing_secret=$(echo "$jsonObject" | jq --raw-output --arg key "$key" '.[$key] // empty' | base64 -d)
+  if [ -z "$existing_secret" ]; then
+    echo "ERROR: existing camunda-credentials secret is missing key '$key'."
+    exit 1
+  fi
+  echo "$existing_secret"
+}
+
+# Generate credentials. These are baked into resources/camunda-credentials.yaml
+# and (for the orchestration OIDC secret) into load-test-values.yaml. Any
+# subsequent `make install` reapplies the same manifest, so the secret in the
+# cluster always matches the value the load test starter authenticates with.
+# `head -c 20` closes the pipe early; upstream `tr` then takes SIGPIPE and
+# returns 141 under `set -o pipefail`. Wrap in a subshell so the harmless
+# SIGPIPE doesn't trip `set -e` in the caller.
+function gen_password() { ( set +o pipefail; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20 ); }
+function gen_token()    { openssl rand -hex 16; }
+
+
+# If the secret already exists in the cluster, preserve all existing values to avoid breaking any live load test.
+# If the secret doesn't exist, generate new random values for all keys.
+# This might happend on CI/GitHub Workflows that update existing load tests but do not persist the credentials across runs.
+if kubectl -n "$namespace" get secret camunda-credentials >/dev/null 2>&1; then
+  echo "Secret 'camunda-credentials' already exists in namespace '$namespace'; preserving existing credentials."
+  jsonObject=$(kubectl -n "$namespace" get secret camunda-credentials -o jsonpath='{.data}')
+
+  IDENTITY_FIRSTUSER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-firstuser-password")
+  IDENTITY_KEYCLOAK_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-admin-password")
+  IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-postgresql-admin-password")
+  IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-postgresql-user-password")
+  IDENTITY_POSTGRESQL_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-postgresql-admin-password")
+  IDENTITY_POSTGRESQL_USER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-postgresql-user-password")
+  CONNECTORS_SECRET=$(get_existing_secret "$jsonObject" "connectors-security-authentication-oidc-secret")
+  ORCHESTRATION_SECRET=$(get_existing_secret "$jsonObject" "orchestration-security-authentication-oidc-secret")
+  IDENTITY_ADMIN_CLIENT_TOKEN=$(get_existing_secret "$jsonObject" "identity-admin-client-token")
+  IDENTITY_OPTIMIZE_CLIENT_TOKEN=$(get_existing_secret "$jsonObject" "identity-optimize-client-token")
+
+else
+  echo "Generating new credentials for secret 'camunda-credentials'."
+  IDENTITY_FIRSTUSER_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD=$(gen_password)
+  IDENTITY_POSTGRESQL_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_POSTGRESQL_USER_PASSWORD=$(gen_password)
+  CONNECTORS_SECRET=$(gen_password)
+  ORCHESTRATION_SECRET=$(gen_password)
+  IDENTITY_ADMIN_CLIENT_TOKEN=$(gen_token)
+  IDENTITY_OPTIMIZE_CLIENT_TOKEN=$(gen_token)
+fi
+
+# Bake the orchestration OIDC secret into the load-test starter values.
+sed_inplace "s|__SECRET__|$ORCHESTRATION_SECRET|" load-test-values.yaml
+
+# Bake the credential values into the secret manifest.
+sed_inplace "s|__IDENTITY_FIRSTUSER_PASSWORD__|$IDENTITY_FIRSTUSER_PASSWORD|"                                 resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_KEYCLOAK_ADMIN_PASSWORD__|$IDENTITY_KEYCLOAK_ADMIN_PASSWORD|"                       resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD__|$IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD|" resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD__|$IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD|"   resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_POSTGRESQL_ADMIN_PASSWORD__|$IDENTITY_POSTGRESQL_ADMIN_PASSWORD|"                   resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_POSTGRESQL_USER_PASSWORD__|$IDENTITY_POSTGRESQL_USER_PASSWORD|"                     resources/camunda-credentials.yaml
+sed_inplace "s|__ORCHESTRATION_SECRET__|$ORCHESTRATION_SECRET|"                                               resources/camunda-credentials.yaml
+sed_inplace "s|__CONNECTORS_SECRET__|$CONNECTORS_SECRET|"                                                     resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_ADMIN_CLIENT_TOKEN__|$IDENTITY_ADMIN_CLIENT_TOKEN|"                                 resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_OPTIMIZE_CLIENT_TOKEN__|$IDENTITY_OPTIMIZE_CLIENT_TOKEN|"                           resources/camunda-credentials.yaml
+
+# Add/update helm repositories
+helm repo add camunda https://helm.camunda.io/ --force-update
+helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/ --force-update
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update
+helm repo update
+
+# Clone Platform Helm so we can run the latest chart
+git clone --depth 1 --branch main --single-branch https://github.com/camunda/camunda-platform-helm.git
+
+# Make deps
+helm dependency build "camunda-platform-helm/charts/$helm_chart"
+
+echo
+echo "Scaffolding complete. Next steps:"
+echo "  cd $namespace"
+echo "  make install   # applies resources/namespace.yaml + resources/camunda-credentials.yaml and deploys"
+echo
+echo "Deadline: $deadline_date (TTL = $ttl_days day(s)). To extend, edit deadline-date in resources/namespace.yaml and run \`make create-namespace\`."

--- a/load-tests/setup/stable-89/resources/camunda-credentials.yaml
+++ b/load-tests/setup/stable-89/resources/camunda-credentials.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  identity-firstuser-password: "__IDENTITY_FIRSTUSER_PASSWORD__"
+  identity-keycloak-admin-password: "__IDENTITY_KEYCLOAK_ADMIN_PASSWORD__"
+  identity-keycloak-postgresql-admin-password: "__IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD__"
+  identity-keycloak-postgresql-user-password: "__IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD__"
+  identity-postgresql-admin-password: "__IDENTITY_POSTGRESQL_ADMIN_PASSWORD__"
+  identity-postgresql-user-password: "__IDENTITY_POSTGRESQL_USER_PASSWORD__"
+  orchestration-security-authentication-oidc-secret: "__ORCHESTRATION_SECRET__"
+  connectors-security-authentication-oidc-secret: "__CONNECTORS_SECRET__"
+  identity-admin-client-token: "__IDENTITY_ADMIN_CLIENT_TOKEN__"
+  identity-optimize-client-token: "__IDENTITY_OPTIMIZE_CLIENT_TOKEN__"

--- a/load-tests/setup/stable-89/resources/namespace.yaml
+++ b/load-tests/setup/stable-89/resources/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: __NAMESPACE__
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: __AUTHOR__
+    deadline-date: "__DEADLINE_DATE__"
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__

--- a/load-tests/setup/stable-89/values/camunda-platform-override-values.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-override-values.yaml
@@ -1,0 +1,5 @@
+# Consistency check overrides for the max stress scenario.
+# This file is injected as application-override.yml (loaded after and overrides application.yml)
+# when scenario=max, to disable checks that would add overhead during maximum-load tests.
+zeebe.broker.experimental.consistencyChecks.enablePreconditions: "false"
+zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "false"

--- a/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
@@ -1,0 +1,340 @@
+# Default load test values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This file is used to override the default values of the chart.
+# The values are optimized for running the load tests with a Camunda cluster on GKE.
+#
+# This is a YAML-formatted file.
+# Per default we run with the Orchestration Cluster, Optimize, Connectors, and Identity
+# Keycloak as identity provider with OIDC authentication, but you can easily
+# switch to other configurations by changing the values in this file or by overriding them via the
+# command line when installing the chart.
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  commonLabels:
+    camunda.io/created-by: __AUTHOR__
+    camunda.io/purpose: load-test
+
+  # Disable global ingress
+  ingress:
+    enabled: false
+  image:
+    # Image.repository defines the repository from which to fetch the docker images
+    repository: "registry.camunda.cloud/team-zeebe"
+    # Image.tag defines the tag / version which should be used in the chart
+    tag: SNAPSHOT
+    ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    pullPolicy: Always
+    ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets:
+      - name: harbor-registry
+
+  # Default node configuration for all the components, unless specific
+  # reconfigured.
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  # Identity authentication is enabled for Optimize
+  identity:
+    auth:
+      enabled: true
+      optimize:
+        clientId: optimize
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: identity-optimize-client-token
+  security:
+    authentication:
+      type: oidc
+
+identity:
+  enabled: true
+  fullnameOverride: identity # we override the names for simplicity of the deployment
+  firstUser:
+    secret:
+      existingSecret: camunda-credentials
+      existingSecretKey: identity-firstuser-password
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/management-identity/miscellaneous/configuration-variables/#google-stackdriver-json-logging
+    - name: IDENTITY_LOG_APPENDER
+      value: Stackdriver
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+optimize:
+  enabled: true
+  fullnameOverride: optimize # we override the names for simplicity of the deployment
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        historyCleanup:
+          cronTrigger: '*/30 * * * *'
+          ttl: 'P1D'
+          processDataCleanup:
+            enabled: true
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
+    - name: OPTIMIZE_LOG_APPENDER
+      value: Stackdriver
+
+    # Configure Optimize to use the full size of the ES/OS cluster it connects
+    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
+    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
+    # the cluster.
+    # Ideally, this value should default to the number of Elasticsearch nodes
+    # in the cluster.
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+
+    # Improve performances of Optimize for the load tests.
+    # This is load-test specific and different configuration of cluster
+    # configuration (different hardware resources for instance) and/or type of
+    # workload may benefit (or even require) from a different value here.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+      value: "1000" # default 200
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+identityKeycloak:
+  enabled: true
+  fullnameOverride: keycloak # we override the names for simplicity of the deployment
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+  extraEnvVars:
+    # https://www.keycloak.org/server/logging#_console
+    - name: KC_LOG_CONSOLE_OUTPUT
+      value: json
+  postgresql:
+    fullnameOverride: keycloak-postgresql # we override the names for simplicity of the deployment
+
+connectors:
+  enabled: true
+  fullnameOverride: connectors # we override the names for simplicity of the deployment
+  security:
+    authentication:
+      method: oidc
+      oidc:
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: connectors-security-authentication-oidc-secret
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/connectors/connectors-configuration/#google-stackdriver-json-logging
+    - name: CONNECTORS_LOG_APPENDER
+      value: stackdriver
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+webModeler:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  security:
+    authentication:
+      method: oidc
+      unprotectedApi: false
+      oidc:
+        secret:
+          ## @param orchestration.security.authentication.oidc.secret.existingSecret can be used to reference an existing Kubernetes Secret containing the client secret.
+          existingSecret: camunda-credentials
+          ## @param orchestration.security.authentication.oidc.secret.existingSecretKey defines the key within the existing secret object.
+          existingSecretKey: orchestration-security-authentication-oidc-secret
+
+    authorizations:
+      enabled: true
+    initialization:
+      authorizations:
+        # Grant the orchestration client (load tester) permission to create resources (BPMN/DMN)
+        - ownerType: CLIENT
+          ownerId: orchestration
+          resourceType: RESOURCE
+          resourceId: "*"
+          permissions:
+            - CREATE
+        # Grant the orchestration client permissions to manage and observe process instances
+        - ownerType: CLIENT
+          ownerId: orchestration
+          resourceType: PROCESS_DEFINITION
+          resourceId: "*"
+          permissions:
+            - CREATE_PROCESS_INSTANCE
+            - UPDATE_PROCESS_INSTANCE
+            - READ_PROCESS_INSTANCE
+            - READ_PROCESS_DEFINITION
+        # Grant the orchestration client permission to publish messages
+        # (required by realistic benchmark workers: customer_notification,
+        # dispute_process_request_proof_from_vendor)
+        - ownerType: CLIENT
+          ownerId: orchestration
+          resourceType: MESSAGE
+          resourceId: "*"
+          permissions:
+            - CREATE
+  # For simplicity of the deployment, we override the names to camunda
+  # This means we will have pods like: camunda-0, camunda-1, camunda-2
+  fullnameOverride: camunda
+  image:
+    registry: docker.io
+    repository: camunda/camunda
+    tag: "SNAPSHOT"
+  ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
+  clusterSize: "3"
+  ## @param core.partitionCount defines how many partitions are set up in the cluster
+  partitionCount: "3"
+  ## @param core.replicationFactor defines how each partition is replicated, the value defines the number of nodes
+  replicationFactor: "3"
+  ## @param core.cpuThreadCount defines how many threads can be used for the processing on each broker pod
+  cpuThreadCount: "3"
+  ## @param core.ioThreadCount defines how many threads can be used for the exporting on each broker pod
+  ioThreadCount: "3"
+  # Resources of the orchestration cluster
+  resources:
+    requests:
+      cpu: 3000m
+      memory: 4Gi
+    limits:
+      cpu: 3000m
+      memory: 4Gi
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+  ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+  pvcSize: "64Gi"
+  ## @param core.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.
+  # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.
+  pvcStorageClassName: benchmark-ssd-zonal-v1
+  # @extra core.containerSecurityContext defines the security options the container should be run with
+  containerSecurityContext:
+    ## @param core.containerSecurityContext.allowPrivilegeEscalation
+    allowPrivilegeEscalation: true
+    ## @param core.containerSecurityContext.privileged
+    privileged: true
+    ## @param core.containerSecurityContext.runAsNonRoot
+    runAsNonRoot: true
+    ## @param core.containerSecurityContext.runAsUser
+    runAsUser: 1000
+    capabilities:
+      add: ["NET_ADMIN"]
+  javaOpts: >-
+    -XX:MaxRAMPercentage=25.0
+    -XX:+ExitOnOutOfMemoryError
+    -XX:+HeapDumpOnOutOfMemoryError
+    -XX:HeapDumpPath=/usr/local/camunda/data
+    -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log
+    -XX:NativeMemoryTracking=summary
+    -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M
+
+  # We set extra configuration to configure additional settings for Camunda application, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+        zeebe.broker.executionMetricsExporterEnabled: "true"
+        camunda.flags.jfr.metrics: "true"
+        # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+        zeebe.broker.data.disk.freeSpace.processing: "3GB"
+        zeebe.broker.data.disk.freeSpace.replication: "2GB"
+        # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+        # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+
+        # Camunda Exporter configuration
+        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+        zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+
+        # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+        zeebe.broker.flowControl.write.enabled: "true"
+        zeebe.broker.flowControl.write.limit: 10000
+        zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
+    # like disabling consistency checks without duplicating the full application.yml content.
+    - file: application-override.yml
+      content: "# no overrides"
+
+  # Zeebe config
+  extraVolumes:
+    - name: logs
+      emptyDir: {}
+  ## @param core.extraVolumeMounts can be used to mount extra volumes for the broker pods, useful for additional exporters
+  extraVolumeMounts:
+    - name: logs
+      mountPath: /usr/local/camunda/logs
+  # Retention for the ES Exporter indices - legacy Zeebe indices
+  retention:
+    enabled: true
+    minimumAge: 1d
+  # Retention for the Camunda Exporter
+  history:
+    retention:
+      ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
+      enabled: true
+      ## @param core.history.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
+      minimumAge: 1d
+      policyName: "camunda-retention-policy"
+  # @param core.env can be used to set extra environment variables in each broker container
+  env:
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail when this file is not mounted (e.g. RDBMS / no-secondary-storage scenarios).
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
+# Change these settings to configure a different way to collect metrics
+prometheusServiceMonitor:
+  enabled: true
+  labels:
+    release: monitoring
+  scrapeInterval: 30s

--- a/load-tests/setup/stable-89/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-elasticsearch.yaml
@@ -1,0 +1,77 @@
+# Elasticsearch values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This configures Elasticsearch when it's used for Optimize AND as the Camunda secondary storage.
+#
+# If you want to configure Elasticsearch only for Optimize and use another
+# secondary storage option for Camunda, see
+# the "camunda-platform-values-optimize-elasticsearch.yaml" file.
+# If you make changes to this file or the
+# "camunda-platform-values-optimize-elasticsearch.yaml" file, make sure to keep
+# the other file in sync (minus the secondary storage-only options).
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  elasticsearch:
+    enabled: true
+    url:
+      # The Elasticsearch host value used to connect to Elasticsearch depends
+      # on the "elasticsearch.fullnameOverride" value.
+      # If you change the "elasticsearch.fullnameOverride" value, make sure to
+      # update this host value accordingly.
+      host: elastic
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  # We need to explicitly set the secondary storage type to ELS
+  # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS
+  data:
+    secondaryStorage:
+      type: elasticsearch
+
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  enabled: true
+  # Override the default name for ConfigMap, Service, etc.
+  # Changing this value also changes the name of the Kubernetes Service used by
+  # the other components to connect to Elasticsearch, make sure to update
+  # the "global.elasticsearch.url.host" value accordingly.
+  fullnameOverride: elastic
+  clusterName: elasticsearch
+  master:
+    fullnameOverride: elastic
+    nameOverride: elastic
+    ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
+    replicaCount: 3
+    pdb:
+      minAvailable: 2
+    ## @param elasticsearch.master.heapSize
+    heapSize: 3g
+    persistence:
+      ## @param elasticsearch.master.persistence.size
+      size: 512Gi
+      storageClass: benchmark-ssd-zonal-v1
+      accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        cpu: 7000m
+        memory: 8Gi
+      limits:
+        cpu: 7000m
+        memory: 8Gi
+    nodeSelector:
+      component: benchmark-n2-standard-8
+      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-8
+        effect: NoSchedule
+  extraConfig:
+    logger.org.elasticsearch.deprecation: "OFF"

--- a/load-tests/setup/stable-89/values/camunda-platform-values-mariadb.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-mariadb.yaml
@@ -1,0 +1,113 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  # needed to allow the pass-through-cache for Bitnami images
+  security:
+    allowInsecureImages: true
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        url: jdbc:mariadb://mariadb:3306/camunda
+
+###########################################################################
+#
+#    MARIA DB
+#
+###########################################################################
+# Use the internal registry mirror to avoid Docker Hub rate limiting in the benchmark cluster
+image:
+  registry: europe-west1-docker.pkg.dev
+  repository: camunda-benchmark/dockerhub/bitnamilegacy/mariadb
+  tag: "latest"
+
+auth:
+  rootPassword: camunda
+  database: camunda
+  username: camunda
+  password: camunda
+  rootHost: "%"
+
+primary:
+  resources:
+    requests:
+      memory: 8Gi
+      cpu: 3000m
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+
+  nodeSelector:
+    component: benchmark-n2-standard-8
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-8
+      effect: NoSchedule
+
+  persistence:
+    size: 512Gi
+    storageClass: "benchmark-ssd-zonal-v1"
+
+  configuration: |-
+    [mysqld]
+    # ---- Bitnami required paths -----------------------------------------------
+    # primary.configuration replaces the ENTIRE my.cnf. Bitnami's init script
+    # normally injects these at runtime, so they must be included explicitly here.
+    skip-name-resolve
+    explicit_defaults_for_timestamp
+    basedir=/opt/bitnami/mariadb
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    datadir=/bitnami/mariadb/data
+    tmpdir=/opt/bitnami/mariadb/tmp
+    max_allowed_packet=16M
+    bind-address=0.0.0.0
+    pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+    log-error=/opt/bitnami/mariadb/logs/mysqld.log
+    character-set-server=utf8mb4
+    collation-server=utf8mb4_uca1400_ai_ci
+
+    # ---- Performance tuning ---------------------------------------------------
+    innodb_log_buffer_size         = 128M      # default 64MB; doubled to reduce redo flush frequency
+    innodb_flush_log_at_trx_commit = 2         # default 1 (full fsync per commit); flush once/sec instead
+    innodb_flush_method            = O_DIRECT  # default on Linux; explicit for clarity
+
+    # Buffer pool (default: 128MB)
+    innodb_buffer_pool_size        = 6G        # ~50% of 12Gi limit
+
+    # Write I/O (not a dynamic variable — must live in my.cnf, cannot SET GLOBAL)
+    innodb_write_io_threads        = 8         # default 4; doubled for write-heavy workload
+
+    # MVCC Purge safety valves (defaults: 0 = unlimited)
+    innodb_max_purge_lag           = 10000000  # throttle DML if unpurged rows exceed this
+    innodb_max_purge_lag_delay     = 300000    # cap the imposed delay at 300ms
+
+    # Monitoring
+    slow_query_log                 = ON        # default OFF
+    long_query_time                = 1         # default 10s
+    log_queries_not_using_indexes  = ON        # default OFF
+    min_examined_row_limit         = 100       # suppress noise from single-row writes
+
+    [client]
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    default-character-set=utf8mb4
+
+    [manager]
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid

--- a/load-tests/setup/stable-89/values/camunda-platform-values-mssql.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-mssql.yaml
@@ -1,0 +1,23 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        # Load-test only: intra-cluster traffic is within the same namespace.
+        # Encryption is disabled to match the standard MSSQL test configuration
+        # used across the QA module (application-rdbmsMSSQL.yaml, docker-compose.yml).
+        url: "jdbc:sqlserver://mssql:1433;Encrypt=false"
+        username: sa
+        # Load-test only: credentials are hardcoded inline, consistent with the
+        # MySQL and PostgreSQL load-test values files (e.g. inlineSecret: camunda).
+        # Do not use these credentials in production environments.
+        secret:
+          inlineSecret: "Camunda#8_demo"

--- a/load-tests/setup/stable-89/values/camunda-platform-values-mysql.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-mysql.yaml
@@ -1,0 +1,148 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  # needed to allow the pass-through-cache for mysql images
+  security:
+    allowInsecureImages: true
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        url: jdbc:mysql://mysql:3306/camunda
+
+  ####
+  #### MySQL manually mounted driver
+  ####
+  extraVolumeMounts:
+    - name: jdbcdrivers
+      mountPath: /driver-lib
+  extraVolumes:
+    - name: jdbcdrivers
+      emptyDir: {}
+  initContainers:
+    - name: fetch-jdbc-drivers
+      image: alpine:3.19
+      imagePullPolicy: Always
+      command:
+        - sh
+        - -c
+        - >
+          wget https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.6.0/mysql-connector-j-9.6.0.jar
+          -O /driver-lib/mysql-driver.jar
+      volumeMounts:
+        - name: jdbcdrivers
+          mountPath: /driver-lib
+      securityContext:
+        runAsUser: 1001
+
+###########################################################################
+#
+#    #     # #     #  #####   #####  #
+#    ##   ## #     # #     # #     # #
+#    # # # # #     # #       #     # #
+#    #  #  # #     #  #####  #     # #
+#    #     #  #   #       # #  ## ## #
+#    #     #   # #  #     #  #    ## #
+#    #     #    #    #####    #### ## ######
+#
+###########################################################################
+# Use the internal registry mirror to avoid Docker Hub rate limiting in the benchmark cluster
+image:
+  registry: europe-west1-docker.pkg.dev
+  repository: camunda-benchmark/dockerhub/bitnamilegacy/mysql
+  tag: "latest"
+
+auth:
+  rootPassword: camunda
+  database: camunda
+  username: camunda
+  password: camunda
+  rootHost: "%"
+
+primary:
+  resources:
+    requests:
+      memory: 8Gi
+      cpu: 3000m
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+  persistence:
+    size: 512Gi
+    storageClass: "benchmark-ssd-zonal-v1"
+
+  configuration: |-
+    [mysqld]
+    # ---- Bitnami required paths -----------------------------------------------
+    # primary.configuration replaces the ENTIRE my.cnf. Bitnami's init script
+    # normally injects these at runtime, so they must be included explicitly here.
+    skip-name-resolve
+    explicit_defaults_for_timestamp
+    basedir=/opt/bitnami/mysql
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    datadir=/bitnami/mysql/data
+    tmpdir=/opt/bitnami/mysql/tmp
+    max_allowed_packet=16M
+    bind-address=0.0.0.0
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+    log-error=/opt/bitnami/mysql/logs/mysqld.log
+    character-set-server=utf8mb4
+    collation-server=utf8mb4_general_ci
+
+    # ---- Performance tuning ---------------------------------------------------
+    # InnoDB Redo Log (default: 100MB — far too small for write-heavy)
+    innodb_log_buffer_size         = 128M      # default 64MB; doubled to reduce redo flush frequency
+    innodb_redo_log_capacity       = 4G        # default 100MB; like max_wal_size in PostgreSQL
+    innodb_flush_log_at_trx_commit = 2         # default 1 (full fsync per commit); flush once/sec instead
+    innodb_flush_method            = O_DIRECT  # default on Linux; explicit for clarity
+
+    # Buffer pool (default: 128MB)
+    innodb_buffer_pool_size        = 6G        # ~50% of 12Gi limit
+
+    # Write I/O (not a dynamic variable — must live in my.cnf, cannot SET GLOBAL)
+    innodb_write_io_threads        = 8         # default 4; doubled for write-heavy workload
+
+    # MVCC Purge safety valves (defaults: 0 = unlimited)
+    innodb_max_purge_lag           = 10000000  # throttle DML if unpurged rows exceed this
+    innodb_max_purge_lag_delay     = 300000    # cap the imposed delay at 300ms
+
+    # Monitoring
+    slow_query_log                 = ON        # default OFF
+    long_query_time                = 1         # default 10s
+    log_queries_not_using_indexes  = ON        # default OFF
+    min_examined_row_limit         = 100       # suppress noise from single-row writes
+
+    [client]
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    default-character-set=utf8mb4
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+
+    [manager]
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid

--- a/load-tests/setup/stable-89/values/camunda-platform-values-none.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-none.yaml
@@ -1,0 +1,69 @@
+# Values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This file is used to override the default values of the chart.
+# The values are optimized for running the load tests with a Camunda cluster on GKE.
+#
+# This is a YAML-formatted file.
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  # No secondary storage in this configuration: Elasticsearch is disabled and
+  # `noSecondaryStorage` short-circuits all secondary-storage-dependent components.
+  elasticsearch:
+    enabled: false
+  noSecondaryStorage: true
+
+optimize:
+  enabled: false
+
+connectors:
+  enabled: false
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  exporters:
+    camunda:
+      enabled: false
+  # No secondary storage backend — pairs with `global.noSecondaryStorage: true` above.
+  data:
+    secondaryStorage:
+      type: none
+  # We set extra configuration to configure additional settings for Camunda application, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+        zeebe.broker.executionMetricsExporterEnabled: "true"
+        camunda.flags.jfr.metrics: "true"
+        # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+        zeebe.broker.data.disk.freeSpace.processing: "3GB"
+        zeebe.broker.data.disk.freeSpace.replication: "2GB"
+        # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+        # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+        # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+        zeebe.broker.flowControl.write.enabled: "true"
+        zeebe.broker.flowControl.write.limit: 10000
+        zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
+    # like disabling consistency checks without duplicating the full application.yml content.
+    - file: application-override.yml
+      content: "# no overrides"
+  history:
+    retention:
+      enabled: false
+
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  enabled: false

--- a/load-tests/setup/stable-89/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-opensearch.yaml
@@ -1,0 +1,97 @@
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  elasticsearch:
+    enabled: false
+
+  opensearch:
+    enabled: true
+    url:
+      protocol: http
+      host: "opensearch"
+      port: 9200
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  # We need to explicitly set the secondary storage type to OpenSearch
+  # overriding the default value of elasticsearch
+  data:
+    secondaryStorage:
+      type: opensearch
+
+#################################################################################################
+################################################### Disable Elasticsearch when using OpenSearch
+#################################################################################################
+elasticsearch:
+  enabled: false
+
+###########################################################################
+#######
+#     # #####  ###### #    #  ####  ######   ##   #####   ####  #    #
+#     # #    # #      ##   # #      #       #  #  #    # #    # #    #
+#     # #####  #####  # #  #  ####  #####  #    # #    # #      ######
+#     # #      #      #  # #      # #      ###### #####  #      #    #
+#     # #      #      #   ## #    # #      #    # #   #  #    # #    #
+####### #      ###### #    #  ####  ###### #    # #    #  ####  #    #
+###########################################################################
+
+# Override values for https://github.com/opensearch-project/helm-charts
+
+clusterName: "opensearch"
+nameOverride: "opensearch"
+masterService: "opensearch"
+
+majorVersion: "2.19.0"
+
+replicas: 3
+
+config:
+  opensearch.yml: |
+    cluster.name: opensearch
+    network.host: 0.0.0.0
+    plugins.security.disabled: true
+    # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
+    logger.org.opensearch.deprecation: "OFF"
+
+extraEnvs:
+  - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    value: "yourStrongPassword123!"
+
+opensearchJavaOpts: "-Xms3g -Xmx3g"
+
+sysctlInit:
+  enabled: true
+sysctlVmMaxMapCount: 262144
+
+resources:
+  requests:
+    cpu: 7000m
+    memory: 8Gi
+  limits:
+    cpu: 7000m
+    memory: 8Gi
+
+persistence:
+  enabled: true
+  size: 512Gi
+  storageClass: benchmark-ssd-zonal-v1
+
+nodeSelector:
+  component: benchmark-n2-standard-8
+  topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-8
+    effect: NoSchedule
+
+antiAffinity: "hard"
+
+protocol: http
+
+securityConfig:
+  enabled: false

--- a/load-tests/setup/stable-89/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -1,0 +1,66 @@
+# Elasticsearch values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This configures Elasticsearch when it's used fr Optimize, but NOT as the Camunda secondary storage.
+# storage.
+#
+# For the Elasticsearch as secondary storage configuration, see the
+# "camunda-platform-values-elasticsearch.yaml" file.
+# If you make changes to this file or the "camunda-platform-values-elasticsearch.yaml" file, make
+# sure to keep the other file in sync (minus the secondary storage-only options).
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  elasticsearch:
+    enabled: true
+    url:
+      # The Elasticsearch host value used to connect to Elasticsearch depends
+      # on the "elasticsearch.fullnameOverride" value.
+      # If you change the "elasticsearch.fullnameOverride" value, make sure to
+      # update this host value accordingly.
+      host: elastic
+
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  enabled: true
+  # Override the default name for ConfigMap, Service, etc.
+  # Changing this value also changes the name of the Kubernetes Service used by
+  # the other components to connect to Elasticsearch, make sure to update
+  # the "global.elasticsearch.url.host" value accordingly.
+  fullnameOverride: elastic
+  clusterName: elasticsearch
+  master:
+    fullnameOverride: elastic
+    nameOverride: elastic
+    ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
+    replicaCount: 3
+    pdb:
+      minAvailable: 2
+    ## @param elasticsearch.master.heapSize
+    heapSize: 3g
+    persistence:
+      ## @param elasticsearch.master.persistence.size
+      size: 512Gi
+      storageClass: benchmark-ssd-zonal-v1
+      accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        cpu: 7000m
+        memory: 8Gi
+      limits:
+        cpu: 7000m
+        memory: 8Gi
+    nodeSelector:
+      component: benchmark-n2-standard-8
+      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-8
+        effect: NoSchedule
+  extraConfig:
+    logger.org.elasticsearch.deprecation: "OFF"

--- a/load-tests/setup/stable-89/values/camunda-platform-values-oracle.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-oracle.yaml
@@ -1,0 +1,48 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        # Load-test only: intra-cluster traffic is within the same namespace.
+        # Connects to the pluggable database FREEPDB1, which is the default PDB
+        # created by the gvenzl/oracle-free image (see databases/oracle.yaml).
+        url: "jdbc:oracle:thin:@//oracle:1521/FREEPDB1"
+        username: camunda
+        # Load-test only: credentials are hardcoded inline, consistent with the
+        # MySQL and PostgreSQL load-test values files (e.g. inlineSecret: camunda).
+        # Do not use these credentials in production environments.
+        secret:
+          inlineSecret: "camunda"
+
+  ####
+  #### Oracle manually mounted driver
+  ####
+  extraVolumeMounts:
+    - name: jdbcdrivers
+      mountPath: /driver-lib
+  extraVolumes:
+    - name: jdbcdrivers
+      emptyDir: {}
+  initContainers:
+    - name: fetch-jdbc-drivers
+      image: alpine:3.19
+      imagePullPolicy: Always
+      command:
+        - sh
+        - -c
+        - >
+          wget https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/23.6.0.24.10/ojdbc11-23.6.0.24.10.jar
+          -O /driver-lib/oracle-driver.jar
+      volumeMounts:
+        - name: jdbcdrivers
+          mountPath: /driver-lib
+      securityContext:
+        runAsUser: 1001

--- a/load-tests/setup/stable-89/values/camunda-platform-values-postgresql.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-postgresql.yaml
@@ -1,0 +1,93 @@
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  postgresql:
+    auth:
+      database: camunda
+      username: camunda
+      password: camunda
+      postgresPassword: camunda
+  # needed to allow the pass-through-cache for postgres images
+  security:
+    allowInsecureImages: true
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        url: jdbc:postgresql://postgresql:5432/camunda
+
+###########################################################################
+#
+#    ######  #######  #####  #######  #####  ######  #######  #####
+#    #     # #     # #     #    #    #     # #     # #       #     #
+#    #     # #     # #          #    #       #     # #       #
+#    ######  #     #  #####     #    #  #### ######  #####    #####
+#    #       #     #       #    #    #     # #   #   #             #
+#    #       #     # #     #    #    #     # #    #  #       #     #
+#    #       #######  #####     #     #####  #     # #######  #####
+#
+###########################################################################
+# Use the internal registry mirror to avoid Docker Hub rate limiting in the benchmark cluster
+image:
+  registry: europe-west1-docker.pkg.dev
+  repository: camunda-benchmark/dockerhub/bitnami/postgresql
+  tag: latest
+
+postgresqlSharedPreloadLibraries: pg_stat_statements
+
+primary:
+  resources:
+    requests:
+      memory: 8Gi
+      cpu: 3000m
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+  persistence:
+    size: 512Gi
+    storageClass: "benchmark-ssd-zonal-v1"
+
+  extendedConfiguration: |-
+    # WAL Performance Tuning
+    wal_buffers = 128MB
+    max_wal_size = 4GB
+    min_wal_size = 1GB
+    checkpoint_timeout = 20min
+    checkpoint_completion_target = 0.9
+    wal_writer_delay = 200ms
+    wal_writer_flush_after = 1MB
+
+    # Memory Settings
+    shared_buffers = 2GB
+    effective_cache_size = 7GB
+    work_mem = 32MB
+    maintenance_work_mem = 1GB
+
+    # Autovacuum - Aggressive for high UPDATE/DELETE volume
+    autovacuum_max_workers = 6
+    autovacuum_naptime = 15s
+    autovacuum_vacuum_scale_factor = 0.03
+    autovacuum_analyze_scale_factor = 0.02
+    autovacuum_vacuum_cost_limit = 5000
+
+    # Monitoring
+    pg_stat_statements.track = all
+    pg_stat_statements.max = 10000
+    track_io_timing = on
+    track_functions = all

--- a/load-tests/setup/stable-89/values/camunda-platform-values-rdbms.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-rdbms.yaml
@@ -1,0 +1,50 @@
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  exporters:
+    camunda:
+      enabled: false
+    rdbms:
+      enabled: true
+  data:
+    secondaryStorage:
+      type: rdbms
+      rdbms:
+        username: camunda
+        secret:
+          inlineSecret: camunda
+        # set to 2001 and not 2000 o´to directly see when queue is full in metrics dashboard
+        queueSize: 2001
+        history:
+          defaultHistoryTTL: PT1H
+          minHistoryCleanupInterval: PT1S
+          maxHistoryCleanupInterval: PT1M
+
+  # Overriding the extraConfiguration for the Platform chart
+  # to disable Camunda Exporter usage and make use of the RDBMS exporter instead, as well as to set some additional configuration for Camunda application
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+        zeebe.broker.executionMetricsExporterEnabled: "true"
+        camunda.flags.jfr.metrics: "true"
+        # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+        zeebe.broker.data.disk.freeSpace.processing: "3GB"
+        zeebe.broker.data.disk.freeSpace.replication: "2GB"
+        # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+        # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+        # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+        zeebe.broker.flowControl.write.enabled: "true"
+        zeebe.broker.flowControl.write.limit: 10000
+        zeebe.broker.flowControl.write.throttling.enabled: "true"
+        # History cleanup adjust batch sizes
+        camunda.data.secondary-storage.rdbms.history.historyCleanupBatchSize: 100000
+        camunda.data.secondary-storage.rdbms.history.historyCleanupProcessInstanceBatchSize: 2000
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
+    # like disabling consistency checks without duplicating the full application.yml content.
+    - file: application-override.yml
+      content: "# no overrides"

--- a/load-tests/setup/stable-89/values/load-test-values.yaml
+++ b/load-tests/setup/stable-89/values/load-test-values.yaml
@@ -1,0 +1,76 @@
+global:
+  commonLabels:
+    camunda.io/created-by: __AUTHOR__
+    camunda.io/purpose: load-test
+  image:
+    repository: registry.camunda.cloud/team-zeebe
+    pullSecrets:
+      - name: harbor-registry
+
+  preferRest:
+    enabled: false
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+  # Enable Stackdriver-formatted JSON logging on starter and worker pods so
+  # Cloud Logging picks up severity, sourceLocation, and serviceContext the
+  # same way it does for zeebe/operate/etc. Toggle is read by
+  # load-tests/load-tester/src/main/resources/log4j2.xml.
+  extraEnvVars:
+    - name: LOAD_TESTER_LOG_APPENDER
+      value: Stackdriver
+    - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+      value: load-tester
+    - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+
+# Saas configuration to run load tests against Camunda SaaS environment
+saas:
+  # Saas.enabled if true enables the load tests to run against Camunda SaaS
+  enabled: true
+
+  # Saas.credentials configuration to connect to a Camunda SaaS cluster
+  credentials:
+    # Saas.existingSecret can be used to configure the secret name that should be referenced by the load tests
+    # applications to retrieve credential information.
+    #
+    # If this value is set, other credentials are not used.
+    #
+    # Credentials Secret need to follow the following format:
+    #
+    # apiVersion: v1
+    # kind: Secret
+    # metadata:
+    #   name: cloud-credentials
+    # type: Opaque
+    # stringData:
+    #   clientId: hH55UFivfw-bbHAuPwN545oyv8tTdW0z
+    #   clientSecret: xtHQB.zBLcQrw4GaP0k_ci~ePjbD8qVlYaFKNo__2a7ZJxL-DAVVHepq~X9elPRb
+    #   zeebeRestAddress: e314a337-a462-4988-a3be-d1f2e153e034.zeebe.ultrawombat.com:443
+    #   authServer: https://login.cloud.ultrawombat.com/oauth/token
+    existingSecret:
+
+    # Saas.credentials.clientId to define the clientId to connect
+    clientId: "orchestration"
+    # Saas.credentials.clientSecret to define the clientSecret to connect
+    clientSecret: "__SECRET__"
+    # Saas.credentials.zeebeRestAddress to define the rest address of the cluster (including port)
+    zeebeRestAddress: "http://camunda-gateway:8080"
+    # SaaS.credentials.authServer to define the authentication server to retrieve JWT tokens
+    authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+    # Saas.credentials.authType to define the authentication type for the starter and workers
+    authType: "OAUTH"
+    # Saas.credentials.zeebeGrpcAddress to define the grpc address of the cluster (including port)
+    zeebeGrpcAddress: "http://camunda-gateway:26500"
+    # Saas.credentials.authorizationAudience to define the auth audience of the cluster
+    authorizationAudience: "orchestration-api"

--- a/load-tests/setup/stable-89/values/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/setup/stable-89/values/prometheus-elasticsearch-exporter-values.yaml
@@ -1,0 +1,30 @@
+fullnameOverride: "prom-els-exporter"
+
+# The target Elasticsearch/OpenSearch cluster is configured at deployment time
+# via: --set es.uri
+
+commonLabels:
+  camunda.io/created-by: __AUTHOR__
+  camunda.io/purpose: load-test
+
+image:
+  # Route through colocated GAR pull-through cache to avoid quay.io rate limiting
+  # Original: quay.io/prometheuscommunity/elasticsearch-exporter
+  repository: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter"
+  # Set your specific exporter version here
+  tag: "v1.10.0"
+
+log:
+  format: json
+
+serviceMonitor:
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: true
+  # Labels used by the service monitor, specific to our prometheus installation
+  labels:
+    release: monitoring
+
+nodeSelector:
+  topology.kubernetes.io/zone: __AVAILABILITY_ZONE__

--- a/load-tests/setup/stable-89/values/values-stable.yaml
+++ b/load-tests/setup/stable-89/values/values-stable.yaml
@@ -1,0 +1,15 @@
+# Additional values file to run on stable VMs
+# Scheduling on stable VMs is useful to observe long-term behavior, such as memory leaks, etc.
+# https://github.com/camunda/camunda-platform-helm/blob/d3276435efc994e45b490f97d7875b4330ec0c42/charts/camunda-platform-8.8/values.yaml#L2945-L2948
+orchestration:
+  # Require n2-standard-2 to ensure the broker is the only application running on its node
+  # However, that node does not have the required cpu/memory capacity
+  nodeSelector:
+    component: benchmark-n2-standard-4-stable
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-4-stable
+    effect: NoSchedule


### PR DESCRIPTION
## Summary

Adds `load-tests/setup/stable-89/` — a copy of `stable/8.9:load-tests/setup/default/` and `stable/8.9:load-tests/setup/newLoadTest.sh` with targeted fixes:
- `newLoadTest.sh`: `. utils.sh` → ROOT_DIR pattern (required for root dispatcher)
- `newLoadTest.sh`: all `cp default/...` + `mkdir -p "$namespace"` → use `TARGET_DIRECTORY="${ROOT_DIR}/${namespace}"` (required so scaffolding lands in the right place when the root dispatcher cd's into stable-89/ before exec)

No other logic changes. All Makefile/values/resources files are byte-for-byte identical to stable/8.9.

## Reviewer verification

Run from the repo root to confirm the diff is only the expected sourcing + path fix:

```bash
git diff origin/stable/8.9:load-tests/setup/default/Makefile load-tests/setup/stable-89/Makefile
git diff origin/stable/8.9:load-tests/setup/newLoadTest.sh load-tests/setup/stable-89/newLoadTest.sh
```

Expected: Makefile identical, newLoadTest.sh diff limited to preamble (ROOT_DIR block) and TARGET_DIRECTORY variable replacing `default/` paths.

Refs: https://github.com/camunda/camunda/issues/54235

🤖 Generated with [Claude Code](https://claude.com/claude-code)