### PR TITLE
feat: add stable-87 load test setup folder on main

### DIFF
--- a/.github/workflows/camunda-load-test-smoke-dispatch.yml
+++ b/.github/workflows/camunda-load-test-smoke-dispatch.yml
@@ -59,9 +59,9 @@ jobs:
           if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-88/'; then
             matrix_entries+=('{"version":"stable-88","orchestration-tag":"8.8-SNAPSHOT"}')
           fi
-          # if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-87/'; then
-          #   matrix_entries+=('{"version":"stable-87","orchestration-tag":"8.7-SNAPSHOT"}')
-          # fi
+          if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-87/'; then
+            matrix_entries+=('{"version":"stable-87","orchestration-tag":"8.7-SNAPSHOT"}')
+          fi
 
           # Default: run main if nothing specific was detected
           if [[ ${#matrix_entries[@]} -eq 0 ]]; then

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -13,7 +13,7 @@ Options:
 All other options are forwarded to the target version's newLoadTest.sh.
 For version-specific help, run: ./newLoadTest.sh --target-version main -h
 
-Available versions: main, stable-89, stable-88
+Available versions: main, stable-89, stable-88, stable-87
 EOF
 }
 

--- a/load-tests/setup/stable-87/Makefile
+++ b/load-tests/setup/stable-87/Makefile
@@ -1,0 +1,236 @@
+namespace ?= __NAMESPACE__
+secondary_storage ?= __STORAGE_TYPE__
+helm_chart ?= camunda-platform-8.7
+enable_optimize ?= __ENABLE_OPTIMIZE__
+enable_webapps ?= __ENABLE_WEBAPPS__
+# Deadline date baked into resources/namespace.yaml by newLoadTest.sh. The
+# `check-deadline` target compares against today's date and fails fast so we
+# don't deploy into a namespace the TTL cleanup workflow is about to delete.
+deadline_date ?= __DEADLINE_DATE__
+curl_image ?= curlimages/curl:7.87.0
+camunda_management_url ?= http://zeebe-gateway:9600
+prometheus_elasticsearch_exporter_chart_version ?= 7.2.1
+# Optional: additional Helm configuration for the Camunda Platform release.
+# Use this to pass extra `--set`/`-f` flags, for example:
+#   make install additional_platform_configuration="--set zeebeGateway.env[0].name=FOO --set zeebeGateway.env[0].value=bar"
+# See the load test README for more examples and details.
+additional_platform_configuration ?=
+# Optional: additional Helm configuration for the load test release.
+# Use this to pass extra `--set`/`-f` flags when installing/upgrading the load tests.
+# See the load test README for example values and guidance.
+additional_load_test_configuration ?=
+
+helm_chart_platform := camunda-platform-helm/charts/$(helm_chart)
+helm_chart_load_tests := camunda-load-tests/camunda-load-tests
+
+# Scenario: controls the workload profile for the load test.
+# Options: latency, realistic, typical, max, archiver
+# Use named targets (make max) or pass directly: make install scenario=max
+scenario ?=
+
+ifeq ($(scenario),latency)
+_scenario_load_test_flags := --set starter.rate=1 --set workers.worker.replicas=1
+_scenario_platform_flags  :=
+else ifeq ($(scenario),realistic)
+_scenario_load_test_flags := -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
+_scenario_platform_flags  :=
+else ifeq ($(scenario),typical)
+_scenario_load_test_flags := --set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn
+_scenario_platform_flags  :=
+else ifeq ($(scenario),max)
+_scenario_load_test_flags := --set starter.rate=300
+_scenario_platform_flags  := --set-file 'zeebe.extraConfiguration.application-override\.yml=./camunda-platform-override-values.yaml'
+else ifeq ($(scenario),archiver)
+_scenario_load_test_flags := --set starter.rate=1 --set starter.rateDuration=10m --set starter.processId=multiInstanceElements --set starter.bpmnXmlPath=bpmn/multiInstanceElements.bpmn --set starter.payloadPath=bpmn/multiInstanceElementsPayload.json --set workers.worker.replicas=0
+_scenario_platform_flags  :=
+else
+_scenario_load_test_flags :=
+_scenario_platform_flags  :=
+endif
+
+# Construct platform values files based on configuration
+# Starting with the defaults, which are always applied and set common baseline configuration for all
+# set ups. The other values files are focused and only contain the necessary overrides for each storage type.
+platform_values := -f camunda-platform-values-defaults.yaml
+
+# Add secondary storage values
+platform_values += -f camunda-platform-values-$(secondary_storage).yaml
+
+# Disable Optimize if not enabled
+ifneq ($(enable_optimize),true)
+	platform_values += --set optimize.enabled=false
+else
+	platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
+endif
+
+# Disable Operate and Tasklist if webapps not enabled
+ifneq ($(enable_webapps),true)
+	platform_values += --set operate.enabled=false
+	platform_values += --set tasklist.enabled=false
+endif
+
+# Platform values with stable configuration
+platform_values_stable := $(platform_values) -f values-stable.yaml
+
+.PHONY: all
+all: install
+
+.PHONY: install
+install: check-deadline create-namespace create-credentials install-platform install-load-test install-elasticsearch-exporter
+
+.PHONY: install-stable
+install-stable: check-deadline create-namespace create-credentials install-platform-stable install-load-test install-elasticsearch-exporter
+
+# Fail fast if the namespace TTL deadline is today or in the past — the TTL
+# cleanup workflow will delete the namespace and undo the install. To extend,
+# either rerun newLoadTest.sh into a new folder or edit `deadline-date` in
+# resources/namespace.yaml and reapply.
+.PHONY: check-deadline
+check-deadline:
+	@today=$$(date +%Y-%m-%d); \
+	if [ "$$today" \> "$(deadline_date)" ] || [ "$$today" = "$(deadline_date)" ]; then \
+		echo "ERROR: namespace deadline-date ($(deadline_date)) is today or earlier (today: $$today)."; \
+		echo "       The TTL cleanup workflow will delete this namespace."; \
+		echo "       To proceed, bump the deadline:"; \
+		echo "         kubectl label namespace $(namespace) deadline-date=YYYY-MM-DD --overwrite"; \
+		echo "       and update resources/namespace.yaml to match, or rerun newLoadTest.sh into a fresh folder."; \
+		exit 1; \
+	fi
+
+# Apply the rendered namespace manifest. Idempotent: the same manifest applies
+# cleanly whether the namespace exists or not, so reruns of `make install`
+# after a TTL deletion recreate the namespace with the same labels and AZ.
+.PHONY: create-namespace
+create-namespace:
+	@echo "Applying namespace manifest for $(namespace)..."
+	kubectl apply -f resources/namespace.yaml
+
+# Apply the camunda-credentials secret. Idempotent: rerunning after a TTL
+# deletion reapplies the SAME credentials, so the orchestration secret in
+# load-test-values.yaml stays in sync with the live secret.
+.PHONY: create-credentials
+create-credentials:
+	@echo "Applying camunda-credentials secret for namespace $(namespace)..."
+	kubectl apply -n $(namespace) -f resources/camunda-credentials.yaml
+
+# Install Elasticsearch Prometheus exporter if secondary_storage is elasticsearch
+.PHONY: install-elasticsearch-exporter
+install-elasticsearch-exporter:
+ifeq ($(secondary_storage),elasticsearch)
+	@echo "Installing Elasticsearch Prometheus Exporter for namespace $(namespace)..."
+	helm upgrade --install elasticsearch-exporter oci://ghcr.io/prometheus-community/charts/prometheus-elasticsearch-exporter \
+    --namespace $(namespace) \
+    --version $(prometheus_elasticsearch_exporter_chart_version) \
+    --wait --timeout 5m0s \
+    -f prometheus-elasticsearch-exporter-values.yaml
+else
+	@echo "Skipping Elasticsearch Prometheus Exporter installation (secondary_storage=$(secondary_storage))"
+endif
+
+# Install/upgrade Camunda Platform helm chart
+.PHONY: install-platform
+install-platform: setup-leader-balancer
+	helm upgrade $(namespace) $(helm_chart_platform) \
+		--install \
+		--namespace $(namespace) \
+		--reset-then-reuse-values \
+		--render-subchart-notes \
+		$(platform_values) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration)
+
+# Install/upgrade Camunda Platform on stable VMs
+.PHONY: install-platform-stable
+install-platform-stable: setup-leader-balancer
+	helm upgrade $(namespace) $(helm_chart_platform) \
+		--install \
+		--namespace $(namespace) \
+		--reset-then-reuse-values \
+		--render-subchart-notes \
+		$(platform_values_stable) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration)
+
+# Install/upgrade load test helm chart
+.PHONY: install-load-test
+install-load-test:
+	helm upgrade $(namespace)-test $(helm_chart_load_tests) \
+		--install \
+		--namespace $(namespace) \
+		--reset-then-reuse-values \
+		--render-subchart-notes \
+		-f load-test-values.yaml \
+		$(_scenario_load_test_flags) \
+		$(additional_load_test_configuration)
+
+# Setup leader balancing cronjob
+.PHONY: setup-leader-balancer
+setup-leader-balancer:
+	@if ! kubectl get cronjob leader-balancer --namespace $(namespace) >/dev/null 2>&1; then \
+		kubectl create cronjob leader-balancer \
+			--namespace $(namespace) \
+			--image=$(curl_image) \
+			--schedule="*/10 * * * *" \
+			-- curl -L -v -X POST $(camunda_management_url)/actuator/rebalance; \
+		echo "Leader balancer cronjob created"; \
+	else \
+		echo "Leader balancer cronjob already exists"; \
+	fi
+
+# Generates templates from the Camunda Platform helm chart
+.PHONY: template
+template:
+	helm template $(namespace) $(helm_chart_platform) \
+		$(platform_values) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration) \
+		--output-dir .
+
+.PHONY: template-stable
+template-stable:
+	helm template $(namespace) $(helm_chart_platform) \
+		$(platform_values_stable) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration) \
+		--output-dir .
+
+# Generates templates from the load test helm chart
+.PHONY: template-load-test
+template-load-test:
+	helm template $(namespace)-test $(helm_chart_load_tests) \
+		-f load-test-values.yaml \
+		$(_scenario_load_test_flags) \
+		$(additional_load_test_configuration) \
+		--output-dir .
+
+# Print the resolved scenario flags without running any Helm commands
+.PHONY: print-scenario
+print-scenario:
+	@echo "Scenario:         $(if $(scenario),$(scenario),(none — chart defaults apply))"
+	@echo "Load test flags:  $(if $(_scenario_load_test_flags),$(_scenario_load_test_flags),(none))"
+	@echo "Platform flags:   $(if $(_scenario_platform_flags),$(_scenario_platform_flags),(none))"
+
+# Workload scenario shortcuts — each runs 'make install' with the corresponding scenario profile.
+# For stable VMs, use: make install-stable scenario=<name>
+.PHONY: latency realistic typical max archiver
+latency:
+	$(MAKE) install scenario=latency
+realistic:
+	$(MAKE) install scenario=realistic
+typical:
+	$(MAKE) install scenario=typical
+max:
+	$(MAKE) install scenario=max
+archiver:
+	$(MAKE) install scenario=archiver
+
+.PHONY: clean
+clean:
+	-helm --namespace $(namespace) uninstall $(namespace)
+	-helm --namespace $(namespace) uninstall $(namespace)-test
+	-helm --namespace $(namespace) uninstall elasticsearch-exporter
+	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/instance=$(namespace)
+	-kubectl delete -n $(namespace) pvc -l app=elasticsearch-master
+	-kubectl delete -n $(namespace) cronjob leader-balancer
+	@echo "Deleting namespace $(namespace) (async, no wait)..."
+	-kubectl delete -f resources/namespace.yaml --wait=false --ignore-not-found

