### PR TITLE
fix: load-test: mitigation for OutOfCpu pods

### DIFF
--- a/load-tests/docs/scripts/verify-test.sh
+++ b/load-tests/docs/scripts/verify-test.sh
@@ -55,17 +55,39 @@ wait_for_pods() {
     wait_output=$(kubectl wait --for=condition=ready pod \
         -l "$label" \
         --timeout="${POD_TIMEOUT}s" -n "$NAMESPACE" 2>&1) && {
+      echo "::group::Wait output"
       echo "$wait_output"
+      echo "::endgroup::"
       echo "${description} are ready in $NAMESPACE"
       return 0
     }
-    echo "Output: '$wait_output'"
+    echo "::group::Wait output"
+    echo "$wait_output"
+    echo "::endgroup::"
 
     # Retry on errors (pod rescheduled/timeouts);
     echo "::error::Not all ${description} are ready in $NAMESPACE"
     if [[ "$attempt" -lt "$max_retries" ]]; then
       echo "Pod wasn't ready yet. Retrying in ${retry_delay}s..."
       sleep "$retry_delay"
+    fi
+
+    # Get pod status
+    pods="$(kubectl get pod --no-headers -o wide -n "$NAMESPACE")"
+    echo "::group::Pods status"
+    echo "$pods"
+    echo "::endgroup::"
+
+    out_of_cpu_pods="$(echo "$pods" | grep OutOfCpu | awk '{print $1}')"
+    if [[ -n "$out_of_cpu_pods" ]]; then
+        echo "Detected pods with OutOfCpu status, will delete them..."
+        # Mitigation: sometimes, many pods are scheduled on the same node and the
+        # kubelet fails to start them with a "OutOfCpu" error.
+        # Although it looks like a Kubernetes bug, these pods stay and are being
+        # taken into account by the `kubectl wait` call above, which then never
+        # terminates successfully.
+        # As a mitigation, we delete these OutOfCpu pods as they are dead anyway.
+        echo "$out_of_cpu_pods" | xargs -t kubectl delete pod -n "$NAMESPACE"
     fi
   done
 


### PR DESCRIPTION
## Description

Sometimes, many pods are scheduled on a single node and the kubelet can't start them all and fail them with the `OutofCpu` error. This [might be a bug in Kubernetes](https://github.com/kubernetes/kubernetes/issues/115325).

To mitigate that, we remove these pods if there are any as they won't start ever anyway:

* Display the status of the pods, so we can debug even after the workflow failed
* Remove OutOfCpu pods: they won't ever run anyway



## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/55384
* https://camunda.slack.com/archives/C0A22S6M4TF/p1781675969020829?thread_ts=1781669496.971129&cid=C0A22S6M4TF