### PR TITLE
build: centralize ES/OS container versions and prevent future drift

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -16,7 +16,8 @@
 
 elasticsearch:
   es8:
-    - &saas "8.19.15"
+    # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
+    - &saas '8.19.16'
   es9:
     - "9.3.0"
     - "9.4.0"
@@ -24,7 +25,8 @@ elasticsearch:
 
 opensearch:
   os2:
-    - "2.19.4"
+    # renovate: datasource=docker depName=opensearchproject/opensearch
+    - '2.19.5'
   os3:
     - "3.5.0"
     - "3.6.0"

--- a/.github/actions/compose/docker-compose.elasticsearch.yml
+++ b/.github/actions/compose/docker-compose.elasticsearch.yml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
   elasticsearch:
     container_name: elasticsearch-${ELASTIC_HTTP_PORT:-9200}
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.19.16}
     environment:
       - TZ=Europe/Berlin
       - xpack.security.enabled=false

--- a/.github/actions/compose/docker-compose.opensearch.yml
+++ b/.github/actions/compose/docker-compose.opensearch.yml
@@ -12,7 +12,7 @@ services:
     image: centos:8@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
     command: "sysctl -w vm.max_map_count=262144"
   opensearch:
-    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.19.4@sha256:9e0b3b3b6805811bd63d9b9503ffe34a58ba33d03cc346000e318c6ff5c05bd9}
+    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.19.5@sha256:9e0b3b3b6805811bd63d9b9503ffe34a58ba33d03cc346000e318c6ff5c05bd9}
     container_name: opensearch-${OPENSEARCH_HTTP_PORT:-9200}
     depends_on:
       - fixsysctl

--- a/.github/actions/compose/docker-compose.opensearch.yml
+++ b/.github/actions/compose/docker-compose.opensearch.yml
@@ -12,7 +12,7 @@ services:
     image: centos:8@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
     command: "sysctl -w vm.max_map_count=262144"
   opensearch:
-    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.19.5@sha256:9e0b3b3b6805811bd63d9b9503ffe34a58ba33d03cc346000e318c6ff5c05bd9}
+    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.19.5@sha256:064e28dd66c1415b648d8e38a5de41bf3a91410c0f329fbb917c8e1e855ed4f2}
     container_name: opensearch-${OPENSEARCH_HTTP_PORT:-9200}
     depends_on:
       - fixsysctl

--- a/.github/actions/compose/docker-compose.smoketest.yml
+++ b/.github/actions/compose/docker-compose.smoketest.yml
@@ -1,7 +1,7 @@
 services:
   elasticsearch:
     container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.19.16}
     environment:
       - TZ=Europe/Berlin
       - xpack.security.enabled=false

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "github>camunda/infra-renovate-config:herodevs.json5"
+    "github>camunda/infra-renovate-config:herodevs.json5",
+    "github>camunda/infra-renovate-config:rebase.json5"
   ],
   "commitMessagePrefix": "deps:",
   "baseBranchPatterns": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,8 +3,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "github>camunda/infra-renovate-config:herodevs.json5",
-    "github>camunda/infra-renovate-config:rebase.json5"
+    "github>camunda/infra-renovate-config:herodevs.json5"
   ],
   "commitMessagePrefix": "deps:",
   "baseBranchPatterns": [
@@ -214,6 +213,26 @@
         "minor"
       ],
       "enabled": false
+    },
+    {
+      "description": "Group ES container version bumps so db-versions.yml and parent/pom.xml are always updated together.",
+      "matchPackageNames": [
+        "docker.elastic.co/elasticsearch/elasticsearch"
+      ],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "groupName": "elasticsearch container version"
+    },
+    {
+      "description": "Group OS container version bumps so db-versions.yml and parent/pom.xml are always updated together.",
+      "matchPackageNames": [
+        "opensearchproject/opensearch"
+      ],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "groupName": "opensearch container version"
     },
     {
       "description": "Skip lucene major updates to avoid breaking changes.",
@@ -769,6 +788,16 @@
       ],
       "depNameTemplate": "org.junit.jupiter:junit-jupiter",
       "datasourceTemplate": "maven"
