### PR TITLE
feat: forward physical tenant to broker requests in gRPC gateway

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -72,6 +72,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRespo
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutResponse;
 import io.camunda.zeebe.gateway.validation.VariableNameLengthValidator;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.util.VersionUtil;
 import io.grpc.Context;
@@ -80,6 +81,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -534,9 +536,8 @@ public final class EndpointManager {
     final BrokerRequest<BrokerResponseT> brokerRequest = requestMapper.apply(grpcRequest);
     brokerRequest.setAuthorization(getClaims());
     final String physicalTenantId = getPhysicalTenantId();
-    if (physicalTenantId != null) {
-      brokerRequest.setPartitionGroup(physicalTenantId);
-    }
+    brokerRequest.setPartitionGroup(
+        Objects.requireNonNullElse(physicalTenantId, Protocol.DEFAULT_PARTITION_GROUP_NAME));
     return brokerRequest;
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.gateway.impl.broker.RequestRetryHandler;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.stream.StreamJobsHandler;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
@@ -532,7 +533,21 @@ public final class EndpointManager {
 
     final BrokerRequest<BrokerResponseT> brokerRequest = requestMapper.apply(grpcRequest);
     brokerRequest.setAuthorization(getClaims());
+    final String physicalTenantId = getPhysicalTenantId();
+    if (physicalTenantId != null) {
+      brokerRequest.setPartitionGroup(physicalTenantId);
+    }
     return brokerRequest;
+  }
+
+  /**
+   * Returns the physical tenant id resolved by the {@code PhysicalTenantInterceptor} and stored in
+   * the gRPC {@link Context}, or {@code null} when no interceptor populated it (e.g. in tests that
+   * invoke the endpoint without the interceptor chain). The id doubles as the partition group name
+   * the request is dispatched to; a {@code null} leaves the request's default group unchanged.
+   */
+  private String getPhysicalTenantId() throws Exception {
+    return Context.current().call(InterceptorUtil.getPhysicalTenantIdKey()::get);
   }
 
   private Map<String, Object> getClaims() throws Exception {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/GatewayTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/GatewayTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.api.util;
 
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.gateway.api.util.StubbedGateway.StubbedJobStreamer;
@@ -35,9 +36,18 @@ public abstract class GatewayTest {
   protected StubbedJobStreamer jobStreamer;
 
   public GatewayTest(final GatewayCfg config, final EngineSecurityConfig securityConfiguration) {
+    this(config, securityConfiguration, PhysicalTenantIds.DEFAULT);
+  }
+
+  public GatewayTest(
+      final GatewayCfg config,
+      final EngineSecurityConfig securityConfiguration,
+      final PhysicalTenantIds physicalTenantIds) {
     actorClock = new ControlledActorClock();
     actorSchedulerRule = new ActorSchedulerRule(actorClock);
-    gatewayRule = new StubbedGatewayRule(actorSchedulerRule, config, securityConfiguration);
+    gatewayRule =
+        new StubbedGatewayRule(
+            actorSchedulerRule, config, securityConfiguration, physicalTenantIds);
     ruleChain = RuleChain.outerRule(actorSchedulerRule).around(gatewayRule);
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.api.util;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.Claim;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.configuration.EngineSecurityConfig;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationMetrics;
+import io.camunda.zeebe.gateway.interceptors.impl.PhysicalTenantInterceptor;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
@@ -78,6 +80,7 @@ public final class StubbedGateway {
   private final ActorScheduler actorScheduler;
   private final GatewayCfg config;
   private final EngineSecurityConfig securityConfiguration;
+  private final PhysicalTenantIds physicalTenantIds;
   private Server server;
 
   public StubbedGateway(
@@ -85,12 +88,14 @@ public final class StubbedGateway {
       final StubbedBrokerClient brokerClient,
       final StubbedJobStreamer jobStreamer,
       final GatewayCfg config,
-      final EngineSecurityConfig securityConfiguration) {
+      final EngineSecurityConfig securityConfiguration,
+      final PhysicalTenantIds physicalTenantIds) {
     this.actorScheduler = actorScheduler;
     this.brokerClient = brokerClient;
     this.jobStreamer = jobStreamer;
     this.config = config;
     this.securityConfiguration = securityConfiguration;
+    this.physicalTenantIds = physicalTenantIds;
   }
 
   public void start() throws IOException {
@@ -108,6 +113,9 @@ public final class StubbedGateway {
             .addService(
                 ServerInterceptors.intercept(
                     gatewayGrpcService,
+                    // listed inner-to-outer: authentication runs first, then physical tenant
+                    // resolution, mirroring the real Gateway interceptor chain
+                    new PhysicalTenantInterceptor(physicalTenantIds),
                     new AuthenticationInterceptor(
                         new AuthenticationHandler.Oidc(
                             new FakeJwtDecoder(),

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGatewayRule.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGatewayRule.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.api.util;
 
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.gateway.RequestMapper;
 import io.camunda.zeebe.gateway.api.util.StubbedGateway.StubbedJobStreamer;
@@ -26,23 +27,31 @@ public final class StubbedGatewayRule extends ExternalResource {
   private final EngineSecurityConfig securityConfiguration;
   private final StubbedBrokerClient brokerClient;
   private final StubbedJobStreamer jobStreamer;
+  private final PhysicalTenantIds physicalTenantIds;
 
   public StubbedGatewayRule(
       final ActorSchedulerRule actorSchedulerRule,
       final GatewayCfg config,
-      final EngineSecurityConfig securityConfiguration) {
+      final EngineSecurityConfig securityConfiguration,
+      final PhysicalTenantIds physicalTenantIds) {
     this.actorSchedulerRule = actorSchedulerRule;
     brokerClient = new StubbedBrokerClient();
     jobStreamer = new StubbedJobStreamer();
     this.config = config;
     this.securityConfiguration = securityConfiguration;
+    this.physicalTenantIds = physicalTenantIds;
   }
 
   @Override
   protected void before() throws Throwable {
     gateway =
         new StubbedGateway(
-            actorSchedulerRule.get(), brokerClient, jobStreamer, config, securityConfiguration);
+            actorSchedulerRule.get(),
+            brokerClient,
+            jobStreamer,
+            config,
+            securityConfiguration,
+            physicalTenantIds);
     gateway.start();
     client = gateway.buildClient();
     asyncClient = gateway.buildAsyncClient();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestPhysicalTenantRoutingTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestPhysicalTenantRoutingTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
 import io.camunda.zeebe.protocol.Protocol;
 import io.grpc.Metadata;
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.MetadataUtils;
 import java.util.Set;
@@ -81,9 +82,12 @@ public class BrokerRequestPhysicalTenantRoutingTest extends GatewayTest {
     // when / then
     assertThatThrownBy(
             () -> unknownClient.completeJob(CompleteJobRequest.newBuilder().setJobKey(1L).build()))
-        .isInstanceOf(StatusRuntimeException.class)
-        .hasMessageContaining("NOT_FOUND")
-        .hasMessageContaining("unknown-tenant");
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            e -> {
+              assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND);
+              assertThat(e.getStatus().getDescription()).contains("unknown-tenant");
+            });
     assertThat(brokerClient.getBrokerRequests()).isEmpty();
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestPhysicalTenantRoutingTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestPhysicalTenantRoutingTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.gateway.api.job.CompleteJobStub;
+import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
+import io.camunda.zeebe.protocol.Protocol;
+import io.grpc.Metadata;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * End-to-end test of physical tenant routing through the real gRPC interceptor chain: a client sets
+ * the {@code Camunda-Physical-Tenant} header, the {@code PhysicalTenantInterceptor} resolves and
+ * validates it into the gRPC context, and the {@link io.camunda.zeebe.gateway.EndpointManager}
+ * forwards it onto the {@link BrokerRequest} as the partition group it is dispatched to.
+ */
+public class BrokerRequestPhysicalTenantRoutingTest extends GatewayTest {
+
+  private static final String KNOWN_TENANT = "tenant-a";
+  private static final Metadata.Key<String> PHYSICAL_TENANT_HEADER =
+      Metadata.Key.of("Camunda-Physical-Tenant", Metadata.ASCII_STRING_MARSHALLER);
+
+  public BrokerRequestPhysicalTenantRoutingTest() {
+    super(
+        new GatewayCfg(),
+        EngineSecurityConfigurations.defaultConfig(),
+        () -> Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, KNOWN_TENANT));
+  }
+
+  @Before
+  public void setup() {
+    new CompleteJobStub().registerWith(brokerClient);
+  }
+
+  @Test
+  public void shouldRouteRequestToPhysicalTenantPartitionGroup() {
+    // given
+    final GatewayBlockingStub tenantClient = withPhysicalTenant(KNOWN_TENANT);
+
+    // when
+    tenantClient.completeJob(CompleteJobRequest.newBuilder().setJobKey(1L).build());
+
+    // then
+    final BrokerRequest<?> brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getPartitionGroup()).isEqualTo(KNOWN_TENANT);
+  }
+
+  @Test
+  public void shouldRouteToDefaultPartitionGroupWhenHeaderAbsent() {
+    // when no Camunda-Physical-Tenant header is sent
+    client.completeJob(CompleteJobRequest.newBuilder().setJobKey(1L).build());
+
+    // then
+    final BrokerRequest<?> brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getPartitionGroup()).isEqualTo(Protocol.DEFAULT_PARTITION_GROUP_NAME);
+  }
+
+  @Test
+  public void shouldRejectRequestForUnknownPhysicalTenant() {
+    // given
+    final GatewayBlockingStub unknownClient = withPhysicalTenant("unknown-tenant");
+
+    // when / then
+    assertThatThrownBy(
+            () -> unknownClient.completeJob(CompleteJobRequest.newBuilder().setJobKey(1L).build()))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("NOT_FOUND")
+        .hasMessageContaining("unknown-tenant");
+    assertThat(brokerClient.getBrokerRequests()).isEmpty();
+  }
+
+  private GatewayBlockingStub withPhysicalTenant(final String physicalTenantId) {
+    final Metadata headers = new Metadata();
+    headers.put(PHYSICAL_TENANT_HEADER, physicalTenantId);
+    return client.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers));
+  }
+}


### PR DESCRIPTION
Implements #50536: the gRPC gateway now dispatches a request to the partition group of the physical tenant the client targeted.

The `PhysicalTenantInterceptor` (#55220) already resolves the `Camunda-Physical-Tenant`
header into the gRPC `Context`, and the `BrokerClient` dispatch path (#50519, already on
`main`) is partition-group aware, but nothing connected the two, so every request was
still routed to the `default` group. This PR closes that gap:

- `EndpointManager.mapToBrokerRequest()` reads the resolved physical tenant id from the
  context and sets it as the `BrokerRequest`'s partition group. A physical tenant is
  implemented as a Raft partition group of the same name, so the id is used directly. This
  one seam covers every unary command and `activateJobs`. When no id is present (endpoint
  invoked without the interceptor chain) the request keeps its default group.

## Tests

- `EndpointManagerPhysicalTenantTest` — unit test of the seam: a context-bound physical
  tenant id becomes the broker request's partition group; absence keeps the default.
- `BrokerRequestPhysicalTenantRoutingTest` — end-to-end over in-process gRPC through the
  real interceptor chain (header → `PhysicalTenantInterceptor` → context → `EndpointManager`
  → partition group), including rejection of an unknown tenant. The `StubbedGateway` harness
  now installs the `PhysicalTenantInterceptor`, mirroring the real `Gateway`.

## Out of scope

- The `topology()` RPC (per-group topology) is deferred to a separate issue.
- `streamActivatedJobs` (job streaming) is out of M1 scope.

## Note

Stacked on #55220 since it depends on the server interceptor.

Closes #50536