### PR TITLE
test: align processes "wait for creation" with Operate not-found behavior

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -250,24 +250,14 @@ test.describe('Processes', () => {
         `${baseUrl}/operate/processes?processDefinitionId=testProcess&processDefinitionVersion=1`,
       );
 
-      await expect(page).toHaveURL(
-        `${baseUrl}/operate/processes?processDefinitionId=testProcess&processDefinitionVersion=1`,
-      );
+      // Operate detects the unknown process definition, surfaces a
+      // "Process could not be found" notification, and strips the invalid
+      // processDefinitionId/processDefinitionVersion params from the URL.
       await expect(
         operateProcessesPage.processCouldNotBeFoundMessage,
       ).toBeVisible();
 
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(operateFiltersPanelPage.processNameFilter).toBeDisabled({
-            timeout: 5000,
-          });
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-        maxRetries: 5,
-      });
+      await expect(page).toHaveURL(`${baseUrl}/operate/processes`);
     });
 
     await test.step('Deploy new process and verify it loads', async () => {


### PR DESCRIPTION
## Problem

The `tests/operate/processes.spec.ts` → **Wait for process creation** test fails in the nightly E2E run for `stable/8.9`. The first step (*Navigate to non-existent process*) encodes Operate behavior that has since changed:

- It asserted the URL keeps `?processDefinitionId=testProcess&processDefinitionVersion=1`.
- It asserted the process **Name** filter becomes `disabled`.

Both retries fail — one on the URL assertion (`Received: http://localhost:8080/operate/processes`), one on `toBeDisabled` (`Received: enabled`).

## Root cause (product behavior change)

In `operate/client/.../ListView/DiagramPanel/index.tsx`, when the process definition resolves to `no-match`, Operate now:
1. **Deletes** `processDefinitionId` / `processDefinitionVersion` from the URL (resetting to `/operate/processes`), and
2. displays a dismissable **"Process could not be found"** notification.

The Name combobox (`ProcessField.tsx`) is only disabled in multi-tenancy / batch-modification mode — never on a not-found process. So the old `toBeDisabled` and param-retaining URL assertions no longer match product behavior.

## Fix

Update the *Navigate to non-existent process* step to assert the actual current behavior: the not-found notification appears and the URL is reset to `/operate/processes`. The second step (deploy + load) is unchanged.

This is a test-only change; no product code is modified.

Nightly run: https://github.com/camunda/camunda/actions/runs/27660912610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/27668340272 -> 1 failing test unrelated to the changes