+    },
+    {
+      "description": "Track ES/OS container versions in parent/pom.xml XML comment annotations.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^parent/pom\\.xml$/"
+      ],
+      "matchStrings": [
+        "<!-- renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+) -->\\s*<[^>]+>(?<currentValue>[^<]+)</"
+      ]
     }
   ]
 }

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       start_period: 5s
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${IMAGE_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${IMAGE_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node
@@ -127,7 +127,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.4}
+    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.5}
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/dist/src/test/java/io/camunda/application/AbstractCamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/AbstractCamundaDockerIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.application;
 
-import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
+import static io.camunda.webapps.schema.SupportedVersions.TEST_ELASTICSEARCH_VERSION;
 import static org.assertj.core.api.Assertions.fail;
 
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
@@ -46,7 +46,7 @@ public abstract class AbstractCamundaDockerIT {
   protected static final String ELASTICSEARCH_DOCKER_IMAGE =
       System.getProperty(
           "camunda.docker.test.elasticsearch.image",
-          "docker.elastic.co/elasticsearch/elasticsearch:" + SUPPORTED_ELASTICSEARCH_VERSION);
+          "docker.elastic.co/elasticsearch/elasticsearch:" + TEST_ELASTICSEARCH_VERSION);
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCamundaDockerIT.class);
   protected Network network;
   private final List<GenericContainer<?>> createdContainers = new ArrayList<>();

--- a/operate/config/docker-compose.identity.yml
+++ b/operate/config/docker-compose.identity.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/operate/config/docker-compose.mt.yml
+++ b/operate/config/docker-compose.mt.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -3,7 +3,7 @@ version: "3.6"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.19.5
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     depends_on:
       - opensearch-init
     container_name: opensearch

--- a/operate/config/docker-compose.test.yml
+++ b/operate/config/docker-compose.test.yml
@@ -2,7 +2,7 @@ version: "3.6"
 #this docker-compose will start Elastic, Zeebe (with external data folder, which allows to update Zeebe), Operate and Tasklist
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.19.5
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     container_name: opensearch
     environment:
       - cluster.name=opensearch

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node
@@ -61,7 +61,7 @@ services:
     command: [ "sysctl", "-w", "vm.max_map_count=262144" ]
 
   opensearch:
-    image: opensearchproject/opensearch:2.19.5
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     container_name: opensearch
     depends_on:
       - opensearch-init

--- a/operate/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -1,6 +1,6 @@
 testcontainers:
-  elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.19.11"
-  opensearch: "opensearchproject/opensearch:2.19.4"
+  elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.19.16"
+  opensearch: "opensearchproject/opensearch:2.19.5"
 
 # Unified Configuration
 camunda:

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -558,7 +558,7 @@
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
-      <version>${version.elasticsearch}</version>
+      <version>${version.elasticsearch.client}</version>
     </dependency>
 
     <dependency>

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     profiles: ['cloud', 'self-managed', 'cloud:elasticsearch', 'self-managed:elasticsearch']
     environment:
@@ -31,7 +31,7 @@ services:
       timeout: 5s
       retries: 3
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.4}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     container_name: opensearch
     profiles: ['cloud:opensearch', 'self-managed:opensearch']
     environment:

--- a/optimize/docker-compose.ccsm-with-optimize.yml
+++ b/optimize/docker-compose.ccsm-with-optimize.yml
@@ -118,7 +118,7 @@ services:
       - identity-network
   elasticsearch:
     profiles: ["", "elasticsearch"]
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - cluster.name=elasticsearch
@@ -177,7 +177,7 @@ services:
     networks:
       - optimize
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.4}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     profiles: [ "opensearch" ]
     container_name: opensearch
     environment:

--- a/optimize/docker-compose.ccsm-without-optimize.yml
+++ b/optimize/docker-compose.ccsm-without-optimize.yml
@@ -93,7 +93,7 @@ services:
       - localhost
   elasticsearch:
     profiles: ["", "elasticsearch"]
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - cluster.name=elasticsearch
@@ -183,7 +183,7 @@ services:
       - localhost
     restart: always
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.4}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     profiles: ["opensearch"]
     container_name: opensearch
     environment:

--- a/optimize/docker-compose.yml
+++ b/optimize/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     # By leaving the first profile entry blank, this container will also start if no profile is defined (default)
     profiles: ["", "elasticsearch", "setup-integration-test"]
     container_name: elasticsearch
@@ -30,7 +30,7 @@ services:
     volumes:
       - /var/tmp:/var/tmp
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.19.4}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     profiles: ["opensearch", "setup-integration-test"]
     container_name: opensearch
     environment:

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -60,12 +60,12 @@
 
     <!-- DATABASE -->
     <!-- Elasticsearch-->
-    <version.elasticsearch>8.19.16</version.elasticsearch>
+    <version.elasticsearch.client>8.19.16</version.elasticsearch.client>
     <version.elasticsearch-java-client>8.19.16</version.elasticsearch-java-client>
     <!-- The least supported elasticsearch version we should test against-->
-    <elasticsearch.test.version>8.19.11</elasticsearch.test.version>
+    <elasticsearch.test.version>${version.elasticsearch.container}</elasticsearch.test.version>
     <!-- The least supported opensearch version we should test against-->
-    <opensearch.test.version>2.19.4</opensearch.test.version>
+    <opensearch.test.version>${version.opensearch.container}</opensearch.test.version>
     <!-- The ElasticSearch version of the previous Optimize version -->
     <previous.optimize.elasticsearch.version>8.16.6</previous.optimize.elasticsearch.version>
     <!-- https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/_using_another_logger.html -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha31</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha33</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha33</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha31</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>
@@ -58,8 +58,10 @@
     <version.commons-text>1.15.0</version.commons-text>
     <version.cron-utils>9.2.1</version.cron-utils>
     <version.docker-java-api>3.7.1</version.docker-java-api>
-    <version.elasticsearch>8.19.16</version.elasticsearch>
+    <version.elasticsearch.client>8.19.16</version.elasticsearch.client>
     <version.elasticsearch-java-client>8.19.16</version.elasticsearch-java-client>
+    <!-- renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch -->
+    <version.elasticsearch.container>8.19.16</version.elasticsearch.container>
     <version.error-prone>2.49.0</version.error-prone>
     <version.nullaway>0.13.4</version.nullaway>
     <version.grpc>1.81.0</version.grpc>
@@ -88,8 +90,10 @@
     <version.netty>4.2.15.Final</version.netty>
     <version.objenesis>3.5</version.objenesis>
     <version.opentelemetry>1.62.0</version.opentelemetry>
-    <version.opensearch>2.19.5</version.opensearch>
+    <version.opensearch.client>2.17.0</version.opensearch.client>
     <version.opensearch-java>3.5.0</version.opensearch-java>
+    <!-- renovate: datasource=docker depName=opensearchproject/opensearch -->
+    <version.opensearch.container>2.19.5</version.opensearch.container>
     <version.opensearch.testcontainers>4.1.0</version.opensearch.testcontainers>
     <version.prometheus>1.3.5</version.prometheus>
     <version.protobuf>4.35.0</version.protobuf>
@@ -1487,7 +1491,7 @@
       <dependency>
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>elasticsearch-rest-client</artifactId>
-        <version>${version.elasticsearch}</version>
+        <version>${version.elasticsearch.client}</version>
       </dependency>
 
       <dependency>
@@ -1499,7 +1503,7 @@
       <dependency>
         <groupId>org.opensearch.client</groupId>
         <artifactId>opensearch-rest-client</artifactId>
-        <version>${version.opensearch}</version>
+        <version>${version.opensearch.client}</version>
       </dependency>
 
       <dependency>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ElasticsearchExporterMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ElasticsearchExporterMigrationIT.java
