### PR TITLE
feat: add stable-88 load test setup folder on main

### DIFF
--- a/.github/workflows/camunda-load-test-smoke-dispatch.yml
+++ b/.github/workflows/camunda-load-test-smoke-dispatch.yml
@@ -56,9 +56,9 @@ jobs:
           if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-89/'; then
             matrix_entries+=('{"version":"stable-89","orchestration-tag":"8.9-SNAPSHOT"}')
           fi
-          # if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-88/'; then
-          #   matrix_entries+=('{"version":"stable-88","orchestration-tag":"8.8-SNAPSHOT"}')
-          # fi
+          if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-88/'; then
+            matrix_entries+=('{"version":"stable-88","orchestration-tag":"8.8-SNAPSHOT"}')
+          fi
           # if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-87/'; then
           #   matrix_entries+=('{"version":"stable-87","orchestration-tag":"8.7-SNAPSHOT"}')
           # fi

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -13,7 +13,7 @@ Options:
 All other options are forwarded to the target version's newLoadTest.sh.
 For version-specific help, run: ./newLoadTest.sh --target-version main -h
 
-Available versions: main, stable-89
+Available versions: main, stable-89, stable-88
 EOF
 }
 

--- a/load-tests/setup/stable-88/Makefile
+++ b/load-tests/setup/stable-88/Makefile
@@ -1,0 +1,273 @@
+namespace ?= __NAMESPACE__
+secondary_storage ?= __STORAGE_TYPE__
+helm_chart ?= camunda-platform-8.8
+enable_optimize ?= __ENABLE_OPTIMIZE__
+# Deadline date baked into resources/namespace.yaml by newLoadTest.sh. The
+# `check-deadline` target compares against today's date and fails fast so we
+# don't deploy into a namespace the TTL cleanup workflow is about to delete.
+deadline_date ?= __DEADLINE_DATE__
+curl_image ?= curlimages/curl:7.87.0
+camunda_management_url ?= http://camunda:9600
+prometheus_elasticsearch_exporter_chart_version ?= 7.2.1
+# Optional: additional Helm configuration for the Camunda Platform release.
+# Use this to pass extra `--set`/`-f` flags, for example:
+#   make install additional_platform_configuration="--set zeebeGateway.env[0].name=FOO --set zeebeGateway.env[0].value=bar"
+# See the load test README for more examples and details.
+additional_platform_configuration ?=
+# Optional: additional Helm configuration for the load test release.
+# Use this to pass extra `--set`/`-f` flags when installing/upgrading the load tests.
+# See the load test README for example values and guidance.
+additional_load_test_configuration ?=
+
+helm_chart_platform := camunda-platform-helm/charts/$(helm_chart)
+helm_chart_load_tests := camunda-load-tests/camunda-load-tests
+
+# Scenario: controls the workload profile for the load test.
+# Options: latency, realistic, typical, max, archiver
+# Use named targets (make max) or pass directly: make install scenario=max
+scenario ?=
+
+ifeq ($(scenario),latency)
+_scenario_load_test_flags := --set starter.rate=1 --set workers.worker.replicas=1
+_scenario_platform_flags  :=
+else ifeq ($(scenario),realistic)
+_scenario_load_test_flags := -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
+_scenario_platform_flags  :=
+else ifeq ($(scenario),typical)
+_scenario_load_test_flags := --set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn
+_scenario_platform_flags  :=
+else ifeq ($(scenario),max)
+_scenario_load_test_flags := --set starter.rate=300
+_scenario_platform_flags  := --set-file 'orchestration.extraConfiguration.application-override\.yml=./camunda-platform-override-values.yaml'
+else ifeq ($(scenario),archiver)
+_scenario_load_test_flags := --set starter.rate=1 --set starter.rateDuration=10m --set starter.processId=multiInstanceElements --set starter.bpmnXmlPath=bpmn/multiInstanceElements.bpmn --set starter.payloadPath=bpmn/multiInstanceElementsPayload.json --set workers.worker.replicas=0
+_scenario_platform_flags  :=
+else
+_scenario_load_test_flags :=
+_scenario_platform_flags  :=
+endif
+
+# Construct platform values files based on configuration
+# Starting with the defaults, which are always applied and set common baseline configuration for all
+# set ups. The other values files are focused and only contain the necessary overrides for each storage type.
+platform_values := -f camunda-platform-values-defaults.yaml
+
+# Makefile-side load-test flags. Separate from `additional_load_test_configuration`,
+# which CI sets on the make command line and would suppress `+=` here.
+_secondary_storage_load_test_flags :=
+
+# Add secondary storage values
+ifeq ($(secondary_storage),none)
+	_secondary_storage_load_test_flags += --set global.extraConfig.load-tester.monitor-data-availability=false
+endif
+platform_values += -f camunda-platform-values-$(secondary_storage).yaml
+
+# Disable Optimize if not enabled
+ifneq ($(enable_optimize),true)
+	platform_values += --set optimize.enabled=false
+else
+	# Optimize needs Elasticsearch or OpenSearch, so enable Elasticsearch if
+	# we are not already creating a cluster for secondary storage.
+	ifeq ($(filter $(secondary_storage),elasticsearch opensearch),)
+		platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
+	endif
+endif
+
+# Platform values with stable configuration
+platform_values_stable := $(platform_values) -f values-stable.yaml
+
+ifeq ($(secondary_storage),elasticsearch)
+	install_es_prom_exporter := true
+	es_prom_exporter_es_uri := http://elastic:9200
+else ifeq ($(secondary_storage),opensearch)
+	install_es_prom_exporter := true
+	es_prom_exporter_es_uri := http://opensearch:9200
+else ifeq ($(enable_optimize),true)
+	install_es_prom_exporter := true
+	es_prom_exporter_es_uri := http://elastic:9200
+else
+	install_es_prom_exporter := false
+endif
+
+.PHONY: all
+all: install
+
+.PHONY: install
+install: check-deadline create-namespace create-credentials install-storage install-platform install-load-test install-elasticsearch-exporter
+
+.PHONY: install-stable
+install-stable: check-deadline create-namespace create-credentials install-storage install-platform-stable install-load-test install-elasticsearch-exporter
+
+# Fail fast if the namespace TTL deadline is today or in the past — the TTL
+# cleanup workflow will delete the namespace and undo the install. To extend,
+# either rerun newLoadTest.sh into a new folder or edit `deadline-date` in
+# resources/namespace.yaml and reapply.
+.PHONY: check-deadline
+check-deadline:
+	@today=$$(date +%Y-%m-%d); \
+	if [ "$$today" \> "$(deadline_date)" ] || [ "$$today" = "$(deadline_date)" ]; then \
+		echo "ERROR: namespace deadline-date ($(deadline_date)) is today or earlier (today: $$today)."; \
+		echo "       The TTL cleanup workflow will delete this namespace."; \
+		echo "       To proceed, bump the deadline:"; \
+		echo "         kubectl label namespace $(namespace) deadline-date=YYYY-MM-DD --overwrite"; \
+		echo "       and update resources/namespace.yaml to match, or rerun newLoadTest.sh into a fresh folder."; \
+		exit 1; \
+	fi
+
+# Apply the rendered namespace manifest. Idempotent: the same manifest applies
+# cleanly whether the namespace exists or not, so reruns of `make install`
+# after a TTL deletion recreate the namespace with the same labels and AZ.
+.PHONY: create-namespace
+create-namespace:
+	@echo "Applying namespace manifest for $(namespace)..."
+	kubectl apply -f resources/namespace.yaml
+
+# Apply the camunda-credentials secret. Idempotent: rerunning after a TTL
+# deletion reapplies the SAME credentials, so the orchestration secret in
+# load-test-values.yaml stays in sync with the live secret.
+.PHONY: create-credentials
+create-credentials:
+	@echo "Applying camunda-credentials secret for namespace $(namespace)..."
+	kubectl apply -n $(namespace) -f resources/camunda-credentials.yaml
+
+.PHONY: install-storage
+install-storage:
+ifeq ($(secondary_storage),opensearch)
+	@echo "Installing OpenSearch cluster for namespace $(namespace)..."
+	helm upgrade --install opensearch opensearch/opensearch \
+		--version "2.31.0" \
+		--namespace $(namespace) \
+		$(platform_values)
+else
+	@echo "Skipping secondary storage installation (secondary_storage=$(secondary_storage))"
+endif
+
+# Install Elasticsearch Prometheus exporter if Elasticsearch/OpenSearch is deployed (secondary storage or Optimize)
+.PHONY: install-elasticsearch-exporter
+install-elasticsearch-exporter:
+ifeq ($(install_es_prom_exporter),true)
+	@echo "Installing Elasticsearch Prometheus Exporter for namespace $(namespace)..."
+	helm upgrade --install elasticsearch-exporter oci://ghcr.io/prometheus-community/charts/prometheus-elasticsearch-exporter \
+    --namespace $(namespace) \
+    --version $(prometheus_elasticsearch_exporter_chart_version) \
+    --wait --timeout 5m0s \
+    -f prometheus-elasticsearch-exporter-values.yaml \
+    --set "es.uri=$(es_prom_exporter_es_uri)"
+else
+	@echo "Skipping Elasticsearch Prometheus Exporter installation (secondary_storage=$(secondary_storage))"
+endif
+
+# Install/upgrade Camunda Platform helm chart
+.PHONY: install-platform
+install-platform: setup-leader-balancer
+	helm upgrade $(namespace) $(helm_chart_platform) \
+		--install \
+		--namespace $(namespace) \
+		--reset-then-reuse-values \
+		--render-subchart-notes \
+		$(platform_values) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration)
+
+# Install/upgrade Camunda Platform on stable VMs
+.PHONY: install-platform-stable
+install-platform-stable: setup-leader-balancer
+	helm upgrade $(namespace) $(helm_chart_platform) \
+		--install \
+		--namespace $(namespace) \
+		--reset-then-reuse-values \
+		--render-subchart-notes \
+		$(platform_values_stable) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration)
+
+# Install/upgrade load test helm chart
+.PHONY: install-load-test
+install-load-test:
+	helm upgrade $(namespace)-test $(helm_chart_load_tests) \
+		--install \
+		--namespace $(namespace) \
+		--reset-then-reuse-values \
+		--render-subchart-notes \
+		-f load-test-values.yaml \
+		$(_scenario_load_test_flags) \
+		$(_secondary_storage_load_test_flags) \
+		$(additional_load_test_configuration)
+
+# Setup leader balancing cronjob
+.PHONY: setup-leader-balancer
+setup-leader-balancer:
+	@if ! kubectl get cronjob leader-balancer --namespace $(namespace) >/dev/null 2>&1; then \
+		kubectl create cronjob leader-balancer \
+			--namespace $(namespace) \
+			--image=$(curl_image) \
+			--schedule="*/10 * * * *" \
+			-- curl -L -v -X POST $(camunda_management_url)/actuator/rebalance; \
+		echo "Leader balancer cronjob created"; \
+	else \
+		echo "Leader balancer cronjob already exists"; \
+	fi
+
+# Generates templates from the Camunda Platform helm chart
+.PHONY: template
+template:
+	helm template $(namespace) $(helm_chart_platform) \
+		$(platform_values) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration) \
+		--output-dir .
+
+.PHONY: template-stable
+template-stable:
+	helm template $(namespace) $(helm_chart_platform) \
+		$(platform_values_stable) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration) \
+		--output-dir .
+
+# Generates templates from the load test helm chart
+.PHONY: template-load-test
+template-load-test:
+	helm template $(namespace)-test $(helm_chart_load_tests) \
+		-f load-test-values.yaml \
+		$(_scenario_load_test_flags) \
+		$(_secondary_storage_load_test_flags) \
+		$(additional_load_test_configuration) \
+		--output-dir .
+
+# Print the resolved scenario flags without running any Helm commands
+.PHONY: print-scenario
+print-scenario:
+	@echo "Scenario:         $(if $(scenario),$(scenario),(none — chart defaults apply))"
+	@echo "Load test flags:  $(if $(_scenario_load_test_flags),$(_scenario_load_test_flags),(none))"
+	@echo "Platform flags:   $(if $(_scenario_platform_flags),$(_scenario_platform_flags),(none))"
+
+# Workload scenario shortcuts — each runs 'make install' with the corresponding scenario profile.
+# For stable VMs, use: make install-stable scenario=<name>
+.PHONY: latency realistic typical max archiver
+latency:
+	$(MAKE) install scenario=latency
+realistic:
+	$(MAKE) install scenario=realistic
+typical:
+	$(MAKE) install scenario=typical
+max:
+	$(MAKE) install scenario=max
+archiver:
+	$(MAKE) install scenario=archiver
+
+.PHONY: clean
+clean:
+	-helm --namespace $(namespace) uninstall $(namespace)
+	-helm --namespace $(namespace) uninstall $(namespace)-test
+	-helm --namespace $(namespace) uninstall elasticsearch-exporter
+	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/instance=$(namespace)
+	-kubectl delete -n $(namespace) pvc -l app=elasticsearch-master
+	-kubectl delete -n $(namespace) cronjob leader-balancer
+ifeq ($(secondary_storage),opensearch)
+	@echo "Cleaning up OpenSearch cluster for namespace $(namespace)..."
+	-helm --namespace $(namespace) uninstall opensearch
+	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/name=opensearch
+endif
+	@echo "Deleting namespace $(namespace) (async, no wait)..."
+	-kubectl delete -f resources/namespace.yaml --wait=false --ignore-not-found

