### PR TITLE
feat: make per PT initialization block required

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName.Form;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
+import org.springframework.core.env.Environment;
+
+/**
+ * Required-override policy for physical-tenant configuration: every explicitly-configured physical
+ * tenant must declare its own {@code initialization} block under {@code
+ * camunda.physical-tenants.<id>.security.initialization.*}.
+ *
+ * <p>The {@code initialization} block seeds tenant-scoped identity (users, roles, authorizations,
+ * tenants, …). Unlike the cluster-wide settings guarded by {@link
+ * PhysicalTenantOverridePolicyValidation}, it must <em>not</em> be inherited from the root:
+ * silently reusing the top-level seed across tenants would create the same admin user /
+ * authorizations in every tenant, defeating tenant isolation. Each tenant therefore has to provide
+ * its own.
+ *
+ * <p>The {@value PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} tenant is exempt: it represents the
+ * root configuration and keeps the top-level {@code camunda.security.initialization}, whether it is
+ * synthesized from the root or declared explicitly.
+ *
+ * <p>Enforcement is pure <em>key inspection</em> over the declared {@code physical-tenants.<id>.*}
+ * keys — the same walk {@link PhysicalTenantResolver#discover(Environment)} does — with no value
+ * comparison and no binding. A tenant that declares no key at or under {@code
+ * security.initialization} fails resolution.
+ */
+@NullMarked
+final class PhysicalTenantRequiredOverrideValidation {
+
+  private static final ConfigurationPropertyName PHYSICAL_TENANTS_NAME =
+      ConfigurationPropertyName.of(Camunda.PREFIX + ".physical-tenants");
+
+  /**
+   * The per-tenant {@code initialization} block, expressed relative to {@code
+   * camunda.physical-tenants.<id>.}. A tenant satisfies the requirement by declaring any key at or
+   * under this name.
+   */
+  private static final ConfigurationPropertyName REQUIRED_INITIALIZATION =
+      ConfigurationPropertyName.of("security.initialization");
+
+  private PhysicalTenantRequiredOverrideValidation() {}
+
+  static void validate(final Environment environment) {
+    final Set<String> declaredTenants = new LinkedHashSet<>();
+    final Set<String> tenantsWithInitialization = new LinkedHashSet<>();
+    final int tenantIdIndex = PHYSICAL_TENANTS_NAME.getNumberOfElements();
+    for (final ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
+      if (source instanceof final IterableConfigurationPropertySource iter) {
+        iter.stream()
+            .filter(PHYSICAL_TENANTS_NAME::isAncestorOf)
+            .forEach(
+                name -> {
+                  if (name.getNumberOfElements() <= tenantIdIndex) {
+                    // only the physical-tenants prefix, no tenant id segment
+                    return;
+                  }
+                  final String tenantId = name.getElement(tenantIdIndex, Form.UNIFORM);
+                  if (tenantId == null || tenantId.isEmpty()) {
+                    // mirror PhysicalTenantResolver.discover — never report a blank tenant id
+                    return;
+                  }
+                  declaredTenants.add(tenantId);
+                  if (name.getNumberOfElements() > tenantIdIndex + 1
+                      && declaresInitialization(name.subName(tenantIdIndex + 1))) {
+                    tenantsWithInitialization.add(tenantId);
+                  }
+                });
+      }
+    }
+
+    final List<String> missing =
+        declaredTenants.stream()
+            .filter(id -> !PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(id))
+            .filter(id -> !tenantsWithInitialization.contains(id))
+            .toList();
+    if (!missing.isEmpty()) {
+      throw new UnifiedConfigurationException(
+          "Each explicitly-configured physical tenant must declare its own initialization block "
+              + "under 'camunda.physical-tenants.<id>.security.initialization.*'; it may not be "
+              + "inherited from the root (the '"
+              + PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID
+              + "' tenant keeps the top-level 'camunda.security.initialization'). Physical tenants "
+              + "missing a required initialization block: "
+              + missing);
+    }
+  }
+
+  private static boolean declaresInitialization(final ConfigurationPropertyName relative) {
+    return REQUIRED_INITIALIZATION.equals(relative)
+        || REQUIRED_INITIALIZATION.isAncestorOf(relative);
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -87,6 +87,7 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
   public static PhysicalTenantResolver of(final Environment environment, final Camunda camunda) {
     final Set<String> physicalTenantIds = discover(environment);
     PhysicalTenantOverridePolicyValidation.validate(environment);
+    PhysicalTenantRequiredOverrideValidation.validate(environment);
     PhysicalTenantAssignedProvidersValidation.validate(environment);
     final Map<String, Camunda> resolvedPhysicalTenants = new LinkedHashMap<>();
     final Binder binder = Binder.get(environment);

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/ExporterArgsOverlayCharacterizationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/ExporterArgsOverlayCharacterizationTest.java
@@ -76,6 +76,10 @@ class ExporterArgsOverlayCharacterizationTest {
     properties.put(
         "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
         "tenanta");
+    // the tenant must provide its own initialization block (required per-PT override)
+    properties.put(
+        "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
+        "tenanta-admin");
     environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
 
     final Camunda camunda = new Camunda();

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+class PhysicalTenantRequiredOverrideValidationTest {
+
+  private static MockEnvironment environmentWith(final Map<String, Object> properties) {
+    final MockEnvironment environment = new MockEnvironment();
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+    return environment;
+  }
+
+  @Test
+  void shouldRejectTenantWithoutInitializationBlock() {
+    // given a non-default tenant that only overrides an unrelated property
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta"));
+
+    // when / then resolution fails fast, naming the offending tenant
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .withMessageContaining("camunda.physical-tenants.<id>.security.initialization")
+        .withMessageContaining("tenanta");
+  }
+
+  @Test
+  void shouldReportEveryTenantMissingInitialization() {
+    // given two non-default tenants, neither declaring an initialization block
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.physical-tenants.tenanta.cluster.partition-count", 7,
+                "camunda.physical-tenants.tenantb.cluster.partition-count", 3));
+
+    // when / then both are reported
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldAllowTenantThatDeclaresInitializationBlock() {
+    // given a non-default tenant providing its own initialization block
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
+                "tenanta-admin"));
+
+    // when / then the requirement is satisfied
+    assertThatCode(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAllowTenantDeclaringAnyKeyUnderInitialization() {
+    // given a tenant that declares a deeply nested initialization key
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.physical-tenants.tenanta.security.initialization.users[0].username",
+                "demo",
+                "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta"));
+
+    // when / then any key at or under security.initialization satisfies the requirement
+    assertThatCode(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldNotRequireInitializationForTheDefaultTenant() {
+    // given an explicitly-declared 'default' tenant without an initialization block
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.physical-tenants.default.data.secondary-storage.elasticsearch.index-prefix",
+                "custom"));
+
+    // when / then the default tenant inherits the top-level initialization and is exempt
+    assertThatCode(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldOnlyRejectTenantsThatAreMissingInitialization() {
+    // given one tenant with an initialization block and one without
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
+                "tenanta-admin",
+                "camunda.physical-tenants.tenantb.cluster.partition-count",
+                3));
+
+    // when / then only the tenant without initialization is reported
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .withMessageContaining("tenantb")
+        .withMessageNotContaining("tenanta");
+  }
+
+  @Test
+  void shouldNotThrowWhenNoTenantsAreDeclared() {
+    // given only root configuration, no physical tenants
+    final MockEnvironment environment = environmentWith(Map.of("camunda.cluster.size", 5));
+
+    // when / then there is nothing to validate
+    assertThatCode(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +50,23 @@ class PhysicalTenantResolverTest {
     environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
   }
 
+  /**
+   * Sets {@code properties} and, for each given non-default tenant, adds the minimal {@code
+   * security.initialization} block that {@link PhysicalTenantRequiredOverrideValidation} now
+   * requires of every explicitly-configured tenant.
+   */
+  private void setProperties(final Map<String, Object> properties, final String... tenantIds) {
+    final Map<String, Object> all = new HashMap<>(properties);
+    for (final String tenantId : tenantIds) {
+      all.put(
+          "camunda.physical-tenants."
+              + tenantId
+              + ".security.initialization.default-roles.admin.users[0]",
+          tenantId + "-admin");
+    }
+    environment.getPropertySources().addFirst(new MapPropertySource("test", all));
+  }
+
   private static String indexPrefixOf(final Camunda camunda) {
     return camunda.getData().getSecondaryStorage().getElasticsearch().getIndexPrefix();
   }
@@ -62,7 +80,9 @@ class PhysicalTenantResolverTest {
             "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
             "tenanta",
             "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
-            "tenantb"));
+            "tenantb"),
+        "tenanta",
+        "tenantb");
 
     // when
     final Map<String, Camunda> resolved = newResolver().getAll();
@@ -82,7 +102,8 @@ class PhysicalTenantResolverTest {
             "camunda.cluster.replication-factor", 3,
             "camunda.physical-tenants.tenanta.cluster.partition-count", 7,
             "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
-                "tenanta"));
+                "tenanta"),
+        "tenanta");
 
     // when
     final Camunda tenantA = newResolver().forPhysicalTenant("tenanta");