--- a/load-tests/setup/stable-87/newLoadTest.sh
+++ b/load-tests/setup/stable-87/newLoadTest.sh
@@ -1,0 +1,298 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The directory where the load tests and shared utilities are located.
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Contains OS specific sed function
+. "${ROOT_DIR}/utils.sh"
+
+set -eo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_webapps] [enable_single_zone]
+
+Arguments:
+  namespace          Base namespace name. Will be prefixed with "c8-" if missing.
+  secondaryStorage   Optional. One of: elasticsearch. Default: elasticsearch.
+  ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
+  enable_optimize    Optional. true|false to enable Optimize. Default: true.
+  enable_webapps     Optional. true|false to enable Operate and Tasklist. Default: true.
+  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true
+
+Options:
+  -h, --help         Show this help message.
+
+Examples:
+  ./newLoadTest.sh demo
+  ./newLoadTest.sh perf elasticsearch 3 true true
+
+This script scaffolds the per-namespace folder including rendered Kubernetes
+manifests under resources/ (namespace + credentials). The cluster itself is
+unchanged by this script — namespace and secret are created on first
+`make install` via `kubectl apply -f resources/...`. Reruns of `make install`
+after a TTL deletion recreate both from the same baked manifests, so
+credentials stay in sync with `load-test-values.yaml`.
+EOF
+}
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ -z "$1" ]; then
+  echo "Error: Missing namespace name."
+  usage
+  exit 1
+fi
+
+### Load test helper script
+### First parameter is used as namespace name
+### For a new namespace a new folder will be created
+
+helm_chart="camunda-platform-8.7"
+namespace="$1"
+
+# Add c8- prefix if not present
+if [[ ! "$namespace" =~ ^c8- ]]; then
+  namespace="c8-$namespace"
+  echo "Namespace prefix added: $namespace"
+fi
+
+# Validate secondaryStorage value
+secondaryStorage="${2:-elasticsearch}"
+if [[ "$secondaryStorage" != "elasticsearch" ]]; then
+  echo "Error: Invalid secondary storage type '$secondaryStorage'"
+  echo "Allowed values are: elasticsearch"
+  exit 1
+fi
+
+# Validate TTL value
+ttl_days="${3:-1}"
+numberRegex='^[0-9]+$'
+if ! [[ $ttl_days =~ $numberRegex ]] ; then
+   echo "Error: TTL '$ttl_days' is not a number"
+   exit 1
+fi
+
+# Validate enable_optimize value
+enable_optimize="${4:-true}"
+enable_optimize=$(echo "$enable_optimize" | tr '[:upper:]' '[:lower:]')
+if [[ "$enable_optimize" != "true" && "$enable_optimize" != "false" ]]; then
+  echo "Error: Invalid enable_optimize value '$enable_optimize'"
+  echo "Allowed values are: true or false"
+  exit 1
+fi
+
+enable_webapps="${5:-true}"
+enable_webapps=$(echo "$enable_webapps" | tr '[:upper:]' '[:lower:]')
+if [[ "$enable_webapps" != "true" && "$enable_webapps" != "false" ]]; then
+  echo "Error: Invalid enable_webapps value '$enable_webapps'"
+  echo "Allowed values are: true or false"
+  exit 1
+fi
+
+enable_single_zone="${6:-true}"
+enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
+
+# Pick a "random" zone, selected from the input value.
+function hashmod_zone() {
+    local input="${1?"Specify an initial value to compute the zone from"}"
+
+    # We can get the list of zones with already created nodes with:
+    # kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io\/zone}{"\n"}{end}' | sort | uniq -c
+    zones=(
+        europe-west1-b
+        europe-west1-c
+        europe-west1-d
+    )
+    nb_zones=${#zones[@]}
+
+    # bc only accept hexadecimal with capitalized letters
+    checksum="$(echo "$input" | md5sum | cut -c 1-32 | tr "a-z" "A-Z")"
+    hashmod="$(echo "ibase=16; $checksum % $nb_zones" | bc)"
+
+    zone="${zones[$hashmod]}"
+    echo "$zone"
+}
+
+# `hashmod_zone` is deterministic, so the zone baked into namespace.yaml and
+# the values files matches any re-applied manifest after TTL deletion.
+if [[ "$enable_single_zone" == "true" ]]; then
+  availability_zone="$(hashmod_zone "$namespace")"
+else
+  availability_zone="~"
+fi
+
+git_author=$(compute_git_author)
+
+# Compute deadline-date once at scaffold time. The Makefile's check-deadline
+# target compares this against today; if it has passed, install fails fast.
+if deadline_date=$(date -d "+${ttl_days} days" +%Y-%m-%d 2>/dev/null); then
+  : # GNU date succeeded
+elif deadline_date=$(date -v +${ttl_days}d +%Y-%m-%d 2>/dev/null); then
+  : # BSD/macOS date succeeded
+else
+  echo "Error: Could not calculate deadline date. Supported on Linux and macOS only."
+  exit 1
+fi
+
+
+# Scaffold the namespace folder with only the files this $secondaryStorage uses.
+# A namespace is bound to its storage at create time; to switch storage, create
+# a new namespace via ./newLoadTest.sh <new-name> <newStorage>.
+TARGET_DIRECTORY="${ROOT_DIR}/${namespace}"
+mkdir -p "$TARGET_DIRECTORY"
+
+# Scaffold the always-copied files into the namespace folder root: the
+# Makefile, the resources/ manifests, four storage-agnostic values files
+# (defaults + override + load-test + stable), and the matching
+# camunda-platform-values-${secondaryStorage}.yaml. Flat layout so the
+# per-namespace Makefile's -f <file>.yaml references resolve unchanged.
+cp -v  "Makefile"                                                "$TARGET_DIRECTORY/"
+cp -rv "resources/"                                              "$TARGET_DIRECTORY/"
+cp -v  "values/camunda-platform-override-values.yaml"           "$TARGET_DIRECTORY/"
+cp -v  "values/load-test-values.yaml"                           "$TARGET_DIRECTORY/"
+cp -v  "values/values-stable.yaml"                              "$TARGET_DIRECTORY/"
+cp -v  "values/camunda-platform-values-defaults.yaml"           "$TARGET_DIRECTORY/"
+cp -v  "values/camunda-platform-values-${secondaryStorage}.yaml" "$TARGET_DIRECTORY/"
+
+# Storage-specific copies.
+case "$secondaryStorage" in
+  elasticsearch)
+    cp -v "values/prometheus-elasticsearch-exporter-values.yaml" "$TARGET_DIRECTORY/"
+    ;;
+esac
+
+if [[ "$enable_optimize" == "true" ]]; then
+  # Optimize needs specifically Elasticsearch (independently from the secondary
+  # storage configuration).
+  cp -v "values/camunda-platform-values-optimize-elasticsearch.yaml" "$TARGET_DIRECTORY/"
+fi
+
+cd "$TARGET_DIRECTORY"
+
+# Bake values into the rendered Makefile.
+sed_inplace "s/__NAMESPACE__/$namespace/"           Makefile
+sed_inplace "s/__STORAGE_TYPE__/$secondaryStorage/" Makefile
+sed_inplace "s/__ENABLE_OPTIMIZE__/$enable_optimize/" Makefile
+sed_inplace "s/__DEADLINE_DATE__/$deadline_date/"    Makefile
+sed_inplace "s/__ENABLE_WEBAPPS__/$enable_webapps/" Makefile
+
+# Bake values into the resource manifests and the platform/load-test values.
+# Values shared with the chart (NAMESPACE, AVAILABILITY_ZONE, AUTHOR) flow into
+# the upstream yaml files via the same sed pass.
+sed_inplace "s/__NAMESPACE__/$namespace/"                       load-test-values.yaml resources/*.yaml
+sed_targets=(*.yaml resources/namespace.yaml)
+sed_inplace "s/__AVAILABILITY_ZONE__/$availability_zone/" "${sed_targets[@]}"
+sed_inplace "s/__AUTHOR__/$git_author/"                   "${sed_targets[@]}"
+sed_inplace "s/__DEADLINE_DATE__/$deadline_date/"                resources/namespace.yaml
+
+# When single-zone is disabled the topology annotation has no useful value;
+# strip the annotation line and the now-empty `annotations:` key so the manifest
+# stays tidy.
+if [[ "$enable_single_zone" != "true" ]]; then
+  sed_inplace "/topology.kubernetes.io\\/zone:/d" resources/namespace.yaml
+  # `sed_inplace` splits args on whitespace and the `annotations:` line pattern
+  # contains literal spaces, so call sed directly with OS-aware -i flag.
+  detect_os
+  if [ "${GO_OS}" == "darwin" ]; then
+    sed -i '' -e '/^  annotations:$/d' resources/namespace.yaml
+  else
+    sed -i    -e '/^  annotations:$/d' resources/namespace.yaml
+  fi
+fi
+
+#############################################################################################
+################################ CREDENTIALS ################################################
+#############################################################################################
+
+function get_existing_secret() {
+  jsonObject=$1
+  key=$2
+  existing_secret=$(echo "$jsonObject" | jq --raw-output --arg key "$key" '.[$key] // empty' | base64 -d)
+  if [ -z "$existing_secret" ]; then
+    echo "ERROR: existing camunda-credentials secret is missing key '$key'."
+    exit 1
+  fi
+  echo "$existing_secret"
+}
+
+# Generate credentials. These are baked into resources/camunda-credentials.yaml
+# and (for the orchestration OIDC secret) into load-test-values.yaml. Any
+# subsequent `make install` reapplies the same manifest, so the secret in the
+# cluster always matches the value the load test starter authenticates with.
+# `head -c 20` closes the pipe early; upstream `tr` then takes SIGPIPE and
+# returns 141 under `set -o pipefail`. Wrap in a subshell so the harmless
+# SIGPIPE doesn't trip `set -e` in the caller.
+function gen_password() { ( set +o pipefail; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20 ); }
+function gen_token()    { openssl rand -hex 16; }
+
+
+# If the secret already exists in the cluster, preserve all existing values to avoid breaking any live load test.
+# If the secret doesn't exist, generate new random values for all keys.
+# This might happend on CI/GitHub Workflows that update existing load tests but do not persist the credentials across runs.
+if kubectl -n "$namespace" get secret camunda-credentials >/dev/null 2>&1; then
+  echo "Secret 'camunda-credentials' already exists in namespace '$namespace'; preserving existing credentials."
+  jsonObject=$(kubectl -n "$namespace" get secret camunda-credentials -o jsonpath='{.data}')
+
+  IDENTITY_FIRSTUSER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-firstuser-password")
+  IDENTITY_KEYCLOAK_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-admin-password")
+  IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-postgresql-admin-password")
+  IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-postgresql-user-password")
+  IDENTITY_POSTGRESQL_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-postgresql-admin-password")
+  IDENTITY_POSTGRESQL_USER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-postgresql-user-password")
+  IDENTITY_ADMIN_CLIENT_TOKEN=$(get_existing_secret "$jsonObject" "identity-admin-client-token")
+  IDENTITY_OPTIMIZE_CLIENT_TOKEN=$(get_existing_secret "$jsonObject" "identity-optimize-client-token")
+  IDENTITY_ZEEBE_CLIENT_TOKEN=$(get_existing_secret "$jsonObject" "identity-zeebe-client-token")
+else
+  echo "Generating new credentials for secret 'camunda-credentials'."
+  IDENTITY_FIRSTUSER_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD=$(gen_password)
+  IDENTITY_POSTGRESQL_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_POSTGRESQL_USER_PASSWORD=$(gen_password)
+  IDENTITY_ADMIN_CLIENT_TOKEN=$(gen_token)
+  IDENTITY_OPTIMIZE_CLIENT_TOKEN=$(gen_token)
+  IDENTITY_ZEEBE_CLIENT_TOKEN=$(gen_token)
+fi
+
+# Bake the Zeebe OIDC secret into the load-test starter values.
+sed_inplace "s|__SECRET__|$IDENTITY_ZEEBE_CLIENT_TOKEN|" load-test-values.yaml
+
+# Bake the credential values into the secret manifest.
+sed_inplace "s|__IDENTITY_FIRSTUSER_PASSWORD__|$IDENTITY_FIRSTUSER_PASSWORD|"                                 resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_KEYCLOAK_ADMIN_PASSWORD__|$IDENTITY_KEYCLOAK_ADMIN_PASSWORD|"                       resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD__|$IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD|" resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD__|$IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD|"   resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_POSTGRESQL_ADMIN_PASSWORD__|$IDENTITY_POSTGRESQL_ADMIN_PASSWORD|"                   resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_POSTGRESQL_USER_PASSWORD__|$IDENTITY_POSTGRESQL_USER_PASSWORD|"                     resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_ADMIN_CLIENT_TOKEN__|$IDENTITY_ADMIN_CLIENT_TOKEN|"                                 resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_OPTIMIZE_CLIENT_TOKEN__|$IDENTITY_OPTIMIZE_CLIENT_TOKEN|"                           resources/camunda-credentials.yaml
+sed_inplace "s|__IDENTITY_ZEEBE_CLIENT_TOKEN__|$IDENTITY_ZEEBE_CLIENT_TOKEN|"                                 resources/camunda-credentials.yaml
+
+# Add/update helm repositories
+helm repo add camunda https://helm.camunda.io/ --force-update
+helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/ --force-update
+helm repo update
+
+# Clone Camunda Platform Helm so we can run the latest chart
+# TODO: 347642d30179479f8ab8a2f00b2d979be05f5a8c is the latest commit before the removal of the
+# embedded Bitnami Helm Chart.
+# We should remove the checkout of this specific revision once we have a solution to replace these
+# removed dependencies.
+git clone --depth 1 --revision 347642d30179479f8ab8a2f00b2d979be05f5a8c --single-branch https://github.com/camunda/camunda-platform-helm.git
+
+# Make deps
+helm dependency build "camunda-platform-helm/charts/$helm_chart"
+
+set +x
+echo
+echo "Scaffolding complete. Next steps:"
+echo "  cd $namespace"
+echo "  make install   # applies resources/namespace.yaml + resources/camunda-credentials.yaml and deploys"
+echo
+echo "Deadline: $deadline_date (TTL = $ttl_days day(s)). Bump it via resources/namespace.yaml + kubectl label, or rerun this script."

--- a/load-tests/setup/stable-87/resources/camunda-credentials.yaml
+++ b/load-tests/setup/stable-87/resources/camunda-credentials.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  identity-firstuser-password: "__IDENTITY_FIRSTUSER_PASSWORD__"
+  identity-keycloak-admin-password: "__IDENTITY_KEYCLOAK_ADMIN_PASSWORD__"
+  identity-keycloak-postgresql-admin-password: "__IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD__"
+  identity-keycloak-postgresql-user-password: "__IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD__"
+  identity-postgresql-admin-password: "__IDENTITY_POSTGRESQL_ADMIN_PASSWORD__"
+  identity-postgresql-user-password: "__IDENTITY_POSTGRESQL_USER_PASSWORD__"
+  identity-admin-client-token: "__IDENTITY_ADMIN_CLIENT_TOKEN__"
+  identity-optimize-client-token: "__IDENTITY_OPTIMIZE_CLIENT_TOKEN__"
+  identity-zeebe-client-token: "__IDENTITY_ZEEBE_CLIENT_TOKEN__"

--- a/load-tests/setup/stable-87/resources/namespace.yaml
+++ b/load-tests/setup/stable-87/resources/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: __NAMESPACE__
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: __AUTHOR__
+    deadline-date: "__DEADLINE_DATE__"
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__

--- a/load-tests/setup/stable-87/values/camunda-platform-override-values.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-override-values.yaml
@@ -1,0 +1,5 @@
+# Consistency check overrides for the max stress scenario.
+# This file is injected as application-override.yml (loaded after and overrides application.yml)
+# when scenario=max, to disable checks that would add overhead during maximum-load tests.
+zeebe.broker.experimental.consistencyChecks.enablePreconditions: "false"
+zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "false"

--- a/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
@@ -1,0 +1,455 @@
+# Default load test values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This file is used to override the default values of the chart.
+# The values are optimized for running the load tests with a Camunda cluster on GKE.
+#
+# This is a YAML-formatted file.
+# Per default we run with the Orchestration Cluster, Optimize, Connectors, and Identity
+# Keycloak as identity provider with OIDC authentication, but you can easily
+# switch to other configurations by changing the values in this file or by overriding them via the
+# command line when installing the chart.
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  commonLabels:
+    camunda.io/created-by: __AUTHOR__
+    camunda.io/purpose: load-test
+
+  # Disable global ingress
+  ingress:
+    enabled: false
+  image:
+    # Image.repository defines the repository from which to fetch the docker images
+    repository: "registry.camunda.cloud/team-zeebe"
+    # Image.tag defines the tag / version which should be used in the chart
+    tag: 8.7.0
+    ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    pullPolicy: Always
+    ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets:
+      - name: harbor-registry
+
+  identity:
+    auth:
+      enabled: true
+      zeebe:
+        existingSecret:
+          name: camunda-credentials
+        existingSecretKey: identity-zeebe-client-token
+      optimize:
+        clientId: optimize
+        existingSecret: camunda-credentials
+        existingSecretKey: identity-optimize-client-token
+      operate:
+        clientId: operate
+        existingSecret: camunda-credentials
+        existingSecretKey: identity-operate-client-token
+      tasklist:
+        clientId: tasklist
+        existingSecret: camunda-credentials
+        existingSecretKey: identity-tasklist-client-token
+      connectors:
+        clientId: connectors
+        existingSecret: camunda-credentials
+        existingSecretKey: identity-connectors-client-token
+  # To override the names - and remove the release name from the names
+  # Allows shorter names like zeebe-0, zeebe-1, etc.
+  # Especially useful for the services, which are just zeebe-gateway and zeebe
+  zeebeClusterName: zeebe
+
+identity:
+  enabled: true
+  fullnameOverride: identity # we override the names for simplicity of the deployment
+  firstUser:
+    existingSecret: camunda-credentials
+    existingSecretKey: identity-firstuser-password
+  env:
+    # https://docs.camunda.io/docs/8.7/self-managed/identity/miscellaneous/configure-logging/#stackdriver
+    - name: IDENTITY_LOG_APPENDER
+      value: Stackdriver
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+optimize:
+  enabled: true
+  fullnameOverride: optimize # we override the names for simplicity of the deployment
+  resources:
+    requests:
+      cpu: 1
+      memory: 2Gi
+    limits:
+      cpu: 2
+      memory: 4Gi
+
+  # Optimize reads historyCleanup only from environment-config.yaml (its custom config loader),
+  # not from application.yml via spring.config.import.
+  # To provide a different/additional configuration from the default configuration, we therefore
+  # have to override the full environment-config.yaml via `configuration` and repeat the default
+  # configuration: to see the differences compared to the default one, see the marker in the
+  # configuration itself.
+  # ES host/port use Optimize's ${VAR:default} placeholder syntax so they stay dynamic at
+  # runtime (the deployment sets OPTIMIZE_ELASTICSEARCH_HOST / OPTIMIZE_ELASTICSEARCH_HTTP_PORT).
+  configuration: |
+    zeebe:
+      enabled: true
+      partitionCount: 3
+      name: "zeebe-record"
+    es:
+      connection:
+        nodes:
+          - host: "${OPTIMIZE_ELASTICSEARCH_HOST:localhost}"
+            httpPort: ${OPTIMIZE_ELASTICSEARCH_HTTP_PORT:9200}
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "ccsm"
+    security:
+      auth:
+        cookie:
+          same-site:
+            enabled: false
+        ccsm:
+          redirectRootUrl: "http://localhost:8083"
+    api:
+      audience: "optimize-api"
+      jwtSetUri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+
+    ## Changed from the default configuration
+    # Configure and enable the process data cleanup
+    historyCleanup:
+      cronTrigger: '*/30 * * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true
+  env:
+    # https://docs.camunda.io/docs/8.7/self-managed/optimize-deployment/configuration/logging/#google-stackdriver-json-logging
+    - name: JSON_LOGGING
+      value: "true"
+
+    # Configure Optimize to use the full size of the ES/OS cluster it connects
+    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
+    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
+    # the cluster.
+    # Ideally, this value should default to the number of Elasticsearch nodes
+    # in the cluster.
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+
+    # Improve performances of Optimize for the load tests.
+    # This is load-test specific and different configuration of cluster
+    # configuration (different hardware resources for instance) and/or type of
+    # workload may benefit (or even require) from a different value here.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+      value: "1000" # default 200
+
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+identityKeycloak:
+  enabled: true
+  fullnameOverride: keycloak # we override the names for simplicity of the deployment
+  auth:
+    adminUser: admin
+    existingSecret: camunda-credentials
+    passwordSecretKey: identity-keycloak-admin-password
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+  extraEnvVars:
+    # https://www.keycloak.org/server/logging#_console
+    - name: KC_LOG_CONSOLE_OUTPUT
+      value: json
+  postgresql:
+    fullnameOverride: keycloak-postgresql # we override the names for simplicity of the deployment
+    auth:
+      existingSecret: camunda-credentials
+      secretKeys:
+        adminPasswordKey: identity-keycloak-postgresql-admin-password
+        userPasswordKey: identity-keycloak-postgresql-user-password
+
+
+operate:
+  enabled: true
+  fullnameOverride: operate # we override the names for simplicity of the deployment
+  resources:
+    requests:
+      cpu: 600m
+      memory: 400Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+  # Retention can be used to define the data in Elasticsearch (ILM).
+  retention:
+    enabled: true
+    minimumAge: 1d
+  env:
+    # https://docs.camunda.io/docs/8.7/self-managed/operate-deployment/operate-configuration/#json-logging-configuration
+    - name: OPERATE_LOG_APPENDER
+      value: Stackdriver
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+tasklist:
+  enabled: true
+  fullnameOverride: tasklist # we override the names for simplicity of the deployment
+  resources:
+    requests:
+      cpu: 400m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+  # Retention can be used to define the data in Elasticsearch (ILM).
+  retention:
+    enabled: true
+  env:
+    # https://docs.camunda.io/docs/8.7/self-managed/tasklist-deployment/tasklist-configuration/#json-logging-configuration
+    - name: TASKLIST_LOG_APPENDER
+      value: Stackdriver
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+connectors:
+  enabled: true
+  fullnameOverride: connectors # we override the names for simplicity of the deployment
+  resources:
+    requests:
+      cpu: 1
+      memory: 1Gi
+    limits:
+      cpu: 2
+      memory: 2Gi
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/connectors/connectors-configuration/#google-stackdriver-json-logging
+    - name: CONNECTORS_LOG_APPENDER
+      value: stackdriver
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+webModeler:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+zeebe:
+  # Image configuration to configure the zeebe image specifics
+  image:
+    registry: docker.io
+    repository: camunda/zeebe
+    tag: 8.7-SNAPSHOT
+  # ClusterSize defines the amount of brokers (=replicas), which are deployed via helm
+  clusterSize: "3"
+  # PartitionCount defines how many zeebe partitions are set up in the cluster
+  partitionCount: "3"
+  # ReplicationFactor defines how each partition is replicated, the value defines the number of nodes
+  replicationFactor: "3"
+  # CpuThreadCount defines how many threads can be used for the processing on each broker pod
+  cpuThreadCount: "3"
+  # IoThreadCount defines how many threads can be used for the exporting on each broker pod
+  ioThreadCount: "3"
+  # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+  resources:
+    requests:
+      cpu: 3000m
+      memory: 4Gi
+    limits:
+      cpu: 3000m
+      memory: 4Gi
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+  # PvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+  pvcSize: "64Gi"
+  # PvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim. It is recommended to use a storage class, which is backed with a SSD.
+  # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.
+  pvcStorageClassName: benchmark-ssd-zonal-v1
+  # ContainerSecurityContext defines the security options the Zeebe broker container should be run with
+  containerSecurityContext:
+    ## @param securityContext.allowPrivilegeEscalation
+    allowPrivilegeEscalation: true
+    ## @param securityContext.privileged
+    privileged: true
+    ## @param securityContext.readOnlyRootFilesystem
+    readOnlyRootFilesystem: true
+    ## @param securityContext.runAsUser
+    runAsUser: 1000
+    capabilities:
+      add: ["NET_ADMIN"]
+  javaOpts: >-
+    -XX:MaxRAMPercentage=25.0
+    -XX:+ExitOnOutOfMemoryError
+    -XX:+HeapDumpOnOutOfMemoryError
+    -XX:HeapDumpPath=/usr/local/zeebe/data
+    -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
+    -Xlog:gc*:file=/usr/local/zeebe/data/gc.log:time:filecount=7,filesize=8M
+
+  # We set extra configuration to configure additional settings for Broker and Gateway, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    application.yml: |
+      zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+      zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+      zeebe.broker.executionMetricsExporterEnabled: "true"
+      zeebe.broker.data.diskUsageCommandWatermark: "0.8"
+      zeebe.broker.data.diskUsageReplicationWatermark: "0.9"
+
+      # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+      zeebe.broker.flowControl.write.enabled: "true"
+      zeebe.broker.flowControl.write.limit: 4000
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max)
+    # to change settings like disabling consistency checks without duplicating the full application.yml content.
+    application-override.yml: "# no overrides"
+
+  # Zeebe config
+  extraVolumes:
+    - name: logs
+      emptyDir: {}
+  ## @param zeebe.extraVolumeMounts can be used to mount extra volumes for the broker pods
+  extraVolumeMounts:
+    - name: logs
+      mountPath: /usr/local/zeebe/logs
+  # Retention can be used to define the data in Elasticsearch (ILM).
+  retention:
+    ## @param zeebe.retention.enabled if true, the ILM Policy is created and applied to the index templates.
+    enabled: true
+    ## @param zeebe.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
+    minimumAge: 1d # Optimize needs time to import data before ILM cleanup
+  # @param core.env can be used to set extra environment variables in each broker container
+  env:
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/zeebe/config/application.yml,optional:/usr/local/zeebe/config/application-override.yml"
+
+zeebeGateway:
+  # Replicas defines how many standalone gateways are deployed
+  replicas: 2
+
+  # Image configuration to configure the zeebe-gateway image specifics
+  image:
+    # Image.repository defines which image repository to use
+    repository: camunda/zeebe
+    # Image.registry defines which image registry to use
+    registry: docker.io
+    # Image.tag defines the tag / version which should be used in the chart
+    tag: 8.7-SNAPSHOT
+  # LogLevel defines the log level which is used by the gateway
+  logLevel: debug
+
+  # We set extra configuration to configure additional settings for Broker and Gateway, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    application.yml: |
+      zeebe.gateway.monitoring.enabled: "true"
+      zeebe.gateway.threads.managementThreads: "1"
+
+  # Zeebe config
+  extraVolumes:
+    - name: logs
+      emptyDir: {}
+  ## @param zeebeGateway.extraVolumeMounts can be used to mount extra volumes for the broker pods
+  extraVolumeMounts:
+    - name: logs
+      mountPath: /usr/local/zeebe/logs
+
+  # Env can be used to set extra environment variables in each gateway container
+  env:
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      value: "/usr/local/zeebe/config/application.yml"
+    - name: CAMUNDA_REST_QUERY_ENABLED
+      value: "true"
+
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+  resources:
+    limits:
+      cpu: 450m
+      memory: 1Gi
+    requests:
+      cpu: 450m
+      memory: 1Gi
+
+# Change these settings to configure a different way to collect metrics
+prometheusServiceMonitor:
+  enabled: true
+  labels:
+    release: monitoring
+  scrapeInterval: 30s