--- a/load-tests/setup/stable-88/newLoadTest.sh
+++ b/load-tests/setup/stable-88/newLoadTest.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The directory where the load tests and shared utilities are located.
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Contains OS specific sed function
+. "${ROOT_DIR}/utils.sh"
+
+set -eo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]
+
+Arguments:
+  namespace          Base namespace name. Will be prefixed with "c8-" if missing.
+  secondaryStorage   Optional. One of: elasticsearch, opensearch, none. Default: elasticsearch.
+  ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
+  enable_optimize    Optional. true|false to enable Optimize. Default: true.
+  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true
+
+Options:
+  -h, --help         Show this help message.
+
+Examples:
+  ./newLoadTest.sh demo
+  ./newLoadTest.sh perf opensearch 3 false
+
+This script scaffolds the per-namespace folder including rendered Kubernetes
+manifests under resources/ (namespace + credentials). The cluster itself is
+unchanged by this script — namespace and secret are created on first
+`make install` via `kubectl apply -f resources/...`. Reruns of `make install`
+after a TTL deletion recreate both from the same baked manifests, so
+credentials stay in sync with `load-test-values.yaml`.
+EOF
+}
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ -z "$1" ]; then
+  echo "Error: Missing namespace name."
+  usage
+  exit 1
+fi
+
+### Load test helper script
+### First parameter is used as namespace name
+### For a new namespace a new folder will be created
+
+helm_chart="camunda-platform-8.8"
+namespace="$1"
+
+# Add c8- prefix if not present
+if [[ ! "$namespace" =~ ^c8- ]]; then
+  namespace="c8-$namespace"
+  echo "Namespace prefix added: $namespace"
+fi
+
+# Validate secondaryStorage value
+secondaryStorage="${2:-elasticsearch}"
+if [[ "$secondaryStorage" != "elasticsearch" && "$secondaryStorage" != "opensearch" && "$secondaryStorage" != "none" ]]; then
+  echo "Error: Invalid secondary storage type '$secondaryStorage'"
+  echo "Allowed values are: elasticsearch, opensearch, postgresql, none"
+  exit 1
+fi
+
+# Validate TTL value
+ttl_days="${3:-1}"
+numberRegex='^[0-9]+$'
+if ! [[ $ttl_days =~ $numberRegex ]] ; then
+   echo "Error: TTL '$ttl_days' is not a number"
+   exit 1
+fi
+
+# Validate enable_optimize value
+enable_optimize="${4:-true}"
+enable_optimize=$(echo "$enable_optimize" | tr '[:upper:]' '[:lower:]')
+if [[ "$enable_optimize" != "true" && "$enable_optimize" != "false" ]]; then
+  echo "Error: Invalid enable_optimize value '$enable_optimize'"
+  echo "Allowed values are: true or false"
+  exit 1
+fi
+
+enable_single_zone="${5:-true}"
+enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
+
+# Pick a "random" zone, selected from the input value.
+function hashmod_zone() {
+    local input="${1?"Specify an initial value to compute the zone from"}"
+
+    # We can get the list of zones with already created nodes with:
+    # kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io\/zone}{"\n"}{end}' | sort | uniq -c
+    zones=(
+        europe-west1-b
+        europe-west1-c
+        europe-west1-d
+    )
+    nb_zones=${#zones[@]}
+
+    # bc only accept hexadecimal with capitalized letters
+    checksum="$(echo "$input" | md5sum | cut -c 1-32 | tr "a-z" "A-Z")"
+    hashmod="$(echo "ibase=16; $checksum % $nb_zones" | bc)"
+
+    zone="${zones[$hashmod]}"
+    echo "$zone"
+}
+
+# `hashmod_zone` is deterministic, so the zone baked into namespace.yaml and
+# the values files matches any re-applied manifest after TTL deletion.
+if [[ "$enable_single_zone" == "true" ]]; then
+  availability_zone="$(hashmod_zone "$namespace")"
+else
+  availability_zone="~"
+fi
+
+git_author=$(compute_git_author)
+
+# Compute deadline-date once at scaffold time. The Makefile's check-deadline
+# target compares this against today; if it has passed, install fails fast.
+if deadline_date=$(date -d "+${ttl_days} days" +%Y-%m-%d 2>/dev/null); then
+  : # GNU date succeeded
+elif deadline_date=$(date -v +${ttl_days}d +%Y-%m-%d 2>/dev/null); then
+  : # BSD/macOS date succeeded
+else
+  echo "Error: Could not calculate deadline date. Supported on Linux and macOS only."
+  exit 1
+fi
+
+TARGET_DIRECTORY="${ROOT_DIR}/${namespace}"
+
+# Scaffold the namespace folder with only the files this $secondaryStorage uses.
+# A namespace is bound to its storage at create time; to switch storage, create
+# a new namespace via ./newLoadTest.sh <new-name> <newStorage>.
+mkdir -p "$TARGET_DIRECTORY"
+
+# Scaffold the always-copied files into the namespace folder root: the
+# Makefile, the resources/ manifests, four storage-agnostic values files
+# (defaults + override + load-test + stable), and the matching
+# camunda-platform-values-${secondaryStorage}.yaml. Flat layout so the
+# per-namespace Makefile's -f <file>.yaml references resolve unchanged.
+cp -v  "Makefile"                                                "$TARGET_DIRECTORY/"
+cp -rv "resources/"                                              "$TARGET_DIRECTORY/"
+cp -v  "values/camunda-platform-override-values.yaml"            "$TARGET_DIRECTORY/"
+cp -v  "values/load-test-values.yaml"                            "$TARGET_DIRECTORY/"
+cp -v  "values/values-stable.yaml"                               "$TARGET_DIRECTORY/"
+cp -v  "values/camunda-platform-values-defaults.yaml"            "$TARGET_DIRECTORY/"
+cp -v  "values/camunda-platform-values-${secondaryStorage}.yaml" "$TARGET_DIRECTORY/"
+
+# Storage-specific copies.
+case "$secondaryStorage" in
+  elasticsearch|opensearch)
+    cp -v "values/prometheus-elasticsearch-exporter-values.yaml" "$TARGET_DIRECTORY/"
+    ;;
+esac
+
+if [[ "$enable_optimize" == "true" ]]; then
+  # Optimize needs specifically Elasticsearch (independently from the secondary
+  # storage configuration).
+  cp -v "values/camunda-platform-values-optimize-elasticsearch.yaml" "$TARGET_DIRECTORY/"
+  cp -v "values/prometheus-elasticsearch-exporter-values.yaml"       "$TARGET_DIRECTORY/"
+fi
+
+cd "$TARGET_DIRECTORY"
+
+# Bake values into the rendered Makefile.
+sed_inplace "s/__NAMESPACE__/$namespace/"           Makefile
+sed_inplace "s/__STORAGE_TYPE__/$secondaryStorage/" Makefile
+sed_inplace "s/__ENABLE_OPTIMIZE__/$enable_optimize/" Makefile
+sed_inplace "s/__DEADLINE_DATE__/$deadline_date/"    Makefile
+
+# Bake values into the resource manifests and the platform/load-test values.
+# Values shared with the chart (NAMESPACE, AVAILABILITY_ZONE, AUTHOR) flow into
+# the upstream yaml files via the same sed pass.
+sed_inplace "s/__NAMESPACE__/$namespace/"                       load-test-values.yaml resources/*.yaml
+sed_targets=(*.yaml resources/namespace.yaml)
+sed_inplace "s/__AVAILABILITY_ZONE__/$availability_zone/" "${sed_targets[@]}"
+sed_inplace "s/__AUTHOR__/$git_author/"                   "${sed_targets[@]}"
+sed_inplace "s/__DEADLINE_DATE__/$deadline_date/"                resources/namespace.yaml
+
+# When single-zone is disabled the topology annotation has no useful value;
+# strip the annotation line and the now-empty `annotations:` key so the manifest
+# stays tidy.
+if [[ "$enable_single_zone" != "true" ]]; then
+  sed_inplace "/topology.kubernetes.io\\/zone:/d" resources/namespace.yaml
+  # `sed_inplace` splits args on whitespace and the `annotations:` line pattern
+  # contains literal spaces, so call sed directly with OS-aware -i flag.
+  detect_os
+  if [ "${GO_OS}" == "darwin" ]; then
+    sed -i '' -e '/^  annotations:$/d' resources/namespace.yaml
+  else
+    sed -i    -e '/^  annotations:$/d' resources/namespace.yaml
+  fi
+fi
+
+#############################################################################################
+################################ CREDENTIALS ################################################
+#############################################################################################
+
+function get_existing_secret() {
+  jsonObject=$1
+  key=$2
+  existing_secret=$(echo "$jsonObject" | jq --raw-output --arg key "$key" '.[$key] // empty' | base64 -d)
+  if [ -z "$existing_secret" ]; then
+    echo "ERROR: existing camunda-credentials secret is missing key '$key'."
+    exit 1
+  fi
+  echo "$existing_secret"
+}
+
+# Generate credentials. These are baked into resources/camunda-credentials.yaml
+# and (for the orchestration OIDC secret) into load-test-values.yaml. Any
+# subsequent `make install` reapplies the same manifest, so the secret in the
+# cluster always matches the value the load test starter authenticates with.
+# `head -c 20` closes the pipe early; upstream `tr` then takes SIGPIPE and
+# returns 141 under `set -o pipefail`. Wrap in a subshell so the harmless
+# SIGPIPE doesn't trip `set -e` in the caller.
+function gen_password() { ( set +o pipefail; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20 ); }
+function gen_token()    { openssl rand -hex 16; }
+
+
+# If the secret already exists in the cluster, preserve all existing values to avoid breaking any live load test.
+# If the secret doesn't exist, generate new random values for all keys.
+# This might happend on CI/GitHub Workflows that update existing load tests but do not persist the credentials across runs.
+if kubectl -n "$namespace" get secret camunda-credentials >/dev/null 2>&1; then
+  echo "Secret 'camunda-credentials' already exists in namespace '$namespace'; preserving existing credentials."
+  jsonObject=$(kubectl -n "$namespace" get secret camunda-credentials -o jsonpath='{.data}')
+
+  IDENTITY_FIRSTUSER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-firstuser-password")
+  IDENTITY_KEYCLOAK_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-admin-password")
+  IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-postgresql-admin-password")
+  IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-postgresql-user-password")
+  IDENTITY_POSTGRESQL_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-postgresql-admin-password")
+  IDENTITY_POSTGRESQL_USER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-postgresql-user-password")
+  CONNECTORS_SECRET=$(get_existing_secret "$jsonObject" "connectors-security-authentication-oidc-secret")
+  ORCHESTRATION_SECRET=$(get_existing_secret "$jsonObject" "orchestration-security-authentication-oidc-secret")
+  IDENTITY_ADMIN_CLIENT_TOKEN=$(get_existing_secret "$jsonObject" "identity-admin-client-token")
+  IDENTITY_OPTIMIZE_CLIENT_TOKEN=$(get_existing_secret "$jsonObject" "identity-optimize-client-token")
+
+else
+  echo "Generating new credentials for secret 'camunda-credentials'."
+  IDENTITY_FIRSTUSER_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD=$(gen_password)
+  IDENTITY_POSTGRESQL_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_POSTGRESQL_USER_PASSWORD=$(gen_password)
+  CONNECTORS_SECRET=$(gen_password)
+  ORCHESTRATION_SECRET=$(gen_password)
+  IDENTITY_ADMIN_CLIENT_TOKEN=$(gen_token)
+  IDENTITY_OPTIMIZE_CLIENT_TOKEN=$(gen_token)
+fi
+
+# Bake the orchestration OIDC secret into the load-test starter values.
+sed_inplace "s|__SECRET__|$ORCHESTRATION_SECRET|" load-test-values.yaml
+
+# Bake the credential values into the secret manifest.
+sed_inplace "s|__IDENTITY_FIRSTUSER_PASSWORD__|$IDENTITY_FIRSTUSER_PASSWORD|"                                 resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_KEYCLOAK_ADMIN_PASSWORD__|$IDENTITY_KEYCLOAK_ADMIN_PASSWORD|"                       resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD__|$IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD|" resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD__|$IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD|"   resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_POSTGRESQL_ADMIN_PASSWORD__|$IDENTITY_POSTGRESQL_ADMIN_PASSWORD|"                   resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_POSTGRESQL_USER_PASSWORD__|$IDENTITY_POSTGRESQL_USER_PASSWORD|"                     resources/camunda-credentials.yaml
+sed_inplace "s|__ORCHESTRATION_SECRET__|$ORCHESTRATION_SECRET|"                                               resources/camunda-credentials.yaml
+sed_inplace "s|__CONNECTORS_SECRET__|$CONNECTORS_SECRET|"                                                     resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_ADMIN_CLIENT_TOKEN__|$IDENTITY_ADMIN_CLIENT_TOKEN|"                                 resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_OPTIMIZE_CLIENT_TOKEN__|$IDENTITY_OPTIMIZE_CLIENT_TOKEN|"                           resources/camunda-credentials.yaml
+
+# Add/update helm repositories
+helm repo add camunda https://helm.camunda.io/ --force-update
+helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/ --force-update
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update
+helm repo update
+
+# Clone Camunda Platform Helm so we can run the latest chart
+# TODO: 347642d30179479f8ab8a2f00b2d979be05f5a8c is the latest commit before the removal of the
+# embedded Bitnami Helm Chart.
+# We should remove the checkout of this specific revision once we have a solution to replace these
+# removed dependencies.
+git clone --depth 1 --revision 347642d30179479f8ab8a2f00b2d979be05f5a8c --single-branch https://github.com/camunda/camunda-platform-helm.git
+
+# Make deps
+helm dependency build "camunda-platform-helm/charts/$helm_chart"
+
+set +x
+echo
+echo "Scaffolding complete. Next steps:"
+echo "  cd $namespace"
+echo "  make install   # applies resources/namespace.yaml + resources/camunda-credentials.yaml and deploys"
+echo
+echo "Deadline: $deadline_date (TTL = $ttl_days day(s)). Bump it via resources/namespace.yaml + kubectl label, or rerun this script."

--- a/load-tests/setup/stable-88/resources/camunda-credentials.yaml
+++ b/load-tests/setup/stable-88/resources/camunda-credentials.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  identity-firstuser-password: "__IDENTITY_FIRSTUSER_PASSWORD__"
+  identity-keycloak-admin-password: "__IDENTITY_KEYCLOAK_ADMIN_PASSWORD__"
+  identity-keycloak-postgresql-admin-password: "__IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD__"
+  identity-keycloak-postgresql-user-password: "__IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD__"
+  identity-postgresql-admin-password: "__IDENTITY_POSTGRESQL_ADMIN_PASSWORD__"
+  identity-postgresql-user-password: "__IDENTITY_POSTGRESQL_USER_PASSWORD__"
+  orchestration-security-authentication-oidc-secret: "__ORCHESTRATION_SECRET__"
+  connectors-security-authentication-oidc-secret: "__CONNECTORS_SECRET__"
+  identity-admin-client-token: "__IDENTITY_ADMIN_CLIENT_TOKEN__"
+  identity-optimize-client-token: "__IDENTITY_OPTIMIZE_CLIENT_TOKEN__"

--- a/load-tests/setup/stable-88/resources/namespace.yaml
+++ b/load-tests/setup/stable-88/resources/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: __NAMESPACE__
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: __AUTHOR__
+    deadline-date: "__DEADLINE_DATE__"
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__

--- a/load-tests/setup/stable-88/values/camunda-platform-override-values.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-override-values.yaml
@@ -1,0 +1,5 @@
+# Consistency check overrides for the max stress scenario.
+# This file is injected as application-override.yml (loaded after and overrides application.yml)
+# when scenario=max, to disable checks that would add overhead during maximum-load tests.
+zeebe.broker.experimental.consistencyChecks.enablePreconditions: "false"
+zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "false"

--- a/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
@@ -1,0 +1,381 @@
+# Default load test values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This file is used to override the default values of the chart.
+# The values are optimized for running the load tests with a Camunda cluster on GKE.
+#
+# This is a YAML-formatted file.
+# Per default we run with the Orchestration Cluster, Optimize, Connectors, and Identity
+# Keycloak as identity provider with OIDC authentication, but you can easily
+# switch to other configurations by changing the values in this file or by overriding them via the
+# command line when installing the chart.
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  commonLabels:
+    camunda.io/created-by: __AUTHOR__
+    camunda.io/purpose: load-test
+
+  # Disable global ingress
+  ingress:
+    enabled: false
+  image:
+    # Image.repository defines the repository from which to fetch the docker images
+    repository: "registry.camunda.cloud/team-zeebe"
+    # Image.tag defines the tag / version which should be used in the chart
+    tag: SNAPSHOT
+    ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    pullPolicy: Always
+    ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets:
+      - name: harbor-registry
+
+  # Default node configuration for all the components, unless specific
+  # reconfigured.
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  # Identity authentication is enabled for Optimize
+  identity:
+    auth:
+      enabled: true
+      optimize:
+        clientId: optimize
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: identity-optimize-client-token
+  security:
+    authentication:
+      method: oidc
+
+identity:
+  enabled: true
+  fullnameOverride: identity # we override the names for simplicity of the deployment
+  firstUser:
+    secret:
+      existingSecret: camunda-credentials
+      existingSecretKey: identity-firstuser-password
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/management-identity/miscellaneous/configuration-variables/#google-stackdriver-json-logging
+    - name: IDENTITY_LOG_APPENDER
+      value: Stackdriver
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+optimize:
+  enabled: true
+  fullnameOverride: optimize # we override the names for simplicity of the deployment
+  # Optimize reads historyCleanup only from environment-config.yaml (its custom config loader),
+  # not from application.yml via spring.config.import. We therefore override the full
+  # environment-config.yaml via `configuration` so the cleanup block is in the correct file.
+  # ES host/port use Optimize's ${VAR:default} placeholder syntax so they stay dynamic at
+  # runtime (the deployment sets OPTIMIZE_ELASTICSEARCH_HOST / OPTIMIZE_ELASTICSEARCH_HTTP_PORT).
+  configuration: |
+    zeebe:
+      enabled: true
+      partitionCount: 3
+      name: "zeebe-record"
+    es:
+      connection:
+        nodes:
+          - host: "${OPTIMIZE_ELASTICSEARCH_HOST:localhost}"
+            httpPort: ${OPTIMIZE_ELASTICSEARCH_HTTP_PORT:9200}
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "ccsm"
+    security:
+      auth:
+        cookie:
+          same-site:
+            enabled: false
+        ccsm:
+          redirectRootUrl: "http://localhost:8083"
+    api:
+      audience: "optimize-api"
+      jwtSetUri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+
+    ## Configure Optimize data cleanup
+    historyCleanup:
+      cronTrigger: '*/30 * * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
+    - name: OPTIMIZE_LOG_APPENDER
+      value: Stackdriver
+
+    # Configure Optimize to use the full size of the ES/OS cluster it connects
+    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
+    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
+    # the cluster.
+    # Ideally, this value should default to the number of Elasticsearch nodes
+    # in the cluster.
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+
+    # Improve performances of Optimize for the load tests.
+    # This is load-test specific and different configuration of cluster
+    # configuration (different hardware resources for instance) and/or type of
+    # workload may benefit (or even require) from a different value here.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+      value: "1000" # default 200
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+identityKeycloak:
+  enabled: true
+  fullnameOverride: keycloak # we override the names for simplicity of the deployment
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+  extraEnvVars:
+    # https://www.keycloak.org/server/logging#_console
+    - name: KC_LOG_CONSOLE_OUTPUT
+      value: json
+
+connectors:
+  enabled: true
+  fullnameOverride: connectors # we override the names for simplicity of the deployment
+  security:
+    authentication:
+      method: oidc
+      oidc:
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: connectors-security-authentication-oidc-secret
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/connectors/connectors-configuration/#google-stackdriver-json-logging
+    - name: CONNECTORS_LOG_APPENDER
+      value: stackdriver
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+webModeler:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  security:
+    authentication:
+      method: oidc
+      unprotectedApi: false
+      oidc:
+        secret:
+          ## @param orchestration.security.authentication.oidc.secret.existingSecret can be used to reference an existing Kubernetes Secret containing the client secret.
+          existingSecret: camunda-credentials
+          ## @param orchestration.security.authentication.oidc.secret.existingSecretKey defines the key within the existing secret object.
+          existingSecretKey: orchestration-security-authentication-oidc-secret
+
+    authorizations:
+      enabled: true
+    initialization:
+      authorizations:
+        # Grant the orchestration client (load tester) permission to create resources (BPMN/DMN)
+        - ownerType: CLIENT
+          ownerId: orchestration
+          resourceType: RESOURCE
+          resourceId: "*"
+          permissions:
+            - CREATE
+        # Grant the orchestration client permissions to manage and observe process instances
+        - ownerType: CLIENT
+          ownerId: orchestration
+          resourceType: PROCESS_DEFINITION
+          resourceId: "*"
+          permissions:
+            - CREATE_PROCESS_INSTANCE
+            - UPDATE_PROCESS_INSTANCE
+            - READ_PROCESS_INSTANCE
+            - READ_PROCESS_DEFINITION
+        # Grant the orchestration client permission to publish messages
+        # (required by realistic benchmark workers: customer_notification,
+        # dispute_process_request_proof_from_vendor)
+        - ownerType: CLIENT
+          ownerId: orchestration
+          resourceType: MESSAGE
+          resourceId: "*"
+          permissions:
+            - CREATE
+  # For simplicity of the deployment, we override the names to camunda
+  # This means we will have pods like: camunda-0, camunda-1, camunda-2
+  fullnameOverride: camunda
+  image:
+    registry: docker.io
+    repository: camunda/camunda
+    tag: "8.8-SNAPSHOT"
+  ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
+  clusterSize: "3"
+  ## @param core.partitionCount defines how many partitions are set up in the cluster
+  partitionCount: "3"
+  ## @param core.replicationFactor defines how each partition is replicated, the value defines the number of nodes
+  replicationFactor: "3"
+  ## @param core.cpuThreadCount defines how many threads can be used for the processing on each broker pod
+  cpuThreadCount: "3"
+  ## @param core.ioThreadCount defines how many threads can be used for the exporting on each broker pod
+  ioThreadCount: "3"
+  # Resources of the orchestration cluster
+  resources:
+    requests:
+      cpu: 3000m
+      memory: 4Gi
+    limits:
+      cpu: 3000m
+      memory: 4Gi
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+  ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+  pvcSize: "64Gi"
+  ## @param core.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.
+  # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.
+  pvcStorageClassName: benchmark-ssd-zonal-v1
+  # @extra core.containerSecurityContext defines the security options the container should be run with
+  containerSecurityContext:
+    ## @param core.containerSecurityContext.allowPrivilegeEscalation
+    allowPrivilegeEscalation: true
+    ## @param core.containerSecurityContext.privileged
+    privileged: true
+    ## @param core.containerSecurityContext.runAsNonRoot
+    runAsNonRoot: true
+    ## @param core.containerSecurityContext.runAsUser
+    runAsUser: 1000
+    capabilities:
+      add: ["NET_ADMIN"]
+  javaOpts: >-
+    -XX:MaxRAMPercentage=25.0
+    -XX:+ExitOnOutOfMemoryError
+    -XX:+HeapDumpOnOutOfMemoryError
+    -XX:HeapDumpPath=/usr/local/camunda/data
+    -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log
+    -XX:NativeMemoryTracking=summary
+    -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M
+
+  # We set extra configuration to configure additional settings for Broker and Gateway, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    application.yml: |
+      zeebe.gateway.monitoring.enabled: "true"
+      zeebe.gateway.threads.managementThreads: "1"
+      zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+      zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+      zeebe.broker.executionMetricsExporterEnabled: "true"
+      zeebe.broker.data.disk.freeSpace.processing: "3GB"
+      zeebe.broker.data.disk.freeSpace.replication: "2GB"
+
+      # Camunda Exporter configuration
+      zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+      zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+
+      # We moved the archiver configuration under retention at some point, but still need to support the previous
+      # versions for now, so the configurations for retention are duplicated
+      zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
+      zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
+      # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+      zeebe.broker.flowControl.write.enabled: "true"
+      zeebe.broker.flowControl.write.limit: 10000
+      zeebe.broker.flowControl.write.throttling.enabled: "true"
+      # Disable the importers
+      camunda.tasklist.importerEnabled: "false"
+      camunda.operate.importerEnabled: "false"
+      camunda.operate.elasticsearch.numberOfShards: 3
+      # Schema management has been moved out of exporter - to be bootstrap at start; once
+      camunda.database.retention.enabled: "true"
+      camunda.database.retention.policyName: "camunda-retention-policy"
+      #Metrics:
+      camunda.flags.jfr.metrics: "true"
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max)
+    # to change settings like disabling consistency checks without duplicating the full application.yml content.
+    application-override.yml: "# no overrides"
+
+  # Zeebe config
+  extraVolumes:
+    - name: logs
+      emptyDir: {}
+  ## @param core.extraVolumeMounts can be used to mount extra volumes for the broker pods, useful for additional exporters
+  extraVolumeMounts:
+    - name: logs
+      mountPath: /usr/local/camunda/logs
+  # Retention for the ES Exporter indices - legacy Zeebe indices
+  retention:
+    enabled: true
+    minimumAge: 1d
+  # Retention for the Camunda Exporter
+  history:
+    retention:
+      ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
+      enabled: true
+      ## @param core.history.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
+      minimumAge: 1d
+      policyName: "camunda-retention-policy"
+  # @param core.env can be used to set extra environment variables in each broker container
+  env:
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
+# Change these settings to configure a different way to collect metrics
+prometheusServiceMonitor:
+  enabled: true
+  labels:
+    release: monitoring
+  scrapeInterval: 30s

