### PR TITLE
feat: pass the physicalTenantId to broker requests

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigParameterizedTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigParameterizedTest.java
@@ -134,7 +134,13 @@ public class BasicAuthWebSecurityConfigParameterizedTest {
     @Bean
     public UserServices userServices() {
       return new UserServices(
-          null, null, null, null, new ApiServicesExecutorProvider(ForkJoinPool.commonPool()), null);
+          "default",
+          null,
+          null,
+          null,
+          null,
+          new ApiServicesExecutorProvider(ForkJoinPool.commonPool()),
+          null);
     }
 
     @Bean

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
@@ -85,17 +85,17 @@ public class WebSecurityConfigTestContext {
 
   @Bean
   public RoleServices createRoleServices(final ApiServicesExecutorProvider executorProvider) {
-    return new RoleServices(null, null, null, executorProvider, null);
+    return new RoleServices("default", null, null, null, executorProvider, null);
   }
 
   @Bean
   public GroupServices createGroupServices(final ApiServicesExecutorProvider executorProvider) {
-    return new GroupServices(null, null, null, executorProvider, null);
+    return new GroupServices("default", null, null, null, executorProvider, null);
   }
 
   @Bean
   public TenantServices createTenantServices(final ApiServicesExecutorProvider executorProvider) {
-    return new TenantServices(null, null, null, executorProvider, null);
+    return new TenantServices("default", null, null, null, executorProvider, null);
   }
 
   @Bean

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
@@ -37,7 +37,7 @@ public class WebSecurityOidcTestContext {
   @Bean
   public MappingRuleServices createMappingRuleServices(
       final ApiServicesExecutorProvider executorProvider) {
-    return new MappingRuleServices(null, null, null, executorProvider, null);
+    return new MappingRuleServices("default", null, null, null, executorProvider, null);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -162,23 +162,24 @@ public class CamundaServicesConfiguration {
               // -- leaf services (no service-to-service dependencies) --
               final var form =
                   new FormServices(
-                      brokerClient, securityContextProvider, search, executor, converter);
+                      tenantId, brokerClient, securityContextProvider, search, executor, converter);
               final var incident =
                   new IncidentServices(
-                      brokerClient, securityContextProvider, search, executor, converter);
+                      tenantId, brokerClient, securityContextProvider, search, executor, converter);
               final var variable =
                   new VariableServices(
-                      brokerClient, securityContextProvider, search, executor, converter);
+                      tenantId, brokerClient, securityContextProvider, search, executor, converter);
               final var auditLog =
                   new AuditLogServices(
-                      brokerClient, securityContextProvider, search, executor, converter);
+                      tenantId, brokerClient, securityContextProvider, search, executor, converter);
               final var decisionRequirements =
                   new DecisionRequirementsServices(
-                      brokerClient, securityContextProvider, search, executor, converter);
+                      tenantId, brokerClient, securityContextProvider, search, executor, converter);
 
               // -- mid-tier services (depend on leaf services) --
               final var elementInstance =
                   new ElementInstanceServices(
+                      tenantId,
                       brokerClient,
                       securityContextProvider,
                       search,
@@ -189,11 +190,18 @@ public class CamundaServicesConfiguration {
                       converter);
               final var processDefinition =
                   new ProcessDefinitionServices(
-                      brokerClient, securityContextProvider, search, form, executor, converter);
+                      tenantId,
+                      brokerClient,
+                      securityContextProvider,
+                      search,
+                      form,
+                      executor,
+                      converter);
 
               // -- top-level services --
               final var processInstance =
                   new ProcessInstanceServices(
+                      tenantId,
                       brokerClient,
                       securityContextProvider,
                       search,
@@ -204,6 +212,7 @@ public class CamundaServicesConfiguration {
                       maxNameFieldLength);
               final var userTask =
                   new UserTaskServices(
+                      tenantId,
                       brokerClient,
                       securityContextProvider,
                       search,
@@ -220,38 +229,60 @@ public class CamundaServicesConfiguration {
                   .adHocSubProcessActivityServices(
                       tenantId,
                       new AdHocSubProcessActivityServices(
-                          brokerClient, securityContextProvider, executor, converter))
+                          tenantId, brokerClient, securityContextProvider, executor, converter))
                   .agentHistoryServices(
                       tenantId,
                       new AgentHistoryServices(
-                          brokerClient, securityContextProvider, executor, converter))
+                          tenantId, brokerClient, securityContextProvider, executor, converter))
                   .agentInstanceServices(
                       tenantId,
                       new AgentInstanceServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .auditLogServices(tenantId, auditLog)
                   .authorizationServices(
                       tenantId,
                       new AuthorizationServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .batchOperationServices(
                       tenantId,
                       new BatchOperationServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .clockServices(
                       tenantId,
-                      new ClockServices(brokerClient, securityContextProvider, executor, converter))
+                      new ClockServices(
+                          tenantId, brokerClient, securityContextProvider, executor, converter))
                   .clusterVariableServices(
                       tenantId,
                       new ClusterVariableServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .conditionalServices(
                       tenantId,
                       new ConditionalServices(
-                          brokerClient, securityContextProvider, executor, converter))
+                          tenantId, brokerClient, securityContextProvider, executor, converter))
                   .decisionDefinitionServices(
                       tenantId,
                       new DecisionDefinitionServices(
+                          tenantId,
                           brokerClient,
                           securityContextProvider,
                           search,
@@ -261,11 +292,17 @@ public class CamundaServicesConfiguration {
                   .decisionInstanceServices(
                       tenantId,
                       new DecisionInstanceServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .decisionRequirementsServices(tenantId, decisionRequirements)
                   .documentServices(
                       tenantId,
                       new DocumentServices(
+                          tenantId,
                           brokerClient,
                           securityContextProvider,
                           new SimpleDocumentStoreRegistry(
@@ -278,20 +315,31 @@ public class CamundaServicesConfiguration {
                   .expressionServices(
                       tenantId,
                       new ExpressionServices(
-                          brokerClient, securityContextProvider, executor, converter))
+                          tenantId, brokerClient, securityContextProvider, executor, converter))
                   .formServices(tenantId, form)
                   .globalListenerServices(
                       tenantId,
                       new GlobalListenerServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .groupServices(
                       tenantId,
                       new GroupServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .incidentServices(tenantId, incident)
                   .jobServices(
                       tenantId,
                       new JobServices<>(
+                          tenantId,
                           brokerClient,
                           securityContextProvider,
                           activateJobsHandler,
@@ -302,10 +350,16 @@ public class CamundaServicesConfiguration {
                   .mappingRuleServices(
                       tenantId,
                       new MappingRuleServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .messageServices(
                       tenantId,
                       new MessageServices(
+                          tenantId,
                           brokerClient,
                           securityContextProvider,
                           executor,
@@ -314,12 +368,18 @@ public class CamundaServicesConfiguration {
                   .messageSubscriptionServices(
                       tenantId,
                       new MessageSubscriptionServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .processDefinitionServices(tenantId, processDefinition)
                   .processInstanceServices(tenantId, processInstance)
                   .resourceServices(
                       tenantId,
                       new ResourceServices(
+                          tenantId,
                           brokerClient,
                           securityContextProvider,
                           executor,
@@ -331,26 +391,42 @@ public class CamundaServicesConfiguration {
                   .roleServices(
                       tenantId,
                       new RoleServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .signalServices(
                       tenantId,
                       new SignalServices(
-                          brokerClient, securityContextProvider, executor, converter))
+                          tenantId, brokerClient, securityContextProvider, executor, converter))
                   .tenantServices(
                       tenantId,
                       new TenantServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .topologyServices(
                       tenantId,
                       new TopologyServices(
-                          brokerClient, securityContextProvider, executor, converter))
+                          tenantId, brokerClient, securityContextProvider, executor, converter))
                   .usageMetricsServices(
                       tenantId,
                       new UsageMetricsServices(
-                          brokerClient, securityContextProvider, search, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .userServices(
                       tenantId,
                       new UserServices(
+                          tenantId,
                           brokerClient,
                           securityContextProvider,
                           search,

--- a/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
@@ -17,14 +17,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcessActivityServices> {
+public class AdHocSubProcessActivityServices
+    extends PhysicalTenantScopedApiServices<AdHocSubProcessActivityServices> {
 
   public AdHocSubProcessActivityServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/AgentHistoryServices.java
+++ b/service/src/main/java/io/camunda/service/AgentHistoryServices.java
@@ -15,14 +15,17 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateAgentHistoryRequ
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import java.util.concurrent.CompletableFuture;
 
-public final class AgentHistoryServices extends ApiServices<AgentHistoryServices> {
+public final class AgentHistoryServices
+    extends PhysicalTenantScopedApiServices<AgentHistoryServices> {
 
   public AgentHistoryServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/AgentInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/AgentInstanceServices.java
@@ -30,12 +30,14 @@ public final class AgentInstanceServices
   private final AgentInstanceSearchClient agentInstanceSearchClient;
 
   public AgentInstanceServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final AgentInstanceSearchClient agentInstanceSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/ApiServices.java
+++ b/service/src/main/java/io/camunda/service/ApiServices.java
@@ -16,10 +16,11 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
-import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.function.BiConsumer;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -43,38 +44,25 @@ public abstract class ApiServices<T extends ApiServices<T>> {
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
   }
 
-  protected <R> CompletableFuture<R> sendBrokerRequest(
+  protected final <R> CompletableFuture<R> sendBrokerRequest(
       final BrokerRequest<R> brokerRequest, final CamundaAuthentication authentication) {
     return sendBrokerRequestWithFullResponse(brokerRequest, authentication)
         .thenApplyAsync(BrokerResponse::getResponse, executor);
   }
 
-  protected <R> CompletableFuture<R> sendBrokerRequest(
-      final BrokerRequest<R> brokerRequest,
-      final Duration requestTimeout,
-      final CamundaAuthentication authentication) {
-    return sendBrokerRequestWithFullResponse(brokerRequest, requestTimeout, authentication)
-        .thenApplyAsync(BrokerResponse::getResponse, executor);
-  }
-
-  protected <R> CompletableFuture<BrokerResponse<R>> sendBrokerRequestWithFullResponse(
+  protected final <R> CompletableFuture<BrokerResponse<R>> sendBrokerRequestWithFullResponse(
       final BrokerRequest<R> brokerRequest, final CamundaAuthentication authentication) {
-    final var brokerRequestAuthorization =
-        brokerRequestAuthorizationConverter.convert(authentication);
-    brokerRequest.setAuthorization(brokerRequestAuthorization);
+    brokerRequestMutators().forEach(mutator -> mutator.accept(brokerRequest, authentication));
     return brokerClient.sendRequest(brokerRequest).handleAsync(handleBrokerResponse(), executor);
   }
 
-  protected <R> CompletableFuture<BrokerResponse<R>> sendBrokerRequestWithFullResponse(
-      final BrokerRequest<R> brokerRequest,
-      final Duration requestTimeout,
-      final CamundaAuthentication authentication) {
-    final var brokerRequestAuthorization =
-        brokerRequestAuthorizationConverter.convert(authentication);
-    brokerRequest.setAuthorization(brokerRequestAuthorization);
-    return brokerClient
-        .sendRequest(brokerRequest, requestTimeout)
-        .handleAsync(handleBrokerResponse(), executor);
+  protected List<BiConsumer<BrokerRequest, CamundaAuthentication>> brokerRequestMutators() {
+    return List.of(
+        (brokerRequest, authentication) -> {
+          final var brokerRequestAuthorization =
+              brokerRequestAuthorizationConverter.convert(authentication);
+          brokerRequest.setAuthorization(brokerRequestAuthorization);
+        });
   }
 
   private <R>

--- a/service/src/main/java/io/camunda/service/AuditLogServices.java
+++ b/service/src/main/java/io/camunda/service/AuditLogServices.java
@@ -43,12 +43,14 @@ public class AuditLogServices
   private final AuditLogSearchClient auditLogSearchClient;
 
   public AuditLogServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final AuditLogSearchClient auditLogSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -37,12 +37,14 @@ public class AuthorizationServices
   private final AuthorizationSearchClient authorizationSearchClient;
 
   public AuthorizationServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final AuthorizationSearchClient authorizationSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -38,12 +38,14 @@ public final class BatchOperationServices
   private final BatchOperationSearchClient batchOperationSearchClient;
 
   public BatchOperationServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final BatchOperationSearchClient batchOperationSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/ClockServices.java
+++ b/service/src/main/java/io/camunda/service/ClockServices.java
@@ -16,14 +16,16 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerClockResetRequest;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import java.util.concurrent.CompletableFuture;
 
-public final class ClockServices extends ApiServices<ClockServices> {
+public final class ClockServices extends PhysicalTenantScopedApiServices<ClockServices> {
 
   public ClockServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/ClusterVariableServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterVariableServices.java
@@ -35,12 +35,14 @@ public final class ClusterVariableServices
   private final ClusterVariableSearchClient clusterVariableSearchClient;
 
   public ClusterVariableServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ClusterVariableSearchClient clusterVariableSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/ConditionalServices.java
+++ b/service/src/main/java/io/camunda/service/ConditionalServices.java
@@ -17,14 +17,16 @@ import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalEvalua
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-public class ConditionalServices extends ApiServices<ConditionalServices> {
+public class ConditionalServices extends PhysicalTenantScopedApiServices<ConditionalServices> {
 
   public ConditionalServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -39,6 +39,7 @@ public final class DecisionDefinitionServices
   private final DecisionRequirementsServices decisionRequirementServices;
 
   public DecisionDefinitionServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final DecisionDefinitionSearchClient decisionDefinitionSearchClient,
@@ -46,6 +47,7 @@ public final class DecisionDefinitionServices
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -39,12 +39,18 @@ public final class DecisionInstanceServices
   private final DecisionInstanceSearchClient decisionInstanceSearchClient;
 
   public DecisionInstanceServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityHandler,
       final DecisionInstanceSearchClient decisionInstanceSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
-    super(brokerClient, securityHandler, executorProvider, brokerRequestAuthorizationConverter);
+    super(
+        physicalTenantId,
+        brokerClient,
+        securityHandler,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.decisionInstanceSearchClient = decisionInstanceSearchClient;
   }
 

--- a/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
@@ -30,12 +30,14 @@ public final class DecisionRequirementsServices
   private final DecisionRequirementSearchClient decisionRequirementSearchClient;
 
   public DecisionRequirementsServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final DecisionRequirementSearchClient decisionRequirementSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DocumentServices extends ApiServices<DocumentServices> {
+public class DocumentServices extends PhysicalTenantScopedApiServices<DocumentServices> {
 
   private static final Logger LOG = LoggerFactory.getLogger(DocumentServices.class);
 
@@ -46,6 +46,7 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   private final AuthorizationsConfiguration authorizationsConfig;
 
   public DocumentServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final SimpleDocumentStoreRegistry registry,
@@ -54,6 +55,7 @@ public class DocumentServices extends ApiServices<DocumentServices> {
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -45,6 +45,7 @@ public final class ElementInstanceServices
   private final IncidentServices incidentServices;
 
   public ElementInstanceServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
@@ -54,6 +55,7 @@ public final class ElementInstanceServices
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/FormServices.java
+++ b/service/src/main/java/io/camunda/service/FormServices.java
@@ -26,12 +26,14 @@ public final class FormServices extends SearchQueryService<FormServices, FormQue
   private final FormSearchClient formSearchClient;
 
   public FormServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final FormSearchClient formSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/GlobalListenerServices.java
+++ b/service/src/main/java/io/camunda/service/GlobalListenerServices.java
@@ -33,12 +33,14 @@ public final class GlobalListenerServices
   private final GlobalListenerSearchClient globalListenerSearchClient;
 
   public GlobalListenerServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final GlobalListenerSearchClient globalListenerSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -38,12 +38,14 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
   private final GroupSearchClient groupSearchClient;
 
   public GroupServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final GroupSearchClient groupSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/IncidentServices.java
+++ b/service/src/main/java/io/camunda/service/IncidentServices.java
@@ -38,12 +38,14 @@ public class IncidentServices
   private final IncidentSearchClient incidentSearchClient;
 
   public IncidentServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final IncidentSearchClient incidentSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -52,6 +52,7 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
   private final int maxVariableNameLength;
 
   public JobServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ActivateJobsHandler<T> activateJobsHandler,
@@ -59,6 +60,7 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         activateJobsHandler,
@@ -69,6 +71,7 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
   }
 
   public JobServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ActivateJobsHandler<T> activateJobsHandler,
@@ -77,6 +80,7 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final int maxVariableNameLength) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/MappingRuleServices.java
+++ b/service/src/main/java/io/camunda/service/MappingRuleServices.java
@@ -35,12 +35,14 @@ public class MappingRuleServices
   private final MappingRuleSearchClient mappingRuleSearchClient;
 
   public MappingRuleServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final MappingRuleSearchClient mappingRuleSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/MessageServices.java
+++ b/service/src/main/java/io/camunda/service/MessageServices.java
@@ -22,15 +22,17 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.Nullable;
 
-public final class MessageServices extends ApiServices<MessageServices> {
+public final class MessageServices extends PhysicalTenantScopedApiServices<MessageServices> {
   private final int maxVariableNameLength;
 
   public MessageServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,
@@ -39,12 +41,14 @@ public final class MessageServices extends ApiServices<MessageServices> {
   }
 
   public MessageServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final int maxVariableNameLength) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
+++ b/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
@@ -30,12 +30,14 @@ public class MessageSubscriptionServices
   private final MessageSubscriptionSearchClient searchClient;
 
   public MessageSubscriptionServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final MessageSubscriptionSearchClient searchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/PhysicalTenantScopedApiServices.java
+++ b/service/src/main/java/io/camunda/service/PhysicalTenantScopedApiServices.java
@@ -11,38 +11,36 @@ import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.gateway.impl.broker.request.BrokerExpressionEvaluationRequest;
-import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 
-public final class ExpressionServices extends PhysicalTenantScopedApiServices<ExpressionServices> {
+public abstract class PhysicalTenantScopedApiServices<T extends PhysicalTenantScopedApiServices<T>>
+    extends ApiServices<T> {
 
-  public ExpressionServices(
+  private final String physicalTenantId;
+
+  protected PhysicalTenantScopedApiServices(
       final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
-        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,
         brokerRequestAuthorizationConverter);
+    this.physicalTenantId = physicalTenantId;
   }
 
-  public CompletableFuture<ExpressionRecord> evaluateExpression(
-      final ExpressionEvaluationRequest request, final CamundaAuthentication authentication) {
-    return sendBrokerRequest(
-        new BrokerExpressionEvaluationRequest()
-            .setExpression(request.expression())
-            .setVariables(request.variables())
-            .setScopeKey(request.scopeKey())
-            .setTenantId(request.tenantId()),
-        authentication);
+  @Override
+  protected final List<BiConsumer<BrokerRequest, CamundaAuthentication>> brokerRequestMutators() {
+    return Stream.concat(
+            super.brokerRequestMutators().stream(),
+            Stream.of(
+                (brokerRequest, ignored) -> brokerRequest.setPartitionGroup(physicalTenantId)))
+        .toList();
   }
-
-  public record ExpressionEvaluationRequest(
-      String expression, String tenantId, Long scopeKey, Map<String, Object> variables) {}
 }

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -41,6 +41,7 @@ public class ProcessDefinitionServices
   private final FormServices formServices;
 
   public ProcessDefinitionServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ProcessDefinitionSearchClient processDefinitionSearchClient,
@@ -48,6 +49,7 @@ public class ProcessDefinitionServices
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -91,6 +91,7 @@ public final class ProcessInstanceServices
           Caffeine.newBuilder().maximumSize(MAX_CACHED_DEFINITIONS).build();
 
   public ProcessInstanceServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ProcessInstanceSearchClient processInstanceSearchClient,
@@ -99,6 +100,7 @@ public final class ProcessInstanceServices
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         processInstanceSearchClient,
@@ -111,6 +113,7 @@ public final class ProcessInstanceServices
   }
 
   public ProcessInstanceServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ProcessInstanceSearchClient processInstanceSearchClient,
@@ -120,6 +123,7 @@ public final class ProcessInstanceServices
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final int maxVariableNameLength) {
     this(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         processInstanceSearchClient,
@@ -132,6 +136,7 @@ public final class ProcessInstanceServices
   }
 
   public ProcessInstanceServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ProcessInstanceSearchClient processInstanceSearchClient,
@@ -141,6 +146,7 @@ public final class ProcessInstanceServices
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final RequestRetryHandler requestRetryHandler) {
     this(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         processInstanceSearchClient,
@@ -153,6 +159,7 @@ public final class ProcessInstanceServices
   }
 
   public ProcessInstanceServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ProcessInstanceSearchClient processInstanceSearchClient,
@@ -163,6 +170,7 @@ public final class ProcessInstanceServices
       final RequestRetryHandler requestRetryHandler,
       final int maxVariableNameLength) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/ResourceServices.java
+++ b/service/src/main/java/io/camunda/service/ResourceServices.java
@@ -35,7 +35,7 @@ import io.camunda.zeebe.protocol.record.value.ResourceType;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-public final class ResourceServices extends ApiServices<ResourceServices> {
+public final class ResourceServices extends PhysicalTenantScopedApiServices<ResourceServices> {
 
   private final ProcessDefinitionSearchClient processDefinitionSearchClient;
   private final DecisionRequirementSearchClient decisionRequirementSearchClient;
@@ -43,6 +43,7 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
   private final boolean secondaryStorageEnabled;
 
   public ResourceServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
@@ -52,6 +53,7 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
       final DeployedResourceSearchClient deployedResourceSearchClient,
       final boolean secondaryStorageEnabled) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -38,12 +38,14 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   private final RoleSearchClient roleSearchClient;
 
   public RoleServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final RoleSearchClient roleSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/SignalServices.java
+++ b/service/src/main/java/io/camunda/service/SignalServices.java
@@ -17,14 +17,16 @@ import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-public class SignalServices extends ApiServices<SignalServices> {
+public class SignalServices extends PhysicalTenantScopedApiServices<SignalServices> {
 
   public SignalServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -40,12 +40,14 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   private final TenantSearchClient tenantSearchClient;
 
   public TenantServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final TenantSearchClient tenantSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -27,16 +27,18 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class TopologyServices extends ApiServices<TopologyServices> {
+public final class TopologyServices extends PhysicalTenantScopedApiServices<TopologyServices> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TopologyServices.class);
 
   public TopologyServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -32,12 +32,14 @@ public final class UsageMetricsServices
   private final UsageMetricsSearchClient usageMetricsSearchClient;
 
   public UsageMetricsServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final UsageMetricsSearchClient usageMetricsSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -34,6 +34,7 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
   private final PasswordEncoder passwordEncoder;
 
   public UserServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final UserSearchClient userSearchClient,
@@ -41,6 +42,7 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -78,6 +78,7 @@ public final class UserTaskServices
   private final int maxVariableNameLength;
 
   public UserTaskServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final UserTaskSearchClient userTaskSearchClient,
@@ -89,6 +90,7 @@ public final class UserTaskServices
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         userTaskSearchClient,
@@ -103,6 +105,7 @@ public final class UserTaskServices
   }
 
   public UserTaskServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final UserTaskSearchClient userTaskSearchClient,
@@ -115,6 +118,7 @@ public final class UserTaskServices
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final int maxVariableNameLength) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -26,12 +26,14 @@ public final class VariableServices
   private final VariableSearchClient variableSearchClient;
 
   public VariableServices(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final VariableSearchClient variableSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
@@ -12,22 +12,25 @@ import io.camunda.search.query.SearchQueryBase;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.service.ApiServices;
 import io.camunda.service.ApiServicesExecutorProvider;
+import io.camunda.service.PhysicalTenantScopedApiServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.function.Supplier;
 
-public abstract class SearchQueryService<T extends ApiServices<T>, Q extends SearchQueryBase, D>
-    extends ApiServices<T> {
+public abstract class SearchQueryService<
+        T extends PhysicalTenantScopedApiServices<T>, Q extends SearchQueryBase, D>
+    extends PhysicalTenantScopedApiServices<T> {
 
   protected SearchQueryService(
+      final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
+        physicalTenantId,
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
@@ -41,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class AdHocSubProcessActivityServicesTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private static final long AD_HOC_SUB_PROCESS_INSTANCE_KEY = 123456L;
   private static final String ELEMENT_ID = "activity1";
 
@@ -73,6 +74,7 @@ public class AdHocSubProcessActivityServicesTest {
         .thenReturn(Map.of(USER_TOKEN_CLAIMS, tokenClaims));
     services =
         new AdHocSubProcessActivityServices(
+            PHYSICAL_TENANT_ID,
             brokerClient,
             securityContextProvider,
             executorProvider,
@@ -125,6 +127,7 @@ public class AdHocSubProcessActivityServicesTest {
     assertThat(result).isEqualTo(expectedResponse);
     assertThat(requestCaptor.getValue().getAuthorization().getClaims())
         .containsExactly(entry(USER_TOKEN_CLAIMS, Map.of("claim", "value")));
+    assertThat(requestCaptor.getValue().getPartitionGroup()).isEqualTo(PHYSICAL_TENANT_ID);
   }
 
   @ParameterizedTest

--- a/service/src/test/java/io/camunda/service/AuditLogServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AuditLogServicesTest.java
@@ -37,6 +37,7 @@ import org.mockito.MockitoAnnotations;
 
 class AuditLogServicesTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private static final AuditLogEntity AUDIT_LOG_ENTITY =
       new AuditLogEntity.Builder()
           .auditLogKey("auditLogKey")
@@ -83,6 +84,7 @@ class AuditLogServicesTest {
 
     auditLogServices =
         new AuditLogServices(
+            PHYSICAL_TENANT_ID,
             brokerClient,
             securityContextProvider,
             auditLogSearchClient,

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 public class AuthorizationServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private CamundaAuthentication authentication;
   private AuthorizationServices services;
   private AuthorizationSearchClient client;
@@ -36,6 +37,7 @@ public class AuthorizationServiceTest {
     when(client.withSecurityContext(any())).thenReturn(client);
     services =
         new AuthorizationServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 public final class DecisionDefinitionServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private CamundaAuthentication authentication;
   private DecisionDefinitionServices services;
   private DecisionDefinitionSearchClient client;
@@ -48,6 +49,7 @@ public final class DecisionDefinitionServiceTest {
     when(client.withSecurityContext(any())).thenReturn(client);
     services =
         new DecisionDefinitionServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -52,6 +52,7 @@ import org.mockito.ArgumentCaptor;
 
 class DecisionInstanceServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private static final Long DECISION_INSTANCE_KEY = 1L;
   private static final Long NON_EXISTENT_KEY = 999L;
   private static final String DECISION_INSTANCE_ID = "1-1";
@@ -73,6 +74,7 @@ class DecisionInstanceServiceTest {
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
     services =
         new DecisionInstanceServices(
+            PHYSICAL_TENANT_ID,
             brokerClient,
             securityContextProvider,
             client,
@@ -201,6 +203,7 @@ class DecisionInstanceServiceTest {
     services.deleteDecisionInstance(decisionInstanceKey, null, authentication).join();
 
     // then
+    assertThat(captor.getValue().getPartitionGroup()).isEqualTo(PHYSICAL_TENANT_ID);
     final var brokerRequest = (HistoryDeletionRecord) captor.getValue().getRequestWriter();
     assertThat(brokerRequest.getResourceKey()).isEqualTo(decisionInstanceKey);
     assertThat(brokerRequest.getResourceType()).isEqualTo(HistoryDeletionType.DECISION_INSTANCE);

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 public final class DecisionRequirementsServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private CamundaAuthentication authentication;
   private DecisionRequirementsServices services;
   private DecisionRequirementSearchClient client;
@@ -42,6 +43,7 @@ public final class DecisionRequirementsServiceTest {
     when(client.withSecurityContext(any())).thenReturn(client);
     services =
         new DecisionRequirementsServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/DocumentServicesTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
 
 public class DocumentServicesTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private DocumentServices services;
   private final SimpleDocumentStoreRegistry registry = mock(SimpleDocumentStoreRegistry.class);
   private final AuthorizationChecker authorizationChecker = mock(AuthorizationChecker.class);
@@ -58,6 +59,7 @@ public class DocumentServicesTest {
     authorizationsConfig.setEnabled(false);
     services =
         new DocumentServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             registry,

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -45,6 +45,7 @@ import org.mockito.Mock;
 
 public final class ElementInstanceServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private ElementInstanceServices services;
   private FlowNodeInstanceSearchClient client;
   private WaitStateSearchClient waitStateSearchClient;
@@ -60,6 +61,7 @@ public final class ElementInstanceServiceTest {
     incidentServices = mock(IncidentServices.class);
     services =
         new ElementInstanceServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/FormServiceTest.java
+++ b/service/src/test/java/io/camunda/service/FormServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 public final class FormServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private CamundaAuthentication authentication;
   private FormServices services;
   private FormSearchClient client;
@@ -34,6 +35,7 @@ public final class FormServiceTest {
     when(client.withSecurityContext(any())).thenReturn(client);
     services =
         new FormServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 
 public class GroupServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private GroupServices services;
   private GroupSearchClient client;
   private CamundaAuthentication authentication;
@@ -64,6 +65,7 @@ public class GroupServiceTest {
         .thenReturn(Map.of(AUTHORIZED_USERNAME, authentication.authenticatedUsername()));
     services =
         new GroupServices(
+            PHYSICAL_TENANT_ID,
             stubbedBrokerClient,
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -40,6 +40,7 @@ import org.mockito.ArgumentCaptor;
 
 public final class IncidentServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private IncidentServices services;
   private IncidentSearchClient client;
   private CamundaAuthentication authentication;
@@ -53,6 +54,7 @@ public final class IncidentServiceTest {
 
     services =
         new IncidentServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             securityContextProvider,
             client,

--- a/service/src/test/java/io/camunda/service/JobServiceTest.java
+++ b/service/src/test/java/io/camunda/service/JobServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class JobServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private JobServices<SearchQueryResult<JobEntity>> services;
   private JobSearchClient client;
   private CamundaAuthentication authentication;
@@ -35,6 +36,7 @@ public class JobServiceTest {
     authentication = mock(CamundaAuthentication.class);
     services =
         new JobServices<>(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             null,

--- a/service/src/test/java/io/camunda/service/MappingRuleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingRuleServicesTest.java
@@ -43,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 
 public class MappingRuleServicesTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   ArgumentCaptor<BrokerMappingRuleDeleteRequest> mappingRuleDeleteRequestArgumentCaptor;
   ArgumentCaptor<BrokerMappingRuleUpdateRequest> mappingRuleUpdateRequestArgumentCaptor;
   private MappingRuleServices services;
@@ -70,6 +71,7 @@ public class MappingRuleServicesTest {
     brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
     services =
         new MappingRuleServices(
+            PHYSICAL_TENANT_ID,
             stubbedBrokerClient,
             mock(SecurityContextProvider.class),
             client,
@@ -141,6 +143,7 @@ public class MappingRuleServicesTest {
     final BrokerClient mockBrokerClient = mock(BrokerClient.class);
     final MappingRuleServices testMappingRuleServices =
         new MappingRuleServices(
+            PHYSICAL_TENANT_ID,
             mockBrokerClient,
             mock(SecurityContextProvider.class),
             client,
@@ -157,6 +160,8 @@ public class MappingRuleServicesTest {
 
     // then
     verify(mockBrokerClient).sendRequest(mappingRuleDeleteRequestArgumentCaptor.capture());
+    assertThat(mappingRuleDeleteRequestArgumentCaptor.getValue().getPartitionGroup())
+        .isEqualTo(PHYSICAL_TENANT_ID);
     final var request = mappingRuleDeleteRequestArgumentCaptor.getValue();
     assertThat(request.getRequestWriter().getMappingRuleId()).isEqualTo("id");
   }
@@ -169,6 +174,7 @@ public class MappingRuleServicesTest {
     final BrokerClient mockBrokerClient = mock(BrokerClient.class);
     final MappingRuleServices testMappingRuleServices =
         new MappingRuleServices(
+            PHYSICAL_TENANT_ID,
             mockBrokerClient,
             mock(SecurityContextProvider.class),
             client,
@@ -192,6 +198,8 @@ public class MappingRuleServicesTest {
 
     // then
     verify(mockBrokerClient).sendRequest(mappingRuleUpdateRequestArgumentCaptor.capture());
+    assertThat(mappingRuleUpdateRequestArgumentCaptor.getValue().getPartitionGroup())
+        .isEqualTo(PHYSICAL_TENANT_ID);
     final var request = mappingRuleUpdateRequestArgumentCaptor.getValue();
     assertThat(request.getRequestWriter().getMappingRuleId())
         .isEqualTo(mappingRuleDTO.mappingRuleId());

--- a/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 public class MessageSubscriptionServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private MessageSubscriptionServices services;
   private MessageSubscriptionSearchClient client;
   private CamundaAuthentication authentication;
@@ -42,6 +43,7 @@ public class MessageSubscriptionServiceTest {
     authentication = mock(CamundaAuthentication.class);
     services =
         new MessageSubscriptionServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/ProcessDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessDefinitionServiceTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 public class ProcessDefinitionServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private ProcessDefinitionServices services;
   private ProcessDefinitionSearchClient processDefinitionSearchClient;
   private SecurityContextProvider securityContextProvider;
@@ -55,6 +56,7 @@ public class ProcessDefinitionServiceTest {
 
     services =
         new ProcessDefinitionServices(
+            PHYSICAL_TENANT_ID,
             brokerClient,
             securityContextProvider,
             processDefinitionSearchClient,

--- a/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 final class ProcessInstanceRoundRobinDispatchTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private static final int PARTITION_COUNT = 3;
 
   private BrokerClient brokerClient;
@@ -50,6 +51,7 @@ final class ProcessInstanceRoundRobinDispatchTest {
 
     services =
         new ProcessInstanceServices(
+            PHYSICAL_TENANT_ID,
             brokerClient,
             mock(SecurityContextProvider.class),
             mock(ProcessInstanceSearchClient.class),

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -84,6 +84,7 @@ import org.mockito.ArgumentCaptor;
 
 public final class ProcessInstanceServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private ProcessInstanceServices services;
   private ProcessInstanceSearchClient processInstanceSearchClient;
   private SequenceFlowSearchClient sequenceFlowSearchClient;
@@ -116,6 +117,7 @@ public final class ProcessInstanceServiceTest {
     brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
     services =
         new ProcessInstanceServices(
+            PHYSICAL_TENANT_ID,
             brokerClient,
             securityContextProvider,
             processInstanceSearchClient,
@@ -590,6 +592,7 @@ public final class ProcessInstanceServiceTest {
     services.deleteProcessInstance(processInstanceKey, null, authentication).join();
 
     // then
+    assertThat(captor.getValue().getPartitionGroup()).isEqualTo(PHYSICAL_TENANT_ID);
     final var brokerRequest = (HistoryDeletionRecord) captor.getValue().getRequestWriter();
     assertThat(brokerRequest.getResourceKey()).isEqualTo(processInstanceKey);
     assertThat(brokerRequest.getResourceType()).isEqualTo(HistoryDeletionType.PROCESS_INSTANCE);

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -49,6 +49,7 @@ import org.mockito.ArgumentCaptor;
 
 public class RoleServicesTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private RoleServices services;
   private RoleSearchClient client;
   private CamundaAuthentication authentication;
@@ -67,6 +68,7 @@ public class RoleServicesTest {
     brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
     services =
         new RoleServices(
+            PHYSICAL_TENANT_ID,
             stubbedBrokerClient,
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 public class TenantServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private TenantServices services;
   private TenantSearchClient client;
   private StubbedBrokerClient stubbedBrokerClient;
@@ -68,6 +69,7 @@ public class TenantServiceTest {
     brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
     services =
         new TenantServices(
+            PHYSICAL_TENANT_ID,
             stubbedBrokerClient,
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mockito;
 @NullMarked
 public class TopologyServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private final int partitionId1 = 1;
   private final int partitionId2 = 2;
   private final int partitionId3 = 3;
@@ -62,6 +63,7 @@ public class TopologyServiceTest {
     when(topologyManager.getTopology()).thenReturn(clusterState);
     services =
         new TopologyServices(
+            PHYSICAL_TENANT_ID,
             brokerClient,
             mock(SecurityContextProvider.class),
             mock(ApiServicesExecutorProvider.class),

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public final class UsageMetricsServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private UsageMetricsServices services;
   private UsageMetricsSearchClient client;
   private CamundaAuthentication authentication;
@@ -39,6 +40,7 @@ public final class UsageMetricsServiceTest {
     authentication = mock(CamundaAuthentication.class);
     services =
         new UsageMetricsServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/UserServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserServiceTest.java
@@ -36,6 +36,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class UserServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   ArgumentCaptor<BrokerUserDeleteRequest> userDeleteRequestArgumentCaptor;
   private UserServices services;
   private UserSearchClient client;
@@ -56,6 +57,7 @@ public class UserServiceTest {
     brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
     services =
         new UserServices(
+            PHYSICAL_TENANT_ID,
             brokerClient,
             mock(SecurityContextProvider.class),
             client,
@@ -93,6 +95,8 @@ public class UserServiceTest {
     services.deleteUser(username, authentication);
 
     verify(brokerClient).sendRequest(userDeleteRequestArgumentCaptor.capture());
+    assertThat(userDeleteRequestArgumentCaptor.getValue().getPartitionGroup())
+        .isEqualTo(PHYSICAL_TENANT_ID);
     final var request = userDeleteRequestArgumentCaptor.getValue().getRequestWriter();
     assertThat(request.getUsername()).isEqualTo(username);
     assertThat(request.getUserKey()).isEqualTo(-1L);

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.Test;
 
 public class UserTaskServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private UserTaskServices services;
   private UserTaskSearchClient client;
   private FormServices formServices;
@@ -73,6 +74,7 @@ public class UserTaskServiceTest {
     authentication = mock(CamundaAuthentication.class);
     services =
         new UserTaskServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 
 public class VariableServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "test-tenant";
   private VariableServices services;
   private VariableSearchClient client;
   private CamundaAuthentication authentication;
@@ -44,6 +45,7 @@ public class VariableServiceTest {
     authentication = mock(CamundaAuthentication.class);
     services =
         new VariableServices(
+            PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.gateway.rest.controller;
 import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
-import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import java.util.concurrent.CompletableFuture;
@@ -19,7 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
-@ClusterScoped
 @RequestMapping(path = {"/v1", "/v2"})
 public final class TopologyController {
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -442,6 +442,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         final BrokerClient brokerClient,
         final ActivateJobsHandler<JobActivationResult> activateJobsHandler) {
       return new JobServices<>(
+          "default",
           brokerClient,
           new SecurityContextProvider(),
           activateJobsHandler,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -435,6 +435,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
         final BrokerClient brokerClient,
         final ActivateJobsHandler<JobActivationResult> activateJobsHandler) {
       return new JobServices<>(
+          "default",
           brokerClient,
           new SecurityContextProvider(),
           activateJobsHandler,


### PR DESCRIPTION
## Description

Routes every broker request through the correct physical-tenant partition group by wiring `physicalTenantId` into the service layer.

### What changed

**New intermediate base class** (`PhysicalTenantScopedApiServices`):
- Sits between `ApiServices` and all concrete service classes (both direct subclasses and `SearchQueryService` subclasses)
- Overrides `brokerRequestMutators()` to append a mutator that calls `brokerRequest.setPartitionGroup(physicalTenantId)`, ensuring every outgoing broker request targets the right partition group for its physical tenant

**`ApiServices` refactor**:
- Replaced the duplicated auth-converter logic with a `brokerRequestMutators()` hook (list of `BiConsumer<BrokerRequest, CamundaAuthentication>`) that subclasses can extend
- Removed the `Duration`-overloaded `sendBrokerRequest` variants (unused)

**All 32 service classes** (`AdHocSubProcessActivityServices`, `AgentHistoryServices`, `AuditLogServices`, `AuthorizationServices`, `BatchOperationServices`, `ClockServices`, `ClusterVariableServices`, `ConditionalServices`, `DecisionDefinitionServices`, `DecisionInstanceServices`, `DecisionRequirementsServices`, `DocumentServices`, `ElementInstanceServices`, `ExpressionServices`, `FormServices`, `GlobalListenerServices`, `GroupServices`, `IncidentServices`, `JobServices`, `MappingRuleServices`, `MessageServices`, `MessageSubscriptionServices`, `ProcessDefinitionServices`, `ProcessInstanceServices`, `ResourceServices`, `RoleServices`, `SignalServices`, `TenantServices`, `TopologyServices`, `UsageMetricsServices`, `UserServices`, `UserTaskServices`, `VariableServices`, `AgentInstanceServices`):
- Accept `physicalTenantId` as the first constructor parameter and forward it to `super()`

**`CamundaServicesConfiguration`**:
- Passes `tenantId` (from the per-physical-tenant loop) as the first argument to every service constructor

**Tests**:
- All unit tests updated to pass a custom `"test-tenant"` id to service constructors
- Tests that capture broker requests assert `requestCaptor.getValue().getPartitionGroup()` equals the expected tenant id

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #