### PR TITLE
ci: address all the Zizmor warnings for the load test workflows

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -9,6 +9,7 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Daily Camunda Platform Load Tests
+
 on:
   workflow_dispatch:
      inputs:
@@ -40,10 +41,12 @@ jobs:
       benchmark: ${{ steps.data.outputs.benchmark }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Collect benchmark data
         id: data
         run: |
-          var=${{ inputs.reuse-tag || '' }}
+          var=${INPUTS_REUSE_TAG}
           # ${#var} will return the length of the string
           if [[ ${#var} -eq 0 ]]; then
             echo "Creating new daily load test benchmark"
@@ -54,11 +57,13 @@ jobs:
             # medic-daily-2025-12-18-b1bd4006-test-b1bd400
             # $ echo ${tag%-*}
             # medic-daily-2025-12-18-b1bd4006-test
-            tag=${{ inputs.reuse-tag }}
+            tag=${INPUTS_REUSE_TAG}
             var=${tag%-*}
             echo "Re-creating daily load test, with name: $var and tag: $tag"
             echo "benchmark=$var" >> "$GITHUB_OUTPUT"
           fi
+        env:
+          INPUTS_REUSE_TAG: ${{ inputs.reuse-tag }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -75,7 +80,10 @@ jobs:
     needs:
       - benchmark-data
     uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}
       ttl: 1
@@ -87,7 +95,10 @@ jobs:
     needs:
       - benchmark-data
     uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}-rest
       ttl: 1
@@ -115,6 +126,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
+          persist-credentials: false
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -132,7 +144,10 @@ jobs:
     needs: [ benchmark-data, setup-max-load-test, soak ]
     if: needs.soak.result == 'success' && needs.setup-max-load-test.result == 'success'
     uses: ./.github/workflows/camunda-load-test-metrics.yaml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}
       duration-seconds: '10800'
@@ -143,7 +158,10 @@ jobs:
     needs: [ benchmark-data, setup-max-rest-load-test, soak ]
     if: needs.soak.result == 'success' && needs.setup-max-rest-load-test.result == 'success'
     uses: ./.github/workflows/camunda-load-test-metrics.yaml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}-rest
       duration-seconds: '10800'
@@ -177,6 +195,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
+          persist-credentials: false
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -198,6 +217,8 @@ jobs:
     permissions: { }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
@@ -242,7 +263,10 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/camunda-delete-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}
 
@@ -254,7 +278,10 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/camunda-delete-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}-rest
 
@@ -267,6 +294,8 @@ jobs:
     permissions: { }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/camunda-delete-load-test.yml
+++ b/.github/workflows/camunda-delete-load-test.yml
@@ -15,6 +15,13 @@ on:
         description: 'Exact Kubernetes namespace to delete (caller must already have resolved the name)'
         type: string
         required: true
+    secrets:
+      VAULT_ADDR:
+        required: true
+      VAULT_ROLE_ID:
+        required: true
+      VAULT_SECRET_ID:
+        required: true
   workflow_dispatch:
     inputs:
       namespace:
@@ -40,6 +47,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Teleport
         uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
         with:

--- a/.github/workflows/camunda-load-test-metrics.yaml
+++ b/.github/workflows/camunda-load-test-metrics.yaml
@@ -42,6 +42,13 @@ on:
       results-json:
         description: 'JSON object {name: number, ...} from loadTestMetrics.sh stdout (queries that scrape no data are omitted)'
         value: ${{ jobs.query-and-summarize.outputs.results-json }}
+    secrets:
+      VAULT_ADDR:
+        required: true
+      VAULT_ROLE_ID:
+        required: true
+      VAULT_SECRET_ID:
+        required: true
 
 defaults:
   run:
@@ -76,6 +83,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Import Prometheus credentials from Vault
         id: secrets

--- a/.github/workflows/camunda-load-test-smoke-dispatch.yml
+++ b/.github/workflows/camunda-load-test-smoke-dispatch.yml
@@ -35,10 +35,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: detect
         name: Detect which setup versions changed
         run: |
