### PR TITLE
feat: add sort toggle to conversation history

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -21,6 +21,9 @@ import {ConversationHistory} from './index';
 import {searchResult} from 'modules/testUtils';
 import {mockAgentInstanceHistoryItem} from 'modules/mocks/mockAgentInstanceHistoryItem';
 import {Paths} from 'modules/Routes';
+import {mockServer} from 'modules/mock-server/node';
+import {http} from 'msw';
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
 
 const AGENT_INSTANCE_KEY = '2251799813851828';
 
@@ -172,6 +175,52 @@ describe('<ConversationHistory />', () => {
         },
       ),
     ).toBeInTheDocument();
+  });
+
+  it('should toggle the history sort order when the sort button is clicked', async () => {
+    let query;
+    mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
+    mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
+    mockServer.use(
+      http.post(
+        endpoints.searchAgentInstanceHistory.getUrl({
+          agentInstanceKey: AGENT_INSTANCE_KEY,
+        }),
+        async ({request}) => void (query = await request.json()),
+      ),
+    );
+
+    const {user} = render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    const sortButton = screen.getByRole('button', {name: 'Most recent first'});
+    expect(sortButton).toBeVisible();
+    expect(query).toEqual(
+      expect.objectContaining({
+        sort: [{field: 'producedAt', order: 'desc'}],
+      }),
+    );
+
+    await user.click(sortButton);
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    expect(screen.getByRole('button', {name: 'Oldest first'})).toBeVisible();
+    expect(query).toEqual(
+      expect.objectContaining({
+        sort: [{field: 'producedAt', order: 'asc'}],
+      }),
+    );
   });
 
   it('should render document references', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -178,15 +178,16 @@ describe('<ConversationHistory />', () => {
   });
 
   it('should toggle the history sort order when the sort button is clicked', async () => {
-    let query;
-    mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
-    mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
+    let query: unknown;
     mockServer.use(
       http.post(
         endpoints.searchAgentInstanceHistory.getUrl({
           agentInstanceKey: AGENT_INSTANCE_KEY,
         }),
-        async ({request}) => void (query = await request.json()),
+        async ({request}) => {
+          query = await request.json();
+          return Response.json(searchResult([]));
+        },
       ),
     );
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -6,7 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {SkeletonText} from '@carbon/react';
+import {useState} from 'react';
+import {Button, SkeletonText} from '@carbon/react';
+import {SortAscending, SortDescending} from '@carbon/react/icons';
+import type {QuerySortOrder} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
@@ -21,9 +24,11 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   agentInstanceKey,
   enablePeriodicRefetch,
 }) => {
+  const [sortOrder, setSortOrder] = useState<QuerySortOrder>('desc');
   const {selectElement} = useProcessInstanceElementSelection();
   const {data, status} = useAgentInstanceHistory(agentInstanceKey, {
     enablePeriodicRefetch,
+    sortOrder,
   });
 
   if (status === 'pending') {
@@ -44,6 +49,16 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
 
   return (
     <ConversationContainer>
+      <Button
+        kind="ghost"
+        size="xs"
+        renderIcon={sortOrder === 'desc' ? SortDescending : SortAscending}
+        onClick={() =>
+          setSortOrder((prev) => (prev === 'desc' ? 'asc' : 'desc'))
+        }
+      >
+        {sortOrder === 'desc' ? 'Most recent first' : 'Oldest first'}
+      </Button>
       {data.items.map((item) => (
         <ConversationMessage
           key={item.historyItemKey}

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
@@ -7,28 +7,31 @@
  */
 
 import {useQuery} from '@tanstack/react-query';
-import type {SearchAgentInstanceHistoryRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {
+  QuerySortOrder,
+  SearchAgentInstanceHistoryRequestBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 import {searchAgentInstanceHistory} from 'modules/api/v2/agentInstances/searchAgentInstanceHistory';
 import {queryKeys} from '../queryKeys';
 
-const HISTORY_PAYLOAD: SearchAgentInstanceHistoryRequestBody = {
-  sort: [{field: 'producedAt', order: 'desc'}],
-  filter: {commitStatus: 'COMMITTED'},
-};
-
 const useAgentInstanceHistory = (
   agentInstanceKey: string,
-  options?: {enablePeriodicRefetch?: boolean},
+  options?: {enablePeriodicRefetch?: boolean; sortOrder?: QuerySortOrder},
 ) => {
+  const historyPayload: SearchAgentInstanceHistoryRequestBody = {
+    sort: [{field: 'producedAt', order: options?.sortOrder ?? 'desc'}],
+    filter: {commitStatus: 'COMMITTED'},
+  };
+
   return useQuery({
     queryKey: queryKeys.agentInstanceHistory.search(
       agentInstanceKey,
-      HISTORY_PAYLOAD,
+      historyPayload,
     ),
     queryFn: async ({signal}) => {
       const {response, error} = await searchAgentInstanceHistory(
         agentInstanceKey,
-        HISTORY_PAYLOAD,
+        historyPayload,
         signal,
       );
       if (response !== null) {


### PR DESCRIPTION
## Description

This PR adds a sort toggle to the conversation history. The default sort order is "Most recent first" and can be toggled to "oldest first".

For the toggle, I decided to use simple XS button. This contrasts with the design prototype, which uses a custom designed element (slightly smaller text, no color, no micro-animations). Sometimes I am fine with adding something custom, but usually we should try to stick with the chosen design system and not design against it. In this case, I decided to stick with the design system...

## Related issues

relates #51928
