### PR TITLE
Ensure migrated variable records have root process instance key

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -397,6 +397,8 @@ public class ProcessInstanceMigrationMigrateProcessor
                         .setScopeKey(elementInstance.getKey())
                         .setName(variable.name())
                         .setProcessInstanceKey(elementInstance.getValue().getProcessInstanceKey())
+                        .setRootProcessInstanceKey(
+                            elementInstance.getValue().getRootProcessInstanceKey())
                         .setProcessDefinitionKey(targetProcessDefinition.getKey())
                         .setBpmnProcessId(targetProcessDefinition.getBpmnProcessId())
                         .setTenantId(elementInstance.getValue().getTenantId())));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateVariablesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateVariablesTest.java
@@ -108,6 +108,7 @@ public class MigrateVariablesTest {
         .describedAs("Expect that the other variable data did not change")
         .hasName(variable.getName())
         .hasProcessInstanceKey(variable.getProcessInstanceKey())
+        .hasRootProcessInstanceKey(variable.getRootProcessInstanceKey())
         .hasScopeKey(variable.getScopeKey())
         .hasTenantId(variable.getTenantId());
     assertThat(
@@ -124,6 +125,7 @@ public class MigrateVariablesTest {
         .describedAs("Expect that the other variable data did not change")
         .hasName(variable2.getName())
         .hasProcessInstanceKey(variable2.getProcessInstanceKey())
+        .hasRootProcessInstanceKey(variable2.getRootProcessInstanceKey())
         .hasScopeKey(variable2.getScopeKey())
         .hasTenantId(variable2.getTenantId());
   }
@@ -204,6 +206,7 @@ public class MigrateVariablesTest {
         .describedAs("Expect that the other variable data did not change")
         .hasName(variable.getName())
         .hasProcessInstanceKey(variable.getProcessInstanceKey())
+        .hasRootProcessInstanceKey(variable.getRootProcessInstanceKey())
         .hasScopeKey(variable.getScopeKey())
         .hasTenantId(variable.getTenantId());
     assertThat(
@@ -220,6 +223,7 @@ public class MigrateVariablesTest {
         .describedAs("Expect that the other variable data did not change")
         .hasName(variable2.getName())
         .hasProcessInstanceKey(variable2.getProcessInstanceKey())
+        .hasRootProcessInstanceKey(variable2.getRootProcessInstanceKey())
         .hasScopeKey(variable2.getScopeKey())
         .hasTenantId(variable2.getTenantId());
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
@@ -62,7 +62,13 @@ public class MigratedVariableHandler implements ExportHandler<VariableEntity, Va
         .setId(VariableForListViewEntity.getIdBy(recordValue.getScopeKey(), recordValue.getName()))
         .setProcessDefinitionKey(recordValue.getProcessDefinitionKey())
         .setPosition(record.getPosition())
-        .setBpmnProcessId(recordValue.getBpmnProcessId());
+        .setBpmnProcessId(recordValue.getBpmnProcessId())
+        .setProcessInstanceKey(recordValue.getProcessInstanceKey());
+
+    final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
@@ -128,6 +128,8 @@ public class MigratedVariableHandlerTest {
     final VariableRecordValue variableRecordValue =
         ImmutableVariableRecordValue.builder()
             .from(factory.generateObject(VariableRecordValue.class))
+            .withProcessInstanceKey(1234L)
+            .withRootProcessInstanceKey(1233L)
             .withValue("doNotCareAboutThis")
             .withTenantId("tenantId")
             .build();
@@ -148,11 +150,14 @@ public class MigratedVariableHandlerTest {
     assertThat(variableEntity.getProcessDefinitionKey())
         .isEqualTo(variableRecordValue.getProcessDefinitionKey());
     assertThat(variableEntity.getPosition()).isEqualTo(variableRecord.getPosition());
+    assertThat(variableEntity.getProcessInstanceKey())
+        .isEqualTo(variableRecordValue.getProcessInstanceKey());
+    assertThat(variableEntity.getRootProcessInstanceKey())
+        .isEqualTo(variableRecordValue.getRootProcessInstanceKey());
 
     assertThat(variableEntity.getKey()).isEqualTo(0);
     assertThat(variableEntity.getName()).isNull();
     assertThat(variableEntity.getScopeKey()).isNull();
-    assertThat(variableEntity.getProcessInstanceKey()).isNull();
     assertThat(variableEntity.getValue()).isNull();
     assertThat(variableEntity.getIsPreview()).isFalse();
     assertThat(variableEntity.getFullValue()).isNull();


### PR DESCRIPTION
This was something I spotted when working on the [archiver-less PoC](https://github.com/camunda/camunda/pull/52595/changes/229babe65c0046d460ea7a6a06b150523c09ee3c).  The `VariableRecord` sent when migrating process instances did not have the root process instance key attached.

This isn't a big deal, but as they do have the `processInstanceKey` set it's probably best to also include the `rootProcessInstanceKey`.

I've then also updated the handler to set those values on the entity - just in case we ever do an upsert where the document does not exist.

In practice this isn't a massive deal, but we might need `rootProcessInstanceKey` for other things in the future.