--- a/load-tests/setup/stable-88/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-elasticsearch.yaml
@@ -1,0 +1,76 @@
+# Elasticsearch values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This configures Elasticsearch when it's used for Optimize AND as the Camunda secondary storage.
+#
+# If you want to configure Elasticsearch only for Optimize and use another
+# secondary storage option for Camunda, see
+# the "camunda-platform-values-optimize-elasticsearch.yaml" file.
+# If you make changes to this file or the
+# "camunda-platform-values-optimize-elasticsearch.yaml" file, make sure to keep
+# the other file in sync (minus the secondary storage-only options).
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  elasticsearch:
+    enabled: true
+    url:
+      # The Elasticsearch host value used to connect to Elasticsearch depends
+      # on the "elasticsearch.fullnameOverride" value.
+      # If you change the "elasticsearch.fullnameOverride" value, make sure to
+      # update this host value accordingly.
+      host: elastic
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  # We need to explicitly set the secondary storage type to ELS
+  # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch
+  data:
+    secondaryStorage:
+      type: elasticsearch
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  enabled: true
+  # Override the default name for ConfigMap, Service, etc.
+  # Changing this value also changes the name of the Kubernetes Service used by
+  # the other components to connect to Elasticsearch, make sure to update
+  # the "global.elasticsearch.url.host" value accordingly.
+  fullnameOverride: elastic
+  clusterName: elasticsearch
+  master:
+    fullnameOverride: elastic
+    nameOverride: elastic
+    ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
+    replicaCount: 3
+    pdb:
+      minAvailable: 2
+    ## @param elasticsearch.master.heapSize
+    heapSize: 3g
+    persistence:
+      ## @param elasticsearch.master.persistence.size
+      size: 512Gi
+      storageClass: benchmark-ssd-zonal-v1
+      accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        cpu: 7000m
+        memory: 8Gi
+      limits:
+        cpu: 7000m
+        memory: 8Gi
+    nodeSelector:
+      component: benchmark-n2-standard-8
+      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-8
+        effect: NoSchedule
+  extraConfig:
+    logger.org.elasticsearch.deprecation: "OFF"