@@ -102,7 +123,8 @@ class PhysicalTenantResolverTest {
             "zeebe.broker.cluster.partitionsCount",
             9,
             "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
-            "tenanta"));
+            "tenanta"),
+        "tenanta");
 
     // when
     final Camunda tenantA = newResolver().forPhysicalTenant("tenanta");
@@ -123,7 +145,8 @@ class PhysicalTenantResolverTest {
             "camunda.data.secondary-storage.elasticsearch.index-prefix", "default",
             "camunda.physical-tenants.tenanta.document.aws.aws1.bucket-name", "tenant-bucket",
             "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
-                "tenanta"));
+                "tenanta"),
+        "tenanta");
 
     // when
     final PhysicalTenantResolver resolver = newResolver();
@@ -178,7 +201,8 @@ class PhysicalTenantResolverTest {
             "camunda.cluster.size",
             5,
             "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
-            "tenanta"));
+            "tenanta"),
+        "tenanta");
 
     // when
     final PhysicalTenantResolver resolver = newResolver();
@@ -223,7 +247,9 @@ class PhysicalTenantResolverTest {
             "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.url",
                 "http://shared:9200",
             "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.url",
-                "http://shared:9200"));
+                "http://shared:9200"),
+        "tenanta",
+        "tenantb");
 
     // when / then resolution fails fast at boot
     assertThatExceptionOfType(UnifiedConfigurationException.class)
