### PR TITLE
fix: Add Routing for Reindex by ID Deletion

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTask.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTask.java
@@ -125,11 +125,13 @@ public final class ReschedulingTask implements RunnableTask {
   }
 
   private void logError(final Throwable error) {
+    final var cause = error.getCause();
+    final var msg = cause != null ? cause.getMessage() : error.getMessage();
     periodicLogger.logError(
         "Error occurred while performing a background task {}; error message {}; operation will be retried",
         error,
         task.getCaption(),
-        error.getCause().getMessage());
+        msg);
   }
 
   private void reschedule(final long delay) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -33,8 +33,8 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
   private final String destinationIdx;
   private final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
       idsSupplier;
-  private final TriFunction<String, String, List<String>, CompletableFuture<Long>> reindexer;
-  private final BiFunction<String, List<String>, CompletableFuture<Long>> deleter;
+  private final TriFunction<String, String, List<IdWithRouting>, CompletableFuture<Long>> reindexer;
+  private final BiFunction<String, List<IdWithRouting>, CompletableFuture<Long>> deleter;
   private final Executor executor;
   private final CamundaExporterMetrics metrics;
   private final Logger logger;
@@ -53,8 +53,8 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
       final String destinationIdx,
       final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
           idsSupplier,
-      final TriFunction<String, String, List<String>, CompletableFuture<Long>> reindexer,
-      final BiFunction<String, List<String>, CompletableFuture<Long>> deleter,
+      final TriFunction<String, String, List<IdWithRouting>, CompletableFuture<Long>> reindexer,
+      final BiFunction<String, List<IdWithRouting>, CompletableFuture<Long>> deleter,
       final Executor executor,
       final CamundaExporterMetrics metrics,
       final Logger logger) {
@@ -152,16 +152,18 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
 
   private CompletableFuture<Long> reindex(final ArchiveDocIdsBatch<SortFieldType> response) {
     return reindexer
-        .apply(sourceIdx, destinationIdx, response.ids())
+        .apply(sourceIdx, destinationIdx, response.documents())
         .thenApply(
-            reindexCount -> validateProcessedCount("reindex", reindexCount, response.ids().size()));
+            reindexCount ->
+                validateProcessedCount("reindex", reindexCount, response.documents().size()));
   }
 
   private CompletableFuture<Long> delete(final ArchiveDocIdsBatch<SortFieldType> response) {
     return deleter
-        .apply(sourceIdx, response.ids())
+        .apply(sourceIdx, response.documents())
         .thenApply(
-            deleteCount -> validateProcessedCount("delete", deleteCount, response.ids().size()));
+            deleteCount ->
+                validateProcessedCount("delete", deleteCount, response.documents().size()));
   }
 
   private long validateProcessedCount(
@@ -187,17 +189,24 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
     return false;
   }
 