--- a/load-tests/setup/stable-87/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-elasticsearch.yaml
@@ -1,0 +1,76 @@
+# Elasticsearch values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This configures Elasticsearch when it's used for Optimize AND as the Camunda secondary storage.
+#
+# If you want to configure Elasticsearch only for Optimize and use another
+# secondary storage option for Camunda, see
+# the "camunda-platform-values-optimize-elasticsearch.yaml" file.
+# If you make changes to this file or the
+# "camunda-platform-values-optimize-elasticsearch.yaml" file, make sure to keep
+# the other file in sync (minus the secondary storage-only options).
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  elasticsearch:
+    enabled: true
+    url:
+      # The Elasticsearch host value used to connect to Elasticsearch depends
+      # on the "elasticsearch.fullnameOverride" value.
+      # If you change the "elasticsearch.fullnameOverride" value, make sure to
+      # update this host value accordingly.
+      host: elastic
+
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  # We need to explicitly set the secondary storage type to ELS
+  # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES
+  data:
+    secondaryStorage:
+      type: elasticsearch
+
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  enabled: true
+  imageTag: 8.9.2
+  # Override the default name for ConfigMap, Service, etc.
+  # Changing this value also changes the name of the Kubernetes Service used by
+  # the other components to connect to Elasticsearch, make sure to update
+  # the "global.elasticsearch.url.host" value accordingly.
+  fullnameOverride: elastic
+  master:
+    fullnameOverride: elastic
+    nameOverride: elastic
+    ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
+    replicaCount: 3
+    pdb:
+      minAvailable: 2
+    ## @param elasticsearch.master.heapSize
+    heapSize: 3g
+    persistence:
+      ## @param elasticsearch.master.persistence.size
+      size: 512Gi
+      storageClass: benchmark-ssd-zonal-v1
+      accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        cpu: 7000m
+        memory: 8Gi
+      limits:
+        cpu: 7000m
+        memory: 8Gi
+    nodeSelector:
+      component: benchmark-n2-standard-8
+      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-8
+        effect: NoSchedule

