### PR TITLE
spike: physical-tenant routing of authorization reads (ADR-0005, reference only)

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -9,7 +9,6 @@ package io.camunda.authentication.service;
 
 import static io.camunda.service.authorization.Authorizations.COMPONENT_ACCESS_AUTHORIZATION;
 
-import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
@@ -20,6 +19,7 @@ import io.camunda.security.core.port.in.CamundaUserPort;
 import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -82,9 +82,7 @@ public class BasicCamundaUserService implements CamundaUserPort {
   protected UserEntity getUser(final CamundaAuthentication authentication) {
     final var username = authentication.authenticatedUsername();
     return serviceRegistry
-        .userServices(
-            PhysicalTenantIds
-                .DEFAULT_PHYSICAL_TENANT_ID) // TODO replace with contextual physicalTenantId
+        .userServices(PhysicalTenantContext.current())
         .getUser(username, CamundaAuthentication.anonymous());
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -10,7 +10,6 @@ package io.camunda.authentication.service;
 import static io.camunda.security.api.model.authz.EntityType.GROUP;
 import static io.camunda.security.api.model.authz.EntityType.MAPPING_RULE;
 
-import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.RoleEntity;
@@ -23,6 +22,7 @@ import io.camunda.security.core.port.out.MembershipQuery;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
@@ -65,9 +65,7 @@ public class DefaultMembershipService implements MembershipPort {
     }
     final var ids =
         serviceRegistry
-            .mappingRuleServices(
-                PhysicalTenantIds
-                    .DEFAULT_PHYSICAL_TENANT_ID) // TODO replace with contextual physicalTenantId
+            .mappingRuleServices(PhysicalTenantContext.current())
             .getMatchingMappingRules(query.tokenClaims(), CamundaAuthentication.anonymous())
             .map(MappingRuleEntity::mappingRuleId)
             .collect(Collectors.toSet());
@@ -90,9 +88,7 @@ public class DefaultMembershipService implements MembershipPort {
     final var owners = buildOwners(query);
     final var ids =
         serviceRegistry
-            .groupServices(
-                PhysicalTenantIds
-                    .DEFAULT_PHYSICAL_TENANT_ID) // TODO replace with contextual physicalTenantId
+            .groupServices(PhysicalTenantContext.current())
             .getGroupsByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous())
             .stream()
             .map(GroupEntity::groupId)
@@ -108,9 +104,7 @@ public class DefaultMembershipService implements MembershipPort {
     }
     final var ids =
         serviceRegistry
-            .roleServices(
-                PhysicalTenantIds
-                    .DEFAULT_PHYSICAL_TENANT_ID) // TODO replace with contextual physicalTenantId
+            .roleServices(PhysicalTenantContext.current())
             .getRolesByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous())
             .stream()
             .map(RoleEntity::roleId)
@@ -128,9 +122,7 @@ public class DefaultMembershipService implements MembershipPort {
       owners.put(EntityType.ROLE, new HashSet<>(query.resolvedRoleIds()));
     }
     return serviceRegistry
-        .tenantServices(
-            PhysicalTenantIds
-                .DEFAULT_PHYSICAL_TENANT_ID) // TODO replace with contextual physicalTenantId
+        .tenantServices(PhysicalTenantContext.current())
         .getTenantsByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous())
         .stream()
         .map(TenantEntity::tenantId)

--- a/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServicePhysicalTenantTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServicePhysicalTenantTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.core.port.out.MembershipPort.PrincipalType;
+import io.camunda.security.core.port.out.MembershipQuery;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.service.GroupServices;
+import io.camunda.service.MappingRuleServices;
+import io.camunda.service.RoleServices;
+import io.camunda.service.TenantServices;
+import io.camunda.service.registry.DefaultServiceRegistry;
+import io.camunda.spring.utils.PhysicalTenantContext;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * SPIKE (ADR-0005) <b>A.1 proof</b>: request-time identity and membership resolution routes to the
+ * in-context physical tenant via {@link PhysicalTenantContext#current()}.
+ *
+ * <p>These tests exercise the <b>real</b> thread-bound context (not a stubbed supplier) to confirm
+ * that each {@link DefaultMembershipService} lookup method dispatches to the {@link
+ * DefaultServiceRegistry} entry for the in-context tenant ("tenant-b"), and never touches the
+ * "default" tenant's services.
+ */
+@ExtendWith(MockitoExtension.class)
+final class DefaultMembershipServicePhysicalTenantTest {
+
+  // "tenant-b" services — the ones that must be invoked
+  @Mock private MappingRuleServices tenantBMappingRuleServices;
+  @Mock private GroupServices tenantBGroupServices;
+  @Mock private RoleServices tenantBRoleServices;
+  @Mock private TenantServices tenantBTenantServices;
+
+  // "default" services — must never be invoked
+  @Mock private MappingRuleServices defaultMappingRuleServices;
+  @Mock private GroupServices defaultGroupServices;
+  @Mock private RoleServices defaultRoleServices;
+  @Mock private TenantServices defaultTenantServices;
+
+  private DefaultMembershipService service;
+
+  @BeforeEach
+  void setUp() {
+    final var serviceRegistry =
+        DefaultServiceRegistry.of(
+            b ->
+                b.mappingRuleServices("default", defaultMappingRuleServices)
+                    .groupServices("default", defaultGroupServices)
+                    .roleServices("default", defaultRoleServices)
+                    .tenantServices("default", defaultTenantServices)
+                    .mappingRuleServices("tenant-b", tenantBMappingRuleServices)
+                    .groupServices("tenant-b", tenantBGroupServices)
+                    .roleServices("tenant-b", tenantBRoleServices)
+                    .tenantServices("tenant-b", tenantBTenantServices));
+    // CamundaSecurityLibraryProperties defaults: no groups-claim configured, so groupIds() hits
+    // the DB path (groupServices) rather than in-memory OIDC extraction.
+    service = new DefaultMembershipService(serviceRegistry, new CamundaSecurityLibraryProperties());
+  }
+
+  @AfterEach
+  void clearRequestContext() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  void shouldRouteMappingRuleIdsToPhysicalTenantInContext() {
+    // given — token claims non-empty so mappingRuleIds() does not short-circuit on empty claims
+    when(tenantBMappingRuleServices.getMatchingMappingRules(any(), any()))
+        .thenReturn(Stream.empty());
+    bindRequestWithPhysicalTenant("tenant-b");
+    final var query = new MembershipQuery(Map.of("sub", "alice"), "alice", PrincipalType.USER);
+
+    // when
+    service.mappingRuleIds(query);
+
+    // then
+    verify(tenantBMappingRuleServices).getMatchingMappingRules(any(), any());
+    verify(defaultMappingRuleServices, never()).getMatchingMappingRules(any(), any());
+  }
+
+  @Test
+  void shouldRouteGroupIdsToPhysicalTenantInContext() {
+    // given — groups-claim not configured, so groupIds() falls through to DB lookup
+    when(tenantBGroupServices.getGroupsByMemberTypeAndMemberIds(any(), any()))
+        .thenReturn(List.of());
+    bindRequestWithPhysicalTenant("tenant-b");
+    final var query = new MembershipQuery(Map.of("sub", "alice"), "alice", PrincipalType.USER);
+
+    // when
+    service.groupIds(query);
+
+    // then
+    verify(tenantBGroupServices).getGroupsByMemberTypeAndMemberIds(any(), any());
+    verify(defaultGroupServices, never()).getGroupsByMemberTypeAndMemberIds(any(), any());
+  }
+
+  @Test
+  void shouldRouteRoleIdsToPhysicalTenantInContext() {
+    // given
+    when(tenantBRoleServices.getRolesByMemberTypeAndMemberIds(any(), any())).thenReturn(List.of());
+    bindRequestWithPhysicalTenant("tenant-b");
+    final var query =
+        new MembershipQuery(Map.of("sub", "alice"), "alice", PrincipalType.USER)
+            .withMappingRuleIds(List.of())
+            .withGroupIds(List.of());
+
+    // when
+    service.roleIds(query);
+
+    // then
+    verify(tenantBRoleServices).getRolesByMemberTypeAndMemberIds(any(), any());
+    verify(defaultRoleServices, never()).getRolesByMemberTypeAndMemberIds(any(), any());
+  }
+
+  @Test
+  void shouldRouteTenantIdsToPhysicalTenantInContext() {
+    // given
+    when(tenantBTenantServices.getTenantsByMemberTypeAndMemberIds(any(), any()))
+        .thenReturn(List.of());
+    bindRequestWithPhysicalTenant("tenant-b");
+    final var query =
+        new MembershipQuery(Map.of("sub", "alice"), "alice", PrincipalType.USER)
+            .withMappingRuleIds(List.of())
+            .withGroupIds(List.of())
+            .withRoleIds(List.of());
+
+    // when
+    service.tenantIds(query);
+
+    // then
+    verify(tenantBTenantServices).getTenantsByMemberTypeAndMemberIds(any(), any());
+    verify(defaultTenantServices, never()).getTenantsByMemberTypeAndMemberIds(any(), any());
+  }
+
+  private static void bindRequestWithPhysicalTenant(final String physicalTenantId) {
+    final var request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, physicalTenantId);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -7,8 +7,7 @@
  */
 package io.camunda.application.commons.rdbms;
 
-import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-
+import io.camunda.application.commons.search.PhysicalTenantRoutingAuthorizationReader;
 import io.camunda.application.commons.search.PhysicalTenantSearchClientReaders;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
@@ -37,6 +36,7 @@ import java.sql.DatabaseMetaData;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,10 +122,25 @@ public class RdbmsConfiguration {
         new ResourceAccessDelegatingController(resourceAccessControllers));
   }
 
+  /**
+   * SPIKE (ADR-0005): route authorization reads to the physical tenant in context instead of
+   * binding to the {@code default} tenant's reader (#55252) — the RDBMS counterpart of the ES/OS
+   * routing in {@code SearchClientReaderConfiguration}, over the per-PT {@code RdbmsTenantReaders}
+   * introduced in #54474. This single {@code authorizationReader} bean feeds both the control-plane
+   * {@code AuthorizationRepositoryAdapter} and the data-plane {@code
+   * SearchAuthorizationScopeRepository}. Was: {@code
+   * defaultReaders(rdbmsTenantReaders).authorizationReader();} (default-pinned).
+   */
   @Bean
   public AuthorizationReader authorizationReader(
       final Map<String, RdbmsTenantReaders> rdbmsTenantReaders) {
-    return defaultReaders(rdbmsTenantReaders).authorizationReader();
+    final Map<String, AuthorizationReader> readersByPhysicalTenant =
+        rdbmsTenantReaders.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> (AuthorizationReader) e.getValue().authorizationReader()));
+    return new PhysicalTenantRoutingAuthorizationReader(readersByPhysicalTenant);
   }
 
   @Bean