-          changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          changed=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")
 
           run_all=false
           if echo "$changed" | grep -qE '\.github/workflows/camunda-load-test'; then
@@ -81,7 +82,10 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-versions.outputs.matrix) }}
     uses: ./.github/workflows/camunda-load-test-smoke.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       target-version: ${{ matrix.version }}
       orchestration-tag: ${{ matrix.orchestration-tag }}

--- a/.github/workflows/camunda-load-test-smoke.yml
+++ b/.github/workflows/camunda-load-test-smoke.yml
@@ -7,6 +7,7 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Camunda Smoke Load Test
+
 on:
   workflow_call:
     inputs:
@@ -25,6 +26,13 @@ on:
         type: string
         default: ""
         required: false
+    secrets:
+      VAULT_ADDR:
+        required: true
+      VAULT_ROLE_ID:
+        required: true
+      VAULT_SECRET_ID:
+        required: true
   workflow_dispatch:
     inputs:
       target-version:
@@ -75,15 +83,19 @@ jobs:
       - id: compute-namespace
         name: Compute safe namespace from PR author, number and version
         run: |
-          author="${{ steps.sanitize-author.outputs.branch_name || github.actor }}"
+          author="${SANITIZED_AUTHOR_BRANCH_NAME:-$GITHUB_ACTOR}"
           pr_number="${{ github.event.pull_request.number || github.run_id }}"
-          version_slug="${{ inputs.target-version || 'main' }}"
+          version_slug="${INPUTS_TARGET_VERSION:-main}"
           version_slug_sanitized="${version_slug//-/}"
           echo "namespace=c8-smoke-${author}-${pr_number}-${version_slug_sanitized}" >> "$GITHUB_OUTPUT"
+        env:
+          SANITIZED_AUTHOR_BRANCH_NAME: ${{ steps.sanitize-author.outputs.branch_name }}
+          INPUTS_TARGET_VERSION: ${{ inputs.target-version }}
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
+          persist-credentials: false
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -98,7 +110,10 @@ jobs:
     name: Smoke Install
     needs: sanitize-branch-name
     uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
       ref: ${{ github.event.pull_request.head.ref || inputs.ref || github.event.inputs.ref }}
@@ -119,7 +134,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     uses: ./.github/workflows/camunda-verify-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
 
@@ -129,7 +147,10 @@ jobs:
     name: Smoke update
     needs: [sanitize-branch-name, verify-install]
     uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
       ref: ${{ github.event.pull_request.head.ref || inputs.ref || github.event.inputs.ref }}
@@ -150,7 +171,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     uses: ./.github/workflows/camunda-verify-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
 
@@ -162,6 +186,9 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/camunda-delete-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -215,6 +215,13 @@ on:
         type: string
         default: ""
         required: false
+    secrets:
+      VAULT_ADDR:
+        required: true
+      VAULT_ROLE_ID:
+        required: true
+      VAULT_SECRET_ID:
+        required: true
 
 env:
   CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
@@ -238,31 +245,49 @@ jobs:
     steps:
       - name: Show summary
         run: |-
