### PR TITLE
feat: implement signal subscription wait-states

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/SignalWaitStateDetails.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/SignalWaitStateDetails.java
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.enums;
+package io.camunda.client.api.search.response;
 
-public enum WaitStateType {
-  JOB,
-  MESSAGE,
-  TIMER,
-  USER_TASK,
-  SIGNAL,
-  UNKNOWN_ENUM_VALUE;
+/** Details of an element instance waiting on a signal. */
+public interface SignalWaitStateDetails extends WaitStateDetails {
+
+  String getSignalName();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
@@ -67,6 +67,9 @@ public class ElementInstanceWaitStateResultImpl implements ElementInstanceWaitSt
       case USER_TASK:
         return new UserTaskWaitStateDetailsImpl(
             (io.camunda.client.protocol.rest.UserTaskWaitStateDetails) item);
+      case SIGNAL:
+        return new SignalWaitStateDetailsImpl(
+            (io.camunda.client.protocol.rest.SignalWaitStateDetails) item);
       default:
         return null;
     }
@@ -74,7 +77,7 @@ public class ElementInstanceWaitStateResultImpl implements ElementInstanceWaitSt
 
   @Override
   public WaitStateType getWaitStateType() {
-    return details.getWaitStateType();
+    return details != null ? details.getWaitStateType() : WaitStateType.UNKNOWN_ENUM_VALUE;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SignalWaitStateDetailsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SignalWaitStateDetailsImpl.java
@@ -13,13 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.enums;
+package io.camunda.client.impl.search.response;
 
-public enum WaitStateType {
-  JOB,
-  MESSAGE,
-  TIMER,
-  USER_TASK,
-  SIGNAL,
-  UNKNOWN_ENUM_VALUE;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.SignalWaitStateDetails;
+
+public class SignalWaitStateDetailsImpl implements SignalWaitStateDetails {
+
+  private final String signalName;
+
+  public SignalWaitStateDetailsImpl(
+      final io.camunda.client.protocol.rest.SignalWaitStateDetails details) {
+    signalName = details.getSignalName();
+  }
+
+  @Override
+  public WaitStateType getWaitStateType() {
+    return WaitStateType.SIGNAL;
+  }
+
+  @Override
+  public String getSignalName() {
+    return signalName;
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.WaitStateDetails.WaitStateType;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
+import io.camunda.search.entities.WaitStateSignalDetails;
 import io.camunda.search.entities.WaitStateTimerDetails;
 import io.camunda.search.entities.WaitStateUserTaskDetails;
 import org.slf4j.Logger;
@@ -61,6 +62,7 @@ public class WaitStateEntityMapper {
         case MESSAGE -> OBJECT_MAPPER.readValue(detailsJson, WaitStateMessageDetails.class);
         case USER_TASK -> OBJECT_MAPPER.readValue(detailsJson, WaitStateUserTaskDetails.class);
         case TIMER -> OBJECT_MAPPER.readValue(detailsJson, WaitStateTimerDetails.class);
+        case SIGNAL -> OBJECT_MAPPER.readValue(detailsJson, WaitStateSignalDetails.class);
       };
     } catch (final Exception e) {
       LOG.warn("Failed to parse wait state details for type {}: {}", waitStateType, e.getMessage());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -137,6 +137,7 @@ import io.camunda.gateway.protocol.model.RoleSearchQueryResult;
 import io.camunda.gateway.protocol.model.RoleUserResult;
 import io.camunda.gateway.protocol.model.RoleUserSearchResult;
 import io.camunda.gateway.protocol.model.SearchQueryPageResponse;
+import io.camunda.gateway.protocol.model.SignalWaitStateDetails;
 import io.camunda.gateway.protocol.model.StatusMetric;
 import io.camunda.gateway.protocol.model.TenantClientResult;
 import io.camunda.gateway.protocol.model.TenantClientSearchResult;
@@ -216,6 +217,7 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
+import io.camunda.search.entities.WaitStateSignalDetails;
 import io.camunda.search.entities.WaitStateTimerDetails;
 import io.camunda.search.entities.WaitStateUserTaskDetails;
 import io.camunda.search.query.SearchQueryResult;
@@ -726,6 +728,13 @@ public final class SearchQueryResponseMapper {
                       .waitStateType(WaitStateTypeEnum.TIMER.name())
                       .dueDate(dueDate)
                       .repetitions(repetitions)
+                      .build())
+              .build();
+      case WaitStateSignalDetails(final var signalName) ->
+          base.details(
+                  SignalWaitStateDetails.Builder.create()
+                      .waitStateType(WaitStateTypeEnum.SIGNAL.name())
+                      .signalName(signalName)
                       .build())
               .build();
     };

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateSignalIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateSignalIT.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.it.waitstate;
 
+import static io.camunda.it.util.TestHelper.cancelInstance;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.search.enums.WaitStateElementType;
 import io.camunda.client.api.search.enums.WaitStateType;
 import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
@@ -29,8 +31,8 @@ import org.junit.jupiter.api.Test;
  * Verifies the element instance wait-state search command for signal-based wait states. Each test
  * deploys its own isolated process to avoid interference with shared state.
  *
- * <p>Start-event and boundary-event signal subscription filtering is covered at the unit level in
- * {@code SignalBasedWaitStateTransformerTest}.
+ * <p>Boundary-event signal subscription filtering is covered at the unit level in {@code
+ * SignalBasedWaitStateTransformerTest}.
  */
 @MultiDbTest
 public class WaitStateSignalIT {
@@ -206,6 +208,151 @@ public class WaitStateSignalIT {
 
     // then
     assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldNotTrackSignalStartEventSubscriptionAsWaitState() {
+    // given — a process whose only trigger is a signal start event; these subscriptions have
+    //   processInstanceKey == -1 and must never produce a wait-state entry
+    final BpmnModelInstance startEventProcess =
+        Bpmn.createExecutableProcess("signalStartOnlyProcess")
+            .startEvent()
+            .signal("startOnlySignal")
+            .endEvent()
+            .done();
+
+    // Deploy a second process with an ICE to generate known export traffic so we can verify
+    // the exporter has processed the signal subscription records before asserting.
+    final BpmnModelInstance iceProcess =
+        Bpmn.createExecutableProcess("signalStartTrafficProcess")
+            .startEvent()
+            .intermediateCatchEvent("ice-marker")
+            .signal("startTrafficSignal")
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, startEventProcess, "signalStartOnlyProcess.bpmn");
+    deployProcessAndWaitForIt(camundaClient, iceProcess, "signalStartTrafficProcess.bpmn");
+
+    final var trafficInstance = startProcessInstance(camundaClient, "signalStartTrafficProcess");
+    final long pik = trafficInstance.getProcessInstanceKey();
+
+    // when — wait for the ICE wait state; this proves the exporter has caught up on all
+    //   signal records, including the start-event subscription for signalStartOnlyProcess
+    Awaitility.await("ICE wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(
+                                f -> f.processInstanceKey(pik).waitStateType(WaitStateType.SIGNAL))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // then — ALL signal wait states in the system must have a positive processInstanceKey;
+    //   signal start-event subscriptions (processInstanceKey == -1) must not appear
+    final var allSignalWaitStates =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.waitStateType(WaitStateType.SIGNAL))
+            .send()
+            .join()
+            .items();
+
+    assertThat(allSignalWaitStates)
+        .isNotEmpty()
+        .allSatisfy(ws -> assertThat(Long.parseLong(ws.getProcessInstanceKey())).isPositive());
+
+    // cleanup
+    cancelInstance(camundaClient, trafficInstance);
+  }
+
+  @Test
+  void shouldUpdateWaitStateWhenSignalElementIsMigrated() {
+    // given — V1 has ICE "signal-catch-v1", V2 has ICE "signal-catch-v2" at the same position
+    final BpmnModelInstance v1 =
+        Bpmn.createExecutableProcess("signalMigrationV1")
+            .startEvent()
+            .intermediateCatchEvent("signal-catch-v1")
+            .signal("migrationSignalV1")
+            .endEvent()
+            .done();
+    final BpmnModelInstance v2 =
+        Bpmn.createExecutableProcess("signalMigrationV2")
+            .startEvent()
+            .intermediateCatchEvent("signal-catch-v2")
+            .signal("migrationSignalV2")
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, v1, "signalMigrationV1.bpmn");
+    final long v2Key =
+        deployProcessAndWaitForIt(camundaClient, v2, "signalMigrationV2.bpmn")
+            .getProcessDefinitionKey();
+
+    final var instance = startProcessInstance(camundaClient, "signalMigrationV1");
+    final long pik = instance.getProcessInstanceKey();
+
+    Awaitility.await("wait state with signal-catch-v1 should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(
+                        item -> assertThat(item.getElementId()).isEqualTo("signal-catch-v1")));
+
+    // when — migrate the process instance, remapping signal-catch-v1 → signal-catch-v2
+    camundaClient
+        .newMigrateProcessInstanceCommand(pik)
+        .migrationPlan(
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(v2Key)
+                .addMappingInstruction("signal-catch-v1", "signal-catch-v2")
+                .build())
+        .send()
+        .join();
+
+    // then — wait state is updated to reflect the new element id
+    Awaitility.await("wait state should be updated to signal-catch-v2")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(
+                        item -> assertThat(item.getElementId()).isEqualTo("signal-catch-v2")));
+
+    // cleanup
+    cancelInstance(camundaClient, instance);
+    Awaitility.await("wait state should be removed after cancellation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateSignalIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateSignalIT.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.waitstate;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
+import io.camunda.client.api.search.response.SignalWaitStateDetails;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the element instance wait-state search command for signal-based wait states. Each test
+ * deploys its own isolated process to avoid interference with shared state.
+ *
+ * <p>Start-event and boundary-event signal subscription filtering is covered at the unit level in
+ * {@code SignalBasedWaitStateTransformerTest}.
+ */
+@MultiDbTest
+public class WaitStateSignalIT {
+
+  private static final String SIGNAL_NAME = "mySignal";
+  private static final String CATCH_TASK = "signal-catch";
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldReturnSignalWaitState() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("signalWaitStateProcess")
+            .startEvent()
+            .intermediateCatchEvent(CATCH_TASK)
+            .signal(SIGNAL_NAME)
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "signalWaitStateProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "signalWaitStateProcess").getProcessInstanceKey();
+
+    // when
+    Awaitility.await("signal wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final List<ElementInstanceWaitStateResult> items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.processInstanceKey(pik))
+                      .send()
+                      .join()
+                      .items();
+
+              // then
+              assertThat(items).hasSize(1);
+              final var item = items.getFirst();
+              assertThat(item.getElementId()).isEqualTo(CATCH_TASK);
+              assertThat(item.getElementType())
+                  .isEqualTo(WaitStateElementType.INTERMEDIATE_CATCH_EVENT);
+              assertThat(item.getDetails()).isInstanceOf(SignalWaitStateDetails.class);
+              final var signalDetails = (SignalWaitStateDetails) item.getDetails();
+              assertThat(signalDetails.getWaitStateType()).isEqualTo(WaitStateType.SIGNAL);
+              assertThat(signalDetails.getSignalName()).isEqualTo(SIGNAL_NAME);
+            });
+  }
+
+  @Test
+  void shouldFilterByWaitStateTypeSignal() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("signalFilterProcess")
+            .startEvent()
+            .intermediateCatchEvent("signal-filter-catch")
+            .signal("filterSignal")
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "signalFilterProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "signalFilterProcess").getProcessInstanceKey();
+
+    Awaitility.await("signal wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.waitStateType(WaitStateType.SIGNAL).processInstanceKey(pik))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getDetails()).isInstanceOf(SignalWaitStateDetails.class);
+  }
+
+  @Test
+  void shouldRemoveWaitStateWhenSignalIsReceived() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("signalRemovalProcess")
+            .startEvent()
+            .intermediateCatchEvent("removal-catch")
+            .signal("removalSignal")
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "signalRemovalProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "signalRemovalProcess").getProcessInstanceKey();
+
+    Awaitility.await("signal wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when — broadcast the signal to progress the instance
+    camundaClient.newBroadcastSignalCommand().signalName("removalSignal").send().join();
+
+    // then — wait state is removed
+    Awaitility.await("wait state should be removed after signal broadcast")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldReturnEmptyWhenFilteringByJobTypeForSignalProcess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("signalNegativeProcess")
+            .startEvent()
+            .intermediateCatchEvent("negative-catch")
+            .signal("negativeSignal")
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "signalNegativeProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "signalNegativeProcess").getProcessInstanceKey();
+
+    Awaitility.await("signal wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // when — filter by JOB type while the instance is waiting on a signal
+    final var result =
+        camundaClient
+            .newElementInstanceWaitStateSearchRequest()
+            .filter(f -> f.waitStateType(WaitStateType.JOB).processInstanceKey(pik))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldNotTrackSignalBoundaryEventSubscriptionAsWaitState() {
+    // given — process with a service task that has a signal boundary event attached
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("signalBoundaryProcess")
+            .startEvent()
+            .serviceTask("boundary-task", t -> t.zeebeJobType("boundary-job"))
+            .boundaryEvent("signal-boundary")
+            .signal("boundarySignal")
+            .endEvent()
+            .moveToActivity("boundary-task")
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "signalBoundaryProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "signalBoundaryProcess").getProcessInstanceKey();
+
+    // when — wait for the process to be at the service task (a JOB wait state appears)
+    Awaitility.await("job wait state should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik).waitStateType(WaitStateType.JOB))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // then — the boundary event subscription must never appear as a SIGNAL wait state.
+    // Use a stabilisation window: assert continuously for 2 s so a late-arriving record would fail.
+    Awaitility.await("no signal wait state should appear for a boundary event subscription")
+        .during(Duration.ofSeconds(2))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(
+                                f -> f.processInstanceKey(pik).waitStateType(WaitStateType.SIGNAL))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.WaitStateDetails.WaitStateType;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
+import io.camunda.search.entities.WaitStateSignalDetails;
 import io.camunda.search.entities.WaitStateTimerDetails;
 import io.camunda.search.entities.WaitStateUserTaskDetails;
 import org.slf4j.Logger;
@@ -63,6 +64,7 @@ public class WaitStateEntityTransformer
         case MESSAGE -> OBJECT_MAPPER.readValue(detailsJson, WaitStateMessageDetails.class);
         case USER_TASK -> OBJECT_MAPPER.readValue(detailsJson, WaitStateUserTaskDetails.class);
         case TIMER -> OBJECT_MAPPER.readValue(detailsJson, WaitStateTimerDetails.class);
+        case SIGNAL -> OBJECT_MAPPER.readValue(detailsJson, WaitStateSignalDetails.class);
       };
     } catch (final Exception e) {
       LOG.warn("Failed to parse wait state details for type {}: {}", waitStateType, e.getMessage());

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateDetails.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateDetails.java
@@ -11,7 +11,8 @@ public sealed interface WaitStateDetails
     permits WaitStateJobDetails,
         WaitStateMessageDetails,
         WaitStateUserTaskDetails,
-        WaitStateTimerDetails {
+        WaitStateTimerDetails,
+        WaitStateSignalDetails {
 
   WaitStateType waitStateType();
 
@@ -19,6 +20,7 @@ public sealed interface WaitStateDetails
     JOB,
     MESSAGE,
     USER_TASK,
-    TIMER
+    TIMER,
+    SIGNAL
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateSignalDetails.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateSignalDetails.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.util.ObjectBuilder;
+import org.jspecify.annotations.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WaitStateSignalDetails(@Nullable String signalName) implements WaitStateDetails {
+
+  @Override
+  public WaitStateDetails.WaitStateType waitStateType() {
+    return WaitStateDetails.WaitStateType.SIGNAL;
+  }
+
+  public static class Builder implements ObjectBuilder<WaitStateSignalDetails> {
+    private @Nullable String signalName;
+
+    public Builder signalName(final @Nullable String signalName) {
+      this.signalName = signalName;
+      return this;
+    }
+
+    @Override
+    public WaitStateSignalDetails build() {
+      return new WaitStateSignalDetails(signalName);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -508,7 +508,7 @@ public final class CatchEventBehavior {
         .setTenantId(context.getTenantId())
         .setProcessInstanceKey(context.getProcessInstanceKey())
         .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
-        .setBpmnElementType(event.getElementType().name());
+        .setBpmnElementType(event.getElementType());
 
     final var subscriptionKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -505,7 +505,9 @@ public final class CatchEventBehavior {
         .setBpmnProcessId(context.getBpmnProcessId())
         .setCatchEventInstanceKey(context.getElementInstanceKey())
         .setCatchEventId(event.getId())
-        .setTenantId(context.getTenantId());
+        .setTenantId(context.getTenantId())
+        .setProcessInstanceKey(context.getProcessInstanceKey())
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
 
     final var subscriptionKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -507,7 +507,8 @@ public final class CatchEventBehavior {
         .setCatchEventId(event.getId())
         .setTenantId(context.getTenantId())
         .setProcessInstanceKey(context.getProcessInstanceKey())
-        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
+        .setBpmnElementType(event.getElementType().name());
 
     final var subscriptionKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
@@ -51,6 +52,13 @@ public final class WaitStateConfigs {
           .withRemoveIntents(
               MessageSubscriptionIntent.CORRELATED, MessageSubscriptionIntent.DELETED)
           .withWaitStateType(WaitStateType.MESSAGE);
+
+  public static final WaitStateTransformerConfig SIGNAL_CONFIG =
+      WaitStateTransformerConfig.of(ValueType.SIGNAL_SUBSCRIPTION)
+          .withAddIntents(SignalSubscriptionIntent.CREATED)
+          .withUpdateIntents(SignalSubscriptionIntent.MIGRATED)
+          .withRemoveIntents(SignalSubscriptionIntent.DELETED)
+          .withWaitStateType(WaitStateType.SIGNAL);
 
   private WaitStateConfigs() {}
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalBasedWaitStateTransformer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import static io.camunda.zeebe.exporter.common.waitstate.WaitStateConfigs.SIGNAL_CONFIG;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformerConfig;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
+
+public class SignalBasedWaitStateTransformer
+    implements WaitStateTransformer<SignalSubscriptionRecordValue> {
+
+  @Override
+  public WaitStateTransformerConfig config() {
+    return SIGNAL_CONFIG;
+  }
+
+  @Override
+  public boolean triggersAdd(final Record<SignalSubscriptionRecordValue> record) {
+    return config().triggersAdd(record) && isInstanceSubscription(record);
+  }
+
+  @Override
+  public boolean triggersUpdate(final Record<SignalSubscriptionRecordValue> record) {
+    return config().triggersUpdate(record) && isInstanceSubscription(record);
+  }
+
+  @Override
+  public boolean triggersRemoval(final Record<SignalSubscriptionRecordValue> record) {
+    return config().triggersRemoval(record) && isInstanceSubscription(record);
+  }
+
+  @Override
+  public void extract(
+      final Record<SignalSubscriptionRecordValue> record, final WaitStateEntry entry) {
+    entry
+        .setElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+        .setDetails(new SignalWaitStateDetails(record.getValue().getSignalName()));
+  }
+
+  /** Returns false for process-level start-event subscriptions that have no running instance. */
+  private static boolean isInstanceSubscription(
+      final Record<SignalSubscriptionRecordValue> record) {
+    return record.getValue().getCatchEventInstanceKey() != -1;
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalBasedWaitStateTransformer.java
@@ -25,6 +25,14 @@ public class SignalBasedWaitStateTransformer
   }
 
   @Override
+  public void extract(
+      final Record<SignalSubscriptionRecordValue> record, final WaitStateEntry entry) {
+    entry
+        .setElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+        .setDetails(new SignalWaitStateDetails(record.getValue().getSignalName()));
+  }
+
+  @Override
   public boolean triggersAdd(final Record<SignalSubscriptionRecordValue> record) {
     return config().triggersAdd(record) && isInstanceSubscription(record);
   }
@@ -39,17 +47,14 @@ public class SignalBasedWaitStateTransformer
     return config().triggersRemoval(record) && isInstanceSubscription(record);
   }
 
-  @Override
-  public void extract(
-      final Record<SignalSubscriptionRecordValue> record, final WaitStateEntry entry) {
-    entry
-        .setElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
-        .setDetails(new SignalWaitStateDetails(record.getValue().getSignalName()));
-  }
-
-  /** Returns false for process-level start-event subscriptions that have no running instance. */
+  /**
+   * Returns true only for intermediate catch event subscriptions, skipping start and boundary
+   * events.
+   */
   private static boolean isInstanceSubscription(
       final Record<SignalSubscriptionRecordValue> record) {
-    return record.getValue().getCatchEventInstanceKey() != -1;
+    return BpmnElementType.INTERMEDIATE_CATCH_EVENT
+        .name()
+        .equals(record.getValue().getBpmnElementType());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalBasedWaitStateTransformer.java
@@ -28,7 +28,7 @@ public class SignalBasedWaitStateTransformer
   public void extract(
       final Record<SignalSubscriptionRecordValue> record, final WaitStateEntry entry) {
     entry
-        .setElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+        .setElementType(record.getValue().getBpmnElementType())
         .setDetails(new SignalWaitStateDetails(record.getValue().getSignalName()));
   }
 
@@ -53,8 +53,6 @@ public class SignalBasedWaitStateTransformer
    */
   private static boolean isInstanceSubscription(
       final Record<SignalSubscriptionRecordValue> record) {
-    return BpmnElementType.INTERMEDIATE_CATCH_EVENT
-        .name()
-        .equals(record.getValue().getBpmnElementType());
+    return BpmnElementType.INTERMEDIATE_CATCH_EVENT.equals(record.getValue().getBpmnElementType());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalWaitStateDetails.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalWaitStateDetails.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
+
+public record SignalWaitStateDetails(String signalName) implements WaitStateDetails {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
@@ -28,6 +28,7 @@ public final class WaitStateTransformerRegistry {
         JobBasedWaitStateTransformer::new,
         UserTaskBasedWaitStateTransformer::new,
         TimerBasedWaitStateTransformer::new,
+        SignalBasedWaitStateTransformer::new,
         MessageBasedWaitStateTransformer::new);
   }
 

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalBasedWaitStateTransformerTest.java
@@ -39,7 +39,7 @@ class SignalBasedWaitStateTransformerTest {
             .withBpmnProcessId("my-process")
             .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             .withSignalName("mySignal")
-            .withBpmnElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT.name())
+            .withBpmnElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
             .build();
 
     final Record<SignalSubscriptionRecordValue> record =
@@ -140,15 +140,16 @@ class SignalBasedWaitStateTransformerTest {
   }
 
   @Test
-  void shouldSkipPreV810RecordsWithEmptyBpmnElementType() {
-    // given — records exported before 8.10 have an empty bpmnElementType string
+  void shouldSkipPreV810RecordsWithUnspecifiedBpmnElementType() {
+    // given — records from before 8.10 don't carry bpmnElementType; EnumProperty defaults to
+    // UNSPECIFIED
     final SignalSubscriptionRecordValue value =
         ImmutableSignalSubscriptionRecordValue.builder()
             .from(factory.generateObject(SignalSubscriptionRecordValue.class))
             .withProcessInstanceKey(200L)
             .withRootProcessInstanceKey(200L)
             .withBpmnProcessId("my-process")
-            .withBpmnElementType("")
+            .withBpmnElementType(BpmnElementType.UNSPECIFIED)
             .build();
 
     final Record<SignalSubscriptionRecordValue> record =
@@ -174,7 +175,7 @@ class SignalBasedWaitStateTransformerTest {
             .withRootProcessInstanceKey(200L)
             .withBpmnProcessId("my-process")
             .withSignalName("mySignal")
-            .withBpmnElementType(elementType.name())
+            .withBpmnElementType(elementType)
             .build();
 
     return factory.generateRecord(

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/SignalBasedWaitStateTransformerTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableSignalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class SignalBasedWaitStateTransformerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final SignalBasedWaitStateTransformer transformer = new SignalBasedWaitStateTransformer();
+
+  @Test
+  void shouldExtractDetailsFromSignalCreatedRecord() {
+    // given
+    final SignalSubscriptionRecordValue value =
+        ImmutableSignalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(SignalSubscriptionRecordValue.class))
+            .withRootProcessInstanceKey(100L)
+            .withProcessInstanceKey(200L)
+            .withCatchEventInstanceKey(300L)
+            .withCatchEventId("signal-catch")
+            .withBpmnProcessId("my-process")
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .withSignalName("mySignal")
+            .withBpmnElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT.name())
+            .build();
+
+    final Record<SignalSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.SIGNAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(SignalSubscriptionIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then — identity fields
+    assertThat(entry.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entry.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entry.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entry.getElementId()).isEqualTo("signal-catch");
+    assertThat(entry.getBpmnProcessId()).isEqualTo("my-process");
+    assertThat(entry.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(entry.getPartitionId()).isEqualTo(record.getPartitionId());
+
+    // then — classification
+    assertThat(entry.getWaitStateType()).isEqualTo(WaitStateType.SIGNAL);
+    assertThat(entry.getElementType()).isEqualTo(BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // then — signal-specific details
+    assertThat(entry.getDetails()).isInstanceOf(SignalWaitStateDetails.class);
+    final var details = (SignalWaitStateDetails) entry.getDetails();
+    assertThat(details.signalName()).isEqualTo("mySignal");
+  }
+
+  @Test
+  void shouldTriggerAddOnCreatedForIntermediateCatchEvent() {
+    // given
+    final Record<SignalSubscriptionRecordValue> record =
+        buildRecord(SignalSubscriptionIntent.CREATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(transformer.triggersAdd(record)).isTrue();
+    assertThat(transformer.triggersUpdate(record)).isFalse();
+    assertThat(transformer.triggersRemoval(record)).isFalse();
+  }
+
+  @Test
+  void shouldTriggerRemovalOnDeleted() {
+    // given
+    final Record<SignalSubscriptionRecordValue> record =
+        buildRecord(SignalSubscriptionIntent.DELETED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(transformer.triggersAdd(record)).isFalse();
+    assertThat(transformer.triggersUpdate(record)).isFalse();
+    assertThat(transformer.triggersRemoval(record)).isTrue();
+  }
+
+  @Test
+  void shouldTriggerUpdateOnMigrated() {
+    // given
+    final Record<SignalSubscriptionRecordValue> record =
+        buildRecord(SignalSubscriptionIntent.MIGRATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(transformer.triggersAdd(record)).isFalse();
+    assertThat(transformer.triggersUpdate(record)).isTrue();
+    assertThat(transformer.triggersRemoval(record)).isFalse();
+  }
+
+  @Test
+  void shouldSkipStartEventSubscriptions() {
+    // given — start event subscriptions have no running instance; bpmnElementType = START_EVENT
+    final Record<SignalSubscriptionRecordValue> created =
+        buildRecord(SignalSubscriptionIntent.CREATED, BpmnElementType.START_EVENT);
+    final Record<SignalSubscriptionRecordValue> deleted =
+        buildRecord(SignalSubscriptionIntent.DELETED, BpmnElementType.START_EVENT);
+
+    // when / then
+    assertThat(transformer.triggersAdd(created)).isFalse();
+    assertThat(transformer.triggersUpdate(created)).isFalse();
+    assertThat(transformer.triggersRemoval(created)).isFalse();
+    assertThat(transformer.triggersRemoval(deleted)).isFalse();
+  }
+
+  @Test
+  void shouldSkipBoundaryEventSubscriptions() {
+    // given — boundary events interrupt the host element and must not appear as their own wait
+    // state
+    final Record<SignalSubscriptionRecordValue> created =
+        buildRecord(SignalSubscriptionIntent.CREATED, BpmnElementType.BOUNDARY_EVENT);
+    final Record<SignalSubscriptionRecordValue> deleted =
+        buildRecord(SignalSubscriptionIntent.DELETED, BpmnElementType.BOUNDARY_EVENT);
+
+    // when / then
+    assertThat(transformer.triggersAdd(created)).isFalse();
+    assertThat(transformer.triggersUpdate(created)).isFalse();
+    assertThat(transformer.triggersRemoval(created)).isFalse();
+    assertThat(transformer.triggersRemoval(deleted)).isFalse();
+  }
+
+  @Test
+  void shouldSkipPreV810RecordsWithEmptyBpmnElementType() {
+    // given — records exported before 8.10 have an empty bpmnElementType string
+    final SignalSubscriptionRecordValue value =
+        ImmutableSignalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(SignalSubscriptionRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(200L)
+            .withBpmnProcessId("my-process")
+            .withBpmnElementType("")
+            .build();
+
+    final Record<SignalSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.SIGNAL_SUBSCRIPTION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(SignalSubscriptionIntent.CREATED)
+                    .withValue(value));
+
+    // when / then
+    assertThat(transformer.triggersAdd(record)).isFalse();
+    assertThat(transformer.triggersUpdate(record)).isFalse();
+    assertThat(transformer.triggersRemoval(record)).isFalse();
+  }
+
+  private Record<SignalSubscriptionRecordValue> buildRecord(
+      final SignalSubscriptionIntent intent, final BpmnElementType elementType) {
+    final SignalSubscriptionRecordValue value =
+        ImmutableSignalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(SignalSubscriptionRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(200L)
+            .withBpmnProcessId("my-process")
+            .withSignalName("mySignal")
+            .withBpmnElementType(elementType.name())
+            .build();
+
+    return factory.generateRecord(
+        ValueType.SIGNAL_SUBSCRIPTION,
+        r -> r.withRecordType(RecordType.EVENT).withIntent(intent).withValue(value));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -37,6 +37,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MODIFI
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_MESSAGE_SUBSCRIPTION;
 import static io.camunda.zeebe.protocol.record.ValueType.RESOURCE;
 import static io.camunda.zeebe.protocol.record.ValueType.ROLE;
+import static io.camunda.zeebe.protocol.record.ValueType.SIGNAL_SUBSCRIPTION;
 import static io.camunda.zeebe.protocol.record.ValueType.TENANT;
 import static io.camunda.zeebe.protocol.record.ValueType.TIMER;
 import static io.camunda.zeebe.protocol.record.ValueType.USAGE_METRIC;
@@ -425,7 +426,8 @@ public class CamundaExporter implements Exporter {
             GLOBAL_LISTENER,
             AGENT_INSTANCE,
             AGENT_HISTORY,
-            TIMER);
+            TIMER,
+            SIGNAL_SUBSCRIPTION);
 
     @Override
     public boolean acceptType(final RecordType recordType) {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-signal-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-signal-subscription-template.json
@@ -42,6 +42,15 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "bpmnElementType": {
+              "type": "keyword"
+            },
+            "elementId": {
+              "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-signal-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-signal-subscription-template.json
@@ -36,6 +36,12 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-signal-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-signal-subscription-template.json
@@ -48,6 +48,15 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "bpmnElementType": {
+              "type": "keyword"
+            },
+            "elementId": {
+              "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-signal-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-signal-subscription-template.json
@@ -42,6 +42,12 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -848,11 +848,13 @@ components:
           MESSAGE: '#/components/schemas/MessageWaitStateDetails'
           USER_TASK: '#/components/schemas/UserTaskWaitStateDetails'
           TIMER: '#/components/schemas/TimerWaitStateDetails'
+          SIGNAL: '#/components/schemas/SignalWaitStateDetails'
       oneOf:
         - $ref: '#/components/schemas/JobWaitStateDetails'
         - $ref: '#/components/schemas/MessageWaitStateDetails'
         - $ref: '#/components/schemas/UserTaskWaitStateDetails'
         - $ref: '#/components/schemas/TimerWaitStateDetails'
+        - $ref: '#/components/schemas/SignalWaitStateDetails'
 
     WaitStateTypeEnum:
       description: The type of waiting state an element instance is in.
@@ -862,6 +864,7 @@ components:
         - MESSAGE
         - USER_TASK
         - TIMER
+        - SIGNAL
 
     BaseWaitStateDetails:
       description: Common fields shared by all wait-state details variants.
@@ -962,6 +965,19 @@ components:
           nullable: true
           type: integer
           format: int32
+
+    SignalWaitStateDetails:
+      type: object
+      required:
+        - waitStateType
+        - signalName
+      allOf:
+        - $ref: '#/components/schemas/BaseWaitStateDetails'
+      properties:
+        signalName:
+          description: The name of the signal being awaited.
+          type: string
+      x-added-in-version: "8.10"
 
     AdHocSubProcessActivateActivityReference:
       type: object

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
@@ -10,10 +10,12 @@ package io.camunda.zeebe.protocol.impl.record.value.signal;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.agrona.DirectBuffer;
@@ -48,7 +50,8 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
-  private final StringProperty bpmnElementTypeProp = new StringProperty(BPMN_ELEMENT_TYPE_KEY, "");
+  private final EnumProperty<BpmnElementType> bpmnElementTypeProp =
+      new EnumProperty<>(BPMN_ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public SignalSubscriptionRecord() {
     super(9);
@@ -189,11 +192,11 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public String getBpmnElementType() {
-    return bufferAsString(bpmnElementTypeProp.getValue());
+  public BpmnElementType getBpmnElementType() {
+    return bpmnElementTypeProp.getValue();
   }
 
-  public SignalSubscriptionRecord setBpmnElementType(final String bpmnElementType) {
+  public SignalSubscriptionRecord setBpmnElementType(final BpmnElementType bpmnElementType) {
     bpmnElementTypeProp.setValue(bpmnElementType);
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
@@ -33,6 +33,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue BPMN_ELEMENT_TYPE_KEY = new StringValue("bpmnElementType");
 
   private final LongProperty processDefinitionKeyProp =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
@@ -47,9 +48,10 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final StringProperty bpmnElementTypeProp = new StringProperty(BPMN_ELEMENT_TYPE_KEY, "");
 
   public SignalSubscriptionRecord() {
-    super(8);
+    super(9);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(signalNameProp)
         .declareProperty(catchEventIdProp)
@@ -57,7 +59,8 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(catchEventInstanceKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(processInstanceKeyProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(bpmnElementTypeProp);
   }
 
   public void wrap(final SignalSubscriptionRecord record) {
@@ -69,6 +72,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
     tenantIdProp.setValue(record.getTenantId());
     processInstanceKeyProp.setValue(record.getProcessInstanceKey());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    bpmnElementTypeProp.setValue(record.getBpmnElementType());
   }
 
   @JsonIgnore
@@ -181,6 +185,16 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
 
   public SignalSubscriptionRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnElementType() {
+    return bufferAsString(bpmnElementTypeProp.getValue());
+  }
+
+  public SignalSubscriptionRecord setBpmnElementType(final String bpmnElementType) {
+    bpmnElementTypeProp.setValue(bpmnElementType);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
@@ -30,6 +30,9 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue CATCH_EVENT_INSTANCE_KEY_KEY =
       new StringValue("catchEventInstanceKey");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   private final LongProperty processDefinitionKeyProp =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
@@ -40,15 +43,21 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
       new LongProperty(CATCH_EVENT_INSTANCE_KEY_KEY, -1L);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty processInstanceKeyProp =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public SignalSubscriptionRecord() {
-    super(6);
+    super(8);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(signalNameProp)
         .declareProperty(catchEventIdProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(catchEventInstanceKeyProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(processInstanceKeyProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   public void wrap(final SignalSubscriptionRecord record) {
@@ -58,6 +67,8 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
     catchEventIdProp.setValue(record.getCatchEventId());
     catchEventInstanceKeyProp.setValue(record.getCatchEventInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
+    processInstanceKeyProp.setValue(record.getProcessInstanceKey());
+    rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
   }
 
   @JsonIgnore
@@ -138,6 +149,38 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
 
   public SignalSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @JsonIgnore
+  @Override
+  public String getElementId() {
+    return getCatchEventId();
+  }
+
+  @JsonIgnore
+  @Override
+  public long getElementInstanceKey() {
+    return getCatchEventInstanceKey();
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public SignalSubscriptionRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public SignalSubscriptionRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2559,6 +2559,7 @@ final class JsonSerializableToJsonTest {
                   .setProcessDefinitionKey(processDefinitionKey)
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setCatchEventInstanceKey(3L)
+                  .setBpmnElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
                   .setTenantId("acme");
             },
         """
@@ -2566,7 +2567,7 @@ final class JsonSerializableToJsonTest {
                   "catchEventId": "startEvent",
                   "signalName": "name",
                   "catchEventInstanceKey":3,
-                  "bpmnElementType":"",
+                  "bpmnElementType":"INTERMEDIATE_CATCH_EVENT",
                   "processInstanceKey":-1,
                   "processDefinitionKey":22334,
                   "rootProcessInstanceKey":-1,
@@ -2594,7 +2595,7 @@ final class JsonSerializableToJsonTest {
                   "catchEventId":"",
                   "signalName":"",
                   "catchEventInstanceKey":-1,
-                  "bpmnElementType":"",
+                  "bpmnElementType":"UNSPECIFIED",
                   "processInstanceKey":-1,
                   "processDefinitionKey":22334,
                   "rootProcessInstanceKey":-1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2563,12 +2563,14 @@ final class JsonSerializableToJsonTest {
             },
         """
                 {
+                  "processInstanceKey":-1,
                   "processDefinitionKey":22334,
-                  "signalName": "name",
-                  "catchEventId": "startEvent",
                   "bpmnProcessId": "process",
-                  "catchEventInstanceKey":3,
-                  "tenantId": "acme"
+                  "tenantId": "acme",
+                  "rootProcessInstanceKey":-1,
+                  "catchEventId": "startEvent",
+                  "signalName": "name",
+                  "catchEventInstanceKey":3
                 }
                 """
       },
@@ -2588,12 +2590,14 @@ final class JsonSerializableToJsonTest {
             },
         """
                 {
+                  "processInstanceKey":-1,
                   "processDefinitionKey":22334,
-                  "signalName":"",
-                  "catchEventId":"",
                   "bpmnProcessId":"",
-                  "catchEventInstanceKey":-1,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "rootProcessInstanceKey":-1,
+                  "catchEventId":"",
+                  "signalName":"",
+                  "catchEventInstanceKey":-1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2563,14 +2563,15 @@ final class JsonSerializableToJsonTest {
             },
         """
                 {
-                  "processInstanceKey":-1,
-                  "processDefinitionKey":22334,
-                  "bpmnProcessId": "process",
-                  "tenantId": "acme",
-                  "rootProcessInstanceKey":-1,
                   "catchEventId": "startEvent",
                   "signalName": "name",
-                  "catchEventInstanceKey":3
+                  "catchEventInstanceKey":3,
+                  "bpmnElementType":"",
+                  "processInstanceKey":-1,
+                  "processDefinitionKey":22334,
+                  "rootProcessInstanceKey":-1,
+                  "bpmnProcessId": "process",
+                  "tenantId": "acme"
                 }
                 """
       },
@@ -2590,14 +2591,15 @@ final class JsonSerializableToJsonTest {
             },
         """
                 {
-                  "processInstanceKey":-1,
-                  "processDefinitionKey":22334,
-                  "bpmnProcessId":"",
-                  "tenantId": "<default>",
-                  "rootProcessInstanceKey":-1,
                   "catchEventId":"",
                   "signalName":"",
-                  "catchEventInstanceKey":-1
+                  "catchEventInstanceKey":-1,
+                  "bpmnElementType":"",
+                  "processInstanceKey":-1,
+                  "processDefinitionKey":22334,
+                  "rootProcessInstanceKey":-1,
+                  "bpmnProcessId":"",
+                  "tenantId": "<default>"
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/SignalSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/SignalSubscriptionRecord.golden
@@ -33,6 +33,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue BPMN_ELEMENT_TYPE_KEY = new StringValue("bpmnElementType");
 
   private final LongProperty processDefinitionKeyProp =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
@@ -47,9 +48,11 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final StringProperty bpmnElementTypeProp =
+      new StringProperty(BPMN_ELEMENT_TYPE_KEY, "");
 
   public SignalSubscriptionRecord() {
-    super(8);
+    super(9);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(signalNameProp)
         .declareProperty(catchEventIdProp)
@@ -57,7 +60,8 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(catchEventInstanceKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(processInstanceKeyProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(bpmnElementTypeProp);
   }
 
   public void wrap(final SignalSubscriptionRecord record) {
@@ -69,6 +73,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
     tenantIdProp.setValue(record.getTenantId());
     processInstanceKeyProp.setValue(record.getProcessInstanceKey());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    bpmnElementTypeProp.setValue(record.getBpmnElementType());
   }
 
   @JsonIgnore
@@ -181,6 +186,16 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
 
   public SignalSubscriptionRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnElementType() {
+    return bufferAsString(bpmnElementTypeProp.getValue());
+  }
+
+  public SignalSubscriptionRecord setBpmnElementType(final String bpmnElementType) {
+    bpmnElementTypeProp.setValue(bpmnElementType);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/SignalSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/SignalSubscriptionRecord.golden
@@ -30,6 +30,9 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue CATCH_EVENT_INSTANCE_KEY_KEY =
       new StringValue("catchEventInstanceKey");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   private final LongProperty processDefinitionKeyProp =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
@@ -40,15 +43,21 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
       new LongProperty(CATCH_EVENT_INSTANCE_KEY_KEY, -1L);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty processInstanceKeyProp =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public SignalSubscriptionRecord() {
-    super(6);
+    super(8);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(signalNameProp)
         .declareProperty(catchEventIdProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(catchEventInstanceKeyProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(processInstanceKeyProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   public void wrap(final SignalSubscriptionRecord record) {
@@ -58,6 +67,8 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
     catchEventIdProp.setValue(record.getCatchEventId());
     catchEventInstanceKeyProp.setValue(record.getCatchEventInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
+    processInstanceKeyProp.setValue(record.getProcessInstanceKey());
+    rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
   }
 
   @JsonIgnore
@@ -138,6 +149,38 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
 
   public SignalSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @JsonIgnore
+  @Override
+  public String getElementId() {
+    return getCatchEventId();
+  }
+
+  @JsonIgnore
+  @Override
+  public long getElementInstanceKey() {
+    return getCatchEventInstanceKey();
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public SignalSubscriptionRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public SignalSubscriptionRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/SignalSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/SignalSubscriptionRecord.golden
@@ -10,10 +10,12 @@ package io.camunda.zeebe.protocol.impl.record.value.signal;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.agrona.DirectBuffer;
@@ -48,8 +50,8 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
-  private final StringProperty bpmnElementTypeProp =
-      new StringProperty(BPMN_ELEMENT_TYPE_KEY, "");
+  private final EnumProperty<BpmnElementType> bpmnElementTypeProp =
+      new EnumProperty<>(BPMN_ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public SignalSubscriptionRecord() {
     super(9);
@@ -190,11 +192,11 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public String getBpmnElementType() {
-    return bufferAsString(bpmnElementTypeProp.getValue());
+  public BpmnElementType getBpmnElementType() {
+    return bpmnElementTypeProp.getValue();
   }
 
-  public SignalSubscriptionRecord setBpmnElementType(final String bpmnElementType) {
+  public SignalSubscriptionRecord setBpmnElementType(final BpmnElementType bpmnElementType) {
     bpmnElementTypeProp.setValue(bpmnElementType);
     return this;
   }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/SignalSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/SignalSubscriptionRecordValue.java
@@ -27,7 +27,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableSignalSubscriptionRecordValue.Builder.class)
-public interface SignalSubscriptionRecordValue extends RecordValue, TenantOwned {
+public interface SignalSubscriptionRecordValue extends RecordValue, TenantOwned, WaitStateRelated {
 
   /**
    * @return the process key tied to the subscription
@@ -53,4 +53,46 @@ public interface SignalSubscriptionRecordValue extends RecordValue, TenantOwned 
    * @return the name of the signal
    */
   String getSignalName();
+
+  /**
+   * @return the key of the process instance, or {@code -1L} if not set (e.g. start-event
+   *     subscriptions that are not tied to a running instance)
+   * @since 8.10
+   */
+  @Override
+  long getProcessInstanceKey();
+
+  /**
+   * @return the key of the root process instance, or {@code -1L} if not set
+   * @since 8.10
+   */
+  @Override
+  long getRootProcessInstanceKey();
+
+  /**
+   * Bridges {@link WaitStateRelated#getElementId()} to {@link #getCatchEventId()}.
+   *
+   * <p>Implementations should annotate this override with {@code @JsonIgnore} to avoid duplicating
+   * {@code catchEventId} in serialised output.
+   *
+   * @since 8.10
+   */
+  @Override
+  default String getElementId() {
+    return getCatchEventId();
+  }
+
+  /**
+   * Bridges {@link WaitStateRelated#getElementInstanceKey()} to {@link
+   * #getCatchEventInstanceKey()}.
+   *
+   * <p>Implementations should annotate this override with {@code @JsonIgnore} to avoid duplicating
+   * {@code catchEventInstanceKey} in serialised output.
+   *
+   * @since 8.10
+   */
+  @Override
+  default long getElementInstanceKey() {
+    return getCatchEventInstanceKey();
+  }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/SignalSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/SignalSubscriptionRecordValue.java
@@ -55,6 +55,13 @@ public interface SignalSubscriptionRecordValue extends RecordValue, TenantOwned,
   String getSignalName();
 
   /**
+   * @return the BPMN element type of the catch event (e.g. {@code INTERMEDIATE_CATCH_EVENT}, {@code
+   *     BOUNDARY_EVENT}, {@code START_EVENT}), or an empty string if not set
+   * @since 8.10
+   */
+  String getBpmnElementType();
+
+  /**
    * @return the key of the process instance, or {@code -1L} if not set (e.g. start-event
    *     subscriptions that are not tied to a running instance)
    * @since 8.10

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/SignalSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/SignalSubscriptionRecordValue.java
@@ -56,10 +56,11 @@ public interface SignalSubscriptionRecordValue extends RecordValue, TenantOwned,
 
   /**
    * @return the BPMN element type of the catch event (e.g. {@code INTERMEDIATE_CATCH_EVENT}, {@code
-   *     BOUNDARY_EVENT}, {@code START_EVENT}), or an empty string if not set
+   *     BOUNDARY_EVENT}, {@code START_EVENT}), or {@link BpmnElementType#UNSPECIFIED} for records
+   *     written before 8.10 that do not carry this field
    * @since 8.10
    */
-  String getBpmnElementType();
+  BpmnElementType getBpmnElementType();
 
   /**
    * @return the key of the process instance, or {@code -1L} if not set (e.g. start-event


### PR DESCRIPTION
## Description

- Added `bpmnElementType`, `processInstanceKey`, `rootProcessInstanceKey` to `SignalSubscriptionRecordValue` and record impl; engine populates all three on subscription creation
- `SignalBasedWaitStateTransformer` filters to `INTERMEDIATE_CATCH_EVENT` only — excludes start events (empty `bpmnElementType` on old records also filtered) and boundary events
- `WaitStateSignalDetails` / `WaitStateType.SIGNAL` threaded through exporter-common, search-domain, RDBMS mapper, query-transformer, OpenAPI spec, HTTP gateway mapper, and Java client
- ES/OS index templates updated with three new long/keyword fields
- `ElementInstanceWaitStateResultImpl.getWaitStateType()` null-safe for unknown future server-side wait state types
- `WaitStateSignalIT`: 6 tests — create, filter by type, removal after broadcast, negative job filter, start event not tracked, boundary event not tracked

## Related issues

closes https://github.com/camunda/camunda/issues/51980
closes https://github.com/camunda/camunda/issues/49435
