### PR TITLE
55078 implement io token trend 2

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -973,6 +973,57 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   // ---------------------------------------------------------------------------
+  // Reports without configured definitions (seeded dashboard reports)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldEvaluateAcrossAllDefinitionsWhenReportHasNoConfiguredDefinitions() {
+    // given completed agentic instances spread across two different process definitions; the seeded
+    // report carries no definitions, so an empty definitions list must mean "all", not "none"
+    persistProcessInstances(
+        List.of(
+            agenticInstance("proc-no-def-a", "1", 100L, 50L).build(),
+            agenticInstance("proc-no-def-a", "1", 100L, 50L).build(),
+            agenticInstance("proc-no-def-b", "1", 100L, 50L).build()));
+
+    // when
+    final Double completed = evaluateNumber(KPI_COMPLETED_REPORT_ID, noExtraFilters());
+
+    // then every completed agentic instance is counted regardless of its definition
+    assertThat(completed).isEqualTo(3.0);
+  }
+
+  @Test
+  void shouldScopeByDateAcrossAllDefinitionsWhenReportHasNoConfiguredDefinitions() {
+    // given in-window instances on two definitions plus an out-of-window instance
+    final OffsetDateTime now = OffsetDateTime.now();
+    final ProcessInstanceDto recentA =
+        agenticInstance("proc-no-def-a", "1", 100L, 50L)
+            .startDate(now.minusHours(3))
+            .endDate(now.minusHours(2))
+            .build();
+    final ProcessInstanceDto recentB =
+        agenticInstance("proc-no-def-b", "1", 100L, 50L)
+            .startDate(now.minusHours(3))
+            .endDate(now.minusHours(2))
+            .build();
+    final ProcessInstanceDto old =
+        agenticInstance("proc-no-def-a", "1", 100L, 50L)
+            .startDate(now.minusDays(10))
+            .endDate(now.minusDays(9))
+            .build();
+
+    persistProcessInstances(List.of(recentA, recentB, old));
+
+    // when applying a rolling date filter to the definition-less report
+    final Double completed =
+        evaluateNumber(KPI_COMPLETED_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS));
+
+    // then the global filters still apply across all definitions: only the 2 in-window instances
+    assertThat(completed).isEqualTo(2.0);
+  }
+
+  // ---------------------------------------------------------------------------
   // Duration stability
   // ---------------------------------------------------------------------------
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterESTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.plan.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.es.filter.ProcessQueryFilterEnhancerES;
+import io.camunda.optimize.service.db.es.report.interpreter.groupby.process.ProcessGroupByInterpreterFacadeES;
+import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GenericProcessExecutionPlanInterpreterESTest {
+
+  @Mock private ProcessDefinitionReader processDefinitionReader;
+  @Mock private OptimizeElasticsearchClient esClient;
+  @Mock private ProcessQueryFilterEnhancerES queryFilterEnhancer;
+  @Mock private ProcessGroupByInterpreterFacadeES groupByInterpreter;
+  @Mock private ProcessViewInterpreterFacadeES viewInterpreter;
+  @Mock private ConfigurationService configurationService;
+
+  @SuppressWarnings("unchecked")
+  @Mock
+  private ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context;
+
+  private GenericProcessExecutionPlanInterpreterES underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest =
+        new GenericProcessExecutionPlanInterpreterES(
+            processDefinitionReader,
+            esClient,
+            queryFilterEnhancer,
+            groupByInterpreter,
+            viewInterpreter,
+            configurationService);
+  }
+
+  @Test
+  void shouldExcludeAllInstancesForManagementReportWithNoDefinitions() {
+    // given a management report whose user has access to no definitions
+    final BoolQuery baseQuery = buildBaseQuery(reportData(true, List.of()));
+
+    // then all instances are excluded via a mustNot match-all clause
+    assertThat(baseQuery.mustNot())
+        .anySatisfy(query -> assertThat(query._kind()).isEqualTo(Query.Kind.MatchAll));
+  }
+
+  @Test
+  void shouldNotExcludeAllInstancesForNonManagementReportWithNoDefinitions() {
+    // given a non-management report with no definitions (e.g. a seeded dashboard report)
+    final BoolQuery baseQuery = buildBaseQuery(reportData(false, List.of()));
+
+    // then no exclude-all clause and no definition-scoping clause is added, so other query filters
+    // apply across all instances
+    assertThat(baseQuery.mustNot()).isEmpty();
+    assertThat(baseQuery.should()).isEmpty();
+    assertThat(baseQuery.minimumShouldMatch()).isNull();
+  }
+
+  private BoolQuery buildBaseQuery(final ProcessReportDataDto reportData) {
+    when(context.getReportData()).thenReturn(reportData);
+    return underTest.getBaseQueryBuilder(context).build();
+  }
+
+  private static ProcessReportDataDto reportData(
+      final boolean managementReport, final List<ReportDataDefinitionDto> definitions) {
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    reportData.setManagementReport(managementReport);
+    reportData.setDefinitions(definitions);
+    return reportData;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterOSTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.plan.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.os.report.filter.ProcessQueryFilterEnhancerOS;
+import io.camunda.optimize.service.db.os.report.interpreter.groupby.process.ProcessGroupByInterpreterFacadeOS;
+import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+@ExtendWith(MockitoExtension.class)
+class GenericProcessExecutionPlanInterpreterOSTest {
+
+  @Mock private ProcessDefinitionReader processDefinitionReader;
+  @Mock private OptimizeOpenSearchClient osClient;
+  @Mock private ProcessQueryFilterEnhancerOS queryFilterEnhancer;
+  @Mock private ProcessGroupByInterpreterFacadeOS groupByInterpreter;
+  @Mock private ProcessViewInterpreterFacadeOS viewInterpreter;
+  @Mock private ConfigurationService configurationService;
+
+  @SuppressWarnings("unchecked")
+  @Mock
+  private ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context;
+
+  private GenericProcessExecutionPlanInterpreterOS underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest =
+        new GenericProcessExecutionPlanInterpreterOS(
+            processDefinitionReader,
+            osClient,
+            queryFilterEnhancer,
+            groupByInterpreter,
+            viewInterpreter,
+            configurationService);
+  }
+
+  @Test
+  void shouldExcludeAllInstancesForManagementReportWithNoDefinitions() {
+    // given a management report whose user has access to no definitions
+    // (lenient: the management branch does not apply filterQueries today, but stubbing guards
+    // against an NPE should it start to)
+    lenient().when(queryFilterEnhancer.filterQueries(any(), any())).thenReturn(List.of());
+    final BoolQuery baseQuery = buildBaseQuery(reportData(true, List.of()));
+
+    // then all instances are excluded via a (not match-all) filter clause
+    assertThat(baseQuery.filter())
+        .anySatisfy(
+            query -> {
+              assertThat(query._kind()).isEqualTo(Query.Kind.Bool);
+              assertThat(query.bool().mustNot())
+                  .anySatisfy(
+                      mustNot -> assertThat(mustNot._kind()).isEqualTo(Query.Kind.MatchAll));
+            });
+  }
+
+  @Test
+  void shouldNotExcludeAllInstancesForNonManagementReportWithNoDefinitions() {
+    // given a non-management report with no definitions (e.g. a seeded dashboard report)
+    when(queryFilterEnhancer.filterQueries(any(), any())).thenReturn(List.of());
+    final BoolQuery baseQuery = buildBaseQuery(reportData(false, List.of()));
+
+    // then no exclude-all clause and no definition-scoping clause is added, so other query filters
+    // apply across all instances
+    assertThat(baseQuery.filter()).isEmpty();
+    assertThat(baseQuery.should()).isEmpty();
+    assertThat(baseQuery.minimumShouldMatch()).isNull();
+  }
+
+  private BoolQuery buildBaseQuery(final ProcessReportDataDto reportData) {
+    when(context.getReportData()).thenReturn(reportData);
+    return underTest.baseQueryBuilder(context).build();
+  }
+
+  private static ProcessReportDataDto reportData(
+      final boolean managementReport, final List<ReportDataDefinitionDto> definitions) {
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    reportData.setManagementReport(managementReport);
+    reportData.setDefinitions(definitions);
+    return reportData;
+  }
+}

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.tsx
@@ -185,9 +185,13 @@ it('should include definitions in evaluate calls when a process is selected', as
     .prop('loadTile') as (id: string, filter: unknown[], params: unknown) => void;
   loadTile('report-id', [], {});
 
-  expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, [
-    {key: 'my-process', versions: ['all']},
-  ]);
+  expect(evaluateReport).toHaveBeenCalledWith(
+    'report-id',
+    [],
+    {},
+    [{key: 'my-process', versions: ['all']}],
+    'week'
+  );
 });
 
 it('should pass empty definitions in evaluate calls when no process is selected', async () => {
@@ -200,5 +204,20 @@ it('should pass empty definitions in evaluate calls when no process is selected'
     .prop('loadTile') as (id: string, filter: unknown[], params: unknown) => void;
   loadTile('report-id', [], {});
 
-  expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, []);
+  expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, [], 'week');
+});
+
+it('should derive the groupByDateUnit from the selected preset', async () => {
+  const node = shallow(<AgenticControlPlane />);
+  await runAllEffects();
+
+  (node.find('FilterBar').prop('onPresetChange') as (v: string) => void)('7d');
+
+  const loadTile = node
+    .find('.kpi-section')
+    .find('DashboardRenderer')
+    .prop('loadTile') as (id: string, filter: unknown[], params: unknown) => void;
+  loadTile('report-id', [], {});
+
+  expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, [], 'day');
 });

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
@@ -43,12 +43,6 @@ interface RollingFilter {
   };
 }
 