@@ -152,16 +167,5 @@ public class RdbmsConfiguration {
   HealthContributor rdbmsStatusHealthIndicator(final DataSource dataSource) {
     // Equivalent to what Boot would normally wire for "db"
     return new DataSourceHealthIndicator(dataSource);
-  }
-
-  private static RdbmsTenantReaders defaultReaders(
-      final Map<String, RdbmsTenantReaders> rdbmsTenantReaders) {
-    final var defaults = rdbmsTenantReaders.get(DEFAULT_PHYSICAL_TENANT_ID);
-    if (defaults == null) {
-      throw new IllegalStateException(
-          "Missing default physical tenant '%s' in rdbmsTenantReaders; known tenants: %s"
-              .formatted(DEFAULT_PHYSICAL_TENANT_ID, rdbmsTenantReaders.keySet()));
-    }
-    return defaults;
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -17,6 +17,7 @@ import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.RdbmsTenantReaders;
 import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProviderFactory;
+import io.camunda.db.rdbms.read.security.RdbmsResourceAccessController;
 import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
 import io.camunda.db.rdbms.read.service.RdbmsTableRowCountMetrics;
 import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
@@ -26,13 +27,22 @@ import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.search.clients.CamundaSearchClients;
+import io.camunda.search.clients.auth.AnonymousResourceAccessController;
+import io.camunda.search.clients.auth.DefaultResourceAccessProvider;
+import io.camunda.search.clients.auth.DisabledResourceAccessProvider;
 import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.SearchClientReaders;
+import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.security.core.authz.ResourceAccessController;
+import io.camunda.security.core.authz.ResourceAccessProvider;
+import io.camunda.security.core.authz.TenantAccessProvider;
+import io.camunda.security.impl.SearchAuthorizationScopeRepository;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,10 +126,28 @@ public class RdbmsConfiguration {
   @Bean
   public CamundaSearchClients camundaSearchClients(
       final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
-      final List<ResourceAccessController> resourceAccessControllers) {
+      final Map<String, RdbmsTenantReaders> rdbmsTenantReaders,
+      final CamundaSecurityLibraryProperties cslProperties,
+      final TenantAccessProvider tenantAccessProvider) {
+    final Map<String, ResourceAccessController> racByTenant = new HashMap<>();
+    for (final Map.Entry<String, RdbmsTenantReaders> entry : rdbmsTenantReaders.entrySet()) {
+      final String tenantId = entry.getKey();
+      final AuthorizationReader reader = entry.getValue().authorizationReader();
+      final var scopeRepo = new SearchAuthorizationScopeRepository(reader);
+      final var checker = new AuthorizationChecker(scopeRepo);
+      final ResourceAccessProvider provider =
+          cslProperties.getAuthorizations().isEnabled()
+              ? new DefaultResourceAccessProvider(checker)
+              : new DisabledResourceAccessProvider();
+      final ResourceAccessController rac =
+          new RdbmsResourceAccessController(provider, tenantAccessProvider);
+      final ResourceAccessController delegating =
+          new ResourceAccessDelegatingController(
+              List.of(new AnonymousResourceAccessController(), rac));
+      racByTenant.put(tenantId, delegating);
+    }
     return new CamundaSearchClients(
-        physicalTenantSearchClientReaders.readersByPhysicalTenant(),
-        new ResourceAccessDelegatingController(resourceAccessControllers));
+        physicalTenantSearchClientReaders.readersByPhysicalTenant(), racByTenant);
   }
 
   /**

--- a/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReader.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReader.java
@@ -28,16 +28,18 @@ import org.jspecify.annotations.NullMarked;
  * used by Spring Security's permission checks.
  *
  * <p>The control-plane runs exclusively on the request thread — the engine never invokes {@code
- * hasPermission} — where the pre-security filter (ADR-0003) has already stamped the physical tenant.
- * Thread-bound resolution via {@link PhysicalTenantContext#current()} is therefore safe here,
- * including in a standalone-gateway deployment (the permission check only ever runs on the gateway's
- * request thread). {@code current()} falls back to {@code default} for non-prefixed cluster requests.
+ * hasPermission} — where the pre-security filter (ADR-0003) has already stamped the physical
+ * tenant. Thread-bound resolution via {@link PhysicalTenantContext#current()} is therefore safe
+ * here, including in a standalone-gateway deployment (the permission check only ever runs on the
+ * gateway's request thread). {@code current()} falls back to {@code default} for non-prefixed
+ * cluster requests.
  *
  * <p><b>The data-plane does NOT rely on thread-local resolution.</b> Result authorization inside
  * {@code CamundaSearchClients} is <em>instance-bound</em>: {@code withPhysicalTenant(pt)} selects
- * that tenant's {@code ResourceAccessController} (built over the tenant's {@link AuthorizationReader}),
- * so it stays correct even when the search runs off the request thread (e.g. batch operations in the
- * engine), where no {@link PhysicalTenantContext} is bound. See ADR-0005's two-mechanism decision.
+ * that tenant's {@code ResourceAccessController} (built over the tenant's {@link
+ * AuthorizationReader}), so it stays correct even when the search runs off the request thread (e.g.
+ * batch operations in the engine), where no {@link PhysicalTenantContext} is bound. See ADR-0005's
+ * two-mechanism decision.
  */
 @NullMarked
 public final class PhysicalTenantRoutingAuthorizationReader implements AuthorizationReader {

--- a/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReader.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReader.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import io.camunda.search.clients.reader.AuthorizationReader;
+import io.camunda.search.entities.AuthorizationEntity;
+import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.spring.utils.PhysicalTenantContext;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * SPIKE (ADR-0005): a physical-tenant-routing {@link AuthorizationReader}.
+ *
+ * <p>Resolves the physical tenant in context on each call and delegates to that tenant's reader, so
+ * authorization reads target the in-context tenant's secondary storage rather than a single
+ * {@code default}-pinned reader (#55252). Because both authorization-read consumers inject the same
+ * {@code AuthorizationReader} bean — the control-plane {@code AuthorizationRepositoryAdapter} (Spring
+ * Security permission checks) and the data-plane {@code SearchAuthorizationScopeRepository}
+ * ({@code CamundaSearchClients} result authorization) — re-pointing that one bean here makes both
+ * paths physical-tenant aware.
+ *
+ * <p>This implements the ADR-0005 <b>control-plane</b> mechanism: lazy resolution via {@link
+ * PhysicalTenantContext#current()}. The pre-security filter (ADR-0003) guarantees the id is stamped
+ * on the request before the check runs, and {@code current()} falls back to {@code default} for
+ * non-prefixed cluster requests.
+ *
+ * <p><b>Spike caveat:</b> on the data-plane this relies on the thread-bound {@link
+ * PhysicalTenantContext} being present where the check executes. If a search runs off the request
+ * thread (e.g. the API-services executor), the thread-local would fall back to {@code default}. The
+ * ADR-0005 <b>data-plane</b> decision (instance-bound resolution via the {@code CamundaSearchClients}
+ * instance's tenant) addresses that and is the larger structural change this spike deliberately
+ * does not yet make — see the spike notes.
+ */
+@NullMarked
+public final class PhysicalTenantRoutingAuthorizationReader implements AuthorizationReader {
+
+  private final Map<String, AuthorizationReader> readersByPhysicalTenant;
+  private final Supplier<String> physicalTenantIdSupplier;
+
+  public PhysicalTenantRoutingAuthorizationReader(
+      final Map<String, AuthorizationReader> readersByPhysicalTenant) {
+    this(readersByPhysicalTenant, PhysicalTenantContext::current);
+  }
+
+  PhysicalTenantRoutingAuthorizationReader(
+      final Map<String, AuthorizationReader> readersByPhysicalTenant,
+      final Supplier<String> physicalTenantIdSupplier) {
+    this.readersByPhysicalTenant = Map.copyOf(readersByPhysicalTenant);
+    this.physicalTenantIdSupplier = physicalTenantIdSupplier;
+  }
+
+  @Override
+  public SearchQueryResult<AuthorizationEntity> search(
+      final AuthorizationQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return current().search(query, resourceAccessChecks);
+  }
+
+  @Override
+  public AuthorizationEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return current().getById(id, resourceAccessChecks);
+  }
+
+  @Override
+  public AuthorizationEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    return current().getByKey(key, resourceAccessChecks);
+  }
+
+  private AuthorizationReader current() {
+    final var physicalTenantId = physicalTenantIdSupplier.get();
+    final var reader = readersByPhysicalTenant.get(physicalTenantId);
+    if (reader == null) {
+      throw new IllegalStateException(
+          "No AuthorizationReader registered for physical tenant '" + physicalTenantId + "'");
+    }
+    return reader;
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReader.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReader.java
@@ -21,24 +21,26 @@ import org.jspecify.annotations.NullMarked;
  * SPIKE (ADR-0005): a physical-tenant-routing {@link AuthorizationReader}.
  *
  * <p>Resolves the physical tenant in context on each call and delegates to that tenant's reader, so
- * authorization reads target the in-context tenant's secondary storage rather than a single
- * {@code default}-pinned reader (#55252). Because both authorization-read consumers inject the same
- * {@code AuthorizationReader} bean — the control-plane {@code AuthorizationRepositoryAdapter} (Spring
- * Security permission checks) and the data-plane {@code SearchAuthorizationScopeRepository}
- * ({@code CamundaSearchClients} result authorization) — re-pointing that one bean here makes both
- * paths physical-tenant aware.
+ * authorization reads target the in-context tenant's secondary storage rather than a single {@code
+ * default}-pinned reader (#55252). Because both authorization-read consumers inject the same {@code
+ * AuthorizationReader} bean — the control-plane {@code AuthorizationRepositoryAdapter} (Spring
+ * Security permission checks) and the data-plane {@code SearchAuthorizationScopeRepository} ({@code
+ * CamundaSearchClients} result authorization) — re-pointing that one bean here makes both paths
+ * physical-tenant aware.
  *
- * <p>This implements the ADR-0005 <b>control-plane</b> mechanism: lazy resolution via {@link
- * PhysicalTenantContext#current()}. The pre-security filter (ADR-0003) guarantees the id is stamped
- * on the request before the check runs, and {@code current()} falls back to {@code default} for
- * non-prefixed cluster requests.
+ * <p>Resolution is lazy via {@link PhysicalTenantContext#current()}. The pre-security filter
+ * (ADR-0003) guarantees the id is stamped on the request before the check runs, and {@code
+ * current()} falls back to {@code default} for non-prefixed cluster requests.
  *
- * <p><b>Spike caveat:</b> on the data-plane this relies on the thread-bound {@link
- * PhysicalTenantContext} being present where the check executes. If a search runs off the request
- * thread (e.g. the API-services executor), the thread-local would fall back to {@code default}. The
- * ADR-0005 <b>data-plane</b> decision (instance-bound resolution via the {@code CamundaSearchClients}
- * instance's tenant) addresses that and is the larger structural change this spike deliberately
- * does not yet make — see the spike notes.
+ * <p><b>Data-plane spike finding:</b> this thread-bound resolution is sufficient for the data-plane
+ * too, not only the control-plane. The data-plane authorization read runs <em>synchronously on the
+ * request thread</em> — {@code SearchQueryService#executeSearchRequest} calls {@code
+ * searchRequest.get()} inline, and the {@code ApiServices} executor is used only for the broker
+ * (write) path, never for reads — so the thread-bound {@link PhysicalTenantContext} is present
+ * where the check executes (proven by {@code PhysicalTenantRoutingAuthorizationReaderTest}). The
+ * instance-bound data-plane mechanism the ADR floated as a hedge against off-request-thread
+ * execution is therefore not required for the API read paths; it would only matter for a future
+ * consumer that performs an authorization-checked search off the request thread.
  */
 @NullMarked
 public final class PhysicalTenantRoutingAuthorizationReader implements AuthorizationReader {

--- a/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReader.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReader.java
@@ -18,29 +18,26 @@ import java.util.function.Supplier;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * SPIKE (ADR-0005): a physical-tenant-routing {@link AuthorizationReader}.
+ * SPIKE (ADR-0005): the <b>control-plane</b> physical-tenant-routing {@link AuthorizationReader}.
  *
- * <p>Resolves the physical tenant in context on each call and delegates to that tenant's reader, so
- * authorization reads target the in-context tenant's secondary storage rather than a single {@code
- * default}-pinned reader (#55252). Because both authorization-read consumers inject the same {@code
- * AuthorizationReader} bean — the control-plane {@code AuthorizationRepositoryAdapter} (Spring
- * Security permission checks) and the data-plane {@code SearchAuthorizationScopeRepository} ({@code
- * CamundaSearchClients} result authorization) — re-pointing that one bean here makes both paths
- * physical-tenant aware.
+ * <p>Resolves {@link PhysicalTenantContext#current()} on each call and delegates to that tenant's
+ * {@link AuthorizationReader}, so a control-plane permission check reads the in-context tenant's
+ * authorization data instead of a single {@code default}-pinned reader (#55252). It is the
+ * <b>control-plane</b> mechanism of ADR-0005's two-mechanism decision: the reader behind the
+ * OC-supplied {@code AuthorizationRepositoryPort} adapter ({@code AuthorizationRepositoryAdapter})
+ * used by Spring Security's permission checks.
  *
- * <p>Resolution is lazy via {@link PhysicalTenantContext#current()}. The pre-security filter
- * (ADR-0003) guarantees the id is stamped on the request before the check runs, and {@code
- * current()} falls back to {@code default} for non-prefixed cluster requests.
+ * <p>The control-plane runs exclusively on the request thread — the engine never invokes {@code
+ * hasPermission} — where the pre-security filter (ADR-0003) has already stamped the physical tenant.
+ * Thread-bound resolution via {@link PhysicalTenantContext#current()} is therefore safe here,
+ * including in a standalone-gateway deployment (the permission check only ever runs on the gateway's
+ * request thread). {@code current()} falls back to {@code default} for non-prefixed cluster requests.
  *
- * <p><b>Data-plane spike finding:</b> this thread-bound resolution is sufficient for the data-plane
- * too, not only the control-plane. The data-plane authorization read runs <em>synchronously on the
- * request thread</em> — {@code SearchQueryService#executeSearchRequest} calls {@code
- * searchRequest.get()} inline, and the {@code ApiServices} executor is used only for the broker
- * (write) path, never for reads — so the thread-bound {@link PhysicalTenantContext} is present
- * where the check executes (proven by {@code PhysicalTenantRoutingAuthorizationReaderTest}). The
- * instance-bound data-plane mechanism the ADR floated as a hedge against off-request-thread
- * execution is therefore not required for the API read paths; it would only matter for a future
- * consumer that performs an authorization-checked search off the request thread.
+ * <p><b>The data-plane does NOT rely on thread-local resolution.</b> Result authorization inside
+ * {@code CamundaSearchClients} is <em>instance-bound</em>: {@code withPhysicalTenant(pt)} selects
+ * that tenant's {@code ResourceAccessController} (built over the tenant's {@link AuthorizationReader}),
+ * so it stays correct even when the search runs off the request thread (e.g. batch operations in the
+ * engine), where no {@link PhysicalTenantContext} is bound. See ADR-0005's two-mechanism decision.
  */
 @NullMarked
 public final class PhysicalTenantRoutingAuthorizationReader implements AuthorizationReader {

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -11,15 +11,27 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.search.clients.CamundaSearchClients;
+import io.camunda.search.clients.auth.AnonymousResourceAccessController;
+import io.camunda.search.clients.auth.DefaultResourceAccessProvider;
+import io.camunda.search.clients.auth.DisabledResourceAccessProvider;
+import io.camunda.search.clients.auth.DocumentBasedResourceAccessController;
 import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.impl.NoDBSearchClientsProxy;
 import io.camunda.search.clients.reader.AuthorizationReader;
+import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.search.clients.reader.impl.NoopAuthorizationReader;
 import io.camunda.search.es.clients.ElasticsearchSearchClient;
 import io.camunda.search.os.clients.OpensearchSearchClient;
+import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.security.core.authz.ResourceAccessController;
+import io.camunda.security.core.authz.ResourceAccessProvider;
+import io.camunda.security.core.authz.TenantAccessProvider;
+import io.camunda.security.impl.SearchAuthorizationScopeRepository;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -59,9 +71,27 @@ public class SearchClientConfiguration {
   })
   public CamundaSearchClients camundaSearchClients(
       final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
-      final List<ResourceAccessController> resourceAccessControllers) {
+      final CamundaSecurityLibraryProperties cslProperties,
+      final TenantAccessProvider tenantAccessProvider) {
+    final Map<String, ResourceAccessController> racByTenant = new HashMap<>();
+    for (final Map.Entry<String, SearchClientReaders> entry :
+        physicalTenantSearchClientReaders.readersByPhysicalTenant().entrySet()) {
+      final String tenantId = entry.getKey();
+      final AuthorizationReader reader = entry.getValue().authorizationReader();
+      final var scopeRepo = new SearchAuthorizationScopeRepository(reader);
+      final var checker = new AuthorizationChecker(scopeRepo);
+      final ResourceAccessProvider provider =
+          cslProperties.getAuthorizations().isEnabled()
+              ? new DefaultResourceAccessProvider(checker)
+              : new DisabledResourceAccessProvider();
+      final ResourceAccessController rac =
+          new DocumentBasedResourceAccessController(provider, tenantAccessProvider);
+      final ResourceAccessController delegating =
+          new ResourceAccessDelegatingController(
+              List.of(new AnonymousResourceAccessController(), rac));
+      racByTenant.put(tenantId, delegating);
+    }
     return new CamundaSearchClients(
-        physicalTenantSearchClientReaders.readersByPhysicalTenant(),
-        new ResourceAccessDelegatingController(resourceAccessControllers));
+        physicalTenantSearchClientReaders.readersByPhysicalTenant(), racByTenant);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -8,12 +8,12 @@
 package io.camunda.application.commons.search;
 
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -42,24 +42,20 @@ public class SearchClientReaderConfiguration {
         });
   }
 
+  /**
+   * SPIKE (ADR-0005): route authorization reads to the physical tenant in context instead of
+   * binding to the {@code default} tenant's reader (#55252). Both authorization-read consumers — the
+   * control-plane {@code AuthorizationRepositoryAdapter} and the data-plane {@code
+   * SearchAuthorizationScopeRepository} — inject this single bean, so re-pointing it here covers both
+   * paths. Was: {@code requireDefault(physicalTenantSearchClientReaders.readersByPhysicalTenant(),
+   * ...).authorizationReader();} (default-pinned).
+   */
   @Bean
   public AuthorizationReader authorizationReader(
       final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders) {
-    return requireDefault(
-            physicalTenantSearchClientReaders.readersByPhysicalTenant(),
-            "physicalTenantSearchClientReaders")
-        .authorizationReader();
-  }
-
-  private static <T> T requireDefault(final Map<String, T> beansByTenant, final String beanName) {
-    final var defaultBean = beansByTenant.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    if (defaultBean == null) {
-      throw new IllegalStateException(
-          "Missing '"
-              + PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID
-              + "' tenant entry in "
-              + beanName);
-    }
-    return defaultBean;
+    final Map<String, AuthorizationReader> readersByPhysicalTenant =
+        physicalTenantSearchClientReaders.readersByPhysicalTenant().entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().authorizationReader()));
+    return new PhysicalTenantRoutingAuthorizationReader(readersByPhysicalTenant);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -44,10 +44,11 @@ public class SearchClientReaderConfiguration {
 
   /**
    * SPIKE (ADR-0005): route authorization reads to the physical tenant in context instead of
-   * binding to the {@code default} tenant's reader (#55252). Both authorization-read consumers — the
-   * control-plane {@code AuthorizationRepositoryAdapter} and the data-plane {@code
-   * SearchAuthorizationScopeRepository} — inject this single bean, so re-pointing it here covers both
-   * paths. Was: {@code requireDefault(physicalTenantSearchClientReaders.readersByPhysicalTenant(),
+   * binding to the {@code default} tenant's reader (#55252). Both authorization-read consumers —
+   * the control-plane {@code AuthorizationRepositoryAdapter} and the data-plane {@code
+   * SearchAuthorizationScopeRepository} — inject this single bean, so re-pointing it here covers
+   * both paths. Was: {@code
+   * requireDefault(physicalTenantSearchClientReaders.readersByPhysicalTenant(),
    * ...).authorizationReader();} (default-pinned).
    */
   @Bean

--- a/dist/src/test/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReaderTest.java
@@ -33,9 +33,9 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  * the control-plane resolves the in-context tenant's reader via {@link
  * PhysicalTenantContext#current()}.
  *
- * <p>These tests exercise the <b>real</b> thread-bound context (not a stubbed supplier) to confirm a
- * read is routed to the in-context tenant's reader, falls back to {@code default} when no request is
- * bound, and fails fast for an unconfigured tenant. (The data-plane is proven separately and
+ * <p>These tests exercise the <b>real</b> thread-bound context (not a stubbed supplier) to confirm
+ * a read is routed to the in-context tenant's reader, falls back to {@code default} when no request
+ * is bound, and fails fast for an unconfigured tenant. (The data-plane is proven separately and
  * instance-bound — see {@code CamundaSearchClientsPhysicalTenantResourceAccessControllerTest}.)
  */
 final class PhysicalTenantRoutingAuthorizationReaderTest {

--- a/dist/src/test/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReaderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.reader.AuthorizationReader;
+import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.spring.utils.PhysicalTenantContext;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * SPIKE (ADR-0005) data-plane proof. The data-plane authorization read ({@code
+ * CamundaSearchClients} -> {@code ResourceAccessController} -> CSL {@code AuthorizationChecker} ->
+ * {@code SearchAuthorizationScopeRepository} -> {@code AuthorizationReader}) runs <b>synchronously
+ * on the request thread</b>: {@code SearchQueryService#executeSearchRequest} calls {@code
+ * searchRequest.get()} inline, and the {@code ApiServices} executor is used only for the broker
+ * (write) path, never for reads. The pre-security filter (ADR-0003) stamps the physical tenant on
+ * that same thread before Spring Security runs.
+ *
+ * <p>Therefore the data-plane's physical-tenant correctness is fully delegated to this routing
+ * reader resolving {@link PhysicalTenantContext#current()}. These tests exercise the <b>real</b>
+ * thread-bound context (not a stubbed supplier) to confirm a read is routed to the in-context
+ * tenant's reader, falls back to {@code default} when no request is bound, and fails fast for an
+ * unconfigured tenant.
+ */
+final class PhysicalTenantRoutingAuthorizationReaderTest {
+
+  private final AuthorizationReader defaultReader = mock(AuthorizationReader.class);
+  private final AuthorizationReader tenantBReader = mock(AuthorizationReader.class);
+  private final Map<String, AuthorizationReader> readersByPhysicalTenant =
+      Map.of("default", defaultReader, "tenant-b", tenantBReader);
+
+  @AfterEach
+  void clearRequestContext() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  void shouldRouteReadToPhysicalTenantInContext() {
+    // given
+    when(tenantBReader.search(any(), any())).thenReturn(SearchQueryResult.empty());
+    bindRequestWithPhysicalTenant("tenant-b");
+    final var reader = new PhysicalTenantRoutingAuthorizationReader(readersByPhysicalTenant);
+
+    // when
+    reader.search(AuthorizationQuery.of(q -> q), ResourceAccessChecks.disabled());
+
+    // then
+    verify(tenantBReader).search(any(), any());
+    verifyNoInteractions(defaultReader);
+  }
+
+  @Test
+  void shouldFallBackToDefaultWhenNoRequestBound() {
+    // given
+    when(defaultReader.search(any(), any())).thenReturn(SearchQueryResult.empty());
+    RequestContextHolder.resetRequestAttributes();
+    final var reader = new PhysicalTenantRoutingAuthorizationReader(readersByPhysicalTenant);
+
+    // when
+    reader.search(AuthorizationQuery.of(q -> q), ResourceAccessChecks.disabled());
+
+    // then
+    verify(defaultReader).search(any(), any());
+    verifyNoInteractions(tenantBReader);
+  }
+
+  @Test
+  void shouldFailFastForUnconfiguredPhysicalTenant() {
+    // given
+    bindRequestWithPhysicalTenant("tenant-x");
+    final var reader = new PhysicalTenantRoutingAuthorizationReader(readersByPhysicalTenant);
+
+    // when / then
+    assertThatThrownBy(
+            () -> reader.search(AuthorizationQuery.of(q -> q), ResourceAccessChecks.disabled()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("tenant-x");
+  }
+
+  private static void bindRequestWithPhysicalTenant(final String physicalTenantId) {
+    final var request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, physicalTenantId);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/PhysicalTenantRoutingAuthorizationReaderTest.java
@@ -27,19 +27,16 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 /**
- * SPIKE (ADR-0005) data-plane proof. The data-plane authorization read ({@code
- * CamundaSearchClients} -> {@code ResourceAccessController} -> CSL {@code AuthorizationChecker} ->
- * {@code SearchAuthorizationScopeRepository} -> {@code AuthorizationReader}) runs <b>synchronously
- * on the request thread</b>: {@code SearchQueryService#executeSearchRequest} calls {@code
- * searchRequest.get()} inline, and the {@code ApiServices} executor is used only for the broker
- * (write) path, never for reads. The pre-security filter (ADR-0003) stamps the physical tenant on
- * that same thread before Spring Security runs.
+ * SPIKE (ADR-0005) <b>control-plane</b> proof. The control-plane permission check ({@code
+ * AuthorizationRepositoryAdapter} -> this {@link PhysicalTenantRoutingAuthorizationReader}) runs on
+ * the request thread, where the pre-security filter (ADR-0003) has stamped the physical tenant. So
+ * the control-plane resolves the in-context tenant's reader via {@link
+ * PhysicalTenantContext#current()}.
  *
- * <p>Therefore the data-plane's physical-tenant correctness is fully delegated to this routing
- * reader resolving {@link PhysicalTenantContext#current()}. These tests exercise the <b>real</b>
- * thread-bound context (not a stubbed supplier) to confirm a read is routed to the in-context
- * tenant's reader, falls back to {@code default} when no request is bound, and fails fast for an
- * unconfigured tenant.
+ * <p>These tests exercise the <b>real</b> thread-bound context (not a stubbed supplier) to confirm a
+ * read is routed to the in-context tenant's reader, falls back to {@code default} when no request is
+ * bound, and fails fast for an unconfigured tenant. (The data-plane is proven separately and
+ * instance-bound — see {@code CamundaSearchClientsPhysicalTenantResourceAccessControllerTest}.)
  */
 final class PhysicalTenantRoutingAuthorizationReaderTest {
 

--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -16,11 +16,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>configuration-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-domain</artifactId>
     </dependency>
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -11,7 +11,6 @@ import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_ID_NOT_F
 import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_KEY_NOT_FOUND;
 import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_MULTIPLE_IDS_NOT_FOUND;
 
-import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.search.clients.reader.SearchEntityReader;
 import io.camunda.search.clients.reader.SearchQueryStatisticsReader;
@@ -128,46 +127,61 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A router over per-physical-tenant search clients. The base instance is <em>unscoped</em> — it
+ * holds no default physical tenant. Callers <strong>must</strong> call {@link
+ * #withPhysicalTenant(String)} before issuing any reads; unscoped reads fail fast with {@link
+ * IllegalStateException}.
+ *
+ * <p>This is intentional: silently falling back to a "default" tenant is the bug class we are
+ * eliminating (ADR-0005 B.3). The engine scopes per partition via PR #55401; until that lands,
+ * engine reads will throw — the desired loud behaviour over silent-default reads.
+ *
+ * <p>See ADR-0005 B.3 for the full design rationale.
+ */
 public class CamundaSearchClients implements SearchClientsProxy {
 
   private static final Logger LOG = LoggerFactory.getLogger(CamundaSearchClients.class);
 
-  private final SearchClientReaders readers;
+  /** Null when the base instance is unscoped (no physical tenant selected yet). */
+  private final SearchClientReaders scopedReaders;
+
   private final Map<String, SearchClientReaders> tenantReaders;
+
   private final String currentPhysicalTenantId;
   private final Map<String, ResourceAccessController> resourceAccessControllerByTenant;
-  private final ResourceAccessController resourceAccessController;
+
+  /** Null when the base instance is unscoped (no physical tenant selected yet). */
+  private final ResourceAccessController scopedResourceAccessController;
+
   private final SecurityContext securityContext;
 
   /**
    * Backward-compatible ctor: a single {@link ResourceAccessController} is shared across all
-   * physical tenants. All existing construction sites compile and behave unchanged.
+   * physical tenants. The base instance is <em>unscoped</em>; call {@link
+   * #withPhysicalTenant(String)} before reading.
    */
   public CamundaSearchClients(
       final Map<String, SearchClientReaders> tenantReaders,
       final ResourceAccessController resourceAccessController) {
     this(
         tenantReaders,
-        PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+        null,
         tenantReaders.keySet().stream()
             .collect(Collectors.toMap(k -> k, k -> resourceAccessController)),
         null);
   }
 
   /**
-   * SPIKE (ADR-0005) data-plane ctor: per-PT {@link ResourceAccessController} map. The active
-   * controller is selected from the map by the current physical tenant id when {@link
-   * #withPhysicalTenant(String)} is called, so authorization scope checks follow the search
-   * client's tenant even when running off the request thread.
+   * SPIKE (ADR-0005) data-plane ctor: per-PT {@link ResourceAccessController} map. The base
+   * instance is <em>unscoped</em>; call {@link #withPhysicalTenant(String)} to obtain a scoped
+   * client whose reads are routed to the correct tenant's controller — so authorization scope
+   * checks follow the search client's tenant even when running off the request thread.
    */
   public CamundaSearchClients(
       final Map<String, SearchClientReaders> tenantReaders,
       final Map<String, ResourceAccessController> resourceAccessControllerByTenant) {
-    this(
-        tenantReaders,
-        PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-        resourceAccessControllerByTenant,
-        null);
+    this(tenantReaders, null, resourceAccessControllerByTenant, null);
   }
 
   private CamundaSearchClients(
@@ -176,67 +190,101 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final Map<String, ResourceAccessController> resourceAccessControllerByTenant,
       final SecurityContext securityContext) {
     this.tenantReaders = Map.copyOf(tenantReaders);
-    readers = this.tenantReaders.get(currentPhysicalTenantId);
-    if (readers == null) {
-      throw new IllegalArgumentException(
-          "Missing readers for physical tenant '%s'. Known physical tenants: %s"
-              .formatted(currentPhysicalTenantId, this.tenantReaders.keySet()));
-    }
     this.currentPhysicalTenantId = currentPhysicalTenantId;
     this.resourceAccessControllerByTenant = Map.copyOf(resourceAccessControllerByTenant);
-    resourceAccessController = this.resourceAccessControllerByTenant.get(currentPhysicalTenantId);
-    if (resourceAccessController == null) {
-      throw new IllegalArgumentException(
-          "Missing ResourceAccessController for physical tenant '%s'. Known physical tenants: %s"
-              .formatted(currentPhysicalTenantId, this.resourceAccessControllerByTenant.keySet()));
-    }
     this.securityContext = securityContext;
+
+    // Only resolve scoped fields when a physical tenant has been selected.
+    if (currentPhysicalTenantId != null) {
+      scopedReaders = this.tenantReaders.get(currentPhysicalTenantId);
+      if (scopedReaders == null) {
+        throw new IllegalArgumentException(
+            "Missing readers for physical tenant '%s'. Known physical tenants: %s"
+                .formatted(currentPhysicalTenantId, this.tenantReaders.keySet()));
+      }
+      scopedResourceAccessController =
+          this.resourceAccessControllerByTenant.get(currentPhysicalTenantId);
+      if (scopedResourceAccessController == null) {
+        throw new IllegalArgumentException(
+            "Missing ResourceAccessController for physical tenant '%s'. Known physical tenants: %s"
+                .formatted(
+                    currentPhysicalTenantId, this.resourceAccessControllerByTenant.keySet()));
+      }
+    } else {
+      // Unscoped base: construction is allowed; reads are blocked by the accessors below.
+      scopedReaders = null;
+      scopedResourceAccessController = null;
+    }
+  }
+
+  /**
+   * Returns the scoped readers. Throws {@link IllegalStateException} if this instance has not been
+   * scoped via {@link #withPhysicalTenant(String)}.
+   */
+  private SearchClientReaders readers() {
+    if (scopedReaders == null) {
+      throw new IllegalStateException(
+          "CamundaSearchClients has no physical tenant scoped — call withPhysicalTenant(...) before reading");
+    }
+    return scopedReaders;
+  }
+
+  /**
+   * Returns the scoped resource-access controller. Throws {@link IllegalStateException} if this
+   * instance has not been scoped via {@link #withPhysicalTenant(String)}.
+   */
+  private ResourceAccessController resourceAccessController() {
+    if (scopedResourceAccessController == null) {
+      throw new IllegalStateException(
+          "CamundaSearchClients has no physical tenant scoped — call withPhysicalTenant(...) before reading");
+    }
+    return scopedResourceAccessController;
   }
 
   @Override
   public AgentInstanceEntity getAgentInstance(final long key) {
-    return doGetWithReader(readers.agentInstanceReader(), key)
+    return doGetWithReader(readers().agentInstanceReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Agent Instance", key));
   }
 
   @Override
   public SearchQueryResult<AgentInstanceEntity> searchAgentInstances(
       final AgentInstanceQuery query) {
-    return doSearchWithReader(readers.agentInstanceReader(), query);
+    return doSearchWithReader(readers().agentInstanceReader(), query);
   }
 
   @Override
   public AuthorizationEntity getAuthorization(final long key) {
-    return doGetWithReader(readers.authorizationReader(), key)
+    return doGetWithReader(readers().authorizationReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Authorization", key));
   }
 
   @Override
   public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
       final AuthorizationQuery query) {
-    return doSearchWithReader(readers.authorizationReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(readers().authorizationReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(final SequenceFlowQuery query) {
-    return doSearchWithReader(readers.sequenceFlowReader(), query);
+    return doSearchWithReader(readers().sequenceFlowReader(), query);
   }
 
   @Override
   public SearchQueryResult<MessageSubscriptionEntity> searchMessageSubscriptions(
       final MessageSubscriptionQuery query) {
-    return doSearchWithReader(readers.messageSubscriptionReader(), query);
+    return doSearchWithReader(readers().messageSubscriptionReader(), query);
   }
 
   @Override
   public SearchQueryResult<CorrelatedMessageSubscriptionEntity>
       searchCorrelatedMessageSubscriptions(final CorrelatedMessageSubscriptionQuery query) {
-    return doSearchWithReader(readers.correlatedMessageSubscriptionReader(), query);
+    return doSearchWithReader(readers().correlatedMessageSubscriptionReader(), query);
   }
 
   @Override
   public MessageSubscriptionEntity getMessageSubscription(final long key) {
-    return doGetWithReader(readers.messageSubscriptionReader(), key)
+    return doGetWithReader(readers().messageSubscriptionReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Message Subscription", key));
   }
 
@@ -244,7 +292,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public ClusterVariableEntity getClusterVariable(final String name, final String tenant) {
     return doGet(
             resourceAccessChecks ->
-                readers
+                readers()
                     .clusterVariableReader()
                     .getTenantScopedClusterVariable(name, tenant, resourceAccessChecks))
         .orElseThrow(
@@ -257,7 +305,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public ClusterVariableEntity getClusterVariable(final String name) {
     return doGet(
             resourceAccessChecks ->
-                readers
+                readers()
                     .clusterVariableReader()
                     .getGloballyScopedClusterVariable(name, resourceAccessChecks))
         .orElseThrow(
@@ -269,18 +317,18 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<ClusterVariableEntity> searchClusterVariables(
       final ClusterVariableQuery query) {
-    return doSearchWithReader(readers.clusterVariableReader(), query);
+    return doSearchWithReader(readers().clusterVariableReader(), query);
   }
 
   @Override
   public AuditLogEntity getAuditLog(final String id) {
-    return doGetWithReader(readers.auditLogReader(), id)
+    return doGetWithReader(readers().auditLogReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Audit log", id));
   }
 
   @Override
   public SearchQueryResult<AuditLogEntity> searchAuditLogs(final AuditLogQuery query) {
-    return doSearchWithReader(readers.auditLogReader(), query);
+    return doSearchWithReader(readers().auditLogReader(), query);
   }
 
   @Override
@@ -296,13 +344,14 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   @Override
   public CamundaSearchClients withSecurityContext(final SecurityContext securityContext) {
+    // Preserves the current physical-tenant scope (which may be null for the unscoped base).
     return new CamundaSearchClients(
         tenantReaders, currentPhysicalTenantId, resourceAccessControllerByTenant, securityContext);
   }
 
   @Override
   public MappingRuleEntity getMappingRule(final String id) {
-    return doGetWithReader(readers.mappingRuleReader(), id)
+    return doGetWithReader(readers().mappingRuleReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Mapping Rule", id));
   }
 
@@ -310,78 +359,78 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public SearchQueryResult<MappingRuleEntity> searchMappingRules(
       final MappingRuleQuery mappingRuleQuery) {
     return doSearchWithReader(
-        readers.mappingRuleReader(), mappingRuleQuery, this::disableTenantCheck);
+        readers().mappingRuleReader(), mappingRuleQuery, this::disableTenantCheck);
   }
 
   @Override
   public DecisionDefinitionEntity getDecisionDefinition(final long key) {
-    return doGetWithReader(readers.decisionDefinitionReader(), key)
+    return doGetWithReader(readers().decisionDefinitionReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Decision Definition", key));
   }
 
   @Override
   public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
       final DecisionDefinitionQuery query) {
-    return doSearchWithReader(readers.decisionDefinitionReader(), query);
+    return doSearchWithReader(readers().decisionDefinitionReader(), query);
   }
 
   @Override
   public DecisionInstanceEntity getDecisionInstance(final String id) {
-    return doGetWithReader(readers.decisionInstanceReader(), id)
+    return doGetWithReader(readers().decisionInstanceReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Decision Instance", id));
   }
 
   @Override
   public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
       final DecisionInstanceQuery query) {
-    return doSearchWithReader(readers.decisionInstanceReader(), query);
+    return doSearchWithReader(readers().decisionInstanceReader(), query);
   }
 
   @Override
   public DecisionRequirementsEntity getDecisionRequirements(
       final long key, final boolean includeXml) {
-    return doGet(a -> readers.decisionRequirementsReader().getByKey(key, a, includeXml))
+    return doGet(a -> readers().decisionRequirementsReader().getByKey(key, a, includeXml))
         .orElseThrow(() -> entityByKeyNotFoundException("Decision Requirements", key));
   }
 
   @Override
   public SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
       final DecisionRequirementsQuery query) {
-    return doSearchWithReader(readers.decisionRequirementsReader(), query);
+    return doSearchWithReader(readers().decisionRequirementsReader(), query);
   }
 
   @Override
   public FlowNodeInstanceEntity getFlowNodeInstance(final long key) {
-    return doGetWithReader(readers.flowNodeInstanceReader(), key)
+    return doGetWithReader(readers().flowNodeInstanceReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Element Instance", key));
   }
 
   @Override
   public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
       final FlowNodeInstanceQuery query) {
-    return doSearchWithReader(readers.flowNodeInstanceReader(), query);
+    return doSearchWithReader(readers().flowNodeInstanceReader(), query);
   }
 
   @Override
   public FormEntity getForm(final long key) {
-    return doGetWithReader(readers.formReader(), key)
+    return doGetWithReader(readers().formReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Form", key));
   }
 
   @Override
   public SearchQueryResult<FormEntity> searchForms(final FormQuery query) {
-    return doSearchWithReader(readers.formReader(), query);
+    return doSearchWithReader(readers().formReader(), query);
   }
 
   @Override
   public IncidentEntity getIncident(final long key) {
-    return doGetWithReader(readers.incidentReader(), key)
+    return doGetWithReader(readers().incidentReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Incident", key));
   }
 
   @Override
   public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery query) {
-    return doSearchWithReader(readers.incidentReader(), query);
+    return doSearchWithReader(readers().incidentReader(), query);
   }
 
   @Override
@@ -389,7 +438,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
       incidentProcessInstanceStatisticsByError(
           final IncidentProcessInstanceStatisticsByErrorQuery query) {
 
-    return doSearchWithReader(readers.incidentProcessInstanceStatisticsByErrorReader(), query);
+    return doSearchWithReader(readers().incidentProcessInstanceStatisticsByErrorReader(), query);
   }
 
   @Override
@@ -397,19 +446,20 @@ public class CamundaSearchClients implements SearchClientsProxy {
       searchIncidentProcessInstanceStatisticsByDefinition(
           final IncidentProcessInstanceStatisticsByDefinitionQuery query) {
 
-    return doSearchWithReader(readers.incidentProcessInstanceStatisticsByDefinitionReader(), query);
+    return doSearchWithReader(
+        readers().incidentProcessInstanceStatisticsByDefinitionReader(), query);
   }
 
   @Override
   public ProcessDefinitionEntity getProcessDefinition(final long key) {
-    return doGetWithReader(readers.processDefinitionReader(), key)
+    return doGetWithReader(readers().processDefinitionReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Process Definition", key));
   }
 
   @Override
   public SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
       final ProcessDefinitionQuery query) {
-    return doSearchWithReader(readers.processDefinitionReader(), query);
+    return doSearchWithReader(readers().processDefinitionReader(), query);
   }
 
   @Override
@@ -417,7 +467,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final ProcessDefinitionStatisticsFilter filter) {
     return doReadWithResourceAccessController(
         access ->
-            readers
+            readers()
                 .processDefinitionStatisticsReader()
                 .aggregate(new ProcessDefinitionFlowNodeStatisticsQuery(filter), access));
   }
@@ -425,7 +475,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity>
       processDefinitionInstanceStatistics(final ProcessDefinitionInstanceStatisticsQuery query) {
-    return doSearchWithReader(readers.processDefinitionInstanceStatisticsReader(), query);
+    return doSearchWithReader(readers().processDefinitionInstanceStatisticsReader(), query);
   }
 
   @Override
@@ -433,26 +483,26 @@ public class CamundaSearchClients implements SearchClientsProxy {
       getProcessDefinitionMessageSubscriptionStatistics(
           final ProcessDefinitionMessageSubscriptionStatisticsQuery query) {
     return doSearchWithReader(
-        readers.processDefinitionMessageSubscriptionStatisticsReader(), query);
+        readers().processDefinitionMessageSubscriptionStatisticsReader(), query);
   }
 
   @Override
   public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity>
       processDefinitionInstanceVersionStatistics(
           final ProcessDefinitionInstanceVersionStatisticsQuery query) {
-    return doSearchWithReader(readers.processDefinitionInstanceVersionStatisticsReader(), query);
+    return doSearchWithReader(readers().processDefinitionInstanceVersionStatisticsReader(), query);
   }
 
   @Override
   public ProcessInstanceEntity getProcessInstance(final long processInstanceKey) {
-    return doGetWithReader(readers.processInstanceReader(), processInstanceKey)
+    return doGetWithReader(readers().processInstanceReader(), processInstanceKey)
         .orElseThrow(() -> entityByKeyNotFoundException("Process Instance", processInstanceKey));
   }
 
   @Override
   public SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(
       final ProcessInstanceQuery query) {
-    return doSearchWithReader(readers.processInstanceReader(), query);
+    return doSearchWithReader(readers().processInstanceReader(), query);
   }
 
   @Override
@@ -460,7 +510,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final long processInstanceKey) {
     return doReadWithResourceAccessController(
         access ->
-            readers
+            readers()
                 .processInstanceStatisticsReader()
                 .aggregate(
                     new ProcessInstanceFlowNodeStatisticsQuery(
@@ -470,152 +520,152 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<JobEntity> searchJobs(final JobQuery query) {
-    return doSearchWithReader(readers.jobReader(), query);
+    return doSearchWithReader(readers().jobReader(), query);
   }
 
   @Override
   public GlobalJobStatisticsEntity getGlobalJobStatistics(final GlobalJobStatisticsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.jobMetricsBatchReader().getGlobalJobStatistics(query, access));
+        access -> readers().jobMetricsBatchReader().getGlobalJobStatistics(query, access));
   }
 
   @Override
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       final JobTypeStatisticsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.jobMetricsBatchReader().getJobTypeStatistics(query, access));
+        access -> readers().jobMetricsBatchReader().getJobTypeStatistics(query, access));
   }
 
   @Override
   public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
       final JobWorkerStatisticsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.jobMetricsBatchReader().getJobWorkerStatistics(query, access));
+        access -> readers().jobMetricsBatchReader().getJobWorkerStatistics(query, access));
   }
 
   @Override
   public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
       final JobTimeSeriesStatisticsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.jobMetricsBatchReader().getJobTimeSeriesStatistics(query, access));
+        access -> readers().jobMetricsBatchReader().getJobTimeSeriesStatistics(query, access));
   }
 
   @Override
   public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
       final JobErrorStatisticsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.jobMetricsBatchReader().getJobErrorStatistics(query, access));
+        access -> readers().jobMetricsBatchReader().getJobErrorStatistics(query, access));
   }
 
   @Override
   public RoleEntity getRole(final String id) {
-    return doGetWithReader(readers.roleReader(), id)
+    return doGetWithReader(readers().roleReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Role", id));
   }
 
   @Override
   public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery query) {
-    return doSearchWithReader(readers.roleReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(readers().roleReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public SearchQueryResult<RoleMemberEntity> searchRoleMembers(final RoleMemberQuery query) {
-    return doSearchWithReader(readers.roleMemberReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(readers().roleMemberReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public TenantEntity getTenant(final String id) {
-    return doGetWithReader(readers.tenantReader(), id)
+    return doGetWithReader(readers().tenantReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Tenant", id));
   }
 
   @Override
   public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery query) {
-    return doSearchWithReader(readers.tenantReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(readers().tenantReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public SearchQueryResult<TenantMemberEntity> searchTenantMembers(final TenantMemberQuery query) {
-    return doSearchWithReader(readers.tenantMemberReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(readers().tenantMemberReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public GroupEntity getGroup(final String id) {
-    return doGetWithReader(readers.groupReader(), id)
+    return doGetWithReader(readers().groupReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Group", id));
   }
 
   @Override
   public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
-    return doSearchWithReader(readers.groupReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(readers().groupReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupMemberQuery query) {
-    return doSearchWithReader(readers.groupMemberReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(readers().groupMemberReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public UserEntity getUser(final String username) {
-    return doGetWithReader(readers.userReader(), username)
+    return doGetWithReader(readers().userReader(), username)
         .orElseThrow(() -> entityByUsernameNotFoundException(username));
   }
 
   @Override
   public SearchQueryResult<UserEntity> searchUsers(final UserQuery query) {
-    return doSearchWithReader(readers.userReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(readers().userReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public UserTaskEntity getUserTask(final long key) {
-    return doGetWithReader(readers.userTaskReader(), key)
+    return doGetWithReader(readers().userTaskReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("User Task", key));
   }
 
   @Override
   public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery query) {
-    return doSearchWithReader(readers.userTaskReader(), query);
+    return doSearchWithReader(readers().userTaskReader(), query);
   }
 
   @Override
   public VariableEntity getVariable(final long key) {
-    return doGetWithReader(readers.variableReader(), key)
+    return doGetWithReader(readers().variableReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Variable", key));
   }
 
   @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery query) {
-    return doSearchWithReader(readers.variableReader(), query);
+    return doSearchWithReader(readers().variableReader(), query);
   }
 
   @Override
   public UsageMetricStatisticsEntity usageMetricStatistics(final UsageMetricsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.usageMetricsReader().usageMetricStatistics(query, access));
+        access -> readers().usageMetricsReader().usageMetricStatistics(query, access));
   }
 
   @Override
   public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsTUQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.usageMetricsTUReader().usageMetricTUStatistics(query, access));
+        access -> readers().usageMetricsTUReader().usageMetricTUStatistics(query, access));
   }
 
   @Override
   public BatchOperationEntity getBatchOperation(final String id) {
-    return doGetWithReader(readers.batchOperationReader(), id)
+    return doGetWithReader(readers().batchOperationReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Batch Operation", id));
   }
 
   @Override
   public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
       final BatchOperationQuery query) {
-    return doSearchWithReader(readers.batchOperationReader(), query);
+    return doSearchWithReader(readers().batchOperationReader(), query);
   }
 
   @Override
   public SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
       final BatchOperationItemQuery query) {
-    return doSearchWithReader(readers.batchOperationItemReader(), query);
+    return doSearchWithReader(readers().batchOperationItemReader(), query);
   }
 
   @Override
@@ -623,7 +673,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final String listenerId, final GlobalListenerType listenerType) {
     return doGet(
             resourceAccessChecks ->
-                readers
+                readers()
                     .globalListenerReader()
                     .getGlobalListener(listenerId, listenerType, resourceAccessChecks))
         .orElseThrow(
@@ -638,25 +688,25 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<GlobalListenerEntity> searchGlobalListeners(
       final GlobalListenerQuery query) {
-    return doSearchWithReader(readers.globalListenerReader(), query);
+    return doSearchWithReader(readers().globalListenerReader(), query);
   }
 
   @Override
   public DeployedResourceEntity getDeployedResource(final long key) {
-    return doGet(a -> readers.deployedResourceReader().getByKey(key, a))
+    return doGet(a -> readers().deployedResourceReader().getByKey(key, a))
         .orElseThrow(() -> entityByKeyNotFoundException("Resource", key));
   }
 
   @Override
   public DeployedResourceEntity getDeployedResourceMetadata(final long key) {
-    return doGet(a -> readers.deployedResourceReader().getByKeyMetadata(key, a))
+    return doGet(a -> readers().deployedResourceReader().getByKeyMetadata(key, a))
         .orElseThrow(() -> entityByKeyNotFoundException("Resource", key));
   }
 
   @Override
   public SearchQueryResult<DeployedResourceEntity> searchDeployedResources(
       final DeployedResourceQuery query) {
-    return doSearchWithReader(readers.deployedResourceReader(), query);
+    return doSearchWithReader(readers().deployedResourceReader(), query);
   }
 
   protected <T, Q extends TypedSearchQuery<?, ?>> Optional<T> doGetWithReader(
@@ -769,12 +819,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   protected <T> T doReadWithResourceAccessController(
       final Function<ResourceAccessChecks, T> applier) {
-    return resourceAccessController.doSearch(securityContext, applier);
+    return resourceAccessController().doSearch(securityContext, applier);
   }
 
   protected <T> T doGetWithResourceAccessController(
       final Function<ResourceAccessChecks, T> applier) {
-    return resourceAccessController.doGet(securityContext, applier);
+    return resourceAccessController().doGet(securityContext, applier);
   }
 
   protected CamundaSearchException entityByKeyNotFoundException(
@@ -800,7 +850,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<WaitStateEntity> searchWaitStates(
       final ElementInstanceWaitStateQuery query) {
-    return doSearchWithReader(readers.waitStateReader(), query);
+    return doSearchWithReader(readers().waitStateReader(), query);
   }
 
   private CamundaSearchException entityByIdNotFoundException(

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -135,23 +135,45 @@ public class CamundaSearchClients implements SearchClientsProxy {
   private final SearchClientReaders readers;
   private final Map<String, SearchClientReaders> tenantReaders;
   private final String currentPhysicalTenantId;
+  private final Map<String, ResourceAccessController> resourceAccessControllerByTenant;
   private final ResourceAccessController resourceAccessController;
   private final SecurityContext securityContext;
 
+  /**
+   * Backward-compatible ctor: a single {@link ResourceAccessController} is shared across all
+   * physical tenants. All existing construction sites compile and behave unchanged.
+   */
   public CamundaSearchClients(
       final Map<String, SearchClientReaders> tenantReaders,
       final ResourceAccessController resourceAccessController) {
     this(
         tenantReaders,
         PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-        resourceAccessController,
+        tenantReaders.keySet().stream()
+            .collect(Collectors.toMap(k -> k, k -> resourceAccessController)),
+        null);
+  }
+
+  /**
+   * SPIKE (ADR-0005) data-plane ctor: per-PT {@link ResourceAccessController} map. The active
+   * controller is selected from the map by the current physical tenant id when {@link
+   * #withPhysicalTenant(String)} is called, so authorization scope checks follow the search
+   * client's tenant even when running off the request thread.
+   */
+  public CamundaSearchClients(
+      final Map<String, SearchClientReaders> tenantReaders,
+      final Map<String, ResourceAccessController> resourceAccessControllerByTenant) {
+    this(
+        tenantReaders,
+        PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+        resourceAccessControllerByTenant,
         null);
   }
 
   private CamundaSearchClients(
       final Map<String, SearchClientReaders> tenantReaders,
       final String currentPhysicalTenantId,
-      final ResourceAccessController resourceAccessController,
+      final Map<String, ResourceAccessController> resourceAccessControllerByTenant,
       final SecurityContext securityContext) {
     this.tenantReaders = Map.copyOf(tenantReaders);
     readers = this.tenantReaders.get(currentPhysicalTenantId);
@@ -161,7 +183,13 @@ public class CamundaSearchClients implements SearchClientsProxy {
               .formatted(currentPhysicalTenantId, this.tenantReaders.keySet()));
     }
     this.currentPhysicalTenantId = currentPhysicalTenantId;
-    this.resourceAccessController = resourceAccessController;
+    this.resourceAccessControllerByTenant = Map.copyOf(resourceAccessControllerByTenant);
+    resourceAccessController = this.resourceAccessControllerByTenant.get(currentPhysicalTenantId);
+    if (resourceAccessController == null) {
+      throw new IllegalArgumentException(
+          "Missing ResourceAccessController for physical tenant '%s'. Known physical tenants: %s"
+              .formatted(currentPhysicalTenantId, this.resourceAccessControllerByTenant.keySet()));
+    }
     this.securityContext = securityContext;
   }
 
@@ -263,13 +291,13 @@ public class CamundaSearchClients implements SearchClientsProxy {
               .formatted(physicalTenantId, tenantReaders.keySet()));
     }
     return new CamundaSearchClients(
-        tenantReaders, physicalTenantId, resourceAccessController, securityContext);
+        tenantReaders, physicalTenantId, resourceAccessControllerByTenant, securityContext);
   }
 
   @Override
   public CamundaSearchClients withSecurityContext(final SecurityContext securityContext) {
     return new CamundaSearchClients(
-        tenantReaders, currentPhysicalTenantId, resourceAccessController, securityContext);
+        tenantReaders, currentPhysicalTenantId, resourceAccessControllerByTenant, securityContext);
   }
 
   @Override

--- a/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsPhysicalTenantResourceAccessControllerTest.java
+++ b/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsPhysicalTenantResourceAccessControllerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -55,26 +56,22 @@ class CamundaSearchClientsPhysicalTenantResourceAccessControllerTest {
   }
 
   @Test
-  void shouldUseDefaultPhysicalTenantWhenNotSwitched() {
-    // given
+  void shouldFailFastWhenNoPhysicalTenantScoped() {
+    // given — unscoped base instance: withPhysicalTenant was never called
     final var readersDefault = mock(SearchClientReaders.class);
     final var readersB = mock(SearchClientReaders.class);
     final var racDefault = mock(ResourceAccessController.class);
     final var racB = mock(ResourceAccessController.class);
-
-    when(racDefault.doSearch(any(), any())).thenReturn(SearchQueryResult.empty());
-    when(racB.doSearch(any(), any())).thenReturn(SearchQueryResult.empty());
 
     final var clients =
         new CamundaSearchClients(
             Map.of("default", readersDefault, "tenant-b", readersB),
             Map.of("default", racDefault, "tenant-b", racB));
 
-    // when — no withPhysicalTenant call; must default to "default"
-    clients.searchAuthorizations(AuthorizationQuery.of(q -> q));
-
-    // then — only the default controller must be invoked; tenant-b controller must not be touched
-    verify(racDefault).doSearch(any(), any());
-    verifyNoInteractions(racB);
+    // when / then — any read on the unscoped base must fail fast; silently reading "default" is the
+    // bug class we are eliminating (ADR-0005 B.3)
+    assertThatThrownBy(() -> clients.searchAuthorizations(AuthorizationQuery.of(q -> q)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("withPhysicalTenant");
   }
 }

--- a/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsPhysicalTenantResourceAccessControllerTest.java
+++ b/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsPhysicalTenantResourceAccessControllerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.reader.SearchClientReaders;
+import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.core.authz.ResourceAccessController;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SPIKE (ADR-0005) data-plane proof test: verifies that {@link CamundaSearchClients} selects the
+ * per-PT {@link ResourceAccessController} when {@link
+ * CamundaSearchClients#withPhysicalTenant(String)} is called, so the authorization scope check
+ * follows the search client's physical tenant — not a thread-local — and therefore works correctly
+ * even when the search runs off the request thread (e.g. inside the engine).
+ */
+class CamundaSearchClientsPhysicalTenantResourceAccessControllerTest {
+
+  @Test
+  void shouldRouteResourceAccessCheckToPhysicalTenantInContext() {
+    // given
+    final var readersDefault = mock(SearchClientReaders.class);
+    final var readersB = mock(SearchClientReaders.class);
+    final var racDefault = mock(ResourceAccessController.class);
+    final var racB = mock(ResourceAccessController.class);
+
+    when(racDefault.doSearch(any(), any())).thenReturn(SearchQueryResult.empty());
+    when(racB.doSearch(any(), any())).thenReturn(SearchQueryResult.empty());
+
+    final var clients =
+        new CamundaSearchClients(
+            Map.of("default", readersDefault, "tenant-b", readersB),
+            Map.of("default", racDefault, "tenant-b", racB));
+
+    // when — switch to tenant-b before issuing the search
+    clients.withPhysicalTenant("tenant-b").searchAuthorizations(AuthorizationQuery.of(q -> q));
+
+    // then — only the tenant-b controller must be invoked; the default controller must not be
+    // touched
+    verify(racB).doSearch(any(), any());
+    verifyNoInteractions(racDefault);
+  }
+
+  @Test
+  void shouldUseDefaultPhysicalTenantWhenNotSwitched() {
+    // given
+    final var readersDefault = mock(SearchClientReaders.class);
+    final var readersB = mock(SearchClientReaders.class);
+    final var racDefault = mock(ResourceAccessController.class);
+    final var racB = mock(ResourceAccessController.class);
+
+    when(racDefault.doSearch(any(), any())).thenReturn(SearchQueryResult.empty());
+    when(racB.doSearch(any(), any())).thenReturn(SearchQueryResult.empty());
+
+    final var clients =
+        new CamundaSearchClients(
+            Map.of("default", readersDefault, "tenant-b", readersB),
+            Map.of("default", racDefault, "tenant-b", racB));
+
+    // when — no withPhysicalTenant call; must default to "default"
+    clients.searchAuthorizations(AuthorizationQuery.of(q -> q));
+
+    // then — only the default controller must be invoked; tenant-b controller must not be touched
+    verify(racDefault).doSearch(any(), any());
+    verifyNoInteractions(racB);
+  }
+}


### PR DESCRIPTION
## Reference spike for ADR-0005 — NOT for merge (draft proof)

Validates the **two-mechanism** physical-tenant authorization-read design in ADR-0005 (#55325). Each mechanism is chosen by execution context, over the shared per-PT `AuthorizationReader`.

### Data-plane → instance-bound (per-PT `ResourceAccessController`)
- `CamundaSearchClients` holds a `Map<String, ResourceAccessController>`; `withPhysicalTenant(pt)` selects that PT's controller (backward-compatible: the single-controller constructor still works, maps it across all tenants).
- **`CamundaSearchClients` no longer holds a `default` scope.** The base instance is now unscoped (both public ctors pass `null` instead of `DEFAULT_PHYSICAL_TENANT_ID`). `withPhysicalTenant(pt)` is mandatory before any read; unscoped reads throw `IllegalStateException` immediately. Silently falling back to `"default"` is the bug class we're eliminating (ADR-0005 B.3).
- Guarded private accessors `readers()` and `resourceAccessController()` enforce the fail-fast contract at all ~65 call sites (fields renamed to `scopedReaders` / `scopedResourceAccessController`).
- The engine is expected to scope per partition via PR #55401; until that lands, engine reads will throw — the desired loud behaviour over silent-default reads.
- Wired in the app for both backends: `SearchClientConfiguration` (ES/OS, `DocumentBasedResourceAccessController`) and `RdbmsConfiguration` (RDBMS, `RdbmsResourceAccessController`) build one `AuthorizationReader → SearchAuthorizationScopeRepository → AuthorizationChecker → ResourceAccessProvider → RAC` chain per PT.
- Correct **off the request thread** (e.g. batch operations in the engine), which is why it must be instance-bound, not thread-local.
- Proof: `CamundaSearchClientsPhysicalTenantResourceAccessControllerTest` — `withPhysicalTenant("tenant-b")` routes the access check to tenant-b's controller; the default controller is untouched. `shouldFailFastWhenNoPhysicalTenantScoped` verifies that an unscoped call throws `IllegalStateException`.

### Control-plane → request-scoped (`PhysicalTenantRoutingAuthorizationReader`)
- The `AuthorizationRepositoryAdapter` (Spring Security permission checks) resolves `PhysicalTenantContext.current()` → that PT's `AuthorizationReader`. The control-plane only ever runs on the gateway's request thread (the engine never calls `hasPermission`), so thread-bound resolution is safe — including in standalone deployments.
- Proof: `PhysicalTenantRoutingAuthorizationReaderTest` — drives the real thread-bound `PhysicalTenantContext`.

### A.1 — Request-time identity & membership resolution (ADR-0005)
- `DefaultMembershipService` (4 call sites: `mappingRuleIds`, `groupIds`, `roleIds`, `tenantIds`) and `BasicCamundaUserService` (`getUser`) now resolve `PhysicalTenantContext.current()` instead of `DEFAULT_PHYSICAL_TENANT_ID`. These all run on the request thread, where ADR-0003's pre-security filter has already stamped the PT.
- Flipped call sites: `DefaultMembershipService#mappingRuleIds`, `#groupIds`, `#roleIds`, `#tenantIds`; `BasicCamundaUserService#getUser`.
- Not flipped (reported): `WebSecurityConfig#adminUserPresencePort` — `AdminUserPresenceAdapter` takes a single `RoleServices` instance at construction time (wired once at boot, not request-scoped); a simple argument swap would not achieve dynamic routing. Needs the adapter to accept a `ServiceRegistry` and call `roleServices(PhysicalTenantContext.current())` at check time, or iterate all PTs — execution work.
- Not present in this worktree: `OidcCamundaUserService` (the class does not exist in this branch).
- Proof: `DefaultMembershipServicePhysicalTenantTest` — binds a `MockHttpServletRequest` with `"tenant-b"`, verifies all four membership methods dispatch to tenant-b's services; asserts `default` services are never invoked.

### Scope / execution follow-up (not in this proof)
- The shared `AuthorizationScopeRepositoryPort` / `AuthorizationChecker` (CSL config + `ServiceRegistry`) still resolve via the request-scoped reader bean — correct for their request-path use; routing those per-PT (or confirming request-only) is execution work.
- `TenantAccessProvider` stays shared (logical tenants resolve from the authentication, no per-PT storage read).
- `AdminUserPresenceAdapter` PT routing (see A.1 note above) is execution work.
- Engine read scoping per partition: PR #55401.

Builds green; all proof tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)