### PR TITLE
ci: sparse-checkout stable-88 setup from main (stable/8.8)

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -460,6 +460,7 @@ jobs:
             load-tests/setup/stable-88
             load-tests/setup/newLoadTest.sh
             load-tests/setup/utils.sh
+            .github/actions
       # camunda-platform-8.10 requires Helm CLI v4; runners ship v3.x.
       - name: Set up Helm
         uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -455,7 +455,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: main
+          sparse-checkout: |
+            load-tests/setup/stable-88
+            load-tests/setup/newLoadTest.sh
+            load-tests/setup/utils.sh
       # camunda-platform-8.10 requires Helm CLI v4; runners ship v3.x.
       - name: Set up Helm
         uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
@@ -513,7 +517,7 @@ jobs:
           git config user.name ${{ github.actor }}
           # Render the load-test folder. newLoadTest.sh no longer creates the namespace — that
           # happens on `make install` via `kubectl apply -f resources/namespace.yaml`.
-          ./newLoadTest.sh ${{ env.NAMESPACE }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
+          ./newLoadTest.sh --target-version stable-88 ${{ env.NAMESPACE }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
       - name: Install latest Camunda Platform
         run: |
           cd load-tests/setup/${{ env.NAMESPACE }}


### PR DESCRIPTION
## Summary

Updates the install job in `camunda-load-test.yml` to sparse-checkout `load-tests/setup/stable-88/` from `main` instead of the full `stable/8.8` checkout. The scaffold step now calls `./newLoadTest.sh --target-version stable-88`.

**Prerequisite:** `ck-stable-88` (#55308) must merge before this PR can merge.

## Reviewer verification

```bash
git diff origin/stable/8.8 -- .github/workflows/camunda-load-test.yml
```

Refs: https://github.com/camunda/camunda/issues/54235

🤖 Generated with [Claude Code](https://claude.com/claude-code)