### PR TITLE
docs: add @since 8.10 annotations to new TimerRecordValue fields

### DIFF
--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TimerRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TimerRecordValue.java
@@ -33,6 +33,7 @@ public interface TimerRecordValue
   /**
    * @return the BPMN element type of the timer element (e.g. INTERMEDIATE_CATCH_EVENT,
    *     BOUNDARY_EVENT, START_EVENT), or UNSPECIFIED if unknown.
+   * @since 8.10
    */
   BpmnElementType getElementType();
 
@@ -74,12 +75,14 @@ public interface TimerRecordValue
 
   /**
    * @return the root process instance key, or -1L if this is a start-event subscription
+   * @since 8.10
    */
   @Override
   long getRootProcessInstanceKey();
 
   /**
    * @return the BPMN process id of the process that owns this timer
+   * @since 8.10
    */
   @Override
   String getBpmnProcessId();
@@ -87,6 +90,8 @@ public interface TimerRecordValue
   /**
    * Delegates to {@link #getTargetElementId()}: the target element id IS the BPMN element id of the
    * timer catch/boundary event.
+   *
+   * @since 8.10
    */
   @Override
   default String getElementId() {


### PR DESCRIPTION
## Description

Add `@since 8.10` annotations to new TimerRecordValue fields.

## Related issues

related to https://github.com/camunda/camunda/issues/51977
