### PR TITLE
perf: avoid heap copy when reading snapshot chunks

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
@@ -44,7 +44,7 @@ public final class SnapshotChunkImpl
     totalCount = chunk.getTotalCount();
     chunkName = chunk.getChunkName();
     checksum = chunk.getChecksum();
-    content.wrap(chunk.getContent());
+    content.wrap(chunk.getContentBuffer());
     fileBlockPosition = chunk.getFileBlockPosition();
     totalFileSize = chunk.getTotalFileSize();
   }
@@ -157,7 +157,7 @@ public final class SnapshotChunkImpl
   public long getTotalFileSize() {
     // backwards comptability
     if (totalFileSize == SnapshotChunkDecoder.totalFileSizeNullValue()) {
-      return getContent().length;
+      return content.capacity();
     }
 
     return totalFileSize;

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunk.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunk.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.snapshots;
 
+import java.nio.ByteBuffer;
+
 /** A chunk of an already persisted Snapshot. */
 public interface SnapshotChunk {
 
@@ -34,6 +36,13 @@ public interface SnapshotChunk {
    * @return the content of the current chunk
    */
   byte[] getContent();
+
+  /**
+   * @return the content of the current chunk as a {@link ByteBuffer}
+   */
+  default ByteBuffer getContentBuffer() {
+    return ByteBuffer.wrap(getContent()).asReadOnlyBuffer();
+  }
 
   /**
    * @return the index of the part of the chunk contents.

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.snapshots.impl;
 
 import io.camunda.zeebe.snapshots.SnapshotChunk;
 import io.camunda.zeebe.snapshots.SnapshotChunkReader;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
@@ -109,9 +110,9 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
     try (final var file = new RandomAccessFile(filePath, "r")) {
       final var fileLength = file.length();
       final var bytesToRead = Math.min(maximumChunkSize, fileLength - offset);
-      final byte[] buffer = new byte[(int) bytesToRead];
-      file.seek(offset);
-      file.readFully(buffer);
+      final var buffer = ByteBuffer.allocateDirect(Math.toIntExact(bytesToRead));
+      readFully(file, buffer, offset);
+      buffer.flip();
 
       final var fileBlockPosition = offset;
       offset += bytesToRead;
@@ -124,6 +125,19 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
           snapshotID, totalCount, fileName, buffer, fileBlockPosition, fileLength);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
+    }
+  }
+
+  private static void readFully(
+      final RandomAccessFile file, final ByteBuffer buffer, final long position)
+      throws IOException {
+    long bytesRead = 0;
+    while (buffer.hasRemaining()) {
+      final int read = file.getChannel().read(buffer, position + bytesRead);
+      if (read < 0) {
+        throw new EOFException("Unexpected end of snapshot chunk file");
+      }
+      bytesRead += read;
     }
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.snapshots.impl;
 
 import io.camunda.zeebe.snapshots.SnapshotChunk;
+import java.nio.ByteBuffer;
 import java.util.zip.CRC32C;
 import java.util.zip.Checksum;
 
@@ -16,8 +17,12 @@ final class SnapshotChunkUtil {
   private SnapshotChunkUtil() {}
 
   static long createChecksum(final byte[] content) {
+    return createChecksum(ByteBuffer.wrap(content));
+  }
+
+  static long createChecksum(final ByteBuffer content) {
     final Checksum checksum = newChecksum();
-    checksum.update(content);
+    checksum.update(content.asReadOnlyBuffer());
     return checksum.getValue();
   }
 
@@ -29,7 +34,7 @@ final class SnapshotChunkUtil {
       final String snapshotId,
       final int totalCount,
       final String fileName,
-      final byte[] fileData,
+      final ByteBuffer fileData,
       final long fileBlockPosition,
       final long totalFileSize) {
 
@@ -42,7 +47,7 @@ final class SnapshotChunkUtil {
     private final String snapshotId;
     private final int totalCount;
     private final String chunkName;
-    private final byte[] content;
+    private final ByteBuffer content;
     private final long checksum;
     private final long fileBlockPosition;
     private final long totalFileSize;
@@ -52,14 +57,14 @@ final class SnapshotChunkUtil {
         final int totalCount,
         final String chunkName,
         final long checksum,
-        final byte[] content,
+        final ByteBuffer content,
         final long fileBlockPosition,
         final long totalFileSize) {
       this.snapshotId = snapshotId;
       this.totalCount = totalCount;
       this.chunkName = chunkName;
       this.checksum = checksum;
-      this.content = content;
+      this.content = content.asReadOnlyBuffer().slice();
       this.fileBlockPosition = fileBlockPosition;
       this.totalFileSize = totalFileSize;
     }
@@ -86,7 +91,15 @@ final class SnapshotChunkUtil {
 
     @Override
     public byte[] getContent() {
-      return content;
+      final var contentBuffer = getContentBuffer();
+      final var bytes = new byte[contentBuffer.remaining()];
+      contentBuffer.get(bytes);
+      return bytes;
+    }
+
+    @Override
+    public ByteBuffer getContentBuffer() {
+      return content.asReadOnlyBuffer();
     }
 
     @Override

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
@@ -99,7 +99,10 @@ public final class FileBasedSnapshotChunkReaderTest {
         assertThat(chunk.getSnapshotId()).isEqualTo(snapshotDirectory.getFileName().toString());
         assertThat(chunk.getTotalCount()).isEqualTo(SNAPSHOT_CHUNK.size());
         assertThat(chunk.getChecksum())
-            .isEqualTo(SnapshotChunkUtil.createChecksum(chunk.getContent()));
+            .isEqualTo(SnapshotChunkUtil.createChecksum(chunk.getContentBuffer()));
+        assertThat(chunk.getContentBuffer())
+            .as("file chunks should expose direct buffers for snapshot replication")
+            .matches(ByteBuffer::isDirect);
         assertThat(snapshotDirectory.resolve(chunk.getChunkName()))
             .hasBinaryContent(chunk.getContent());
       }


### PR DESCRIPTION
## Description

Closes #53803.

Snapshot chunk replication currently reads file chunks into a `byte[]`, then wraps that array for the Atomix snapshot encoder. This keeps `SnapshotChunk#getContent()` for existing call sites, but adds a `ByteBuffer` view so the sender path can avoid materializing the byte array.

Changes included:
- read file chunks into direct `ByteBuffer`s in `FileBasedSnapshotChunkReader`
- expose `SnapshotChunk#getContentBuffer()` with a default byte-array-backed implementation for compatibility
- store file-based chunks as read-only buffers and only allocate a byte array when `getContent()` is explicitly requested
- let the Atomix snapshot encoder wrap the chunk buffer directly
- cover the file-based reader path with a regression assertion that chunks expose direct buffers

Validation:
- `gh run list --branch main --limit 5 --repo camunda/camunda`
- `./mvnw.cmd spotless:apply license:format -pl zeebe/snapshot,zeebe/atomix/cluster -T2`
- `./mvnw.cmd install -pl zeebe/snapshot,zeebe/atomix/cluster -am -Dquickly -T2`
- `./mvnw.cmd verify -pl zeebe/snapshot -Dtest=FileBasedSnapshotChunkReaderTest -DskipITs -Dquickly -DskipTests=false -T2`
- `git diff --check`

Backport: not requested in the issue; happy to add labels if maintainers want this in stable branches.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #53803