### PR TITLE
feat: implement AgentHistory search endpoint

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsTenantReaders.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsTenantReaders.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read;
 
+import io.camunda.db.rdbms.read.service.AgentHistoryDbReader;
 import io.camunda.db.rdbms.read.service.AgentInstanceDbReader;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
@@ -58,6 +59,7 @@ import io.camunda.search.clients.reader.SearchClientReaders;
  */
 public record RdbmsTenantReaders(
     AgentInstanceDbReader agentInstanceReader,
+    AgentHistoryDbReader agentHistoryReader,
     AuditLogDbReader auditLogReader,
     AuthorizationDbReader authorizationReader,
     BatchOperationDbReader batchOperationReader,
@@ -107,6 +109,7 @@ public record RdbmsTenantReaders(
       final RdbmsMapperBundle mappers, final RdbmsReaderConfig readerConfig) {
     return new RdbmsTenantReaders(
         new AgentInstanceDbReader(mappers.agentInstanceMapper(), readerConfig),
+        new AgentHistoryDbReader(readerConfig),
         new AuditLogDbReader(mappers.auditLogMapper(), readerConfig),
         new AuthorizationDbReader(mappers.authorizationMapper(), readerConfig),
         new BatchOperationDbReader(mappers.batchOperationMapper(), readerConfig),
@@ -159,6 +162,7 @@ public record RdbmsTenantReaders(
   public SearchClientReaders toSearchClientReaders() {
     return new SearchClientReaders(
         agentInstanceReader,
+        agentHistoryReader,
         authorizationReader,
         batchOperationReader,
         batchOperationItemReader,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentHistoryDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentHistoryDbReader.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
+import io.camunda.search.clients.reader.AgentHistoryReader;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+
+public class AgentHistoryDbReader extends AbstractEntityReader<AgentInstanceHistoryEntity>
+    implements AgentHistoryReader {
+
+  public AgentHistoryDbReader(final RdbmsReaderConfig readerConfig) {
+    super(null, readerConfig);
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceHistoryEntity> search(
+      final AgentInstanceHistoryQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException(
+        "AgentHistoryDbReader is not yet implemented. Tracked in #55271.");
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.search;
 
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.clients.cache.ProcessCache;
+import io.camunda.search.clients.reader.AgentHistoryDocumentReader;
 import io.camunda.search.clients.reader.AgentInstanceDocumentReader;
 import io.camunda.search.clients.reader.AuditLogDocumentReader;
 import io.camunda.search.clients.reader.AuthorizationDocumentReader;
@@ -66,6 +67,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate;
 import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
@@ -99,6 +101,8 @@ public final class SearchClientReadersFactory {
     // --- Phase 1: Simple readers (no cross-reader dependencies) ---
     final var agentInstanceReader =
         new AgentInstanceDocumentReader(executor, descriptors.get(AgentInstanceTemplate.class));
+    final var agentHistoryReader =
+        new AgentHistoryDocumentReader(executor, descriptors.get(AgentHistoryTemplate.class));
     final var authorizationReader =
         new AuthorizationDocumentReader(executor, descriptors.get(AuthorizationIndex.class));
     final var batchOperationReader =
@@ -214,6 +218,7 @@ public final class SearchClientReadersFactory {
     // --- Assemble ---
     return new SearchClientReaders(
         agentInstanceReader,
+        agentHistoryReader,
         authorizationReader,
         batchOperationReader,
         batchOperationItemReader,

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -234,7 +234,12 @@ public class CamundaServicesConfiguration {
                   .agentHistoryServices(
                       tenantId,
                       new AgentHistoryServices(
-                          tenantId, brokerClient, securityContextProvider, executor, converter))
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          search,
+                          executor,
+                          converter))
                   .agentInstanceServices(
                       tenantId,
                       new AgentInstanceServices(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -41,11 +41,13 @@ import io.camunda.gateway.protocol.model.StringFilterProperty;
 import io.camunda.gateway.protocol.model.UserTaskAuditLogFilter;
 import io.camunda.gateway.protocol.model.UserTaskVariableFilter;
 import io.camunda.gateway.protocol.model.VariableValueFilterProperty;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.filter.AgentInstanceFilter;
+import io.camunda.search.filter.AgentInstanceHistoryFilter;
 import io.camunda.search.filter.AuditLogFilter;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
@@ -1568,6 +1570,46 @@ public class SearchQueryFilterMapper {
           .ifPresent(builder::versionTagOperations);
     }
 
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
+  }
+
+  static Either<List<String>, AgentInstanceHistoryFilter> toAgentInstanceHistoryFilter(
+      final io.camunda.gateway.protocol.model.@Nullable AgentInstanceHistoryFilter filter,
+      final long agentInstanceKey) {
+    final var builder = FilterBuilders.agentInstanceHistory();
+    final List<String> validationErrors = new ArrayList<>();
+    // Inject agentInstanceKey from path variable — not present in the REST filter model
+    builder.agentInstanceKeyOperations(List.of(Operation.eq(agentInstanceKey)));
+    if (filter == null || filter.getCommitStatus() == null) {
+      // Default to COMMITTED when the caller omits commitStatus
+      builder.commitStatusOperations(
+          List.of(
+              Operation.eq(
+                  AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus.COMMITTED.name())));
+    }
+    if (filter != null) {
+      ofNullable(filter.getHistoryItemKey())
+          .map(mapToKeyOperations("historyItemKey", validationErrors))
+          .ifPresent(builder::historyItemKeyOperations);
+      ofNullable(filter.getRole()).map(mapToStringOperations()).ifPresent(builder::roleOperations);
+      ofNullable(filter.getElementInstanceKey())
+          .map(mapToKeyOperations("elementInstanceKey", validationErrors))
+          .ifPresent(builder::elementInstanceKeyOperations);
+      ofNullable(filter.getJobKey())
+          .map(mapToKeyOperations("jobKey", validationErrors))
+          .ifPresent(builder::jobKeyOperations);
+      ofNullable(filter.getIteration())
+          .map(mapToIntegerOperations("iteration", validationErrors))
+          .ifPresent(builder::iterationOperations);
+      ofNullable(filter.getCommitStatus())
+          .map(mapToStringOperations())
+          .ifPresent(builder::commitStatusOperations);
+      ofNullable(filter.getProducedAt())
+          .map(mapToOffsetDateTimeOperations("producedAt", validationErrors))
+          .ifPresent(builder::producedAtOperations);
+    }
     return validationErrors.isEmpty()
         ? Either.right(builder.build())
         : Either.left(validationErrors);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -24,6 +24,7 @@ import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
@@ -262,6 +263,31 @@ public final class SearchQueryRequestMapper {
             SearchQuerySortRequestMapper::applyAgentInstanceSortField);
     final var filter = SearchQueryFilterMapper.toAgentInstanceFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::agentInstanceSearchQuery);
+  }
+
+  public static Either<ProblemDetail, AgentInstanceHistoryQuery> toAgentInstanceHistoryQuery(
+      final AgentInstanceHistorySearchQuery request, final long agentInstanceKey) {
+    if (request == null) {
+      final var filter =
+          SearchQueryFilterMapper.toAgentInstanceHistoryFilter(null, agentInstanceKey);
+      return buildSearchQuery(
+          filter,
+          Either.right(null),
+          Either.right(null),
+          SearchQueryBuilders::agentInstanceHistorySearchQuery);
+    }
+
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        SearchQuerySortRequestMapper.toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromAgentInstanceHistorySearchQuerySortRequest(
+                request.getSort()),
+            SortOptionBuilders::agentInstanceHistory,
+            SearchQuerySortRequestMapper::applyAgentInstanceHistorySortField);
+    final var filter =
+        SearchQueryFilterMapper.toAgentInstanceHistoryFilter(request.getFilter(), agentInstanceKey);
+    return buildSearchQuery(
+        filter, sort, page, SearchQueryBuilders::agentInstanceHistorySearchQuery);
   }
 
   public static Either<ProblemDetail, JobQuery> toJobQuery(final JobSearchQuery request) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -17,11 +17,21 @@ import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
 import io.camunda.gateway.protocol.model.AgentInstanceDefinition;
+import io.camunda.gateway.protocol.model.AgentInstanceDocumentContent;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryCommitStatusEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemMetrics;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemResult;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceHistorySearchQueryResult;
 import io.camunda.gateway.protocol.model.AgentInstanceLimits;
+import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
 import io.camunda.gateway.protocol.model.AgentInstanceMetrics;
+import io.camunda.gateway.protocol.model.AgentInstanceObjectContent;
 import io.camunda.gateway.protocol.model.AgentInstanceResult;
 import io.camunda.gateway.protocol.model.AgentInstanceSearchQueryResult;
 import io.camunda.gateway.protocol.model.AgentInstanceStatusEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceTextContent;
+import io.camunda.gateway.protocol.model.AgentInstanceToolCall;
 import io.camunda.gateway.protocol.model.AgentTool;
 import io.camunda.gateway.protocol.model.AuditLogActorTypeEnum;
 import io.camunda.gateway.protocol.model.AuditLogCategoryEnum;
@@ -57,6 +67,7 @@ import io.camunda.gateway.protocol.model.DecisionInstanceSearchQueryResult;
 import io.camunda.gateway.protocol.model.DecisionInstanceStateEnum;
 import io.camunda.gateway.protocol.model.DecisionRequirementsResult;
 import io.camunda.gateway.protocol.model.DecisionRequirementsSearchQueryResult;
+import io.camunda.gateway.protocol.model.DocumentMetadataResponse;
 import io.camunda.gateway.protocol.model.ElementInstanceResult;
 import io.camunda.gateway.protocol.model.ElementInstanceSearchQueryResult;
 import io.camunda.gateway.protocol.model.ElementInstanceStateEnum;
@@ -163,6 +174,7 @@ import io.camunda.gateway.protocol.model.VariableSearchResult;
 import io.camunda.gateway.protocol.model.WaitStateElementTypeEnum;
 import io.camunda.gateway.protocol.model.WaitStateTypeEnum;
 import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -2081,6 +2093,122 @@ public final class SearchQueryResponseMapper {
                             .map(SearchQueryResponseMapper::toAgentInstanceResult)
                             .toList())
                 .orElseGet(Collections::emptyList))
+        .build();
+  }
+
+  public static AgentInstanceHistoryItemResult toAgentHistoryItemResult(
+      final AgentInstanceHistoryEntity entity) {
+    final var content =
+        ofNullable(entity.content())
+            .map(
+                items ->
+                    items.stream()
+                        .map(SearchQueryResponseMapper::toAgentInstanceMessageContent)
+                        .toList())
+            .orElseGet(Collections::emptyList);
+
+    final var toolCalls =
+        ofNullable(entity.toolCalls())
+            .map(
+                calls ->
+                    calls.stream().map(SearchQueryResponseMapper::toAgentInstanceToolCall).toList())
+            .orElseGet(Collections::emptyList);
+
+    final var m = entity.metrics();
+    final var metrics =
+        AgentInstanceHistoryItemMetrics.Builder.create()
+            .inputTokens(m.inputTokens())
+            .outputTokens(m.outputTokens())
+            .durationMs(m.durationMs())
+            .build();
+
+    return AgentInstanceHistoryItemResult.Builder.create()
+        .historyItemKey(keyToString(entity.historyItemKey()))
+        .agentInstanceKey(keyToString(entity.agentInstanceKey()))
+        .elementInstanceKey(keyToString(entity.elementInstanceKey()))
+        .jobKey(keyToString(entity.jobKey()))
+        .jobLease(entity.jobLease())
+        .iteration(entity.iteration())
+        .role(AgentInstanceHistoryRoleEnum.fromValue(entity.role().name()))
+        .content(content)
+        .toolCalls(toolCalls)
+        .metrics(metrics)
+        .commitStatus(AgentInstanceHistoryCommitStatusEnum.fromValue(entity.commitStatus().name()))
+        .producedAt(formatDate(entity.producedAt()))
+        .build();
+  }
+
+  public static AgentInstanceHistorySearchQueryResult toAgentHistorySearchQueryResponse(
+      final SearchQueryResult<AgentInstanceHistoryEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return AgentInstanceHistorySearchQueryResult.Builder.create()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(
+                    items ->
+                        items.stream()
+                            .map(SearchQueryResponseMapper::toAgentHistoryItemResult)
+                            .toList())
+                .orElseGet(Collections::emptyList))
+        .build();
+  }
+
+  private static AgentInstanceMessageContent toAgentInstanceMessageContent(
+      final AgentInstanceHistoryEntity.ContentItem item) {
+    return switch (item.contentType()) {
+      case TEXT ->
+          AgentInstanceTextContent.Builder.create()
+              .contentType(item.contentType().name())
+              .text(requireNonNullElse(item.text(), ""))
+              .build();
+      case DOCUMENT ->
+          AgentInstanceDocumentContent.Builder.create()
+              .contentType(item.contentType().name())
+              .documentReference(
+                  toDocumentReference(
+                      requireNonNull(item.documentReference(), "documentReference")))
+              .build();
+      case OBJECT ->
+          AgentInstanceObjectContent.Builder.create()
+              .contentType(item.contentType().name())
+              .object(requireNonNullElse(item.object(), Collections.emptyMap()))
+              .build();
+    };
+  }
+
+  private static io.camunda.gateway.protocol.model.DocumentReference toDocumentReference(
+      final AgentInstanceHistoryEntity.DocumentReference ref) {
+    return io.camunda.gateway.protocol.model.DocumentReference.Builder.create()
+        .camundaDocumentType(
+            io.camunda.gateway.protocol.model.DocumentReference.CamundaDocumentTypeEnum.CAMUNDA)
+        .storeId(ref.storeId())
+        .documentId(ref.documentId())
+        .contentHash(ref.contentHash())
+        .metadata(toDocumentMetadataResponse(ref.metadata()))
+        .build();
+  }
+
+  private static DocumentMetadataResponse toDocumentMetadataResponse(
+      final AgentInstanceHistoryEntity.DocumentMetadata meta) {
+    return DocumentMetadataResponse.Builder.create()
+        .fileName(meta.fileName())
+        .expiresAt(formatDateOrNull(meta.expiresAt()))
+        .size(meta.size())
+        .contentType(meta.contentType())
+        .customProperties(meta.customProperties())
+        .processDefinitionId(meta.processDefinitionId())
+        .processInstanceKey(keyToStringOrNull(meta.processInstanceKey()))
+        .build();
+  }
+
+  private static AgentInstanceToolCall toAgentInstanceToolCall(
+      final AgentInstanceHistoryEntity.ToolCall call) {
+    return AgentInstanceToolCall.Builder.create()
+        .toolCallId(call.toolCallId())
+        .toolName(call.toolName())
+        .elementId(call.elementId())
+        .arguments(call.arguments())
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -12,6 +12,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_UNKN
 
 import io.camunda.gateway.protocol.model.*;
 import io.camunda.gateway.protocol.model.GlobalTaskListenerSearchQuerySortRequest.FieldEnum;
+import io.camunda.search.sort.AgentInstanceHistorySort;
 import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.search.sort.AuthorizationSort;
 import io.camunda.search.sort.BatchOperationItemSort;
@@ -1088,6 +1089,29 @@ public class SearchQuerySortRequestMapper {
     }
 
     return Either.right(null);
+  }
+
+  static List<SearchQuerySortRequest<AgentInstanceHistorySearchQuerySortRequest.FieldEnum>>
+      fromAgentInstanceHistorySearchQuerySortRequest(
+          final List<AgentInstanceHistorySearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
+  static List<String> applyAgentInstanceHistorySortField(
+      final AgentInstanceHistorySearchQuerySortRequest.FieldEnum field,
+      final AgentInstanceHistorySort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
+    if (field == null) {
+      validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+    } else {
+      switch (field) {
+        case HISTORY_ITEM_KEY -> builder.historyItemKey();
+        case ITERATION -> builder.iteration();
+        case PRODUCED_AT -> builder.producedAt();
+        default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
+      }
+    }
+    return validationErrors;
   }
 
   private static void applySortOrder(

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -18,6 +18,15 @@ import io.camunda.gateway.protocol.model.JobListenerEventTypeEnum;
 import io.camunda.gateway.protocol.model.JobSearchQueryResult;
 import io.camunda.gateway.protocol.model.JobWaitStateDetails;
 import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentMetadata;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentReference;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Metrics;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
@@ -57,6 +66,7 @@ import io.camunda.security.api.model.user.CamundaUserDTO;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class SearchQueryResponseMapperTest {
@@ -1009,5 +1019,180 @@ class SearchQueryResponseMapperTest {
     // then
     final var responseDetails = (JobWaitStateDetails) result.getItems().getFirst().getDetails();
     assertThat(responseDetails.getListenerEventType()).isNull();
+  }
+
+  @Nested
+  class AgentHistoryItemResult {
+
+    @Test
+    void shouldMapTextContentItem() {
+      // given
+      final var producedAt = OffsetDateTime.parse("2025-01-01T10:00:00Z");
+      final var entity =
+          new AgentInstanceHistoryEntity(
+              100L,
+              200L,
+              300L,
+              400L,
+              500L,
+              "process-1",
+              "tenant-1",
+              600L,
+              "lease-1",
+              3,
+              AgentInstanceHistoryRole.USER,
+              List.of(new ContentItem(ContentType.TEXT, "Hello", null, null)),
+              List.of(),
+              new Metrics(10, 20, 30),
+              AgentInstanceHistoryCommitStatus.COMMITTED,
+              producedAt);
+
+      // when
+      final var result = SearchQueryResponseMapper.toAgentHistoryItemResult(entity);
+
+      // then
+      assertThat(result.getHistoryItemKey()).isEqualTo("100");
+      assertThat(result.getAgentInstanceKey()).isEqualTo("200");
+      assertThat(result.getElementInstanceKey()).isEqualTo("300");
+      assertThat(result.getJobKey()).isEqualTo("600");
+      assertThat(result.getJobLease()).isEqualTo("lease-1");
+      assertThat(result.getIteration()).isEqualTo(3);
+      assertThat(result.getRole().getValue()).isEqualTo("USER");
+      assertThat(result.getCommitStatus().getValue()).isEqualTo("COMMITTED");
+      assertThat(result.getMetrics().getInputTokens()).isEqualTo(10);
+      assertThat(result.getMetrics().getOutputTokens()).isEqualTo(20);
+      assertThat(result.getMetrics().getDurationMs()).isEqualTo(30);
+      assertThat(result.getContent()).hasSize(1);
+      assertThat(result.getContent().get(0).getContentType()).isEqualTo("TEXT");
+    }
+
+    @Test
+    void shouldMapDocumentContentItem() {
+      // given
+      final var docMeta =
+          new DocumentMetadata("text/pdf", "report.pdf", null, 1024L, "pd-1", 999L, Map.of());
+      final var docRef = new DocumentReference("store-1", "doc-1", "hash-abc", docMeta);
+      final var entity =
+          new AgentInstanceHistoryEntity(
+              1L,
+              2L,
+              3L,
+              4L,
+              5L,
+              "pd-1",
+              "<default>",
+              6L,
+              "",
+              null,
+              AgentInstanceHistoryRole.ASSISTANT,
+              List.of(new ContentItem(ContentType.DOCUMENT, null, docRef, null)),
+              List.of(),
+              new Metrics(0, 0, 0),
+              AgentInstanceHistoryCommitStatus.PENDING,
+              OffsetDateTime.now());
+
+      // when
+      final var result = SearchQueryResponseMapper.toAgentHistoryItemResult(entity);
+
+      // then
+      assertThat(result.getContent()).hasSize(1);
+      final var content = result.getContent().get(0);
+      assertThat(content.getContentType()).isEqualTo("DOCUMENT");
+      assertThat(result.getRole().getValue()).isEqualTo("ASSISTANT");
+    }
+
+    @Test
+    void shouldMapNullContentAndToolCallsAsEmptyLists() {
+      // given
+      final var entity =
+          new AgentInstanceHistoryEntity(
+              1L,
+              2L,
+              3L,
+              4L,
+              5L,
+              "",
+              "<default>",
+              6L,
+              "",
+              null,
+              AgentInstanceHistoryRole.TOOL_RESULT,
+              null,
+              null,
+              new Metrics(0, 0, 0),
+              AgentInstanceHistoryCommitStatus.DISCARDED,
+              OffsetDateTime.now());
+
+      // when
+      final var result = SearchQueryResponseMapper.toAgentHistoryItemResult(entity);
+
+      // then
+      assertThat(result.getContent()).isEmpty();
+      assertThat(result.getToolCalls()).isEmpty();
+    }
+
+    @Test
+    void shouldMapToolCalls() {
+      // given
+      final var toolCall = new ToolCall("tc-1", "MyTool", "elem-1", Map.of("param", "value"));
+      final var entity =
+          new AgentInstanceHistoryEntity(
+              1L,
+              2L,
+              3L,
+              4L,
+              5L,
+              "",
+              "<default>",
+              6L,
+              "",
+              1,
+              AgentInstanceHistoryRole.ASSISTANT,
+              List.of(),
+              List.of(toolCall),
+              new Metrics(5, 10, 100),
+              AgentInstanceHistoryCommitStatus.COMMITTED,
+              OffsetDateTime.now());
+
+      // when
+      final var result = SearchQueryResponseMapper.toAgentHistoryItemResult(entity);
+
+      // then
+      assertThat(result.getToolCalls()).hasSize(1);
+      assertThat(result.getToolCalls().get(0).getToolCallId()).isEqualTo("tc-1");
+      assertThat(result.getToolCalls().get(0).getToolName()).isEqualTo("MyTool");
+      assertThat(result.getToolCalls().get(0).getElementId()).isEqualTo("elem-1");
+    }
+
+    @Test
+    void shouldWrapEntityListInSearchQueryResult() {
+      // given
+      final var entity =
+          new AgentInstanceHistoryEntity(
+              42L,
+              7L,
+              8L,
+              9L,
+              10L,
+              "",
+              "<default>",
+              11L,
+              "",
+              null,
+              AgentInstanceHistoryRole.USER,
+              List.of(),
+              List.of(),
+              new Metrics(0, 0, 0),
+              AgentInstanceHistoryCommitStatus.COMMITTED,
+              OffsetDateTime.now());
+      final var queryResult = new SearchQueryResult<>(1L, false, List.of(entity), null, null);
+
+      // when
+      final var response = SearchQueryResponseMapper.toAgentHistorySearchQueryResponse(queryResult);
+
+      // then
+      assertThat(response.getItems()).hasSize(1);
+      assertThat(response.getItems().get(0).getHistoryItemKey()).isEqualTo("42");
+    }
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AgentHistoryDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AgentHistoryDocumentReader.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class AgentHistoryDocumentReader extends DocumentBasedReader implements AgentHistoryReader {
+
+  public AgentHistoryDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceHistoryEntity> search(
+      final AgentInstanceHistoryQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException(
+        "AgentHistoryDocumentReader is not yet implemented. Tracked in #55268.");
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/AgentHistoryReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/AgentHistoryReader.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
+
+public interface AgentHistoryReader
+    extends SearchEntityReader<AgentInstanceHistoryEntity, AgentInstanceHistoryQuery> {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.reader;
 
 public record SearchClientReaders(
     AgentInstanceReader agentInstanceReader,
+    AgentHistoryReader agentHistoryReader,
     AuthorizationReader authorizationReader,
     BatchOperationReader batchOperationReader,
     BatchOperationItemReader batchOperationItemReader,

--- a/search/search-client/src/main/java/io/camunda/search/clients/AgentHistorySearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/AgentHistorySearchClient.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.core.auth.SecurityContext;
+
+public interface AgentHistorySearchClient {
+
+  SearchQueryResult<AgentInstanceHistoryEntity> searchAgentHistoryItems(
+      AgentInstanceHistoryQuery query);
+
+  AgentHistorySearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.search.clients.reader.SearchEntityReader;
 import io.camunda.search.clients.reader.SearchQueryStatisticsReader;
 import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -67,6 +68,7 @@ import io.camunda.search.exception.TenantAccessDeniedException;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.ProcessInstanceStatisticsFilter;
 import io.camunda.search.page.SearchQueryPage.SearchQueryResultType;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
@@ -175,6 +177,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public SearchQueryResult<AgentInstanceEntity> searchAgentInstances(
       final AgentInstanceQuery query) {
     return doSearchWithReader(readers.agentInstanceReader(), query);
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceHistoryEntity> searchAgentHistoryItems(
+      final AgentInstanceHistoryQuery query) {
+    return doSearchWithReader(readers.agentHistoryReader(), query);
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -12,7 +12,8 @@ import io.camunda.search.clients.tenant.PhysicalTenantScoped;
 import io.camunda.security.core.auth.SecurityContext;
 
 public interface SearchClientsProxy
-    extends AgentInstanceSearchClient,
+    extends AgentHistorySearchClient,
+        AgentInstanceSearchClient,
         AuditLogSearchClient,
         AuthorizationSearchClient,
         BatchOperationSearchClient,

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.impl;
 
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -55,6 +56,7 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.exception.NoSecondaryStorageException;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
@@ -112,6 +114,12 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<AgentInstanceEntity> searchAgentInstances(
       final AgentInstanceQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceHistoryEntity> searchAgentHistoryItems(
+      final AgentInstanceHistoryQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -11,6 +11,7 @@ import static java.util.Collections.emptyList;
 
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -56,6 +57,7 @@ import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
@@ -114,6 +116,12 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<AgentInstanceEntity> searchAgentInstances(
       final AgentInstanceQuery query) {
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceHistoryEntity> searchAgentHistoryItems(
+      final AgentInstanceHistoryQuery query) {
     return SearchQueryResult.empty();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Search-domain representation of a single AGENT_HISTORY item. Technology-neutral — consumed by the
+ * REST mapper and produced by the ES/OS and RDBMS readers.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AgentInstanceHistoryEntity(
+    Long historyItemKey,
+    Long agentInstanceKey,
+    Long elementInstanceKey,
+    Long processInstanceKey,
+    Long processDefinitionKey,
+    String processDefinitionId,
+    String tenantId,
+    Long jobKey,
+    String jobLease,
+    @Nullable Integer iteration,
+    AgentInstanceHistoryRole role,
+    List<ContentItem> content,
+    List<ToolCall> toolCalls,
+    Metrics metrics,
+    AgentInstanceHistoryCommitStatus commitStatus,
+    OffsetDateTime producedAt)
+    implements TenantOwnedEntity {
+
+  public AgentInstanceHistoryEntity {
+    Objects.requireNonNull(historyItemKey, "historyItemKey");
+    Objects.requireNonNull(agentInstanceKey, "agentInstanceKey");
+    Objects.requireNonNull(elementInstanceKey, "elementInstanceKey");
+    Objects.requireNonNull(processInstanceKey, "processInstanceKey");
+    Objects.requireNonNull(processDefinitionKey, "processDefinitionKey");
+    Objects.requireNonNull(processDefinitionId, "processDefinitionId");
+    Objects.requireNonNull(tenantId, "tenantId");
+    Objects.requireNonNull(jobKey, "jobKey");
+    Objects.requireNonNull(jobLease, "jobLease");
+    Objects.requireNonNull(role, "role");
+    Objects.requireNonNull(metrics, "metrics");
+    Objects.requireNonNull(commitStatus, "commitStatus");
+    Objects.requireNonNull(producedAt, "producedAt");
+    // Mutable lists required — readers may hydrate by calling .add()
+    content = content != null ? new ArrayList<>(content) : new ArrayList<>();
+    toolCalls = toolCalls != null ? new ArrayList<>(toolCalls) : new ArrayList<>();
+  }
+
+  public enum AgentInstanceHistoryRole {
+    USER,
+    ASSISTANT,
+    TOOL_RESULT
+  }
+
+  public enum AgentInstanceHistoryCommitStatus {
+    COMMITTED,
+    PENDING,
+    DISCARDED
+  }
+
+  /**
+   * A single content block within a history item. The {@code text}, {@code documentReference}, and
+   * {@code object} fields are mutually exclusive based on {@code contentType}.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record ContentItem(
+      ContentType contentType,
+      @Nullable String text,
+      @Nullable DocumentReference documentReference,
+      @Nullable Map<String, Object> object) {
+
+    public ContentItem {
+      Objects.requireNonNull(contentType, "contentType");
+      object = object != null ? new HashMap<>(object) : new HashMap<>();
+    }
+
+    public enum ContentType {
+      TEXT,
+      DOCUMENT,
+      OBJECT
+    }
+  }
+
+  /** A document reference embedded in a {@link ContentItem}. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record DocumentReference(
+      String storeId, String documentId, @Nullable String contentHash, DocumentMetadata metadata) {
+
+    public DocumentReference {
+      Objects.requireNonNull(storeId, "storeId");
+      Objects.requireNonNull(documentId, "documentId");
+      Objects.requireNonNull(metadata, "metadata");
+    }
+  }
+
+  /** Metadata for a {@link DocumentReference}. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record DocumentMetadata(
+      String contentType,
+      String fileName,
+      @Nullable OffsetDateTime expiresAt,
+      Long size,
+      @Nullable String processDefinitionId,
+      @Nullable Long processInstanceKey,
+      Map<String, Object> customProperties) {
+
+    public DocumentMetadata {
+      Objects.requireNonNull(contentType, "contentType");
+      Objects.requireNonNull(fileName, "fileName");
+      Objects.requireNonNull(size, "size");
+      customProperties =
+          customProperties != null ? new HashMap<>(customProperties) : new HashMap<>();
+    }
+  }
+
+  /** A tool call embedded in a history item. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record ToolCall(
+      String toolCallId,
+      String toolName,
+      @Nullable String elementId,
+      @Nullable Map<String, Object> arguments) {
+
+    public ToolCall {
+      Objects.requireNonNull(toolCallId, "toolCallId");
+      Objects.requireNonNull(toolName, "toolName");
+      arguments = arguments != null ? new HashMap<>(arguments) : new HashMap<>();
+    }
+  }
+
+  /** Per-call token and latency metrics. Zero-valued rather than null when not available. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Metrics(long inputTokens, long outputTokens, long durationMs) {}
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceHistoryFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceHistoryFilter.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.util.FilterUtil;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record AgentInstanceHistoryFilter(
+    List<Operation<Long>> agentInstanceKeyOperations,
+    List<Operation<Long>> historyItemKeyOperations,
+    List<Operation<String>> roleOperations,
+    List<Operation<Long>> elementInstanceKeyOperations,
+    List<Operation<Long>> jobKeyOperations,
+    List<Operation<Integer>> iterationOperations,
+    List<Operation<String>> commitStatusOperations,
+    List<Operation<OffsetDateTime>> producedAtOperations)
+    implements FilterBase {
+
+  public static AgentInstanceHistoryFilter of(
+      final Function<AgentInstanceHistoryFilter.Builder, ObjectBuilder<AgentInstanceHistoryFilter>>
+          fn) {
+    return FilterBuilders.agentInstanceHistory(fn);
+  }
+
+  public static final class Builder implements ObjectBuilder<AgentInstanceHistoryFilter> {
+
+    private List<Operation<Long>> agentInstanceKeyOperations;
+    private List<Operation<Long>> historyItemKeyOperations;
+    private List<Operation<String>> roleOperations;
+    private List<Operation<Long>> elementInstanceKeyOperations;
+    private List<Operation<Long>> jobKeyOperations;
+    private List<Operation<Integer>> iterationOperations;
+    private List<Operation<String>> commitStatusOperations;
+    private List<Operation<OffsetDateTime>> producedAtOperations;
+
+    public Builder agentInstanceKeyOperations(final List<Operation<Long>> operations) {
+      agentInstanceKeyOperations = addValuesToList(agentInstanceKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder agentInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return agentInstanceKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder agentInstanceKeys(final Long value, final Long... values) {
+      return agentInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder historyItemKeyOperations(final List<Operation<Long>> operations) {
+      historyItemKeyOperations = addValuesToList(historyItemKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder historyItemKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return historyItemKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder historyItemKeys(final Long value, final Long... values) {
+      return historyItemKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder roleOperations(final List<Operation<String>> operations) {
+      roleOperations = addValuesToList(roleOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder roleOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return roleOperations(collectValues(operation, operations));
+    }
+
+    public Builder roles(
+        final AgentInstanceHistoryRole value, final AgentInstanceHistoryRole... values) {
+      final String[] rest = new String[values.length];
+      for (int i = 0; i < values.length; i++) {
+        rest[i] = values[i].name();
+      }
+      return roleOperations(FilterUtil.mapDefaultToOperation(value.name(), rest));
+    }
+
+    public Builder elementInstanceKeyOperations(final List<Operation<Long>> operations) {
+      elementInstanceKeyOperations = addValuesToList(elementInstanceKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder elementInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return elementInstanceKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder elementInstanceKeys(final Long value, final Long... values) {
+      return elementInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder jobKeyOperations(final List<Operation<Long>> operations) {
+      jobKeyOperations = addValuesToList(jobKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder jobKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return jobKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder jobKeys(final Long value, final Long... values) {
+      return jobKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder iterationOperations(final List<Operation<Integer>> operations) {
+      iterationOperations = addValuesToList(iterationOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder iterationOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return iterationOperations(collectValues(operation, operations));
+    }
+
+    public Builder iterations(final Integer value, final Integer... values) {
+      return iterationOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder commitStatusOperations(final List<Operation<String>> operations) {
+      commitStatusOperations = addValuesToList(commitStatusOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder commitStatusOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return commitStatusOperations(collectValues(operation, operations));
+    }
+
+    public Builder commitStatuses(
+        final AgentInstanceHistoryCommitStatus value,
+        final AgentInstanceHistoryCommitStatus... values) {
+      final String[] rest = new String[values.length];
+      for (int i = 0; i < values.length; i++) {
+        rest[i] = values[i].name();
+      }
+      return commitStatusOperations(FilterUtil.mapDefaultToOperation(value.name(), rest));
+    }
+
+    public Builder producedAtOperations(final List<Operation<OffsetDateTime>> operations) {
+      producedAtOperations = addValuesToList(producedAtOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder producedAtOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return producedAtOperations(collectValues(operation, operations));
+    }
+
+    @Override
+    public AgentInstanceHistoryFilter build() {
+      return new AgentInstanceHistoryFilter(
+          Objects.requireNonNullElse(agentInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(historyItemKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(roleOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(elementInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(jobKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(iterationOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(commitStatusOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(producedAtOperations, Collections.emptyList()));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -23,6 +23,16 @@ public final class FilterBuilders {
     return fn.apply(agentInstance()).build();
   }
 
+  public static AgentInstanceHistoryFilter.Builder agentInstanceHistory() {
+    return new AgentInstanceHistoryFilter.Builder();
+  }
+
+  public static AgentInstanceHistoryFilter agentInstanceHistory(
+      final Function<AgentInstanceHistoryFilter.Builder, ObjectBuilder<AgentInstanceHistoryFilter>>
+          fn) {
+    return fn.apply(agentInstanceHistory()).build();
+  }
+
   public static UsageMetricsFilter.Builder usageMetrics() {
     return new UsageMetricsFilter.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/query/AgentInstanceHistoryQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/AgentInstanceHistoryQuery.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.AgentInstanceHistoryFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.AgentInstanceHistorySort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public final record AgentInstanceHistoryQuery(
+    AgentInstanceHistoryFilter filter, AgentInstanceHistorySort sort, SearchQueryPage page)
+    implements TypedSearchQuery<AgentInstanceHistoryFilter, AgentInstanceHistorySort> {
+
+  public static AgentInstanceHistoryQuery of(
+      final Function<Builder, ObjectBuilder<AgentInstanceHistoryQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
+      implements TypedSearchQueryBuilder<
+          AgentInstanceHistoryQuery,
+          Builder,
+          AgentInstanceHistoryFilter,
+          AgentInstanceHistorySort> {
+
+    private static final AgentInstanceHistoryFilter EMPTY_FILTER =
+        FilterBuilders.agentInstanceHistory().build();
+    private static final AgentInstanceHistorySort EMPTY_SORT =
+        SortOptionBuilders.agentInstanceHistory().build();
+
+    private AgentInstanceHistoryFilter filter;
+    private AgentInstanceHistorySort sort;
+
+    @Override
+    public Builder filter(final AgentInstanceHistoryFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final AgentInstanceHistorySort value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<
+                AgentInstanceHistoryFilter.Builder, ObjectBuilder<AgentInstanceHistoryFilter>>
+            fn) {
+      return filter(FilterBuilders.agentInstanceHistory(fn));
+    }
+
+    public Builder sort(
+        final Function<AgentInstanceHistorySort.Builder, ObjectBuilder<AgentInstanceHistorySort>>
+            fn) {
+      return sort(SortOptionBuilders.agentInstanceHistory(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public AgentInstanceHistoryQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new AgentInstanceHistoryQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -23,6 +23,16 @@ public final class SearchQueryBuilders {
     return fn.apply(agentInstanceSearchQuery()).build();
   }
 
+  public static AgentInstanceHistoryQuery.Builder agentInstanceHistorySearchQuery() {
+    return new AgentInstanceHistoryQuery.Builder();
+  }
+
+  public static AgentInstanceHistoryQuery agentInstanceHistorySearchQuery(
+      final Function<AgentInstanceHistoryQuery.Builder, ObjectBuilder<AgentInstanceHistoryQuery>>
+          fn) {
+    return fn.apply(agentInstanceHistorySearchQuery()).build();
+  }
+
   public static UsageMetricsQuery.Builder usageMetricsSearchQuery() {
     return new UsageMetricsQuery.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/AgentInstanceHistorySort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/AgentInstanceHistorySort.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record AgentInstanceHistorySort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static AgentInstanceHistorySort of(
+      final Function<AgentInstanceHistorySort.Builder, ObjectBuilder<AgentInstanceHistorySort>>
+          fn) {
+    return SortOptionBuilders.agentInstanceHistory(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<Builder>
+      implements ObjectBuilder<AgentInstanceHistorySort> {
+
+    public Builder historyItemKey() {
+      currentOrdering = new FieldSorting("historyItemKey", null);
+      return this;
+    }
+
+    public Builder iteration() {
+      currentOrdering = new FieldSorting("iteration", null);
+      return this;
+    }
+
+    public Builder producedAt() {
+      currentOrdering = new FieldSorting("producedAt", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public AgentInstanceHistorySort build() {
+      return new AgentInstanceHistorySort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -23,6 +23,16 @@ public final class SortOptionBuilders {
     return fn.apply(agentInstance()).build();
   }
 
+  public static AgentInstanceHistorySort.Builder agentInstanceHistory() {
+    return new AgentInstanceHistorySort.Builder();
+  }
+
+  public static AgentInstanceHistorySort agentInstanceHistory(
+      final Function<AgentInstanceHistorySort.Builder, ObjectBuilder<AgentInstanceHistorySort>>
+          fn) {
+    return fn.apply(agentInstanceHistory()).build();
+  }
+
   public static UsageMetricsSort.Builder usageMetrics() {
     return new UsageMetricsSort.Builder();
   }

--- a/service/src/main/java/io/camunda/service/AgentHistoryServices.java
+++ b/service/src/main/java/io/camunda/service/AgentHistoryServices.java
@@ -7,8 +7,15 @@
  */
 package io.camunda.service;
 
+import static io.camunda.service.authorization.Authorizations.AGENT_HISTORY_READ_AUTHORIZATION;
+
+import io.camunda.search.clients.AgentHistorySearchClient;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateAgentHistoryRequest;
@@ -16,12 +23,16 @@ import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryReco
 import java.util.concurrent.CompletableFuture;
 
 public final class AgentHistoryServices
-    extends PhysicalTenantScopedApiServices<AgentHistoryServices> {
+    extends SearchQueryService<
+        AgentHistoryServices, AgentInstanceHistoryQuery, AgentInstanceHistoryEntity> {
+
+  private final AgentHistorySearchClient agentHistorySearchClient;
 
   public AgentHistoryServices(
       final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
+      final AgentHistorySearchClient agentHistorySearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
@@ -30,10 +41,23 @@ public final class AgentHistoryServices
         securityContextProvider,
         executorProvider,
         brokerRequestAuthorizationConverter);
+    this.agentHistorySearchClient = agentHistorySearchClient;
   }
 
   public CompletableFuture<AgentHistoryRecord> createAgentHistoryItem(
       final AgentHistoryRecord record, final CamundaAuthentication authentication) {
     return sendBrokerRequest(new BrokerCreateAgentHistoryRequest(record), authentication);
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceHistoryEntity> search(
+      final AgentInstanceHistoryQuery query, final CamundaAuthentication authentication) {
+    return executeSearchRequest(
+        () ->
+            agentHistorySearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, AGENT_HISTORY_READ_AUTHORIZATION))
+                .searchAgentHistoryItems(query));
   }
 }

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -12,6 +12,7 @@ import static io.camunda.security.api.model.authz.PermissionType.ACCESS;
 import static io.camunda.security.api.model.authz.PermissionType.READ_TASK_LISTENER;
 
 import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -41,6 +42,10 @@ public abstract class Authorizations {
 
   public static final RequiredAuthorization<AgentInstanceEntity> AGENT_INSTANCE_READ_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.processDefinition().readProcessInstance());
+
+  public static final RequiredAuthorization<AgentInstanceHistoryEntity>
+      AGENT_HISTORY_READ_AUTHORIZATION =
+          RequiredAuthorization.of(a -> a.processDefinition().readProcessInstance());
 
   public static final RequiredAuthorization<AuthorizationEntity> AUTHORIZATION_READ_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.authorization().read());

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -964,8 +964,7 @@ components:
           items:
             $ref: '#/components/schemas/AgentInstanceToolCall'
         metrics:
-          description: Per-call token and latency metrics. Present on ASSISTANT items only.
-          nullable: true
+          description: Per-call token and latency metrics. Zero-valued when not available.
           allOf:
             - $ref: '#/components/schemas/AgentInstanceHistoryItemMetrics'
         commitStatus:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -16,6 +16,8 @@ import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryCommitStatusFilterProperty;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleFilterProperty;
 import io.camunda.gateway.protocol.model.AgentInstanceStatusFilterProperty;
 import io.camunda.gateway.protocol.model.AuditLogActorTypeFilterProperty;
 import io.camunda.gateway.protocol.model.AuditLogResultFilterProperty;
@@ -48,6 +50,8 @@ import io.camunda.gateway.protocol.model.StringFilterProperty;
 import io.camunda.gateway.protocol.model.UserTaskStateFilterProperty;
 import io.camunda.gateway.protocol.model.WaitStateElementTypeFilterProperty;
 import io.camunda.gateway.protocol.model.WaitStateTypeFilterProperty;
+import io.camunda.zeebe.gateway.rest.deserializer.AgentInstanceHistoryCommitStatusFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.AgentInstanceHistoryRoleFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.AgentInstanceStatusFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.AuditLogActorTypeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.AuditLogCategoryFilterPropertyDeserializer;
@@ -156,6 +160,12 @@ public class JacksonConfig {
     module.addDeserializer(
         AgentInstanceStatusFilterProperty.class,
         new AgentInstanceStatusFilterPropertyDeserializer());
+    module.addDeserializer(
+        AgentInstanceHistoryRoleFilterProperty.class,
+        new AgentInstanceHistoryRoleFilterPropertyDeserializer());
+    module.addDeserializer(
+        AgentInstanceHistoryCommitStatusFilterProperty.class,
+        new AgentInstanceHistoryCommitStatusFilterPropertyDeserializer());
     module.addDeserializer(
         WaitStateElementTypeFilterProperty.class,
         new WaitStateElementTypeFilterPropertyDeserializer());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
@@ -15,10 +15,13 @@ import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceHistorySearchQuery;
+import io.camunda.gateway.protocol.model.AgentInstanceHistorySearchQueryResult;
 import io.camunda.gateway.protocol.model.AgentInstanceResult;
 import io.camunda.gateway.protocol.model.AgentInstanceSearchQuery;
 import io.camunda.gateway.protocol.model.AgentInstanceSearchQueryResult;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.registry.ServiceRegistry;
@@ -114,6 +117,17 @@ public class AgentInstanceController {
         .fold(RestErrorMapper::mapProblemToResponse, query -> search(physicalTenantId, query));
   }
 
+  @RequiresSecondaryStorage
+  @CamundaPostMapping(path = "/{agentInstanceKey}/history/search")
+  public ResponseEntity<AgentInstanceHistorySearchQueryResult> searchAgentInstanceHistory(
+      @PhysicalTenantId final String physicalTenantId,
+      @PathVariable("agentInstanceKey") final long agentInstanceKey,
+      @RequestBody(required = false) final AgentInstanceHistorySearchQuery request) {
+    return SearchQueryRequestMapper.toAgentInstanceHistoryQuery(request, agentInstanceKey)
+        .fold(
+            RestErrorMapper::mapProblemToResponse, query -> searchHistory(physicalTenantId, query));
+  }
+
   private CompletableFuture<ResponseEntity<Object>> create(
       final String physicalTenantId, final AgentInstanceRecord record) {
     final var agentInstanceServices = serviceRegistry.agentInstanceServices(physicalTenantId);
@@ -150,6 +164,18 @@ public class AgentInstanceController {
           agentInstanceServices.search(query, authenticationProvider.getCamundaAuthentication());
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toAgentInstanceSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  private ResponseEntity<AgentInstanceHistorySearchQueryResult> searchHistory(
+      final String physicalTenantId, final AgentInstanceHistoryQuery query) {
+    final var agentHistoryServices = serviceRegistry.agentHistoryServices(physicalTenantId);
+    try {
+      final var result =
+          agentHistoryServices.search(query, authenticationProvider.getCamundaAuthentication());
+      return ResponseEntity.ok(SearchQueryResponseMapper.toAgentHistorySearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
@@ -121,7 +121,7 @@ public class AgentInstanceController {
   @CamundaPostMapping(path = "/{agentInstanceKey}/history/search")
   public ResponseEntity<AgentInstanceHistorySearchQueryResult> searchAgentInstanceHistory(
       @PhysicalTenantId final String physicalTenantId,
-      @PathVariable("agentInstanceKey") final long agentInstanceKey,
+      @PathVariable final long agentInstanceKey,
       @RequestBody(required = false) final AgentInstanceHistorySearchQuery request) {
     return SearchQueryRequestMapper.toAgentInstanceHistoryQuery(request, agentInstanceKey)
         .fold(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/AgentInstanceHistoryCommitStatusFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/AgentInstanceHistoryCommitStatusFilterPropertyDeserializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.gateway.protocol.model.AdvancedAgentInstanceHistoryCommitStatusFilter;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryCommitStatusEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryCommitStatusFilterProperty;
+
+public class AgentInstanceHistoryCommitStatusFilterPropertyDeserializer
+    extends FilterDeserializer<
+        AgentInstanceHistoryCommitStatusFilterProperty, AgentInstanceHistoryCommitStatusEnum> {
+
+  @Override
+  protected Class<? extends AgentInstanceHistoryCommitStatusFilterProperty> getFinalType() {
+    return AdvancedAgentInstanceHistoryCommitStatusFilter.class;
+  }
+
+  @Override
+  protected Class<AgentInstanceHistoryCommitStatusEnum> getImplicitValueType() {
+    return AgentInstanceHistoryCommitStatusEnum.class;
+  }
+
+  @Override
+  protected AgentInstanceHistoryCommitStatusFilterProperty createFromImplicitValue(
+      final AgentInstanceHistoryCommitStatusEnum value) {
+    return AdvancedAgentInstanceHistoryCommitStatusFilter.Builder.create().$eq(value).build();
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/AgentInstanceHistoryRoleFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/AgentInstanceHistoryRoleFilterPropertyDeserializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.gateway.protocol.model.AdvancedAgentInstanceHistoryRoleFilter;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleFilterProperty;
+
+public class AgentInstanceHistoryRoleFilterPropertyDeserializer
+    extends FilterDeserializer<
+        AgentInstanceHistoryRoleFilterProperty, AgentInstanceHistoryRoleEnum> {
+
+  @Override
+  protected Class<? extends AgentInstanceHistoryRoleFilterProperty> getFinalType() {
+    return AdvancedAgentInstanceHistoryRoleFilter.class;
+  }
+
+  @Override
+  protected Class<AgentInstanceHistoryRoleEnum> getImplicitValueType() {
+    return AgentInstanceHistoryRoleEnum.class;
+  }
+
+  @Override
+  protected AgentInstanceHistoryRoleFilterProperty createFromImplicitValue(
+      final AgentInstanceHistoryRoleEnum value) {
+    return AdvancedAgentInstanceHistoryRoleFilter.Builder.create().$eq(value).build();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Metrics;
+import io.camunda.search.filter.AgentInstanceHistoryFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.AgentHistoryServices;
+import io.camunda.service.AgentInstanceServices;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(AgentInstanceController.class)
+class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
+
+  private static final String AGENT_INSTANCES_URL = "/v2/agent-instances";
+  private static final long AGENT_INSTANCE_KEY = 9007199254741017L;
+  private static final long ELEMENT_INSTANCE_KEY = 2251799813685248L;
+  private static final long JOB_KEY = 2251799813685249L;
+  private static final long HISTORY_ITEM_KEY = 9007199254741018L;
+  private static final OffsetDateTime PRODUCED_AT =
+      OffsetDateTime.parse("2025-01-01T10:00:00+00:00");
+
+  private static final AgentInstanceHistoryEntity HISTORY_ENTITY =
+      new AgentInstanceHistoryEntity(
+          HISTORY_ITEM_KEY,
+          AGENT_INSTANCE_KEY,
+          ELEMENT_INSTANCE_KEY,
+          9007199254741001L,
+          9007199254740992L,
+          "myProcess",
+          "<default>",
+          JOB_KEY,
+          "job-lease-1",
+          1,
+          AgentInstanceHistoryRole.USER,
+          List.of(new ContentItem(ContentType.TEXT, "Hello agent", null, null)),
+          List.of(),
+          new Metrics(10L, 20L, 100L),
+          AgentInstanceHistoryCommitStatus.COMMITTED,
+          PRODUCED_AT);
+
+  private static final String HISTORY_SEARCH_URL =
+      AGENT_INSTANCES_URL + "/" + AGENT_INSTANCE_KEY + "/history/search";
+
+  private static final String EXPECTED_SEARCH_RESPONSE =
+      """
+      {
+        "items": [
+          {
+            "historyItemKey": "%d",
+            "agentInstanceKey": "%d",
+            "elementInstanceKey": "%d",
+            "jobKey": "%d",
+            "jobLease": "job-lease-1",
+            "iteration": 1,
+            "role": "USER",
+            "content": [{ "contentType": "TEXT", "text": "Hello agent" }],
+            "toolCalls": [],
+            "metrics": { "inputTokens": 10, "outputTokens": 20, "durationMs": 100 },
+            "commitStatus": "COMMITTED",
+            "producedAt": "2025-01-01T10:00:00.000Z"
+          }
+        ],
+        "page": {
+          "totalItems": 1,
+          "startCursor": "f",
+          "endCursor": "v",
+          "hasMoreTotalItems": false
+        }
+      }
+      """
+          .formatted(HISTORY_ITEM_KEY, AGENT_INSTANCE_KEY, ELEMENT_INSTANCE_KEY, JOB_KEY);
+
+  @MockitoBean private AgentInstanceServices agentInstanceServices;
+  @MockitoBean private AgentHistoryServices agentHistoryServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean private ServiceRegistry serviceRegistry;
+
+  @BeforeEach
+  void setUp() {
+    when(serviceRegistry.agentInstanceServices(any())).thenReturn(agentInstanceServices);
+    when(serviceRegistry.agentHistoryServices(any())).thenReturn(agentHistoryServices);
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void shouldSearchAgentHistoryWithEmptyBody() {
+    // given
+    when(agentHistoryServices.search(any(AgentInstanceHistoryQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceHistoryEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(HISTORY_ENTITY))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(HISTORY_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.LENIENT);
+
+    // verify that agentInstanceKey is injected and COMMITTED is applied as default
+    verify(agentHistoryServices)
+        .search(
+            eq(
+                new AgentInstanceHistoryQuery.Builder()
+                    .filter(
+                        new AgentInstanceHistoryFilter.Builder()
+                            .agentInstanceKeyOperations(List.of(Operation.eq(AGENT_INSTANCE_KEY)))
+                            .commitStatusOperations(List.of(Operation.eq("COMMITTED")))
+                            .build())
+                    .build()),
+            any());
+  }
+
+  @Test
+  void shouldSearchAgentHistoryWithRoleFilter() {
+    // given
+    when(agentHistoryServices.search(any(AgentInstanceHistoryQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceHistoryEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(HISTORY_ENTITY))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(HISTORY_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "role": { "$eq": "USER" }
+              }
+            }
+            """)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.LENIENT);
+
+    verify(agentHistoryServices)
+        .search(
+            eq(
+                new AgentInstanceHistoryQuery.Builder()
+                    .filter(
+                        new AgentInstanceHistoryFilter.Builder()
+                            .agentInstanceKeyOperations(List.of(Operation.eq(AGENT_INSTANCE_KEY)))
+                            .commitStatusOperations(List.of(Operation.eq("COMMITTED")))
+                            .roleOperations(List.of(Operation.eq("USER")))
+                            .build())
+                    .build()),
+            any());
+  }
+
+  @Test
+  void shouldSearchAgentHistoryWithExplicitCommitStatusFilter() {
+    // given
+    when(agentHistoryServices.search(any(AgentInstanceHistoryQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceHistoryEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(HISTORY_ENTITY))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(HISTORY_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "commitStatus": { "$eq": "PENDING" }
+              }
+            }
+            """)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    // verify that an explicit commitStatus overrides the COMMITTED default
+    verify(agentHistoryServices)
+        .search(
+            eq(
+                new AgentInstanceHistoryQuery.Builder()
+                    .filter(
+                        new AgentInstanceHistoryFilter.Builder()
+                            .agentInstanceKeyOperations(List.of(Operation.eq(AGENT_INSTANCE_KEY)))
+                            .commitStatusOperations(List.of(Operation.eq("PENDING")))
+                            .build())
+                    .build()),
+            any());
+  }
+}


### PR DESCRIPTION
## Description

Adds `POST /v2/agent-instances/{agentInstanceKey}/history/search` — the search endpoint for agent history items produced by the AI agent connector. This is part of the larger AgentHistory feature that stores and surfaces the message history (user prompts, assistant responses, tool calls, and tool results) exchanged during a process-instance AI task execution.

### What is changing and why

**Search-domain types** (`AgentInstanceHistoryEntity`, `AgentInstanceHistoryFilter`, `AgentInstanceHistoryQuery`, `AgentInstanceHistorySort`) model a single history item in the technology-neutral layer consumed by both the REST mapper and secondary-storage readers. The entity mirrors the OpenAPI response schema, using nested value types (`ContentItem`, `DocumentReference`, `DocumentMetadata`, `ToolCall`, `Metrics`) and two enums (`AgentInstanceHistoryRole`, `AgentInstanceHistoryCommitStatus`).

**OpenAPI correction** — `metrics` on `AgentInstanceHistoryItemResult` was marked `nullable: true`. Metrics are always present (zero-valued when not available), so the nullable flag was removed to avoid generating unnecessary `@Nullable` annotations in client SDKs.

**Search client and stub readers** — `AgentHistorySearchClient`, `AgentHistoryReader` (interface), `AgentHistoryDocumentReader` (ES/OS), and `AgentHistoryDbReader` (RDBMS) wire the search-client abstraction. The ES/OS and RDBMS implementations are stubs that throw `UnsupportedOperationException` and are guarded with `@RequiresSecondaryStorage`, so the controller is fully testable today while the actual secondary-storage implementations can land in follow-on PRs without breaking anything.

**Service layer** — `AgentHistoryServices` is extended to implement `SearchQueryService`. The `search()` method enforces `AGENT_HISTORY_READ_AUTHORIZATION` using the `processDefinition().readProcessInstance()` permission — consistent with how other engine-managed entities gate read access to history data of a process instance.

**Mapper chain** — `SearchQueryFilterMapper`, `SearchQuerySortMapper`, `SearchQueryRequestMapper`, and `SearchQueryResponseMapper` each gain an agent-history leg, completing the request-to-query and query-to-response pipeline.

**REST controller** — `AgentInstanceController` exposes the new endpoint, delegating through the mapper chain to `AgentHistoryServices.search()`.

**Jackson deserializers** — `AgentInstanceHistoryRoleFilterProperty` and `AgentInstanceHistoryCommitStatusFilterProperty` require explicit `FilterDeserializer` subclasses (registered in `JacksonConfig`) to handle the `{"$eq": "USER"}` filter syntax. Without these, any request body containing an enum filter would fail with HTTP 400.

### Design decisions

**`agentInstanceKey` injected as filter in the mapper, not in the controller** — the path variable is merged into the filter inside `SearchQueryFilterMapper.toAgentInstanceHistoryFilter`, following the same pattern used by other sub-resource search endpoints. This keeps the controller a thin routing layer with no domain logic.

**`commitStatus` defaults to `COMMITTED`** — history search is expected to return only committed items by default, matching the semantics of the history-creation endpoint. Callers can explicitly pass `PENDING` or `DISCARDED` to override.

**`processDefinitionId` in the entity but not in the REST response** — the field is carried through the search layer for authorisation checks (`processDefinition().readProcessInstance()`) without exposing it to API consumers, consistent with how other entities handle auth-internal fields.

**Stub readers over deferred wiring** — using `UnsupportedOperationException` stubs means the controller, service, and mapper are fully exercisable in unit tests now, while the ES/OS and RDBMS implementations can land independently without requiring this PR to be blocked by them.

### What is NOT in this PR

- ES/OS index reader implementation → #55268
- RDBMS reader implementation → #55271

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55267