### PR TITLE
feat: make the engine use SearchClient of scoping partitionGroup

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -141,7 +141,9 @@ public final class PartitionManagerImpl
             topologyManager,
             featureFlags,
             securityConfig,
-            searchClientsProxy,
+            searchClientsProxy != null
+                ? searchClientsProxy.withPhysicalTenant(partitionGroup)
+                : null,
             brokerRequestAuthorizationConverter,
             clusterConfigurationService,
             rocksDbResources);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -16,9 +16,11 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberConfig;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.partitioning.RecoveryPartitionManager;
+import io.camunda.zeebe.broker.partitioning.startup.ZeebePartitionFactory;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -45,6 +47,7 @@ class PartitionManagerStepTest {
   private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
   private static final Duration TIME_OUT = Duration.ofSeconds(10);
+  private static final String PHYSICAL_TENANT_ID = "custom";
 
   static {
     final var networkCfg = TEST_BROKER_CONFIG.getGateway().getNetwork();
@@ -52,8 +55,7 @@ class PartitionManagerStepTest {
   }
 
   private final Logger log = LoggerFactory.getLogger(PartitionManagerStepTest.class);
-  private final PartitionManagerStep sut =
-      new PartitionManagerStep(PartitionManagerImpl.DEFAULT_GROUP_NAME);
+  private final PartitionManagerStep sut = new PartitionManagerStep(PHYSICAL_TENANT_ID);
   private MockBrokerStartupContext testBrokerStartupContext;
 
   @Test
@@ -62,7 +64,7 @@ class PartitionManagerStepTest {
     final var actual = sut.getName();
 
     // then
-    assertThat(actual).isEqualTo("Partition Manager [default]");
+    assertThat(actual).isEqualTo("Partition Manager [custom]");
   }
 
   @Nested
@@ -115,9 +117,7 @@ class PartitionManagerStepTest {
     @AfterEach
     void tearDown() {
       final var partitionManager =
-          testBrokerStartupContext
-              .getPartitionManagers()
-              .get(PartitionManagerImpl.DEFAULT_GROUP_NAME);
+          testBrokerStartupContext.getPartitionManagers().get(PHYSICAL_TENANT_ID);
       if (partitionManager != null) {
         partitionManager.stop().join();
       }
@@ -146,9 +146,7 @@ class PartitionManagerStepTest {
 
       // then
       final var partitionManager =
-          testBrokerStartupContext
-              .getPartitionManagers()
-              .get(PartitionManagerImpl.DEFAULT_GROUP_NAME);
+          testBrokerStartupContext.getPartitionManagers().get(PHYSICAL_TENANT_ID);
       assertThat(partitionManager).isNotNull();
     }
 
@@ -178,11 +176,47 @@ class PartitionManagerStepTest {
 
       // then
       final var partitionManager =
-          testBrokerStartupContext
-              .getPartitionManagers()
-              .get(PartitionManagerImpl.DEFAULT_GROUP_NAME);
+          testBrokerStartupContext.getPartitionManagers().get(PHYSICAL_TENANT_ID);
 
       assertThat(partitionManager).isInstanceOf(RecoveryPartitionManager.class);
+    }
+
+    @Test
+    void shouldScopeSearchClientProxyToPartitionGroup() throws Exception {
+      // given
+      final var scopedProxy = mock(SearchClientsProxy.class);
+      final var searchClientsProxy = mock(SearchClientsProxy.class);
+      when(searchClientsProxy.withPhysicalTenant(PHYSICAL_TENANT_ID)).thenReturn(scopedProxy);
+      testBrokerStartupContext.setSearchClientsProxy(searchClientsProxy);
+
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+
+      // then — the scoped proxy (not the original unscoped one) is wired into ZeebePartitionFactory
+      final var partitionManager =
+          (PartitionManagerImpl)
+              testBrokerStartupContext.getPartitionManagers().get(PHYSICAL_TENANT_ID);
+      final var factoryField = PartitionManagerImpl.class.getDeclaredField("zeebePartitionFactory");
+      factoryField.setAccessible(true);
+      final var zeebeFactory = factoryField.get(partitionManager);
+
+      final var proxyField = ZeebePartitionFactory.class.getDeclaredField("searchClientsProxy");
+      proxyField.setAccessible(true);
+
+      assertThat(proxyField.get(zeebeFactory)).isSameAs(scopedProxy);
+    }
+
+    @Test
+    void shouldNotFailWhenSearchClientProxyIsNull() {
+      // given
+      testBrokerStartupContext.setSearchClientsProxy(null);
+
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+
+      // then
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
     }
   }
 
@@ -209,8 +243,7 @@ class PartitionManagerStepTest {
       // manager submission fail, so the step stores no manager; we inject the mock ourselves.
       final ActorFuture<BrokerStartupContext> startupFuture = CONCURRENCY_CONTROL.createFuture();
       sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
-      testBrokerStartupContext.addPartitionManager(
-          PartitionManagerImpl.DEFAULT_GROUP_NAME, mockPartitionManager);
+      testBrokerStartupContext.addPartitionManager(PHYSICAL_TENANT_ID, mockPartitionManager);
       shutdownFuture = CONCURRENCY_CONTROL.createFuture();
     }
 
@@ -223,9 +256,7 @@ class PartitionManagerStepTest {
       // then
       verify(mockPartitionManager).stop();
       final var partitionManager =
-          testBrokerStartupContext
-              .getPartitionManagers()
-              .get(PartitionManagerImpl.DEFAULT_GROUP_NAME);
+          testBrokerStartupContext.getPartitionManagers().get(PHYSICAL_TENANT_ID);
       assertThat(partitionManager).isNull();
     }
 
@@ -244,8 +275,7 @@ class PartitionManagerStepTest {
       // given
       final var recoveryPartitionManager = mock(RecoveryPartitionManager.class);
       when(recoveryPartitionManager.stop()).thenReturn(CompletableActorFuture.completed(null));
-      testBrokerStartupContext.addPartitionManager(
-          PartitionManagerImpl.DEFAULT_GROUP_NAME, recoveryPartitionManager);
+      testBrokerStartupContext.addPartitionManager(PHYSICAL_TENANT_ID, recoveryPartitionManager);
 
       // when
       sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The engine uses the Secondary storage SearchClient for BatchOperations processing
This pull request makes a targeted update to how the `searchClientsProxy` is initialized in the `PartitionManagerImpl` constructor to that the search client is now associated with a specific physical tenant

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to https://github.com/camunda/camunda/issues/52061
