### PR TITLE
test: delete OpenSearch indices serially to avoid AWS kraken throw

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
@@ -90,7 +90,19 @@ public class OSClient implements DocumentClient {
 
   @Override
   public void deleteAllIndices(final String indexPrefix) throws IOException {
-    opensearchClient.indices().delete(DeleteIndexRequest.of(b -> b.index("*")));
+    // Delete indices one per request to avoid tripping the AWS Managed OpenSearch
+    // kraken-index-management-extension, which throws IllegalArgumentException ("Cannot get
+    // metadata
+    // for more than one index ... when using a custom index type") when a single cluster-state
+    // change deletes more than one index, aborting the ISM sweep and failing concurrent searches.
+    // See camunda/camunda#52892.
+    final var indices =
+        opensearchClient.cat().indices(r -> r.index("*")).valueBody().stream()
+            .map(IndicesRecord::index)
+            .toList();
+    for (final var index : indices) {
+      opensearchClient.indices().delete(DeleteIndexRequest.of(b -> b.index(index)));
+    }
   }
 
   @Override

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/AWSOpenSearchSetupHelper.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/AWSOpenSearchSetupHelper.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.cat.indices.IndicesRecord;
 import org.opensearch.client.opensearch.cluster.DeleteComponentTemplateRequest;
 import org.opensearch.client.opensearch.cluster.PutClusterSettingsRequest;
 import org.opensearch.client.opensearch.cluster.PutClusterSettingsRequest.Builder;
@@ -107,7 +108,18 @@ public class AWSOpenSearchSetupHelper extends OpenSearchSetupHelper {
   @Override
   public void cleanup(final String prefix) {
     try {
-      client.indices().delete(new DeleteIndexRequest.Builder().index(prefix + "*").build());
+      // Delete indices one per request to avoid tripping the AWS Managed OpenSearch
+      // kraken-index-management-extension, which throws IllegalArgumentException ("Cannot get
+      // metadata for more than one index ... when using a custom index type") when a single
+      // cluster-state change deletes more than one index, aborting the ISM sweep and failing
+      // concurrent searches across the shared domain. See camunda/camunda#52892.
+      final var indices =
+          client.cat().indices(r -> r.index(prefix + "*")).valueBody().stream()
+              .map(IndicesRecord::index)
+              .toList();
+      for (final var index : indices) {
+        client.indices().delete(new DeleteIndexRequest.Builder().index(index).build());
+      }
     } catch (final IOException e) {
       LOGGER.warn("Exception on cleaning indexes {}", prefix, e);
     }

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
@@ -13,6 +13,7 @@ import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -126,6 +127,31 @@ public abstract class SearchDBExtension implements BeforeAllCallback, AfterAllCa
 
   public boolean isAws() {
     return false;
+  }
+
+  /**
+   * Deletes all OpenSearch indices matching the given prefix, one index per request.
+   *
+   * <p>AWS Managed OpenSearch ships the closed-source {@code kraken-index-management-extension},
+   * which registers a custom-typed ISM metadata service. When a single cluster-state change deletes
+   * more than one index, the open-source {@code ManagedIndexCoordinator} delete sweep calls {@code
+   * getMultiTypeISMIndexMetadata} with all deleted index names and throws {@code
+   * IllegalArgumentException: Cannot get metadata for more than one index ... when using a custom
+   * index type}, aborting the sweep and failing concurrent searches. Deleting indices individually
+   * keeps each cluster event to a single index and avoids the throw. See camunda/camunda#52892.
+   *
+   * @param prefix the index name prefix; a trailing {@code *} wildcard is appended for lookup
+   */
+  public void deleteOpenSearchIndicesByPrefix(final String prefix) throws IOException {
+    final var matchingIndices =
+        osClient()
+            .indices()
+            .get(r -> r.index(prefix + "*").ignoreUnavailable(true).allowNoIndices(true))
+            .result()
+            .keySet();
+    for (final var index : matchingIndices) {
+      osClient().indices().delete(r -> r.index(index).ignoreUnavailable(true));
+    }
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -101,7 +101,7 @@ final class CamundaExporterIT {
     if (openSearchAwsInstanceUrl.isEmpty()) {
       searchDB.esClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
     }
-    searchDB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+    searchDB.deleteOpenSearchIndicesByPrefix(CUSTOM_PREFIX);
   }
 
   @TestTemplate

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterBulkConsistencyIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterBulkConsistencyIT.java
@@ -98,7 +98,7 @@ final class ExporterBulkConsistencyIT {
     if (openSearchAwsInstanceUrl.isEmpty()) {
       SEARCH_DB.esClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
     }
-    SEARCH_DB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+    SEARCH_DB.deleteOpenSearchIndicesByPrefix(CUSTOM_PREFIX);
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/UserTaskVariableExportIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/UserTaskVariableExportIT.java
@@ -66,7 +66,7 @@ final class UserTaskVariableExportIT {
     if (openSearchAwsInstanceUrl.isEmpty()) {
       searchDB.esClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
     }
-    searchDB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+    searchDB.deleteOpenSearchIndicesByPrefix(CUSTOM_PREFIX);
   }
 
   @TestTemplate

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -94,7 +94,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
     if (openSearchAwsInstanceUrl.isEmpty()) {
       searchDB.esClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
     }
-    searchDB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+    searchDB.deleteOpenSearchIndicesByPrefix(CUSTOM_PREFIX);
 
     if (executor != null) {
       executor.shutdown();

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
@@ -30,6 +30,7 @@ import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.ExpandWildcard;
 import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.cat.indices.IndicesRecord;
 import org.opensearch.client.opensearch.cluster.DeleteComponentTemplateRequest;
 import org.opensearch.client.opensearch.cluster.GetComponentTemplateResponse;
 import org.opensearch.client.opensearch.core.GetResponse;
@@ -175,13 +176,24 @@ final class TestClient implements CloseableSilently {
 
   void deleteIndices() {
     try {
-      osClient
-          .indices()
-          .delete(
-              DeleteIndexRequest.builder()
-                  .index(config.index.prefix + "*")
-                  .expandWildcards(ExpandWildcard.All)
-                  .build());
+      // Delete indices one per request to avoid tripping the AWS Managed OpenSearch
+      // kraken-index-management-extension, which throws IllegalArgumentException ("Cannot get
+      // metadata for more than one index ... when using a custom index type") when a single
+      // cluster-state change deletes more than one index, aborting the ISM sweep and failing
+      // concurrent searches. See camunda/camunda#52892.
+      final var indices =
+          osClient.cat().indices(r -> r.index(config.index.prefix + "*")).valueBody().stream()
+              .map(IndicesRecord::index)
+              .toList();
+      for (final var index : indices) {
+        osClient
+            .indices()
+            .delete(
+                DeleteIndexRequest.builder()
+                    .index(index)
+                    .expandWildcards(ExpandWildcard.All)
+                    .build());
+      }
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }


### PR DESCRIPTION
## Description

The camunda-exporter OpenSearch integration tests fail on **AWS Managed OpenSearch** (not on vanilla Testcontainers OpenSearch). This is a draft to **empirically validate a candidate fix** via the AWS-MOS dispatch workflow before requesting review.

### Root cause (verified)

AWS Managed OpenSearch ships the closed-source `kraken-index-management-extension`, which registers a **custom-typed** `IndexMetadataService`. The open-source ISM `ManagedIndexCoordinator.sweepClusterChangedEvent` reacts to cluster-state changes once ISM is engaged (i.e. retention enabled). Its **index-deletion branch** calls:

```kotlin
indexMetadataProvider.getMultiTypeISMIndexMetadata(indexNames = deletedIndices)
```

and the OSS guard throws when a custom type is registered **and** more than one index is deleted in one event:

```kotlin
// IndexMetadataProvider.kt
if (types.any { it != DEFAULT_INDEX_TYPE } && indexNames.size > 1)
    throw IllegalArgumentException(MULTIPLE_INDICES_CUSTOM_INDEX_TYPE_ERROR)
    // "Cannot get metadata for more than one index name/pattern when using a custom index type"
```

The sweep aborts and concurrent search shards fail with `search_phase_execution_exception: all shards failed`. Because the OpenSearch IT jobs share one AWS MOS domain, one suite's teardown can break another suite's in-flight archiver searches → cascading `CompletableFuture[Incomplete] within 5S` / `TimeoutException` failures.

Evidence (run `27597140710`, attempt 2 — rerun after enabling AWS OpenSearch application logs): 182 throws per cluster on OS 2.19 and 3.5, zero circuit-breaker / OOM. Live `GET /_cat/plugins` confirms `kraken` + `kraken-index-management-extension` present; the two `camunda-*-retention-policy` policies have no `ism_template`.

### The trigger in our tests

The camunda-exporter archiver itself only deletes **documents**, never indices. The multi-index delete comes from the IT teardowns, which delete every custom-prefixed index in a **single wildcard request**:

```java
searchDB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
```

### The change

Add `SearchDBExtension.deleteOpenSearchIndicesByPrefix(prefix)`, which resolves matching indices and deletes them **one per request**, so each cluster-state change removes at most one index and never trips the kraken guard. The four OpenSearch teardowns (`CamundaExporterIT`, `ExporterBulkConsistencyIT`, `UserTaskVariableExportIT`, `ArchiverJobIT`) use it. The Elasticsearch (Testcontainers, no kraken) branch is unchanged. `OpenSearchArchiverRepositoryIT` already deletes indices individually, so it needs no change.

### Validation

- [x] `search-test-utils` compiles; `camunda-exporter` test-compiles; spotless applied
- [ ] **Dispatch `AWS OpenSearch Manual/Scheduled Run Integration Tests` (`zeebe-aws-os-dispatch-tests.yml`) on this branch for OS 2.19 and 3.5 and confirm the archiver ITs go green** — this is the whole point of the draft

## Related issues

Related to #52892

> [!NOTE]
> This addresses the **IT symptom**. Whether production ISM retention ever deletes >1 index per cluster event (the self-managed exposure) is a separate question and not covered here.