--- a/load-tests/setup/stable-87/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -1,0 +1,66 @@
+# Elasticsearch values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This configures Elasticsearch when it's used fr Optimize, but NOT as the Camunda secondary storage.
+# storage.
+#
+# For the Elasticsearch as secondary storage configuration, see the
+# "camunda-platform-values-elasticsearch.yaml" file.
+# If you make changes to this file or the "camunda-platform-values-elasticsearch.yaml" file, make
+# sure to keep the other file in sync (minus the secondary storage-only options).
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  elasticsearch:
+    enabled: true
+    url:
+      # The Elasticsearch host value used to connect to Elasticsearch depends
+      # on the "elasticsearch.fullnameOverride" value.
+      # If you change the "elasticsearch.fullnameOverride" value, make sure to
+      # update this host value accordingly.
+      host: elastic
+
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  enabled: true
+  # Override the default name for ConfigMap, Service, etc.
+  # Changing this value also changes the name of the Kubernetes Service used by
+  # the other components to connect to Elasticsearch, make sure to update
+  # the "global.elasticsearch.url.host" value accordingly.
+  fullnameOverride: elastic
+  clusterName: elasticsearch
+  master:
+    fullnameOverride: elastic
+    nameOverride: elastic
+    ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
+    replicaCount: 3
+    pdb:
+      minAvailable: 2
+    ## @param elasticsearch.master.heapSize
+    heapSize: 3g
+    persistence:
+      ## @param elasticsearch.master.persistence.size
+      size: 512Gi
+      storageClass: benchmark-ssd-zonal-v1
+      accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        cpu: 7000m
+        memory: 8Gi
+      limits:
+        cpu: 7000m
+        memory: 8Gi
+    nodeSelector:
+      component: benchmark-n2-standard-8
+      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-8
+        effect: NoSchedule
+  extraConfig:
+    logger.org.elasticsearch.deprecation: "OFF"

