### PR TITLE
fix: update wait-state on JobIntent.FAILED and RETRIES_UPDATED

### DIFF
--- a/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
@@ -131,11 +131,18 @@
 
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.WaitStateDbModel">
     UPDATE ${prefix}WAIT_STATE
-    SET ELEMENT_INSTANCE_KEY  = #{elementInstanceKey},
-        ELEMENT_ID            = #{elementId},
-        ELEMENT_TYPE          = #{elementType},
-        PROCESS_DEFINITION_ID = #{processDefinitionId},
-        DETAILS               = #{details, jdbcType=CLOB}
+    <set>
+      ELEMENT_INSTANCE_KEY  = #{elementInstanceKey},
+      <!--
+        elementId is conditionally updated because the transformer nulls it for FAILED /
+        RETRIES_UPDATED records that may carry the NO_CATCH_EVENT_FOUND sentinel. Omitting
+        it from the SET clause preserves the stored value instead of overwriting it.
+      -->
+      <if test="elementId != null">ELEMENT_ID = #{elementId},</if>
+      ELEMENT_TYPE          = #{elementType},
+      PROCESS_DEFINITION_ID = #{processDefinitionId},
+      DETAILS               = #{details, jdbcType=CLOB}
+    </set>
     WHERE WAIT_STATE_KEY = #{waitStateKey}
   </update>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateJobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/WaitStateJobIT.java
@@ -416,9 +416,7 @@ public class WaitStateJobIT {
             .endEvent()
             .done();
 
-    final long v1Key =
-        deployProcessAndWaitForIt(camundaClient, v1, "waitStateMigrationProcessV1.bpmn")
-            .getProcessDefinitionKey();
+    deployProcessAndWaitForIt(camundaClient, v1, "waitStateMigrationProcessV1.bpmn");
     final long v2Key =
         deployProcessAndWaitForIt(camundaClient, v2, "waitStateMigrationProcessV2.bpmn")
             .getProcessDefinitionKey();
@@ -481,6 +479,213 @@ public class WaitStateJobIT {
                             .join()
                             .items())
                     .isEmpty());