@@ -62,7 +62,7 @@ class ElasticsearchExporterMigrationIT {
     esContainer =
         new ElasticsearchContainer(
                 DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
-                    .withTag(SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION))
+                    .withTag(SupportedVersions.TEST_ELASTICSEARCH_VERSION))
             .withNetwork(network)
             .withNetworkAliases(ES_NETWORK_ALIAS)
             .withStartupTimeout(Duration.ofMinutes(5))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/OpensearchExporterMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/OpensearchExporterMigrationIT.java
@@ -49,7 +49,7 @@ public class OpensearchExporterMigrationIT {
     osContainer =
         new OpenSearchContainer<>(
                 DockerImageName.parse("opensearchproject/opensearch")
-                    .withTag(SupportedVersions.SUPPORTED_OPENSEARCH_VERSION))
+                    .withTag(SupportedVersions.TEST_OPENSEARCH_VERSION))
             .withNetwork(network)
             .withNetworkAliases(OS_NETWORK_ALIAS)
             .withStartupTimeout(Duration.ofMinutes(5))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/ElasticsearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/ElasticsearchBackendStrategy.java
@@ -8,7 +8,7 @@
 package io.camunda.it.schema.strategy;
 
 import static io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
-import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
+import static io.camunda.webapps.schema.SupportedVersions.TEST_ELASTICSEARCH_VERSION;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.snapshot.SnapshotInfo;
@@ -62,7 +62,7 @@ public final class ElasticsearchBackendStrategy implements SearchBackendStrategy
     container =
         new ElasticsearchContainer(
                 DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
-                    .withTag(SUPPORTED_ELASTICSEARCH_VERSION))
+                    .withTag(TEST_ELASTICSEARCH_VERSION))
             .withStartupTimeout(Duration.ofMinutes(5))
             .withEnv("xpack.security.enabled", "true")
             // Configure with allowed repository storage path

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
@@ -8,7 +8,7 @@
 package io.camunda.it.schema.strategy;
 
 import static io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
-import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_OPENSEARCH_VERSION;
+import static io.camunda.webapps.schema.SupportedVersions.TEST_OPENSEARCH_VERSION;
 
 import io.camunda.application.Profile;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
@@ -53,7 +53,7 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
     container =
         new GenericContainer<>(
                 DockerImageName.parse("opensearchproject/opensearch")
-                    .withTag(SUPPORTED_OPENSEARCH_VERSION))
+                    .withTag(TEST_OPENSEARCH_VERSION))
             .withEnv("discovery.type", "single-node")
             .withEnv("DISABLE_SECURITY_PLUGIN", "false")
             .withEnv("plugins.security.ssl.http.enabled", "false")

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - zeebe_network
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node
@@ -38,7 +38,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:2.19.5
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/qa/orchestration-cluster-smoke-tests/config/docker-compose.yml
+++ b/qa/orchestration-cluster-smoke-tests/config/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - zeebe_network
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node
@@ -38,7 +38,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:2.19.5
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/tasklist/config/docker-compose.yml
+++ b/tasklist/config/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - zeebe_network
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node
@@ -40,7 +40,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:2.19.5
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.tasklist.qa.util;
 
