### PR TITLE
fix: format double-valued RocksDB options correctly on OS X

### DIFF
--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbOptionsFormatter.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbOptionsFormatter.java
@@ -67,7 +67,7 @@ final class RocksDbOptionsFormatter {
     }
 
     // Fallback to regular Java String.format
-    return String.format("%,f", value);
+    return String.format("%f", value);
   }
 
   private static boolean ensureLibCIsAvailable() {
@@ -84,11 +84,12 @@ final class RocksDbOptionsFormatter {
         libC = LibraryLoader.create(LibC.class).load("c");
       }
       runtime = Runtime.getRuntime(libC);
+      return true;
     } catch (final Throwable e) {
       libCUnavailable = true;
       LOG.warn("Failed to load libc for sprintf formatting, will fall back to String.format", e);
+      return false;
     }
-    return true;
   }
 
   /** Interface to access libc functions via JNR-FFI. */
@@ -98,9 +99,9 @@ final class RocksDbOptionsFormatter {
      *
      * @param str output buffer
      * @param format format string
-     * @param value the double value to format
+     * @param args the values to format
      * @return number of characters written (excluding null terminator)
      */
-    int sprintf(@Out Pointer str, @In String format, double value);
+    int sprintf(@Out Pointer str, @In String format, Object... args);
   }
 }


### PR DESCRIPTION
Double-valued options for RocksDB were always being set as 0.0 on OS X due to a bug in the code which formats them to be read by RocksDB's locale-sensitive options parsing - the sprintf call has variadic arguments, and on OS X the FFI library needs to know this in order to pass those arguments on the stack rather than via registers.

This was causing test failures on OS X - it didn't seem to cause obvious issues running Zeebe, but something might crop up on longer runs.

I also fixed a couple of minor related issues in the same code:
- The fallback option could generate thousands separators if we ever passed a value large enough - RocksDB can't parse those
- The function to load the native bindings returned the wrong value on failure in the first instance, which just means we'd try, log and fall back instead of shortcutting to the fallback

closes: #55389