### PR TITLE
test: enforce async index creation for indexes on pre-existing tables

### DIFF
--- a/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/ChangelogAsyncIndexTest.java
+++ b/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/ChangelogAsyncIndexTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import liquibase.Liquibase;
+import liquibase.change.core.CreateIndexChange;
+import liquibase.change.core.CreateTableChange;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.DatabaseFactory;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.Test;
+
+class ChangelogAsyncIndexTest {
+
+  private static final String MASTER_CHANGELOG = "db/changelog/rdbms-exporter/changelog-master.xml";
+  private static final String ASYNC_INDEX_TEST_MASTER = "db/changelog/async-index-test/master.xml";
+
+  private static List<ChangeSet> loadChangeSets(final String masterChangelog) throws Exception {
+    // Use H2 as a lightweight database for changelog introspection (no DB connection needed)
+    final var database = DatabaseFactory.getInstance().getDatabase("h2");
+    final var liquibase =
+        new Liquibase(masterChangelog, new ClassLoaderResourceAccessor(), database);
+    liquibase.setChangeLogParameter("prefix", "");
+    liquibase.setChangeLogParameter("userCharColumnSize", 4000);
+    liquibase.setChangeLogParameter("errorMessageSize", 4000);
+    liquibase.setChangeLogParameter("treePathSize", 4000);
+    return liquibase.getDatabaseChangeLog().getChangeSets();
+  }
+
+  @Test
+  void shouldUseAsyncIndexCreationForIndexesOnPreExistingTables() throws Exception {
+    // given
+    final var changeSets = loadChangeSets(MASTER_CHANGELOG);
+
+    // when checking for locking createIndex changesets that target tables from a different file
+    final var violations = findLockingIndexesOnPreExistingTables(changeSets);
+
+    // then there should be none — indexes on pre-existing tables must use concurrent/online SQL
+    assertThat(violations)
+        .as(
+            "Changesets using <createIndex> on a table defined in a different changelog file must "
+                + "use async SQL (CONCURRENTLY / WITH (ONLINE = ON) / ONLINE) instead")
+        .isEmpty();
+  }
+
+  /**
+   * Verifies that {@link #shouldUseAsyncIndexCreationForIndexesOnPreExistingTables()} actually
+   * catches violations. Loads a deliberately broken fixture changelog that creates an index with
+   * standard {@code <createIndex>} on a table defined in a prior file, and asserts the violation is
+   * detected.
+   */
+  @Test
+  void shouldDetectLockingIndexViolationInFixture() throws Exception {
+    // given: a fixture changelog where v2 adds a locking <createIndex> on a table from v1
+    final var fixtureChangeSets = loadChangeSets(ASYNC_INDEX_TEST_MASTER);
+
+    // when
+    final var violations = findLockingIndexesOnPreExistingTables(fixtureChangeSets);
+
+    // then: the intentional violation in v2-locking-index.xml is detected
+    assertThat(violations).containsExactly("create_test_entity_name_index");
+  }
+
+  /**
+   * Returns the IDs of changesets that use a locking {@code <createIndex>} on a table that was
+   * created in a different changelog file. Such indexes must use database-specific async SQL (e.g.
+   * {@code CREATE INDEX CONCURRENTLY} on PostgreSQL) to avoid blocking table access during startup.
+   */
+  private static List<String> findLockingIndexesOnPreExistingTables(
+      final List<ChangeSet> changeSets) {
+    // Build a map of tableName -> source file path using createTable changesets
+    final Map<String, String> tableCreatedInFile = new HashMap<>();
+    for (final var cs : changeSets) {
+      for (final var change : cs.getChanges()) {
+        if (change instanceof final CreateTableChange createTable) {
+          tableCreatedInFile.put(createTable.getTableName(), cs.getFilePath());
+        }
+      }
+    }
+
+    return changeSets.stream()
+        .filter(cs -> cs.getChanges().stream().anyMatch(c -> c instanceof CreateIndexChange))
+        .filter(
+            cs -> {
+              final var indexChange =
+                  cs.getChanges().stream()
+                      .filter(c -> c instanceof CreateIndexChange)
+                      .map(c -> (CreateIndexChange) c)
+                      .findFirst()
+                      .orElseThrow();
+              final String tableFile = tableCreatedInFile.get(indexChange.getTableName());
+              // A violation only when the table was created in a DIFFERENT file
+              return tableFile != null && !tableFile.equals(cs.getFilePath());
+            })
+        .map(ChangeSet::getId)
+        .collect(Collectors.toList());
+  }
+}

--- a/db/rdbms-schema/src/test/resources/db/changelog/async-index-test/master.xml
+++ b/db/rdbms-schema/src/test/resources/db/changelog/async-index-test/master.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <include file="/db/changelog/async-index-test/v1-base.xml"/>
+  <include file="/db/changelog/async-index-test/v2-locking-index.xml"/>
+
+</databaseChangeLog>

--- a/db/rdbms-schema/src/test/resources/db/changelog/async-index-test/v1-base.xml
+++ b/db/rdbms-schema/src/test/resources/db/changelog/async-index-test/v1-base.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!--suppress LiquibaseXmlUnresolvedProperty -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <!-- Base table created in this file (v1) -->
+  <changeSet id="create_test_entity_table" author="camunda">
+    <createTable tableName="TEST_ENTITY">
+      <column name="ENTITY_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="NAME" type="NVARCHAR(256)"/>
+    </createTable>
+  </changeSet>
+
+</databaseChangeLog>

--- a/db/rdbms-schema/src/test/resources/db/changelog/async-index-test/v2-locking-index.xml
+++ b/db/rdbms-schema/src/test/resources/db/changelog/async-index-test/v2-locking-index.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!--suppress LiquibaseXmlUnresolvedProperty -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <!--
+    INTENTIONAL VIOLATION: this index uses a locking <createIndex> on TEST_ENTITY,
+    which was created in a different (prior) changelog file (v1-base.xml).
+    This fixture is used by ChangelogAsyncIndexTest to verify the enforcement test
+    actually catches the violation.
+  -->
+  <changeSet id="create_test_entity_name_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="IDX_TEST_ENTITY_NAME" tableName="TEST_ENTITY"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="TEST_ENTITY" indexName="IDX_TEST_ENTITY_NAME">
+      <column name="NAME"/>
+    </createIndex>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Summary

- Adds `ChangelogAsyncIndexTest` to detect any standard `<createIndex>` changeset that targets a table created in a different (earlier) changelog file
- Such changesets acquire a table-level lock during Liquibase startup, which can block Camunda and trigger unwanted Kubernetes pod restarts
- The required pattern for adding an index to a pre-existing table is per-DBMS `<sql>` with `CREATE INDEX CONCURRENTLY` (PostgreSQL), `WITH (ONLINE = ON)` (MSSQL), `ALGORITHM=INPLACE LOCK=NONE` (MySQL/MariaDB), or `ONLINE` (Oracle)
- Includes a deliberately broken fixture changelog (`v1-base.xml` + `v2-locking-index.xml`) to verify the enforcement test actually catches violations rather than being vacuously green

Closes #55393

## Test plan

- [ ] `ChangelogAsyncIndexTest#shouldUseAsyncIndexCreationForIndexesOnPreExistingTables` passes on the production changelog (no current violations)
- [ ] `ChangelogAsyncIndexTest#shouldDetectLockingIndexViolationInFixture` catches the intentional violation in the test fixture
- [ ] All existing `ChangelogIdempotencyTest` tests still pass unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)