-function presetToGroupByDateUnit(presetId: string): string {
-  if (presetId === '7d') return 'day';
-  if (presetId === '30d') return 'week';
-  return 'month';
-}
-
 function presetToFilter(preset: (typeof DATE_PRESETS)[number]): RollingFilter {
   return {
     type: 'instanceEndDate',
@@ -74,7 +68,6 @@ export function AgenticControlPlane() {
   }, [mightFail]);
 
   const selectedPreset = DATE_PRESETS.find((p) => p.id === preset)!;
-  const definitions = processScope ? [{key: processScope, versions: ['all']}] : [];
   const filter = [presetToFilter(selectedPreset)];
 
   const scopedEvaluateReport = useCallback(
@@ -82,18 +75,11 @@ export function AgenticControlPlane() {
       id: ReportEvaluationPayload,
       tileFilter: Parameters<typeof evaluateReport>[1],
       query: Parameters<typeof evaluateReport>[2]
-    ) => evaluateReport(id, tileFilter, query, definitions),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [processScope]
-  );
-
-  const scopedEvaluateTokenTrendReport = useCallback(
-    (
-      id: ReportEvaluationPayload,
-      tileFilter: Parameters<typeof evaluateReport>[1],
-      query: Parameters<typeof evaluateReport>[2]
-    ) => evaluateReport(id, tileFilter, query, definitions, presetToGroupByDateUnit(preset)),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    ) => {
+      const definitions = processScope ? [{key: processScope, versions: ['all']}] : [];
+      const groupByDateUnit = DATE_PRESETS.find((p) => p.id === preset)!.groupByDateUnit;
+      return evaluateReport(id, tileFilter, query, definitions, groupByDateUnit);
+    },
     [processScope, preset]
   );
 
