### PR TITLE
fix: use full reactor build for Optimize E2E backend (INC-5968)

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -468,8 +468,10 @@ jobs:
           project_name: e2e
           additional_flags: "--profile self-managed"
 
-      - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild -Dskip.docker
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
@@ -617,8 +619,10 @@ jobs:
         with:
           directory: ./optimize/client
           node-version: ${{ steps.pom-info.outputs.x_version_node }}
-      - name: Build backend
-        run: ./mvnw -T1C clean install -Dmaven.test.skip=true -DskipChecks -Dskip.docker -pl optimize/backend -am -PskipFrontendBuild
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild -Dskip.docker
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
       - name: Start backend


### PR DESCRIPTION
Replaces the partial fix (-Dmaven.test.skip=true -DskipChecks) with the build-zeebe full reactor install for both E2E jobs.

The narrow -pl optimize/backend -am build cannot resolve SNAPSHOT artifacts on release/merge-back branches: artifacts pulled transitively via external deps (e.g. zeebe-client-java via zeebe-test-container, BOM-managed to ${project.version}) are not in the -am closure, so their producers are not built locally and the bumped SNAPSHOT isn't in nexus yet. The earlier -Dmaven.test.skip change also broke in-reactor test-jar production (zeebe-scheduler:tests).

build-zeebe builds the entire reactor, installing every jar and test-jar to local .m2, so all transitive resolution succeeds. Matches the proven pattern already on stable/8.8 and the optimize-it-* jobs. -Dskip.docker avoids the optimize Docker image build (optimize/pom.xml defaults skip.docker=false).

Cleans up the partial fix backported here via #55088.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