--- a/load-tests/setup/stable-88/values/camunda-platform-values-none.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-none.yaml
@@ -1,0 +1,67 @@
+# Values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This file is used to override the default values of the chart.
+# The values are optimized for running the load tests with a Camunda cluster on GKE.
+#
+# This is a YAML-formatted file.
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  # No secondary storage in this configuration: Elasticsearch is disabled and
+  # `noSecondaryStorage` short-circuits all secondary-storage-dependent components.
+  elasticsearch:
+    enabled: false
+  noSecondaryStorage: true
+
+optimize:
+  enabled: false
+
+connectors:
+  enabled: false
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  exporters:
+    camunda:
+      enabled: false
+  # No secondary storage backend — pairs with `global.noSecondaryStorage: true` above.
+  data:
+    secondaryStorage:
+      type: none
+  # We set extra configuration to configure additional settings for Camunda application, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    application.yml: |
+      # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+      zeebe.broker.executionMetricsExporterEnabled: "true"
+      camunda.flags.jfr.metrics: "true"
+      # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+      zeebe.broker.data.disk.freeSpace.processing: "3GB"
+      zeebe.broker.data.disk.freeSpace.replication: "2GB"
+      # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+      # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+      zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+      zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+      # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+      zeebe.broker.flowControl.write.enabled: "true"
+      zeebe.broker.flowControl.write.limit: 10000
+      zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
+    # like disabling consistency checks without duplicating the full application.yml content.
+    application-override.yml: "# no overrides"
+  history:
+    retention:
+      enabled: false
+
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  enabled: false