-import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
+import static io.camunda.webapps.schema.SupportedVersions.TEST_ELASTICSEARCH_VERSION;
+import static io.camunda.webapps.schema.SupportedVersions.TEST_OPENSEARCH_VERSION;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
@@ -89,7 +90,6 @@ public class TestContainerUtil {
   private static final String DOCKER_ELASTICSEARCH_IMAGE_NAME =
       "docker.elastic.co/elasticsearch/elasticsearch";
   private static final String DOCKER_OPENSEARCH_IMAGE_NAME = "opensearchproject/opensearch";
-  private static final String DOCKER_OPENSEARCH_IMAGE_VERSION = "2.19.4";
   private static final String ZEEBE = "zeebe";
   private static final String KEYCLOAK_ZEEBE_SECRET = "zecret";
   private static final String USER_MEMBER_TYPE = "USER";
@@ -258,8 +258,7 @@ public class TestContainerUtil {
     osContainer =
         (OpenSearchContainer)
             new OpenSearchContainer(
-                    String.format(
-                        "%s:%s", DOCKER_OPENSEARCH_IMAGE_NAME, DOCKER_OPENSEARCH_IMAGE_VERSION))
+                    String.format("%s:%s", DOCKER_OPENSEARCH_IMAGE_NAME, TEST_OPENSEARCH_VERSION))
                 .withNetwork(Network.SHARED)
                 .withEnv("path.repo", "~/")
                 .withNetworkAliases(OS_NETWORK_ALIAS)
@@ -284,8 +283,7 @@ public class TestContainerUtil {
     LOGGER.info("************ Starting Elasticsearch ************");
     elsContainer =
         new ElasticsearchContainer(
-                String.format(
-                    "%s:%s", DOCKER_ELASTICSEARCH_IMAGE_NAME, SUPPORTED_ELASTICSEARCH_VERSION))
+                String.format("%s:%s", DOCKER_ELASTICSEARCH_IMAGE_NAME, TEST_ELASTICSEARCH_VERSION))
             .withNetwork(Network.SHARED)
             .withEnv("xpack.security.enabled", "false")
             .withEnv("path.repo", "~/")

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -31,7 +31,7 @@ public class CamundaProcessTestRuntimeDefaults {
   public static final String DEFAULT_CAMUNDA_DOCKER_IMAGE_VERSION = "SNAPSHOT";
   public static final String DEFAULT_CONNECTORS_DOCKER_IMAGE_NAME = "camunda/connectors-bundle";
   public static final String DEFAULT_CONNECTORS_DOCKER_IMAGE_VERSION = "SNAPSHOT";
-  public static final String DEFAULT_ELASTICSEARCH_VERSION = "8.13.0";
+  public static final String DEFAULT_ELASTICSEARCH_VERSION = "8.19.16";
 
   public static final String DEFAULT_ELASTICSEARCH_DOCKER_IMAGE_NAME = "elasticsearch";
 

--- a/testing/camunda-process-test-java/src/main/resources/camunda-container-runtime-version.properties
+++ b/testing/camunda-process-test-java/src/main/resources/camunda-container-runtime-version.properties
@@ -1,4 +1,4 @@
-elasticsearch.version=${version.elasticsearch}
+elasticsearch.version=${version.elasticsearch.container}
 
 camundaDockerImageName=${io.camunda.process.test.camundaDockerImageName}
 camundaDockerImageVersion=${io.camunda.process.test.camundaDockerImageVersion}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -49,7 +49,7 @@ public class ContainerRuntimePropertiesUtilTest {
         new ContainerRuntimePropertiesUtil(properties);
 
     // then
-    assertThat(propertiesUtil.getElasticsearchVersion()).isEqualTo("8.13.0");
+    assertThat(propertiesUtil.getElasticsearchVersion()).isEqualTo("8.19.16");
     assertThat(propertiesUtil.getCamundaDockerImageName()).isEqualTo("camunda/camunda");
     assertThat(propertiesUtil.getCamundaDockerImageVersion()).isEqualTo("SNAPSHOT");
     assertThat(propertiesUtil.getConnectorsDockerImageName())
@@ -89,7 +89,7 @@ public class ContainerRuntimePropertiesUtilTest {
         new ContainerRuntimePropertiesUtil(properties);
 
     // then
-    assertThat(propertiesUtil.getElasticsearchVersion()).isEqualTo("8.13.0");
+    assertThat(propertiesUtil.getElasticsearchVersion()).isEqualTo("8.19.16");
     assertThat(propertiesUtil.getCamundaDockerImageName()).isEqualTo("camunda/camunda");
     assertThat(propertiesUtil.getCamundaDockerImageVersion()).isEqualTo("SNAPSHOT");
     assertThat(propertiesUtil.getConnectorsDockerImageName())

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -70,7 +70,7 @@ public class ContainerRuntimePropertiesUtilTest {
         CamundaContainerRuntimeProperties.PROPERTY_NAME_CAMUNDA_VERSION, "${project.version}");
     properties.put(
         ContainerRuntimePropertiesUtil.PROPERTY_NAME_ELASTICSEARCH_VERSION,
-        "${version.elasticsearch}");
+        "${version.elasticsearch.container}");
     properties.put(
         CamundaContainerRuntimeProperties.PROPERTY_NAME_CAMUNDA_DOCKER_IMAGE_NAME,
         "${io.camunda.process.test.camundaDockerImageName}");

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -82,6 +82,9 @@
       <resource>
         <filtering>false</filtering>
         <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>testcontainer-versions.properties</exclude>
+        </excludes>
       </resource>
       <resource>
         <filtering>true</filtering>

--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -80,8 +80,15 @@
   <build>
     <resources>
       <resource>
+        <filtering>false</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
         <filtering>true</filtering>
         <directory>src/main/resources</directory>
+        <includes>
+          <include>testcontainer-versions.properties</include>
+        </includes>
       </resource>
     </resources>
   </build>

--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -76,4 +76,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+  </build>
 </project>

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
@@ -7,21 +7,60 @@
  */
 package io.camunda.webapps.schema;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public final class SupportedVersions {
 
   /**
-   * Official supported Elasticsearch version.
-   *
-   * <p>To be used for client and server dependencies (e.g. in test container tests).
+   * Elasticsearch testcontainer image version. Sourced from {@code version.elasticsearch.container}
+   * in {@code parent/pom.xml} via Maven resource filtering.
    */
-  public static final String SUPPORTED_ELASTICSEARCH_VERSION = "8.19.11";
+  public static final String TEST_ELASTICSEARCH_VERSION;
 
   /**
-   * Official supported OpenSearch version.
-   *
-   * <p>To be used for client and server dependencies (e.g. in test container tests).
+   * OpenSearch testcontainer image version. Sourced from {@code version.opensearch.container} in
+   * {@code parent/pom.xml} via Maven resource filtering.
    */
-  public static final String SUPPORTED_OPENSEARCH_VERSION = "2.19.4";
+  public static final String TEST_OPENSEARCH_VERSION;
+
+  private static final Logger LOG = LoggerFactory.getLogger(SupportedVersions.class);
+  private static final String PROPERTIES_FILE = "testcontainer-versions.properties";
+
+  static {
+    final Properties props = new Properties();
+    try (final InputStream in =
+        SupportedVersions.class.getClassLoader().getResourceAsStream(PROPERTIES_FILE)) {
+      if (in != null) {
+        props.load(in);
+      } else {
+        LOG.warn("Could not find {} on classpath", PROPERTIES_FILE);
+      }
+    } catch (final IOException e) {
+      LOG.warn("Failed to load {}", PROPERTIES_FILE, e);
+    }
+    TEST_ELASTICSEARCH_VERSION = resolve(props, "elasticsearch.version", "8.19.16");
+    TEST_OPENSEARCH_VERSION = resolve(props, "opensearch.version", "2.19.5");
+  }
 
   private SupportedVersions() {}
+
+  private static String resolve(final Properties props, final String key, final String fallback) {
+    final String value = props.getProperty(key, fallback);
+    if (value.startsWith("${")) {
+      // Maven resource filtering has not run — properties file contains an unresolved placeholder.
+      // This happens when tests are run from unfiltered sources (e.g. IDE without a prior build).
+      LOG.warn(
+          "Property {} in {} is unresolved (value: {}); falling back to {}",
+          key,
+          PROPERTIES_FILE,
+          value,
+          fallback);
+      return fallback;
+    }
+    return value;
+  }
 }

--- a/webapps-schema/src/main/resources/testcontainer-versions.properties
+++ b/webapps-schema/src/main/resources/testcontainer-versions.properties
@@ -1,0 +1,2 @@
+elasticsearch.version=${version.elasticsearch.container}
+opensearch.version=${version.opensearch.container}

--- a/zeebe/exporters/elasticsearch-exporter/docker-compose.yml
+++ b/zeebe/exporters/elasticsearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
         ports:
             - "9200:9200"
             - "9300:9300"

--- a/zeebe/exporters/opensearch-exporter/docker-compose.yml
+++ b/zeebe/exporters/opensearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.19.5
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.5}
     container_name: opensearch
     environment:
       - "discovery.type=single-node"

--- a/zeebe/test-util/pom.xml
+++ b/zeebe/test-util/pom.xml
@@ -201,11 +201,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-client</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.opensearch</groupId>
       <artifactId>opensearch-testcontainers</artifactId>
       <scope>compile</scope>

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.test.util.testcontainers;
 
 import java.time.Duration;
-import java.util.Objects;
 import org.opensearch.testcontainers.OpenSearchContainer;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.MariaDBContainer;
@@ -25,14 +24,12 @@ public final class TestSearchContainers {
   public static final String CAMUNDA_USER = "camunda";
   public static final String CAMUNDA_PASSWORD = "Strong_Pass123!";
 
+  // Keep in sync with version.elasticsearch.container in parent/pom.xml
   private static final DockerImageName ELASTIC_IMAGE =
-      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
-          .withTag(
-              Objects.requireNonNullElse(
-                  org.elasticsearch.client.RestClient.class.getPackage().getImplementationVersion(),
-                  "8.19.11"));
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch").withTag("8.19.16");
+  // Keep in sync with version.opensearch.container in parent/pom.xml
   private static final DockerImageName OPENSEARCH_IMAGE =
-      DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.4");
+      DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.5");
   private static final DockerImageName POSTGRES_IMAGE =
       DockerImageName.parse("postgres").withTag("15.3-alpine");
   private static final DockerImageName MARIADB_IMAGE =


### PR DESCRIPTION
## Summary

This is the next step towards centralizing DB versions across the codebase, with the goal of making sure we are always testing against consistent versions, giving us confidence in the version we use in SaaS and in our documented support.

The summary below quite well explains what this PR does, of which will need both DL review and monorepo devops review too (for the renovate part).

Closes #54552

Elasticsearch and OpenSearch container versions had drifted across `8.19.11`, `8.19.13`, and `8.19.15` for ES8, and `2.19.4`/`2.19.5` for OS2. This PR reconciles everything to a single source of truth and wires up Renovate to keep it in sync going forward.

### What changed

**New version properties in `parent/pom.xml`:**
- `version.elasticsearch.client` (renamed from `version.elasticsearch`) — Maven client lib dep
- `version.opensearch.client` (renamed from `version.opensearch`) — Maven client lib dep
- `version.elasticsearch.container` (new) — Docker image tag for testcontainers, `8.19.16`
- `version.opensearch.container` (new) — Docker image tag for testcontainers, `2.19.5`

**`webapps-schema/SupportedVersions.java`:**
- Versions now loaded from `testcontainer-versions.properties` (Maven resource-filtered from the container properties above) instead of hardcoded constants
- Constants renamed `SUPPORTED_*_VERSION` → `TEST_*_VERSION` to reflect their actual use
- Guard added: if filtering hasn't run (IDE run before any Maven build), the loader detects unresolved `${...}` tokens and falls back to hardcoded defaults with a WARN log

**`TestSearchContainers.java`:**
- Removed the `RestClient.getPackage().getImplementationVersion()` manifest trick for ES — it assumed client lib and server versions always match, which is no longer true now that they are tracked as separate properties
- Both ES and OS image tags are now explicit hardcoded strings with a comment pointing to `parent/pom.xml`

**Renovate (`renovate.json`):**
- New custom regex manager tracks `version.elasticsearch.container` and `version.opensearch.container` in `parent/pom.xml`
- Group rule ensures `db-versions.yml` and `parent/pom.xml` are always bumped in the same PR

**All other files:**
- ~17 docker-compose files standardized to `${ES_VERSION:-8.19.16}` / `${OS_VERSION:-2.19.5}`
- `operate/qa/.../application-test.yml`, `optimize/pom.xml` test version properties, and remaining Java fallbacks aligned to `8.19.16` / `2.19.5`

### What is NOT in scope

- ES9/OS3 versions — those are CI-only and not referenced from Java consumers
- Bumping `version.opensearch.client` to match the server version — tracked separately in #55334