### PR TITLE
feat: add bpmnProcessId to AgentHistory

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentHistoryTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentHistoryTemplate.java
@@ -29,6 +29,7 @@ public class AgentHistoryTemplate extends AbstractTemplateDescriptor
   public static final String KEY = "key";
   public static final String ELEMENT_INSTANCE_KEY = "elementInstanceKey";
   public static final String TENANT_ID = "tenantId";
+  public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String JOB_KEY = "jobKey";
   public static final String JOB_LEASE = "jobLease";
   public static final String ITERATION = "iteration";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
@@ -53,6 +53,9 @@ public final class AgentHistoryEntity
   private String tenantId;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String bpmnProcessId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
   private int partitionId;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
@@ -162,6 +165,15 @@ public final class AgentHistoryEntity
 
   public AgentHistoryEntity setTenantId(final String tenantId) {
     this.tenantId = tenantId;
+    return this;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public AgentHistoryEntity setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
     return this;
   }
 
@@ -286,6 +298,7 @@ public final class AgentHistoryEntity
         rootProcessInstanceKey,
         processDefinitionKey,
         tenantId,
+        bpmnProcessId,
         partitionId,
         jobKey,
         jobLease,
@@ -317,6 +330,7 @@ public final class AgentHistoryEntity
         && rootProcessInstanceKey == that.rootProcessInstanceKey
         && processDefinitionKey == that.processDefinitionKey
         && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && partitionId == that.partitionId
         && jobKey == that.jobKey
         && Objects.equals(jobLease, that.jobLease)
@@ -351,6 +365,9 @@ public final class AgentHistoryEntity
         + processDefinitionKey
         + ", tenantId='"
         + tenantId