--- a/load-tests/setup/stable-88/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-opensearch.yaml
@@ -1,0 +1,97 @@
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  elasticsearch:
+    enabled: false
+
+  opensearch:
+    enabled: true
+    url:
+      protocol: http
+      host: "opensearch"
+      port: 9200
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  # We need to explicitly set the secondary storage type to OpenSearch
+  # overriding the default value of elasticsearch
+  data:
+    secondaryStorage:
+      type: opensearch
+
+#################################################################################################
+################################################### Disable Elasticsearch when using OpenSearch
+#################################################################################################
+elasticsearch:
+  enabled: false
+
+###########################################################################
+#######
+#     # #####  ###### #    #  ####  ######   ##   #####   ####  #    #
+#     # #    # #      ##   # #      #       #  #  #    # #    # #    #
+#     # #####  #####  # #  #  ####  #####  #    # #    # #      ######
+#     # #      #      #  # #      # #      ###### #####  #      #    #
+#     # #      #      #   ## #    # #      #    # #   #  #    # #    #
+####### #      ###### #    #  ####  ###### #    # #    #  ####  #    #
+###########################################################################
+
+# Override values for https://github.com/opensearch-project/helm-charts
+
+clusterName: "opensearch"
+nameOverride: "opensearch"
+masterService: "opensearch"
+
+majorVersion: "2.19.0"
+
+replicas: 3
+
+config:
+  opensearch.yml: |
+    cluster.name: opensearch
+    network.host: 0.0.0.0
+    plugins.security.disabled: true
+    # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
+    logger.org.opensearch.deprecation: "OFF"
+
+extraEnvs:
+  - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    value: "yourStrongPassword123!"
+
+opensearchJavaOpts: "-Xms3g -Xmx3g"
+
+sysctlInit:
+  enabled: true
+sysctlVmMaxMapCount: 262144
+
+resources:
+  requests:
+    cpu: 7000m
+    memory: 8Gi
+  limits:
+    cpu: 7000m
+    memory: 8Gi
+
+persistence:
+  enabled: true
+  size: 512Gi
+  storageClass: benchmark-ssd-zonal-v1
+
+nodeSelector:
+  component: benchmark-n2-standard-8
+  topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-8
+    effect: NoSchedule
+
+antiAffinity: "hard"
+
+protocol: http
+
+securityConfig:
+  enabled: false

