### PR TITLE
ci: remove legacy marker from Operate Docker workflow

### DIFF
--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -2,7 +2,7 @@
 # test location: operate/qa/integration-tests
 # type: CI
 # owner: @camunda/core-features
-name: "[Legacy] Operate / Docker"
+name: "Operate / Docker"
 on:
   push:
     branches:
@@ -53,14 +53,14 @@ jobs:
           - 5000:5000
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
-      - uses: hadolint/hadolint-action@v3.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           ignore: DL3018 # redundant when pinning the base image
           dockerfile: operate.Dockerfile
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v3.4.0
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -71,19 +71,19 @@ jobs:
             secret/data/github.com/organizations/camunda NEXUS_PSW;
             secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
       - name: Login to Minimus
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: reg.mini.dev
           username: minimus
           password: ${{ steps.secrets.outputs.minimus-token }}
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "adopt"
           java-version: "21"
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'
-        uses: s4u/maven-settings-action@v4.0.0
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0
         with:
           githubServer: false
           servers: |
@@ -96,11 +96,11 @@ jobs:
       - name: Build backend
         run: ./mvnw clean install -B -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           driver-opts: network=host
       - name: Build and push to local registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         env:
           DOCKER_BUILD_SUMMARY: false
           DOCKER_BUILD_RECORD_UPLOAD: false


### PR DESCRIPTION
## Description

The `operate-docker-tests` workflow runs `StartupIT` — the only test that boots the standalone `camunda/operate` Docker image as a non-root / arbitrary OpenShift UID (`1000620000:0`) and verifies it starts and serves `/v2/topology`.

Investigation under #55319 found:
- The standalone `camunda/operate` image is still built and published on `stable/8.9` (e.g. `8.9.9`, `8.9-SNAPSHOT`) via the `operate-docker` job in `camunda-platform-release.yml`.
- No other test covers this image at runtime — `NonDefaultContainerSetupTest` exercises the unified `camunda/camunda` image, and the release-time `verify.sh` only checks static labels/manifest.
- The workflow is healthy and not flaky (no real test failures in the last ~6 weeks).
- Pinned action SHAs (as required by policy)

Rather than retiring it as legacy, keep it as a standard CI workflow guarding the shipped image. This change only drops the `[Legacy]` prefix from the workflow display name; no triggers, jobs, or steps are modified.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #55319