+  }
+
+  @Test
+  void shouldReflectCurrentRetriesAfterJobFailure() {
+    // given — isolated single-task process, configured retries = 3
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateRetriesProcess")
+            .startEvent()
+            .serviceTask("retries-task")
+            .zeebeJobType("retries-svc")
+            .zeebeJobRetries("3")
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateRetriesProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateRetriesProcess").getProcessInstanceKey();
+
+    Awaitility.await("wait state should appear with retries=3")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.processInstanceKey(pik))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+              assertThat(items.getFirst().getDetails()).isInstanceOf(JobWaitStateDetails.class);
+              assertThat(((JobWaitStateDetails) items.getFirst().getDetails()).getRetries())
+                  .isEqualTo(3);
+            });
+
+    // when — fail the job once, leaving 2 retries
+    final long jobKey1 =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType("retries-svc")
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst()
+            .getKey();
+    camundaClient.newFailCommand(jobKey1).retries(2).errorMessage("fail 1").send().join();
+
+    Awaitility.await("wait state should reflect retries=2 after first failure")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.processInstanceKey(pik))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+              assertThat(items.getFirst().getDetails()).isInstanceOf(JobWaitStateDetails.class);
+              assertThat(((JobWaitStateDetails) items.getFirst().getDetails()).getRetries())
+                  .isEqualTo(2);
+            });
+
+    // when — fail the job again with retries=0, triggering an incident
+    final long jobKey2 =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType("retries-svc")
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst()
+            .getKey();
+    camundaClient
+        .newFailCommand(jobKey2)
+        .retries(0)
+        .errorMessage("fail 2 - exhausted")
+        .send()
+        .join();
+
+    // then — retries=0 even though an incident is raised
+    Awaitility.await("wait state should reflect retries=0 after exhaustion")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.processInstanceKey(pik))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+              assertThat(items.getFirst().getDetails()).isInstanceOf(JobWaitStateDetails.class);
+              assertThat(((JobWaitStateDetails) items.getFirst().getDetails()).getRetries())
+                  .isEqualTo(0);
+            });
+
+    // cleanup — cancel the incident-stalled instance so it doesn't interfere with other tests
+    camundaClient.newCancelInstanceCommand(pik).execute();
+    waitForProcessInstanceToBeTerminated(camundaClient, pik);
+  }
+
+  @Test
+  void shouldReflectCurrentRetriesAfterRetriesUpdated() {
+    // given — isolated single-task process, configured retries = 3
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateRetriesUpdateProcess")
+            .startEvent()
+            .serviceTask("retries-update-task")
+            .zeebeJobType("retries-update-svc")
+            .zeebeJobRetries("3")
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateRetriesUpdateProcess.bpmn");
+
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateRetriesUpdateProcess")
+            .getProcessInstanceKey();
+
+    Awaitility.await("wait state should appear with retries=3")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.processInstanceKey(pik))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+              assertThat(items.getFirst().getDetails()).isInstanceOf(JobWaitStateDetails.class);
+              assertThat(((JobWaitStateDetails) items.getFirst().getDetails()).getRetries())
+                  .isEqualTo(3);
+            });
+
+    // when — fail the job with retries=0 to trigger an incident
+    final long jobKey =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType("retries-update-svc")
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst()
+            .getKey();
+    camundaClient.newFailCommand(jobKey).retries(0).errorMessage("exhausted").send().join();
+
+    Awaitility.await("wait state should reflect retries=0 after exhaustion")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.processInstanceKey(pik))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+              assertThat(items.getFirst().getDetails()).isInstanceOf(JobWaitStateDetails.class);
+              assertThat(((JobWaitStateDetails) items.getFirst().getDetails()).getRetries())
+                  .isEqualTo(0);
+            });
+
+    // wait for the incident to be raised before updating retries
+    Awaitility.await("incident should appear for the stalled process instance")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .until(
+            () ->
+                !camundaClient
+                    .newIncidentSearchRequest()
+                    .filter(f -> f.processInstanceKey(pik))
+                    .send()
+                    .join()
+                    .items()
+                    .isEmpty());
+
+    // when — update retries to 2, triggering a RETRIES_UPDATED record
+    camundaClient.newUpdateRetriesCommand(jobKey).retries(2).send().join();
+
+    // then — wait state should reflect the updated retries count
+    Awaitility.await("wait state should reflect retries=2 after retries update")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newElementInstanceWaitStateSearchRequest()
+                      .filter(f -> f.processInstanceKey(pik))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+              assertThat(items.getFirst().getDetails()).isInstanceOf(JobWaitStateDetails.class);
+              assertThat(((JobWaitStateDetails) items.getFirst().getDetails()).getRetries())
+                  .isEqualTo(2);
+            });
+
+    // cleanup — cancel the incident-stalled instance so it doesn't interfere with other tests
+    camundaClient.newCancelInstanceCommand(pik).execute();
+    waitForProcessInstanceToBeTerminated(camundaClient, pik);
   }
 
   /**

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigs.java
@@ -28,7 +28,7 @@ public final class WaitStateConfigs {
   public static final WaitStateTransformerConfig JOB_CONFIG =
       WaitStateTransformerConfig.of(ValueType.JOB)
           .withAddIntents(JobIntent.CREATED)
-          .withUpdateIntents(JobIntent.MIGRATED)
+          .withUpdateIntents(JobIntent.MIGRATED, JobIntent.FAILED, JobIntent.RETRIES_UPDATED)
           .withRemoveIntents(JobIntent.COMPLETED, JobIntent.CANCELED)
           .withWaitStateType(WaitStateType.JOB);
 

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformerConfig;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -28,6 +29,7 @@ public class JobBasedWaitStateTransformer implements WaitStateTransformer<JobRec
   @Override
   public void extract(final Record<JobRecordValue> record, final WaitStateEntry entry) {
     final JobRecordValue value = record.getValue();
+    clearElementIdIfSentinelRisk(record, entry);
     entry
         .setElementType(value.getElementType())
         .setDetails(
@@ -37,6 +39,18 @@ public class JobBasedWaitStateTransformer implements WaitStateTransformer<JobRec
                 value.getJobKind(),
                 listenerEventType(value),
                 value.getRetries()));
+  }
+
+  /**
+   * FAILED and RETRIES_UPDATED records may carry "NO_CATCH_EVENT_FOUND" as elementId when a BPMN
+   * error has no matching catch event. Nulling elementId here prevents update handlers from
+   * overwriting the stored elementId with that sentinel value.
+   */
+  private static void clearElementIdIfSentinelRisk(
+      final Record<JobRecordValue> record, final WaitStateEntry entry) {
+    if (record.getIntent() == JobIntent.FAILED || record.getIntent() == JobIntent.RETRIES_UPDATED) {
+      entry.setElementId(null);
+    }
   }
 
   private static @Nullable JobListenerEventType listenerEventType(final JobRecordValue value) {

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformerTest.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class JobBasedWaitStateTransformerTest {
 
@@ -226,5 +228,80 @@ class JobBasedWaitStateTransformerTest {
     assertThat(transformer.triggersRemoval(canceled)).isTrue();
     assertThat(transformer.triggersAdd(completed)).isFalse();
     assertThat(transformer.triggersAdd(canceled)).isFalse();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = JobIntent.class,
+      names = {"FAILED", "RETRIES_UPDATED"})
+  @SuppressWarnings("unchecked")
+  void shouldTriggerUpdateForSentinelRiskIntents(final JobIntent intent) {
+    // given
+    final Record<JobRecordValue> record =
+        (Record<JobRecordValue>)
+            (Record<?>)
+                factory.generateRecord(
+                    ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(intent));
+
+    // when / then
+    assertThat(transformer.triggersUpdate(record)).isTrue();
+    assertThat(transformer.triggersAdd(record)).isFalse();
+    assertThat(transformer.triggersRemoval(record)).isFalse();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = JobIntent.class,
+      names = {"FAILED", "RETRIES_UPDATED"})
+  @SuppressWarnings("unchecked")
+  void shouldClearElementIdForSentinelRiskIntents(final JobIntent intent) {
+    // given
+    final Record<JobRecordValue> record =
+        (Record<JobRecordValue>)
+            (Record<?>)
+                factory.generateRecord(
+                    ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(intent));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then — elementId is null so update handlers preserve the stored value
+    assertThat(entry.getElementId()).isNull();
+  }
+
+  @Test
+  void shouldExtractRemainingRetriesFromJobFailedRecord() {
+    // given
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("retry-service")
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withJobListenerEventType(JobListenerEventType.UNSPECIFIED)
+            .withRetries(1)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("retry-task")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withKey(888L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(JobIntent.FAILED)
+                    .withValue(value));
+
+    // when
+    final var entry = transformer.transform(record);
+
+    // then
+    assertThat(entry.getDetails()).isInstanceOf(JobWaitStateDetails.class);
+    final var details = (JobWaitStateDetails) entry.getDetails();
+    assertThat(details.retries()).isEqualTo(1);
   }
 }

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -121,6 +121,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/AbstractWaitStateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/AbstractWaitStateHandler.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.WaitStateRelated;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shared logic for all wait-state export handlers. Subclasses decide which records they handle and
+ * how to flush the entity to the batch request.
+ *
+ * @param <R> the record value type handled by the injected transformer
+ */
+@NullMarked
+public abstract class AbstractWaitStateHandler<R extends RecordValue & WaitStateRelated>
+    implements ExportHandler<WaitStateEntity, R> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractWaitStateHandler.class);
+
+  protected final String indexName;
+  protected final WaitStateTransformer<R> transformer;
+  protected final ObjectMapper objectMapper;
+
+  protected AbstractWaitStateHandler(
+      final String indexName,
+      final WaitStateTransformer<R> transformer,
+      final ObjectMapper objectMapper) {
+    this.indexName = indexName;
+    this.transformer = transformer;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return transformer.config().valueType();
+  }
+
+  @Override
+  public Class<WaitStateEntity> getEntityType() {
+    return WaitStateEntity.class;
+  }
+
+  @Override
+  public List<String> generateIds(final Record<R> record) {
+    return List.of(String.valueOf(record.getKey()));
+  }
+
+  @Override
+  public WaitStateEntity createNewEntity(final String id) {
+    return new WaitStateEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<R> record, final WaitStateEntity entity) {
+    final var entry = transformer.transform(record);
+
+    entity
+        .setRootProcessInstanceKey(entry.getRootProcessInstanceKey())
+        .setProcessInstanceKey(entry.getProcessInstanceKey())
+        .setElementInstanceKey(entry.getElementInstanceKey())
+        .setElementId(entry.getElementId())
+        .setElementType(entry.getElementType() != null ? entry.getElementType().name() : null)
+        .setWaitStateType(entry.getWaitStateType() != null ? entry.getWaitStateType().name() : null)
+        .setBpmnProcessId(entry.getBpmnProcessId())
+        .setDetails(serializeDetails(entry.getDetails()))
+        .setTenantId(entry.getTenantId())
+        .setPartitionId(entry.getPartitionId());
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  @VisibleForTesting
+  public WaitStateTransformer<R> getTransformer() {
+    return transformer;
+  }
+
+  protected @Nullable String serializeDetails(final @Nullable WaitStateDetails details) {
+    if (details == null) {
+      return null;
+    }
+    try {
+      return objectMapper.writeValueAsString(details);
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to serialize wait state details: {}", e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateHandlerBuilder.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateHandlerBuilder.java
@@ -17,8 +17,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Builds matched pairs of {@link WaitStateAddHandler} and {@link WaitStateRemoveHandler} from a set
- * of {@link WaitStateTransformer}s, so that handler registration stays concise and DRY.
+ * Builds matched triples of {@link WaitStateAddHandler}, {@link WaitStateUpdateHandler}, and {@link
+ * WaitStateRemoveHandler} from a set of {@link WaitStateTransformer}s, so that handler registration
+ * stays concise and DRY.
  *
  * <p>Usage:
  *
@@ -47,6 +48,7 @@ public final class WaitStateHandlerBuilder {
   public <R extends RecordValue & WaitStateRelated> WaitStateHandlerBuilder addTransformer(
       final WaitStateTransformer<R> transformer) {
     handlers.add(new WaitStateAddHandler<>(indexName, transformer, objectMapper));
+    handlers.add(new WaitStateUpdateHandler<>(indexName, transformer, objectMapper));
     handlers.add(new WaitStateRemoveHandler<>(indexName, transformer));
     return this;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateUpdateHandler.java
@@ -10,24 +10,28 @@ package io.camunda.exporter.handlers.waitstate;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.value.WaitStateRelated;
+import java.util.HashMap;
+import java.util.Map;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Writes a new {@link WaitStateEntity} to the wait-state index when a process element enters a
- * waiting state for the first time.
+ * Updates mutable fields of an existing {@link WaitStateEntity} in the wait-state index when a
+ * process element's waiting state changes (e.g. job migrated, retries updated). Uses upsert so the
+ * document is created if it was never written by an add handler (e.g. on replay after restart).
  *
  * @param <R> the record value type handled by the injected transformer
  */
 @NullMarked
-public class WaitStateAddHandler<R extends RecordValue & WaitStateRelated>
+public class WaitStateUpdateHandler<R extends RecordValue & WaitStateRelated>
     extends AbstractWaitStateHandler<R> {
 
-  public WaitStateAddHandler(
+  public WaitStateUpdateHandler(
       final String indexName,
       final WaitStateTransformer<R> transformer,
       final ObjectMapper objectMapper) {
@@ -36,12 +40,23 @@ public class WaitStateAddHandler<R extends RecordValue & WaitStateRelated>
 
   @Override
   public boolean handlesRecord(final Record<R> record) {
-    return transformer.triggersAdd(record);
+    return transformer.triggersUpdate(record);
   }
 
   @Override
   public void flush(final WaitStateEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    final Map<String, Object> updateFields = new HashMap<>();
+    // elementId and bpmnProcessId are null when the transformer called
+    // clearElementIdIfSentinelRisk() (e.g. FAILED / RETRIES_UPDATED); include them only when
+    // explicitly set (e.g. MIGRATED). bpmnProcessId changes on cross-process migration.
+    if (entity.getElementId() != null) {
+      updateFields.put(WaitStateTemplate.ELEMENT_ID, entity.getElementId());
+    }
+    if (entity.getBpmnProcessId() != null) {
+      updateFields.put(WaitStateTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());
+    }
+    updateFields.put(WaitStateTemplate.DETAILS, entity.getDetails());
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -19,6 +19,7 @@ import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler;
 import io.camunda.exporter.handlers.waitstate.WaitStateAddHandler;
 import io.camunda.exporter.handlers.waitstate.WaitStateRemoveHandler;
+import io.camunda.exporter.handlers.waitstate.WaitStateUpdateHandler;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -153,6 +154,7 @@ public class DefaultExporterResourceProviderTest {
         provider.getExportHandlers().stream()
             .filter(handler -> !(handler instanceof AuditLogHandler))
             .filter(handler -> !(handler instanceof WaitStateAddHandler))
+            .filter(handler -> !(handler instanceof WaitStateUpdateHandler))
             .filter(handler -> !(handler instanceof WaitStateRemoveHandler))
             .toList();
 
@@ -384,6 +386,10 @@ public class DefaultExporterResourceProviderTest {
     // For WaitState handlers, extract RecordValue from the transformer instance for the same reason
     if (handler instanceof final WaitStateAddHandler<?> waitStateAddHandler) {
       return findRecordValueTypeParameterFromClass(waitStateAddHandler.getTransformer().getClass());
+    }
+    if (handler instanceof final WaitStateUpdateHandler<?> waitStateUpdateHandler) {
+      return findRecordValueTypeParameterFromClass(
+          waitStateUpdateHandler.getTransformer().getClass());
     }
     if (handler instanceof final WaitStateRemoveHandler<?> waitStateRemoveHandler) {
       return findRecordValueTypeParameterFromClass(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/ConditionWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/ConditionWaitStateHandlerTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.ConditionBasedWaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableConditionalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end integration test for the conditional-subscription wait-state handler triple produced
+ * by {@link WaitStateHandlerBuilder} with {@link ConditionBasedWaitStateTransformer}.
+ *
+ * <p>Validates: {@code CREATED} writes the entry, {@code MIGRATED} upserts it, {@code DELETED}
+ * removes it, and {@code TRIGGERED} removes it only when the subscription is interrupting. Only
+ * {@link BpmnElementType#INTERMEDIATE_CATCH_EVENT} subscriptions with a valid process-instance
+ * context are tracked.
+ */
+class ConditionWaitStateHandlerTest {
+
+  private static final String INDEX_NAME = "test-wait-state";
+  private static final long RECORD_KEY = 999L;
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private WaitStateAddHandler<ConditionalSubscriptionRecordValue> addHandler;
+  private WaitStateUpdateHandler<ConditionalSubscriptionRecordValue> updateHandler;
+  private WaitStateRemoveHandler<ConditionalSubscriptionRecordValue> removeHandler;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new ConditionBasedWaitStateTransformer())
+            .build();
+
+    addHandler =
+        (WaitStateAddHandler<ConditionalSubscriptionRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateAddHandler)
+                .findFirst()
+                .orElseThrow();
+    updateHandler =
+        (WaitStateUpdateHandler<ConditionalSubscriptionRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateUpdateHandler)
+                .findFirst()
+                .orElseThrow();
+    removeHandler =
+        (WaitStateRemoveHandler<ConditionalSubscriptionRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateRemoveHandler)
+                .findFirst()
+                .orElseThrow();
+  }
+
+  @Test
+  void shouldBuilderProduceExactlyThreeHandlers() {
+    // when
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new ConditionBasedWaitStateTransformer())
+            .build();
+
+    // then — one add + one update + one remove
+    assertThat(handlers).hasSize(3);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateAddHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateUpdateHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateRemoveHandler).count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldAddHandlerAcceptCreatedForIntermediateCatchEvent() {
+    // given
+    final var created =
+        record(ConditionalSubscriptionIntent.CREATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(created)).isTrue();
+    assertThat(updateHandler.handlesRecord(created)).isFalse();
+    assertThat(removeHandler.handlesRecord(created)).isFalse();
+  }
+
+  @Test
+  void shouldAllHandlersRejectSubscriptionsWithoutProcessInstanceContext() {
+    // given — processInstanceKey == -1 means root start event with no instance context
+    final var created =
+        record(
+            ConditionalSubscriptionIntent.CREATED,
+            BpmnElementType.INTERMEDIATE_CATCH_EVENT,
+            -1L,
+            100L);
+    final var deleted =
+        record(
+            ConditionalSubscriptionIntent.DELETED,
+            BpmnElementType.INTERMEDIATE_CATCH_EVENT,
+            -1L,
+            100L);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(created)).isFalse();
+    assertThat(removeHandler.handlesRecord(deleted)).isFalse();
+  }
+
+  @Test
+  void shouldAllHandlersRejectBoundaryEventSubscriptions() {
+    // given — boundary events are not tracked as wait states
+    final var created =
+        record(ConditionalSubscriptionIntent.CREATED, BpmnElementType.BOUNDARY_EVENT);
+    final var deleted =
+        record(ConditionalSubscriptionIntent.DELETED, BpmnElementType.BOUNDARY_EVENT);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(created)).isFalse();
+    assertThat(removeHandler.handlesRecord(deleted)).isFalse();
+  }
+
+  @Test
+  void shouldAllHandlersRejectStartEventSubscriptions() {
+    // given — start event subscriptions (event subprocess) are not tracked
+    final var created = record(ConditionalSubscriptionIntent.CREATED, BpmnElementType.START_EVENT);
+    final var deleted = record(ConditionalSubscriptionIntent.DELETED, BpmnElementType.START_EVENT);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(created)).isFalse();
+    assertThat(removeHandler.handlesRecord(deleted)).isFalse();
+  }
+
+  @Test
+  void shouldUpdateHandlerAcceptMigratedAndRejectCreated() {
+    // given
+    final var migrated =
+        record(ConditionalSubscriptionIntent.MIGRATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+    final var created =
+        record(ConditionalSubscriptionIntent.CREATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(updateHandler.handlesRecord(migrated)).isTrue();
+    assertThat(addHandler.handlesRecord(migrated)).isFalse();
+    assertThat(removeHandler.handlesRecord(migrated)).isFalse();
+    assertThat(updateHandler.handlesRecord(created)).isFalse();
+  }
+
+  @Test
+  void shouldRemoveHandlerAcceptDeletedIntent() {
+    // given
+    final var deleted =
+        record(ConditionalSubscriptionIntent.DELETED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(removeHandler.handlesRecord(deleted)).isTrue();
+    assertThat(addHandler.handlesRecord(deleted)).isFalse();
+    assertThat(updateHandler.handlesRecord(deleted)).isFalse();
+  }
+
+  @Test
+  void shouldRemoveHandlerAcceptTriggeredOnlyWhenInterrupting() {
+    // given
+    final var triggeredInterrupting =
+        record(
+            ConditionalSubscriptionIntent.TRIGGERED,
+            BpmnElementType.INTERMEDIATE_CATCH_EVENT,
+            true);
+    final var triggeredNonInterrupting =
+        record(
+            ConditionalSubscriptionIntent.TRIGGERED,
+            BpmnElementType.INTERMEDIATE_CATCH_EVENT,
+            false);
+
+    // when / then — TRIGGERED removes only when the subscription is interrupting
+    assertThat(removeHandler.handlesRecord(triggeredInterrupting)).isTrue();
+    assertThat(removeHandler.handlesRecord(triggeredNonInterrupting)).isFalse();
+  }
+
+  @Test
+  void shouldWriteEntityWithConditionDetails() throws Exception {
+    // given
+    final var value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withCondition("= x > 5")
+            .withVariableEvents(List.of("create", "update"))
+            .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .withCatchEventId("catch-condition")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withBpmnProcessId("test-process")
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final var conditionRecord =
+        cast(
+            factory.generateRecord(
+                ValueType.CONDITIONAL_SUBSCRIPTION,
+                r ->
+                    r.withKey(RECORD_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(ConditionalSubscriptionIntent.CREATED)
+                        .withValue(value)));
+    final var entity = addHandler.createNewEntity(String.valueOf(RECORD_KEY));
+
+    // when
+    addHandler.updateEntity(conditionRecord, entity);
+
+    // then
+    assertThat(entity.getElementId()).isEqualTo("catch-condition");
+    assertThat(entity.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entity.getWaitStateType()).isEqualTo(WaitStateType.CONDITION.name());
+
+    // then — condition-specific details serialised as JSON
+    final var details = objectMapper.readTree(entity.getDetails());
+    assertThat(details.get("expression").textValue()).isEqualTo("= x > 5");
+    assertThat(details.get("events").isArray()).isTrue();
+    assertThat(details.get("events").get(0).textValue()).isEqualTo("create");
+    assertThat(details.get("events").get(1).textValue()).isEqualTo("update");
+  }
+
+  @Test
+  void shouldNormalizeEmptyVariableEventsToCreateAndUpdate() throws Exception {
+    // given — empty variableEvents means "all events" in the engine; transformer normalises to
+    // explicit list
+    final var value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withCondition("= active")
+            .withVariableEvents(List.of())
+            .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .withCatchEventId("catch-condition")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withBpmnProcessId("test-process")
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final var conditionRecord =
+        cast(
+            factory.generateRecord(
+                ValueType.CONDITIONAL_SUBSCRIPTION,
+                r ->
+                    r.withKey(RECORD_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(ConditionalSubscriptionIntent.CREATED)
+                        .withValue(value)));
+    final var entity = addHandler.createNewEntity(String.valueOf(RECORD_KEY));
+
+    // when
+    addHandler.updateEntity(conditionRecord, entity);
+
+    // then — empty variableEvents normalised to ["create", "update"]
+    final var details = objectMapper.readTree(entity.getDetails());
+    assertThat(details.get("events").size()).isEqualTo(2);
+    assertThat(details.get("events").get(0).textValue()).isEqualTo("create");
+    assertThat(details.get("events").get(1).textValue()).isEqualTo("update");
+  }
+
+  @Test
+  void shouldBothHandlersUseTheSameDocumentId() {
+    // given
+    final var created =
+        record(ConditionalSubscriptionIntent.CREATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+    final var deleted =
+        record(ConditionalSubscriptionIntent.DELETED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when
+    final var addIds = addHandler.generateIds(created);
+    final var removeIds = removeHandler.generateIds(deleted);
+
+    // then — same stable document id (record key) used for write and delete
+    assertThat(addIds).containsExactly(String.valueOf(RECORD_KEY));
+    assertThat(removeIds).containsExactly(String.valueOf(RECORD_KEY));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Record<ConditionalSubscriptionRecordValue> record(
+      final ConditionalSubscriptionIntent intent, final BpmnElementType elementType) {
+    return record(intent, elementType, 200L, 100L);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Record<ConditionalSubscriptionRecordValue> record(
+      final ConditionalSubscriptionIntent intent,
+      final BpmnElementType elementType,
+      final long processInstanceKey,
+      final long rootProcessInstanceKey) {
+    final var value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withElementType(elementType)
+            .withProcessInstanceKey(processInstanceKey)
+            .withRootProcessInstanceKey(rootProcessInstanceKey)
+            .withBpmnProcessId(processInstanceKey == -1L ? "" : "test-process")
+            .build();
+    return (Record<ConditionalSubscriptionRecordValue>)
+        (Record<? extends RecordValue>)
+            factory.generateRecord(
+                ValueType.CONDITIONAL_SUBSCRIPTION,
+                r ->
+                    r.withKey(RECORD_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(intent)
+                        .withValue(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Record<ConditionalSubscriptionRecordValue> record(
+      final ConditionalSubscriptionIntent intent,
+      final BpmnElementType elementType,
+      final boolean interrupting) {
+    final var value =
+        ImmutableConditionalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(ConditionalSubscriptionRecordValue.class))
+            .withElementType(elementType)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withBpmnProcessId("test-process")
+            .withInterrupting(interrupting)
+            .build();
+    return (Record<ConditionalSubscriptionRecordValue>)
+        (Record<? extends RecordValue>)
+            factory.generateRecord(
+                ValueType.CONDITIONAL_SUBSCRIPTION,
+                r ->
+                    r.withKey(RECORD_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(intent)
+                        .withValue(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<ConditionalSubscriptionRecordValue> cast(
+      final Record<? extends RecordValue> record) {
+    return (Record<ConditionalSubscriptionRecordValue>) record;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers.waitstate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
 import io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer;
@@ -34,12 +36,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * End-to-end integration test for the job wait-state handler pair produced by {@link
+ * End-to-end integration test for the job wait-state handler triple produced by {@link
  * WaitStateHandlerBuilder} with {@link JobBasedWaitStateTransformer}.
  *
- * <p>Validates the full lifecycle: a {@code JOB.CREATED} event writes the wait-state entry, and a
- * subsequent {@code JOB.COMPLETED} or {@code JOB.CANCELED} event removes it using the same stable
- * document id (the jobKey).
+ * <p>Validates the full lifecycle: a {@code JOB.CREATED} event writes the wait-state entry, {@code
+ * MIGRATED}/{@code FAILED}/{@code RETRIES_UPDATED} upsert it, and {@code COMPLETED}/{@code
+ * CANCELED} remove it using the same stable document id (the jobKey).
  */
 class JobWaitStateHandlerTest {
 
@@ -50,6 +52,7 @@ class JobWaitStateHandlerTest {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   private WaitStateAddHandler<JobRecordValue> addHandler;
+  private WaitStateUpdateHandler<JobRecordValue> updateHandler;
   private WaitStateRemoveHandler<JobRecordValue> removeHandler;
 
   @BeforeEach
@@ -66,6 +69,12 @@ class JobWaitStateHandlerTest {
                 .filter(h -> h instanceof WaitStateAddHandler)
                 .findFirst()
                 .orElseThrow();
+    updateHandler =
+        (WaitStateUpdateHandler<JobRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateUpdateHandler)
+                .findFirst()
+                .orElseThrow();
     removeHandler =
         (WaitStateRemoveHandler<JobRecordValue>)
             handlers.stream()
@@ -75,7 +84,7 @@ class JobWaitStateHandlerTest {
   }
 
   @Test
-  void shouldAddHandlerHandleCreatedAndRemoveHandlerNotHandle() {
+  void shouldAddHandlerAcceptCreatedRecordOnly() {
     // given
     final var created = jobRecord(JobIntent.CREATED);
     final var completed = jobRecord(JobIntent.COMPLETED);
@@ -190,13 +199,14 @@ class JobWaitStateHandlerTest {
   }
 
   @Test
-  void shouldAddHandlerHandleMigratedEvent() {
+  void shouldUpdateHandlerAcceptMigratedEventNotAddHandler() {
     // given
     final var migrated = jobRecord(JobIntent.MIGRATED);
 
-    // when / then — MIGRATED is an upsert, handled by the add handler, not the remove handler
-    assertThat(addHandler.handlesRecord(migrated)).isTrue();
+    // when / then — MIGRATED is an update intent, handled by updateHandler, not addHandler
+    assertThat(addHandler.handlesRecord(migrated)).isFalse();
     assertThat(removeHandler.handlesRecord(migrated)).isFalse();
+    assertThat(updateHandler.handlesRecord(migrated)).isTrue();
   }
 
   @Test
@@ -205,7 +215,7 @@ class JobWaitStateHandlerTest {
     final var migrated = jobRecord(JobIntent.MIGRATED);
 
     // when
-    final var ids = addHandler.generateIds(migrated);
+    final var ids = updateHandler.generateIds(migrated);
 
     // then — same stable document id as CREATED so the upsert updates the existing entry
     assertThat(ids).containsExactly(String.valueOf(JOB_KEY));
@@ -237,12 +247,13 @@ class JobWaitStateHandlerTest {
                         .withRecordType(RecordType.EVENT)
                         .withIntent(JobIntent.MIGRATED)
                         .withValue(jobValue)));
-    final var entity = addHandler.createNewEntity(String.valueOf(JOB_KEY));
+    final var entity = updateHandler.createNewEntity(String.valueOf(JOB_KEY));
 
     // when
-    addHandler.updateEntity(record, entity);
+    updateHandler.updateEntity(record, entity);
 
-    // then — entity reflects the post-migration element id; all other fields are also updated
+    // then — entity reflects the post-migration element id (update handler sends ELEMENT_ID +
+    // DETAILS only)
     assertThat(entity.getElementId()).isEqualTo("task-after-migration");
     assertThat(entity.getElementType()).isEqualTo(BpmnElementType.SERVICE_TASK.name());
     assertThat(entity.getProcessInstanceKey()).isEqualTo(200L);
@@ -253,14 +264,80 @@ class JobWaitStateHandlerTest {
   }
 
   @Test
-  void shouldBuilderProduceExactlyTwoHandlers() {
+  void shouldUpdateHandlerAcceptFailedAndRetriesUpdated() {
+    // given
+    final var failed = jobRecord(JobIntent.FAILED);
+    final var retriesUpdated = jobRecord(JobIntent.RETRIES_UPDATED);
+    final var created = jobRecord(JobIntent.CREATED);
+
+    // when / then — FAILED and RETRIES_UPDATED are update intents; CREATED is not
+    assertThat(updateHandler.handlesRecord(failed)).isTrue();
+    assertThat(updateHandler.handlesRecord(retriesUpdated)).isTrue();
+    assertThat(updateHandler.handlesRecord(created)).isFalse();
+  }
+
+  @Test
+  void shouldUpdateHandlerSkipsElementIdWhenNullDueToSentinelRisk() throws PersistenceException {
+    // given — FAILED/RETRIES_UPDATED: transformer nulls elementId to avoid overwriting stored value
+    final var id = String.valueOf(JOB_KEY);
+    final var entity = new WaitStateEntity().setId(id).setDetails("{\"retries\":0}");
+    final var batchRequest = mock(BatchRequest.class);
+
+    // when
+    updateHandler.flush(entity, batchRequest);
+
+    // then — only DETAILS in the update map; ELEMENT_ID is skipped
+    verify(batchRequest)
+        .upsert(
+            eq(INDEX_NAME),
+            eq(id),
+            eq(entity),
+            argThat(map -> map.containsKey(WaitStateTemplate.DETAILS) && map.size() == 1));
+  }
+
+  @Test
+  void shouldUpdateHandlerIncludesElementIdWhenPresentForMigration() throws PersistenceException {
+    // given — MIGRATED: elementId and bpmnProcessId are populated with values from the target
+    // process definition (bpmnProcessId changes on cross-process migration)
+    final var id = String.valueOf(JOB_KEY);
+    final var entity =
+        new WaitStateEntity()
+            .setId(id)
+            .setElementId("task-after-migration")
+            .setBpmnProcessId("target-process")
+            .setDetails("{\"retries\":3}");
+    final var batchRequest = mock(BatchRequest.class);
+
+    // when
+    updateHandler.flush(entity, batchRequest);
+
+    // then — ELEMENT_ID, BPMN_PROCESS_ID and DETAILS are all sent
+    verify(batchRequest)
+        .upsert(
+            eq(INDEX_NAME),
+            eq(id),
+            eq(entity),
+            argThat(
+                map ->
+                    map.containsKey(WaitStateTemplate.ELEMENT_ID)
+                        && map.containsKey(WaitStateTemplate.BPMN_PROCESS_ID)
+                        && map.containsKey(WaitStateTemplate.DETAILS)
+                        && map.size() == 3));
+  }
+
+  @Test
+  void shouldBuilderProduceExactlyThreeHandlers() {
+    // when
     final var handlers =
         WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
             .addTransformer(new JobBasedWaitStateTransformer())
             .build();
 
-    assertThat(handlers).hasSize(2);
+    // then — one add + one update + one remove
+    assertThat(handlers).hasSize(3);
     assertThat(handlers.stream().filter(h -> h instanceof WaitStateAddHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateUpdateHandler).count())
         .isEqualTo(1);
     assertThat(handlers.stream().filter(h -> h instanceof WaitStateRemoveHandler).count())
         .isEqualTo(1);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/MessageWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/MessageWaitStateHandlerTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.MessageBasedWaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end integration test for the message-subscription wait-state handler triple produced by
+ * {@link WaitStateHandlerBuilder} with {@link MessageBasedWaitStateTransformer}.
+ *
+ * <p>Validates: {@code CREATED} writes the entry, {@code MIGRATED} upserts it, and {@code
+ * CORRELATED}/{@code DELETED} remove it. Only {@link BpmnElementType#RECEIVE_TASK} and {@link
+ * BpmnElementType#INTERMEDIATE_CATCH_EVENT} subscriptions are tracked.
+ */
+class MessageWaitStateHandlerTest {
+
+  private static final String INDEX_NAME = "test-wait-state";
+  private static final long RECORD_KEY = 999L;
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private WaitStateAddHandler<MessageSubscriptionRecordValue> addHandler;
+  private WaitStateUpdateHandler<MessageSubscriptionRecordValue> updateHandler;
+  private WaitStateRemoveHandler<MessageSubscriptionRecordValue> removeHandler;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new MessageBasedWaitStateTransformer())
+            .build();
+
+    addHandler =
+        (WaitStateAddHandler<MessageSubscriptionRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateAddHandler)
+                .findFirst()
+                .orElseThrow();
+    updateHandler =
+        (WaitStateUpdateHandler<MessageSubscriptionRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateUpdateHandler)
+                .findFirst()
+                .orElseThrow();
+    removeHandler =
+        (WaitStateRemoveHandler<MessageSubscriptionRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateRemoveHandler)
+                .findFirst()
+                .orElseThrow();
+  }
+
+  @Test
+  void shouldBuilderProduceExactlyThreeHandlers() {
+    // when
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new MessageBasedWaitStateTransformer())
+            .build();
+
+    // then — one add + one update + one remove
+    assertThat(handlers).hasSize(3);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateAddHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateUpdateHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateRemoveHandler).count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldAddHandlerAcceptCreatedForReceiveTaskAndIntermediateCatchEvent() {
+    // given
+    final var receiveTaskCreated =
+        record(MessageSubscriptionIntent.CREATED, BpmnElementType.RECEIVE_TASK);
+    final var catchEventCreated =
+        record(MessageSubscriptionIntent.CREATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(receiveTaskCreated)).isTrue();
+    assertThat(addHandler.handlesRecord(catchEventCreated)).isTrue();
+  }
+
+  @Test
+  void shouldAllHandlersRejectBoundaryEventSubscriptions() {
+    // given — boundary events represent interrupts, not explicit waits; they must never be tracked
+    final var created = record(MessageSubscriptionIntent.CREATED, BpmnElementType.BOUNDARY_EVENT);
+    final var migrated = record(MessageSubscriptionIntent.MIGRATED, BpmnElementType.BOUNDARY_EVENT);
+    final var correlated =
+        record(MessageSubscriptionIntent.CORRELATED, BpmnElementType.BOUNDARY_EVENT);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(created)).isFalse();
+    assertThat(updateHandler.handlesRecord(migrated)).isFalse();
+    assertThat(removeHandler.handlesRecord(correlated)).isFalse();
+  }
+
+  @Test
+  void shouldUpdateHandlerAcceptMigratedAndRejectCreated() {
+    // given
+    final var migrated = record(MessageSubscriptionIntent.MIGRATED, BpmnElementType.RECEIVE_TASK);
+    final var created = record(MessageSubscriptionIntent.CREATED, BpmnElementType.RECEIVE_TASK);
+
+    // when / then
+    assertThat(updateHandler.handlesRecord(migrated)).isTrue();
+    assertThat(addHandler.handlesRecord(migrated)).isFalse();
+    assertThat(removeHandler.handlesRecord(migrated)).isFalse();
+    assertThat(updateHandler.handlesRecord(created)).isFalse();
+  }
+
+  @Test
+  void shouldRemoveHandlerAcceptCorrelatedAndDeleted() {
+    // given
+    final var correlated =
+        record(MessageSubscriptionIntent.CORRELATED, BpmnElementType.RECEIVE_TASK);
+    final var deleted = record(MessageSubscriptionIntent.DELETED, BpmnElementType.RECEIVE_TASK);
+
+    // when / then
+    assertThat(removeHandler.handlesRecord(correlated)).isTrue();
+    assertThat(removeHandler.handlesRecord(deleted)).isTrue();
+    assertThat(addHandler.handlesRecord(correlated)).isFalse();
+    assertThat(updateHandler.handlesRecord(correlated)).isFalse();
+  }
+
+  @Test
+  void shouldWriteEntityWithMessageDetails() throws Exception {
+    // given
+    final var value =
+        ImmutableMessageSubscriptionRecordValue.builder()
+            .from(factory.generateObject(MessageSubscriptionRecordValue.class))
+            .withMessageName("order-received")
+            .withCorrelationKey("order-123")
+            .withElementType(BpmnElementType.RECEIVE_TASK)
+            .withElementId("receive-order")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final var messageRecord =
+        cast(
+            factory.generateRecord(
+                ValueType.MESSAGE_SUBSCRIPTION,
+                r ->
+                    r.withKey(RECORD_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(MessageSubscriptionIntent.CREATED)
+                        .withValue(value)));
+    final var entity = addHandler.createNewEntity(String.valueOf(RECORD_KEY));
+
+    // when
+    addHandler.updateEntity(messageRecord, entity);
+
+    // then
+    assertThat(entity.getElementId()).isEqualTo("receive-order");
+    assertThat(entity.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entity.getWaitStateType()).isEqualTo(WaitStateType.MESSAGE.name());
+
+    // then — message-specific details serialised as JSON
+    final var details = objectMapper.readTree(entity.getDetails());
+    assertThat(details.get("messageName").textValue()).isEqualTo("order-received");
+    assertThat(details.get("correlationKey").textValue()).isEqualTo("order-123");
+  }
+
+  @Test
+  void shouldBothHandlersUseTheSameDocumentId() {
+    // given
+    final var created = record(MessageSubscriptionIntent.CREATED, BpmnElementType.RECEIVE_TASK);
+    final var correlated =
+        record(MessageSubscriptionIntent.CORRELATED, BpmnElementType.RECEIVE_TASK);
+
+    // when
+    final var addIds = addHandler.generateIds(created);
+    final var removeIds = removeHandler.generateIds(correlated);
+
+    // then — same stable document id (record key) used for write and delete
+    assertThat(addIds).containsExactly(String.valueOf(RECORD_KEY));
+    assertThat(removeIds).containsExactly(String.valueOf(RECORD_KEY));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Record<MessageSubscriptionRecordValue> record(
+      final MessageSubscriptionIntent intent, final BpmnElementType elementType) {
+    final var value =
+        ImmutableMessageSubscriptionRecordValue.builder()
+            .from(factory.generateObject(MessageSubscriptionRecordValue.class))
+            .withElementType(elementType)
+            .build();
+    return (Record<MessageSubscriptionRecordValue>)
+        (Record<? extends RecordValue>)
+            factory.generateRecord(
+                ValueType.MESSAGE_SUBSCRIPTION,
+                r ->
+                    r.withKey(RECORD_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(intent)
+                        .withValue(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<MessageSubscriptionRecordValue> cast(
+      final Record<? extends RecordValue> record) {
+    return (Record<MessageSubscriptionRecordValue>) record;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/SignalWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/SignalWaitStateHandlerTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.SignalBasedWaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableSignalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end integration test for the signal-subscription wait-state handler triple produced by
+ * {@link WaitStateHandlerBuilder} with {@link SignalBasedWaitStateTransformer}.
+ *
+ * <p>Validates: {@code SIGNAL_SUBSCRIPTION.CREATED} writes the entry, {@code MIGRATED} upserts it,
+ * and {@code DELETED} removes it. Only {@link BpmnElementType#INTERMEDIATE_CATCH_EVENT}
+ * subscriptions are tracked — start and boundary event subscriptions are skipped.
+ */
+class SignalWaitStateHandlerTest {
+
+  private static final String INDEX_NAME = "test-wait-state";
+  private static final long RECORD_KEY = 999L;
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private WaitStateAddHandler<SignalSubscriptionRecordValue> addHandler;
+  private WaitStateUpdateHandler<SignalSubscriptionRecordValue> updateHandler;
+  private WaitStateRemoveHandler<SignalSubscriptionRecordValue> removeHandler;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new SignalBasedWaitStateTransformer())
+            .build();
+
+    addHandler =
+        (WaitStateAddHandler<SignalSubscriptionRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateAddHandler)
+                .findFirst()
+                .orElseThrow();
+    updateHandler =
+        (WaitStateUpdateHandler<SignalSubscriptionRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateUpdateHandler)
+                .findFirst()
+                .orElseThrow();
+    removeHandler =
+        (WaitStateRemoveHandler<SignalSubscriptionRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateRemoveHandler)
+                .findFirst()
+                .orElseThrow();
+  }
+
+  @Test
+  void shouldBuilderProduceExactlyThreeHandlers() {
+    // when
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new SignalBasedWaitStateTransformer())
+            .build();
+
+    // then — one add + one update + one remove
+    assertThat(handlers).hasSize(3);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateAddHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateUpdateHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateRemoveHandler).count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldAddHandlerAcceptCreatedForIntermediateCatchEventOnly() {
+    // given
+    final var catchEventCreated =
+        record(SignalSubscriptionIntent.CREATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+    final var startEventCreated =
+        record(SignalSubscriptionIntent.CREATED, BpmnElementType.START_EVENT);
+    final var boundaryEventCreated =
+        record(SignalSubscriptionIntent.CREATED, BpmnElementType.BOUNDARY_EVENT);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(catchEventCreated)).isTrue();
+    assertThat(addHandler.handlesRecord(startEventCreated)).isFalse();
+    assertThat(addHandler.handlesRecord(boundaryEventCreated)).isFalse();
+  }
+
+  @Test
+  void shouldAllHandlersRejectStartAndBoundaryEventSubscriptions() {
+    // given — start events have no process instance context; boundary events are interrupts
+    final var startDeleted = record(SignalSubscriptionIntent.DELETED, BpmnElementType.START_EVENT);
+    final var boundaryDeleted =
+        record(SignalSubscriptionIntent.DELETED, BpmnElementType.BOUNDARY_EVENT);
+    final var startMigrated =
+        record(SignalSubscriptionIntent.MIGRATED, BpmnElementType.START_EVENT);
+
+    // when / then
+    assertThat(removeHandler.handlesRecord(startDeleted)).isFalse();
+    assertThat(removeHandler.handlesRecord(boundaryDeleted)).isFalse();
+    assertThat(updateHandler.handlesRecord(startMigrated)).isFalse();
+  }
+
+  @Test
+  void shouldUpdateHandlerAcceptMigratedAndRejectCreated() {
+    // given
+    final var migrated =
+        record(SignalSubscriptionIntent.MIGRATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+    final var created =
+        record(SignalSubscriptionIntent.CREATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(updateHandler.handlesRecord(migrated)).isTrue();
+    assertThat(addHandler.handlesRecord(migrated)).isFalse();
+    assertThat(removeHandler.handlesRecord(migrated)).isFalse();
+    assertThat(updateHandler.handlesRecord(created)).isFalse();
+  }
+
+  @Test
+  void shouldRemoveHandlerAcceptDeletedOnly() {
+    // given — signal subscriptions have only one removal intent (no "correlation" concept)
+    final var deleted =
+        record(SignalSubscriptionIntent.DELETED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+    final var created =
+        record(SignalSubscriptionIntent.CREATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(removeHandler.handlesRecord(deleted)).isTrue();
+    assertThat(addHandler.handlesRecord(deleted)).isFalse();
+    assertThat(updateHandler.handlesRecord(deleted)).isFalse();
+    assertThat(removeHandler.handlesRecord(created)).isFalse();
+  }
+
+  @Test
+  void shouldWriteEntityWithSignalDetails() throws Exception {
+    // given
+    final var value =
+        ImmutableSignalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(SignalSubscriptionRecordValue.class))
+            .withSignalName("order-confirmed")
+            .withBpmnElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .withCatchEventId("signal-catch")
+            .withCatchEventInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withBpmnProcessId("my-process")
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final var signalRecord =
+        cast(
+            factory.generateRecord(
+                ValueType.SIGNAL_SUBSCRIPTION,
+                r ->
+                    r.withKey(RECORD_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(SignalSubscriptionIntent.CREATED)
+                        .withValue(value)));
+    final var entity = addHandler.createNewEntity(String.valueOf(RECORD_KEY));
+
+    // when
+    addHandler.updateEntity(signalRecord, entity);
+
+    // then
+    assertThat(entity.getElementId()).isEqualTo("signal-catch");
+    assertThat(entity.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entity.getWaitStateType()).isEqualTo(WaitStateType.SIGNAL.name());
+
+    // then — signal-specific details serialised as JSON
+    final var details = objectMapper.readTree(entity.getDetails());
+    assertThat(details.get("signalName").textValue()).isEqualTo("order-confirmed");
+  }
+
+  @Test
+  void shouldBothHandlersUseTheSameDocumentId() {
+    // given
+    final var created =
+        record(SignalSubscriptionIntent.CREATED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+    final var deleted =
+        record(SignalSubscriptionIntent.DELETED, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when
+    final var addIds = addHandler.generateIds(created);
+    final var removeIds = removeHandler.generateIds(deleted);
+
+    // then — same stable document id (record key) used for write and delete
+    assertThat(addIds).containsExactly(String.valueOf(RECORD_KEY));
+    assertThat(removeIds).containsExactly(String.valueOf(RECORD_KEY));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Record<SignalSubscriptionRecordValue> record(
+      final SignalSubscriptionIntent intent, final BpmnElementType elementType) {
+    final var value =
+        ImmutableSignalSubscriptionRecordValue.builder()
+            .from(factory.generateObject(SignalSubscriptionRecordValue.class))
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withBpmnProcessId("my-process")
+            .withBpmnElementType(elementType)
+            .build();
+    return (Record<SignalSubscriptionRecordValue>)
+        (Record<? extends RecordValue>)
+            factory.generateRecord(
+                ValueType.SIGNAL_SUBSCRIPTION,
+                r ->
+                    r.withKey(RECORD_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(intent)
+                        .withValue(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<SignalSubscriptionRecordValue> cast(
+      final Record<? extends RecordValue> record) {
+    return (Record<SignalSubscriptionRecordValue>) record;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/TimerWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/TimerWaitStateHandlerTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.TimerBasedWaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableTimerRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end integration test for the timer wait-state handler triple produced by {@link
+ * WaitStateHandlerBuilder} with {@link TimerBasedWaitStateTransformer}.
+ *
+ * <p>Validates: {@code TIMER.CREATED} writes the entry, {@code MIGRATED} upserts it, and {@code
+ * TRIGGERED}/{@code CANCELED} remove it. Only intermediate catch event timers with a valid process
+ * instance key are tracked.
+ */
+class TimerWaitStateHandlerTest {
+
+  private static final String INDEX_NAME = "test-wait-state";
+  private static final long RECORD_KEY = 999L;
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private WaitStateAddHandler<TimerRecordValue> addHandler;
+  private WaitStateUpdateHandler<TimerRecordValue> updateHandler;
+  private WaitStateRemoveHandler<TimerRecordValue> removeHandler;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new TimerBasedWaitStateTransformer())
+            .build();
+
+    addHandler =
+        (WaitStateAddHandler<TimerRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateAddHandler)
+                .findFirst()
+                .orElseThrow();
+    updateHandler =
+        (WaitStateUpdateHandler<TimerRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateUpdateHandler)
+                .findFirst()
+                .orElseThrow();
+    removeHandler =
+        (WaitStateRemoveHandler<TimerRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateRemoveHandler)
+                .findFirst()
+                .orElseThrow();
+  }
+
+  @Test
+  void shouldBuilderProduceExactlyThreeHandlers() {
+    // when
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new TimerBasedWaitStateTransformer())
+            .build();
+
+    // then — one add + one update + one remove
+    assertThat(handlers).hasSize(3);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateAddHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateUpdateHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateRemoveHandler).count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldAddHandlerAcceptCreatedForProcessInstanceIntermediateCatchEvent() {
+    // given — valid: processInstanceKey set, elementType is INTERMEDIATE_CATCH_EVENT
+    final var created =
+        timerRecord(TimerIntent.CREATED, 200L, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(created)).isTrue();
+  }
+
+  @Test
+  void shouldAllHandlersRejectTimerStartEvents() {
+    // given — processInstanceKey == -1 means a timer start event subscription (no process instance)
+    final var created =
+        timerRecord(TimerIntent.CREATED, -1L, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+    final var triggered =
+        timerRecord(TimerIntent.TRIGGERED, -1L, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(created)).isFalse();
+    assertThat(updateHandler.handlesRecord(created)).isFalse();
+    assertThat(removeHandler.handlesRecord(triggered)).isFalse();
+  }
+
+  @Test
+  void shouldAllHandlersRejectBoundaryTimerEvents() {
+    // given — boundary events interrupt the host element; they are not standalone wait states
+    final var created = timerRecord(TimerIntent.CREATED, 200L, BpmnElementType.BOUNDARY_EVENT);
+    final var triggered = timerRecord(TimerIntent.TRIGGERED, 200L, BpmnElementType.BOUNDARY_EVENT);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(created)).isFalse();
+    assertThat(updateHandler.handlesRecord(created)).isFalse();
+    assertThat(removeHandler.handlesRecord(triggered)).isFalse();
+  }
+
+  @Test
+  void shouldUpdateHandlerAcceptMigratedAndRejectCreated() {
+    // given
+    final var migrated =
+        timerRecord(TimerIntent.MIGRATED, 200L, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+    final var created =
+        timerRecord(TimerIntent.CREATED, 200L, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(updateHandler.handlesRecord(migrated)).isTrue();
+    assertThat(addHandler.handlesRecord(migrated)).isFalse();
+    assertThat(removeHandler.handlesRecord(migrated)).isFalse();
+    assertThat(updateHandler.handlesRecord(created)).isFalse();
+  }
+
+  @Test
+  void shouldRemoveHandlerAcceptTriggeredAndCanceled() {
+    // given
+    final var triggered =
+        timerRecord(TimerIntent.TRIGGERED, 200L, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+    final var canceled =
+        timerRecord(TimerIntent.CANCELED, 200L, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when / then
+    assertThat(removeHandler.handlesRecord(triggered)).isTrue();
+    assertThat(removeHandler.handlesRecord(canceled)).isTrue();
+    assertThat(addHandler.handlesRecord(triggered)).isFalse();
+    assertThat(updateHandler.handlesRecord(triggered)).isFalse();
+  }
+
+  @Test
+  void shouldWriteEntityWithTimerDetails() throws Exception {
+    // given
+    final var value =
+        ImmutableTimerRecordValue.builder()
+            .from(factory.generateObject(TimerRecordValue.class))
+            .withDueDate(1_000_000L)
+            .withRepetitions(2)
+            .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .withTargetElementId("timer-catch")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withBpmnProcessId("my-process")
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final var timerRecord =
+        cast(
+            factory.generateRecord(
+                ValueType.TIMER,
+                r ->
+                    r.withKey(RECORD_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(TimerIntent.CREATED)
+                        .withValue(value)));
+    final var entity = addHandler.createNewEntity(String.valueOf(RECORD_KEY));
+
+    // when
+    addHandler.updateEntity(timerRecord, entity);
+
+    // then
+    assertThat(entity.getElementId()).isEqualTo("timer-catch");
+    assertThat(entity.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entity.getWaitStateType()).isEqualTo(WaitStateType.TIMER.name());
+
+    // then — timer-specific details serialised as JSON
+    final var details = objectMapper.readTree(entity.getDetails());
+    assertThat(details.get("dueDate").longValue()).isEqualTo(1_000_000L);
+    assertThat(details.get("repetitions").intValue()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldBothHandlersUseTheSameDocumentId() {
+    // given
+    final var created =
+        timerRecord(TimerIntent.CREATED, 200L, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+    final var triggered =
+        timerRecord(TimerIntent.TRIGGERED, 200L, BpmnElementType.INTERMEDIATE_CATCH_EVENT);
+
+    // when
+    final var addIds = addHandler.generateIds(created);
+    final var removeIds = removeHandler.generateIds(triggered);
+
+    // then — same stable document id (record key) used for write and delete
+    assertThat(addIds).containsExactly(String.valueOf(RECORD_KEY));
+    assertThat(removeIds).containsExactly(String.valueOf(RECORD_KEY));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Record<TimerRecordValue> timerRecord(
+      final TimerIntent intent, final long processInstanceKey, final BpmnElementType elementType) {
+    final var value =
+        ImmutableTimerRecordValue.builder()
+            .from(factory.generateObject(TimerRecordValue.class))
+            .withProcessInstanceKey(processInstanceKey)
+            .withRootProcessInstanceKey(processInstanceKey == -1L ? -1L : 100L)
+            .withBpmnProcessId(processInstanceKey == -1L ? "" : "my-process")
+            .withElementType(elementType)
+            .build();
+    return (Record<TimerRecordValue>)
+        (Record<? extends RecordValue>)
+            factory.generateRecord(
+                ValueType.TIMER,
+                r ->
+                    r.withKey(RECORD_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(intent)
+                        .withValue(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<TimerRecordValue> cast(final Record<? extends RecordValue> record) {
+    return (Record<TimerRecordValue>) record;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/UserTaskWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/UserTaskWaitStateHandlerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers.waitstate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
 import io.camunda.zeebe.exporter.common.waitstate.transformers.UserTaskBasedWaitStateTransformer;
@@ -32,7 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * End-to-end integration test for the native user task wait-state handler pair produced by {@link
+ * End-to-end integration test for the native user task wait-state handler triple produced by {@link
  * WaitStateHandlerBuilder} with {@link UserTaskBasedWaitStateTransformer}.
  *
  * <p>Validates the full lifecycle: a {@code USER_TASK.CREATED} event writes the wait-state entry,
@@ -48,6 +50,7 @@ class UserTaskWaitStateHandlerTest {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   private WaitStateAddHandler<UserTaskRecordValue> addHandler;
+  private WaitStateUpdateHandler<UserTaskRecordValue> updateHandler;
   private WaitStateRemoveHandler<UserTaskRecordValue> removeHandler;
 
   @BeforeEach
@@ -64,6 +67,12 @@ class UserTaskWaitStateHandlerTest {
                 .filter(h -> h instanceof WaitStateAddHandler)
                 .findFirst()
                 .orElseThrow();
+    updateHandler =
+        (WaitStateUpdateHandler<UserTaskRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateUpdateHandler)
+                .findFirst()
+                .orElseThrow();
     removeHandler =
         (WaitStateRemoveHandler<UserTaskRecordValue>)
             handlers.stream()
@@ -73,7 +82,7 @@ class UserTaskWaitStateHandlerTest {
   }
 
   @Test
-  void shouldAddHandlerHandleCreatedAndRemoveHandlerNotHandle() {
+  void shouldAddHandlerAcceptCreatedRecordOnly() {
     // given
     final var created = userTaskRecord(UserTaskIntent.CREATED);
     final var completed = userTaskRecord(UserTaskIntent.COMPLETED);
@@ -86,16 +95,19 @@ class UserTaskWaitStateHandlerTest {
   }
 
   @Test
-  void shouldAddHandlerHandleMigratedAndUpdatedEvents() {
+  void shouldUpdateHandlerAcceptMigratedAndUpdatedNotAddHandler() {
     // given
     final var migrated = userTaskRecord(UserTaskIntent.MIGRATED);
     final var updated = userTaskRecord(UserTaskIntent.UPDATED);
 
-    // when / then — MIGRATED and UPDATED are upserts, handled by the add handler
-    assertThat(addHandler.handlesRecord(migrated)).isTrue();
-    assertThat(addHandler.handlesRecord(updated)).isTrue();
+    // when / then — MIGRATED and UPDATED are update intents, handled by updateHandler, not
+    // addHandler
+    assertThat(addHandler.handlesRecord(migrated)).isFalse();
+    assertThat(addHandler.handlesRecord(updated)).isFalse();
     assertThat(removeHandler.handlesRecord(migrated)).isFalse();
     assertThat(removeHandler.handlesRecord(updated)).isFalse();
+    assertThat(updateHandler.handlesRecord(migrated)).isTrue();
+    assertThat(updateHandler.handlesRecord(updated)).isTrue();
   }
 
   @Test
@@ -141,12 +153,13 @@ class UserTaskWaitStateHandlerTest {
   void shouldUpdateEntityElementIdOnUserTaskMigrated() throws Exception {
     // given — a record with the post-migration elementId
     final var record = userTaskRecordWithDetails(UserTaskIntent.MIGRATED, "task-after-migration");
-    final var entity = addHandler.createNewEntity(String.valueOf(USER_TASK_KEY));
+    final var entity = updateHandler.createNewEntity(String.valueOf(USER_TASK_KEY));
 
     // when
-    addHandler.updateEntity(record, entity);
+    updateHandler.updateEntity(record, entity);
 
-    // then — entity reflects the post-migration element id; all other fields are also updated
+    // then — entity reflects the post-migration element id (update handler sends ELEMENT_ID +
+    // DETAILS only)
     assertThat(entity.getElementId()).isEqualTo("task-after-migration");
     assertThat(entity.getElementType()).isEqualTo(BpmnElementType.USER_TASK.name());
     assertThat(entity.getProcessInstanceKey()).isEqualTo(200L);
@@ -192,14 +205,80 @@ class UserTaskWaitStateHandlerTest {
   }
 
   @Test
-  void shouldBuilderProduceExactlyTwoHandlers() {
+  void shouldUpdateHandlerHandleMigratedAndUpdated() {
+    // given
+    final var migrated = userTaskRecord(UserTaskIntent.MIGRATED);
+    final var updated = userTaskRecord(UserTaskIntent.UPDATED);
+    final var created = userTaskRecord(UserTaskIntent.CREATED);
+
+    // when / then — MIGRATED and UPDATED are update intents; CREATED is not
+    assertThat(updateHandler.handlesRecord(migrated)).isTrue();
+    assertThat(updateHandler.handlesRecord(updated)).isTrue();
+    assertThat(updateHandler.handlesRecord(created)).isFalse();
+  }
+
+  @Test
+  void shouldUpdateHandlerSkipsElementIdWhenNull() throws PersistenceException {
+    // given — elementId null means no migration, only task metadata changed
+    final var id = String.valueOf(USER_TASK_KEY);
+    final var entity = new WaitStateEntity().setId(id).setDetails("{\"taskKey\":999}");
+    final var batchRequest = mock(BatchRequest.class);
+
+    // when
+    updateHandler.flush(entity, batchRequest);
+
+    // then — only DETAILS in the update map; ELEMENT_ID is skipped
+    verify(batchRequest)
+        .upsert(
+            eq(INDEX_NAME),
+            eq(id),
+            eq(entity),
+            argThat(map -> map.containsKey(WaitStateTemplate.DETAILS) && map.size() == 1));
+  }
+
+  @Test
+  void shouldUpdateHandlerIncludesElementIdWhenPresentForMigration() throws PersistenceException {
+    // given — MIGRATED: elementId and bpmnProcessId are populated with values from the target
+    // process definition (bpmnProcessId changes on cross-process migration)
+    final var id = String.valueOf(USER_TASK_KEY);
+    final var entity =
+        new WaitStateEntity()
+            .setId(id)
+            .setElementId("task-after-migration")
+            .setBpmnProcessId("target-process")
+            .setDetails("{\"taskKey\":999}");
+    final var batchRequest = mock(BatchRequest.class);
+
+    // when
+    updateHandler.flush(entity, batchRequest);
+
+    // then — ELEMENT_ID, BPMN_PROCESS_ID and DETAILS are all sent
+    verify(batchRequest)
+        .upsert(
+            eq(INDEX_NAME),
+            eq(id),
+            eq(entity),
+            argThat(
+                map ->
+                    map.containsKey(WaitStateTemplate.ELEMENT_ID)
+                        && map.containsKey(WaitStateTemplate.BPMN_PROCESS_ID)
+                        && map.containsKey(WaitStateTemplate.DETAILS)
+                        && map.size() == 3));
+  }
+
+  @Test
+  void shouldBuilderProduceExactlyThreeHandlers() {
+    // when
     final var handlers =
         WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
             .addTransformer(new UserTaskBasedWaitStateTransformer())
             .build();
 
-    assertThat(handlers).hasSize(2);
+    // then — one add + one update + one remove
+    assertThat(handlers).hasSize(3);
     assertThat(handlers.stream().filter(h -> h instanceof WaitStateAddHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateUpdateHandler).count())
         .isEqualTo(1);
     assertThat(handlers.stream().filter(h -> h instanceof WaitStateRemoveHandler).count())
         .isEqualTo(1);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/WaitStateHandlerBuilderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/WaitStateHandlerBuilderTest.java
@@ -19,21 +19,22 @@ class WaitStateHandlerBuilderTest {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  void shouldProduceAddAndRemoveHandlerForEachTransformer() {
+  void shouldProduceAddUpdateAndRemoveHandlerForEachTransformer() {
     // when
     final var handlers =
         WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
             .addTransformer(new JobBasedWaitStateTransformer())
             .build();
 
-    // then — one add + one remove
-    assertThat(handlers).hasSize(2);
+    // then — one add + one update + one remove
+    assertThat(handlers).hasSize(3);
     assertThat(handlers).hasAtLeastOneElementOfType(WaitStateAddHandler.class);
+    assertThat(handlers).hasAtLeastOneElementOfType(WaitStateUpdateHandler.class);
     assertThat(handlers).hasAtLeastOneElementOfType(WaitStateRemoveHandler.class);
   }
 
   @Test
-  void shouldProduceFourHandlersForTwoTransformers() {
+  void shouldProduceSixHandlersForTwoTransformers() {
     // when
     final var handlers =
         WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
@@ -41,8 +42,8 @@ class WaitStateHandlerBuilderTest {
             .addTransformer(new JobBasedWaitStateTransformer())
             .build();
 
-    // then — two transformers → four handlers
-    assertThat(handlers).hasSize(4);
+    // then — two transformers → six handlers
+    assertThat(handlers).hasSize(6);
   }
 
   @Test

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -59,7 +59,7 @@ import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceCancella
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceHistoryDeletionBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceMigrationBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceModificationBatchOperationExportHandler;
-import io.camunda.exporter.rdbms.handlers.waitstate.WaitStateAddHandler;
+import io.camunda.exporter.rdbms.handlers.waitstate.WaitStateAddUpdateHandler;
 import io.camunda.exporter.rdbms.handlers.waitstate.WaitStateRemoveHandler;
 import io.camunda.exporter.rdbms.replication.LsnReplicationControllerFactory;
 import io.camunda.exporter.rdbms.replication.ReplicationControllerFactory;
@@ -390,7 +390,7 @@ public class RdbmsExporterWrapper implements Exporter {
             transformer -> {
               builder.withHandler(
                   transformer.config().valueType(),
-                  new WaitStateAddHandler<>(waitStateWriter, transformer, objectMapper));
+                  new WaitStateAddUpdateHandler<>(waitStateWriter, transformer, objectMapper));
               builder.withHandler(
                   transformer.config().valueType(),
                   new WaitStateRemoveHandler<>(waitStateWriter, transformer));

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddUpdateHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddUpdateHandler.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.waitstate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import io.camunda.db.rdbms.write.service.WaitStateWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.WaitStateRelated;
+import io.camunda.zeebe.util.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Inserts or updates a {@link WaitStateDbModel} when a process element enters or transitions a
+ * waiting state. The row is keyed by the stable entity key (e.g. jobKey, userTaskKey).
+ *
+ * @param <R> the record value type handled by the injected transformer
+ */
+public class WaitStateAddUpdateHandler<R extends RecordValue & WaitStateRelated>
+    implements RdbmsExportHandler<R> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WaitStateAddUpdateHandler.class);
+
+  private final WaitStateWriter waitStateWriter;
+  private final WaitStateTransformer<R> transformer;
+  private final ObjectMapper objectMapper;
+
+  public WaitStateAddUpdateHandler(
+      final WaitStateWriter waitStateWriter,
+      final WaitStateTransformer<R> transformer,
+      final ObjectMapper objectMapper) {
+    this.waitStateWriter = waitStateWriter;
+    this.transformer = transformer;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean canExport(final Record<R> record) {
+    return transformer.triggersAdd(record) || transformer.triggersUpdate(record);
+  }
+
+  @Override
+  public void export(final Record<R> record) {
+    final var entry = transformer.transform(record);
+    final var model = map(record, entry);
+    if (transformer.triggersUpdate(record)) {
+      waitStateWriter.update(model);
+    } else {
+      waitStateWriter.create(model);
+    }
+  }
+
+  @VisibleForTesting
+  public WaitStateTransformer<R> getTransformer() {
+    return transformer;
+  }
+
+  private WaitStateDbModel map(final Record<R> record, final WaitStateEntry entry) {
+    return new WaitStateDbModel.Builder()
+        .waitStateKey(record.getKey())
+        .rootProcessInstanceKey(entry.getRootProcessInstanceKey())
+        .processInstanceKey(entry.getProcessInstanceKey())
+        .elementInstanceKey(entry.getElementInstanceKey())
+        .elementId(entry.getElementId())
+        .elementType(entry.getElementType() != null ? entry.getElementType().name() : null)
+        .waitStateType(entry.getWaitStateType() != null ? entry.getWaitStateType().name() : null)
+        .processDefinitionId(entry.getBpmnProcessId())
+        .details(serializeDetails(entry.getDetails()))
+        .tenantId(entry.getTenantId())
+        .partitionId(record.getPartitionId())
+        .build();
+  }
+
+  private String serializeDetails(final WaitStateDetails details) {
+    if (details == null) {
+      return null;
+    }
+    try {
+      return objectMapper.writeValueAsString(details);
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to serialize wait state details: {}", e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddUpdateHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddUpdateHandlerTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import io.camunda.db.rdbms.write.service.WaitStateWriter;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.UserTaskBasedWaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WaitStateAddUpdateHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Mock private WaitStateWriter waitStateWriter;
+  @Captor private ArgumentCaptor<WaitStateDbModel> modelCaptor;
+
+  private WaitStateAddUpdateHandler<JobRecordValue> handler;
+
+  @BeforeEach
+  void setUp() {
+    handler =
+        new WaitStateAddUpdateHandler<>(
+            waitStateWriter, new JobBasedWaitStateTransformer(), objectMapper);
+  }
+
+  @Test
+  void shouldAcceptJobMigratedRecord() {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(JobIntent.MIGRATED));
+
+    // when / then
+    assertThat(handler.canExport(record)).isTrue();
+  }
+
+  @Test
+  void shouldUpdateWaitStateRowOnMigratedExport() {
+    // given
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("payment-service")
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withJobListenerEventType(JobListenerEventType.UNSPECIFIED)
+            .withRetries(3)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("task-after-migration")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withKey(999L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(JobIntent.MIGRATED)
+                    .withValue(value));
+
+    // when
+    handler.export(record);
+
+    // then — update (not insert) is called with the post-migration elementId
+    verify(waitStateWriter).update(modelCaptor.capture());
+    final WaitStateDbModel model = modelCaptor.getValue();
+    assertThat(model.waitStateKey()).isEqualTo(999L);
+    assertThat(model.elementId()).isEqualTo("task-after-migration");
+    assertThat(model.elementType()).isEqualTo(BpmnElementType.SERVICE_TASK.name());
+  }
+
+  @Test
+  void shouldExportJobCreatedRecord() {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(JobIntent.CREATED));
+
+    // when / then
+    assertThat(handler.canExport(record)).isTrue();
+  }
+
+  @Test
+  void shouldNotExportJobCompletedRecord() {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(JobIntent.COMPLETED));
+
+    // when / then
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldInsertWaitStateRowOnExport() {
+    // given
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("payment-service")
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withJobListenerEventType(JobListenerEventType.UNSPECIFIED)
+            .withRetries(3)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("task-payment")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withBpmnProcessId("payment-process")
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withKey(999L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(JobIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(waitStateWriter).create(modelCaptor.capture());
+    final WaitStateDbModel model = modelCaptor.getValue();
+    assertThat(model.waitStateKey()).isEqualTo(999L);
+    assertThat(model.rootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(model.processInstanceKey()).isEqualTo(200L);
+    assertThat(model.elementInstanceKey()).isEqualTo(300L);
+    assertThat(model.elementId()).isEqualTo("task-payment");
+    assertThat(model.elementType()).isEqualTo(BpmnElementType.SERVICE_TASK.name());
+    assertThat(model.waitStateType()).isEqualTo(WaitStateType.JOB.name());
+    assertThat(model.processDefinitionId()).isEqualTo("payment-process");
+    assertThat(model.tenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(model.partitionId()).isEqualTo(record.getPartitionId());
+    assertThat(model.details())
+        .contains("\"jobType\":\"payment-service\"")
+        .contains("\"jobKind\":\"BPMN_ELEMENT\"")
+        .contains("\"retries\":3");
+  }
+
+  @Test
+  void shouldPreserveElementIdOnJobFailedExport() {
+    // given — FAILED records may carry NO_CATCH_EVENT_FOUND as elementId; the model
+    // must have null elementId so the SQL conditional skips overwriting ELEMENT_ID.
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("payment-service")
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withJobListenerEventType(JobListenerEventType.UNSPECIFIED)
+            .withRetries(0)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("NO_CATCH_EVENT_FOUND")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withKey(999L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(JobIntent.FAILED)
+                    .withValue(value));
+
+    // when
+    handler.export(record);
+
+    // then — update is called, and elementId is null so SQL preserves the stored value
+    verify(waitStateWriter).update(modelCaptor.capture());
+    final WaitStateDbModel model = modelCaptor.getValue();
+    assertThat(model.elementId()).isNull();
+    assertThat(model.details()).contains("\"retries\":0");
+  }
+
+  @Test
+  void shouldInsertWaitStateRowOnUserTaskCreated() {
+    // given
+    final WaitStateAddUpdateHandler<UserTaskRecordValue> userTaskHandler =
+        new WaitStateAddUpdateHandler<>(
+            waitStateWriter, new UserTaskBasedWaitStateTransformer(), objectMapper);
+    final Record<UserTaskRecordValue> record =
+        userTaskRecord(UserTaskIntent.CREATED, "approve-task");
+
+    // when
+    userTaskHandler.export(record);
+
+    // then
+    verify(waitStateWriter).create(modelCaptor.capture());
+    final WaitStateDbModel model = modelCaptor.getValue();
+    assertThat(model.waitStateKey()).isEqualTo(999L);
+    assertThat(model.elementId()).isEqualTo("approve-task");
+    assertThat(model.elementType()).isEqualTo(BpmnElementType.USER_TASK.name());
+    assertThat(model.waitStateType()).isEqualTo(WaitStateType.USER_TASK.name());
+    assertThat(model.details())
+        .contains("\"taskKey\":999")
+        .contains("\"dueDate\":\"2026-10-13T10:00:00+01:00\"");
+  }
+
+  @Test
+  void shouldUpdateWaitStateRowOnUserTaskUpdated() {
+    // given
+    final WaitStateAddUpdateHandler<UserTaskRecordValue> userTaskHandler =
+        new WaitStateAddUpdateHandler<>(
+            waitStateWriter, new UserTaskBasedWaitStateTransformer(), objectMapper);
+    final Record<UserTaskRecordValue> record =
+        userTaskRecord(UserTaskIntent.UPDATED, "approve-task");
+
+    // when
+    userTaskHandler.export(record);
+
+    // then — UPDATED is an update intent, so update (not insert) is called
+    verify(waitStateWriter).update(modelCaptor.capture());
+    final WaitStateDbModel model = modelCaptor.getValue();
+    assertThat(model.waitStateKey()).isEqualTo(999L);
+    assertThat(model.elementId()).isEqualTo("approve-task");
+    assertThat(model.waitStateType()).isEqualTo(WaitStateType.USER_TASK.name());
+  }
+
+  private Record<UserTaskRecordValue> userTaskRecord(
+      final UserTaskIntent intent, final String elementId) {
+    final UserTaskRecordValue value =
+        ImmutableUserTaskRecordValue.builder()
+            .from(factory.generateObject(UserTaskRecordValue.class))
+            .withUserTaskKey(999L)
+            .withDueDate("2026-10-13T10:00:00+01:00")
+            .withElementId(elementId)
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    return factory.generateRecord(
+        ValueType.USER_TASK,
+        r -> r.withKey(999L).withRecordType(RecordType.EVENT).withIntent(intent).withValue(value));
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `JobIntent.FAILED` and `JobIntent.RETRIES_UPDATED` to `WaitStateConfigs.JOB_CONFIG` update intents so the wait-state projection is refreshed whenever a job fails or retries are reset
- `POST /v2/element-instances/wait-states/search` now returns `details.retries` with the current remaining count instead of the frozen value from job creation
- Unit tests verify `triggersUpdate()` for both intents and that `extract()` reads the decremented retry count from a `FAILED` record
- Acceptance test covers the full failure lifecycle: retries 3 → 2 → 0

## Root Cause

`WaitStateConfigs.JOB_CONFIG` only had `MIGRATED` as an update intent. On `FAILED` and `RETRIES_UPDATED` the wait-state projection was never refreshed, so `details` retained the retry count from `CREATED` time.

Enabling these intents required additional changes beyond just registering them:

- **`JobBasedWaitStateTransformer`** — added `clearElementIdIfSentinelRisk()` to null `elementId` on `FAILED`/`RETRIES_UPDATED`, preventing the `NO_CATCH_EVENT_FOUND` sentinel (set by the engine when a BPMN error has no matching catch event) from overwriting the stored element id.
- **`WaitStateAddHandler` → split into `WaitStateAddHandler` + `WaitStateUpdateHandler`** — the update handler flushes only `DETAILS` (and optionally `ELEMENT_ID`) so that immutable fields (tenant, partition, process keys) are not overwritten on every retry update.
- **RDBMS `WaitStateMapper.xml`** — the `UPDATE` statement conditionally omits `ELEMENT_ID` when the transformer has nulled it (sentinel-risk intents), mirroring the ES/OS upsert partial-field logic.

## Test Plan

- [ ] `zeebe/exporter-common` unit tests: `JobBasedWaitStateTransformerTest` (all passing locally)
- [ ] `zeebe/exporters/camunda-exporter` handler tests: `JobWaitStateHandlerTest`, `UserTaskWaitStateHandlerTest`, and new tests for message/timer/signal/condition handlers (all passing locally)
- [ ] `qa/acceptance-tests` acceptance test: `WaitStateJobIT#shouldReflectCurrentRetriesAfterJobFailure` (compile-verified; requires live cluster for full run)

Closes #55274