### PR TITLE
perf: avoid wrapping broker responses as exceptions

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
@@ -96,7 +96,9 @@ public class FlowControlServiceImpl implements FlowControlService {
                   request.setBrokerId(brokerId);
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
-                  return client.sendRequest(request);
+                  return client
+                      .sendRequest(request)
+                      .thenApply(response -> response.getResponseOrThrow());
                 })
             .toArray(CompletableFuture<?>[]::new);
     return CompletableFuture.allOf(requests);
@@ -117,9 +119,10 @@ public class FlowControlServiceImpl implements FlowControlService {
     return client
         .sendRequest(request)
         .thenApply(
-            response ->
-                new FlowControlStatus(
-                    partitionId, LimitSerializer.deserialize(response.getResponse().getPayload())));
+            response -> {
+              final var payload = response.getResponseOrThrow().getPayload();
+              return new FlowControlStatus(partitionId, LimitSerializer.deserialize(payload));
+            });
   }
 
   private HashSet<BrokerMemberId> getMembers(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
@@ -12,7 +12,10 @@ import static java.lang.Long.max;
 import io.camunda.zeebe.backup.common.CheckpointIdGenerator;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
@@ -169,9 +172,24 @@ public final class BackupRequestHandler implements BackupApi {
                       ignored ->
                           responses.stream()
                               .map(CompletableFuture::join)
-                              .map(BrokerResponse::getResponse)
+                              .map(BackupRequestHandler::getResponseOrThrow)
                               .collect(Collectors.toSet()));
             });
+  }
+
+  private static <R> R getResponseOrThrow(final BrokerResponse<R> response) {
+    if (response == null) {
+      throw new IllegalBrokerResponseException("Expected broker response, but received null");
+    } else if (response.isResponse()) {
+      return response.getResponse();
+    } else if (response.isError()) {
+      throw new BrokerErrorException(response.getError());
+    } else if (response.isRejection()) {
+      throw new BrokerRejectionException(response.getRejection());
+    }
+
+    throw new IllegalBrokerResponseException(
+        "Expected broker response to be either response, rejection, or error, but is neither of them");
   }
 
   private List<BackupStatus> aggregateBackupList(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
@@ -12,10 +12,7 @@ import static java.lang.Long.max;
 import io.camunda.zeebe.backup.common.CheckpointIdGenerator;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
-import io.camunda.zeebe.broker.client.api.BrokerErrorException;
-import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
@@ -172,24 +169,9 @@ public final class BackupRequestHandler implements BackupApi {
                       ignored ->
                           responses.stream()
                               .map(CompletableFuture::join)
-                              .map(BackupRequestHandler::getResponseOrThrow)
+                              .map(BrokerResponse::getResponseOrThrow)
                               .collect(Collectors.toSet()));
             });