--- a/load-tests/setup/stable-88/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -1,0 +1,66 @@
+# Elasticsearch values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This configures Elasticsearch when it's used fr Optimize, but NOT as the Camunda secondary storage.
+# storage.
+#
+# For the Elasticsearch as secondary storage configuration, see the
+# "camunda-platform-values-elasticsearch.yaml" file.
+# If you make changes to this file or the "camunda-platform-values-elasticsearch.yaml" file, make
+# sure to keep the other file in sync (minus the secondary storage-only options).
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  elasticsearch:
+    enabled: true
+    url:
+      # The Elasticsearch host value used to connect to Elasticsearch depends
+      # on the "elasticsearch.fullnameOverride" value.
+      # If you change the "elasticsearch.fullnameOverride" value, make sure to
+      # update this host value accordingly.
+      host: elastic
+
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  enabled: true
+  # Override the default name for ConfigMap, Service, etc.
+  # Changing this value also changes the name of the Kubernetes Service used by
+  # the other components to connect to Elasticsearch, make sure to update
+  # the "global.elasticsearch.url.host" value accordingly.
+  fullnameOverride: elastic
+  clusterName: elasticsearch
+  master:
+    fullnameOverride: elastic
+    nameOverride: elastic
+    ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
+    replicaCount: 3
+    pdb:
+      minAvailable: 2
+    ## @param elasticsearch.master.heapSize
+    heapSize: 3g
+    persistence:
+      ## @param elasticsearch.master.persistence.size
+      size: 512Gi
+      storageClass: benchmark-ssd-zonal-v1
+      accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        cpu: 7000m
+        memory: 8Gi
+      limits:
+        cpu: 7000m
+        memory: 8Gi
+    nodeSelector:
+      component: benchmark-n2-standard-8
+      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-8
+        effect: NoSchedule
+  extraConfig:
+    logger.org.elasticsearch.deprecation: "OFF"

