### PR TITLE
ci: route build-*-frontend and Harbor build failures to core-features-medic

### DIFF
--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -50,6 +50,7 @@ env:
   MEDIC_TEST_AUTOMATION: '<!subteam^S09UF0EV0HG|test-automation-medic>'
   MEDIC_DISTRIBUTION: '<!subteam^S053K7C7QKU|distribution-medic>'
   MEDIC_MONOREPO_DEVOPS: '<!subteam^S07D6C6B18T|monorepo-devops-medic>'
+  MEDIC_CORE_FEATURES: '<!subteam^S08P2CU9V8W|core-features-medic>'
   # Marker used in the Slack message text so subsequent runs can find
   # their own previous message via conversations.history. Includes the
   # base ref so concurrent streaks on `main` and `stable/x` don't
@@ -317,6 +318,9 @@ jobs:
                 ;;
               "@camunda/monorepo-devops-team")
                 mentions+=("${MEDIC_MONOREPO_DEVOPS}")
+                ;;
+              "@camunda/core-features")
+                mentions+=("${MEDIC_CORE_FEATURES}")
                 ;;
             esac
           done <<<"$OWNERS"

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -270,7 +270,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/monorepo-devops-team"
+            OWNER_TEAM="@camunda/core-features"
             FAILURE_CATEGORY="orchestration_frontend_build"
           fi
           jq -n \
@@ -326,7 +326,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/monorepo-devops-team"
+            OWNER_TEAM="@camunda/core-features"
             FAILURE_CATEGORY="orchestration_frontend_build"
           fi
           jq -n \
@@ -382,7 +382,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/monorepo-devops-team"
+            OWNER_TEAM="@camunda/core-features"
             FAILURE_CATEGORY="orchestration_frontend_build"
           fi
           jq -n \
@@ -532,7 +532,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/monorepo-devops-team"
+            OWNER_TEAM="@camunda/core-features"
             FAILURE_CATEGORY="orchestration_build_and_push"
           fi
           jq -n \


### PR DESCRIPTION
## What
Routes failures of the **frontend build jobs** (`build-operate-frontend`, `build-tasklist-frontend`, `build-identity-frontend`) and the **Harbor image build/push job** in `docker-build-helm-integration.yml` to the **core features medic** (`<!subteam^S08P2CU9V8W|core-features-medic>`).

## How
AlwaysGreen pings the medic that owns a failed job, derived from the `owner_team` each job writes into its `alwaysgreen-failure-context` artifact, which `alwaysgreen-streak-detector.yml` maps to a Slack subteam.

- `docker-build-helm-integration.yml`: change `owner_team`/`escalation_team` for the four jobs from `@camunda/monorepo-devops-team` to `@camunda/core-features` (only in the `orchestration_frontend_build` and `orchestration_build_and_push` failure-context steps; other jobs unchanged).
- `alwaysgreen-streak-detector.yml`: add `MEDIC_CORE_FEATURES` (subteam `S08P2CU9V8W`) and a `@camunda/core-features` case to the owner→medic map. Without this the retagged failures would map to no medic.

`@camunda/core-features` → `core-features-medic` is the canonical mapping already in `.ci/scripts/ci/setup-medic-lookup.sh`.

Targets `stable/8.9`. Companion PRs open against main + stable/8.7–8.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)