--- a/load-tests/setup/stable-87/values/load-test-values.yaml
+++ b/load-tests/setup/stable-87/values/load-test-values.yaml
@@ -1,0 +1,64 @@
+global:
+  # Enable Stackdriver-formatted JSON logging on starter and worker pods so
+  # Cloud Logging picks up severity, sourceLocation, and serviceContext the
+  # same way it does for zeebe/operate/etc. Toggle is read by
+  # load-tests/load-tester/src/main/resources/log4j2.xml.
+  extraEnvVars:
+    - name: LOAD_TESTER_LOG_APPENDER
+      value: Stackdriver
+    - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+      value: load-tester
+    - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+
+  commonLabels:
+    camunda.io/created-by: __AUTHOR__
+    camunda.io/purpose: load-test
+  image:
+    repository: registry.camunda.cloud/team-zeebe
+    pullSecrets:
+      - name: harbor-registry
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+# OAuth configuration for load tests to connect to the Zeebe gateway via Identity/Keycloak.
+# In 8.7, all components are deployed separately (unlike 8.8's unified orchestration cluster).
+# The gateway is 'zeebe-gateway' and Identity uses Keycloak for OIDC tokens.
+saas:
+  # OAuth enabled — gateway enforces auth when global.identity.auth.enabled=true
+  enabled: true
+
+  # Saas.credentials configuration to connect to a Zeebe gateway with OIDC
+  credentials:
+    # Saas.existingSecret can be used to configure the secret name that should be referenced by the load tests
+    # applications to retrieve credential information.
+    #
+    # If this value is set, other credentials are not used.
+    existingSecret:
+
+    # Saas.credentials.clientId to define the clientId to connect
+    clientId: "zeebe"
+    # Saas.credentials.clientSecret to define the clientSecret to connect
+    clientSecret: "__SECRET__"
+    # Saas.credentials.zeebeRestAddress to define the rest address of the cluster (including port)
+    # Use headless service so DNS returns all pod IPs for client-side load balancing.
+    zeebeRestAddress: "http://zeebe-gateway:8080"
+    # SaaS.credentials.authServer to define the authentication server to retrieve JWT tokens
+    authServer: "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"
+    # Saas.credentials.authType to define the authentication type for the starter and workers
+    authType: "OAUTH"
+    # Saas.credentials.zeebeGrpcAddress to define the grpc address of the cluster (including port)
+    # Use headless service so DNS returns all pod IPs for gRPC round_robin client-side load balancing.
+    zeebeGrpcAddress: "http://zeebe-gateway:26500"
+    # Saas.credentials.authorizationAudience to define the auth audience of the cluster
+    authorizationAudience: "zeebe-api"