-          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
-          ## Load test: `${{ env.NAMESPACE }}`
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Load test: \`${NAMESPACE}\`
 
-          > 📊 **[Open Grafana Dashboard](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${{ env.NAMESPACE }})**
+          > 📊 **[Open Grafana Dashboard](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${NAMESPACE})**
 
           | Input | Value |
           |-------|-------|
-          | Name | `${{ inputs.name }}` |
-          | Ref | `${{ inputs.ref }}` |
-          | Scenario | `${{ inputs.scenario }}` |
-          | Secondary storage | `${{ inputs.secondary-storage-type }}` |
-          | Reuse tag | ${{ inputs.reuse-tag || '—' }} |
-          | Orchestration tag | ${{ inputs.orchestration-tag || '—' }} |
-          | Load test load | ${{ inputs.load-test-load || '—' }} |
-          | Platform helm values | ${{ inputs.platform-helm-values || '—' }} |
-          | TTL (days) | `${{ inputs.ttl }}` |
-          | Stable VMs | `${{ inputs.stable-vms }}` |
-          | Enable Optimize | `${{ inputs.enable-optimize }}` |
-          | Enable Optimize report metrics | `${{ inputs.enable-optimize-report-metrics }}` |
-          | Build frontend | `${{ inputs.build-frontend }}` |
-          | Perform read benchmarks | `${{ inputs.perform-read-benchmarks }}` |
-          | Optimize tag | ${{ inputs.optimize-tag || '—' }} |
-          | Identity tag | ${{ inputs.identity-tag || '—' }} |
-          | Connectors tag | ${{ inputs.connectors-tag || '—' }} |
+          | Name | \`${INPUTS_NAME}\` |
+          | Ref | \`${INPUTS_REF}\` |
+          | Scenario | \`${INPUTS_SCENARIO}\` |
+          | Secondary storage | \`${INPUTS_SECONDARY_STORAGE_TYPE}\` |
+          | Reuse tag | ${INPUTS_REUSE_TAG:----} |
+          | Orchestration tag | ${INPUTS_ORCHESTRATION_TAG:----} |
+          | Load test load | ${INPUTS_LOAD_TEST_LOAD:----} |
+          | Platform helm values | ${INPUTS_PLATFORM_HELM_VALUES:----} |
+          | TTL (days) | \`${INPUTS_TTL}\` |
+          | Stable VMs | \`${INPUTS_STABLE_VMS}\` |
+          | Enable Optimize | \`${INPUTS_ENABLE_OPTIMIZE}\` |
+          | Enable Optimize report metrics | \`${INPUTS_ENABLE_OPTIMIZE_REPORT_METRICS}\` |
+          | Build frontend | \`${INPUTS_BUILD_FRONTEND}\` |
+          | Perform read benchmarks | \`${INPUTS_PERFORM_READ_BENCHMARKS}\` |
+          | Optimize tag | ${INPUTS_OPTIMIZE_TAG:----} |
+          | Identity tag | ${INPUTS_IDENTITY_TAG:----} |
+          | Connectors tag | ${INPUTS_CONNECTORS_TAG:----} |
           EOF
+        env:
+          INPUTS_NAME: ${{ inputs.name }}
+          INPUTS_REF: ${{ inputs.ref }}
+          INPUTS_SCENARIO: ${{ inputs.scenario }}
+          INPUTS_SECONDARY_STORAGE_TYPE: ${{ inputs.secondary-storage-type }}
+          INPUTS_REUSE_TAG: ${{ inputs.reuse-tag }}
+          INPUTS_ORCHESTRATION_TAG: ${{ inputs.orchestration-tag }}
+          INPUTS_LOAD_TEST_LOAD: ${{ inputs.load-test-load }}
+          INPUTS_PLATFORM_HELM_VALUES: ${{ inputs.platform-helm-values }}
+          INPUTS_TTL: ${{ inputs.ttl }}
+          INPUTS_STABLE_VMS: ${{ inputs.stable-vms }}
+          INPUTS_ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
+          INPUTS_ENABLE_OPTIMIZE_REPORT_METRICS: ${{ inputs.enable-optimize-report-metrics }}
+          INPUTS_BUILD_FRONTEND: ${{ inputs.build-frontend }}
+          INPUTS_PERFORM_READ_BENCHMARKS: ${{ inputs.perform-read-benchmarks }}
+          INPUTS_OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
+          INPUTS_IDENTITY_TAG: ${{ inputs.identity-tag }}
+          INPUTS_CONNECTORS_TAG: ${{ inputs.connectors-tag }}
 
   calculate-image-tag:
     name: Calculate Image Tag
@@ -280,13 +305,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - name: Get image tag
         id: image-tag
         if: ${{ inputs.orchestration-tag == '' && inputs.reuse-tag == '' }}
         run: |
-          image_tag="${{ inputs.name }}-$(git rev-parse --short HEAD)"
+          image_tag="${INPUTS_NAME}-$(git rev-parse --short HEAD)"
           echo "image-tag=${image_tag}" >> "$GITHUB_OUTPUT"
           echo "**Built image tag:** \`${image_tag}\`" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          INPUTS_NAME: ${{ inputs.name }}
       - name: Validate Docker image tags exist
         if: ${{ inputs.orchestration-tag != '' || inputs.optimize-tag != '' || inputs.identity-tag != '' || inputs.connectors-tag != '' }}
         env:
@@ -358,6 +386,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -441,6 +470,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -450,9 +480,13 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl load-tests/load-tester -am install
       - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${NEEDS_CALCULATE_IMAGE_TAG_OUTPUTS_IMAGE_TAG}"
+        env:
+          NEEDS_CALCULATE_IMAGE_TAG_OUTPUTS_IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
       - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${NEEDS_CALCULATE_IMAGE_TAG_OUTPUTS_IMAGE_TAG}"
+        env:
+          NEEDS_CALCULATE_IMAGE_TAG_OUTPUTS_IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -485,6 +519,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       # camunda-platform-8.10 requires Helm CLI v4; runners ship v3.x.
       - name: Set up Helm
         uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
@@ -539,16 +574,21 @@ jobs:
           cd load-tests/setup
           # The namespace label created-by will not be able resolve the actual user which triggered
           # the GitHub action by default. We need to correctly configure the git user here to make it work
-          git config user.name ${{ github.actor }}
+          git config user.name "${GITHUB_ACTOR}"
           # Render the load-test folder. newLoadTest.sh no longer creates the namespace — that
           # happens on `make install` via `kubectl apply -f resources/namespace.yaml`.
-          ./newLoadTest.sh --target-version ${{ inputs.target-version || 'main' }} ${{ env.NAMESPACE }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
+          ./newLoadTest.sh --target-version "${INPUTS_TARGET_VERSION:-main}" "${NAMESPACE}" "${INPUTS_SECONDARY_STORAGE_TYPE}" "${INPUTS_TTL}" "${INPUTS_ENABLE_OPTIMIZE}"
+        env:
+          INPUTS_SECONDARY_STORAGE_TYPE: ${{ inputs.secondary-storage-type }}
+          INPUTS_TARGET_VERSION: ${{ inputs.target-version }}
+          INPUTS_TTL: ${{ inputs.ttl }}
+          INPUTS_ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
       - name: Install latest Camunda Platform
         run: |
-          cd load-tests/setup/${{ env.NAMESPACE }}
+          cd "load-tests/setup/${NAMESPACE}"
 
           # Build load test configuration
-          load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
+          load_test_config="--set global.image.tag=${NEEDS_CALCULATE_IMAGE_TAG_OUTPUTS_IMAGE_TAG} \
                             --set global.image.repository=${{ env.IMAGE_REPOSITORY }} \
                             --set global.image.pullSecrets[0].name=harbor-registry \
                             --set global.performReadBenchmarks=${{inputs.perform-read-benchmarks}}"
@@ -560,14 +600,14 @@ jobs:
           fi
 
           # Append custom load test inputs
-          load_test_config="$load_test_config ${{ inputs.load-test-load }}"
+          load_test_config="$load_test_config ${INPUTS_LOAD_TEST_LOAD}"
 
           # Resolve image registry/repository: Docker Hub when orchestration-tag is set, internal registry otherwise
           # optimize_repo is only consumed in the custom build path where orchestration-tag is empty
           image_registry="${{ inputs.orchestration-tag != '' && 'docker.io' || 'registry.camunda.cloud' }}"
           camunda_repo="${{ inputs.orchestration-tag != '' && 'camunda/camunda' || 'team-zeebe/camunda' }}"
           optimize_repo="${{ inputs.orchestration-tag != '' && 'camunda/optimize' || 'team-zeebe/optimize' }}"
-          image_tag="${{ needs.calculate-image-tag.outputs.image-tag }}"
+          image_tag="${NEEDS_CALCULATE_IMAGE_TAG_OUTPUTS_IMAGE_TAG}"
 
           # Build platform configuration
           additional_platform_config="--set global.image.tag=${image_tag} \
@@ -577,11 +617,11 @@ jobs:
 
           # Append optimize image config: optimize-tag wins if set, otherwise custom builds use internal registry
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
-            if [[ -n "${{ inputs.optimize-tag }}" ]]; then
+            if [[ -n "${INPUTS_OPTIMIZE_TAG}" ]]; then
               # Explicit optimize tag provided: use it directly (Docker Hub image)
               additional_platform_config+=" \
-                --set optimize.image.tag=${{ inputs.optimize-tag }}"
-            elif [[ -z "${{ inputs.orchestration-tag }}" ]]; then
+                --set optimize.image.tag=${INPUTS_OPTIMIZE_TAG}"
+            elif [[ -z "${INPUTS_ORCHESTRATION_TAG}" ]]; then
               # Custom build without explicit optimize tag: use the built image from internal registry
               additional_platform_config+=" \
                 --set optimize.image.registry=${image_registry} \
@@ -591,54 +631,68 @@ jobs:
           fi
 
           # Append identity image config if a dedicated tag is provided
-          if [[ -n "${{ inputs.identity-tag }}" ]]; then
+          if [[ -n "${INPUTS_IDENTITY_TAG}" ]]; then
             additional_platform_config+=" \
-              --set identity.image.tag=${{ inputs.identity-tag }}"
+              --set identity.image.tag=${INPUTS_IDENTITY_TAG}"
           fi
 
           # Append connectors image config if a dedicated tag is provided
-          if [[ -n "${{ inputs.connectors-tag }}" ]]; then
+          if [[ -n "${INPUTS_CONNECTORS_TAG}" ]]; then
             additional_platform_config+=" \
-              --set connectors.image.tag=${{ inputs.connectors-tag }}"
+              --set connectors.image.tag=${INPUTS_CONNECTORS_TAG}"
           fi
 
           # Append user-provided helm values if present
-          if [[ -n "${{ inputs.platform-helm-values }}" ]]; then
-            additional_platform_config+=" ${{ inputs.platform-helm-values }}"
+          if [[ -n "${INPUTS_PLATFORM_HELM_VALUES}" ]]; then
+            additional_platform_config+=" ${INPUTS_PLATFORM_HELM_VALUES}"
           fi
 
           make ${{ inputs.stable-vms && 'install-stable' || 'install' }} \
-            scenario=${{ inputs.scenario }} \
-            secondary_storage=${{ inputs.secondary-storage-type }} \
+            scenario="${INPUTS_SCENARIO}" \
+            secondary_storage="${INPUTS_SECONDARY_STORAGE_TYPE}" \
             enable_optimize=${{ inputs.enable-optimize }} \
             additional_platform_configuration="$additional_platform_config" \
             additional_load_test_configuration="$load_test_config"
+        env:
+          NEEDS_CALCULATE_IMAGE_TAG_OUTPUTS_IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          INPUTS_LOAD_TEST_LOAD: ${{ inputs.load-test-load }}
+          INPUTS_OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
+          INPUTS_ORCHESTRATION_TAG: ${{ inputs.orchestration-tag }}
+          INPUTS_IDENTITY_TAG: ${{ inputs.identity-tag }}
+          INPUTS_CONNECTORS_TAG: ${{ inputs.connectors-tag }}
+          INPUTS_PLATFORM_HELM_VALUES: ${{ inputs.platform-helm-values }}
+          INPUTS_SCENARIO: ${{ inputs.scenario }}
+          INPUTS_SECONDARY_STORAGE_TYPE: ${{ inputs.secondary-storage-type }}
       - name: Annotate namespace with workflow run URL
         run: |
           # Traceability annotation, applied after `make install` has created the namespace.
-          kubectl annotate namespace ${{ env.NAMESPACE }} \
+          kubectl annotate namespace "${NAMESPACE}" \
             "github.com/workflow-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --overwrite
       - name: Summarize platform deployment
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Camunda platform \`${{ inputs.name }}\` values
+            ## Camunda platform \`${INPUTS_NAME}\` values
             \`\`\`yaml
-            $(helm get values ${{ env.NAMESPACE }} -n ${{ env.NAMESPACE }})
+            $(helm get values "${NAMESPACE}" -n "${NAMESPACE}")
             \`\`\`
           EOF
+        env:
+          INPUTS_NAME: ${{ inputs.name }}
       - name: Summarize load test deployment
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
             # Load test
-            The test has been set up successfully. You can observe it [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${{ env.NAMESPACE }})
-            ## Load test \`${{ inputs.name }}\` values
+            The test has been set up successfully. You can observe it [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${NAMESPACE})
+            ## Load test \`${INPUTS_NAME}\` values
             \`\`\`yaml
-            $(helm get values ${{ env.NAMESPACE }}-test -n ${{ env.NAMESPACE }})
+            $(helm get values "${NAMESPACE}-test" -n "${NAMESPACE}")
             \`\`\`
           EOF
+        env:
+          INPUTS_NAME: ${{ inputs.name }}
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -11,6 +11,7 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Camunda Pull Request Benchmark
+
 on:
   workflow_call:
     inputs:
@@ -70,15 +71,19 @@ jobs:
       - id: compute-namespace
         name: Compute safe namespace from PR author, number and the database type
         run: |
-          author="${{ steps.sanitize-author.outputs.branch_name }}"
-          db_type="${{ steps.sanitize-db-type.outputs.branch_name }}"
+          author="${STEPS_SANITIZE_AUTHOR_OUTPUTS_BRANCH_NAME}"
+          db_type="${STEPS_SANITIZE_DB_TYPE_OUTPUTS_BRANCH_NAME}"
           pr_number="${{ github.event.pull_request.number }}"
           echo "namespace=c8-${author}-pr-${pr_number}-${db_type}" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_SANITIZE_AUTHOR_OUTPUTS_BRANCH_NAME: ${{ steps.sanitize-author.outputs.branch_name }}
+          STEPS_SANITIZE_DB_TYPE_OUTPUTS_BRANCH_NAME: ${{ steps.sanitize-db-type.outputs.branch_name }}
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
+          persist-credentials: false
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -96,7 +101,10 @@ jobs:
       (github.event.action == 'labeled' && github.event.label.name == inputs.label) ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, inputs.label))
     uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
       ref: ${{ inputs.ref }}
@@ -112,6 +120,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Wait for load test to stabilize
         run: sleep 1800  # 30 minutes
       - name: Observe build status
@@ -128,10 +138,8 @@ jobs:
     name: Run Profiling
     needs: [sanitize-branch-name, await-benchmark]
     uses: ./.github/workflows/profile-load-test.yml
-    secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
-      pod: ''
       database: ${{ needs.sanitize-branch-name.outputs.storage-type }}
 
   resolve-daily-namespace:
@@ -147,6 +155,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Teleport
         uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
         with:
@@ -193,7 +203,10 @@ jobs:
     name: Collect PR namespace metrics
     needs: [sanitize-branch-name, await-benchmark]
     uses: ./.github/workflows/camunda-load-test-metrics.yaml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
       duration-seconds: '1800'
@@ -203,7 +216,10 @@ jobs:
     needs: resolve-daily-namespace
     if: needs.resolve-daily-namespace.outputs.daily-namespace != ''
     uses: ./.github/workflows/camunda-load-test-metrics.yaml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: ${{ needs.resolve-daily-namespace.outputs.daily-namespace }}
       duration-seconds: '1800'
@@ -232,6 +248,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Convert queries.yaml to JSON for render step
         run: yq -o=json '.' load-tests/docs/scripts/queries.yaml > /tmp/queries.json
       - name: Build comparison markdown
@@ -266,6 +284,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Post comparison comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -307,7 +327,10 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/camunda-delete-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
 
@@ -322,15 +345,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
       - name: Comment PR with profiling results
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          STORAGE_TYPE: ${{ needs.sanitize-branch-name.outputs.storage-type }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
+            const storageType = process.env.STORAGE_TYPE;
 
             // List all downloaded artifacts
             const artifactPath = 'artifacts';
@@ -343,12 +371,12 @@ jobs:
               run_id: context.runId,
             });
 
-            let comment = '## Profiling Results - ${{ needs.sanitize-branch-name.outputs.storage-type }}\n\n';
+            let comment = `## Profiling Results - ${storageType}\n\n`;
             comment += 'The benchmark has been profiled with the following events:\n\n';
             comment += '| Event | Pod | Artifact |\n';
             comment += '|-------|-----|----------|\n';
 
