### PR TITLE
feat: add bpmnProcessId to AGENT_HISTORY protocol, engine processor, and exporter handler

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentHistoryTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentHistoryTemplate.java
@@ -27,6 +27,7 @@ public class AgentHistoryTemplate extends AbstractTemplateDescriptor
   public static final String INDEX_VERSION = "8.10.0";
 
   public static final String KEY = "key";
+  public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String ELEMENT_INSTANCE_KEY = "elementInstanceKey";
   public static final String TENANT_ID = "tenantId";
   public static final String JOB_KEY = "jobKey";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
@@ -47,6 +47,9 @@ public final class AgentHistoryEntity
   private long rootProcessInstanceKey;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String bpmnProcessId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
   private long processDefinitionKey;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
@@ -152,6 +155,15 @@ public final class AgentHistoryEntity
 
   public AgentHistoryEntity setProcessDefinitionKey(final long processDefinitionKey) {
     this.processDefinitionKey = processDefinitionKey;
+    return this;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public AgentHistoryEntity setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
     return this;
   }
 
@@ -284,6 +296,7 @@ public final class AgentHistoryEntity
         elementInstanceKey,
         processInstanceKey,
         rootProcessInstanceKey,
+        bpmnProcessId,
         processDefinitionKey,
         tenantId,
         partitionId,
@@ -315,6 +328,7 @@ public final class AgentHistoryEntity
         && elementInstanceKey == that.elementInstanceKey
         && processInstanceKey == that.processInstanceKey
         && rootProcessInstanceKey == that.rootProcessInstanceKey
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && processDefinitionKey == that.processDefinitionKey
         && Objects.equals(tenantId, that.tenantId)
         && partitionId == that.partitionId
@@ -347,6 +361,9 @@ public final class AgentHistoryEntity
         + processInstanceKey
         + ", rootProcessInstanceKey="
         + rootProcessInstanceKey
+        + ", bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
         + ", processDefinitionKey="
         + processDefinitionKey
         + ", tenantId='"

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-history.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-history.json
@@ -20,6 +20,9 @@
       "rootProcessInstanceKey": {
         "type": "long"
       },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
       "processDefinitionKey": {
         "type": "long"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-history.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-history.json
@@ -20,6 +20,9 @@
       "rootProcessInstanceKey": {
         "type": "long"
       },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
       "processDefinitionKey": {
         "type": "long"
       },

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -64,13 +64,14 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
       return;
     }
 
+    final var bpmnProcessId = agentInstanceRecord.getBpmnProcessId();
     final var authRequest =
         AuthorizationRequest.builder()
             .command(command)
             .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
             .permissionType(PermissionType.UPDATE_PROCESS_INSTANCE)
             .tenantId(agentInstanceRecord.getTenantId())