-  public record ArchiveDocIdsBatch<T>(List<String> ids, List<T> searchAfter) {
+  public record ArchiveDocIdsBatch<T>(List<IdWithRouting> documents, List<T> searchAfter) {
     static <T> ArchiveDocIdsBatch<T> empty() {
       return new ArchiveDocIdsBatch<>(List.of(), List.of());
     }
 
-    static <T> ArchiveDocIdsBatch<T> from(final List<String> ids, final List<T> searchAfter) {
-      return new ArchiveDocIdsBatch<>(ids, searchAfter);
+    static <T> ArchiveDocIdsBatch<T> from(
+        final List<IdWithRouting> documents, final List<T> searchAfter) {
+      return new ArchiveDocIdsBatch<>(documents, searchAfter);
     }
 
     public boolean isEmpty() {
-      return ids.isEmpty();
+      return documents.isEmpty();
+    }
+  }
+
+  public record IdWithRouting(String id, String routing) {
+    public static IdWithRouting of(final String id) {
+      return new IdWithRouting(id, null);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -77,12 +77,7 @@ public abstract class ArchiverJob<B extends ArchiveBatch> implements BackgroundT
         // measure the time it takes all in all, including searching, reindexing, deletion
         // There is some overhead with the scheduling at the executor, but this
         // should be negligible
-        .thenComposeAsync(
-            count -> {
-              exporterMetrics.measureArchivingDuration(timer);
-              return CompletableFuture.completedFuture(count);
-            },
-            executor);
+        .whenCompleteAsync((val, err) -> exporterMetrics.measureArchivingDuration(timer), executor);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -31,6 +31,7 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest.Builder;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.OperationType;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsResponse;
@@ -44,6 +45,7 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -257,11 +259,6 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             });
   }
 
-  @VisibleForTesting
-  void invalidateLifeCycleCache(final String indexName) {
-    lifeCyclePolicyApplied.invalidate(indexName);
-  }
-
   @Override
   public CompletableFuture<Void> setLifeCycleToAllIndexes() {
     final var retention = config.getRetention();
@@ -430,6 +427,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   @VisibleForTesting
+  void invalidateLifeCycleCache(final String indexName) {
+    lifeCyclePolicyApplied.invalidate(indexName);
+  }
+
+  @VisibleForTesting
   CompletableFuture<ArchiveDocIdsBatch<FieldValue>> getArchiveDocIdsBatch(
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
@@ -464,17 +466,21 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
                 return ArchiveDocIdsBatch.empty();
               }
               return ArchiveDocIdsBatch.from(
-                  hits.stream().map(Hit::id).toList(), hits.getLast().sort());
+                  hits.stream().map(h -> new IdWithRouting(h.id(), h.routing())).toList(),
+                  hits.getLast().sort());
             });
   }
 
   @VisibleForTesting
   CompletableFuture<Long> reindexDocumentsById(
-      final String sourceIndexName, final String destinationIndexName, final List<String> docIds) {
-    if (docIds.isEmpty()) {
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final List<IdWithRouting> docs) {
+    if (docs.isEmpty()) {
       return CompletableFuture.completedFuture(0L);
     }
 
+    final var docIds = docs.stream().map(IdWithRouting::id).toList();
     final var query = QueryBuilders.bool(q -> q.filter(b -> b.ids(id -> id.values(docIds))));
     final var request =
         new ReindexRequest.Builder()
@@ -513,14 +519,18 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
 
   @VisibleForTesting
   CompletableFuture<Long> deleteDocumentsById(
-      final String sourceIndexName, final List<String> docIds) {
-    if (docIds.isEmpty()) {
+      final String sourceIndexName, final List<IdWithRouting> docs) {
+    if (docs.isEmpty()) {
       return CompletableFuture.completedFuture(0L);
     }
 
     final var operations =
-        docIds.stream()
-            .map(docId -> new BulkOperation.Builder().delete(d -> d.id(docId)).build())
+        docs.stream()
+            .map(
+                d ->
+                    new BulkOperation.Builder()
+                        .delete(del -> del.id(d.id()).routing(d.routing()))
+                        .build())
             .toList();
 
     final var request =
@@ -542,7 +552,12 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
           "Deleting reindexed documents from %s index completed with %d failures"
               .formatted(sourceIndex, errorCount));
     }
-    return response.items().size();
+
+    // only count DELETE bulk operation where result was `deleted`
+    return response.items().stream()
+        .filter(i -> OperationType.Delete.equals(i.operationType()))
+        .filter(i -> "deleted".equals(i.result()))
+        .count();
   }
 
   private Query finishedProcessInstancesQuery(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -64,6 +64,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import javax.annotation.WillCloseWhenClosed;
@@ -497,7 +498,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .thenApplyAsync(
             response -> {
               validateReindexResponse(sourceIndexName, response);
-              return response.total();
+              return getReindexedDocumentsCount(response);
             },
             executor)
         .whenCompleteAsync(
@@ -510,11 +511,17 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       throw new IllegalStateException("Reindex request from %s timed out".formatted(sourceIndex));
     }
     final var failures = response.failures();
-    if (failures != null && !failures.isEmpty()) {
+    if (!failures.isEmpty()) {
       throw new IllegalStateException(
           "Reindex request from %s index completed with %d failures"
               .formatted(sourceIndex, failures.size()));
     }
+  }
+
+  private static long getReindexedDocumentsCount(final ReindexResponse response) {
+    return Math.addExact(
+        Objects.requireNonNullElse(response.created(), 0L),
+        Objects.requireNonNullElse(response.updated(), 0L));
   }
 
   @VisibleForTesting

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -378,12 +378,13 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             taskSupplier::moveNextBatch, count -> taskSupplier.isComplete())
         .thenComposeAsync(
             ignored -> {
-              // don't set the lifecycle if nothing was moved
-              // as it also might mean the index does not exist anyway
-              if (taskSupplier.getTotalArchived() > 0L) {
-                return setIndexLifeCycle(destinationIndexName);
-              }
-              return CompletableFuture.completedFuture(null);
+              // always trigger set life cycle, which checks whether the policy was previously
+              // applied and, if so, skips it. If nothing moved and the destination index is
+              // not present, we already set .allowNoIndices(true), which prevents it from erroring.
+              // However, if nothing moved because we previously moved them, but the call errored
+              // at the put policy stage, this will reapply the policy and ensure no index is
+              // left without the ILM policy.
+              return setIndexLifeCycle(destinationIndexName);
             },
             executor)
         .thenApply(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -31,7 +31,6 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest.Builder;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
-import co.elastic.clients.elasticsearch.core.bulk.OperationType;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsResponse;
@@ -562,10 +561,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     }
 
     // only count DELETE bulk operation where result was `deleted`
-    return response.items().stream()
-        .filter(i -> OperationType.Delete.equals(i.operationType()))
-        .filter(i -> "deleted".equals(i.result()))
-        .count();
+    return response.items().stream().filter(i -> "deleted".equals(i.result())).count();
   }
 
   private Query finishedProcessInstancesQuery(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -253,8 +253,13 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
 
     return applyPolicyToIndices(policyName, destinationIndexName)
         .thenApply(
-            ok -> {
-              lifeCyclePolicyApplied.put(destinationIndexName, policyName);
+            applied -> {
+              // Only cache when the policy was actually applied to a real index. If the dest
+              // didn't exist yet (applied=false), we deliberately skip the cache update so a
+              // later call (after the index is created by reindex) re-applies the policy.
+              if (Boolean.TRUE.equals(applied)) {
+                lifeCyclePolicyApplied.put(destinationIndexName, policyName);
+              }
               return null;
             });
   }
@@ -623,11 +628,39 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         ListViewTemplate.ROOT_PROCESS_INSTANCE_KEY);
   }
 