-            const artifactPrefix = 'flamegraph-${{ needs.sanitize-branch-name.outputs.storage-type }}';
+            const artifactPrefix = `flamegraph-${storageType}`;
             const regex = new RegExp(artifactPrefix + '-(\\w+)-(\\w+-\\d+)');
             artifacts.forEach(artifact => {
               const match = artifact.match(regex);
@@ -359,7 +387,7 @@ jobs:
                 // Find the artifact ID for this artifact name
                 const artifactInfo = workflowArtifacts.artifacts.find(a => a.name === artifact);
                 if (artifactInfo) {
-                  const downloadUrl = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${artifactInfo.id}`;
+                  const downloadUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${artifactInfo.id}`;
                   comment += `| ${event} | ${pod} | [Download](${downloadUrl}) |\n`;
                 } else {
                   comment += `| ${event} | ${pod} | N/A |\n`;
@@ -367,7 +395,7 @@ jobs:
               }
             });
 
-            comment += '\n📊 [View all artifacts and workflow summary](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\n';
+            comment += `\n📊 [View all artifacts and workflow summary](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})\n`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -395,6 +423,9 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/camunda-delete-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -11,6 +11,7 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Camunda Release load test workflow
+
 on:
   workflow_dispatch:
     inputs:
@@ -62,6 +63,13 @@ on:
         type: string
         default: ""
         required: false