@@ -117,7 +103,7 @@ export function AgenticControlPlane() {
     {
       key: 'token',
       titleKey: 'agenticControlPlane.tokenUsage',
-      loadTile: scopedEvaluateTokenTrendReport,
+      loadTile: scopedEvaluateReport,
     },
     {
       key: 'reliabilityAndToolCalls',

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.tsx
@@ -17,15 +17,40 @@ import {t} from 'translation';
 import './FilterBar.scss';
 
 export const DATE_PRESETS = [
-  {id: '7d', translationKey: 'agenticControlPlane.presets.last7Days', value: 7, unit: 'days'},
-  {id: '30d', translationKey: 'agenticControlPlane.presets.last30Days', value: 30, unit: 'days'},
-  {id: '3m', translationKey: 'agenticControlPlane.presets.last3Months', value: 3, unit: 'months'},
-  {id: '6m', translationKey: 'agenticControlPlane.presets.last6Months', value: 6, unit: 'months'},
+  {
+    id: '7d',
+    translationKey: 'agenticControlPlane.presets.last7Days',
+    value: 7,
+    unit: 'days',
+    groupByDateUnit: 'day',
+  },
+  {
+    id: '30d',
+    translationKey: 'agenticControlPlane.presets.last30Days',
+    value: 30,
+    unit: 'days',
+    groupByDateUnit: 'week',
+  },
+  {
+    id: '3m',
+    translationKey: 'agenticControlPlane.presets.last3Months',
+    value: 3,
+    unit: 'months',
+    groupByDateUnit: 'month',
+  },
+  {
+    id: '6m',
+    translationKey: 'agenticControlPlane.presets.last6Months',
+    value: 6,
+    unit: 'months',
+    groupByDateUnit: 'month',
+  },
   {
     id: '12m',
     translationKey: 'agenticControlPlane.presets.last12Months',
     value: 12,
     unit: 'months',
+    groupByDateUnit: 'month',
   },
 ] as const;
 


### PR DESCRIPTION
## Description

Single source of truth for agentic date presets    

What
   - DATE_PRESETS now owns its groupByDateUnit per entry — the standalone presetToGroupByDateUnit mapping is gone.                                                                                  
   - Removed the dedicated scopedEvaluateTokenTrendReport callback; a single scopedEvaluateReport forwards the preset's unit on every report (the backend ignores it unless the report groups by date).                                                                                                    

Why
  - Two places encoded the same preset → date-unit knowledge. Consolidating onto the preset list removes the duplication and the extra callback (DRY/KISS).

Tests
   - Frontend: assert the forwarded unit and cover preset-to-unit derivation (22 passing).     
   - Backend: unit + IT coverage for process reports with no configured definitions — management reports exclude all instances; non-management evaluate across all definitions while still applying other filters (ES + OS interpreters + agentic KPI IT).                        

## Related issues

closes https://github.com/camunda/camunda/issues/55078