--- a/load-tests/setup/stable-88/values/load-test-values.yaml
+++ b/load-tests/setup/stable-88/values/load-test-values.yaml
@@ -1,0 +1,78 @@
+global:
+  commonLabels:
+    camunda.io/created-by: __AUTHOR__
+    camunda.io/purpose: load-test
+  image:
+    repository: registry.camunda.cloud/team-zeebe
+    pullSecrets:
+      - name: harbor-registry
+
+  preferRest:
+    enabled: false
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+  # Enable Stackdriver-formatted JSON logging on starter and worker pods so
+  # Cloud Logging picks up severity, sourceLocation, and serviceContext the
+  # same way it does for zeebe/operate/etc. Toggle is read by
+  # load-tests/load-tester/src/main/resources/log4j2.xml.
+  extraEnvVars:
+    - name: LOAD_TESTER_LOG_APPENDER
+      value: Stackdriver
+    - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+      value: load-tester
+    - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+
+# Saas configuration to run load tests against Camunda SaaS environment
+saas:
+  # Saas.enabled if true enables the load tests to run against Camunda SaaS
+  enabled: true
+
+  # Saas.credentials configuration to connect to a Camunda SaaS cluster
+  credentials:
+    # Saas.existingSecret can be used to configure the secret name that should be referenced by the load tests
+    # applications to retrieve credential information.
+    #
+    # If this value is set, other credentials are not used.
+    #
+    # Credentials Secret need to follow the following format:
+    #
+    # apiVersion: v1
+    # kind: Secret
+    # metadata:
+    #   name: cloud-credentials
+    # type: Opaque
+    # stringData:
+    #   clientId: hH55UFivfw-bbHAuPwN545oyv8tTdW0z
+    #   clientSecret: xtHQB.zBLcQrw4GaP0k_ci~ePjbD8qVlYaFKNo__2a7ZJxL-DAVVHepq~X9elPRb
+    #   zeebeRestAddress: e314a337-a462-4988-a3be-d1f2e153e034.zeebe.ultrawombat.com:443
+    #   authServer: https://login.cloud.ultrawombat.com/oauth/token
+    existingSecret:
+
+    # Saas.credentials.clientId to define the clientId to connect
+    clientId: "orchestration"
+    # Saas.credentials.clientSecret to define the clientSecret to connect
+    clientSecret: "__SECRET__"
+    # Saas.credentials.zeebeRestAddress to define the rest address of the cluster (including port)
+    # Use headless service so DNS returns all pod IPs for client-side load balancing.
+    zeebeRestAddress: "http://camunda-gateway:8080"
+    # SaaS.credentials.authServer to define the authentication server to retrieve JWT tokens
+    authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+    # Saas.credentials.authType to define the authentication type for the starter and workers
+    authType: "OAUTH"
+    # Saas.credentials.zeebeGrpcAddress to define the grpc address of the cluster (including port)
+    # Use headless service so DNS returns all pod IPs for gRPC round_robin client-side load balancing.
+    zeebeGrpcAddress: "http://camunda-gateway:26500"
+    # Saas.credentials.authorizationAudience to define the auth audience of the cluster
+    authorizationAudience: "orchestration-api"

