### PR TITLE
test: add isLatestVersion totalItems regression coverage for orchestration E2E

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Page, Locator} from '@playwright/test';
+import {Page, Locator, expect} from '@playwright/test';
 
 type OptionalFilter =
   | 'Process Instance Key'
@@ -32,6 +32,7 @@ class OperateDecisionsPage {
   readonly evaluatedCheckbox: Locator;
   readonly failedCheckbox: Locator;
   readonly decisionInstancesList: Locator;
+  readonly getOptionByName: (name: string, exact?: boolean) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -58,6 +59,8 @@ class OperateDecisionsPage {
     this.evaluatedCheckbox = page.getByRole('checkbox', {name: 'Evaluated'});
     this.failedCheckbox = page.getByRole('checkbox', {name: 'Failed'});
     this.decisionInstancesList = page.getByTestId('data-list');
+    this.getOptionByName = (name: string, exact = true) =>
+      this.filterRegion.getByRole('option', {name, exact});
   }
 
   async clickViewDecisionInstanceLink(
@@ -86,16 +89,19 @@ class OperateDecisionsPage {
 
   async selectDecisionName(option: string): Promise<void> {
     await this.decisionNameFilter.click();
-    await this.filterRegion
-      .getByRole('option', {name: option, exact: true})
-      .click();
+    await this.getOptionByName(option).click();
   }
 
   async selectVersion(option: string): Promise<void> {
     await this.decisionVersionFilter.click();
-    await this.filterRegion
-      .getByRole('option', {name: option, exact: true})
-      .click();
+    await this.getOptionByName(option).click();
+  }
+
+  async assertDecisionNameOptionVisible(option: string): Promise<void> {
+    await this.decisionNameFilter.click();
+    await this.decisionNameFilter.fill(option);
+    await expect(this.getOptionByName(option)).toBeVisible({timeout: 10_000});
+    await this.page.keyboard.press('Escape');
   }
 
   async clearComboBox(): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -180,6 +180,13 @@ export class OperateFiltersPanelPage {
     await expect(this.processVersionFilter).toBeEnabled({timeout: 3000});
   }
 
+  async assertProcessNameOptionVisible(option: string) {
+    await this.processNameFilter.click();
+    await this.processNameFilter.fill(option);
+    await expect(this.getOptionByName(option)).toBeVisible({timeout: 10_000});
+    await this.page.keyboard.press('Escape');
+  }
+
   async selectVersion(option: string) {
     await expect(this.processNameFilter).toBeVisible();
     await expect(this.processVersionFilter).toBeEnabled();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
@@ -719,7 +719,7 @@ test.describe.parallel('Search Decision Definitions API Tests', () => {
             data: {
               filter: {
                 isLatestVersion: true,
-                decisionDefinitionId: {$like: `dd-isLatest-${suffix}-*`},
+                decisionRequirementsName: `drs-${suffix}`,
               },
               page: {limit: 5},
             },
@@ -742,7 +742,7 @@ test.describe.parallel('Search Decision Definitions API Tests', () => {
           '/decision-definitions/search',
           {
             isLatestVersion: true,
-            decisionDefinitionId: {$like: `dd-isLatest-${suffix}-*`},
+            decisionRequirementsName: `drs-${suffix}`,
           },
           5,
         );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
@@ -6,19 +6,26 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {randomUUID} from 'node:crypto';
 import {test, expect} from '@playwright/test';
 import {
   buildUrl,
   jsonHeaders,
+  assertStatusCode,
   assertUnauthorizedRequest,
   assertPaginatedRequest,
   assertBadRequest,
 } from '../../../../utils/http';
-import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  defaultAssertionOptions,
+  extendedAssertionOptions,
+} from '../../../../utils/constants';
 import {
   assertDecisionDefinitionInResponse,
   DECISION_DEFINITION_RESPONSE_FROM_DEPLOYMENT,
   deployDecisionAndStoreResponse,
+  seedUniqueDecisionDefinitions,
+  walkLatestVersionCursor,
 } from '@requestHelpers';
 import {DecisionDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 import {validateResponse} from 'json-body-assertions';
@@ -691,5 +698,66 @@ test.describe.parallel('Search Decision Definitions API Tests', () => {
         decisionDefinition2.decisionDefinitionKey as string,
       );
     }).toPass(defaultAssertionOptions);
+  });
+
+  test.describe('isLatestVersion totalItems', () => {
+    let suffix: string;
+
+    test.beforeAll(async () => {
+      suffix = randomUUID().slice(0, 8);
+      await seedUniqueDecisionDefinitions(suffix, 15, 5);
+    });
+
+    test('totalItems reflects unique count beyond page limit', async ({
+      request,
+    }) => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/decision-definitions/search', {}),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                isLatestVersion: true,
+                decisionDefinitionId: {$like: `dd-isLatest-${suffix}-*`},
+              },
+              page: {limit: 5},
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        expect(body.page.totalItems).toBe(15);
+        expect(body.items).toHaveLength(5);
+        expect(body.page.endCursor).toBeTruthy();
+      }).toPass(extendedAssertionOptions);
+    });
+
+    test('forward cursor pagination collects all unique latest-version items', async ({
+      request,
+    }) => {
+      await expect(async () => {
+        const items = await walkLatestVersionCursor(
+          request,
+          '/decision-definitions/search',
+          {
+            isLatestVersion: true,
+            decisionDefinitionId: {$like: `dd-isLatest-${suffix}-*`},
+          },
+          5,
+        );
+        const uniqueIds = new Set(
+          (items as {decisionDefinitionId?: string}[]).map(
+            (item) => item.decisionDefinitionId,
+          ),
+        );
+        expect(uniqueIds.size).toBe(15);
+        expect(
+          [...uniqueIds].every((id) =>
+            id?.startsWith(`dd-isLatest-${suffix}-`),
+          ),
+        ).toBe(true);
+      }).toPass(extendedAssertionOptions);
+    });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
@@ -725,6 +725,14 @@ test.describe.parallel('Search Decision Definitions API Tests', () => {
             },
           },
         );
+        await validateResponse(
+          {
+            path: '/decision-definitions/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
         await assertStatusCode(res, 200);
         const body = await res.json();
         expect(body.page.totalItems).toBe(15);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {randomUUID} from 'node:crypto';
 import {expect, test} from '@playwright/test';
 import {
   assertBadRequest,
@@ -17,7 +18,14 @@ import {
 } from '../../../../utils/http';
 import {validateResponseShape} from '../../../../json-body-assertions';
 import {createInstances, deploy} from '../../../../utils/zeebeClient';
-import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  defaultAssertionOptions,
+  extendedAssertionOptions,
+} from '../../../../utils/constants';
+import {
+  seedUniqueProcessDefinitions,
+  walkLatestVersionCursor,
+} from '@requestHelpers';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Process Definition Search API', () => {
@@ -300,5 +308,100 @@ test.describe.parallel('Process Definition Search API', () => {
       data: {},
     });
     await assertUnauthorizedRequest(res);
+  });
+
+  test.describe('isLatestVersion totalItems', () => {
+    let suffix: string;
+
+    test.beforeAll(async () => {
+      suffix = randomUUID().slice(0, 8);
+      await seedUniqueProcessDefinitions(suffix, 15, 5);
+    });
+
+    test('totalItems reflects unique count beyond page limit', async ({
+      request,
+    }) => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/process-definitions/search'),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                isLatestVersion: true,
+                processDefinitionId: {$like: `pd-isLatest-${suffix}-*`},
+              },
+              page: {limit: 5},
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        expect(body.page.totalItems).toBe(15);
+        expect(body.items).toHaveLength(5);
+        expect(body.page.endCursor).toBeTruthy();
+      }).toPass(extendedAssertionOptions);
+    });
+
+    test('forward cursor pagination collects all unique latest-version items', async ({
+      request,
+    }) => {
+      await expect(async () => {
+        const items = await walkLatestVersionCursor(
+          request,
+          '/process-definitions/search',
+          {
+            isLatestVersion: true,
+            processDefinitionId: {$like: `pd-isLatest-${suffix}-*`},
+          },
+          5,
+        );
+        const uniqueIds = new Set(
+          (items as {processDefinitionId?: string}[]).map(
+            (item) => item.processDefinitionId,
+          ),
+        );
+        expect(uniqueIds.size).toBe(15);
+        expect(
+          [...uniqueIds].every((id) =>
+            id?.startsWith(`pd-isLatest-${suffix}-`),
+          ),
+        ).toBe(true);
+      }).toPass(extendedAssertionOptions);
+    });
+
+    test('rejects pagination with from when isLatestVersion is set', async ({
+      request,
+    }) => {
+      const res = await request.post(buildUrl('/process-definitions/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {isLatestVersion: true},
+          page: {from: 5, limit: 5},
+        },
+      });
+      await assertInvalidArgument(
+        res,
+        400,
+        "The field 'from' is not supported",
+      );
+    });
+
+    test('rejects pagination with before when isLatestVersion is set', async ({
+      request,
+    }) => {
+      const res = await request.post(buildUrl('/process-definitions/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {isLatestVersion: true},
+          page: {before: 'some-cursor', limit: 5},
+        },
+      });
+      await assertInvalidArgument(
+        res,
+        400,
+        "The field 'before' is not supported",
+      );
+    });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
@@ -337,6 +337,14 @@ test.describe.parallel('Process Definition Search API', () => {
         );
         await assertStatusCode(res, 200);
         const body = await res.json();
+        validateResponseShape(
+          {
+            path: '/process-definitions/search',
+            method: 'POST',
+            status: '200',
+          },
+          body,
+        );
         expect(body.page.totalItems).toBe(15);
         expect(body.items).toHaveLength(5);
         expect(body.page.endCursor).toBeTruthy();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionsIsLatestVersionFilter.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionsIsLatestVersionFilter.spec.ts
@@ -73,7 +73,6 @@ test.describe('Operate — Decisions isLatestVersion filter', () => {
   });
 
   test('Decision Name dropdown shows all unique latest-version definitions including beyond first page', async ({
-    page,
     operateDecisionsPage,
   }) => {
     // Regression: before the fix the dropdown truncated at ~100 entries because
@@ -85,18 +84,7 @@ test.describe('Operate — Decisions isLatestVersion filter', () => {
 
     for (const idx of indicesToCheck) {
       const id = seededIds[idx]!;
-      // Open the combobox, type the full ID to filter to exactly one match
-      // (avoids Carbon ComboBox virtualisation hiding offscreen options), then
-      // close before the next iteration.
-      await operateDecisionsPage.decisionNameFilter.click();
-      await operateDecisionsPage.decisionNameFilter.fill(id);
-      await expect(
-        operateDecisionsPage.filterRegion.getByRole('option', {
-          name: id,
-          exact: true,
-        }),
-      ).toBeVisible({timeout: 10_000});
-      await page.keyboard.press('Escape');
+      await operateDecisionsPage.assertDecisionNameOptionVisible(id);
     }
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionsIsLatestVersionFilter.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionsIsLatestVersionFilter.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {randomUUID} from 'node:crypto';
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
+import {
+  seedUniqueDecisionDefinitions,
+  waitForLatestVersionTotalItems,
+} from '@requestHelpers';
+
+/**
+ * Regression tests for the ES/OS bug where `/decision-definitions/search` with
+ * `isLatestVersion: true` returned `page.totalItems` equal to the server page
+ * size (~100) instead of the actual count of unique latest-version definitions.
+ *
+ * The bug caused the Decision Name combobox in Operate to truncate at the first
+ * ~100 definitions, hiding any beyond that.  N=120 comfortably exceeds the
+ * server default.
+ */
+
+const SEED_COUNT = 120;
+const REDEPLOY_FOR_V2_COUNT = 10;
+
+let suffix: string;
+let seededIds: string[];
+
+test.beforeAll(async ({request}) => {
+  suffix = randomUUID().slice(0, 8);
+  seededIds = await seedUniqueDecisionDefinitions(
+    suffix,
+    SEED_COUNT,
+    REDEPLOY_FOR_V2_COUNT,
+  );
+  // Wait until the search index reflects all seeded definitions so that the UI
+  // combobox can load them before the tests start.
+  await waitForLatestVersionTotalItems(
+    request,
+    '/decision-definitions/search',
+    {
+      isLatestVersion: true,
+      decisionDefinitionId: {$like: `dd-isLatest-${suffix}-*`},
+    },
+    SEED_COUNT,
+  );
+});
+
+test.describe('Operate — Decisions isLatestVersion filter', () => {
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickDecisionsTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Decision Name dropdown shows all unique latest-version definitions including beyond first page', async ({
+    operateDecisionsPage,
+  }) => {
+    // Regression: before the fix the dropdown truncated at ~100 entries because
+    // the API returned totalItems equal to the server page size instead of the
+    // real count.  We verify both within the first 100 (indices 0, 49, 99) and
+    // beyond (index 119) to confirm the full list is available.
+    const indicesToCheck = [0, 49, 99, SEED_COUNT - 1];
+
+    for (const idx of indicesToCheck) {
+      const id = seededIds[idx]!;
+      // Type the full ID to filter the combobox to exactly one match, avoiding
+      // Carbon ComboBox virtualisation hiding offscreen options.
+      await operateDecisionsPage.decisionNameFilter.fill(id);
+      await expect(
+        operateDecisionsPage.filterRegion.getByRole('option', {
+          name: id,
+          exact: true,
+        }),
+      ).toBeVisible({timeout: 10_000});
+      // Clear before the next iteration.
+      await operateDecisionsPage.decisionNameFilter.fill('');
+    }
+  });
+
+  test('Selecting a multi-version decision defaults to its latest version', async ({
+    operateDecisionsPage,
+  }) => {
+    // seededIds[0] was redeployed to version 2 in beforeAll.
+    const multiVersionId = seededIds[0]!;
+    await operateDecisionsPage.selectDecisionName(multiVersionId);
+    await expect
+      .poll(() => operateDecisionsPage.decisionVersionFilter.innerText())
+      .toBe('2');
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionsIsLatestVersionFilter.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionsIsLatestVersionFilter.spec.ts
@@ -40,13 +40,15 @@ test.beforeAll(async ({request}) => {
     REDEPLOY_FOR_V2_COUNT,
   );
   // Wait until the search index reflects all seeded definitions so that the UI
-  // combobox can load them before the tests start.
+  // combobox can load them before the tests start.  Scoped via
+  // `decisionRequirementsName` because the v2 search endpoint does not support
+  // advanced operators on `decisionDefinitionId`.
   await waitForLatestVersionTotalItems(
     request,
     '/decision-definitions/search',
     {
       isLatestVersion: true,
-      decisionDefinitionId: {$like: `dd-isLatest-${suffix}-*`},
+      decisionRequirementsName: `drs-${suffix}`,
     },
     SEED_COUNT,
   );
@@ -65,18 +67,22 @@ test.describe('Operate — Decisions isLatestVersion filter', () => {
   });
 
   test('Decision Name dropdown shows all unique latest-version definitions including beyond first page', async ({
+    page,
     operateDecisionsPage,
   }) => {
     // Regression: before the fix the dropdown truncated at ~100 entries because
     // the API returned totalItems equal to the server page size instead of the
     // real count.  We verify both within the first 100 (indices 0, 49, 99) and
     // beyond (index 119) to confirm the full list is available.
+    await expect(operateDecisionsPage.decisionNameFilter).toBeVisible();
     const indicesToCheck = [0, 49, 99, SEED_COUNT - 1];
 
     for (const idx of indicesToCheck) {
       const id = seededIds[idx]!;
-      // Type the full ID to filter the combobox to exactly one match, avoiding
-      // Carbon ComboBox virtualisation hiding offscreen options.
+      // Open the combobox, type the full ID to filter to exactly one match
+      // (avoids Carbon ComboBox virtualisation hiding offscreen options), then
+      // close before the next iteration.
+      await operateDecisionsPage.decisionNameFilter.click();
       await operateDecisionsPage.decisionNameFilter.fill(id);
       await expect(
         operateDecisionsPage.filterRegion.getByRole('option', {
@@ -84,19 +90,7 @@ test.describe('Operate — Decisions isLatestVersion filter', () => {
           exact: true,
         }),
       ).toBeVisible({timeout: 10_000});
-      // Clear before the next iteration.
-      await operateDecisionsPage.decisionNameFilter.fill('');
+      await page.keyboard.press('Escape');
     }
-  });
-
-  test('Selecting a multi-version decision defaults to its latest version', async ({
-    operateDecisionsPage,
-  }) => {
-    // seededIds[0] was redeployed to version 2 in beforeAll.
-    const multiVersionId = seededIds[0]!;
-    await operateDecisionsPage.selectDecisionName(multiVersionId);
-    await expect
-      .poll(() => operateDecisionsPage.decisionVersionFilter.innerText())
-      .toBe('2');
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionsIsLatestVersionFilter.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionsIsLatestVersionFilter.spec.ts
@@ -27,7 +27,13 @@ import {
  */
 
 const SEED_COUNT = 120;
-const REDEPLOY_FOR_V2_COUNT = 10;
+// The regression is triggered purely by `isLatestVersion: true` with more than
+// the server page size (~100) of unique definitions, regardless of how many
+// versions each has — so we deploy a single version per definition.  Operate's
+// dropdown shows the DMN `name` attribute of the latest version, so adding a
+// v2 deployment would change the option label (e.g. `${did}-v2`) and break the
+// id-based lookup below.
+const REDEPLOY_FOR_V2_COUNT = 0;
 
 let suffix: string;
 let seededIds: string[];

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processesIsLatestVersionFilter.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processesIsLatestVersionFilter.spec.ts
@@ -71,7 +71,6 @@ test.describe('Operate — Processes isLatestVersion filter', () => {
   });
 
   test('Process Name dropdown shows all unique latest-version definitions including beyond first page', async ({
-    page,
     operateFiltersPanelPage,
   }) => {
     // Regression: before the fix the dropdown truncated at ~100 entries because
@@ -83,15 +82,7 @@ test.describe('Operate — Processes isLatestVersion filter', () => {
 
     for (const idx of indicesToCheck) {
       const id = seededIds[idx]!;
-      // Open the combobox, type the full ID to filter to exactly one match
-      // (avoids Carbon ComboBox virtualisation hiding offscreen options), then
-      // close before the next iteration.
-      await operateFiltersPanelPage.processNameFilter.click();
-      await operateFiltersPanelPage.processNameFilter.fill(id);
-      await expect(
-        operateFiltersPanelPage.getOptionByName(id, true),
-      ).toBeVisible({timeout: 10_000});
-      await page.keyboard.press('Escape');
+      await operateFiltersPanelPage.assertProcessNameOptionVisible(id);
     }
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processesIsLatestVersionFilter.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processesIsLatestVersionFilter.spec.ts
@@ -65,35 +65,27 @@ test.describe('Operate — Processes isLatestVersion filter', () => {
   });
 
   test('Process Name dropdown shows all unique latest-version definitions including beyond first page', async ({
+    page,
     operateFiltersPanelPage,
   }) => {
     // Regression: before the fix the dropdown truncated at ~100 entries because
     // the API returned totalItems equal to the server page size instead of the
     // real count.  We verify both within the first 100 (indices 0, 49, 99) and
     // beyond (index 119) to confirm the full list is available.
+    await expect(operateFiltersPanelPage.processNameFilter).toBeVisible();
     const indicesToCheck = [0, 49, 99, SEED_COUNT - 1];
 
     for (const idx of indicesToCheck) {
       const id = seededIds[idx]!;
-      // Type the full ID to filter the combobox to exactly one match, avoiding
-      // Carbon ComboBox virtualisation hiding offscreen options.
+      // Open the combobox, type the full ID to filter to exactly one match
+      // (avoids Carbon ComboBox virtualisation hiding offscreen options), then
+      // close before the next iteration.
+      await operateFiltersPanelPage.processNameFilter.click();
       await operateFiltersPanelPage.processNameFilter.fill(id);
       await expect(
         operateFiltersPanelPage.getOptionByName(id, true),
       ).toBeVisible({timeout: 10_000});
-      // Clear the input before the next iteration.
-      await operateFiltersPanelPage.processNameFilter.fill('');
+      await page.keyboard.press('Escape');
     }
-  });
-
-  test('Selecting a multi-version process defaults to its latest version', async ({
-    operateFiltersPanelPage,
-  }) => {
-    // seededIds[0] was redeployed to version 2 in beforeAll.
-    const multiVersionId = seededIds[0]!;
-    await operateFiltersPanelPage.selectProcess(multiVersionId);
-    await expect
-      .poll(() => operateFiltersPanelPage.processVersionFilter.innerText())
-      .toBe('2');
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processesIsLatestVersionFilter.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processesIsLatestVersionFilter.spec.ts
@@ -27,7 +27,13 @@ import {
  */
 
 const SEED_COUNT = 120;
-const REDEPLOY_FOR_V2_COUNT = 10;
+// The regression is triggered purely by `isLatestVersion: true` with more than
+// the server page size (~100) of unique definitions, regardless of how many
+// versions each has — so we deploy a single version per definition.  Operate's
+// dropdown shows the BPMN `name` attribute of the latest version, so adding a
+// v2 deployment would change the option label (e.g. `${pid}-v2`) and break the
+// id-based lookup below.
+const REDEPLOY_FOR_V2_COUNT = 0;
 
 let suffix: string;
 let seededIds: string[];

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processesIsLatestVersionFilter.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processesIsLatestVersionFilter.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {randomUUID} from 'node:crypto';
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
+import {
+  seedUniqueProcessDefinitions,
+  waitForLatestVersionTotalItems,
+} from '@requestHelpers';
+
+/**
+ * Regression tests for the ES/OS bug where `/process-definitions/search` with
+ * `isLatestVersion: true` returned `page.totalItems` equal to the server page
+ * size (~100) instead of the actual count of unique latest-version definitions.
+ *
+ * The bug caused the Process Name combobox in Operate to truncate at the first
+ * ~100 definitions, hiding any beyond that.  N=120 comfortably exceeds the
+ * server default.
+ */
+
+const SEED_COUNT = 120;
+const REDEPLOY_FOR_V2_COUNT = 10;
+
+let suffix: string;
+let seededIds: string[];
+
+test.beforeAll(async ({request}) => {
+  suffix = randomUUID().slice(0, 8);
+  seededIds = await seedUniqueProcessDefinitions(
+    suffix,
+    SEED_COUNT,
+    REDEPLOY_FOR_V2_COUNT,
+  );
+  // Wait until the search index reflects all seeded definitions so that the UI
+  // combobox can load them before the tests start.
+  await waitForLatestVersionTotalItems(
+    request,
+    '/process-definitions/search',
+    {
+      isLatestVersion: true,
+      processDefinitionId: {$like: `pd-isLatest-${suffix}-*`},
+    },
+    SEED_COUNT,
+  );
+});
+
+test.describe('Operate — Processes isLatestVersion filter', () => {
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Process Name dropdown shows all unique latest-version definitions including beyond first page', async ({
+    operateFiltersPanelPage,
+  }) => {
+    // Regression: before the fix the dropdown truncated at ~100 entries because
+    // the API returned totalItems equal to the server page size instead of the
+    // real count.  We verify both within the first 100 (indices 0, 49, 99) and
+    // beyond (index 119) to confirm the full list is available.
+    const indicesToCheck = [0, 49, 99, SEED_COUNT - 1];
+
+    for (const idx of indicesToCheck) {
+      const id = seededIds[idx]!;
+      // Type the full ID to filter the combobox to exactly one match, avoiding
+      // Carbon ComboBox virtualisation hiding offscreen options.
+      await operateFiltersPanelPage.processNameFilter.fill(id);
+      await expect(
+        operateFiltersPanelPage.getOptionByName(id, true),
+      ).toBeVisible({timeout: 10_000});
+      // Clear the input before the next iteration.
+      await operateFiltersPanelPage.processNameFilter.fill('');
+    }
+  });
+
+  test('Selecting a multi-version process defaults to its latest version', async ({
+    operateFiltersPanelPage,
+  }) => {
+    // seededIds[0] was redeployed to version 2 in beforeAll.
+    const multiVersionId = seededIds[0]!;
+    await operateFiltersPanelPage.selectProcess(multiVersionId);
+    await expect
+      .poll(() => operateFiltersPanelPage.processVersionFilter.innerText())
+      .toBe('2');
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -108,6 +108,12 @@ export {
 export {type AuditLog} from './audit-log-requestHelpers';
 export {evaluateExpression, EXPRESSION_URL} from './expression-requestHelpers';
 export {
+  seedUniqueProcessDefinitions,
+  seedUniqueDecisionDefinitions,
+  walkLatestVersionCursor,
+  waitForLatestVersionTotalItems,
+} from './latest-version-test-helpers';
+export {
   type VariableRecord,
   isRootScope,
   isLocalScope,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/latest-version-test-helpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/latest-version-test-helpers.ts
@@ -51,9 +51,15 @@ export async function seedUniqueProcessDefinitions(
 
 /**
  * Deploys N unique decision definitions with IDs `dd-isLatest-${suffix}-0` …
- * `dd-isLatest-${suffix}-${count-1}`.  The first `redeployForV2Count` are
- * redeployed with a name change so that Zeebe registers them as version 2.
- * Returns the array of seeded decision definition IDs.
+ * `dd-isLatest-${suffix}-${count-1}`.  All deployments share the same DRG name
+ * `drs-${suffix}`, which lets tests scope queries via `decisionRequirementsName`
+ * (the v2 search endpoint does not support advanced operators on
+ * `decisionDefinitionId`, so a name-prefix `$like` is not available).
+ * Each deployment uses a unique DRG id so Zeebe creates a separate DRG per
+ * decision rather than versioning a shared one.
+ *
+ * The first `redeployForV2Count` decisions are redeployed with a name change so
+ * Zeebe registers them as version 2.  Returns the seeded decision IDs.
  */
 export async function seedUniqueDecisionDefinitions(
   suffix: string,
@@ -61,18 +67,26 @@ export async function seedUniqueDecisionDefinitions(
   redeployForV2Count: number,
 ): Promise<string[]> {
   const ids: string[] = [];
+  const drgName = `drs-${suffix}`;
   for (let i = 0; i < count; i++) {
     const did = `dd-isLatest-${suffix}-${i}`;
+    const drgId = `def-${suffix}-${i}`;
     ids.push(did);
     await deployWithSubstitutions('./resources/simpleDecisionTable1.dmn', {
+      Definitions_1lja2g1: drgId,
+      'name="DRD"': `name="${drgName}"`,
       Decision_f6ej9i5: did,
       SingleTableDecision: did,
     });
   }
   for (let i = 0; i < redeployForV2Count; i++) {
     const did = ids[i]!;
-    // Same id, different name → Zeebe creates version 2 of the decision.
+    const drgId = `def-${suffix}-${i}`;
+    // Same DRG id and decision id, different decision name → Zeebe creates v2
+    // of the DRG and v2 of the decision under the stable decision id.
     await deployWithSubstitutions('./resources/simpleDecisionTable1.dmn', {
+      Definitions_1lja2g1: drgId,
+      'name="DRD"': `name="${drgName}"`,
       Decision_f6ej9i5: did,
       SingleTableDecision: `${did}-v2`,
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/latest-version-test-helpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/latest-version-test-helpers.ts
@@ -22,6 +22,11 @@ export async function seedUniqueProcessDefinitions(
   count: number,
   redeployForV2Count: number,
 ): Promise<string[]> {
+  if (redeployForV2Count > count) {
+    throw new Error(
+      `redeployForV2Count (${redeployForV2Count}) must not exceed count (${count}).`,
+    );
+  }
   const ids: string[] = [];
   for (let i = 0; i < count; i++) {
     const pid = `pd-isLatest-${suffix}-${i}`;
@@ -66,6 +71,11 @@ export async function seedUniqueDecisionDefinitions(
   count: number,
   redeployForV2Count: number,
 ): Promise<string[]> {
+  if (redeployForV2Count > count) {
+    throw new Error(
+      `redeployForV2Count (${redeployForV2Count}) must not exceed count (${count}).`,
+    );
+  }
   const ids: string[] = [];
   const drgName = `drs-${suffix}`;
   for (let i = 0; i < count; i++) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/latest-version-test-helpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/latest-version-test-helpers.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, type APIRequestContext} from '@playwright/test';
+import {deployWithSubstitutions} from '../zeebeClient';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+import {extendedAssertionOptions} from '../constants';
+
+/**
+ * Deploys N unique process definitions with IDs `pd-isLatest-${suffix}-0` …
+ * `pd-isLatest-${suffix}-${count-1}`.  The first `redeployForV2Count` are
+ * redeployed with a name tweak so that Zeebe registers them as version 2.
+ * Returns the array of seeded process definition IDs.
+ */
+export async function seedUniqueProcessDefinitions(
+  suffix: string,
+  count: number,
+  redeployForV2Count: number,
+): Promise<string[]> {
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const pid = `pd-isLatest-${suffix}-${i}`;
+    ids.push(pid);
+    await deployWithSubstitutions(
+      './resources/process_definition_tests_1.bpmn',
+      {
+        process_definition_tests_1: pid,
+      },
+    );
+  }
+  for (let i = 0; i < redeployForV2Count; i++) {
+    const pid = ids[i]!;
+    // Two-pass substitution: step 1 replaces both the `id` and `name` attributes
+    // with `pid`; step 2 then changes only the `name` attribute to `${pid}-v2` so
+    // the file content differs and Zeebe registers a new version for the same id.
+    await deployWithSubstitutions(
+      './resources/process_definition_tests_1.bpmn',
+      {
+        process_definition_tests_1: pid,
+        [`name="${pid}"`]: `name="${pid}-v2"`,
+      },
+    );
+  }
+  return ids;
+}
+
+/**
+ * Deploys N unique decision definitions with IDs `dd-isLatest-${suffix}-0` …
+ * `dd-isLatest-${suffix}-${count-1}`.  The first `redeployForV2Count` are
+ * redeployed with a name change so that Zeebe registers them as version 2.
+ * Returns the array of seeded decision definition IDs.
+ */
+export async function seedUniqueDecisionDefinitions(
+  suffix: string,
+  count: number,
+  redeployForV2Count: number,
+): Promise<string[]> {
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const did = `dd-isLatest-${suffix}-${i}`;
+    ids.push(did);
+    await deployWithSubstitutions('./resources/simpleDecisionTable1.dmn', {
+      Decision_f6ej9i5: did,
+      SingleTableDecision: did,
+    });
+  }
+  for (let i = 0; i < redeployForV2Count; i++) {
+    const did = ids[i]!;
+    // Same id, different name → Zeebe creates version 2 of the decision.
+    await deployWithSubstitutions('./resources/simpleDecisionTable1.dmn', {
+      Decision_f6ej9i5: did,
+      SingleTableDecision: `${did}-v2`,
+    });
+  }
+  return ids;
+}
+
+/**
+ * Paginates forward through a search endpoint until a page returns fewer items
+ * than `limit`, collecting all items across pages.
+ */
+export async function walkLatestVersionCursor(
+  request: APIRequestContext,
+  endpoint: string,
+  filter: Record<string, unknown>,
+  limit: number,
+): Promise<unknown[]> {
+  const allItems: unknown[] = [];
+  let afterCursor: string | null = null;
+
+  for (;;) {
+    const pageParams: Record<string, unknown> = {limit};
+    if (afterCursor !== null) {
+      pageParams.after = afterCursor;
+    }
+    const res = await request.post(buildUrl(endpoint), {
+      headers: jsonHeaders(),
+      data: {filter, page: pageParams},
+    });
+    await assertStatusCode(res, 200);
+    const body = (await res.json()) as {
+      items?: unknown[];
+      page?: {endCursor?: string | null};
+    };
+    const items = body.items ?? [];
+    allItems.push(...items);
+    if (items.length < limit) {
+      break;
+    }
+    afterCursor = body.page?.endCursor ?? null;
+    if (afterCursor === null) {
+      break;
+    }
+  }
+
+  return allItems;
+}
+
+/**
+ * Polls a search endpoint with `page.limit: 1` until `page.totalItems` reaches
+ * at least `expectedTotal`, absorbing ES/OS indexing lag.
+ * Uses `extendedAssertionOptions` (90 s timeout).
+ */
+export async function waitForLatestVersionTotalItems(
+  request: APIRequestContext,
+  endpoint: string,
+  filter: Record<string, unknown>,
+  expectedTotal: number,
+): Promise<void> {
+  await expect(async () => {
+    const res = await request.post(buildUrl(endpoint), {
+      headers: jsonHeaders(),
+      data: {filter, page: {limit: 1}},
+    });
+    await assertStatusCode(res, 200);
+    const body = (await res.json()) as {page?: {totalItems?: number}};
+    expect(body.page?.totalItems).toBeGreaterThanOrEqual(expectedTotal);
+  }).toPass(extendedAssertionOptions);
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/latest-version-test-helpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/latest-version-test-helpers.ts
@@ -116,8 +116,16 @@ export async function walkLatestVersionCursor(
 ): Promise<unknown[]> {
   const allItems: unknown[] = [];
   let afterCursor: string | null = null;
+  const seenCursors = new Set<string>();
+  const maxPages = 200;
+  let pageCount = 0;
 
   for (;;) {
+    if (pageCount++ >= maxPages) {
+      throw new Error(
+        `walkLatestVersionCursor exceeded maxPages=${maxPages} for ${endpoint} (limit=${limit}).`,
+      );
+    }
     const pageParams: Record<string, unknown> = {limit};
     if (afterCursor !== null) {
       pageParams.after = afterCursor;
@@ -136,10 +144,18 @@ export async function walkLatestVersionCursor(
     if (items.length < limit) {
       break;
     }
-    afterCursor = body.page?.endCursor ?? null;
-    if (afterCursor === null) {
+
+    const nextCursor = body.page?.endCursor ?? null;
+    if (nextCursor === null) {
       break;
     }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error(
+        `walkLatestVersionCursor detected repeated endCursor='${nextCursor}' for ${endpoint}.`,
+      );
+    }
+    seenCursors.add(nextCursor);
+    afterCursor = nextCursor;
   }
 
   return allItems;


### PR DESCRIPTION
## Description

Adds regression coverage for the isLatestVersion totalItems bug in the orchestration cluster E2E suite and aligns the new Operate UI specs with page object best practices.

### What changed
- Added API regression tests for process-definition and decision-definition latest-version pagination/totalItems behavior.
- Added Operate UI regression tests validating latest-version dropdown coverage beyond the first server page.
- Refactored the new Operate UI specs to use page object methods for combobox interaction and option assertions, removing direct locator/keyboard handling from test bodies.

### Validation
- On-demand workflow (main): https://github.com/camunda/camunda/actions/runs/27621655416
- On-demand workflow (stable/8.9): https://github.com/camunda/camunda/actions/runs/27635250283
- Local checks for this follow-up refactor:
  - `npx eslint` on changed files
  - `npx tsc --noEmit`
  - `npx playwright test --list` for the two new Operate specs

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55382
parent #51622