-            .addResourceId(agentInstanceRecord.getBpmnProcessId())
+            .addResourceId(bpmnProcessId)
             .build();
     final var authResult = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (authResult.isLeft()) {
@@ -118,6 +119,7 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
             .setElementInstanceKey(jobElementInstanceKey)
             .setProcessInstanceKey(job.getProcessInstanceKey())
             .setRootProcessInstanceKey(job.getRootProcessInstanceKey())
+            .setBpmnProcessId(bpmnProcessId)
             .setProcessDefinitionKey(job.getProcessDefinitionKey())
             .setTenantId(job.getTenantId())
             .setJobKey(commandValue.getJobKey())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
@@ -62,6 +62,7 @@ public class AgentHistoryCreateTest {
     assertThat(created.getValue().getAgentInstanceKey()).isEqualTo(agentInstanceKey);
     assertThat(created.getValue().getJobKey()).isEqualTo(jobKey);
     assertThat(created.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+    assertThat(created.getValue().getBpmnProcessId()).isEqualTo(PROCESS_ID);
 
     final var committed =
         RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -96,6 +96,7 @@ public class AgentHistoryHandler
         .setElementInstanceKey(value.getElementInstanceKey())
         .setProcessInstanceKey(value.getProcessInstanceKey())
         .setRootProcessInstanceKey(value.getRootProcessInstanceKey())
+        .setBpmnProcessId(value.getBpmnProcessId())
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
         .setTenantId(value.getTenantId())
         .setJobKey(value.getJobKey())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -128,6 +128,7 @@ final class AgentHistoryHandlerTest {
             .withElementInstanceKey(elementInstanceKey)
             .withProcessInstanceKey(processInstanceKey)
             .withRootProcessInstanceKey(rootProcessInstanceKey)
+            .withBpmnProcessId("my-process")
             .withProcessDefinitionKey(processDefinitionKey)
             .withTenantId(tenantId)
             .withJobKey(jobKey)
@@ -174,6 +175,7 @@ final class AgentHistoryHandlerTest {
     assertThat(entity.getElementInstanceKey()).isEqualTo(elementInstanceKey);
     assertThat(entity.getProcessInstanceKey()).isEqualTo(processInstanceKey);
     assertThat(entity.getRootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
+    assertThat(entity.getBpmnProcessId()).isEqualTo("my-process");
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
     assertThat(entity.getTenantId()).isEqualTo(tenantId);
     assertThat(entity.getJobKey()).isEqualTo(jobKey);
@@ -579,6 +581,7 @@ final class AgentHistoryHandlerTest {
         .withElementInstanceKey(1L)
         .withProcessInstanceKey(10L)
         .withRootProcessInstanceKey(10L)
+        .withBpmnProcessId("my-process")
         .withProcessDefinitionKey(20L)
         .withTenantId("<default>")
         .withJobKey(30L)

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
@@ -34,6 +34,9 @@
             "rootProcessInstanceKey": {
               "type": "long"
             },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
             "processDefinitionKey": {
               "type": "long"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
@@ -40,6 +40,9 @@
             "rootProcessInstanceKey": {
               "type": "long"
             },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
             "processDefinitionKey": {
               "type": "long"
             },

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -29,6 +29,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
   private final StringProperty tenantIdProp =
@@ -47,12 +48,13 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new ObjectProperty<>("metrics", new AgentHistoryMetrics());
 
   public AgentHistoryRecord() {
-    super(15);
+    super(16);
     declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(jobKeyProp)
@@ -122,6 +124,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public AgentHistoryRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4889,7 +4889,8 @@ final class JsonSerializableToJsonTest {
                       .setJobLease("job-lease-abc123")
                       .setIteration(3)
                       .setRole(AgentHistoryRole.ASSISTANT)
-                      .setProducedAt(1748860800000L);
+                      .setProducedAt(1748860800000L)
+                      .setBpmnProcessId("process");
               record.addContent(
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.TEXT)
@@ -4983,6 +4984,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
+          "bpmnProcessId": "process",
           "processDefinitionKey": -1
         }
         """
@@ -5006,6 +5008,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
+          "bpmnProcessId": "",
           "processDefinitionKey": -1
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -37,6 +37,7 @@ final class AgentHistoryRecordTest {
     assertThat(record.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     assertThat(record.getProcessInstanceKey()).isEqualTo(-1L);
     assertThat(record.getRootProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(record.getBpmnProcessId()).isEmpty();
     assertThat(record.getProcessDefinitionKey()).isEqualTo(-1L);
   }
 
@@ -222,6 +223,7 @@ final class AgentHistoryRecordTest {
     // given
     final AgentHistoryRecord original =
         new AgentHistoryRecord()
+            .setBpmnProcessId("my-process")
             .setTenantId("tenant-a")
             .setProcessInstanceKey(2251799813685260L)
             .setRootProcessInstanceKey(2251799813685262L)
@@ -233,6 +235,7 @@ final class AgentHistoryRecordTest {
 
     // then
     assertThat(copy.getTenantId()).isEqualTo("tenant-a");
+    assertThat(copy.getBpmnProcessId()).isEqualTo("my-process");
     assertThat(copy.getProcessInstanceKey()).isEqualTo(2251799813685260L);
     assertThat(copy.getRootProcessInstanceKey()).isEqualTo(2251799813685262L);
     assertThat(copy.getProcessDefinitionKey()).isEqualTo(2251799813685261L);

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
@@ -29,6 +29,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
   private final StringProperty tenantIdProp =
@@ -47,12 +48,13 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new ObjectProperty<>("metrics", new AgentHistoryMetrics());
 
   public AgentHistoryRecord() {
-    super(15);
+    super(16);
     declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(jobKeyProp)
@@ -122,6 +124,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public AgentHistoryRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -43,6 +43,9 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   /** Returns the key of the root process instance in the hierarchy. */
   long getRootProcessInstanceKey();
 
+  /** Returns the BPMN process ID of the process definition associated with this entry. */
+  String getBpmnProcessId();
+
   /**
    * @return the key of the process definition
    */


### PR DESCRIPTION
## Description

### Overview

Adds `bpmnProcessId` to every layer of the `AGENT_HISTORY` stack: the protocol record interface and implementation, the engine processor, and the Camunda exporter ES/OS handler with its secondary-storage entity and index templates.

### Why this is needed

The upcoming agent-history search endpoint enforces `PROCESS_DEFINITION:READ_PROCESS_INSTANCE` authorization **per history item** using the BPMN process ID as the resource identifier. The authorization check is expressed as:

```java
RequiredAuthorization<AgentInstanceHistoryEntity> AGENT_HISTORY_READ_AUTHORIZATION =
    RequiredAuthorization.of(a -> a.processDefinition().readProcessInstance());
```

This requires a String `bpmnProcessId` in the ES/OS document at read time. The value must travel from the engine through the protocol record into secondary storage:

```
AgentHistoryCreateProcessor
  → AgentHistoryRecord (CREATED event)
  → AgentHistoryHandler.updateEntity()
  → AgentHistoryEntity / ES/OS document
  → AgentHistoryDocumentReader (Part 2) maps to AgentInstanceHistoryEntity.processDefinitionId
```

Before this PR every layer was missing the field, so authorization could not be scoped per process definition.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55374
