### PR TITLE
fix: log WARN if operate process cache does not find process

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/cache/ProcessCache.java
+++ b/operate/schema/src/main/java/io/camunda/operate/cache/ProcessCache.java
@@ -12,6 +12,8 @@ import static io.camunda.operate.util.ThreadUtil.sleepFor;
 import io.camunda.operate.entities.ProcessEntity;
 import io.camunda.operate.entities.ProcessFlowNodeEntity;
 import io.camunda.operate.store.ProcessStore;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
@@ -26,6 +28,8 @@ import org.springframework.util.StringUtils;
 public class ProcessCache {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCache.class);
+  private static final Logger THROTTLED_LOGGER =
+      new ThrottledLogger(LOGGER, Duration.ofSeconds(60L));
   private static final int CACHE_MAX_SIZE = 100;
   private static final int MAX_ATTEMPTS = 5;
   private static final long WAIT_TIME = 200;
@@ -139,6 +143,13 @@ public class ProcessCache {
             attemptsCount,
             (attemptsCount - 1) * sleepInMilliseconds);
       }
+    }
+    if (foundProcess.isEmpty()) {
+      THROTTLED_LOGGER.warn(
+          "Unable to find process {} after {} attempts and wait of {} ms.",
+          processDefinitionKey,
+          attemptsCount,
+          attemptsCount * sleepInMilliseconds);
     }
     return foundProcess;
   }


### PR DESCRIPTION
we only do this if all retries have been exhausted as we might expect a few retries under normal operation.

I'll follow up with a PR to make retries configurable, but thought it best to get the logging changed sooner.

## Related issues

Refs #55011
