### PR TITLE
feat: add pagination to conversation history

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -81,6 +81,27 @@ describe('<ConversationHistory />', () => {
     ).toBeInTheDocument();
   });
 
+  it('should show a hint when there are no conversation messages', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+        isVisible
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    expect(
+      screen.getByText('No conversation with this agent instance found.'),
+    ).toBeInTheDocument();
+  });
+
   it('should render conversation items with text', async () => {
     mockSearchAgentInstanceHistory().withSuccess(
       searchResult([
@@ -183,6 +204,7 @@ describe('<ConversationHistory />', () => {
 
   it('should toggle the history sort order when the sort button is clicked', async () => {
     let query: unknown;
+    const item = mockAgentInstanceHistoryItem();
     mockServer.use(
       http.post(
         endpoints.searchAgentInstanceHistory.getUrl({
@@ -190,7 +212,7 @@ describe('<ConversationHistory />', () => {
         }),
         async ({request}) => {
           query = await request.json();
-          return Response.json(searchResult([]));
+          return Response.json(searchResult([item]));
         },
       ),
     );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -50,6 +50,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
+        isVisible
       />,
       {wrapper: createWrapper()},
     );
@@ -66,6 +67,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
+        isVisible
       />,
       {wrapper: createWrapper()},
     );
@@ -104,6 +106,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
+        isVisible
       />,
       {wrapper: createWrapper()},
     );
@@ -153,6 +156,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
+        isVisible
       />,
       {wrapper: createWrapper()},
     );
@@ -195,6 +199,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
+        isVisible
       />,
       {wrapper: createWrapper()},
     );
@@ -254,6 +259,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
+        isVisible
       />,
       {wrapper: createWrapper()},
     );
@@ -330,6 +336,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
+        isVisible
       />,
       {wrapper: createWrapper()},
     );
@@ -377,6 +384,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
+        isVisible
       />,
       {wrapper: createWrapper()},
     );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -224,6 +224,59 @@ describe('<ConversationHistory />', () => {
     );
   });
 
+  it('should show a "Show more" button when more items exist and load them on click', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult(
+        [
+          mockAgentInstanceHistoryItem({
+            historyItemKey: '2',
+            role: 'ASSISTANT',
+            content: [{contentType: 'TEXT', text: 'Second page message'}],
+          }),
+        ],
+        2,
+      ),
+    );
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult(
+        [
+          mockAgentInstanceHistoryItem({
+            historyItemKey: '1',
+            role: 'USER',
+            content: [{contentType: 'TEXT', text: 'First page message'}],
+          }),
+        ],
+        2,
+      ),
+    );
+
+    const {user} = render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    expect(screen.getByText('First page message')).toBeInTheDocument();
+    expect(screen.queryByText('Second page message')).not.toBeInTheDocument();
+
+    const showMoreButton = screen.getByRole('button', {name: 'Show more'});
+    expect(showMoreButton).toBeInTheDocument();
+
+    await user.click(showMoreButton);
+
+    expect(await screen.findByText('Second page message')).toBeInTheDocument();
+    expect(screen.getByText('First page message')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Show more'}),
+    ).not.toBeInTheDocument();
+  });
+
   it('should render document references', async () => {
     mockSearchAgentInstanceHistory().withSuccess(
       searchResult([

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -13,7 +13,7 @@ import type {QuerySortOrder} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
-import {ConversationContainer, ErrorHint, ShowMoreButton} from './styled';
+import {ConversationContainer, StatusHint, ShowMoreButton} from './styled';
 import {flattenPaginatedPages} from 'modules/queries/flattenPaginatedPages';
 
 type ConversationHistoryProps = {
@@ -46,10 +46,12 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   }
 
   if (status === 'error') {
+    return <StatusHint>Failed to load conversation history.</StatusHint>;
+  }
+
+  if (data.items.length === 0) {
     return (
-      <ErrorHint data-testid="conversation-history-error">
-        Failed to load conversation history.
-      </ErrorHint>
+      <StatusHint>No conversation with this agent instance found.</StatusHint>
     );
   }
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -13,7 +13,8 @@ import type {QuerySortOrder} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
-import {ConversationContainer, ErrorHint} from './styled';
+import {ConversationContainer, ErrorHint, ShowMoreButton} from './styled';
+import {flattenPaginatedPages} from 'modules/queries/flattenPaginatedPages';
 
 type ConversationHistoryProps = {
   agentInstanceKey: string;
@@ -26,10 +27,12 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
 }) => {
   const [sortOrder, setSortOrder] = useState<QuerySortOrder>('desc');
   const {selectElement} = useProcessInstanceElementSelection();
-  const {data, status} = useAgentInstanceHistory(agentInstanceKey, {
-    enablePeriodicRefetch,
-    sortOrder,
-  });
+  const {data, status, hasNextPage, fetchNextPage, isFetchingNextPage} =
+    useAgentInstanceHistory(agentInstanceKey, {
+      enablePeriodicRefetch,
+      sortOrder,
+      select: flattenPaginatedPages,
+    });
 
   if (status === 'pending') {
     return (
@@ -73,6 +76,12 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
           }}
         />
       ))}
+      {isFetchingNextPage && <SkeletonText paragraph lineCount={2} />}
+      {!isFetchingNextPage && hasNextPage && (
+        <ShowMoreButton kind="ghost" size="sm" onClick={() => fetchNextPage()}>
+          Show more
+        </ShowMoreButton>
+      )}
     </ConversationContainer>
   );
 };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -18,17 +18,20 @@ import {flattenPaginatedPages} from 'modules/queries/flattenPaginatedPages';
 
 type ConversationHistoryProps = {
   agentInstanceKey: string;
+  isVisible: boolean;
   enablePeriodicRefetch: boolean;
 };
 
 const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   agentInstanceKey,