--- a/load-tests/setup/stable-87/values/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/setup/stable-87/values/prometheus-elasticsearch-exporter-values.yaml
@@ -1,0 +1,30 @@
+fullnameOverride: "prom-els-exporter"
+
+es:
+  uri: http://elastic:9200
+
+commonLabels:
+  camunda.io/created-by: __AUTHOR__
+  camunda.io/purpose: load-test
+
+image:
+  # Route through colocated GAR pull-through cache to avoid quay.io rate limiting
+  # Original: quay.io/prometheuscommunity/elasticsearch-exporter
+  repository: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter"
+  # Set your specific exporter version here
+  tag: "v1.10.0"
+
+log:
+  format: json
+
+serviceMonitor:
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: true
+  # Labels used by the service monitor, specific to our prometheus installation
+  labels:
+    release: monitoring
+
+nodeSelector:
+  topology.kubernetes.io/zone: __AVAILABILITY_ZONE__

--- a/load-tests/setup/stable-87/values/values-stable.yaml
+++ b/load-tests/setup/stable-87/values/values-stable.yaml
@@ -1,0 +1,34 @@
+# Additional values file to run on stable VMs
+# Scheduling on stable VMs is useful to observe long-term behavior, such as memory leaks, etc.
+# https://github.com/camunda/camunda-platform-helm/blob/22051fea1fbd831171cce58292ea53ee2593d8b4/charts/camunda-platform-8.7/values.yaml#L969-L972
+zeebe:
+  # Require n2-standard-4-stable to ensure the broker is the only application running on its node
+  nodeSelector:
+    component: benchmark-n2-standard-4-stable
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-4-stable
+    effect: NoSchedule
+
+# Support of 10.x camunda platform
+zeebeGateway:
+  # Prefer scheduling on any non-spot VM
+  # GKE does not let us add the cloud.google.com/gke-spot label manually, so when an instance is
+  # not a spot VM, that node label simply is not present. When it is a spot VM, then the value is
+  # set to true.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: cloud.google.com/gke-spot
+                operator: DoesNotExist
+
+  tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-4-stable
+    effect: NoSchedule


### PR DESCRIPTION
## Summary

Adds `load-tests/setup/stable-87/` — a copy of `stable/8.7:load-tests/setup/default/` and `stable/8.7:load-tests/setup/newLoadTest.sh` with:
- ROOT_DIR sourcing pattern
- `set -exo` → `set -eo` (xtrace removed — prevents secret leakage into GHA logs)
- Extra `enable_webapps` parameter preserved (8.7-specific)
- elasticsearch-only (no opensearch/none/rdbms)

## Reviewer verification

```bash
git diff origin/stable/8.7:load-tests/setup/default/ load-tests/setup/stable-87/
git diff origin/stable/8.7:load-tests/setup/newLoadTest.sh load-tests/setup/stable-87/newLoadTest.sh
```

Refs: https://github.com/camunda/camunda/issues/54235

🤖 Generated with [Claude Code](https://claude.com/claude-code)