### PR TITLE
fix: use local fonts for offline setup

### DIFF
--- a/optimize/client/src/style.scss
+++ b/optimize/client/src/style.scss
@@ -1,7 +1,7 @@
 @use '@carbon/react' as * with (
   $css--reset: false,
   $css--default-type: false,
-  $font-path: 'https://fonts.camunda.io'
+  $font-path: '@ibm/plex'
 ); // the 'with' part is temporary solution and has to be deleted when whole Optimize will be carbonized
 
 @use '@carbon/react/scss/fonts/sans';


### PR DESCRIPTION
## Description

Backport of #46467 to stable/optimize-8.7.

The Optimize client loaded IBM Plex fonts from the external `https://fonts.camunda.io` host via Carbon's `$font-path`. In air-gapped / firewalled installations these requests are blocked, causing a fallback to the default browser font and tripping security policies that forbid outbound requests to external hosts.

Point `$font-path` at the bundled `@ibm/plex` package (already present transitively via `@carbon/react`, same approach used by tasklist on this branch) so no external request is made.

## Related issues

related to https://github.com/camunda/camunda/issues/45970
