### PR TITLE
deps: update c8run versions to 8.8.28

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,8 +1,8 @@
 ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.8.27
+CAMUNDA_VERSION=8.8.28
 # docker images moved to a shortened tag, override compose with this value when using --docker
-CAMUNDA_DOCKER_VERSION=8.8.27
+CAMUNDA_DOCKER_VERSION=8.8.28
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
 CONNECTORS_VERSION=8.8.14
 # version of docker compose artifact (used for --docker option)


### PR DESCRIPTION
## Summary

- Bumps `CAMUNDA_VERSION` and `CAMUNDA_DOCKER_VERSION` from `8.8.27` → `8.8.28` in `c8run/.env`
- `CONNECTORS_VERSION` unchanged at `8.8.14` (no connectors update in this patch)

Pre-requisite for the c8run RC artifact build targeting the `8.8.28` release.

## Test plan

- [ ] Merge after camunda-distributions Renovate PR #445 is merged
- [ ] Trigger `c8run-release.yaml` workflow after merge