+        + '\''
+        + ", bpmnProcessId='"
+        + bpmnProcessId
         + '\''
         + ", partitionId="
         + partitionId

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-history.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-history.json
@@ -26,6 +26,9 @@
       "tenantId": {
         "type": "keyword"
       },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
       "partitionId": {
         "type": "integer"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-history.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-history.json
@@ -26,6 +26,9 @@
       "tenantId": {
         "type": "keyword"
       },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
       "partitionId": {
         "type": "integer"
       },

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -120,6 +120,7 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
             .setRootProcessInstanceKey(job.getRootProcessInstanceKey())
             .setProcessDefinitionKey(job.getProcessDefinitionKey())
             .setTenantId(job.getTenantId())
+            .setBpmnProcessId(agentInstanceRecord.getBpmnProcessId())
             .setJobKey(commandValue.getJobKey())
             .setJobLease(commandValue.getJobLease())
             .setIteration(commandValue.getIteration())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
@@ -62,6 +62,7 @@ public class AgentHistoryCreateTest {
     assertThat(created.getValue().getAgentInstanceKey()).isEqualTo(agentInstanceKey);
     assertThat(created.getValue().getJobKey()).isEqualTo(jobKey);
     assertThat(created.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+    assertThat(created.getValue().getBpmnProcessId()).isEqualTo(PROCESS_ID);
 
     final var committed =
         RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -98,6 +98,7 @@ public class AgentHistoryHandler
         .setRootProcessInstanceKey(value.getRootProcessInstanceKey())
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
         .setTenantId(value.getTenantId())
+        .setBpmnProcessId(value.getBpmnProcessId())
         .setJobKey(value.getJobKey())
         .setJobLease(value.getJobLease())
         .setIteration(ExporterUtil.positiveOrNull(value.getIteration()))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -99,6 +99,7 @@ final class AgentHistoryHandlerTest {
     final long rootProcessInstanceKey = 250L;
     final long processDefinitionKey = 400L;
     final String tenantId = "<default>";
+    final String bpmnProcessId = "my-process";
     final long jobKey = 500L;
     final String jobLease = "lease-token-abc";
     final int iteration = 3;
@@ -130,6 +131,7 @@ final class AgentHistoryHandlerTest {
             .withRootProcessInstanceKey(rootProcessInstanceKey)
             .withProcessDefinitionKey(processDefinitionKey)
             .withTenantId(tenantId)
+            .withBpmnProcessId(bpmnProcessId)
             .withJobKey(jobKey)
             .withJobLease(jobLease)
             .withIteration(iteration)
@@ -176,6 +178,7 @@ final class AgentHistoryHandlerTest {
     assertThat(entity.getRootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
     assertThat(entity.getTenantId()).isEqualTo(tenantId);
+    assertThat(entity.getBpmnProcessId()).isEqualTo(bpmnProcessId);
     assertThat(entity.getJobKey()).isEqualTo(jobKey);
     assertThat(entity.getJobLease()).isEqualTo(jobLease);
     assertThat(entity.getIteration()).isEqualTo(iteration);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
@@ -40,6 +40,9 @@
             "tenantId": {
               "type": "keyword"
             },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
             "jobKey": {
               "type": "long"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-history-template.json
@@ -46,6 +46,9 @@
             "tenantId": {
               "type": "keyword"
             },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
             "jobKey": {
               "type": "long"
             },

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -33,6 +33,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new LongProperty("processDefinitionKey", -1L);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
   private final StringProperty jobLeaseProp = new StringProperty("jobLease", "");
   private final IntegerProperty iterationProp = new IntegerProperty("iteration", 0);
@@ -47,7 +48,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new ObjectProperty<>("metrics", new AgentHistoryMetrics());
 
   public AgentHistoryRecord() {
-    super(15);
+    super(16);
     declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -55,6 +56,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
+        .declareProperty(bpmnProcessIdProp)
         .declareProperty(jobKeyProp)
         .declareProperty(jobLeaseProp)
         .declareProperty(iterationProp)
@@ -132,6 +134,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public AgentHistoryRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4889,6 +4889,7 @@ final class JsonSerializableToJsonTest {
                       .setJobLease("job-lease-abc123")
                       .setIteration(3)
                       .setRole(AgentHistoryRole.ASSISTANT)
+                      .setBpmnProcessId("invoice-handling-process")
                       .setProducedAt(1748860800000L);
               record.addContent(
                   new AgentHistoryMessageContent()
@@ -4983,6 +4984,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
+          "bpmnProcessId": "invoice-handling-process",
           "processDefinitionKey": -1
         }
         """
@@ -5006,6 +5008,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
+          "bpmnProcessId": "",
           "processDefinitionKey": -1
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -35,6 +35,7 @@ final class AgentHistoryRecordTest {
     assertThat(record.getRole()).isEqualTo(AgentHistoryRole.UNSPECIFIED);
     assertThat(record.getProducedAt()).isEqualTo(-1L);
     assertThat(record.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(record.getBpmnProcessId()).isEmpty();
     assertThat(record.getProcessInstanceKey()).isEqualTo(-1L);
     assertThat(record.getRootProcessInstanceKey()).isEqualTo(-1L);
     assertThat(record.getProcessDefinitionKey()).isEqualTo(-1L);
@@ -223,6 +224,7 @@ final class AgentHistoryRecordTest {
     final AgentHistoryRecord original =
         new AgentHistoryRecord()
             .setTenantId("tenant-a")
+            .setBpmnProcessId("invoice-handling-process")
             .setProcessInstanceKey(2251799813685260L)
             .setRootProcessInstanceKey(2251799813685262L)
             .setProcessDefinitionKey(2251799813685261L);
@@ -233,6 +235,7 @@ final class AgentHistoryRecordTest {
 
     // then
     assertThat(copy.getTenantId()).isEqualTo("tenant-a");
+    assertThat(copy.getBpmnProcessId()).isEqualTo("invoice-handling-process");
     assertThat(copy.getProcessInstanceKey()).isEqualTo(2251799813685260L);
     assertThat(copy.getRootProcessInstanceKey()).isEqualTo(2251799813685262L);
     assertThat(copy.getProcessDefinitionKey()).isEqualTo(2251799813685261L);

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
@@ -33,6 +33,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new LongProperty("processDefinitionKey", -1L);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
   private final StringProperty jobLeaseProp = new StringProperty("jobLease", "");
   private final IntegerProperty iterationProp = new IntegerProperty("iteration", 0);
@@ -47,7 +48,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new ObjectProperty<>("metrics", new AgentHistoryMetrics());
 
   public AgentHistoryRecord() {
-    super(15);
+    super(16);
     declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -55,6 +56,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
+        .declareProperty(bpmnProcessIdProp)
         .declareProperty(jobKeyProp)
         .declareProperty(jobLeaseProp)
         .declareProperty(iterationProp)
@@ -132,6 +134,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public AgentHistoryRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -55,6 +55,9 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   @Override
   String getTenantId();
 
+  /** Returns the BPMN process id of the process definition this history entry belongs to. */
+  String getBpmnProcessId();
+
   /** Returns the key of the job that triggered the agent for this entry. */
   long getJobKey();
 


### PR DESCRIPTION
## Summary

Carries `bpmnProcessId` end-to-end through the AGENT_HISTORY pipeline so it lands on every `AgentHistoryEntity` document in ES/OS.

- Protocol — adds `getBpmnProcessId()` to `AgentHistoryRecordValue` and a `StringProperty` (empty-string sentinel) to `AgentHistoryRecord`; golden snapshot updated to match.
- Engine — `AgentHistoryCreateProcessor` populates the new field from the in-scope `AgentInstanceRecord` (the same value already used for the authorization check, so no new state lookup).
- Storage — `AgentHistoryEntity` gains a `@SinceVersion(requireDefault = false)` field; `AgentHistoryTemplate` exposes the `BPMN_PROCESS_ID` constant; all four ES/OS index template JSONs map it as `keyword`.
- Exporter — `AgentHistoryHandler.updateEntity()` copies the field; `flush()` is unchanged so partial updates on COMMITTED/DISCARDED still write only `commitStatus`.

Test coverage:
- `AgentHistoryCreateTest.shouldEmitCreatedEventOnHappyPath` asserts the field matches the deployed BPMN id.
- `AgentHistoryHandlerTest.shouldUpdateEntityForAllHandledIntents` asserts round-trip into the entity.

Out of scope (intentional): `AgentHistoryFilterTransformer` / reader (covered by #55268), RDBMS layer (Part 3 of #51511), filterable/sortable surface.

Closes #55374
Unblocks #55268

## Test plan

- [ ] CI green on `zeebe-protocol-impl` (protocol golden snapshot matches new field layout).
- [ ] CI green on `zeebe-engine` (AgentHistoryCreateTest assertion passes).
- [ ] CI green on `camunda-exporter` (AgentHistoryHandlerTest assertion passes).
- [ ] CI green on `webapps-schema` compile.
- [ ] Full-repo CI compile remains green.

Note: local baseline was skipped because `security/` requires an authenticated Camunda Artifactory that external contributors don't have; verification is fully on CI.