+    secrets:
+      VAULT_ADDR:
+        required: true
+      VAULT_ROLE_ID:
+        required: true
+      VAULT_SECRET_ID:
+        required: true
 
 defaults:
   run:
@@ -92,7 +100,10 @@ jobs:
     name: Create release load test
     needs: sanitize-inputs
     uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       name: ${{ needs.sanitize-inputs.outputs.sanitized-name }}
       ref: main
@@ -112,6 +123,8 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/camunda-scheduled-release-load-tests.yml
+++ b/.github/workflows/camunda-scheduled-release-load-tests.yml
@@ -7,6 +7,7 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Scheduled Camunda Release Load Tests
+
 on:
   schedule:
     - cron: '0 2 * * 1-5' # every weekday (Mon-Fri) at 02:00 UTC
@@ -57,7 +58,10 @@ jobs:
   release-load-test-main:
     name: Release load test (main)
     uses: ./.github/workflows/camunda-release-load-test.yaml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       name: schedule-release-main
       tag: '8.9.1'
@@ -69,7 +73,10 @@ jobs:
     needs: [release-load-test-8-7]
     if: always()
     uses: ./.github/workflows/camunda-verify-and-cleanup-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: c8-schedule-release-8-7-x
 
@@ -78,7 +85,10 @@ jobs:
     needs: [release-load-test-8-8]
     if: always()
     uses: ./.github/workflows/camunda-verify-and-cleanup-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: c8-schedule-release-8-8-x
 
