### PR TITLE
fix: use full reactor build for Optimize E2E backend (INC-5968)

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -468,8 +468,10 @@ jobs:
           project_name: e2e
           additional_flags: "--profile self-managed"
 
-      - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild -Dskip.docker
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
@@ -617,8 +619,10 @@ jobs:
         with:
           directory: ./optimize/client
           node-version: ${{ steps.pom-info.outputs.x_version_node }}
-      - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild -Dskip.docker
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
       - name: Start backend


### PR DESCRIPTION
## Summary

Replaces the partial fix on `main` (`-Dmaven.test.skip=true -DskipChecks`, landed via #55052) with the **full reactor build** (`build-zeebe`) for both Optimize E2E jobs — the same fix already on `stable/8.8`.

## Why the partial fix is wrong

The narrow `-pl optimize/backend -am` build can't resolve SNAPSHOT artifacts on release/merge-back branches:

- `zeebe-client-java` is pulled transitively via the **external** `io.zeebe:zeebe-test-container` and BOM-managed to `${project.version}`. `-am` doesn't descend into external artifacts, so its producer (`clients/java-deprecated`) is never in the build set → not built locally → the bumped SNAPSHOT (e.g. `8.8.28-SNAPSHOT`) isn't in nexus yet → fail.
- `-Dmaven.test.skip=true` additionally broke in-reactor **test-jar** production, surfacing `zeebe-scheduler:jar:tests` failures.

Both are structural — no `-am` flag tweak fixes them.

## Fix

`build-zeebe` builds the **entire reactor**, installing every jar and test-jar to local `.m2`, so all transitive resolution resolves locally. `-Dskip.docker` skips the optimize Docker image build (`optimize/pom.xml` defaults `skip.docker=false`). Matches `optimize-it-*` jobs and `stable/8.8`.

Verified green on `release-8.8.27` in #55154 (Smoke 17m, Cloud 10m).

Fixes INC-5968 on `main`. Companion PR for `stable/8.9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)