+  isVisible,
   enablePeriodicRefetch,
 }) => {
   const [sortOrder, setSortOrder] = useState<QuerySortOrder>('desc');
   const {selectElement} = useProcessInstanceElementSelection();
   const {data, status, hasNextPage, fetchNextPage, isFetchingNextPage} =
     useAgentInstanceHistory(agentInstanceKey, {
+      enabled: isVisible,
       enablePeriodicRefetch,
       sortOrder,
       select: flattenPaginatedPages,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {Button} from '@carbon/react';
 import styled from 'styled-components';
 
 const ConversationContainer = styled.div`
@@ -22,4 +23,8 @@ const ErrorHint = styled.span`
   color: var(--cds-text-primary);
 `;
 
-export {ConversationContainer, ErrorHint};
+const ShowMoreButton = styled(Button)`
+  align-self: center;
+`;
+
+export {ConversationContainer, ErrorHint, ShowMoreButton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
@@ -15,7 +15,7 @@ const ConversationContainer = styled.div`
   gap: var(--cds-spacing-04);
 `;
 
-const ErrorHint = styled.span`
+const StatusHint = styled.span`
   font-size: var(--cds-body-compact-01-font-size);
   font-weight: var(--cds-body-compact-01-font-weight);
   line-height: var(--cds-body-compact-01-line-height);
@@ -27,4 +27,4 @@ const ShowMoreButton = styled(Button)`
   align-self: center;
 `;
 
-export {ConversationContainer, ErrorHint, ShowMoreButton};
+export {ConversationContainer, StatusHint, ShowMoreButton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -6,9 +6,41 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen, within} from 'modules/testing-library';
+import {
+  act,
+  render,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from 'modules/testing-library';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import type {ReactNode} from 'react';
+import {mockSearchAgentInstanceHistory} from 'modules/mocks/api/v2/agentInstances/searchAgentInstanceHistory';
+import {searchResult} from 'modules/testUtils';
+import {Paths} from 'modules/Routes';
 import {AgentDetails} from './index';
 import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+
+vi.mock('modules/feature-flags', () => ({
+  IS_CONVERSATION_HISTORY_ENABLED: true,
+}));
+
+function createWrapper() {
+  const queryClient = getMockQueryClient();
+  return ({children}: {children: ReactNode}) => {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
 
 const mockAgentInstance: AgentInstance = {
   agentInstanceKey: '2251799813851828',
@@ -47,6 +79,7 @@ describe('<AgentDetails />', () => {
         isLoading={false}
         isError={false}
       />,
+      {wrapper: createWrapper()},
     );
 
     expect(screen.getByText('AI Agent')).toBeInTheDocument();
@@ -63,6 +96,7 @@ describe('<AgentDetails />', () => {
         isLoading={false}
         isError={false}
       />,
+      {wrapper: createWrapper()},
     );
 
     const statusSection = screen.getByTestId('agent-status-section');
@@ -78,6 +112,7 @@ describe('<AgentDetails />', () => {
         isLoading={false}
         isError={false}
       />,
+      {wrapper: createWrapper()},
     );
 
     const statusSection = screen.getByTestId('agent-status-section');
@@ -91,6 +126,7 @@ describe('<AgentDetails />', () => {
         isLoading={false}
         isError={false}
       />,
+      {wrapper: createWrapper()},
     );
 
     const statusSection = screen.getByTestId('agent-status-section');
@@ -106,6 +142,7 @@ describe('<AgentDetails />', () => {
         isLoading={false}
         isError={false}
       />,
+      {wrapper: createWrapper()},
     );
 
     const statusSection = screen.getByTestId('agent-status-section');
@@ -121,6 +158,7 @@ describe('<AgentDetails />', () => {
         isLoading={false}
         isError={false}
       />,
+      {wrapper: createWrapper()},
     );
 
     const statusSection = screen.getByTestId('agent-status-section');
@@ -164,6 +202,7 @@ describe('<AgentDetails />', () => {
         isLoading={false}
         isError={false}
       />,
+      {wrapper: createWrapper()},
     );
 
     const modelCalls = screen.getByRole('article', {name: 'Model Calls'});
@@ -196,6 +235,7 @@ describe('<AgentDetails />', () => {
         isLoading={false}
         isError={false}
       />,
+      {wrapper: createWrapper()},
     );
 
     const section = screen.getByTestId('agent-model-section');
@@ -214,6 +254,7 @@ describe('<AgentDetails />', () => {
         isLoading={false}
         isError={false}
       />,
+      {wrapper: createWrapper()},
     );
 
     const section = screen.getByTestId('agent-system-prompt-section');
@@ -228,5 +269,39 @@ describe('<AgentDetails />', () => {
     expect(
       within(section).getByRole('button', {name: 'Expand'}),
     ).toBeInTheDocument();
+  });
+
+  it('should not fetch the conversation history until its accordion item is opened', async () => {
+    const historySpy = vi.fn();
+    mockSearchAgentInstanceHistory(
+      mockAgentInstance.agentInstanceKey,
+    ).withSuccess(searchResult([]), {mockResolverFn: historySpy});
+
+    const {user} = render(
+      <AgentDetails
+        agentInstance={mockAgentInstance}
+        isLoading={false}
+        isError={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    const section = screen.getByTestId('agent-conversation-history-section');
+    expect(section).toBeInTheDocument();
+
+    // Flush potentially pending queries otherwise this test cannot break.
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {});
+    expect(historySpy).not.toHaveBeenCalled();
+
+    await user.click(
+      within(section).getByRole('button', {name: 'Conversation history'}),
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    expect(historySpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useState} from 'react';
 import type {
   AgentInstance,
   AgentInstanceStatus,
@@ -74,6 +75,9 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
   isLoading,
   isError,
 }) => {
+  const [isConversationHistoryOpen, setIsConversationHistoryOpen] =
+    useState(false);
+
   if (isLoading) {
     return (
       <AgentDetailsContainer>
@@ -139,6 +143,8 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
         {IS_CONVERSATION_HISTORY_ENABLED && (
           <AccordionItem
             data-testid="agent-conversation-history-section"
+            open={isConversationHistoryOpen}
+            onHeadingClick={({isOpen}) => setIsConversationHistoryOpen(isOpen)}
             title={
               <SectionTitle icon={<Chat size={16} />}>
                 Conversation history
@@ -147,6 +153,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
           >
             <ConversationHistory
               agentInstanceKey={agentInstance.agentInstanceKey}
+              isVisible={isConversationHistoryOpen}
               enablePeriodicRefetch={isAgentInstanceRunning(agentInstance)}
             />
           </AccordionItem>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -106,7 +106,18 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
   const {metrics, limits, definition} = agentInstance;
 
   return (
-    <AgentDetailsContainer data-testid="agent-details">
+    <AgentDetailsContainer
+      data-testid="agent-details"
+      onKeyDown={(e) => {
+        // TODO: Workaround for https://github.com/carbon-design-system/carbon/issues/22483.
+        if (
+          e.key === 'Escape' &&
+          (e.target as HTMLElement).innerText === 'Conversation history'
+        ) {
+          setIsConversationHistoryOpen(false);
+        }
+      }}
+    >
       <AgentHeading>AI Agent</AgentHeading>
       <Accordion align="start">
         <AccordionItem

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
@@ -18,6 +18,7 @@ import {queryKeys} from '../queryKeys';
 const PAGE_LIMIT = 100;
 
 type QueryOptions<T> = {
+  enabled?: boolean;
   enablePeriodicRefetch?: boolean;
   sortOrder?: QuerySortOrder;
   select?: (result: InfiniteData<SearchAgentInstanceHistoryResponseBody>) => T;
@@ -39,6 +40,10 @@ const useAgentInstanceHistory = <
       agentInstanceKey,
       historyPayload,
     ),
+    enabled: options?.enabled,
+    select: options?.select,
+    staleTime: 5000,
+    refetchInterval: options?.enablePeriodicRefetch ? 5000 : undefined,
     queryFn: async ({pageParam, signal}) => {
       const {response, error} = await searchAgentInstanceHistory(
         agentInstanceKey,
@@ -50,14 +55,11 @@ const useAgentInstanceHistory = <
       }
       throw error;
     },
-    select: options?.select,
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, lastPageParam) => {
       const nextPage = lastPageParam + lastPage.items.length;
       return nextPage >= lastPage.page.totalItems ? null : nextPage;
     },
-    staleTime: 5000,
-    refetchInterval: options?.enablePeriodicRefetch ? 5000 : undefined,
   });
 };
 

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
@@ -6,32 +6,43 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useQuery} from '@tanstack/react-query';
+import {useInfiniteQuery, type InfiniteData} from '@tanstack/react-query';
 import type {
   QuerySortOrder,
   SearchAgentInstanceHistoryRequestBody,
+  SearchAgentInstanceHistoryResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {searchAgentInstanceHistory} from 'modules/api/v2/agentInstances/searchAgentInstanceHistory';
 import {queryKeys} from '../queryKeys';
 
-const useAgentInstanceHistory = (
+const PAGE_LIMIT = 100;
+
+type QueryOptions<T> = {
+  enablePeriodicRefetch?: boolean;
+  sortOrder?: QuerySortOrder;
+  select?: (result: InfiniteData<SearchAgentInstanceHistoryResponseBody>) => T;
+};
+
+const useAgentInstanceHistory = <
+  T = InfiniteData<SearchAgentInstanceHistoryResponseBody>,
+>(
   agentInstanceKey: string,
-  options?: {enablePeriodicRefetch?: boolean; sortOrder?: QuerySortOrder},
+  options?: QueryOptions<T>,
 ) => {
   const historyPayload: SearchAgentInstanceHistoryRequestBody = {
     sort: [{field: 'producedAt', order: options?.sortOrder ?? 'desc'}],
     filter: {commitStatus: 'COMMITTED'},
   };
 
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: queryKeys.agentInstanceHistory.search(
       agentInstanceKey,
       historyPayload,
     ),
-    queryFn: async ({signal}) => {
+    queryFn: async ({pageParam, signal}) => {
       const {response, error} = await searchAgentInstanceHistory(
         agentInstanceKey,
-        historyPayload,
+        {...historyPayload, page: {limit: PAGE_LIMIT, from: pageParam}},
         signal,
       );
       if (response !== null) {
@@ -39,6 +50,13 @@ const useAgentInstanceHistory = (
       }
       throw error;
     },
+    select: options?.select,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      const nextPage = lastPageParam + lastPage.items.length;
+      return nextPage >= lastPage.page.totalItems ? null : nextPage;
+    },
+    staleTime: 5000,
     refetchInterval: options?.enablePeriodicRefetch ? 5000 : undefined,
   });
 };


### PR DESCRIPTION
## Description

This PR adds pagination for the conversation history query. Importantly, the implementation uses an explicit "Show more" button instead of infinite scrolling, and keeps all pages in cache and refreshed (see [Slack thread for info](https://camunda.slack.com/archives/C0AH08C7UA2/p1781620495733269)). We don't really expect many messages, but to avoid too many pages and refresh requests, I have set the **page size to 100**. This PR also side-cars too smaller improvements:
- The conversation history query is now only enabled when the conversation history is visible, i.e. its accordion item open.
- Added a small hint when no conversation messages are found.

## Related issues

relates #51928