-  }
-
-  private static <R> R getResponseOrThrow(final BrokerResponse<R> response) {
-    if (response == null) {
-      throw new IllegalBrokerResponseException("Expected broker response, but received null");
-    } else if (response.isResponse()) {
-      return response.getResponse();
-    } else if (response.isError()) {
-      throw new BrokerErrorException(response.getError());
-    } else if (response.isRejection()) {
-      throw new BrokerRejectionException(response.getRejection());
-    }
-
-    throw new IllegalBrokerResponseException(
-        "Expected broker response to be either response, rejection, or error, but is neither of them");
   }
 
   private List<BackupStatus> aggregateBackupList(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -17,10 +17,7 @@ import io.camunda.zeebe.backup.client.api.BackupDeleteRequest;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.schedule.Schedule;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.BrokerErrorException;
-import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
@@ -346,13 +343,8 @@ public class BackupRetention extends Actor {
   }
 
   private void throwOnBrokerError(final BrokerResponse<?> response) {
-    if (response.isError()) {
-      throw new BrokerErrorException(response.getError());
-    } else if (response.isRejection()) {
-      throw new BrokerRejectionException(response.getRejection());
-    } else if (!response.isResponse()) {
-      throw new IllegalBrokerResponseException(
-          "Expected broker response to be either response, rejection, or error, but is neither of them");
+    if (!response.isResponse()) {
+      throw response.toException();
     }
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -17,7 +17,11 @@ import io.camunda.zeebe.backup.client.api.BackupDeleteRequest;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.schedule.Schedule;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -308,7 +312,7 @@ public class BackupRetention extends Actor {
       final var request = new BackupDeleteRequest();
       request.setPartitionId(context.partitionId);
       request.setBackupId(checkpointId);
-      futures.add(brokerClient.sendRequestWithRetry(request));
+      futures.add(brokerClient.sendRequestWithRetry(request).thenAccept(this::throwOnBrokerError));
     }
 
     CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
@@ -336,6 +340,17 @@ public class BackupRetention extends Actor {
             actor)
         .whenCompleteAsync(future, actor);
     return future;
+  }
+
+  private void throwOnBrokerError(final BrokerResponse<?> response) {
+    if (response.isError()) {
+      throw new BrokerErrorException(response.getError());
+    } else if (response.isRejection()) {
+      throw new BrokerRejectionException(response.getRejection());
+    } else if (!response.isResponse()) {
+      throw new IllegalBrokerResponseException(
+          "Expected broker response to be either response, rejection, or error, but is neither of them");
+    }
   }
 
   private Instant backupTimestamp(final BackupStatus backup) {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -312,7 +312,10 @@ public class BackupRetention extends Actor {
       final var request = new BackupDeleteRequest();
       request.setPartitionId(context.partitionId);
       request.setBackupId(checkpointId);
-      futures.add(brokerClient.sendRequestWithRetry(request).thenAccept(this::throwOnBrokerError));
+      futures.add(
+          brokerClient
+              .sendRequestWithRetry(request)
+              .thenAcceptAsync(this::throwOnBrokerError, actor));
     }
 
     CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
@@ -87,7 +88,8 @@ public class RetentionTest {
     doReturn(List.of(1)).when(clusterState).getPartitions();
 
     lenient()
-        .doReturn(CompletableFuture.completedFuture(null))
+        .doReturn(
+            CompletableFuture.completedFuture(new BrokerResponse<>(new BackupStatusResponse())))
         .when(brokerClient)
         .sendRequestWithRetry(any());
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClient.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClient.java
@@ -33,8 +33,9 @@ public interface BrokerClient extends AutoCloseable {
    * send it to it.
    *
    * @param request request to send
-   * @return future which will be completed when a successful response from the broker is received.
-   *     The future will be completed exceptionally on error or on receiving BrokerRejection.
+   * @return future which will be completed when a response, rejection, or error from the broker is
+   *     received. The future will be completed exceptionally on request dispatch, transport, or
+   *     response parsing errors.
    */
   <T> CompletableFuture<BrokerResponse<T>> sendRequest(BrokerRequest<T> request);
 
@@ -44,8 +45,9 @@ public interface BrokerClient extends AutoCloseable {
    *
    * @param request request to send
    * @param requestTimeout timeout for the request
-   * @return future which will be completed when a successful response from the broker is received.
-   *     The future will be completed exceptionally on error or on receiving BrokerRejection.
+   * @return future which will be completed when a response, rejection, or error from the broker is
+   *     received. The future will be completed exceptionally on request dispatch, transport, or
+   *     response parsing errors.
    */
   <T> CompletableFuture<BrokerResponse<T>> sendRequest(
       BrokerRequest<T> request, Duration requestTimeout);
@@ -56,9 +58,9 @@ public interface BrokerClient extends AutoCloseable {
    * timeout.
    *
    * @param request request to send
-   * @return future which will be completed when a successful response from the broker is
-   *     received.The future will be completed exceptionally on error or on receiving
-   *     BrokerRejection.
+   * @return future which will be completed when a response, rejection, or error from the broker is
+   *     received. The future will be completed exceptionally on request dispatch, transport, or
+   *     response parsing errors.
    */
   <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(BrokerRequest<T> request);
 
@@ -69,9 +71,9 @@ public interface BrokerClient extends AutoCloseable {
    *
    * @param request request to send
    * @param requestTimeout timeout for the request
-   * @return future which will be completed when a successful response from the broker is
-   *     received.The future will be completed exceptionally on error or on receiving
-   *     BrokerRejection.
+   * @return future which will be completed when a response, rejection, or error from the broker is
+   *     received. The future will be completed exceptionally on request dispatch, transport, or
+   *     response parsing errors.
    */
   <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(
       BrokerRequest<T> request, Duration requestTimeout);

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerResponse.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerResponse.java
@@ -7,7 +7,16 @@
  */
 package io.camunda.zeebe.broker.client.api.dto;
 
+import io.camunda.zeebe.broker.client.api.BrokerClientException;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
+
 public class BrokerResponse<T> {
+  private static final String ILLEGAL_SUCCESS_RESPONSE_MESSAGE =
+      "Expected broker response to be error or rejection, but received response";
+  private static final String ILLEGAL_RESPONSE_MESSAGE =
+      "Expected broker response to be either response, rejection, or error, but is neither of them";
 
   private final boolean isResponse;
   private final T response;
@@ -54,6 +63,26 @@ public class BrokerResponse<T> {
 
   public T getResponse() {
     return response;
+  }
+
+  public T getResponseOrThrow() {
+    if (isResponse()) {
+      return response;
+    }
+
+    throw toException();
+  }
+
+  public BrokerClientException toException() {
+    if (isResponse()) {
+      return new IllegalBrokerResponseException(ILLEGAL_SUCCESS_RESPONSE_MESSAGE);
+    } else if (isError()) {
+      return new BrokerErrorException(getError());
+    } else if (isRejection()) {
+      return new BrokerRejectionException(getRejection());
+    }
+
+    return new IllegalBrokerResponseException(ILLEGAL_RESPONSE_MESSAGE);
   }
 
   public int getPartitionId() {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
@@ -12,11 +12,8 @@ import io.atomix.cluster.messaging.MessagingService;
 import io.atomix.cluster.messaging.Subscription;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
-import io.camunda.zeebe.broker.client.api.BrokerErrorException;
-import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -128,14 +125,8 @@ public final class BrokerClientImpl implements BrokerClient {
                 throwableConsumer.accept(error);
               } else if (response.isResponse()) {
                 responseConsumer.accept(response.getKey(), response.getResponse());
-              } else if (response.isRejection()) {
-                throwableConsumer.accept(new BrokerRejectionException(response.getRejection()));
-              } else if (response.isError()) {
-                throwableConsumer.accept(new BrokerErrorException(response.getError()));
               } else {
-                throwableConsumer.accept(
-                    new IllegalBrokerResponseException(
-                        "Expected broker response to be either response, rejection, or error, but is neither of them"));
+                throwableConsumer.accept(response.toException());
               }
             });
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
@@ -12,8 +12,11 @@ import io.atomix.cluster.messaging.MessagingService;
 import io.atomix.cluster.messaging.Subscription;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -121,10 +124,18 @@ public final class BrokerClientImpl implements BrokerClient {
         .sendRequestWithRetry(request)
         .whenComplete(
             (response, error) -> {
-              if (error == null) {
-                responseConsumer.accept(response.getKey(), response.getResponse());
-              } else {
+              if (error != null) {
                 throwableConsumer.accept(error);
+              } else if (response.isResponse()) {
+                responseConsumer.accept(response.getKey(), response.getResponse());
+              } else if (response.isRejection()) {
+                throwableConsumer.accept(new BrokerRejectionException(response.getRejection()));
+              } else if (response.isError()) {
+                throwableConsumer.accept(new BrokerErrorException(response.getError()));
+              } else {
+                throwableConsumer.accept(
+                    new IllegalBrokerResponseException(
+                        "Expected broker response to be either response, rejection, or error, but is neither of them"));
               }
             });
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerResponseException;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
 import io.camunda.zeebe.broker.client.api.PartitionInactiveException;
 import io.camunda.zeebe.broker.client.api.PartitionNotFoundException;
@@ -203,9 +202,7 @@ final class BrokerRequestManager extends Actor {
         responseFuture.complete(response);
         return RequestResult.failed(response.getError().getCode());
       } else {
-        responseFuture.completeExceptionally(
-            new IllegalBrokerResponseException(
-                "Expected broker response to be either response, rejection, or error, but is neither of them"));
+        responseFuture.completeExceptionally(response.toException());
       }
     } catch (final RuntimeException e) {
       responseFuture.completeExceptionally(new BrokerResponseException(e));

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -11,8 +11,6 @@ import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.AdditionalErrorCodes;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
-import io.camunda.zeebe.broker.client.api.BrokerErrorException;
-import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseException;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
@@ -199,10 +197,10 @@ final class BrokerRequestManager extends Actor {
         responseFuture.complete(response);
         return RequestResult.processed();
       } else if (response.isRejection()) {
-        responseFuture.completeExceptionally(new BrokerRejectionException(response.getRejection()));
+        responseFuture.complete(response);
         return RequestResult.processed();
       } else if (response.isError()) {
-        responseFuture.completeExceptionally(new BrokerErrorException(response.getError()));
+        responseFuture.complete(response);
         return RequestResult.failed(response.getError().getCode());
       } else {
         responseFuture.completeExceptionally(

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -58,7 +58,6 @@ import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 public final class BrokerClientTest {
 
@@ -131,14 +130,14 @@ public final class BrokerClientTest {
     registerError(broker, ErrorCode.INTERNAL_ERROR, "test");
 
     // when
-    final Future<?> result = client.sendRequestWithRetry(new TestCommand());
+    final var result = client.sendRequestWithRetry(new TestCommand());
 
     // then
     final var receivedCommandRequests = broker.getReceivedCommandRequests();
     assertThat(result)
-        .failsWithin(Duration.ofSeconds(10))
-        .withThrowableThat()
-        .withCause(new BrokerErrorException(new BrokerError(ErrorCode.INTERNAL_ERROR, "test")));
+        .succeedsWithin(Duration.ofSeconds(10))
+        .extracting(BrokerResponse::getError)
+        .isEqualTo(new BrokerError(ErrorCode.INTERNAL_ERROR, "test"));
     assertThat(receivedCommandRequests).hasSize(1);
     receivedCommandRequests.forEach(
         request -> {
@@ -199,14 +198,13 @@ public final class BrokerClientTest {
     registerError(broker, ErrorCode.PARTITION_LEADER_MISMATCH, "");
 
     // when
-    final Future<?> response = client.sendRequest(new TestCommand());
+    final var response = client.sendRequest(new TestCommand());
 
     // then
     assertThat(response)
-        .failsWithin(Duration.ofSeconds(10))
-        .withThrowableThat()
-        .withCause(
-            new BrokerErrorException(new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, "")));
+        .succeedsWithin(Duration.ofSeconds(10))
+        .extracting(BrokerResponse::getError)
+        .isEqualTo(new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, ""));
   }
 
   @Test
@@ -255,27 +253,26 @@ public final class BrokerClientTest {
   }
 
   @Test
-  void shouldIncludeCallingFrameInExceptionStacktraceOnAsyncRootCause(final TestInfo testInfo) {
+  void shouldRouteBrokerRejectionToCallbackThrowableConsumer() {
     // given
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
     broker
         .onExecuteCommandRequest(TestCommand.VALUE_TYPE, TestCommand.INTENT)
         .respondWith()
-        .rejection();
+        .rejection(RejectionType.INVALID_ARGUMENT, "foo")
+        .value(null)
+        .register();
 
     // when
-    try {
-      client.sendRequestWithRetry(new TestCommand()).join();
-      fail("should throw exception");
-    } catch (final Exception e) {
-      // then
-      assertThat(e.getStackTrace())
-          .anySatisfy(
-              frame -> {
-                assertThat(frame.getClassName()).isEqualTo(getClass().getName());
-                assertThat(frame.getMethodName())
-                    .isEqualTo(testInfo.getTestMethod().orElseThrow().getName());
-              });
-    }
+    client.sendRequestWithRetry(
+        new TestCommand(), (key, response) -> fail("should reject"), errorRef::set);
+
+    // then
+    Awaitility.await("callback throwable received")
+        .untilAsserted(
+            () -> {
+              assertThat(errorRef.get()).isInstanceOf(BrokerRejectionException.class);
+            });
   }
 
   @Test
@@ -299,11 +296,10 @@ public final class BrokerClientTest {
 
     // then
     assertThat(responseFuture)
-        .failsWithin(Duration.ofSeconds(10))
-        .withThrowableThat()
-        .withCause(
-            new BrokerRejectionException(
-                new BrokerRejection(TestCommand.INTENT, 1, RejectionType.INVALID_ARGUMENT, "foo")));
+        .succeedsWithin(Duration.ofSeconds(10))
+        .extracting(BrokerResponse::getRejection)
+        .isEqualTo(
+            new BrokerRejection(TestCommand.INTENT, -1, RejectionType.INVALID_ARGUMENT, "foo"));
   }
 
   @Test
@@ -325,11 +321,10 @@ public final class BrokerClientTest {
 
     // then
     assertThat(responseFuture)
-        .failsWithin(Duration.ofSeconds(10))
-        .withThrowableThat()
-        .withCause(
-            new BrokerRejectionException(
-                new BrokerRejection(TestCommand.INTENT, 1, RejectionType.INVALID_ARGUMENT, "foo")));
+        .succeedsWithin(Duration.ofSeconds(10))
+        .extracting(BrokerResponse::getRejection)
+        .isEqualTo(
+            new BrokerRejection(TestCommand.INTENT, -1, RejectionType.INVALID_ARGUMENT, "foo"));
   }
 
   @Test

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/dto/BrokerResponseTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/dto/BrokerResponseTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.client.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import org.junit.jupiter.api.Test;
+
+final class BrokerResponseTest {
+
+  @Test
+  void shouldReturnResponsePayload() {
+    // given
+    final var response = new BrokerResponse<>("payload", 1, 2);
+
+    // when
+    final var payload = response.getResponseOrThrow();
+
+    // then
+    assertThat(payload).isEqualTo("payload");
+  }
+
+  @Test
+  void shouldConvertErrorResponseToException() {
+    // given
+    final var brokerError = new BrokerError(ErrorCode.INTERNAL_ERROR, "failed");
+    final var response = new BrokerErrorResponse<>(brokerError);
+
+    // when/then
+    assertThatThrownBy(response::getResponseOrThrow)
+        .isInstanceOfSatisfying(
+            BrokerErrorException.class,
+            error -> assertThat(error.getError()).isEqualTo(brokerError));
+  }
+
+  @Test
+  void shouldConvertRejectionResponseToException() {
+    // given
+    final var brokerRejection =
+        new BrokerRejection(JobIntent.COMPLETE, 42L, RejectionType.INVALID_ARGUMENT, "invalid");
+    final var response = new BrokerRejectionResponse<>(brokerRejection);
+
+    // when/then
+    assertThatThrownBy(response::getResponseOrThrow)
+        .isInstanceOfSatisfying(
+            BrokerRejectionException.class,
+            error -> assertThat(error.getRejection()).isEqualTo(brokerRejection));
+  }
+
+  @Test
+  void shouldRejectUnsupportedBrokerResponse() {
+    // given
+    final var response = new BrokerResponse<>();
+
+    // when/then
+    assertThatThrownBy(response::getResponseOrThrow)
+        .isInstanceOf(IllegalBrokerResponseException.class)
+        .hasMessageContaining("Expected broker response");
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.broker.transport.snapshotapi;
 
 import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotRequest.DeleteSnapshotForBootstrapRequest;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotRequest.GetSnapshotChunk;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotResponse.DeleteSnapshotForBootstrapResponse;
@@ -176,6 +179,15 @@ public class SnapshotApiRequestHandler
         .sendRequestWithRetry(new GetScaleUpProgress())
         .thenApplyAsync(
             r -> {
+              if (r.isError()) {
+                throw new BrokerErrorException(r.getError());
+              } else if (r.isRejection()) {
+                throw new BrokerRejectionException(r.getRejection());
+              } else if (!r.isResponse()) {
+                throw new IllegalBrokerResponseException(
+                    "Expected broker response to be either response, rejection, or error, but is neither of them");
+              }
+
               LOG.atLevel(Level.DEBUG)
                   .addKeyValue("transferId", transferId)
                   .log("Received response from broker {}", r.getResponse());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
@@ -9,9 +9,6 @@ package io.camunda.zeebe.broker.transport.snapshotapi;
 
 import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.BrokerErrorException;
-import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
-import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotRequest.DeleteSnapshotForBootstrapRequest;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotRequest.GetSnapshotChunk;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotResponse.DeleteSnapshotForBootstrapResponse;
@@ -179,19 +176,12 @@ public class SnapshotApiRequestHandler
         .sendRequestWithRetry(new GetScaleUpProgress())
         .thenApplyAsync(
             r -> {
-              if (r.isError()) {
-                throw new BrokerErrorException(r.getError());
-              } else if (r.isRejection()) {
-                throw new BrokerRejectionException(r.getRejection());
-              } else if (!r.isResponse()) {
-                throw new IllegalBrokerResponseException(
-                    "Expected broker response to be either response, rejection, or error, but is neither of them");
-              }
+              final var response = r.getResponseOrThrow();
 
               LOG.atLevel(Level.DEBUG)
                   .addKeyValue("transferId", transferId)
-                  .log("Received response from broker {}", r.getResponse());
-              return r.getResponse().getScalingPosition();
+                  .log("Received response from broker {}", response);
+              return response.getScalingPosition();
             },
             actor)
         .whenCompleteAsync(lastProcessedPosition, actor);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
@@ -87,7 +87,9 @@ public class ExportingControlService implements ExportingControlApi {
                   request.setBrokerId(brokerId);
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
-                  return brokerClient.sendRequest(request);
+                  return brokerClient
+                      .sendRequest(request)
+                      .thenApply(response -> response.getResponseOrThrow());
                 })
             .toArray(CompletableFuture<?>[]::new);
     return CompletableFuture.allOf(requests);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/query/impl/QueryApiImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/query/impl/QueryApiImpl.java
@@ -8,6 +8,9 @@
 package io.camunda.zeebe.gateway.query.impl;
 
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.gateway.query.QueryApi;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -70,8 +73,16 @@ public final class QueryApiImpl implements QueryApi {
             (response, error) -> {
               if (error != null) {
                 result.completeExceptionally(error);
-              } else {
+              } else if (response.isResponse()) {
                 result.complete(response.getResponse());
+              } else if (response.isError()) {
+                result.completeExceptionally(new BrokerErrorException(response.getError()));
+              } else if (response.isRejection()) {
+                result.completeExceptionally(new BrokerRejectionException(response.getRejection()));
+              } else {
+                result.completeExceptionally(
+                    new IllegalBrokerResponseException(
+                        "Expected broker response to be either response, rejection, or error, but is neither of them"));
               }
             });
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/query/impl/QueryApiImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/query/impl/QueryApiImpl.java
@@ -8,9 +8,6 @@
 package io.camunda.zeebe.gateway.query.impl;
 
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.BrokerErrorException;
-import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
-import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.gateway.query.QueryApi;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -73,16 +70,12 @@ public final class QueryApiImpl implements QueryApi {
             (response, error) -> {
               if (error != null) {
                 result.completeExceptionally(error);
-              } else if (response.isResponse()) {
-                result.complete(response.getResponse());
-              } else if (response.isError()) {
-                result.completeExceptionally(new BrokerErrorException(response.getError()));
-              } else if (response.isRejection()) {
-                result.completeExceptionally(new BrokerRejectionException(response.getRejection()));
               } else {
-                result.completeExceptionally(
-                    new IllegalBrokerResponseException(
-                        "Expected broker response to be either response, rejection, or error, but is neither of them"));
+                try {
+                  result.complete(response.getResponseOrThrow());
+                } catch (final RuntimeException e) {
+                  result.completeExceptionally(e);
+                }
               }
             });
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
@@ -23,7 +23,9 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
+import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -114,7 +116,8 @@ public class ExportingControlServiceTest {
 
     when(topologyManager.getTopology()).thenReturn(topology);
     when(client.getTopologyManager()).thenReturn(topologyManager);
-    when(client.sendRequest(any())).thenReturn(CompletableFuture.completedFuture(null));
+    when(client.sendRequest(any()))
+        .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(new AdminResponse())));
     return client;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -10,8 +10,10 @@ package io.camunda.zeebe.gateway.impl.broker;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
@@ -140,7 +142,7 @@ public final class RequestRetryHandler {
         .whenComplete(
             (response, error) -> {
               if (error == null) {
-                responseConsumer.accept(response.getKey(), response.getResponse());
+                acceptBrokerResponse(response, responseConsumer, throwableConsumer);
               } else {
                 throwableConsumer.accept(error);
               }
@@ -173,11 +175,13 @@ public final class RequestRetryHandler {
         .apply(request)
         .whenComplete(
             (response, error) -> {
-              if (error == null) {
+              if (error == null && response.isResponse()) {
                 responseConsumer.accept(response.getKey(), response.getResponse());
-              } else if (shouldRetryWithNextPartition(error)) {
+              } else if (shouldRetryWithNextPartition(response, error)) {
                 LOGGER.trace("Failed to create process on partition {}", partitionId, error);
-                errors.add(error);
+                if (error != null) {
+                  errors.add(error);
+                }
                 sendRequestWithRetry(
                     request,
                     requestSender,
@@ -187,7 +191,8 @@ public final class RequestRetryHandler {
                     throwableConsumer,
                     errors);
               } else {
-                throwableConsumer.accept(error);
+                throwableConsumer.accept(
+                    error == null ? toBrokerResponseException(response) : error);
               }
             });
   }
@@ -225,5 +230,41 @@ public final class RequestRetryHandler {
       return code == ErrorCode.PARTITION_LEADER_MISMATCH || code == ErrorCode.RESOURCE_EXHAUSTED;
     }
     return false;
+  }
+
+  private boolean shouldRetryWithNextPartition(
+      final BrokerResponse<?> response, final Throwable error) {
+    if (error != null) {
+      return shouldRetryWithNextPartition(error);
+    }
+
+    if (response.isError()) {
+      final ErrorCode code = response.getError().getCode();
+      return code == ErrorCode.PARTITION_LEADER_MISMATCH || code == ErrorCode.RESOURCE_EXHAUSTED;
+    }
+
+    return false;
+  }
+
+  private <BrokerResponseT> void acceptBrokerResponse(
+      final BrokerResponse<BrokerResponseT> response,
+      final BrokerResponseConsumer<BrokerResponseT> responseConsumer,
+      final Consumer<Throwable> throwableConsumer) {
+    if (response.isResponse()) {
+      responseConsumer.accept(response.getKey(), response.getResponse());
+    } else {
+      throwableConsumer.accept(toBrokerResponseException(response));
+    }
+  }
+
+  private Throwable toBrokerResponseException(final BrokerResponse<?> response) {
+    if (response.isError()) {
+      return new BrokerErrorException(response.getError());
+    } else if (response.isRejection()) {
+      return new BrokerRejectionException(response.getRejection());
+    }
+
+    return new IllegalBrokerResponseException(
+        "Expected broker response to be either response, rejection, or error, but is neither of them");
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -10,10 +10,8 @@ package io.camunda.zeebe.gateway.impl.broker;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
-import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
@@ -178,10 +176,9 @@ public final class RequestRetryHandler {
               if (error == null && response.isResponse()) {
                 responseConsumer.accept(response.getKey(), response.getResponse());
               } else if (shouldRetryWithNextPartition(response, error)) {
-                LOGGER.trace("Failed to create process on partition {}", partitionId, error);
-                if (error != null) {
-                  errors.add(error);
-                }
+                final var cause = toException(response, error);
+                LOGGER.trace("Failed to create process on partition {}", partitionId, cause);
+                errors.add(cause);
                 sendRequestWithRetry(
                     request,
                     requestSender,
@@ -191,8 +188,7 @@ public final class RequestRetryHandler {
                     throwableConsumer,
                     errors);
               } else {
-                throwableConsumer.accept(
-                    error == null ? toBrokerResponseException(response) : error);
+                throwableConsumer.accept(toException(response, error));
               }
             });
   }
@@ -253,18 +249,11 @@ public final class RequestRetryHandler {
     if (response.isResponse()) {
       responseConsumer.accept(response.getKey(), response.getResponse());
     } else {
-      throwableConsumer.accept(toBrokerResponseException(response));
+      throwableConsumer.accept(response.toException());
     }
   }
 
-  private Throwable toBrokerResponseException(final BrokerResponse<?> response) {
-    if (response.isError()) {
-      return new BrokerErrorException(response.getError());
-    } else if (response.isRejection()) {
-      return new BrokerRejectionException(response.getRejection());
-    }
-
-    return new IllegalBrokerResponseException(
-        "Expected broker response to be either response, rejection, or error, but is neither of them");
+  private Throwable toException(final BrokerResponse<?> response, final Throwable error) {
+    return error == null ? response.toException() : error;
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.broker.client.impl.PartitionIdIterator;
 import io.camunda.zeebe.broker.client.impl.RoundRobinDispatchStrategy;
@@ -282,19 +281,7 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
       final InflightActivateJobsRequestState state,
       final ResponseObserverDelegate delegate,
       final BrokerResponse<JobBatchRecord> response) {
-    if (response.isRejection()) {
-      handleResponseError(
-          request, state, delegate, new BrokerRejectionException(response.getRejection()));
-    } else if (response.isError()) {
-      handleResponseError(request, state, delegate, new BrokerErrorException(response.getError()));
-    } else {
-      handleResponseError(
-          request,
-          state,
-          delegate,
-          new IllegalBrokerResponseException(
-              "Expected broker response to be either response, rejection, or error, but is neither of them"));
-    }
+    handleResponseError(request, state, delegate, response.toException());
   }
 
   private boolean isRejection(final Throwable error) {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.broker.client.impl.PartitionIdIterator;
 import io.camunda.zeebe.broker.client.impl.RoundRobinDispatchStrategy;
@@ -148,8 +149,10 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
       final InflightActivateJobsRequestState requestState,
       final ResponseObserverDelegate delegate) {
     return (brokerResponse, error) -> {
-      if (error == null) {
+      if (error == null && brokerResponse.isResponse()) {
         handleResponseSuccess(request, requestState, delegate, brokerResponse);
+      } else if (error == null) {
+        handleBrokerErrorResponse(request, requestState, delegate, brokerResponse);
       } else {
         handleResponseError(request, requestState, delegate, error);
       }
@@ -233,6 +236,9 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
               if (error != null) {
                 Loggers.GATEWAY_LOGGER.info(
                     "Failed to reactivate job {} due to {}", job.key(), error.getMessage());
+              } else if (!response.isResponse()) {
+                Loggers.GATEWAY_LOGGER.info(
+                    "Failed to reactivate job {} due to broker response {}", job.key(), response);
               }
             },
             actor);
@@ -269,6 +275,26 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
           state.setPollPrevPartition(false);
           activateJobs(request, state, delegate);
         });
+  }
+
+  private void handleBrokerErrorResponse(
+      final InflightActivateJobsRequest<T> request,
+      final InflightActivateJobsRequestState state,
+      final ResponseObserverDelegate delegate,
+      final BrokerResponse<JobBatchRecord> response) {
+    if (response.isRejection()) {
+      handleResponseError(
+          request, state, delegate, new BrokerRejectionException(response.getRejection()));
+    } else if (response.isError()) {
+      handleResponseError(request, state, delegate, new BrokerErrorException(response.getError()));
+    } else {
+      handleResponseError(
+          request,
+          state,
+          delegate,
+          new IllegalBrokerResponseException(
+              "Expected broker response to be either response, rejection, or error, but is neither of them"));
+    }
   }
 
   private boolean isRejection(final Throwable error) {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -65,26 +64,25 @@ public final class StubbedBrokerClient implements BrokerClient {
   public <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(
       final BrokerRequest<T> request) {
     final CompletableFuture<BrokerResponse<T>> future = new CompletableFuture<>();
-    sendRequestWithRetry(
-        request,
-        (key, response) ->
-            future.complete(new BrokerResponse<>(response, Protocol.decodePartitionId(key), key)),
-        future::completeExceptionally);
+    brokerRequests.add(request);
+
+    try {
+      final RequestHandler requestHandler = requestHandlers.get(request.getClass());
+      future.complete(requestHandler.handle(request));
+    } catch (final TimeoutException e) {
+      // Preserve timeout semantics so endpoint tests can assert gateway timeout mappings.
+      future.completeExceptionally(e);
+    } catch (final Exception e) {
+      future.completeExceptionally(new BrokerResponseException(e));
+    }
+
     return future;
   }
 
   @Override
   public <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(
       final BrokerRequest<T> request, final Duration requestTimeout) {
-    final CompletableFuture<BrokerResponse<T>> result = new CompletableFuture<>();
-
-    sendRequestWithRetry(
-        request,
-        (key, response) ->
-            result.complete(new BrokerResponse<>(response, Protocol.decodePartitionId(key), key)),
-        result::completeExceptionally);
-
-    return result.orTimeout(requestTimeout.toNanos(), TimeUnit.NANOSECONDS);
+    return sendRequestWithRetry(request).orTimeout(requestTimeout.toNanos(), TimeUnit.NANOSECONDS);
   }
 
   @Override

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -10,12 +10,9 @@ package io.camunda.zeebe.gateway.api.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.BrokerErrorException;
-import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
 import io.camunda.zeebe.broker.client.api.BrokerResponseException;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -97,14 +94,8 @@ public final class StubbedBrokerClient implements BrokerClient {
       try {
         if (response.isResponse()) {
           responseConsumer.accept(response.getKey(), response.getResponse());
-        } else if (response.isRejection()) {
-          throwableConsumer.accept(new BrokerRejectionException(response.getRejection()));
-        } else if (response.isError()) {
-          throwableConsumer.accept(new BrokerErrorException(response.getError()));
         } else {
-          throwableConsumer.accept(
-              new IllegalBrokerResponseException(
-                  "Expected broker response to be either response, rejection, or error, but is neither of them []"));
+          throwableConsumer.accept(response.toException());
         }
       } catch (final RuntimeException e) {
         throwableConsumer.accept(new BrokerResponseException(e));

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.impl.broker;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
@@ -120,6 +121,31 @@ final class RequestRetryHandlerTest {
     assertThat(error.get()).isNull();
     assertThat(result.get()).isEqualTo("result");
     assertThat(brokerClient.partitionsHit).containsExactly(1, 2);
+  }
+
+  @Test
+  void shouldKeepBrokerErrorDetailsWhenRetriesAreExhausted() {
+    // given
+    final var request = new TestBrokerRequest(Optional.empty());
+    brokerClient.setResponse(
+        new BrokerErrorResponse<>(new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure")));
+
+    // when
+    final var error = new AtomicReference<Throwable>();
+    retryHandler.sendRequest(request, (key, response) -> {}, error::set);
+
+    // then
+    assertThat(error.get()).isInstanceOf(RequestRetriesExhaustedException.class);
+    assertThat(error.get().getSuppressed())
+        .hasSize(PARTITION_COUNT)
+        .allSatisfy(
+            suppressed ->
+                assertThat(suppressed)
+                    .isInstanceOfSatisfying(
+                        BrokerErrorException.class,
+                        brokerError ->
+                            assertThat(brokerError.getError().getCode())
+                                .isEqualTo(ErrorCode.RESOURCE_EXHAUSTED)));
   }
 
   @Test

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
@@ -10,12 +10,12 @@ package io.camunda.zeebe.gateway.impl.broker;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
+import io.camunda.zeebe.broker.client.api.dto.BrokerErrorResponse;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
@@ -106,9 +106,10 @@ final class RequestRetryHandlerTest {
   void shouldRetryOnNextRoundRobinPartitionOnResourceExhausted() {
     // given - a broker client that fails with RESOURCE_EXHAUSTED on the first attempt
     final var request = new TestBrokerRequest(Optional.empty());
-    final var exhaustedError =
-        new BrokerErrorException(new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure"));
-    brokerClient.failOnPartitionThenSucceed(exhaustedError);
+    final var exhaustedResponse =
+        new BrokerErrorResponse<String>(
+            new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure"));
+    brokerClient.respondOnPartitionThenSucceed(exhaustedResponse);
 
     // when
     final var result = new AtomicReference<String>();
@@ -205,7 +206,7 @@ final class RequestRetryHandlerTest {
     final List<Integer> partitionsHit = new ArrayList<>();
     private BrokerResponse<String> response;
     private Throwable error;
-    private Throwable failFirstError;
+    private BrokerResponse<String> failFirstResponse;
 
     void setResponse(final BrokerResponse<String> response) {
       this.response = response;
@@ -217,8 +218,8 @@ final class RequestRetryHandlerTest {
       response = null;
     }
 
-    void failOnPartitionThenSucceed(final Throwable firstError) {
-      failFirstError = firstError;
+    void respondOnPartitionThenSucceed(final BrokerResponse<String> firstResponse) {
+      failFirstResponse = firstResponse;
       response = new BrokerResponse<>("result", 1, 1);
       error = null;
     }
@@ -239,8 +240,8 @@ final class RequestRetryHandlerTest {
       if (error != null) {
         return CompletableFuture.failedFuture(error);
       }
-      if (failFirstError != null && count == 1) {
-        return CompletableFuture.failedFuture(failFirstError);
+      if (failFirstResponse != null && count == 1) {
+        return CompletableFuture.completedFuture((BrokerResponse<T>) failFirstResponse);
       }
       return CompletableFuture.completedFuture((BrokerResponse<T>) response);
     }


### PR DESCRIPTION
## Description

Closes #46132.

`BrokerRequestManager` was turning broker errors and rejections into exceptions before completing the request future. That made normal broker responses go through exceptional `CompletableFuture` paths and forced downstream code to unwrap exceptions just to inspect the broker response.

This changes the future-based broker client API to complete with the `BrokerResponse` for broker success, rejection, and error responses. Dispatch, transport, timeout, and response parsing failures still complete exceptionally. Callback-based gateway paths continue to receive exceptions for broker errors and rejections, and direct future consumers now check the response state before reading payloads.

## Verification

- `./mvnw.cmd -pl zeebe/broker-client,zeebe/gateway,zeebe/gateway-grpc,zeebe/broker,zeebe/backup license:format spotless:apply -T1C`
- `./mvnw.cmd verify -pl zeebe/broker-client -Dtest=BrokerClientTest -DskipTests=false -DskipITs -Dquickly`
- `./mvnw.cmd verify -pl zeebe/gateway -Dtest=RequestRetryHandlerTest -DskipTests=false -DskipITs -Dquickly`
- `./mvnw.cmd verify -pl zeebe/broker-client,zeebe/gateway,zeebe/gateway-grpc,zeebe/broker,zeebe/backup -DskipTests -DskipITs -Dquickly -T1C`
- `git diff --check`