--- a/load-tests/setup/stable-88/values/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/setup/stable-88/values/prometheus-elasticsearch-exporter-values.yaml
@@ -1,0 +1,30 @@
+fullnameOverride: "prom-els-exporter"
+
+# The target Elasticsearch/OpenSearch cluster is configured at deployment time
+# via: --set es.uri
+
+commonLabels:
+  camunda.io/created-by: __AUTHOR__
+  camunda.io/purpose: load-test
+
+image:
+  # Route through colocated GAR pull-through cache to avoid quay.io rate limiting
+  # Original: quay.io/prometheuscommunity/elasticsearch-exporter
+  repository: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter"
+  # Set your specific exporter version here
+  tag: "v1.10.0"
+
+log:
+  format: json
+
+serviceMonitor:
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: true
+  # Labels used by the service monitor, specific to our prometheus installation
+  labels:
+    release: monitoring
+
+nodeSelector:
+  topology.kubernetes.io/zone: __AVAILABILITY_ZONE__

--- a/load-tests/setup/stable-88/values/values-stable.yaml
+++ b/load-tests/setup/stable-88/values/values-stable.yaml
@@ -1,0 +1,15 @@
+# Additional values file to run on stable VMs
+# Scheduling on stable VMs is useful to observe long-term behavior, such as memory leaks, etc.
+# https://github.com/camunda/camunda-platform-helm/blob/d3276435efc994e45b490f97d7875b4330ec0c42/charts/camunda-platform-8.8/values.yaml#L2945-L2948
+orchestration:
+  # Require n2-standard-2 to ensure the broker is the only application running on its node
+  # However, that node does not have the required cpu/memory capacity
+  nodeSelector:
+    component: benchmark-n2-standard-4-stable
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-4-stable
+    effect: NoSchedule


### PR DESCRIPTION
## Summary

Adds `load-tests/setup/stable-88/` — a copy of `stable/8.8:load-tests/setup/default/` and `stable/8.8:load-tests/setup/newLoadTest.sh` with two targeted fixes:
- `newLoadTest.sh`: `. utils.sh` → ROOT_DIR pattern
- `newLoadTest.sh`: `set -exo` → `set -eo` (xtrace removed — prevents secret leakage into GHA logs)

No databases/ (8.8 does not support mssql/oracle). Values files are elasticsearch/opensearch/none only.

## Reviewer verification

```bash
# Check structural diff (only newLoadTest.sh preamble + set -x removal expected)
git diff origin/stable/8.8:load-tests/setup/default/ load-tests/setup/stable-88/
git diff origin/stable/8.8:load-tests/setup/newLoadTest.sh load-tests/setup/stable-88/newLoadTest.sh
```

Refs: https://github.com/camunda/camunda/issues/54235

🤖 Generated with [Claude Code](https://claude.com/claude-code)