-  private CompletableFuture<PutIndicesSettingsResponse> applyPolicyToIndices(
+  private CompletableFuture<Boolean> applyPolicyToIndices(
       final String policyName, final String indexNamePattern) {
 
-    logger.debug("Applying policy '{}' to indices: {}", policyName, indexNamePattern);
+    // Guard against `PUT _settings` with `allowNoIndices(true)` silently succeeding when no
+    // matching index exists. That silent success would otherwise let the caller mark its cache as
+    // "applied" for an index that hasn't been created yet, and a later real application against
+    // the freshly-created index would be skipped. We only do this check for single-index names —
+    // wildcard/multi-index patterns (used by setLifeCycleToAllIndexes) are not cached and exists
+    // semantics with negation / wildcards are not portable enough to gate on.
+    if (isPattern(indexNamePattern)) {
+      return doPutSettings(policyName, indexNamePattern).thenApply(r -> true);
+    }
 
+    return client
+        .indices()
+        .exists(b -> b.index(indexNamePattern))
+        .thenComposeAsync(
+            exists -> {
+              if (!exists.value()) {
+                logger.debug(
+                    "Skipping policy '{}' for '{}': index does not exist yet",
+                    policyName,
+                    indexNamePattern);
+                return CompletableFuture.completedFuture(false);
+              }
+              return doPutSettings(policyName, indexNamePattern).thenApply(r -> true);
+            },
+            executor);
+  }
+
+  private CompletableFuture<PutIndicesSettingsResponse> doPutSettings(
+      final String policyName, final String indexNamePattern) {
+    logger.debug("Applying policy '{}' to indices: {}", policyName, indexNamePattern);
     final var settingsRequest =
         new PutIndicesSettingsRequest.Builder()
             .settings(settings -> settings.lifecycle(lifecycle -> lifecycle.name(policyName)))
@@ -635,8 +668,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             .allowNoIndices(true)
             .ignoreUnavailable(true)
             .build();
-
     return client.indices().putSettings(settingsRequest);
+  }
+
+  private static boolean isPattern(final String indexNameOrPattern) {
+    return indexNameOrPattern.indexOf('*') >= 0 || indexNameOrPattern.indexOf(',') >= 0;
   }
 
   private ProcessInstanceArchiveBatch createProcessInstanceBatch(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import javax.annotation.WillCloseWhenClosed;
@@ -510,7 +511,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .thenApplyAsync(
             response -> {
               validateReindexResponse(sourceIndexName, response);
-              return response.total();
+              return getReindexedDocumentsCount(response);
             },
             executor)
         .whenCompleteAsync(
@@ -528,6 +529,12 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
           "Reindex request from %s index completed with %d failures"
               .formatted(sourceIndex, failures.size()));
     }
+  }
+
+  private static long getReindexedDocumentsCount(final ReindexResponse response) {
+    return Math.addExact(
+        Objects.requireNonNullElse(response.created(), 0L),
+        Objects.requireNonNullElse(response.updated(), 0L));
   }
 
   @VisibleForTesting

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -20,6 +20,7 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -65,6 +66,7 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchRequest.Builder;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.OperationType;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.opensearch.generic.Requests;
@@ -270,11 +272,6 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             });
   }
 
-  @VisibleForTesting
-  void invalidateLifeCycleCache(final String indexName) {
-    lifeCyclePolicyApplied.invalidate(indexName);
-  }
-
   @Override
   public CompletableFuture<Void> setLifeCycleToAllIndexes() {
     final var retention = config.getRetention();
@@ -445,6 +442,11 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   }
 
   @VisibleForTesting
+  void invalidateLifeCycleCache(final String indexName) {
+    lifeCyclePolicyApplied.invalidate(indexName);
+  }
+
+  @VisibleForTesting
   CompletableFuture<ArchiveDocIdsBatch<FieldValue>> getArchiveDocIdsBatch(
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
@@ -478,17 +480,21 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
                 return ArchiveDocIdsBatch.empty();
               }
               return ArchiveDocIdsBatch.from(
-                  hits.stream().map(Hit::id).toList(), hits.getLast().sort());
+                  hits.stream().map(h -> new IdWithRouting(h.id(), h.routing())).toList(),
+                  hits.getLast().sort());
             });
   }
 
   @VisibleForTesting
   CompletableFuture<Long> reindexDocumentsById(
-      final String sourceIndexName, final String destinationIndexName, final List<String> docIds) {
-    if (docIds.isEmpty()) {
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final List<IdWithRouting> docs) {
+    if (docs.isEmpty()) {
       return CompletableFuture.completedFuture(0L);
     }
 
+    final var docIds = docs.stream().map(IdWithRouting::id).toList();
     final var query = QueryBuilders.bool().filter(b -> b.ids(id -> id.values(docIds))).build();
     final var request =
         new ReindexRequest.Builder()
@@ -526,13 +532,15 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
   @VisibleForTesting
   CompletableFuture<Long> deleteDocumentsById(
-      final String sourceIndexName, final List<String> docIds) {
-    if (docIds.isEmpty()) {
+      final String sourceIndexName, final List<IdWithRouting> docs) {
+    if (docs.isEmpty()) {
       return CompletableFuture.completedFuture(0L);
     }
 
     final var operations =
-        docIds.stream().map(docId -> BulkOperation.of(b -> b.delete(d -> d.id(docId)))).toList();
+        docs.stream()
+            .map(d -> BulkOperation.of(b -> b.delete(del -> del.id(d.id()).routing(d.routing()))))
+            .toList();
 
     final BulkRequest request =
         BulkRequest.of(b -> b.index(sourceIndexName).operations(operations));
@@ -552,7 +560,12 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
           "Deleting reindexed documents from %s index completed with %d failures"
               .formatted(sourceIndex, errorCount));
     }
-    return response.items().size();
+
+    // only count DELETE bulk operation where result was `deleted`
+    return response.items().stream()
+        .filter(i -> OperationType.Delete.equals(i.operationType()))
+        .filter(i -> "deleted".equals(i.result()))
+        .count();
   }
 
   private SearchRequest createUsageMetricSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -67,7 +67,6 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchRequest.Builder;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
-import org.opensearch.client.opensearch.core.bulk.OperationType;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.opensearch.generic.Requests;
@@ -570,10 +569,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     }
 
     // only count DELETE bulk operation where result was `deleted`
-    return response.items().stream()
-        .filter(i -> OperationType.Delete.equals(i.operationType()))
-        .filter(i -> "deleted".equals(i.result()))
-        .count();
+    return response.items().stream().filter(i -> "deleted".equals(i.result())).count();
   }
 
   private SearchRequest createUsageMetricSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -389,12 +389,13 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             taskSupplier::moveNextBatch, count -> taskSupplier.isComplete())
         .thenComposeAsync(
             ignored -> {
-              // don't set the lifecycle if nothing was moved
-              // as it also might mean the index does not exist anyway
-              if (taskSupplier.getTotalArchived() > 0L) {
-                return setIndexLifeCycle(destinationIndexName);
-              }
-              return CompletableFuture.completedFuture(null);
+              // always trigger set life cycle, which checks whether the policy was previously
+              // applied and, if so, skips it. If nothing moved and the destination index is
+              // not present, we already set .allowNoIndices(true), which prevents it from erroring.
+              // However, if nothing moved because we previously moved them, but the call errored
+              // at the put policy stage, this will reapply the policy and ensure no index is
+              // left without the ILM policy.
+              return setIndexLifeCycle(destinationIndexName);
             },
             executor)
         .thenApply(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -266,8 +266,13 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     return applyPolicyToIndices(policyName, destinationIndexName)
         .thenApply(
-            ignored -> {
-              lifeCyclePolicyApplied.put(destinationIndexName, policyName);
+            applied -> {
+              // Only cache when the policy was actually applied to a real index. If the dest
+              // didn't exist yet (applied=false), we deliberately skip the cache update so a
+              // later call (after the index is created by reindex) re-applies the policy.
+              if (Boolean.TRUE.equals(applied)) {
+                lifeCyclePolicyApplied.put(destinationIndexName, policyName);
+              }
               return null;
             });
   }
@@ -682,12 +687,38 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .thenApply(r -> new ArrayList<>(r.result().keySet()));
   }
 
