### PR TITLE
feat: expose additional RocksDB properties as metrics

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -18212,7 +18212,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "Write health signals.\n\n- **Write stopped**: returns 1 when RocksDB has halted writes.\n- **Background errors**: cumulative count of errors hit during background flush/compaction; a non-zero value indicates a serious problem and is often the cause of a write stop.\n\nhttps://github.com/facebook/rocksdb/blob/e66199d848cd484b816d07359f1dc0f0b99e5351/include/rocksdb/db.h#L908",
+          "description": "Returns 1 when RocksDB has halted writes. A sustained value of 1 means the engine cannot make progress on this partition.\n\nhttps://github.com/facebook/rocksdb/blob/e66199d848cd484b816d07359f1dc0f0b99e5351/include/rocksdb/db.h#L908",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -18269,7 +18269,7 @@
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
+            "w": 8,
             "x": 0,
             "y": 3927
           },
@@ -18299,7 +18299,93 @@
               "interval": "",
               "legendFormat": "{{pod}}  stopped write {{partition}}",
               "refId": "A"
+            }
+          ],
+          "title": "Write stopped",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Cumulative count of errors hit during background flush or compaction. A non-zero value indicates a serious problem and is often the cause of a write stop.\n\nhttps://github.com/facebook/rocksdb/blob/e66199d848cd484b816d07359f1dc0f0b99e5351/include/rocksdb/db.h#L908",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
             },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 3927
+          },
+          "id": 735,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
             {
               "datasource": {
                 "type": "prometheus",
@@ -18308,10 +18394,10 @@
               "expr": "sum(zeebe_rocksdb_writes_background_errors{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, partition)",
               "interval": "",
               "legendFormat": "{{pod}}  background errors {{partition}}",
-              "refId": "B"
+              "refId": "A"
             }
           ],
-          "title": "Write stopped / background errors",
+          "title": "Background errors",
           "type": "timeseries"
         },
         {
@@ -18378,8 +18464,8 @@
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
-            "x": 6,
+            "w": 8,
+            "x": 16,
             "y": 3927
           },
           "id": 157,
@@ -18475,10 +18561,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
-            "w": 12,
-            "x": 12,
-            "y": 3927
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 3948
           },
           "id": 146,
           "options": {
@@ -18574,9 +18660,9 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 6,
-            "x": 0,
-            "y": 3933
+            "w": 8,
+            "x": 8,
+            "y": 3941
           },
           "id": 159,
           "options": {
@@ -18672,9 +18758,9 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 6,
-            "x": 6,
-            "y": 3933
+            "w": 8,
+            "x": 16,
+            "y": 3941
           },
           "id": 160,
           "options": {
@@ -18771,9 +18857,9 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 3933
+            "w": 8,
+            "x": 16,
+            "y": 3948
           },
           "id": 153,
           "options": {
@@ -18873,7 +18959,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 3940
+            "y": 3955
           },
           "id": 603,
           "options": {
@@ -18977,9 +19063,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3952
+            "y": 3933
           },