@@ -87,7 +97,10 @@ jobs:
     needs: [release-load-test-8-9]
     if: always()
     uses: ./.github/workflows/camunda-verify-and-cleanup-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: c8-schedule-release-8-9-x
 
@@ -96,7 +109,10 @@ jobs:
     needs: [release-load-test-main]
     if: always()
     uses: ./.github/workflows/camunda-verify-and-cleanup-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: c8-schedule-release-main
 
@@ -114,6 +130,8 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -176,6 +194,8 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/camunda-verify-and-cleanup-load-test.yml
+++ b/.github/workflows/camunda-verify-and-cleanup-load-test.yml
@@ -11,6 +11,13 @@ on:
         description: 'Kubernetes namespace where the load test is deployed'
         type: string
         required: true
+    secrets:
+      VAULT_ADDR:
+        required: true
+      VAULT_ROLE_ID:
+        required: true
+      VAULT_SECRET_ID:
+        required: true
 
 env:
   CLUSTER: camunda-benchmark-prod
@@ -23,7 +30,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     uses: ./.github/workflows/camunda-verify-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: ${{ inputs.namespace }}
 
@@ -35,6 +45,9 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/camunda-delete-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       namespace: ${{ inputs.namespace }}

--- a/.github/workflows/camunda-verify-load-test.yml
+++ b/.github/workflows/camunda-verify-load-test.yml
@@ -10,6 +10,13 @@ on:
         description: 'Kubernetes namespace where the load test is deployed'
         type: string
         required: true
+    secrets:
+      VAULT_ADDR:
+        required: true
+      VAULT_ROLE_ID:
+        required: true
+      VAULT_SECRET_ID:
+        required: true
 
 env:
   CLUSTER: camunda-benchmark-prod
@@ -25,6 +32,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
         with:
           proxy: camunda.teleport.sh:443
@@ -37,7 +46,7 @@ jobs:
       - name: Verify Load test
         env:
           NAMESPACE: ${{ inputs.namespace }}
-        run: load-tests/docs/scripts/verify-test.sh ${{ env.NAMESPACE }}
+        run: load-tests/docs/scripts/verify-test.sh "${NAMESPACE}"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -5,6 +5,7 @@
 # type: CI
 # owner: @camunda/reliability-testing
 name: Camunda weekly medic load test
+
 on:
   workflow_dispatch:
      inputs:
@@ -42,6 +43,8 @@ jobs:
       image-tag: ${{ steps.data.outputs.image-tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Collect test data
         id: data
         env:
@@ -75,6 +78,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -145,6 +150,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -154,9 +161,13 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: ./mvnw -B -DskipTests -DskipChecks -P\!include-optimize -pl load-tests/load-tester -am install
       - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ needs.test-data.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${NEEDS_TEST_DATA_OUTPUTS_IMAGE_TAG}"
+        env:
+          NEEDS_TEST_DATA_OUTPUTS_IMAGE_TAG: ${{ needs.test-data.outputs.image-tag }}
       - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ needs.test-data.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${NEEDS_TEST_DATA_OUTPUTS_IMAGE_TAG}"
+        env:
+          NEEDS_TEST_DATA_OUTPUTS_IMAGE_TAG: ${{ needs.test-data.outputs.image-tag }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -179,7 +190,10 @@ jobs:
       (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
       (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
     uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       name: ${{ needs.test-data.outputs.image-tag }}-rdbms-realistic
       ttl: ${{ fromJSON(inputs.ttl || '28') }}
@@ -199,7 +213,10 @@ jobs:
       (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
       (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
     uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     with:
       name: ${{ needs.test-data.outputs.image-tag }}-opensearch-realistic
       ttl: ${{ fromJSON(inputs.ttl || '28') }}
@@ -210,7 +227,10 @@ jobs:
   setup-realistic-test:
     name: Realistic load test
     uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     needs:
       - test-data
       - build-camunda-image
@@ -229,7 +249,10 @@ jobs:
   setup-latency-test:
     name: Latency test
     uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
     needs:
       - test-data
       - build-camunda-image
@@ -271,6 +294,8 @@ jobs:
     permissions: { }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/pr-load-test-dispatch.yml
+++ b/.github/workflows/pr-load-test-dispatch.yml
@@ -21,6 +21,7 @@
 # No workflow-level concurrency: all event-triggered runs coexist independently. The reusable
 # pipeline's job conditions ensure correct create vs. delete behavior per DB per event.
 name: Camunda PR Benchmark
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
## Description

Done via Claude

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
