### PR TITLE
55289 tokens by process tile

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -16,8 +16,10 @@ import static io.camunda.optimize.service.dashboard.AgenticControlDashboardServi
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_CONSUMERS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_TREND_REPORT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
@@ -41,14 +43,17 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.filter.Insta
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.result.MeasureDto;
 import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
+import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
 import io.camunda.optimize.service.db.report.result.MapCommandResult;
 import io.camunda.optimize.service.db.report.result.NumberCommandResult;
+import io.camunda.optimize.service.exceptions.evaluation.ReportEvaluationException;
 import io.camunda.optimize.service.report.ReportEvaluationService;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -937,9 +942,106 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   // ---------------------------------------------------------------------------
-  // Combined: process definition + date range
+  // Top token consumers by process
   // ---------------------------------------------------------------------------
 
+  @Test
+  void shouldRankProcessesByTotalTokensConsumed() {
+    final String heavyProc = "heavy-agent-process";
+    final String lightProc = "light-agent-process";
+
+    // heavyProc consumes 450 tokens total, lightProc consumes 120
+    persistProcessInstances(
+        List.of(
+            agenticInstanceWithTokens(heavyProc, 200L, 100L).build(),
+            agenticInstanceWithTokens(heavyProc, 100L, 50L).build(),
+            agenticInstanceWithTokens(lightProc, 80L, 40L).build()));
+
+    // when evaluating the top-consumers report grouped by process definition key
+    final List<MapResultEntryDto> buckets = evaluateMapMeasure(TOKEN_CONSUMERS_REPORT_ID, 0);
+
+    // then each process appears with its summed total tokens, ranked with the heaviest first
+    assertThat(buckets)
+        .filteredOn(e -> e.getValue() != null)
+        .extracting(MapResultEntryDto::getKey)
+        .containsExactly(heavyProc, lightProc);
+    assertThat(buckets.stream().filter(e -> heavyProc.equals(e.getKey())).findFirst())
+        .hasValueSatisfying(e -> assertThat(e.getValue()).isCloseTo(450.0, within(1.0)));
+    assertThat(buckets.stream().filter(e -> lightProc.equals(e.getKey())).findFirst())
+        .hasValueSatisfying(e -> assertThat(e.getValue()).isCloseTo(120.0, within(1.0)));
+  }
+
+  @Test
+  void shouldReturnOnlyTopConsumersWithTotalCountWhenPaginated() {
+    // given three processes with distinct total token sums
+    persistProcessInstances(
+        List.of(
+            agenticInstanceWithTokens("proc-a", 300L, 0L).build(),
+            agenticInstanceWithTokens("proc-b", 200L, 0L).build(),
+            agenticInstanceWithTokens("proc-c", 100L, 0L).build()));
+
+    // when evaluating the top-consumers report limited to the two heaviest processes
+    // (limit only, no offset — mirroring how the dashboard frontend requests the tile)
+    final var result =
+        evaluationService.evaluateSavedReportWithAdditionalFilters(
+            USER_ID, UTC, TOKEN_CONSUMERS_REPORT_ID, noExtraFilters(), new PaginationDto(2, null));
+    final CommandEvaluationResult<?> commandResult =
+        ((SingleReportEvaluationResult<?>) result.getEvaluationResult()).getFirstCommandResult();
+    final List<MapResultEntryDto> buckets =
+        ((MapCommandResult) commandResult).getMeasures().getFirst().getData();
+
+    // then only the two heaviest processes are returned, ranked descending
+    assertThat(buckets)
+        .filteredOn(e -> e.getValue() != null)
+        .extracting(MapResultEntryDto::getKey)
+        .containsExactly("proc-a", "proc-b");
+    // and the total distinct process count is surfaced for the "top N of total" label
+    assertThat(commandResult.getPagination().getTotal()).isEqualTo(3L);
+    // and the pagination is valid, so it survives REST mapping and the total reaches the frontend
+    assertThat(commandResult.getPagination().isValid()).isTrue();
+  }
+
+  @Test
+  void shouldRejectNonZeroOffsetForGroupedTopNReport() {
+    // given a top-consumers report (grouped top-N supports a limit but not paging into results)
+    persistProcessInstances(List.of(agenticInstanceWithTokens("proc-a", 300L, 0L).build()));
+
+    // when evaluating it with a non-zero pagination offset
+    final ThrowingCallable evaluation =
+        () ->
+            evaluationService.evaluateSavedReportWithAdditionalFilters(
+                USER_ID, UTC, TOKEN_CONSUMERS_REPORT_ID, noExtraFilters(), new PaginationDto(2, 1));
+
+    // then the request is rejected rather than silently returning a first page
+    assertThatThrownBy(evaluation)
+        .isInstanceOf(ReportEvaluationException.class)
+        .hasMessageContaining("non-zero pagination offset");
+  }
+
+  @Test
+  void shouldRejectNonZeroOffsetWithoutLimitForGroupedTopNReport() {
+    // given a top-consumers report (grouped top-N supports a limit but not paging into results)
+    persistProcessInstances(List.of(agenticInstanceWithTokens("proc-a", 300L, 0L).build()));
+
+    // when evaluating it with a non-zero offset but no limit
+    final ThrowingCallable evaluation =
+        () ->
+            evaluationService.evaluateSavedReportWithAdditionalFilters(
+                USER_ID,
+                UTC,
+                TOKEN_CONSUMERS_REPORT_ID,
+                noExtraFilters(),
+                new PaginationDto(null, 1));
+
+    // then the request is rejected rather than silently ignoring the offset
+    assertThatThrownBy(evaluation)
+        .isInstanceOf(ReportEvaluationException.class)
+        .hasMessageContaining("non-zero pagination offset");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Combined: process definition + date range
+  // ---------------------------------------------------------------------------
   @Test
   void shouldApplyDefinitionAndDateFilterTogether() {
     final String procKeyA = "proc-combo-a";

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -32,10 +32,13 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.util.ProcessFilterBuilder;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.EndDateGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.NoneGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionKeyGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionVersionGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.value.DateGroupByValueDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
+import io.camunda.optimize.dto.optimize.query.sorting.ReportSortingDto;
+import io.camunda.optimize.dto.optimize.query.sorting.SortOrder;
 import io.camunda.optimize.service.db.reader.DashboardReader;
 import io.camunda.optimize.service.db.writer.DashboardWriter;
 import io.camunda.optimize.service.db.writer.ReportWriter;
@@ -82,6 +85,13 @@ public class AgenticControlDashboardService {
   public static final String KPI_TOKEN_TREND_FOOTNOTE = "agenticKpiTokenTrendFootnote";
   public static final String KPI_TOKEN_TREND_FOOTNOTE_KEY =
       "agenticControl.report." + KPI_TOKEN_TREND_FOOTNOTE;
+  public static final String KPI_TOKEN_CONSUMERS_NAME = "agenticKpiTokenConsumersName";
+  public static final String KPI_TOKEN_CONSUMERS_FOOTNOTE = "agenticKpiTokenConsumersFootnote";
+  public static final String KPI_TOKEN_CONSUMERS_FOOTNOTE_KEY =
+      "agenticControl.report." + KPI_TOKEN_CONSUMERS_FOOTNOTE;
+  // Only the top N process definitions by total tokens are returned by the tile; the backend
+  // computes this server-side via report pagination so it scales to very large data sets.
+  public static final int TOKEN_CONSUMERS_LIMIT = 10;
   public static final String KPI_DURATION_P50_NAME = "agenticKpiDurationP50Name";
   public static final String KPI_DURATION_P50_DESCRIPTION = "agenticKpiDurationP50Description";
   public static final String KPI_DURATION_P95_NAME = "agenticKpiDurationP95Name";
@@ -114,6 +124,8 @@ public class AgenticControlDashboardService {
           .toString();
   public static final String TOKEN_TREND_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-token-trend".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String TOKEN_CONSUMERS_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-token-consumers".getBytes(StandardCharsets.UTF_8)).toString();
   public static final String KPI_DURATION_P50_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-duration-p50".getBytes(StandardCharsets.UTF_8)).toString();
   public static final String KPI_DURATION_P95_REPORT_ID =
@@ -123,6 +135,17 @@ public class AgenticControlDashboardService {
           .toString();
 
   private static final long INSTANCE_END_DATE_ROLLING_DAYS = 30L;
+
+  // Tile configuration keys consumed by the Agentic Control Plane frontend.
+  private static final String TILE_CONFIG_SECTION = "section";
+  private static final String TILE_CONFIG_FOOTNOTE = "footnote";
+  private static final String TILE_CONFIG_TOP_N = "topN";
+  // When set, the frontend only renders the tile at the dashboard root (L0) and hides it once a
+  // single process is selected, where a per-process breakdown is no longer meaningful.
+  private static final String TILE_CONFIG_VISIBLE_IN_L0_ONLY = "visibleInL0Only";
+  // Section values that group tiles within the dashboard layout.
+  private static final String TILE_SECTION_TOKEN = "token";
+  private static final String TILE_SECTION_DURATION = "duration";
 
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(AgenticControlDashboardService.class);
@@ -163,6 +186,7 @@ public class AgenticControlDashboardService {
     tiles.add(buildMedianTokensReport());
     tiles.add(buildDurationStabilityReport());
     tiles.add(buildTokenTrendReport());
+    tiles.add(buildTopTokenConsumersReport());
     tiles.add(buildP50DurationReport());
     tiles.add(buildP95DurationReport());
     tiles.add(buildFailureRateByVersionReport());
@@ -320,7 +344,8 @@ public class AgenticControlDashboardService {
             .build();
     reportWriter.createOrUpdateSingleProcessReport(
         id, null, reportData, nameKey, descriptionKey, null);
-    return buildTile(id, position, new DimensionDto(9, 2), Map.of("section", "token"));
+    return buildTile(
+        id, position, new DimensionDto(9, 2), Map.of(TILE_CONFIG_SECTION, TILE_SECTION_TOKEN));
   }
 
   private DashboardReportTileDto buildTokenTrendReport() {
@@ -331,7 +356,11 @@ public class AgenticControlDashboardService {
         TOKEN_TREND_REPORT_ID,
         new PositionDto(0, 4),
         new DimensionDto(9, 4),
-        Map.of("section", "token", "footnote", KPI_TOKEN_TREND_FOOTNOTE_KEY));
+        Map.of(
+            TILE_CONFIG_SECTION,
+            TILE_SECTION_TOKEN,
+            TILE_CONFIG_FOOTNOTE,
+            KPI_TOKEN_TREND_FOOTNOTE_KEY));
   }
 
   // A single multi-measure report (input + output tokens) renders both series as separate lines,
@@ -353,6 +382,57 @@ public class AgenticControlDashboardService {
                 .aggregationTypes(
                     new LinkedHashSet<>(
                         Collections.singletonList(new AggregationDto(AggregationType.SUM))))
+                .build())
+        .filter(
+            ProcessFilterBuilder.filter()
+                .completedInstancesOnly()
+                .add()
+                .hasAgentInstances()
+                .add()
+                .buildList())
+        .agenticControlReport(true)
+        .build();
+  }
+
+  private DashboardReportTileDto buildTopTokenConsumersReport() {
+    reportWriter.createOrUpdateSingleProcessReport(
+        TOKEN_CONSUMERS_REPORT_ID,
+        null,
+        buildTopTokenConsumersReportData(),
+        KPI_TOKEN_CONSUMERS_NAME,
+        null,
+        null);
+    return buildTile(
+        TOKEN_CONSUMERS_REPORT_ID,
+        new PositionDto(0, 10),
+        new DimensionDto(18, 4),
+        Map.of(
+            TILE_CONFIG_SECTION,
+            TILE_SECTION_TOKEN,
+            TILE_CONFIG_FOOTNOTE,
+            KPI_TOKEN_CONSUMERS_FOOTNOTE_KEY,
+            TILE_CONFIG_TOP_N,
+            String.valueOf(TOKEN_CONSUMERS_LIMIT),
+            TILE_CONFIG_VISIBLE_IN_L0_ONLY,
+            Boolean.TRUE));
+  }
+
+  // Total tokens grouped by process definition key, rendered as a horizontal bar chart sorted
+  // descending so the heaviest token consumers surface at the top.
+  private ProcessReportDataDto buildTopTokenConsumersReportData() {
+    return ProcessReportDataDto.builder()
+        .definitions(Collections.emptyList())
+        .view(new ProcessViewDto(ProcessViewEntity.AGENT_INSTANCE, ViewProperty.TOTAL_TOKENS))
+        .groupBy(new ProcessDefinitionKeyGroupByDto())
+        .distributedBy(new NoneDistributedByDto())
+        .visualization(ProcessVisualization.BAR)
+        .configuration(
+            SingleReportConfigurationDto.builder()
+                .aggregationTypes(
+                    new LinkedHashSet<>(
+                        Collections.singletonList(new AggregationDto(AggregationType.SUM))))
+                .horizontalBar(true)
+                .sorting(new ReportSortingDto(ReportSortingDto.SORT_BY_VALUE, SortOrder.DESC))
                 .build())
         .filter(
             ProcessFilterBuilder.filter()
@@ -410,7 +490,11 @@ public class AgenticControlDashboardService {
             .build();
     reportWriter.createOrUpdateSingleProcessReport(
         reportId, null, reportData, nameKey, descriptionKey, null);
-    return buildTile(reportId, position, new DimensionDto(9, 2), Map.of("section", "duration"));
+    return buildTile(
+        reportId,
+        position,
+        new DimensionDto(9, 2),
+        Map.of(TILE_CONFIG_SECTION, TILE_SECTION_DURATION));
   }
 
   private DashboardReportTileDto buildDurationStabilityReport() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterES.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_AGENT_PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import co.elastic.clients.util.NamedValue;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
+import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
+import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Groups agentic token usage by process definition key and, when a limit-only pagination is
+ * supplied, returns only the top N process definitions by the configured measure. The top N is
+ * computed server-side (terms aggregation with {@code size=limit} ordered by the primary measure
+ * plus a cardinality sub-aggregation for the total count) so it scales to large data sets. All
+ * other behaviour is inherited from {@link ProcessGroupByProcessDefinitionKeyInterpreterES}, which
+ * is left untouched for every non-agentic process-definition-key report.
+ */
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class AgenticProcessDefinitionKeyGroupByInterpreterES
+    extends ProcessGroupByProcessDefinitionKeyInterpreterES {
+
+  // Must match the aggregation name used by the superclass so the inherited result handling finds
+  // the buckets.
+  private static final String PROCESS_DEFINITION_KEY_AGGREGATION = "processDefinitionKeyAgg";
+  private static final String PROCESS_DEFINITION_KEY_COUNT_AGGREGATION =
+      "processDefinitionKeyCountAgg";
+
+  public AgenticProcessDefinitionKeyGroupByInterpreterES(
+      final ConfigurationService configurationService,
+      final ProcessDistributedByInterpreterFacadeES distributedByInterpreter,
+      final ProcessViewInterpreterFacadeES viewInterpreter) {
+    super(configurationService, distributedByInterpreter, viewInterpreter);
+  }
+
+  @Override
+  public Set<ProcessGroupBy> getSupportedGroupBys() {
+    return Set.of(PROCESS_GROUP_BY_AGENT_PROCESS_DEFINITION_KEY);
+  }
+
+  @Override
+  public Map<String, Aggregation.Builder.ContainerBuilder> createAggregation(
+      final BoolQuery boolQuery,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final Map<String, Aggregation.Builder.ContainerBuilder> distributedByAggregations =
+        getDistributedByInterpreter().createAggregations(context, boolQuery);
+    final Optional<PaginationDto> topN = topNPagination(context);
+    if (topN.isEmpty() || distributedByAggregations.isEmpty()) {
+      // No limit requested: fall back to the full process-definition-key grouping.
+      return super.createAggregation(boolQuery, context);
+    }
+
+    // Return only the top N process definitions by the configured measure, computed server-side so
+    // we never fetch all buckets for large data sets.
+    final Aggregation.Builder.ContainerBuilder builder =
+        new Aggregation.Builder()
+            .terms(
+                terms ->
+                    terms
+                        .field(PROCESS_DEFINITION_KEY)
+                        .size(topN.get().getLimit())
+                        .order(
+                            NamedValue.of(
+                                primaryMeasureAggregationName(distributedByAggregations),
+                                SortOrder.Desc)));
+    distributedByAggregations.forEach((key, value) -> builder.aggregations(key, value.build()));
+
+    final Map<String, Aggregation.Builder.ContainerBuilder> aggregations = new LinkedHashMap<>();
+    aggregations.put(PROCESS_DEFINITION_KEY_AGGREGATION, builder);
+    aggregations.put(
+        PROCESS_DEFINITION_KEY_COUNT_AGGREGATION,
+        new Aggregation.Builder().cardinality(c -> c.field(PROCESS_DEFINITION_KEY)));
+    return aggregations;
+  }
+
+  @Override
+  protected void addQueryResult(
+      final CompositeCommandResult compositeCommandResult,
+      final ResponseBody<?> response,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    super.addQueryResult(compositeCommandResult, response, context);
+    topNPagination(context)
+        .ifPresent(
+            pagination -> {
+              final var countAggregation =
+                  response.aggregations().get(PROCESS_DEFINITION_KEY_COUNT_AGGREGATION);
+              if (countAggregation != null) {
+                pagination.setTotal((long) countAggregation.cardinality().value());
+              }
+            });
+  }
+
+  private Optional<PaginationDto> topNPagination(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    return context.getPagination().filter(pagination -> pagination.getLimit() != null);
+  }
+
+  // The distributed-by facade emits one sub-aggregation per measure; the first is the primary
+  // measure used to rank the top-N buckets.
+  private static String primaryMeasureAggregationName(
+      final Map<String, Aggregation.Builder.ContainerBuilder> distributedByAggregations) {
+    return distributedByAggregations.keySet().iterator().next();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterOS.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.groupby.process;
+
+import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.termAggregation;
+import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.withSubaggregations;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_AGENT_PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
+
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
+import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
+import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
+import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.TermsAggregation;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Groups agentic token usage by process definition key and, when a limit-only pagination is
+ * supplied, returns only the top N process definitions by the configured measure. The top N is
+ * computed server-side (terms aggregation with {@code size=limit} ordered by the primary measure
+ * plus a cardinality sub-aggregation for the total count) so it scales to large data sets. All
+ * other behaviour is inherited from {@link ProcessGroupByProcessDefinitionKeyInterpreterOS}, which
+ * is left untouched for every non-agentic process-definition-key report.
+ */
+@Component
+@Conditional(OpenSearchCondition.class)
+public class AgenticProcessDefinitionKeyGroupByInterpreterOS
+    extends ProcessGroupByProcessDefinitionKeyInterpreterOS {
+
+  // Must match the aggregation name used by the superclass so the inherited result handling finds
+  // the buckets.
+  private static final String PROCESS_DEFINITION_KEY_AGGREGATION = "processDefinitionKeyAgg";
+  private static final String PROCESS_DEFINITION_KEY_COUNT_AGGREGATION =
+      "processDefinitionKeyCountAgg";
+
+  public AgenticProcessDefinitionKeyGroupByInterpreterOS(
+      final ConfigurationService configurationService,
+      final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter,
+      final ProcessViewInterpreterFacadeOS viewInterpreter) {
+    super(configurationService, distributedByInterpreter, viewInterpreter);
+  }
+
+  @Override
+  public Set<ProcessGroupBy> getSupportedGroupBys() {
+    return Set.of(PROCESS_GROUP_BY_AGENT_PROCESS_DEFINITION_KEY);
+  }
+
+  @Override
+  public Map<String, Aggregation> createAggregation(
+      final Query query,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final Map<String, Aggregation> distributedByAggregations =
+        getDistributedByInterpreter().createAggregations(context, query);
+    final Optional<PaginationDto> topN = topNPagination(context);
+    if (topN.isEmpty() || distributedByAggregations.isEmpty()) {
+      // No limit requested: fall back to the full process-definition-key grouping.
+      return super.createAggregation(query, context);
+    }
+
+    // Return only the top N process definitions by the configured measure, computed server-side so
+    // we never fetch all buckets for large data sets.
+    final TermsAggregation termsAggregation =
+        termAggregation(
+            PROCESS_DEFINITION_KEY,
+            topN.get().getLimit(),
+            Map.of(primaryMeasureAggregationName(distributedByAggregations), SortOrder.Desc));
+    final Aggregation processDefinitionKeyAggregation =
+        withSubaggregations(termsAggregation, distributedByAggregations);
+
+    final Map<String, Aggregation> aggregations = new LinkedHashMap<>();
+    aggregations.put(PROCESS_DEFINITION_KEY_AGGREGATION, processDefinitionKeyAggregation);
+    aggregations.put(
+        PROCESS_DEFINITION_KEY_COUNT_AGGREGATION,
+        Aggregation.of(a -> a.cardinality(c -> c.field(PROCESS_DEFINITION_KEY))));
+    return aggregations;
+  }
+
+  @Override
+  protected void addQueryResult(
+      final CompositeCommandResult compositeCommandResult,
+      final SearchResponse<RawResult> response,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    super.addQueryResult(compositeCommandResult, response, context);
+    topNPagination(context)
+        .ifPresent(
+            pagination -> {
+              final var countAggregation =
+                  response.aggregations().get(PROCESS_DEFINITION_KEY_COUNT_AGGREGATION);
+              if (countAggregation != null) {
+                pagination.setTotal(countAggregation.cardinality().value());
+              }
+            });
+  }
+
+  private Optional<PaginationDto> topNPagination(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    return context.getPagination().filter(pagination -> pagination.getLimit() != null);
+  }
+
+  // The distributed-by facade emits one sub-aggregation per measure; the first is the primary
+  // measure used to rank the top-N buckets.
+  private static String primaryMeasureAggregationName(
+      final Map<String, Aggregation> distributedByAggregations) {
+    return distributedByAggregations.keySet().iterator().next();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/SingleReportEvaluator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/SingleReportEvaluator.java
@@ -71,21 +71,54 @@ public class SingleReportEvaluator {
         .peek(executionPlan -> validatePaginationValues(reportEvaluationContext, executionPlan));
   }
 
-  private <T extends ReportDefinitionDto<?>> void validatePaginationValues(
-      final ReportEvaluationContext<T> reportEvaluationContext, final ExecutionPlan executionPlan) {
+  private void validatePaginationValues(
+      final ReportEvaluationContext<?> reportEvaluationContext, final ExecutionPlan executionPlan) {
     if (executionPlan.isRawDataReport()) {
       addDefaultMissingPaginationValues(reportEvaluationContext);
-    } else {
-      reportEvaluationContext
-          .getPagination()
-          .ifPresent(
-              pagination -> {
-                if (pagination.getLimit() != null || pagination.getOffset() != null) {
-                  throw new OptimizeValidationException(
-                      "Pagination can only be applied to raw data reports");
-                }
-              });
+      return;
     }
+    if (executionPlan.supportsGroupByLimit()) {
+      validateGroupByLimitPagination(reportEvaluationContext);
+      return;
+    }
+    rejectPagination(reportEvaluationContext);
+  }
+
+  /**
+   * A grouped top-N request only carries a limit: the group-by interpreter applies {@code
+   * size=limit} but ignores the offset, so paging into the results is not supported. A non-zero
+   * offset is rejected rather than silently returning a first page that contradicts the request,
+   * and a missing offset is defaulted to 0. This keeps the resulting {@link
+   * io.camunda.optimize.dto.optimize.rest.pagination.PaginationScrollableDto} valid so the "top N
+   * of total" count is serialized back to the client, while injecting no limit and leaving every
+   * other report untouched.
+   */
+  private void validateGroupByLimitPagination(
+      final ReportEvaluationContext<?> reportEvaluationContext) {
+    reportEvaluationContext
+        .getPagination()
+        .ifPresent(
+            pagination -> {
+              if (pagination.getOffset() != null
+                  && pagination.getOffset() != PAGINATION_DEFAULT_OFFSET) {
+                throw new OptimizeValidationException(
+                    "A grouped top-N report only supports a limit; a non-zero pagination offset "
+                        + "is not supported");
+              }
+              pagination.setOffset(PAGINATION_DEFAULT_OFFSET);
+            });
+  }
+
+  private void rejectPagination(final ReportEvaluationContext<?> reportEvaluationContext) {
+    reportEvaluationContext
+        .getPagination()
+        .ifPresent(
+            pagination -> {
+              if (pagination.getLimit() != null || pagination.getOffset() != null) {
+                throw new OptimizeValidationException(
+                    "Pagination can only be applied to raw data reports");
+              }
+            });
   }
 
   private <T extends ReportDefinitionDto<?>> void addDefaultMissingPaginationValues(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/ExecutionPlan.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/ExecutionPlan.java
@@ -11,4 +11,10 @@ public interface ExecutionPlan {
   String getCommandKey();
 
   boolean isRawDataReport();
+
+  // Whether this plan supports server-side top-N limiting via a limit-only report pagination.
+  // Defaults to false so pagination stays rejected for every plan unless it explicitly opts in.
+  default boolean supportsGroupByLimit() {
+    return false;
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/process/ProcessExecutionPlan.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/process/ProcessExecutionPlan.java
@@ -20,6 +20,7 @@ import static io.camunda.optimize.service.db.report.plan.process.ProcessDistribu
 import static io.camunda.optimize.service.db.report.plan.process.ProcessDistributedBy.PROCESS_DISTRIBUTED_BY_PROCESS;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessDistributedBy.PROCESS_DISTRIBUTED_BY_USER_TASK;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessDistributedBy.PROCESS_DISTRIBUTED_BY_VARIABLE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_AGENT_PROCESS_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_ASSIGNEE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_CANDIDATE_GROUP;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_DURATION;
@@ -677,7 +678,7 @@ public enum ProcessExecutionPlan implements ExecutionPlan {
       MAP),
   PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_PROCESS_DEFINITION_KEY(
       PROCESS_VIEW_AGENT_TOTAL_TOKENS,
-      PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY,
+      PROCESS_GROUP_BY_AGENT_PROCESS_DEFINITION_KEY,
       PROCESS_DISTRIBUTED_BY_NONE,
       MAP),
   PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_NONE(
@@ -730,6 +731,11 @@ public enum ProcessExecutionPlan implements ExecutionPlan {
   @Override
   public boolean isRawDataReport() {
     return resultType == RAW_DATA;
+  }
+
+  @Override
+  public boolean supportsGroupByLimit() {
+    return groupBy.isTopNLimitSupported();
   }
 
   private String buildCommandKey() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/process/ProcessGroupBy.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/process/ProcessGroupBy.java
@@ -34,6 +34,11 @@ public enum ProcessGroupBy {
   PROCESS_GROUP_BY_PROCESS_INSTANCE_RUNNING_DATE(new RunningDateGroupByDto()),
   PROCESS_GROUP_BY_PROCESS_INSTANCE_START_DATE(new StartDateGroupByDto()),
   PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY(new ProcessDefinitionKeyGroupByDto()),
+  // Same group-by shape as PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY but routed to a dedicated
+  // interpreter that supports server-side top-N limiting (used by the agentic top token consumers
+  // tile). Reusing the same DTO keeps the report command key unchanged; the distinct enum value
+  // only selects the interpreter, and the flag advertises that a limit-only pagination is allowed.
+  PROCESS_GROUP_BY_AGENT_PROCESS_DEFINITION_KEY(new ProcessDefinitionKeyGroupByDto(), true),
   PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION(new ProcessDefinitionVersionGroupByDto()),
   PROCESS_GROUP_BY_NONE(new NoneGroupByDto()),
   PROCESS_INCIDENT_GROUP_BY_NONE(new NoneGroupByDto()),
@@ -44,12 +49,22 @@ public enum ProcessGroupBy {
   PROCESS_GROUP_BY_VARIABLE(new VariableGroupByDto());
 
   private final ProcessGroupByDto<?> dto;
+  private final boolean topNLimitSupported;
 
   private ProcessGroupBy(final ProcessGroupByDto<?> dto) {
+    this(dto, false);
+  }
+
+  private ProcessGroupBy(final ProcessGroupByDto<?> dto, final boolean topNLimitSupported) {
     this.dto = dto;
+    this.topNLimitSupported = topNLimitSupported;
   }
 
   public ProcessGroupByDto<?> getDto() {
     return this.dto;
+  }
+
+  public boolean isTopNLimitSupported() {
+    return topNLimitSupported;
   }
 }

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -8,6 +8,7 @@
     "tokenUsage": "Token-Nutzung",
     "reliabilityAndToolCalls": "Zuverlässigkeit & Tool-Aufrufe",
     "duration": "Dauer",
+    "topNNotice": "Top {shown} von {total}.",
     "presets": {
       "last7Days": "Letzte 7 Tage",
       "last30Days": "Letzte 30 Tage",
@@ -1570,6 +1571,8 @@
       "agenticDurationStabilityDescription": "P50- und P95-Ausführungsdauer abgeschlossener agentischer Prozessinstanzen über die Zeit im gewählten Zeitraum.",
       "agenticKpiTokenTrendName": "Token-Trend",
       "agenticKpiTokenTrendFootnote": "Wenn die Token-Nutzung ohne mehr Ausführungen steigt, wachsen möglicherweise die Prompts oder das Modell erzeugt längere Ausgaben. Engineering informieren.",
+      "agenticKpiTokenConsumersName": "Top-Token-Verbraucher nach Prozess",
+      "agenticKpiTokenConsumersFootnote": "Die Reduzierung des größten Verbrauchers hat die größte Auswirkung auf die gesamten Token-Kosten.",
       "agenticKpiDurationP50Name": "P50-Ausführungsdauer",
       "agenticKpiDurationP50Description": "Median (P50) der Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum.",
       "agenticKpiDurationP95Name": "P95-Ausführungsdauer",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -8,6 +8,7 @@
     "tokenUsage": "Token usage",
     "reliabilityAndToolCalls": "Reliability & Tool Calls",
     "duration": "Duration",
+    "topNNotice": "Top {shown} of {total}.",
     "presets": {
       "last7Days": "Last 7 days",
       "last30Days": "Last 30 days",
@@ -1570,6 +1571,8 @@
       "agenticDurationStabilityDescription": "P50 and P95 execution duration of completed agentic process instances over time in the selected period.",
       "agenticKpiTokenTrendName": "Token Trend",
       "agenticKpiTokenTrendFootnote": "If token use rises without more executions, prompts may be growing or the model is producing longer outputs. Raise with engineering.",
+      "agenticKpiTokenConsumersName": "Top token consumers by process",
+      "agenticKpiTokenConsumersFootnote": "Reducing the top consumer will have the biggest impact on overall token spend.",
       "agenticKpiDurationP50Name": "P50 execution duration",
       "agenticKpiDurationP50Description": "Median (P50) execution duration of completed agentic process instances in the selected period.",
       "agenticKpiDurationP95Name": "P95 execution duration",

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -42,7 +42,10 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.filter.Compl
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.HasAgentInstancesFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.EndDateGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionVersionGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessGroupByType;
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
+import io.camunda.optimize.dto.optimize.query.sorting.ReportSortingDto;
+import io.camunda.optimize.dto.optimize.query.sorting.SortOrder;
 import io.camunda.optimize.service.db.reader.DashboardReader;
 import io.camunda.optimize.service.db.writer.DashboardWriter;
 import io.camunda.optimize.service.db.writer.ReportWriter;
@@ -90,7 +93,7 @@ public class AgenticControlDashboardServiceTest {
     assertThat(saved.isAgenticControlDashboard()).isTrue();
     assertThat(saved.isManagementDashboard()).isFalse();
     assertThat(saved.getCollectionId()).isNull();
-    assertThat(saved.getTiles()).hasSize(10);
+    assertThat(saved.getTiles()).hasSize(11);
   }
 
   @Test
@@ -172,6 +175,7 @@ public class AgenticControlDashboardServiceTest {
             AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID,
             AgenticControlDashboardService.DURATION_STABILITY_REPORT_ID,
             AgenticControlDashboardService.TOKEN_TREND_REPORT_ID,
+            AgenticControlDashboardService.TOKEN_CONSUMERS_REPORT_ID,
             AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID,
             AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID,
             AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_REPORT_ID);
@@ -235,7 +239,7 @@ public class AgenticControlDashboardServiceTest {
     underTest.reconcile();
 
     // then reports are upserted and dashboard tiles are updated, but dashboard is not recreated
-    verify(reportWriter, times(10))
+    verify(reportWriter, times(11))
         .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
     verify(dashboardWriter, never()).saveDashboard(any());
     verify(dashboardWriter).updateDashboard(any(), any());
@@ -327,6 +331,8 @@ public class AgenticControlDashboardServiceTest {
               AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION,
               AgenticControlDashboardService.KPI_TOKEN_TREND_NAME,
               AgenticControlDashboardService.KPI_TOKEN_TREND_FOOTNOTE,
+              AgenticControlDashboardService.KPI_TOKEN_CONSUMERS_NAME,
+              AgenticControlDashboardService.KPI_TOKEN_CONSUMERS_FOOTNOTE,
               AgenticControlDashboardService.KPI_DURATION_P50_NAME,
               AgenticControlDashboardService.KPI_DURATION_P50_DESCRIPTION,
               AgenticControlDashboardService.KPI_DURATION_P95_NAME,
@@ -425,6 +431,17 @@ public class AgenticControlDashboardServiceTest {
   }
 
   @Test
+  void shouldDefineTopNNoticeLabelInEveryLocale() throws IOException {
+    for (final String locale : new String[] {"en", "de"}) {
+      final Map<String, Object> agenticControlPlane =
+          readLocalizationNode(locale, "agenticControlPlane");
+      assertThat(agenticControlPlane)
+          .as("locale '%s' must define agenticControlPlane.topNNotice", locale)
+          .containsKey("topNNotice");
+    }
+  }
+
+  @Test
   void shouldSeedTokenTrendReportWithBothTokenMeasures() {
     // given
     when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
@@ -497,6 +514,88 @@ public class AgenticControlDashboardServiceTest {
             any(),
             any(),
             any());
+  }
+
+  @Test
+  void shouldSeedTopTokenConsumersReportGroupedByProcessSortedDesc() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then a single total-tokens report grouped by process is seeded as a descending horizontal bar
+    assertThat(captureTopTokenConsumersReport())
+        .satisfies(
+            data -> {
+              assertThat(data.getView().getEntity()).isEqualTo(ProcessViewEntity.AGENT_INSTANCE);
+              assertThat(data.getView().getProperties()).containsExactly(ViewProperty.TOTAL_TOKENS);
+              assertThat(data.getGroupBy().getType())
+                  .isEqualTo(ProcessGroupByType.PROCESS_DEFINITION_KEY);
+              assertThat(data.getVisualization()).isEqualTo(ProcessVisualization.BAR);
+              assertThat(data.getConfiguration().getHorizontalBar()).isTrue();
+              assertThat(data.getConfiguration().getAggregationTypes())
+                  .extracting(AggregationDto::getType)
+                  .containsExactly(AggregationType.SUM);
+              assertThat(data.getConfiguration().getSorting())
+                  .hasValueSatisfying(
+                      sorting -> {
+                        assertThat(sorting.getBy()).contains(ReportSortingDto.SORT_BY_VALUE);
+                        assertThat(sorting.getOrder()).contains(SortOrder.DESC);
+                      });
+            });
+  }
+
+  @Test
+  void shouldPlaceTopTokenConsumersTileFullWidthBelowFailureRateByVersion() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then the consumers tile spans the full grid width directly below the failure-rate-by-version
+    // tile
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    final DashboardReportTileDto failureRate =
+        tileById(saved, AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_REPORT_ID);
+    final DashboardReportTileDto consumers =
+        tileById(saved, AgenticControlDashboardService.TOKEN_CONSUMERS_REPORT_ID);
+
+    assertThat(consumers.getPosition().getX()).isZero();
+    assertThat(consumers.getPosition().getY())
+        .isEqualTo(failureRate.getPosition().getY() + failureRate.getDimensions().getHeight());
+    assertThat(consumers.getDimensions().getWidth()).isEqualTo(18);
+
+    // and it advertises the server-side top-N limit for the frontend to request, and is only
+    // shown at the dashboard root (L0)
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> configuration = (Map<String, Object>) consumers.getConfiguration();
+    assertThat(configuration)
+        .containsEntry("topN", String.valueOf(AgenticControlDashboardService.TOKEN_CONSUMERS_LIMIT))
+        .containsEntry("visibleInL0Only", Boolean.TRUE);
+  }
+
+  private DashboardReportTileDto tileById(
+      final DashboardDefinitionRestDto dashboard, final String id) {
+    return dashboard.getTiles().stream()
+        .filter(tile -> id.equals(tile.getId()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private ProcessReportDataDto captureTopTokenConsumersReport() {
+    final ArgumentCaptor<ProcessReportDataDto> captor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.TOKEN_CONSUMERS_REPORT_ID),
+            isNull(),
+            captor.capture(),
+            eq(AgenticControlDashboardService.KPI_TOKEN_CONSUMERS_NAME),
+            isNull(),
+            isNull());
+    return captor.getValue();
   }
 
   @Test
@@ -603,6 +702,16 @@ public class AgenticControlDashboardServiceTest {
         getClass().getClassLoader().getResourceAsStream("localization/" + locale + ".json")) {
       final Map<String, Object> root = new ObjectMapper().readValue(in, Map.class);
       return (Map<String, Object>) root.get("agenticControl");
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> readLocalizationNode(final String locale, final String node)
+      throws IOException {
+    try (final InputStream in =
+        getClass().getClassLoader().getResourceAsStream("localization/" + locale + ".json")) {
+      final Map<String, Object> root = new ObjectMapper().readValue(in, Map.class);
+      return (Map<String, Object>) root.get(node);
     }
   }
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/plan/process/ProcessExecutionPlanTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/plan/process/ProcessExecutionPlanTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.report.plan.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class ProcessExecutionPlanTest {
+
+  @Test
+  void shouldSupportGroupByLimitOnlyForAgenticTotalTokensGroupedByProcessDefinitionKey() {
+    // given
+    final ProcessExecutionPlan agenticPlan =
+        ProcessExecutionPlan.PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_PROCESS_DEFINITION_KEY;
+
+    // then the agentic top consumers plan opts into server-side top-N limiting
+    assertThat(agenticPlan.supportsGroupByLimit()).isTrue();
+
+    // and no other plan does, so pagination stays rejected everywhere else
+    assertThat(Arrays.stream(ProcessExecutionPlan.values()))
+        .filteredOn(plan -> plan != agenticPlan)
+        .allSatisfy(plan -> assertThat(plan.supportsGroupByLimit()).isFalse());
+  }
+}

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.scss
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.scss
@@ -40,9 +40,21 @@
     margin: 0;
   }
 
-  .tile-footnote {
-    margin: 0.5rem 0 0;
-    padding-top: 0.5rem;
+  .tile-footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    column-gap: 0.25rem;
+
+    &:not(:empty) {
+      margin-top: 0.5rem;
+      padding-top: 0.5rem;
+    }
+  }
+
+  .tile-footnote,
+  .tile-topn-notice {
+    margin: 0;
     font-size: 0.75rem;
     line-height: 1.2;
     color: var(--cds-text-secondary);

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.tsx
@@ -202,3 +202,37 @@ it('should pass empty definitions in evaluate calls when no process is selected'
 
   expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, []);
 });
+
+it('should inject the configured top-N limit when evaluating a tile with a topN config', async () => {
+  const tiles = [
+    {id: 'consumers', configuration: {section: 'token', topN: '10'}, position: {x: 0, y: 0}},
+  ];
+  (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
+
+  const node = shallow(<AgenticControlPlane />);
+  await runAllEffects();
+
+  const loadTile = node
+    .find('.token-section')
+    .find('DashboardRenderer')
+    .prop('loadTile') as (id: string, filter: unknown[], params: unknown) => void;
+  loadTile('consumers', [], {});
+
+  expect(evaluateReport).toHaveBeenCalledWith('consumers', [], {limit: 10}, [], 'week');
+});
+
+it('should not inject a limit for token tiles without a topN config', async () => {
+  const tiles = [{id: 'token-trend', configuration: {section: 'token'}, position: {x: 0, y: 0}}];
+  (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
+
+  const node = shallow(<AgenticControlPlane />);
+  await runAllEffects();
+
+  const loadTile = node
+    .find('.token-section')
+    .find('DashboardRenderer')
+    .prop('loadTile') as (id: string, filter: unknown[], params: unknown) => void;
+  loadTile('token-trend', [], {});
+
+  expect(evaluateReport).toHaveBeenCalledWith('token-trend', [], {}, [], 'week');
+});

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useState, useEffect, useCallback} from 'react';
+import {useState, useEffect, useCallback, useMemo} from 'react';
 
 import {useErrorHandling} from 'hooks';
 import {showError} from 'notifications';
@@ -20,7 +20,8 @@ import type {DashboardTile} from 'types';
 
 import {DATE_PRESETS, FilterBar} from './FilterBar';
 import {loadAgenticDashboard} from './service';
-import {TileFootnote} from './TileFootnote';
+import {TileFooter} from './TileFooter';
+import {getTileTopNLimit} from './tilePagination';
 
 import './AgenticControlPlane.scss';
 
@@ -29,6 +30,7 @@ interface AgenticTileConfiguration {
   visibleInL1Only?: boolean;
   section?: string;
   footnote?: string;
+  topN?: string;
 }
 
 interface RollingFilter {
@@ -87,14 +89,37 @@ export function AgenticControlPlane() {
     [processScope]
   );
 
+  const tileLimitById = useMemo(() => {
+    const map: Record<string, number> = {};
+    dashboard?.tiles?.forEach((tile) => {
+      const limit = getTileTopNLimit(tile);
+      if (limit != null && tile.id) {
+        map[tile.id] = limit;
+      }
+    });
+    return map;
+  }, [dashboard]);
+
   const scopedEvaluateTokenTrendReport = useCallback(
     (
       id: ReportEvaluationPayload,
       tileFilter: Parameters<typeof evaluateReport>[1],
       query: Parameters<typeof evaluateReport>[2]
-    ) => evaluateReport(id, tileFilter, query, definitions, presetToGroupByDateUnit(preset)),
+    ) => {
+      // The top consumers tile only renders the top N processes; the backend computes that
+      // subset server-side when a limit is supplied, so we never fetch every process.
+      const limit = typeof id === 'string' ? tileLimitById[id] : undefined;
+      const scopedQuery = limit ? {...query, limit} : query;
+      return evaluateReport(
+        id,
+        tileFilter,
+        scopedQuery,
+        definitions,
+        presetToGroupByDateUnit(preset)
+      );
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [processScope, preset]
+    [processScope, preset, tileLimitById]
   );
 
   if (!dashboard) {
@@ -158,7 +183,7 @@ export function AgenticControlPlane() {
                 loadTile={loadTile}
                 tiles={tiles}
                 filter={filter}
-                addons={[<TileFootnote key="tile-footnote" />]}
+                addons={[<TileFooter key="tile-footer" />]}
               />
             </div>
           </div>

--- a/optimize/client/src/components/AgenticControlPlane/TileFooter.test.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/TileFooter.test.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {shallow} from 'enzyme';
+
+import {TileFooter} from './TileFooter';
+import {TopNNotice} from './TopNNotice';
+import {TileFootnote} from './TileFootnote';
+
+it('should render the top-N notice and the footnote inside a single footer row', () => {
+  const tile = {configuration: {topN: '10', footnote: 'someKey'}} as never;
+  const data = {result: {pagination: {total: 60}}} as never;
+
+  const node = shallow(<TileFooter tile={tile} data={data} />);
+
+  expect(node.find('.tile-footer')).toHaveLength(1);
+  expect(node.find(TopNNotice)).toHaveLength(1);
+  expect(node.find(TileFootnote)).toHaveLength(1);
+});

--- a/optimize/client/src/components/AgenticControlPlane/TileFooter.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/TileFooter.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {DashboardTile, Report} from 'types';
+
+import {TopNNotice} from './TopNNotice';
+import {TileFootnote} from './TileFootnote';
+
+interface TileFooterProps {
+  tile?: DashboardTile;
+  data?: Report;
+}
+
+// Renders the top-N notice and the footnote inline on a single row. The tile root is a flex
+// column, so the two notices would otherwise stack; wrapping them in one flex item keeps them
+// side by side. Each notice still decides on its own whether it renders anything.
+export function TileFooter({tile, data}: TileFooterProps) {
+  return (
+    <div className="tile-footer">
+      <TopNNotice tile={tile} data={data} />
+      <TileFootnote tile={tile} />
+    </div>
+  );
+}

--- a/optimize/client/src/components/AgenticControlPlane/TopNNotice.test.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/TopNNotice.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {shallow} from 'enzyme';
+
+import {TopNNotice} from './TopNNotice';
+
+const tileWithTopN = {configuration: {topN: '10'}} as never;
+const dataWithTotal = (total: number) => ({result: {pagination: {total}}}) as never;
+
+it('should render nothing without a topN configuration', () => {
+  const node = shallow(<TopNNotice tile={{configuration: {}} as never} data={dataWithTotal(60)} />);
+
+  expect(node.isEmptyRender()).toBe(true);
+});
+
+it('should render nothing when no total is available', () => {
+  const node = shallow(<TopNNotice tile={tileWithTopN} data={{result: {}} as never} />);
+
+  expect(node.isEmptyRender()).toBe(true);
+});
+
+it('should render nothing when the total does not exceed the shown amount', () => {
+  const node = shallow(<TopNNotice tile={tileWithTopN} data={dataWithTotal(10)} />);
+
+  expect(node.isEmptyRender()).toBe(true);
+});
+
+it('should render a "Top N of total" notice when there are more entries than shown', () => {
+  const node = shallow(<TopNNotice tile={tileWithTopN} data={dataWithTotal(60)} />);
+
+  expect(node.find('.tile-topn-notice').text()).toBe('Top 10 of 60.');
+});

--- a/optimize/client/src/components/AgenticControlPlane/TopNNotice.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/TopNNotice.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {t} from 'translation';
+
+import type {DashboardTile, Report} from 'types';
+
+import {getResultTotal, getTileTopNLimit} from './tilePagination';
+
+interface TopNNoticeProps {
+  tile?: DashboardTile;
+  data?: Report;
+}
+
+export function TopNNotice({tile, data}: Readonly<TopNNoticeProps>) {
+  const topN = getTileTopNLimit(tile);
+  const total = getResultTotal(data);
+  // Only surface the notice when the backend truncated the result to the top N.
+  if (topN == null || total == null || total <= topN) {
+       return null;
+  }
+  return <p className="tile-topn-notice">{t('agenticControlPlane.topNNotice', {shown: topN, total})}</p>;
+}

--- a/optimize/client/src/components/AgenticControlPlane/tilePagination.test.ts
+++ b/optimize/client/src/components/AgenticControlPlane/tilePagination.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {DashboardTile} from 'types';
+
+import {getTileTopNLimit} from './tilePagination';
+
+const tileWithTopN = (topN?: unknown): DashboardTile =>
+  ({configuration: {topN}}) as unknown as DashboardTile;
+
+it('should return the parsed limit for a positive integer string', () => {
+  expect(getTileTopNLimit(tileWithTopN('5'))).toBe(5);
+});
+
+it('should return undefined when the tile is missing', () => {
+  expect(getTileTopNLimit(undefined)).toBeUndefined();
+});
+
+it('should return undefined when topN is not configured', () => {
+  expect(getTileTopNLimit(tileWithTopN(undefined))).toBeUndefined();
+});
+
+it('should return undefined for a non-numeric value', () => {
+  expect(getTileTopNLimit(tileWithTopN('abc'))).toBeUndefined();
+});
+
+it('should return undefined for a non-integer value', () => {
+  expect(getTileTopNLimit(tileWithTopN('5.5'))).toBeUndefined();
+});
+
+it('should return undefined for zero or negative values', () => {
+  expect(getTileTopNLimit(tileWithTopN('0'))).toBeUndefined();
+  expect(getTileTopNLimit(tileWithTopN('-3'))).toBeUndefined();
+});

--- a/optimize/client/src/components/AgenticControlPlane/tilePagination.ts
+++ b/optimize/client/src/components/AgenticControlPlane/tilePagination.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {DashboardTile, Report} from 'types';
+
+interface TopNTileConfiguration {
+  topN?: string;
+}
+
+interface PaginatedReportResult {
+  pagination?: {total?: number};
+}
+
+// Returns the configured server-side top-N limit for a tile, or undefined when the tile does not
+// opt into pagination or the configured value is not a positive integer. Centralises the
+// string-to-number parsing of the `topN` tile configuration.
+export function getTileTopNLimit(tile?: DashboardTile): number | undefined {
+  const topN = (tile?.configuration as TopNTileConfiguration | undefined)?.topN;
+  if (!topN) {
+    return undefined;
+  }
+  const parsed = Number(topN);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+// Returns the total number of grouped results reported by the backend pagination, or undefined
+// when the evaluation result is not paginated. Centralises the cast over the untyped report result.
+export function getResultTotal(data?: Report): number | undefined {
+  return (data?.result as PaginatedReportResult | undefined)?.pagination?.total;
+}

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.js
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.js
@@ -187,7 +187,7 @@ export default function OptimizeReportTile({
           }
         />
       </div>
-      {children?.({loadTileData: refreshTile})}
+      {children?.({loadTileData: refreshTile, data})}
     </div>
   );
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationDto.java
@@ -8,12 +8,19 @@
 package io.camunda.optimize.dto.optimize.rest.pagination;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Objects;
 
 public class PaginationDto {
 
   protected Integer limit;
   protected Integer offset;
+
+  // Total number of available entries. Only populated by reports that compute a top-N subset
+  // server-side (e.g. grouped top-N reports) so the UI can render "top N of total"; omitted from
+  // serialization for every other report so their response shape is unchanged.
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  protected Long total;
 
   public PaginationDto(final Integer limit, final Integer offset) {
     this.limit = limit;
@@ -51,6 +58,14 @@ public class PaginationDto {
     this.offset = offset;
   }
 
+  public Long getTotal() {
+    return total;
+  }
+
+  public void setTotal(final Long total) {
+    this.total = total;
+  }
+
   protected boolean canEqual(final Object other) {
     return other instanceof PaginationDto;
   }
@@ -61,16 +76,24 @@ public class PaginationDto {
       return false;
     }
     final PaginationDto that = (PaginationDto) o;
-    return Objects.equals(limit, that.limit) && Objects.equals(offset, that.offset);
+    return Objects.equals(limit, that.limit)
+        && Objects.equals(offset, that.offset)
+        && Objects.equals(total, that.total);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(limit, offset);
+    return Objects.hash(limit, offset, total);
   }
 
   @Override
   public String toString() {
-    return "PaginationDto(limit=" + getLimit() + ", offset=" + getOffset() + ")";
+    return "PaginationDto(limit="
+        + getLimit()
+        + ", offset="
+        + getOffset()
+        + ", total="
+        + getTotal()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableDto.java
@@ -26,6 +26,7 @@ public class PaginationScrollableDto extends PaginationDto {
     final PaginationScrollableDto paginationObject = new PaginationScrollableDto();
     paginationObject.limit = pagination.getLimit();
     paginationObject.offset = pagination.getOffset();
+    paginationObject.total = pagination.getTotal();
     if (pagination instanceof PaginationScrollableDto) {
       paginationObject.scrollId = ((PaginationScrollableDto) pagination).getScrollId();
       paginationObject.scrollTimeout = ((PaginationScrollableDto) pagination).getScrollTimeout();


### PR DESCRIPTION
## Description

Add "Top token consumers by process" tile to the Agentic Control Plane      
                                                                                                                      
  What 

  Adds a new dashboard tile that ranks processes by total token consumption, rendered as a descending horizontal bar chart so the heaviest token consumers surface at the top. The tile shows only the top N processes (default 10) with a "Top N of total" notice and a footnote pointing users to where token-spend reductions have the biggest impact.

  How

   - Server-side top-N: the report groups by process definition key and computes the top N entirely in the search backend (ES/OS terms agg with size=limit ordered by the measure, plus a cardinality sub-agg for the total count), so it scales to large data sets without fetching every bucket. 
   - Pagination plumbing: PaginationDto gains a total field, populated only by grouped top-N reports and surfaced to the UI. SingleReportEvaluator treats grouped top-N as limit-only — it defaults a missing offset to 0 and rejects a non-zero offset rather than returning a page that contradicts the request. 
   - Opt-in gating: ProcessReportDataDto.isGroupByPaginationSupported() is narrowed to agentic control reports grouped by process definition key, so all other reports keep rejecting pagination as before.                                                                                                                                                                                          
   - Frontend: new TileFooter/TopNNotice components and a tilePagination helper (with validated top-N parsing) render the "Top N of total" notice; the tile evaluation injects the configured limit.                                                                                                                                                                                            

  Testing

   - Backend: unit tests for ProcessReportDataDto pagination support, dashboard service tile construction, ES/OS interpreter aggregations; IT coverage for the tile and for offset rejection. 
   - Frontend: tests for tilePagination, TopNNotice, TileFooter, and the control plane integration.  

## Related issues

closes https://github.com/camunda/camunda/issues/55289
