### PR TITLE
fix: throttle endless retry logs (and change error to warn)

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.retry.ActorRetryMechanism.Control;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
+import java.time.Duration;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +24,7 @@ public final class EndlessRetryStrategy implements RetryStrategy {
   private final ActorControl actor;
   private final ActorRetryMechanism retryMechanism;
   private final int maxRetries;
+  private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier terminateCondition;
   private int retryCount;
@@ -67,15 +70,14 @@ public final class EndlessRetryStrategy implements RetryStrategy {
       if (terminateCondition.getAsBoolean()) {
         currentFuture.complete(false);
       } else if (!retryLimitExceeded(++retryCount, maxRetries, exception, LOG, currentFuture)) {
-        actor.run(this::run);
-        actor.yieldThread();
-        LOG.error(
-            "Caught exception {} with message {} (retry {}/{}), will retry...",
-            exception.getClass(),
-            exception.getMessage(),
+        throttledLog.warn(
+            "Caught recoverable exception (retry {}/{}), will retry: {}",
             retryCount,
             maxRetries,
+            exception.getMessage(),
             exception);
+        actor.run(this::run);
+        actor.yieldThread();
       }
     }
   }


### PR DESCRIPTION
This matches the way we log in RecoverableRetryStrategy. EndlessRetryStrategy is now only used to test the retry code, but this will guard against over-logging in case it's reintroduced into production code paths.

The original issue #50992 proposed changes to RecoverableRetryStrategy too, but the spirit of those has imo already been satisfied (it's using a throttled logger now and logging at WARN rather than DEBUG). There was a suggestion to always log at DEBUG even when throttling logs, but that seems to be rejected by later changes to suppress debug logging for the sake of test environment performance.

Closes: #50992