@@ -242,7 +268,9 @@ class PhysicalTenantResolverTest {
                 "tenanta",
             "camunda.physical-tenants.tenantb.data.secondary-storage.type", "rdbms",
             "camunda.physical-tenants.tenantb.data.secondary-storage.rdbms.url",
-                "jdbc:h2:mem:tenantb"));
+                "jdbc:h2:mem:tenantb"),
+        "tenanta",
+        "tenantb");
 
     // when / then resolution fails fast at boot
     assertThatExceptionOfType(UnifiedConfigurationException.class)
@@ -259,7 +287,9 @@ class PhysicalTenantResolverTest {
             "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
                 "tenanta",
             "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
-                "tenantb"));
+                "tenantb"),
+        "tenanta",
+        "tenantb");
 
     // when / then resolution succeeds
     final PhysicalTenantResolver resolver = newResolver();

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
@@ -95,6 +95,12 @@ class MyBatisConfigurationPerTenantIT {
           "jdbc:h2:mem:rdbms-test-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
       props.put(base + "rdbms.username", "sa");
       props.put(base + "rdbms.password", "");
+      // every explicitly-configured tenant must provide its own initialization block
+      props.put(
+          "camunda.physical-tenants."
+              + tenantId
+              + ".security.initialization.default-roles.admin.users[0]",
+          tenantId + "-admin");
     }
     final var env = new MockEnvironment();
     env.getPropertySources().addFirst(new MapPropertySource("test", props));

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsConfigurationPerTenantReadersIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsConfigurationPerTenantReadersIT.java
@@ -157,6 +157,11 @@ class RdbmsConfigurationPerTenantReadersIT {
           "jdbc:h2:mem:rdbms-test-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
       env.setProperty(base + "rdbms.username", "sa");
       env.setProperty(base + "rdbms.password", "");
+      env.setProperty(
+          "camunda.physical-tenants."
+              + tenantId
+              + ".security.initialization.default-roles.admin.users[0]",
+          tenantId + "-admin");
     }
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/LiquibaseMultiTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/LiquibaseMultiTenantIT.java
@@ -69,7 +69,18 @@ class LiquibaseMultiTenantIT {
                 "")
             .withProperty(
                 "camunda.physical-tenants." + TENANT_B + ".data.secondary-storage.rdbms.prefix",
-                PREFIX_B);
+                PREFIX_B)
+            // each explicitly-configured tenant must provide its own initialization block
+            .withProperty(
+                "camunda.physical-tenants."
+                    + TENANT_A
+                    + ".security.initialization.default-roles.admin.users[0]",
+                TENANT_A + "-admin")
+            .withProperty(
+                "camunda.physical-tenants."
+                    + TENANT_B
+                    + ".security.initialization.default-roles.admin.users[0]",
+                TENANT_B + "-admin");
 
     // when
     app.start();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/spring/PhysicalTenantSearchClientReadersConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/spring/PhysicalTenantSearchClientReadersConfigurationIT.java
@@ -136,6 +136,17 @@ public class PhysicalTenantSearchClientReadersConfigurationIT {
               + TENANT_B
               + ".data.secondary-storage.elasticsearch.index-prefix",
           TENANT_B);
+      // each explicitly-configured tenant must provide its own initialization block
+      env.setProperty(
+          "camunda.physical-tenants."
+              + TENANT_A
+              + ".security.initialization.default-roles.admin.users[0]",
+          TENANT_A + "-admin");
+      env.setProperty(
+          "camunda.physical-tenants."
+              + TENANT_B
+              + ".security.initialization.default-roles.admin.users[0]",
+          TENANT_B + "-admin");
       return env;
     }
 


### PR DESCRIPTION
## Description

Startup now fails with a clear error if an explicitly-configured (non-default) PT does not provide its own initialization block — it is a [required per-PT override](https://docs.google.com/document/d/1cwlObmGuwlSptqzqadW4PnWiEsQgtA1NCjnWLkcTNSI/edit?tab=t.0#bookmark=id.da6ost3qf47b) (the default tenant keeps the top-level initialization so not required).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #54731 (AC 2)
