### PR TITLE
fix: don't enforce use of posix_fallocate in tests on non-Linux platforms

### DIFF
--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/PosixSegmentAllocatorTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/PosixSegmentAllocatorTest.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -42,7 +44,8 @@ final class PosixSegmentAllocatorTest {
   }
 
   @Test
-  void shouldPreallocateFile(final @TempDir Path tmpDir) throws IOException {
+  @EnabledOnOs(OS.LINUX)
+  void shouldUsePosixFallocateOnLinux(final @TempDir Path tmpDir) throws IOException {
     // given
     final var allocator =
         new PosixSegmentAllocator(

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/fs/PosixFsTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/fs/PosixFsTest.java
@@ -24,7 +24,7 @@ import java.nio.file.Path;
 import java.util.stream.Stream;
 import jnr.constants.platform.Errno;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
@@ -33,7 +33,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not provide any LibC")
 @Execution(ExecutionMode.CONCURRENT)
 final class PosixFsTest {
   private @TempDir Path tmpDir;
@@ -55,6 +54,9 @@ final class PosixFsTest {
   }
 
   @Test
+  @EnabledOnOs(
+      value = OS.LINUX,
+      disabledReason = "posix_fallocate isn't reliably available on non-Linux platforms")
   void shouldPreallocateFile() throws IOException {
     // given
     final var posixFs = new PosixFs();


### PR DESCRIPTION
The code handles fallback for platforms not supporting posix_fallocate smoothly, but we'd want the test to ensure that we _do_ use posix_fallocate on platforms where we expect it to be present. That excludes Windows, OS X and to a varying degree other BSD-derived systems. We should generally be able to expect it to work on Linux, unless for some reason the temp directory is on a filesystem not supporting it.

closes #55391 