-          "id": 725,
+          "id": 731,
           "options": {
             "legend": {
               "calcs": [],
@@ -19095,9 +19181,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3952
+            "y": 3933
           },
-          "id": 726,
+          "id": 732,
           "options": {
             "legend": {
               "calcs": [],
@@ -19210,12 +19296,12 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 8,
-            "w": 12,
+            "h": 7,
+            "w": 8,
             "x": 0,
-            "y": 3960
+            "y": 3941
           },
-          "id": 727,
+          "id": 733,
           "options": {
             "legend": {
               "calcs": [],
@@ -19308,12 +19394,12 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 3960
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 3948
           },
-          "id": 728,
+          "id": 734,
           "options": {
             "legend": {
               "calcs": [],

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -18212,7 +18212,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "Return 1 if write has been stopped.\n\nhttps://github.com/facebook/rocksdb/blob/e66199d848cd484b816d07359f1dc0f0b99e5351/include/rocksdb/db.h#L908",
+          "description": "Write health signals.\n\n- **Write stopped**: returns 1 when RocksDB has halted writes.\n- **Background errors**: cumulative count of errors hit during background flush/compaction; a non-zero value indicates a serious problem and is often the cause of a write stop.\n\nhttps://github.com/facebook/rocksdb/blob/e66199d848cd484b816d07359f1dc0f0b99e5351/include/rocksdb/db.h#L908",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -18299,9 +18299,19 @@
               "interval": "",
               "legendFormat": "{{pod}}  stopped write {{partition}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum(zeebe_rocksdb_writes_background_errors{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, partition)",
+              "interval": "",
+              "legendFormat": "{{pod}}  background errors {{partition}}",
+              "refId": "B"
             }
           ],
-          "title": "Write stopped",
+          "title": "Write stopped / background errors",
           "type": "timeseries"
         },
         {
@@ -18899,6 +18909,448 @@
             }
           ],
           "title": "Column Family Access Latency 99th percentile",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Rate of RocksDB write *stops* (writes fully halted) per second, broken down by cause. Any sustained non-zero value means ingestion is being blocked. Series are stacked to show total stop pressure.\n\nSourced from the rocksdb.cfstats map (always-on InternalStats).\n\nhttps://github.com/facebook/rocksdb/blob/e66199d848cd484b816d07359f1dc0f0b99e5351/include/rocksdb/db.h",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3952
+          },
+          "id": 725,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_memtable_stop_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "interval": "",
+              "legendFormat": "{{pod}}  memtable {{partition}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_l0_file_count_stop_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "interval": "",
+              "legendFormat": "{{pod}}  L0 file count {{partition}}",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_pending_compaction_bytes_stop_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "interval": "",
+              "legendFormat": "{{pod}}  pending compaction bytes {{partition}}",
+              "refId": "C"
+            }
+          ],
+          "title": "Write stalls - stops by cause",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Rate of RocksDB write *slowdowns* (writes throttled, not halted) per second, broken down by cause. An early-warning signal that precedes write stops. Series are stacked to show total slowdown pressure.\n\nSourced from the rocksdb.cfstats map (always-on InternalStats).\n\nhttps://github.com/facebook/rocksdb/blob/e66199d848cd484b816d07359f1dc0f0b99e5351/include/rocksdb/db.h",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3952
+          },
+          "id": 726,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_memtable_slowdown_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "interval": "",
+              "legendFormat": "{{pod}}  memtable {{partition}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_l0_file_count_slowdown_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "interval": "",
+              "legendFormat": "{{pod}}  L0 file count {{partition}}",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_pending_compaction_bytes_slowdown_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "interval": "",
+              "legendFormat": "{{pod}}  pending compaction bytes {{partition}}",
+              "refId": "C"
+            }
+          ],
+          "title": "Write stalls - slowdowns by cause",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Estimated bytes that compaction still needs to rewrite to reach the target LSM shape (compaction debt). Sustained growth means compaction cannot keep up and precedes pending-compaction-bytes write slowdowns and stops.\n\nhttps://github.com/facebook/rocksdb/blob/e66199d848cd484b816d07359f1dc0f0b99e5351/include/rocksdb/db.h",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3960
+          },
+          "id": 727,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum(zeebe_rocksdb_writes_estimate_pending_compaction_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, partition)",
+              "interval": "",
+              "legendFormat": "{{pod}}  {{partition}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Estimated pending compaction bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Number of immutable (read-only, awaiting flush) memtables, and the number that have already been flushed. A growing pending-flush count means flushes are not keeping up.\n\nhttps://github.com/facebook/rocksdb/blob/e66199d848cd484b816d07359f1dc0f0b99e5351/include/rocksdb/db.h",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3960
+          },
+          "id": 728,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum(zeebe_rocksdb_memory_num_immutable_mem_table{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, partition)",
+              "interval": "",
+              "legendFormat": "{{pod}}  pending flush {{partition}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum(zeebe_rocksdb_memory_num_immutable_mem_table_flushed{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, partition)",
+              "interval": "",
+              "legendFormat": "{{pod}}  flushed {{partition}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Immutable memtables",
           "type": "timeseries"
         }
       ],

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -19000,7 +19000,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_memtable_stop_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_memtable_stop{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
               "interval": "",
               "legendFormat": "{{pod}}  memtable {{partition}}",
               "refId": "A"
@@ -19010,7 +19010,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_l0_file_count_stop_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_l0_file_count_stop{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
               "interval": "",
               "legendFormat": "{{pod}}  L0 file count {{partition}}",
               "refId": "B"
@@ -19020,7 +19020,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_pending_compaction_bytes_stop_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_pending_compaction_bytes_stop{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
               "interval": "",
               "legendFormat": "{{pod}}  pending compaction bytes {{partition}}",
               "refId": "C"
@@ -19118,7 +19118,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_memtable_slowdown_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_memtable_slowdown{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
               "interval": "",
               "legendFormat": "{{pod}}  memtable {{partition}}",
               "refId": "A"
@@ -19128,7 +19128,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_l0_file_count_slowdown_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_l0_file_count_slowdown{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
               "interval": "",
               "legendFormat": "{{pod}}  L0 file count {{partition}}",
               "refId": "B"
@@ -19138,7 +19138,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_pending_compaction_bytes_slowdown_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_pending_compaction_bytes_slowdown{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
               "interval": "",
               "legendFormat": "{{pod}}  pending compaction bytes {{partition}}",
               "refId": "C"

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/RocksDBMetricExporter.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/RocksDBMetricExporter.java
@@ -8,10 +8,12 @@
 package io.camunda.zeebe.db.impl.rocksdb.metrics;
 
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.rocksdb.RocksDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,9 +22,12 @@ import org.slf4j.LoggerFactory;
 public final class RocksDBMetricExporter {
 
   private static final Logger LOG = LoggerFactory.getLogger(RocksDBMetricExporter.class.getName());
+  private static final String CF_STATS_PROPERTY = "rocksdb.cfstats";
 
   private final Map<RocksDbMetricsDoc, StatefulGauge> metrics =
       new EnumMap<>(RocksDbMetricsDoc.class);
+  private final Map<RocksDbIoStallMetricsDoc, AtomicLong> ioStallMetrics =
+      new EnumMap<>(RocksDbIoStallMetricsDoc.class);
   private final MeterRegistry registry;
 
   public RocksDBMetricExporter(final MeterRegistry registry) {
@@ -36,6 +41,8 @@ public final class RocksDBMetricExporter {
       final var gauge = metrics.computeIfAbsent(metric, this::registerMetric);
       exportMetric(database, metric.propertyName(), gauge);
     }
+
+    exportIoStallMetrics(database);
 
     final long elapsedTime = System.nanoTime() - startTime;
     LOG.trace(
@@ -59,5 +66,50 @@ public final class RocksDBMetricExporter {
     } catch (final Exception exception) {
       LOG.debug("Error occurred on exporting metric {}", propertyName, exception);
     }
+  }
+
+  private void exportIoStallMetrics(final RocksDB database) {
+    final Map<String, String> cfStats;
+    try {
+      cfStats = database.getMapProperty(CF_STATS_PROPERTY);
+    } catch (final Exception exception) {
+      LOG.debug("Error occurred on reading property {}", CF_STATS_PROPERTY, exception);
+      return;
+    }
+
+    if (cfStats == null) {
+      return;
+    }
+
+    for (final var metric : RocksDbIoStallMetricsDoc.values()) {
+      final var value = cfStats.get(metric.propertyName());
+      if (value == null) {
+        continue;
+      }
+
+      try {
+        final long count = Long.parseLong(value.trim());
+        ioStallMetrics.computeIfAbsent(metric, this::registerIoStallCounter).set(count);
+      } catch (final NumberFormatException exception) {
+        LOG.debug(
+            "Could not parse io-stall metric {} with value {}",
+            metric.propertyName(),
+            value,
+            exception);
+      }
+    }
+  }
+
+  /**
+   * Registers a {@link FunctionCounter} backed by the returned {@link AtomicLong}. RocksDB hands us
+   * the absolute cumulative count each cycle (not a delta), so the exporter holds the latest value
+   * in the {@code AtomicLong} and the counter simply reports it.
+   */
+  private AtomicLong registerIoStallCounter(final RocksDbIoStallMetricsDoc doc) {
+    final var state = new AtomicLong();
+    FunctionCounter.builder(doc.getName(), state, AtomicLong::doubleValue)
+        .description(doc.getDescription())
+        .register(registry);
+    return state;
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/RocksDBMetricExporter.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/RocksDBMetricExporter.java
@@ -8,12 +8,10 @@
 package io.camunda.zeebe.db.impl.rocksdb.metrics;
 
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
-import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import org.rocksdb.RocksDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +24,7 @@ public final class RocksDBMetricExporter {
 
   private final Map<RocksDbMetricsDoc, StatefulGauge> metrics =
       new EnumMap<>(RocksDbMetricsDoc.class);
-  private final Map<RocksDbIoStallMetricsDoc, AtomicLong> ioStallMetrics =
+  private final Map<RocksDbIoStallMetricsDoc, StatefulGauge> ioStallMetrics =
       new EnumMap<>(RocksDbIoStallMetricsDoc.class);
   private final MeterRegistry registry;
 
@@ -50,7 +48,7 @@ public final class RocksDBMetricExporter {
         TimeUnit.MILLISECONDS.convert(elapsedTime, TimeUnit.NANOSECONDS));
   }
 
-  private StatefulGauge registerMetric(final RocksDbMetricsDoc doc) {
+  private StatefulGauge registerMetric(final RocksDbMeterDoc doc) {
     return StatefulGauge.builder(doc.getName())
         .description(doc.getDescription())
         .register(registry);
@@ -82,14 +80,14 @@ public final class RocksDBMetricExporter {
     }
 
     for (final var metric : RocksDbIoStallMetricsDoc.values()) {
+      final var gauge = ioStallMetrics.computeIfAbsent(metric, this::registerMetric);
       final var value = cfStats.get(metric.propertyName());
       if (value == null) {
         continue;
       }
 
       try {
-        final long count = Long.parseLong(value.trim());
-        ioStallMetrics.computeIfAbsent(metric, this::registerIoStallCounter).set(count);
+        gauge.set(Long.parseLong(value.trim()));
       } catch (final NumberFormatException exception) {
         LOG.debug(
             "Could not parse io-stall metric {} with value {}",
@@ -98,18 +96,5 @@ public final class RocksDBMetricExporter {
             exception);
       }
     }
-  }
-
-  /**
-   * Registers a {@link FunctionCounter} backed by the returned {@link AtomicLong}. RocksDB hands us
-   * the absolute cumulative count each cycle (not a delta), so the exporter holds the latest value
-   * in the {@code AtomicLong} and the counter simply reports it.
-   */
-  private AtomicLong registerIoStallCounter(final RocksDbIoStallMetricsDoc doc) {
-    final var state = new AtomicLong();
-    FunctionCounter.builder(doc.getName(), state, AtomicLong::doubleValue)
-        .description(doc.getDescription())
-        .register(registry);
-    return state;
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/RocksDbIoStallMetricsDoc.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/RocksDbIoStallMetricsDoc.java
@@ -20,12 +20,12 @@ import io.micrometer.core.instrument.Meter.Type;
  * is a cumulative count, since the database was opened, of how many times writes were stopped
  * (fully halted) or slowed down (throttled) for the given reason.
  *
- * <p>These counters come from RocksDB's always-on {@code InternalStats}, so reading them does not
+ * <p>These values come from RocksDB's always-on {@code InternalStats}, so reading them does not
  * require enabling the (more expensive) RocksDB {@code Statistics} object.
  *
- * <p>Each value is a cumulative count and is exported as a counter (see {@link #getType()}). It
- * resets to zero when the database is reopened, which Prometheus {@code rate()} handles as a
- * counter reset.
+ * <p>RocksDB already maintains the cumulative count, so each value is exported as a gauge (see
+ * {@link #getType()}) that mirrors the latest reading. It resets to zero when the database is
+ * reopened, consistent with {@code rocksdb.background-errors} and the other RocksDB gauges.
  */
 public enum RocksDbIoStallMetricsDoc implements RocksDbMeterDoc {
   TOTAL_STOP(
@@ -86,7 +86,7 @@ public enum RocksDbIoStallMetricsDoc implements RocksDbMeterDoc {
 
   @Override
   public Type getType() {
-    return Type.COUNTER;
+    return Type.GAUGE;
   }
 
   @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/RocksDbIoStallMetricsDoc.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/RocksDbIoStallMetricsDoc.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.db.impl.rocksdb.metrics;
+
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+
+/**
+ * Documents the write-stall counters extracted from the RocksDB {@code rocksdb.cfstats} map
+ * property.
+ *
+ * <p>Unlike {@link RocksDbMetricsDoc}, these are not standalone integer properties: each one is a
+ * single entry within the map returned by {@code DB::GetMapProperty("rocksdb.cfstats")}. The value
+ * is a cumulative count, since the database was opened, of how many times writes were stopped
+ * (fully halted) or slowed down (throttled) for the given reason.
+ *
+ * <p>These counters come from RocksDB's always-on {@code InternalStats}, so reading them does not
+ * require enabling the (more expensive) RocksDB {@code Statistics} object.
+ *
+ * <p>Each value is a cumulative count and is exported as a counter (see {@link #getType()}). It
+ * resets to zero when the database is reopened, which Prometheus {@code rate()} handles as a
+ * counter reset.
+ */
+public enum RocksDbIoStallMetricsDoc implements RocksDbMeterDoc {
+  TOTAL_STOP(
+      "total-stops",
+      "io.stalls.stop",
+      "Cumulative number of times writes were fully stopped for any reason"),
+  TOTAL_SLOWDOWN(
+      "total-delays",
+      "io.stalls.slowdown",
+      "Cumulative number of times writes were slowed down for any reason"),
+  MEMTABLE_STOP(
+      "memtable-limit-stops",
+      "io.stalls.memtable.stop",
+      "Cumulative number of write stops caused by too many unflushed memtables"),
+  MEMTABLE_SLOWDOWN(
+      "memtable-limit-delays",
+      "io.stalls.memtable.slowdown",
+      "Cumulative number of write slowdowns caused by approaching the memtable limit"),
+  L0_FILE_COUNT_STOP(
+      "l0-file-count-limit-stops",
+      "io.stalls.l0.file.count.stop",
+      "Cumulative number of write stops caused by hitting the L0 file-count limit"),
+  L0_FILE_COUNT_SLOWDOWN(
+      "l0-file-count-limit-delays",
+      "io.stalls.l0.file.count.slowdown",
+      "Cumulative number of write slowdowns caused by approaching the L0 file-count limit"),
+  PENDING_COMPACTION_STOP(
+      "pending-compaction-bytes-stops",
+      "io.stalls.pending.compaction.bytes.stop",
+      "Cumulative number of write stops caused by exceeding the hard pending-compaction-bytes limit"),
+  PENDING_COMPACTION_SLOWDOWN(
+      "pending-compaction-bytes-delays",
+      "io.stalls.pending.compaction.bytes.slowdown",
+      "Cumulative number of write slowdowns caused by exceeding the soft pending-compaction-bytes limit");
+
+  private static final String ZEEBE_NAMESPACE = "zeebe";
+  private static final String IO_STALLS_NAMESPACE = "rocksdb.writes";
+
+  private final String mapKey;
+  private final String suffix;
+  private final String description;
+
+  RocksDbIoStallMetricsDoc(final String mapKey, final String suffix, final String description) {
+    this.mapKey = mapKey;
+    this.suffix = suffix;
+    this.description = description;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String getName() {
+    return ZEEBE_NAMESPACE + "." + IO_STALLS_NAMESPACE + "." + suffix;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.COUNTER;
+  }
+
+  @Override
+  public KeyName[] getAdditionalKeyNames() {
+    return PartitionKeyNames.values();
+  }
+
+  @Override
+  public String namespace() {
+    return IO_STALLS_NAMESPACE;
+  }
+
+  /** The key under which this counter appears in the {@code rocksdb.cfstats} map. */
+  @Override
+  public String propertyName() {
+    return mapKey;
+  }
+}

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/RocksDbMetricsDoc.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/RocksDbMetricsDoc.java
@@ -132,6 +132,40 @@ public enum RocksDbMetricsDoc implements RocksDbMeterDoc {
     }
   },
 
+  NUM_IMMUTABLE_MEM_TABLE {
+    @Override
+    public String getDescription() {
+      return MEMORY_METRICS_HELP;
+    }
+
+    @Override
+    public String namespace() {
+      return MEMORY_METRICS_PREFIX;
+    }
+
+    @Override
+    public String propertyName() {
+      return "rocksdb.num-immutable-mem-table";
+    }
+  },
+
+  NUM_IMMUTABLE_MEM_TABLE_FLUSHED {
+    @Override
+    public String getDescription() {
+      return MEMORY_METRICS_HELP;
+    }
+
+    @Override
+    public String namespace() {
+      return MEMORY_METRICS_PREFIX;
+    }
+
+    @Override
+    public String propertyName() {
+      return "rocksdb.num-immutable-mem-table-flushed";
+    }
+  },
+
   TOTAL_SST_FILES_SIZE {
     @Override
     public String getDescription() {
@@ -163,6 +197,57 @@ public enum RocksDbMetricsDoc implements RocksDbMeterDoc {
     @Override
     public String propertyName() {
       return "rocksdb.live-sst-files-size";
+    }
+  },
+
+  OBSOLETE_SST_FILES_SIZE {
+    @Override
+    public String getDescription() {
+      return SST_METRICS_HELP;
+    }
+
+    @Override
+    public String namespace() {
+      return SST_METRICS_PREFIX;
+    }
+
+    @Override
+    public String propertyName() {
+      return "rocksdb.obsolete-sst-files-size";
+    }
+  },
+
+  NUM_LIVE_VERSIONS {
+    @Override
+    public String getDescription() {
+      return SST_METRICS_HELP;
+    }
+
+    @Override
+    public String namespace() {
+      return SST_METRICS_PREFIX;
+    }
+
+    @Override
+    public String propertyName() {
+      return "rocksdb.num-live-versions";
+    }
+  },
+
+  NUM_SNAPSHOTS {
+    @Override
+    public String getDescription() {
+      return SST_METRICS_HELP;
+    }
+
+    @Override
+    public String namespace() {
+      return SST_METRICS_PREFIX;
+    }
+
+    @Override
+    public String propertyName() {
+      return "rocksdb.num-snapshots";
     }
   },
 
@@ -214,6 +299,57 @@ public enum RocksDbMetricsDoc implements RocksDbMeterDoc {
     @Override
     public String propertyName() {
       return "rocksdb.estimate-live-data-size";
+    }
+  },
+
+  NUM_ENTRIES_ACTIVE_MEM_TABLE {
+    @Override
+    public String getDescription() {
+      return LIVE_METRICS_HELP;
+    }
+
+    @Override
+    public String namespace() {
+      return LIVE_METRICS_PREFIX;
+    }
+
+    @Override
+    public String propertyName() {
+      return "rocksdb.num-entries-active-mem-table";
+    }
+  },
+
+  NUM_DELETES_ACTIVE_MEM_TABLE {
+    @Override
+    public String getDescription() {
+      return LIVE_METRICS_HELP;
+    }
+
+    @Override
+    public String namespace() {
+      return LIVE_METRICS_PREFIX;
+    }
+
+    @Override
+    public String propertyName() {
+      return "rocksdb.num-deletes-active-mem-table";
+    }
+  },
+
+  NUM_DELETES_IMM_MEM_TABLES {
+    @Override
+    public String getDescription() {
+      return LIVE_METRICS_HELP;
+    }
+
+    @Override
+    public String namespace() {
+      return LIVE_METRICS_PREFIX;
+    }
+
+    @Override
+    public String propertyName() {
+      return "rocksdb.num-deletes-imm-mem-tables";
     }
   },
 
@@ -299,6 +435,40 @@ public enum RocksDbMetricsDoc implements RocksDbMeterDoc {
     @Override
     public String propertyName() {
       return "rocksdb.num-running-compactions";
+    }
+  },
+
+  ESTIMATE_PENDING_COMPACTION_BYTES {
+    @Override
+    public String getDescription() {
+      return WRITE_METRICS_HELP;
+    }
+
+    @Override
+    public String namespace() {
+      return WRITE_METRICS_PREFIX;
+    }
+
+    @Override
+    public String propertyName() {
+      return "rocksdb.estimate-pending-compaction-bytes";
+    }
+  },
+
+  BACKGROUND_ERRORS {
+    @Override
+    public String getDescription() {
+      return WRITE_METRICS_HELP;
+    }
+
+    @Override
+    public String namespace() {
+      return WRITE_METRICS_PREFIX;
+    }
+
+    @Override
+    public String propertyName() {
+      return "rocksdb.background-errors";
     }
   };
 

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBMetricExporterTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBMetricExporterTest.java
@@ -20,8 +20,10 @@ import org.rocksdb.RocksDB;
 
 final class RocksDBMetricExporterTest {
 
+  private static final String CF_STATS_PROPERTY = "rocksdb.cfstats";
+
   @Test
-  void shouldExportIoStallMetricsFromCfStatsMap(@TempDir final File dir) throws Exception {
+  void shouldRegisterAllIoStallGaugesOnExport(@TempDir final File dir) throws Exception {
     // given
     RocksDB.loadLibrary();
     final var registry = new SimpleMeterRegistry();
@@ -33,15 +35,39 @@ final class RocksDBMetricExporterTest {
       // when
       exporter.exportMetrics(db);
 
-      // then -- every documented io-stall counter is present in the cfstats map and was registered
+      // then
       assertThat(RocksDbIoStallMetricsDoc.values())
           .allSatisfy(
               doc ->
-                  assertThat(registry.find(doc.getName()).functionCounter())
-                      .as(
-                          "counter '%s' (cfstats key '%s') is registered",
-                          doc.getName(), doc.propertyName())
+                  assertThat(registry.find(doc.getName()).gauge())
+                      .as("gauge '%s' is registered", doc.getName())
                       .isNotNull());
+    }
+  }
+
+  @Test
+  void shouldExposeAllDocumentedIoStallKeysInCfStats(@TempDir final File dir) throws Exception {
+    // given
+    RocksDB.loadLibrary();
+    final var registry = new SimpleMeterRegistry();
+    final var exporter = new RocksDBMetricExporter(registry);
+
+    try (final var options = new Options().setCreateIfMissing(true);
+        final var db = RocksDB.open(options, dir.getAbsolutePath())) {
+
+      // when
+      exporter.exportMetrics(db);
+      final var cfStats = db.getMapProperty(CF_STATS_PROPERTY);
+
+      // then
+      assertThat(RocksDbIoStallMetricsDoc.values())
+          .allSatisfy(
+              doc ->
+                  assertThat(cfStats)
+                      .as(
+                          "cfstats map contains key '%s' for gauge '%s'",
+                          doc.propertyName(), doc.getName())
+                      .containsKey(doc.propertyName()));
     }
   }
 }

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBMetricExporterTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBMetricExporterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.db.impl.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.impl.rocksdb.metrics.RocksDBMetricExporter;
+import io.camunda.zeebe.db.impl.rocksdb.metrics.RocksDbIoStallMetricsDoc;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+
+final class RocksDBMetricExporterTest {
+
+  @Test
+  void shouldExportIoStallMetricsFromCfStatsMap(@TempDir final File dir) throws Exception {
+    // given
+    RocksDB.loadLibrary();
+    final var registry = new SimpleMeterRegistry();
+    final var exporter = new RocksDBMetricExporter(registry);
+
+    try (final var options = new Options().setCreateIfMissing(true);
+        final var db = RocksDB.open(options, dir.getAbsolutePath())) {
+
+      // when
+      exporter.exportMetrics(db);
+
+      // then -- every documented io-stall counter is present in the cfstats map and was registered
+      assertThat(RocksDbIoStallMetricsDoc.values())
+          .allSatisfy(
+              doc ->
+                  assertThat(registry.find(doc.getName()).functionCounter())
+                      .as(
+                          "counter '%s' (cfstats key '%s') is registered",
+                          doc.getName(), doc.propertyName())
+                      .isNotNull());
+    }
+  }
+}

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBMetricTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBMetricTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.db.impl.rocksdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.db.impl.rocksdb.metrics.RocksDbIoStallMetricsDoc;
 import io.camunda.zeebe.db.impl.rocksdb.metrics.RocksDbMetricsDoc;
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import java.util.Arrays;
@@ -30,6 +31,24 @@ public class RocksDBMetricTest {
     final var metric =
         Arrays.stream(metrics)
             .filter(m -> m.getName().equals("zeebe.rocksdb.memory.cur.size.all.mem.tables"))
+            .findFirst();
+    assertThat(metric).isPresent();
+  }
+
+  @Test
+  public void shouldNameIoStallMetricsCorrectly() {
+    final var metrics = (ExtendedMeterDocumentation[]) RocksDbIoStallMetricsDoc.values();
+    assertThat(metrics)
+        .allSatisfy(
+            m ->
+                assertThat(m.getName())
+                    .startsWith("zeebe.rocksdb.")
+                    .doesNotContain("..")
+                    .doesNotContain("-")
+                    .doesNotContain("_"));
+    final var metric =
+        Arrays.stream(metrics)
+            .filter(m -> m.getName().equals("zeebe.rocksdb.writes.io.stalls.stop"))
             .findFirst();
     assertThat(metric).isPresent();
   }


### PR DESCRIPTION
Extends RocksDbMetricsDoc with further RocksDB integer properties so they are exported as gauges and can be surfaced on the Grafana dashboard:

- memory: num-immutable-mem-table, num-immutable-mem-table-flushed
- sst: obsolete-sst-files-size, num-live-versions, num-snapshots
- live: num-entries-active-mem-table, num-deletes-active-mem-table, num-deletes-imm-mem-tables
- writes: estimate-pending-compaction-bytes, background-errors

Also exposes RocksDB write-stall counters extracted from the rocksdb.cfstats map property as FunctionCounters (zeebe.rocksdb.writes.io.stalls.*), broken down by cause (memtable limit, L0 file count, pending compaction bytes) and severity (stop vs slowdown). These come from RocksDB's always-on InternalStats, so they do not require enabling the more expensive Statistics object.

closes #52365