-  private CompletableFuture<Void> applyPolicyToIndices(
+  private CompletableFuture<Boolean> applyPolicyToIndices(
+      final String policyName, final String indexNamePattern) {
+
+    // Guard against OS ISM endpoints silently succeeding for non-existent indices. That silent
+    // success would otherwise let the caller mark its cache as "applied" for an index that
+    // hasn't been created yet, and a later real application against the freshly-created index
+    // would be skipped. We only do this check for single-index names — wildcard/multi-index
+    // patterns (used by setLifeCycleToAllIndexes) are not cached and exists semantics with
+    // negation / wildcards are not portable enough to gate on.
+    if (isPattern(indexNamePattern)) {
+      return doApplyIsmPolicy(policyName, indexNamePattern).thenApply(ignored -> true);
+    }
+
+    return sendRequestAsync(() -> client.indices().exists(b -> b.index(indexNamePattern)))
+        .thenComposeAsync(
+            exists -> {
+              if (!exists.value()) {
+                logger.debug(
+                    "Skipping policy '{}' for '{}': index does not exist yet",
+                    policyName,
+                    indexNamePattern);
+                return CompletableFuture.completedFuture(false);
+              }
+              return doApplyIsmPolicy(policyName, indexNamePattern).thenApply(ignored -> true);
+            },
+            executor);
+  }
+
+  private CompletableFuture<Void> doApplyIsmPolicy(
       final String policyName, final String indexNamePattern) {
     logger.debug("Applying policy '{}' to indices: {}", policyName, indexNamePattern);
-
     final var jsonpMapper = genericClient._transport().jsonpMapper();
-
     return sendRequestAsync(
             () -> {
               final var addRequest =
@@ -716,6 +747,10 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .thenComposeAsync(
             resp -> checkIsmResponse(resp, "change_policy", policyName, indexNamePattern),
             executor);
+  }
+
+  private static boolean isPattern(final String indexNameOrPattern) {
+    return indexNameOrPattern.indexOf('*') >= 0 || indexNameOrPattern.indexOf(',') >= 0;
   }
 
   private CompletableFuture<Void> checkIsmResponse(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
@@ -56,7 +56,8 @@ public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
       final IndexTemplateDescriptor templateDescriptor, final ProcessInstanceArchiveBatch batch) {
     // 1. First archive docs from dependent indices and `joinRelation={variable OR activity}`
     // from operate-list-view index
-    // 2. Then archive all docs except `joinRelation=processInstance` from operate-list-view index
+    // 2. Then archive all docs except `joinRelation=processInstance` from operate-list-view index;
+    // we use this as a catch-all clause to move all related documents.
     // 3. Then archive all `joinRelation=processInstance` docs from operate-list-view index
     return archiveProcessDependants(batch)
         .thenComposeAsync(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -47,7 +48,9 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             searchAfter ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(List.of("doc1", "doc2"), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(
+                        List.of(IdWithRouting.of("doc1"), IdWithRouting.of("doc2")),
+                        List.of("after1"))),
             (source, dest, ids) -> {
               if (reindexCallCount.incrementAndGet() <= 2) {
                 return CompletableFuture.failedFuture(retryableError);
@@ -94,7 +97,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             searchAfter ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> CompletableFuture.failedFuture(retryableError),
             (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
             DIRECT_EXECUTOR,
@@ -127,7 +130,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             searchAfter ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> CompletableFuture.failedFuture(nonRetryableError),
             (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
             DIRECT_EXECUTOR,
@@ -179,7 +182,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             searchAfter ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> {
               final int call = reindexCallCount.incrementAndGet();
               if (call != 2 && call != 7) {
@@ -238,7 +241,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             searchAfter ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> {
               if (reindexCallCount.incrementAndGet() == 1) {
                 return CompletableFuture.failedFuture(retryableError);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -124,6 +124,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
   void withArchiverJob(final ExporterConfiguration config, final ArchiveJobConsumer<T> jobConsumer)
       throws Exception {
     config.getHistory().getRetention().setEnabled(true);
+    config.getIndex().setNumberOfShards(3);
     createSchemas(config);
 
     final ExporterResourceProvider exporterResourceProvider = exporterResourceProvider(config);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -977,11 +977,17 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   @Test
-  void shouldCacheIndicesWhichHaveRetentionPolicyAppliedAndNotReapplyPointlessly() {
+  void shouldCacheIndicesWhichHaveRetentionPolicyAppliedAndNotReapplyPointlessly()
+      throws IOException {
     // given
     retention.setEnabled(true);
     final var indexName1 = processInstanceIndex + UUID.randomUUID();
     final var indexName2 = processInstanceIndex + UUID.randomUUID();
+    // setIndexLifeCycle now short-circuits when the target index doesn't exist (to avoid
+    // poisoning the applied-policy cache for indices that haven't been created yet), so the
+    // test must create both indices before exercising the cache behavior.
+    testClient.indices().create(r -> r.index(indexName1));
+    testClient.indices().create(r -> r.index(indexName2));
 
     final var clientSpy = spy(new ElasticsearchAsyncClient(transport));
     final var indicesClientSpy = spy(clientSpy.indices());
@@ -1026,6 +1032,11 @@ final class ElasticsearchArchiverRepositoryIT {
     retention.setEnabled(true);
     final var indexName1 = processInstanceIndex + UUID.randomUUID();
     final var indexName2 = processInstanceIndex + UUID.randomUUID();
+    // setIndexLifeCycle now short-circuits when the target index doesn't exist (to avoid
+    // poisoning the applied-policy cache for indices that haven't been created yet), so the
+    // test must create both indices before exercising the cache behavior.
+    testClient.indices().create(r -> r.index(indexName1));
+    testClient.indices().create(r -> r.index(indexName2));
 
     final var clientSpy = spy(new ElasticsearchAsyncClient(transport));
     final var indicesClientSpy = spy(clientSpy.indices());
@@ -1350,6 +1361,46 @@ final class ElasticsearchArchiverRepositoryIT {
         .first()
         .extracting(Hit::id)
         .isEqualTo("3");
+  }
+
+  @Test
+  void shouldDeleteDocumentsByIdWithRoutingOnMultiShardIndex() throws IOException {
+    // given - a 3-shard index seeded with docs whose custom routing differs from their id.
+    // On a multi-shard index, a delete-by-id without routing is routed by hash(_id); for
+    // docs indexed with custom routing this lands on the wrong shard and ES silently
+    // returns result=not_found. This test proves the bulk delete carries routing through
+    // and that getDeletedDocCount only counts items actually deleted.
+    final var indexName = UUID.randomUUID().toString();
+    testClient
+        .indices()
+        .create(r -> r.index(indexName).settings(s -> s.numberOfShards("3").numberOfReplicas("0")));
+
+    final var repository = createRepository();
+    final int total = 50;
+    final var docs =
+        IntStream.rangeClosed(1, total).mapToObj(i -> new TestDocument(String.valueOf(i))).toList();
+    // routing is deliberately different from id, so hash(routing) != hash(id) for most
+    // docs across 3 shards.
+    docs.forEach(d -> index(indexName, d, "r-" + (Integer.parseInt(d.id()) % 7)));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete with the routing each doc was indexed under
+    final var idsWithRouting =
+        docs.stream()
+            .map(d -> new IdWithRouting(d.id(), "r-" + (Integer.parseInt(d.id()) % 7)))
+            .toList();
+    final var result = repository.deleteDocumentsById(indexName, idsWithRouting);
+
+    // then - every doc reports result=deleted, and the index is empty
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(result.join())
+        .as(
+            "all docs must report result=deleted on multi-shard index when routing is carried"
+                + " through; if this drops below %d the routing param is being ignored",
+            total)
+        .isEqualTo(total);
+    testClient.indices().refresh(r -> r.index(indexName));
+    assertThat(testClient.count(c -> c.index(indexName)).count()).isEqualTo(0L);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
@@ -963,8 +964,13 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   private <T extends TDocument> void index(final String index, final T document) {
+    index(index, document, null);
+  }
+
+  private <T extends TDocument> void index(
+      final String index, final T document, final String routing) {
     try {
-      testClient.index(b -> b.index(index).document(document).id(document.id()));
+      testClient.index(b -> b.index(index).document(document).id(document.id()).routing(routing));
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -1157,11 +1163,12 @@ final class ElasticsearchArchiverRepositoryIT {
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
     createProcessInstanceIndex();
-    documents.forEach(doc -> index(processInstanceIndex, doc));
+    documents.forEach(
+        doc -> index(processInstanceIndex, doc, String.valueOf(doc.processInstanceKey())));
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when searching for process instance key 111
-    // then - we expect documents with IDs 1,2 and 4 to be returned
+    // then - we expect documents with IDs 1,2 and 4 to be returned with routing=111
     final var batch =
         repository
             .getArchiveDocIdsBatch(
@@ -1172,7 +1179,10 @@ final class ElasticsearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2", "4");
+    assertThat(batch.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "2", "4");
+    assertThat(batch.documents()).extracting(IdWithRouting::routing).containsOnly("111");
     assertThat(batch.searchAfter()).hasSize(1);
     assertThat(batch.searchAfter().getFirst().stringValue()).isEqualTo("4");
 
@@ -1189,7 +1199,7 @@ final class ElasticsearchArchiverRepositoryIT {
             .join();
 
     assertThat(emptyBatch.isEmpty()).isTrue();
-    assertThat(emptyBatch.ids()).isEmpty();
+    assertThat(emptyBatch.documents()).isEmpty();
     assertThat(emptyBatch.searchAfter()).isEmpty();
 
     // when searching for process instance key 111 with reindex batch size of 2
@@ -1205,7 +1215,9 @@ final class ElasticsearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchPg1.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batchPg1.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "2");
     assertThat(batchPg1.searchAfter().getFirst().stringValue()).isEqualTo("2");
 
     // when searching for process instance key 111 with searchAfter from page 1
@@ -1221,7 +1233,7 @@ final class ElasticsearchArchiverRepositoryIT {
                 batchPg1.searchAfter())
             .join();
 
-    assertThat(batchPg2.ids()).containsExactlyInAnyOrder("4");
+    assertThat(batchPg2.documents()).extracting(IdWithRouting::id).containsExactlyInAnyOrder("4");
     assertThat(batchPg2.searchAfter().getFirst().stringValue()).isEqualTo("4");
 
     // when searching for process instance key 111 with searchAfter from page 2
@@ -1238,7 +1250,7 @@ final class ElasticsearchArchiverRepositoryIT {
             .join();
 
     assertThat(batchPg3.isEmpty()).isTrue();
-    assertThat(batchPg3.ids()).isEmpty();
+    assertThat(batchPg3.documents()).isEmpty();
     assertThat(batchPg3.searchAfter()).isEmpty();
 
     // when searching for process instance key 111 with exclusion filter for joinRelation=activity
@@ -1254,7 +1266,9 @@ final class ElasticsearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchExcluded.ids()).containsExactlyInAnyOrder("1", "4");
+    assertThat(batchExcluded.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "4");
 
     // when searching for process instance key 111 with inclusion filter for joinRelation=variable
     // and exclusion filter for joinRelation=activity
@@ -1269,7 +1283,9 @@ final class ElasticsearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchBothFilters.ids()).containsExactlyInAnyOrder("1", "4");
+    assertThat(batchBothFilters.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "4");
   }
 
   @Test
@@ -1286,7 +1302,8 @@ final class ElasticsearchArchiverRepositoryIT {
 
     // when - reindex the first two documents
     final var result =
-        repository.reindexDocumentsById(sourceIndexName, destIndexName, List.of("1", "2"));
+        repository.reindexDocumentsById(
+            sourceIndexName, destIndexName, List.of(IdWithRouting.of("1"), IdWithRouting.of("2")));
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -1318,7 +1335,9 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(indexName));
 
     // when - delete the first two documents
-    final var result = repository.deleteDocumentsById(indexName, List.of("1", "2"));
+    final var result =
+        repository.deleteDocumentsById(
+            indexName, List.of(IdWithRouting.of("1"), IdWithRouting.of("2")));
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -1351,7 +1370,8 @@ final class ElasticsearchArchiverRepositoryIT {
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
     createProcessInstanceIndex();
-    documents.forEach(doc -> index(processInstanceIndex, doc));
+    documents.forEach(
+        doc -> index(processInstanceIndex, doc, String.valueOf(doc.processInstanceKey())));
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when moving documents by id

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -1404,6 +1404,34 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   @Test
+  void shouldNotCountNotFoundResultsAsDeleted() throws IOException {
+    // given - an index with a single real doc; we will issue a bulk delete that mixes the
+    // real id with non-existent ids so ES returns result=not_found for the latter. The
+    // tightened getDeletedDocCount must exclude not_found items, otherwise the archiver
+    // loop would falsely report progress whenever a delete missed (wrong shard / wrong
+    // routing / already-deleted doc).
+    final var indexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    index(indexName, new TestDocument("1"));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete a mix of one existing id and two non-existent ids
+    final var result =
+        repository.deleteDocumentsById(
+            indexName,
+            List.of(
+                IdWithRouting.of("1"),
+                IdWithRouting.of("does-not-exist-a"),
+                IdWithRouting.of("does-not-exist-b")));
+
+    // then - only the existing doc counts as deleted
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(result.join()).as("not_found items must not be counted as deleted").isEqualTo(1L);
+    testClient.indices().refresh(r -> r.index(indexName));
+    assertThat(testClient.count(c -> c.index(indexName)).count()).isEqualTo(0L);
+  }
+
+  @Test
   void shouldMoveDocumentsById() throws IOException {
     final var repository = createRepository();
     final List<TestProcessDocument> documents = new ArrayList<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -276,7 +276,9 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
             CompletableFuture.completedFuture(searchResponse("4", "5", "6")),
             CompletableFuture.completedFuture(searchResponse()));
     when(client.reindex(any(ReindexRequest.class)))
-        .thenReturn(CompletableFuture.completedFuture(ReindexResponse.of(b -> b.total(3L))));
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                ReindexResponse.of(b -> b.total(3L).created(3L).updated(0L))));
     when(client.bulk(any(BulkRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(bulkResponse("4", "5", "6")));
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -35,6 +35,7 @@ import co.elastic.clients.json.JsonData;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -300,6 +301,39 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
     inOrder.verifyNoMoreInteractions();
   }
 
+  @Test
+  void shouldPropagateRoutingForEachBulkDeleteOperation() {
+    // given
+    final var docs =
+        List.of(
+            new IdWithRouting("4", "routing-4"),
+            new IdWithRouting("5", "routing-5"),
+            new IdWithRouting("6", "routing-6"));
+    when(client.bulk(any(BulkRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(bulkResponse("4", "5", "6")));
+
+    // when
+    final var deleted =
+        ((ElasticsearchArchiverRepository) repository)
+            .deleteDocumentsById("from-index", docs)
+            .join();
+
+    // then
+    assertThat(deleted).isEqualTo(3L);
+
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(client).bulk(captor.capture());
+
+    final var operations = captor.getValue().operations();
+    assertThat(operations).hasSize(3);
+    assertThat(operations.get(0).delete().id()).isEqualTo("4");
+    assertThat(operations.get(0).delete().routing()).isEqualTo("routing-4");
+    assertThat(operations.get(1).delete().id()).isEqualTo("5");
+    assertThat(operations.get(1).delete().routing()).isEqualTo("routing-5");
+    assertThat(operations.get(2).delete().id()).isEqualTo("6");
+    assertThat(operations.get(2).delete().routing()).isEqualTo("routing-6");
+  }
+
   private SearchResponse<Void> searchResponse(final String... ids) {
     final var hits =
         Arrays.stream(ids).map(id -> Hit.<Void>of(h -> h.id(id).index("from-index"))).toList();
@@ -324,7 +358,8 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
                             h.id(id)
                                 .operationType(OperationType.Delete)
                                 .index("from-index")
-                                .status(200)))
+                                .status(200)
+                                .result("deleted")))
             .toList();
     return BulkResponse.of(b -> b.took(123L).errors(false).items(items));
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1502,6 +1502,34 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   @Test
+  void shouldNotCountNotFoundResultsAsDeleted() throws IOException {
+    // given - an index with a single real doc; we will issue a bulk delete that mixes the
+    // real id with non-existent ids so OS returns result=not_found for the latter. The
+    // tightened getDeletedDocCount must exclude not_found items, otherwise the archiver
+    // loop would falsely report progress whenever a delete missed (wrong shard / wrong
+    // routing / already-deleted doc).
+    final var indexName = ARCHIVER_IDX_PREFIX + UUID.randomUUID().toString();
+    final var repository = createRepository();
+    index(indexName, new TestDocument("1"));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete a mix of one existing id and two non-existent ids
+    final var result =
+        repository.deleteDocumentsById(
+            indexName,
+            List.of(
+                IdWithRouting.of("1"),
+                IdWithRouting.of("does-not-exist-a"),
+                IdWithRouting.of("does-not-exist-b")));
+
+    // then - only the existing doc counts as deleted
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(result.join()).as("not_found items must not be counted as deleted").isEqualTo(1L);
+    testClient.indices().refresh(r -> r.index(indexName));
+    assertThat(testClient.count(c -> c.index(indexName)).count()).isEqualTo(0L);
+  }
+
+  @Test
   void shouldMoveDocumentsById() throws IOException {
     final var repository = createRepository();
     final List<TestProcessDocument> documents = new ArrayList<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -991,11 +991,18 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   @Test
-  void shouldCacheIndicesWhichHaveRetentionPolicyAppliedAndNotReapplyPointlessly() {
+  void shouldCacheIndicesWhichHaveRetentionPolicyAppliedAndNotReapplyPointlessly()
+      throws IOException {
     // given
     retention.setEnabled(true);
     final var indexName1 = processInstanceIndex + UUID.randomUUID();
     final var indexName2 = processInstanceIndex + UUID.randomUUID();
+    // setIndexLifeCycle now short-circuits when the target index doesn't exist (to avoid
+    // poisoning the applied-policy cache for indices that haven't been created yet), so the
+    // test must create both the policy and the indices before exercising the cache behavior.
+    createLifeCyclePolicies();
+    testClient.indices().create(r -> r.index(indexName1));
+    testClient.indices().create(r -> r.index(indexName2));
 
     final var asyncClient = createOpenSearchAsyncClient();
     final var genericClientSpy =
@@ -1045,6 +1052,12 @@ final class OpenSearchArchiverRepositoryIT {
     retention.setEnabled(true);
     final var indexName1 = processInstanceIndex + UUID.randomUUID();
     final var indexName2 = processInstanceIndex + UUID.randomUUID();
+    // setIndexLifeCycle now short-circuits when the target index doesn't exist (to avoid
+    // poisoning the applied-policy cache for indices that haven't been created yet), so the
+    // test must create both the policy and the indices before exercising the cache behavior.
+    createLifeCyclePolicies();
+    testClient.indices().create(r -> r.index(indexName1));
+    testClient.indices().create(r -> r.index(indexName2));
 
     final var asyncClient = createOpenSearchAsyncClient();
     final var genericClientSpy =
@@ -1446,6 +1459,46 @@ final class OpenSearchArchiverRepositoryIT {
         .first()
         .extracting(Hit::id)
         .isEqualTo("3");
+  }
+
+  @Test
+  void shouldDeleteDocumentsByIdWithRoutingOnMultiShardIndex() throws IOException {
+    // given - a 3-shard index seeded with docs whose custom routing differs from their id.
+    // On a multi-shard index, a delete-by-id without routing is routed by hash(_id); for
+    // docs indexed with custom routing this lands on the wrong shard and OS silently
+    // returns result=not_found. This test proves the bulk delete carries routing through
+    // and that getDeletedDocCount only counts items actually deleted.
+    final var indexName = ARCHIVER_IDX_PREFIX + UUID.randomUUID().toString();
+    testClient
+        .indices()
+        .create(r -> r.index(indexName).settings(s -> s.numberOfShards(3).numberOfReplicas(0)));
+
+    final var repository = createRepository();
+    final int total = 50;
+    final var docs =
+        IntStream.rangeClosed(1, total).mapToObj(i -> new TestDocument(String.valueOf(i))).toList();
+    // routing is deliberately different from id, so hash(routing) != hash(id) for most
+    // docs across 3 shards.
+    docs.forEach(d -> index(indexName, d, "r-" + (Integer.parseInt(d.id()) % 7)));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete with the routing each doc was indexed under
+    final var idsWithRouting =
+        docs.stream()
+            .map(d -> new IdWithRouting(d.id(), "r-" + (Integer.parseInt(d.id()) % 7)))
+            .toList();
+    final var result = repository.deleteDocumentsById(indexName, idsWithRouting);
+
+    // then - every doc reports result=deleted, and the index is empty
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(result.join())
+        .as(
+            "all docs must report result=deleted on multi-shard index when routing is carried"
+                + " through; if this drops below %d the routing param is being ignored",
+            total)
+        .isEqualTo(total);
+    testClient.indices().refresh(r -> r.index(indexName));
+    assertThat(testClient.count(c -> c.index(indexName)).count()).isEqualTo(0L);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
@@ -1258,11 +1259,12 @@ final class OpenSearchArchiverRepositoryIT {
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
     createProcessInstanceIndex();
-    documents.forEach(doc -> index(processInstanceIndex, doc));
+    documents.forEach(
+        doc -> index(processInstanceIndex, doc, String.valueOf(doc.processInstanceKey())));
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when searching for process instance key 111
-    // then - we expect documents with IDs 1,2 and 4 to be returned
+    // then - we expect documents with IDs 1,2 and 4 to be returned with routing=111
     final var batch =
         repository
             .getArchiveDocIdsBatch(
@@ -1273,7 +1275,10 @@ final class OpenSearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2", "4");
+    assertThat(batch.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "2", "4");
+    assertThat(batch.documents()).extracting(IdWithRouting::routing).containsOnly("111");
     assertThat(batch.searchAfter()).hasSize(1);
     assertThat(batch.searchAfter().getFirst().stringValue()).isEqualTo("4");
 
@@ -1290,7 +1295,7 @@ final class OpenSearchArchiverRepositoryIT {
             .join();
 
     assertThat(emptyBatch.isEmpty()).isTrue();
-    assertThat(emptyBatch.ids()).isEmpty();
+    assertThat(emptyBatch.documents()).isEmpty();
     assertThat(emptyBatch.searchAfter()).isEmpty();
 
     // when searching for process instance key 111 with reindex batch size of 2
@@ -1306,7 +1311,9 @@ final class OpenSearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchPg1.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batchPg1.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "2");
     assertThat(batchPg1.searchAfter().getFirst().stringValue()).isEqualTo("2");
 
     // when searching for process instance key 111 with searchAfter from page 1
@@ -1322,7 +1329,7 @@ final class OpenSearchArchiverRepositoryIT {
                 batchPg1.searchAfter())
             .join();
 
-    assertThat(batchPg2.ids()).containsExactlyInAnyOrder("4");
+    assertThat(batchPg2.documents()).extracting(IdWithRouting::id).containsExactlyInAnyOrder("4");
     assertThat(batchPg2.searchAfter().getFirst().stringValue()).isEqualTo("4");
 
     // when searching for process instance key 111 with searchAfter from page 2
@@ -1339,7 +1346,7 @@ final class OpenSearchArchiverRepositoryIT {
             .join();
 
     assertThat(batchPg3.isEmpty()).isTrue();
-    assertThat(batchPg3.ids()).isEmpty();
+    assertThat(batchPg3.documents()).isEmpty();
     assertThat(batchPg3.searchAfter()).isEmpty();
 
     // when searching for process instance key 111 with exclusion filter for joinRelation=activity
@@ -1355,7 +1362,9 @@ final class OpenSearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchExcluded.ids()).containsExactlyInAnyOrder("1", "4");
+    assertThat(batchExcluded.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "4");
 
     // when searching for process instance key 111 with inclusion filter for joinRelation=variable
     // and exclusion filter for joinRelation=activity
@@ -1370,7 +1379,9 @@ final class OpenSearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchBothFilters.ids()).containsExactlyInAnyOrder("1", "4");
+    assertThat(batchBothFilters.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "4");
   }
 
   @Test
@@ -1387,7 +1398,8 @@ final class OpenSearchArchiverRepositoryIT {
 
     // when - reindex the first two documents
     final var result =
-        repository.reindexDocumentsById(sourceIndexName, destIndexName, List.of("1", "2"));
+        repository.reindexDocumentsById(
+            sourceIndexName, destIndexName, List.of(IdWithRouting.of("1"), IdWithRouting.of("2")));
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -1419,7 +1431,9 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(indexName));
 
     // when - delete the first two documents
-    final var result = repository.deleteDocumentsById(indexName, List.of("1", "2"));
+    final var result =
+        repository.deleteDocumentsById(
+            indexName, List.of(IdWithRouting.of("1"), IdWithRouting.of("2")));
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -1452,7 +1466,8 @@ final class OpenSearchArchiverRepositoryIT {
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
     createProcessInstanceIndex();
-    documents.forEach(doc -> index(processInstanceIndex, doc));
+    documents.forEach(
+        doc -> index(processInstanceIndex, doc, String.valueOf(doc.processInstanceKey())));
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when moving documents by id
@@ -1682,13 +1697,19 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   private <T extends TDocument> void index(final String index, final T document) {
+    index(index, document, null);
+  }
+
+  private <T extends TDocument> void index(
+      final String index, final T document, final String routing) {
     Awaitility.await()
         .ignoreException(OpenSearchException.class)
         .timeout(SEARCH_DB.dataAvailabilityTimeout())
         .until(
             () -> {
               final IndexResponse result =
-                  testClient.index(b -> b.index(index).document(document).id(document.id()));
+                  testClient.index(
+                      b -> b.index(index).document(document).id(document.id()).routing(routing));
               return result != null
                   && (result.result() == Result.Created
                       || result.result() == Result.Updated

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -203,7 +203,9 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
             CompletableFuture.completedFuture(searchResponse("4", "5", "6")),
             CompletableFuture.completedFuture(searchResponse()));
     when(client.reindex(any(ReindexRequest.class)))
-        .thenReturn(CompletableFuture.completedFuture(ReindexResponse.of(b -> b.total(3L))));
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                ReindexResponse.of(b -> b.total(3L).created(3L).updated(0L))));
     when(client.bulk(any(BulkRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(bulkResponse("4", "5", "6")));
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -229,6 +230,37 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
     inOrder.verifyNoMoreInteractions();
   }
 
+  @Test
+  void shouldPropagateRoutingForEachBulkDeleteOperation() throws IOException {
+    // given
+    final var docs =
+        List.of(
+            new IdWithRouting("4", "routing-4"),
+            new IdWithRouting("5", "routing-5"),
+            new IdWithRouting("6", "routing-6"));
+    when(client.bulk(any(BulkRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(bulkResponse("4", "5", "6")));
+
+    // when
+    final var deleted =
+        ((OpenSearchArchiverRepository) repository).deleteDocumentsById("from-index", docs).join();
+
+    // then
+    assertThat(deleted).isEqualTo(3L);
+
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(client).bulk(captor.capture());
+
+    final var operations = captor.getValue().operations();
+    assertThat(operations).hasSize(3);
+    assertThat(operations.get(0).delete().id()).isEqualTo("4");
+    assertThat(operations.get(0).delete().routing()).isEqualTo("routing-4");
+    assertThat(operations.get(1).delete().id()).isEqualTo("5");
+    assertThat(operations.get(1).delete().routing()).isEqualTo("routing-5");
+    assertThat(operations.get(2).delete().id()).isEqualTo("6");
+    assertThat(operations.get(2).delete().routing()).isEqualTo("routing-6");
+  }
+
   private SearchResponse<Object> searchResponse(final String... ids) {
     final var hits =
         Arrays.stream(ids).map(id -> Hit.<Object>of(h -> h.id(id).index("from-index"))).toList();
@@ -253,7 +285,8 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
                             h.id(id)
                                 .operationType(OperationType.Delete)
                                 .index("from-index")
-                                .status(200)))
+                                .status(200)
+                                .result("deleted")))
             .toList();
     return BulkResponse.of(b -> b.took(123L).errors(false).items(items));
   }


### PR DESCRIPTION

## Description

Delete by ID (unlike the query) require routing hints unlike to route the delete operation to the right shard and we missed adding that. This was not caught in our testing as we almost always run tests with single shard.

Adding the routing by reading routing info provided when getting the IDs. Also switching archiver ITs to run with a few shards so that we can spot this sort of things earlier.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/55357
