### PR TITLE
ci: add CI failure diagnosis and incident response skills

### DIFF
--- a/.claude/skills/ci-fix-failure/SKILL.md
+++ b/.claude/skills/ci-fix-failure/SKILL.md
@@ -5,256 +5,161 @@ description: Diagnose a failing GitHub Actions run in camunda/camunda from a run
 
 # CI Job Failure Diagnosis
 
-Given a GitHub Actions run or job URL, walk an unsuccessful (failed, cancelled) run down to the root cause and propose a fix.
-Scope is **diagnose + propose** — never apply, commit, or push automatically.
+**Scope: diagnose + propose. Never apply, commit, or push automatically.**
 
 ## When to use
 
-The user shares any of:
+User shares a GHA URL (`actions/runs/<id>`, `actions/runs/<id>/job/<id>`, or `pull/<n>/checks?check_run_id=<id>`) and asks why it failed.
 
-- A run URL: `https://github.com/camunda/camunda/actions/runs/<run-id>`
-- A job URL: `https://github.com/camunda/camunda/actions/runs/<run-id>/job/<job-id>`
-- A check URL on a PR: `https://github.com/camunda/camunda/pull/<n>/checks?check_run_id=<id>`
-
-…and asks why it failed, or to fix it.
-
-If no URL is given, ask for one — do not guess from recent history.
+- No URL → ask. Don't guess from recent context.
+- Non-`camunda/camunda` repo → tell user this skill assumes monorepo conventions; some fixes won't apply.
 
 ## Prerequisites
 
-- `gh` CLI authenticated against `camunda/camunda`. Verify with `gh auth status`.
-- Working directory should be the repo root so any proposed fix lands in the right tree.
+- `gh auth status` works against `camunda/camunda`.
+- CWD is the repo root.
+
+## Hard rules — read first
+
+1. **NEVER increase a job/step timeout.** Timeouts are contracts. Fix the slow work, the cache, the runner size, or (one-off `pull_request` only) rerun. Per `ci.md` §flaky tests: retry **within** the timeout.
+2. **NEVER propose workflow/cache/retry/sizing changes without reading and quoting [`ci.md`](../../../docs/monorepo-docs/ci.md).** Silent or contradicts → drop. Use the prescribed composite actions (`setup-maven-cache`, `setup-yarn-cache`); cache writes only from `main`/`stable*`.
 
 ## Procedure
 
-### Step 1 — Parse the URL
+### 1. Parse URL → `run_id` (required), `job_id` (optional), `attempt` (optional)
 
-Extract `run_id` (required) and `job_id` (optional). For check URLs, the `check_run_id` query
-param **is** the job id.
+For check URLs, `check_run_id` **is** the job id. `/attempts/<n>` → `attempt=<n>`.
 
-If the URL is for a different repo than `camunda/camunda`, inform the user that for some fixes
-this skill assumes the monorepo's conventions.
-
-### Step 2 — Pull run and job metadata
+### 2. Pull run and job metadata
 
 ```bash
-gh run view <run-id> --repo camunda/camunda --json \
-  status,conclusion,name,headBranch,headSha,event,workflowName,workflowDatabaseId,url,jobs,displayTitle,createdAt
+gh run view <run-id> --repo camunda/camunda [--attempt <n>] --json \
+  status,conclusion,name,headBranch,headSha,event,workflowName,jobs,url,attempt
 ```
 
-Note: `name` and `workflowName`, `headBranch`, `event` (push/pull_request/schedule/workflow_dispatch),
-`headSha`, and the list of jobs with their conclusions.
+Default returns the **latest** attempt — a successful rerun masks the original failure. Always pass `--attempt <n>` if the URL had one; thread it through Step 5's `--log-failed` too.
 
-If the run is still `in_progress`, tell the user and stop — wait for it to finish.
+- `in_progress` → tell user, stop.
+- `success` → tell user, ask what they actually want.
 
-If the run is `success`, tell the user the run passed and ask what they want to look at instead.
+### 3. Identify failing jobs and steps
 
-### Step 3 — Identify failing jobs and steps
+From `jobs[]` where `conclusion ∈ {failure, cancelled}`, find the failing step (`steps[].conclusion`). If `job_id` given, restrict to it.
 
-From the `jobs` array, list every job where `conclusion` is `failure` or `cancelled`. For each,
-find the failing **step** by name from `steps[].conclusion`.
+**Matrix / cascade**: find the upstream root cause first (usually `Java Checks`, `build-*`, `Unit - Back End`). Group identical step failures. Tell user the shortlist before pulling logs.
 
-If a `job_id` was given, restrict to that one job.
-
-For runs with many failing jobs (e.g. matrix builds), **find the upstream root cause first**.
-Most cascade failures share a single foundational job — usually `Java Checks`, a `build-*`
-composite action, or a `Unit - Back End` job. Diagnose that one first; the rest collapse to "we
-couldn't build / test because the foundation broke." Group identical step failures rather than
-treating each matrix shard as distinct.
-
-Tell the user the shortlist before pulling logs (titles + which step failed + the candidate
-upstream job).
-
-### Step 4 — Fetch annotations (mandatory)
-
-GHA annotations are where the most useful failure signal lives — timeout messages, the test that
-hung, the specific assertion. **Always pull annotations before pulling logs**:
+### 4. Fetch annotations (mandatory, before logs)
 
 ```bash
 gh api --paginate "/repos/camunda/camunda/check-runs/<job-id>/annotations?per_page=100" \
   --jq '.[] | {level: .annotation_level, message: .message, path: .path}'
 ```
 
-Look for `level: failure` entries. Common shapes:
+Watch `level: failure`:
 
-- `"The job has exceeded the maximum execution time of 30m0s"` → GHA per-job timeout. The job
-  was killed by GitHub. **This is a real failure, not transient** (see Step 5).
-- `"<TestClass.method> -- Time elapsed: 121.7 s <<< ERROR!"` → the specific test that errored or
-  hung (often appears alongside a timeout annotation, naming the cause).
-- `"The operation was canceled."` → noise from cascade; ignore on its own.
+- `"exceeded the maximum execution time of 30m0s"` → GHA per-job timeout. **Real failure, not transient.**
+- `"<TestClass.method> -- Time elapsed: …s <<< ERROR!"` → the specific test that hung/errored.
+- `"The operation was canceled."` → cascade noise; ignore alone.
 
-If annotations name a specific test or file, you often have enough to diagnose without pulling
-full logs.
+If annotations name a test/file, often enough to skip Step 5.
 
-### Step 5 — Pull logs for the failing step
+### 5. Pull logs for failing step
 
 ```bash
 gh run view <run-id> --repo camunda/camunda --log-failed --job <job-id>
 ```
 
-`--log-failed` only returns failing step output, which is what you want. For each failing job,
-extract:
+Extract: the error line, ±few lines of context, the step + action that ran it.
 
-- The actual error line(s) — exception, assertion message, exit code, missing file
-- A few lines of surrounding context
-- The step name and the action/script that ran it
+`headSha == HEAD` (`git rev-parse HEAD`) → `Read` source files locally; skip `gh api`.
 
-If the log is unhelpful (e.g. cancelled job, process killed with no stack), the annotations
-from Step 4 are your primary signal. For deeper context, grab the full step log via `--log`
-(without `--failed`) and look earlier.
+### 6. Classify
 
-When the run's `headSha` matches your local working tree's `HEAD` (check with
-`git rev-parse HEAD`), just `Read` source files directly — much faster than `gh api`.
+Pick **one** primary category per failing job.
 
-### Step 6 — Classify the failure
+- **A. Code/test** — diff broke something, or test errored/hung. Signals: compile errors, assertion failures, spotless/license, lint, **timeout naming a specific slow test**. → `references/code-test-failures.md`
+- **B. Flaky test** — nondeterministic test failed. Signals: passes on rerun, timing/race, network/container in stack. Repo has a [flaky-test gate](../../../docs/monorepo-docs/flaky-test-gate.md). → `references/flaky-tests.md`
+- **C. Workflow/CI config** — workflow itself is wrong. Signals: actionlint, missing secret, bad `permissions:`, invalid expression, conftest violation. → `references/workflow-config.md`. Also invoke `ci-validation` once fix is drafted.
+- **D. CI Infrastructure / transient** — runner, network, image, or GitHub misbehaved. Signals: `Error waiting for runner`, image pull failure, registry 5xx, OOMKilled with no test signal. → `references/infra-transient.md`
 
-Pick **one** primary category. If multiple jobs fail with different root causes, classify each in parallel subagents.
+**`cancelled` is NOT automatically D.** In this repo it's usually a per-job timeout triggered by a slow/hung test (Category A). For `push` / `merge_group`, every non-success is a real failure — no "transient" merge-queue or base-branch failures exist.
 
-**A. Code / test failure** — the change under test is broken, or a test errored/hung.
-Signals: Java compile errors, JUnit/AssertJ assertion failures, spotless/license violations,
-TypeScript/ESLint errors, Vitest/Playwright failures, **a GHA per-job timeout that names a
-specific slow/hung test in annotations**.
-Next: see `references/code-test-failures.md`.
+Decide by Step 4 annotations:
 
-**B. Flaky test** — a nondeterministic test failed.
-Signals: failure unrelated to the diff, passes on rerun, timing/awaitility/race-y assertion,
-network or container startup in the stack. The repo has a flaky-test gate
-([docs/monorepo-docs/flaky-test-gate.md](../../../docs/monorepo-docs/flaky-test-gate.md)).
-Next: see `references/flaky-tests.md`.
+- timeout + names a test/step → A
+- timeout + step is non-deterministic by history → B
+- runner/image/infra signal, no test in picture → D
+- nothing useful → default A/B over D on `push`/`merge_group`. Prefer A over B without evidence.
 
-**C. Workflow / CI config error** — the workflow itself is wrong.
-Signals: actionlint-style errors, missing secret, bad `permissions:`, invalid expression, action
-not found, conftest/policy violation, runner label typo.
-Next: see `references/workflow-config.md`. Also invoke the `ci-validation` skill once a fix is
-drafted.
+### 7. Find root cause
 
-**D. CI Infrastructure / transient** — runner, network, image, or GitHub itself misbehaved.
-Signals: `Error waiting for runner`, image pull failure, 5xx from a registry, OOMKilled with no
-test signal, GitHub status-page incident.
-Next: see `references/infra-transient.md`.
+Per category:
 
-**Important — handling `cancelled` jobs:**
+- **A**: read failing file at `headSha`. If in diff, read the diff; else `git log -p -- <path>`. Compile/format → message names the line.
+- **B**: search existing flake issue (`gh issue list --repo camunda/camunda --label kind/flake --search "<test>"`); check the flaky-test gate.
+- **C**: read workflow under `.github/workflows/`. Cross-check `ci-workflow-authoring`.
+- **D**: nothing to fix in code; confirm transient.
 
-A `cancelled` conclusion is **not** automatically Category D. In this repo, cancellation is
-usually a GHA per-job timeout, and the timeout was triggered by a slow or hung test or step.
-That's a real failure (Category A) and rerunning won't fix it.
+Drill until you can name the **smallest change** that makes the job pass (file, function, line, or workflow key).
 
-In particular, **for `push` and `merge_group` runs every non-success is a real failure** — there is no such
-thing as a "transient" merge-queue or base branch failure here. Every dequeue costs the engineer a re-queue and
-blocks downstream merges.
+### 8. Gate: read `ci.md` before any workflow/cache/retry/sizing change
 
-When a job is `cancelled`, the Step 4 annotations decide the category:
+This is a **gate**, not a suggestion (see Hard Rule 2). Before proposing any change to `.github/workflows/`, `.github/actions/`, caching, retries, runner sizing, or timeouts:
 
-- Annotation names a timeout AND names a specific test/step → **Category A** (the test/step is
-  the root cause).
-- Annotation names a timeout but the offending step is non-deterministic per its history →
-  **Category B**.
-- Annotation names a runner shutdown, image pull failure, or similar infra signal with no
-  test/step in the picture → **Category D**.
-- No useful annotations at all → fall back to logs and treat with skepticism; default toward
-  A/B over D for `push` and `merge_group` runs.
+1. Open [docs/monorepo-docs/ci.md](../../../docs/monorepo-docs/ci.md) and read the relevant section (Caching strategy §"GitHub Actions Cache"; flake/timeout handling §flaky tests; allowed third-party actions; runner labels).
+2. In the brief's **Proposed fix**, quote the specific `ci.md` rule that authorizes the change ("per `ci.md` §… `setup-yarn-cache` is the prescribed action for NPM caches").
+3. If `ci.md` is silent on the case, fall back to the `ci-workflow-authoring` skill conventions and say so. If `ci.md` contradicts your proposal, drop it.
 
-If you are uncertain between A and B, prefer A — never call something "flaky" without evidence.
+Common contradictions to watch for:
+- "increase timeout" — forbidden (Hard Rule 1).
+- "add `cache-from: type=gha` for Docker" — `ci.md` §caching forbids this.
+- Hand-rolled cache steps when a composite action (`setup-maven-cache`, `setup-yarn-cache`) already exists.
 
-### Step 7 — Find the root cause
+### 9. Apply branch sensitivity (Cat D only)
 
-Following the right reference file, dig in:
+| `event` / `headBranch`            | Bar          | Cat D disposition                                                            |
+|-----------------------------------|--------------|------------------------------------------------------------------------------|
+| `push` to `main`/`stable/*`       | **Strict**   | Hardening primary (retry, caching, mirror, sizing); rerun = unblock, not fix |
+| `merge_group`                     | **Strict**   | Same                                                                         |
+| `pull_request`                    | Looser       | Rerun fine for one-off; harden only if recurring                             |
+| `schedule` / `workflow_dispatch`  | Per-workflow | Harden if `# owner:` is set; otherwise rerun                                 |
 
-- For **A**: read the failing source/test file at `headSha`. If it's a test in the diff, read the
-  diff. If it's an unchanged test, blame the most recent change to it (`git log -p -- <path>`).
-  For compile/format errors, the error message names the line.
-- For **B**: search for an existing flake issue
-  (`gh issue list --repo camunda/camunda --label kind/flake --search "<test name>"`). Check the
-  flaky-test gate doc.
-- For **C**: read the workflow file under `.github/workflows/`. Cross-check with the
-  `ci-workflow-authoring` skill conventions.
-- For **D**: nothing to fix in code — confirm transient, recommend rerun.
+A/B/C: branch only changes the brief framing.
 
-Keep digging until you can name the **smallest change** that would make the job pass — a specific
-file, function, line, or workflow key.
+On strict-bar branches, **never close with "rerun" alone** — name the smallest hardening change in `.github/workflows/` or `.github/actions/` as primary fix.
 
-### Step 8 — Consult `ci.md` before proposing any improvement
-
-Before proposing **any** workflow change, caching change, retry, or sizing change — even a
-one-liner — read the relevant section of
-[docs/monorepo-docs/ci.md](../../../docs/monorepo-docs/ci.md). It is the source of truth for
-CI best-practices in this repo, including:
-
-- **GHA caching strategy** (§ "GitHub Actions Cache"): which dependency types cache (Maven, NPM,
-  Go, Docker), which branches may write to the cache, prescribed actions to use.
-- **Flake handling** (§ flaky tests): how retries-within-timeout and the CI health metrics flow
-  works.
-- **Allowed third-party actions** and pinning rules.
-
-If `ci.md` is silent on the specific case, fall back to `ci-workflow-authoring` for general
-conventions. Never invent a hardening pattern that contradicts `ci.md`.
-
-### Step 9 — Apply branch-sensitivity to the fix
-
-The same root cause has a different "right fix" depending on which branch the run is on. Use this
-table to shape the proposed fix:
-
-| `event` / `headBranch`             | Reliability bar | Right disposition for **transients** (Cat D) |
-|-----------------------------------|-----------------|----------------------------------------------|
-| `push` to `main` or `stable/*`    | **Strict — must always succeed** | Hardening is the primary fix (automated step retry, caching, mirror, sizing). Rerun is an immediate unblock only, not the fix. |
-| `merge_group`                     | **Strict** — every non-success blocks the queue and costs a re-queue | Same as above: hardening primary, rerun secondary. |
-| `pull_request` (feature branch)   | Looser — author can re-trigger | Rerun is acceptable for a one-off transient. Only propose hardening if the signal recurs. |
-| `schedule` / `workflow_dispatch`  | Workflow-specific — read the workflow's owner annotation | Default to hardening if the workflow is owned (`# owner:` in the YAML); otherwise rerun. |
-
-For Category A/B/C (real test, flake, workflow-config), branch doesn't change the diagnosis —
-only the framing of the brief. For Category D, branch flips the disposition.
-
-When the branch is `main`, `stable/*`, or the event is `push`, `schedule` or `merge_group`, never close out the brief
-with just "rerun." Propose the smallest concrete hardening change in `.github/workflows/` (or the
-relevant composite action under `.github/actions/`) as the **primary** fix.
-
-### Step 10 — Brief the user
-
-Reply in this exact shape:
+### 10. Brief
 
 ```
-**Run**: <workflow name> · <branch> · <event> · <run url>
-**Failed jobs**: <count> (<grouped summary if matrix>)
+**Run**: <workflow> · <branch> · <event> · <url>
+**Failed jobs**: <n> (<grouped if matrix>)
 **Category**: A | B | C | D
-**Reliability bar**: strict (main / stable/* / merge_group) | looser (pull_request)
+**Reliability bar**: strict (main/stable/*/merge_group) | looser (pull_request)
 
 **Root cause**
-<1–3 sentences naming the specific file/line/condition>
+<1–3 sentences, specific file/line/condition>
 
 **Proposed fix**
-<concrete edit, command, or action — file path + what to change>
-<for Category D on strict-bar branches: name the hardening (retry action, cache, mirror) as the
- primary fix; rerun is only the immediate unblock>
+<concrete edit + path; for D on strict bar, the hardening is the fix, rerun is the unblock>
 
 **Verification**
-<the exact local command to confirm the fix — usually a module-scoped `./mvnw` or a workflow
-re-run command>
+<exact local command — usually module-scoped `./mvnw`, or a workflow re-run>
 ```
 
-Do not cite the skill's own reference files in the brief (e.g. "per `infra-transient.md`…") —
-just give the answer. The reference files are working notes for you, not the user.
-
-Then **stop**. Do not edit files until the user confirms. If the user confirms, apply the fix,
-re-run the verification command, and report results.
+Don't cite reference files in the brief. **Stop.** Apply only after user confirms; re-run verification; report.
 
 ## Guardrails
 
-- **Diagnose-then-stop.** Apply fixes only after the user's explicit go-ahead.
-- **No silent reruns.** If you think it's a flake, say so and recommend `gh run rerun --failed
-  <run-id> --repo camunda/camunda` — don't trigger it yourself.
-- **Don't blame the diff blindly.** Verify the failing assertion/code is reachable from the
-  changeset before claiming "your PR broke this".
-- **Honor repo conventions.** Format/build via `./mvnw license:format spotless:apply -T1C` then
-  the module-scoped command from `AGENTS.md` — never recommend full-repo builds.
-- **Backports.** For bug fixes that need to land on `stable/*`, ask the user about backports per
-  `AGENTS.md` PR conventions — don't auto-tag.
-- **Flake handling.** Never disable, skip, or `@Disabled` a test. The repo policy is: file an
-  issue with `kind/flake` (via the `create-issue` skill), assign to the engineer, leave the test
-  enabled. If a flake gate auto-disabled it, that's the gate's job — not yours.
+- **Stop after brief.** No edits without user go-ahead.
+- **No silent reruns.** Recommend `gh run rerun --failed <run-id> --repo camunda/camunda`; don't trigger.
+- **Don't blame the diff blindly** — verify the failing code is reachable from the changeset.
+- **Format/build via repo conventions** (`./mvnw license:format spotless:apply -T1C` + module-scoped command from `AGENTS.md`). Never full-repo builds.
+- **Backports** — for bug fixes that may need `stable/*`, ask the user per `AGENTS.md`.
+- **Never disable/skip/@Disabled a flaky test.** File `kind/flake` issue via `create-issue`, assign engineer, leave test enabled.
 
-## Compose with other skills
+## Compose with
 
-- `ci-validation` — run after any workflow file edit before committing.
-- `ci-workflow-authoring` — consult when proposing non-trivial workflow changes.
-- `create-issue` — use to file a flaky-test issue.
-- `ci-incident` — escalate to this if the failure is part of a declared incident, not a single job.
+- `ci-validation` — after any workflow edit, pre-commit.
+- `ci-workflow-authoring` — for non-trivial workflow changes.
+- `create-issue` — to file a flake issue.
+- `ci-incident` — escalate if part of a declared incident, not a single job.

--- a/.claude/skills/ci-fix-failure/SKILL.md
+++ b/.claude/skills/ci-fix-failure/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: ci-fix-failure
+description: Diagnose a failing GitHub Actions run in camunda/camunda from a run or job URL - fetch jobs and logs via gh CLI, classify the failure (code/test, flake, workflow config, infra), find the root cause, and propose a concrete fix. Use whenever the user shares a GitHub Actions run URL, job URL, or asks you to look at "why CI failed", "why this job failed", "what broke in this run", or to fix a red check on a PR. Diagnose-and-propose only - get user confirmation before applying or pushing fixes.
+---
+
+# CI Job Failure Diagnosis
+
+Given a GitHub Actions run or job URL, walk an unsuccessful (failed, cancelled) run down to the root cause and propose a fix.
+Scope is **diagnose + propose** — never apply, commit, or push automatically.
+
+## When to use
+
+The user shares any of:
+
+- A run URL: `https://github.com/camunda/camunda/actions/runs/<run-id>`
+- A job URL: `https://github.com/camunda/camunda/actions/runs/<run-id>/job/<job-id>`
+- A check URL on a PR: `https://github.com/camunda/camunda/pull/<n>/checks?check_run_id=<id>`
+
+…and asks why it failed, or to fix it.
+
+If no URL is given, ask for one — do not guess from recent history.
+
+## Prerequisites
+
+- `gh` CLI authenticated against `camunda/camunda`. Verify with `gh auth status`.
+- Working directory should be the repo root so any proposed fix lands in the right tree.
+
+## Procedure
+
+### Step 1 — Parse the URL
+
+Extract `run_id` (required) and `job_id` (optional). For check URLs, the `check_run_id` query
+param **is** the job id.
+
+If the URL is for a different repo than `camunda/camunda`, inform the user that for some fixes
+this skill assumes the monorepo's conventions.
+
+### Step 2 — Pull run and job metadata
+
+```bash
+gh run view <run-id> --repo camunda/camunda --json \
+  status,conclusion,name,headBranch,headSha,event,workflowName,workflowDatabaseId,url,jobs,displayTitle,createdAt
+```
+
+Note: `name` and `workflowName`, `headBranch`, `event` (push/pull_request/schedule/workflow_dispatch),
+`headSha`, and the list of jobs with their conclusions.
+
+If the run is still `in_progress`, tell the user and stop — wait for it to finish.
+
+If the run is `success`, tell the user the run passed and ask what they want to look at instead.
+
+### Step 3 — Identify failing jobs and steps
+
+From the `jobs` array, list every job where `conclusion` is `failure` or `cancelled`. For each,
+find the failing **step** by name from `steps[].conclusion`.
+
+If a `job_id` was given, restrict to that one job.
+
+For runs with many failing jobs (e.g. matrix builds), **find the upstream root cause first**.
+Most cascade failures share a single foundational job — usually `Java Checks`, a `build-*`
+composite action, or a `Unit - Back End` job. Diagnose that one first; the rest collapse to "we
+couldn't build / test because the foundation broke." Group identical step failures rather than
+treating each matrix shard as distinct.
+
+Tell the user the shortlist before pulling logs (titles + which step failed + the candidate
+upstream job).
+
+### Step 4 — Fetch annotations (mandatory)
+
+GHA annotations are where the most useful failure signal lives — timeout messages, the test that
+hung, the specific assertion. **Always pull annotations before pulling logs**:
+
+```bash
+gh api --paginate "/repos/camunda/camunda/check-runs/<job-id>/annotations?per_page=100" \
+  --jq '.[] | {level: .annotation_level, message: .message, path: .path}'
+```
+
+Look for `level: failure` entries. Common shapes:
+
+- `"The job has exceeded the maximum execution time of 30m0s"` → GHA per-job timeout. The job
+  was killed by GitHub. **This is a real failure, not transient** (see Step 5).
+- `"<TestClass.method> -- Time elapsed: 121.7 s <<< ERROR!"` → the specific test that errored or
+  hung (often appears alongside a timeout annotation, naming the cause).
+- `"The operation was canceled."` → noise from cascade; ignore on its own.
+
+If annotations name a specific test or file, you often have enough to diagnose without pulling
+full logs.
+
+### Step 5 — Pull logs for the failing step
+
+```bash
+gh run view <run-id> --repo camunda/camunda --log-failed --job <job-id>
+```
+
+`--log-failed` only returns failing step output, which is what you want. For each failing job,
+extract:
+
+- The actual error line(s) — exception, assertion message, exit code, missing file
+- A few lines of surrounding context
+- The step name and the action/script that ran it
+
+If the log is unhelpful (e.g. cancelled job, process killed with no stack), the annotations
+from Step 4 are your primary signal. For deeper context, grab the full step log via `--log`
+(without `--failed`) and look earlier.
+
+When the run's `headSha` matches your local working tree's `HEAD` (check with
+`git rev-parse HEAD`), just `Read` source files directly — much faster than `gh api`.
+
+### Step 6 — Classify the failure
+
+Pick **one** primary category. If multiple jobs fail with different root causes, classify each in parallel subagents.
+
+**A. Code / test failure** — the change under test is broken, or a test errored/hung.
+Signals: Java compile errors, JUnit/AssertJ assertion failures, spotless/license violations,
+TypeScript/ESLint errors, Vitest/Playwright failures, **a GHA per-job timeout that names a
+specific slow/hung test in annotations**.
+Next: see `references/code-test-failures.md`.
+
+**B. Flaky test** — a nondeterministic test failed.
+Signals: failure unrelated to the diff, passes on rerun, timing/awaitility/race-y assertion,
+network or container startup in the stack. The repo has a flaky-test gate
+([docs/monorepo-docs/flaky-test-gate.md](../../../docs/monorepo-docs/flaky-test-gate.md)).
+Next: see `references/flaky-tests.md`.
+
+**C. Workflow / CI config error** — the workflow itself is wrong.
+Signals: actionlint-style errors, missing secret, bad `permissions:`, invalid expression, action
+not found, conftest/policy violation, runner label typo.
+Next: see `references/workflow-config.md`. Also invoke the `ci-validation` skill once a fix is
+drafted.
+
+**D. CI Infrastructure / transient** — runner, network, image, or GitHub itself misbehaved.
+Signals: `Error waiting for runner`, image pull failure, 5xx from a registry, OOMKilled with no
+test signal, GitHub status-page incident.
+Next: see `references/infra-transient.md`.
+
+**Important — handling `cancelled` jobs:**
+
+A `cancelled` conclusion is **not** automatically Category D. In this repo, cancellation is
+usually a GHA per-job timeout, and the timeout was triggered by a slow or hung test or step.
+That's a real failure (Category A) and rerunning won't fix it.
+
+In particular, **for `push` and `merge_group` runs every non-success is a real failure** — there is no such
+thing as a "transient" merge-queue or base branch failure here. Every dequeue costs the engineer a re-queue and
+blocks downstream merges.
+
+When a job is `cancelled`, the Step 4 annotations decide the category:
+
+- Annotation names a timeout AND names a specific test/step → **Category A** (the test/step is
+  the root cause).
+- Annotation names a timeout but the offending step is non-deterministic per its history →
+  **Category B**.
+- Annotation names a runner shutdown, image pull failure, or similar infra signal with no
+  test/step in the picture → **Category D**.
+- No useful annotations at all → fall back to logs and treat with skepticism; default toward
+  A/B over D for `push` and `merge_group` runs.
+
+If you are uncertain between A and B, prefer A — never call something "flaky" without evidence.
+
+### Step 7 — Find the root cause
+
+Following the right reference file, dig in:
+
+- For **A**: read the failing source/test file at `headSha`. If it's a test in the diff, read the
+  diff. If it's an unchanged test, blame the most recent change to it (`git log -p -- <path>`).
+  For compile/format errors, the error message names the line.
+- For **B**: search for an existing flake issue
+  (`gh issue list --repo camunda/camunda --label kind/flake --search "<test name>"`). Check the
+  flaky-test gate doc.
+- For **C**: read the workflow file under `.github/workflows/`. Cross-check with the
+  `ci-workflow-authoring` skill conventions.
+- For **D**: nothing to fix in code — confirm transient, recommend rerun.
+
+Keep digging until you can name the **smallest change** that would make the job pass — a specific
+file, function, line, or workflow key.
+
+### Step 8 — Consult `ci.md` before proposing any improvement
+
+Before proposing **any** workflow change, caching change, retry, or sizing change — even a
+one-liner — read the relevant section of
+[docs/monorepo-docs/ci.md](../../../docs/monorepo-docs/ci.md). It is the source of truth for
+CI best-practices in this repo, including:
+
+- **GHA caching strategy** (§ "GitHub Actions Cache"): which dependency types cache (Maven, NPM,
+  Go, Docker), which branches may write to the cache, prescribed actions to use.
+- **Flake handling** (§ flaky tests): how retries-within-timeout and the CI health metrics flow
+  works.
+- **Allowed third-party actions** and pinning rules.
+
+If `ci.md` is silent on the specific case, fall back to `ci-workflow-authoring` for general
+conventions. Never invent a hardening pattern that contradicts `ci.md`.
+
+### Step 9 — Apply branch-sensitivity to the fix
+
+The same root cause has a different "right fix" depending on which branch the run is on. Use this
+table to shape the proposed fix:
+
+| `event` / `headBranch`             | Reliability bar | Right disposition for **transients** (Cat D) |
+|-----------------------------------|-----------------|----------------------------------------------|
+| `push` to `main` or `stable/*`    | **Strict — must always succeed** | Hardening is the primary fix (automated step retry, caching, mirror, sizing). Rerun is an immediate unblock only, not the fix. |
+| `merge_group`                     | **Strict** — every non-success blocks the queue and costs a re-queue | Same as above: hardening primary, rerun secondary. |
+| `pull_request` (feature branch)   | Looser — author can re-trigger | Rerun is acceptable for a one-off transient. Only propose hardening if the signal recurs. |
+| `schedule` / `workflow_dispatch`  | Workflow-specific — read the workflow's owner annotation | Default to hardening if the workflow is owned (`# owner:` in the YAML); otherwise rerun. |
+
+For Category A/B/C (real test, flake, workflow-config), branch doesn't change the diagnosis —
+only the framing of the brief. For Category D, branch flips the disposition.
+
+When the branch is `main`, `stable/*`, or the event is `push`, `schedule` or `merge_group`, never close out the brief
+with just "rerun." Propose the smallest concrete hardening change in `.github/workflows/` (or the
+relevant composite action under `.github/actions/`) as the **primary** fix.
+
+### Step 10 — Brief the user
+
+Reply in this exact shape:
+
+```
+**Run**: <workflow name> · <branch> · <event> · <run url>
+**Failed jobs**: <count> (<grouped summary if matrix>)
+**Category**: A | B | C | D
+**Reliability bar**: strict (main / stable/* / merge_group) | looser (pull_request)
+
+**Root cause**
+<1–3 sentences naming the specific file/line/condition>
+
+**Proposed fix**
+<concrete edit, command, or action — file path + what to change>
+<for Category D on strict-bar branches: name the hardening (retry action, cache, mirror) as the
+ primary fix; rerun is only the immediate unblock>
+
+**Verification**
+<the exact local command to confirm the fix — usually a module-scoped `./mvnw` or a workflow
+re-run command>
+```
+
+Do not cite the skill's own reference files in the brief (e.g. "per `infra-transient.md`…") —
+just give the answer. The reference files are working notes for you, not the user.
+
+Then **stop**. Do not edit files until the user confirms. If the user confirms, apply the fix,
+re-run the verification command, and report results.
+
+## Guardrails
+
+- **Diagnose-then-stop.** Apply fixes only after the user's explicit go-ahead.
+- **No silent reruns.** If you think it's a flake, say so and recommend `gh run rerun --failed
+  <run-id> --repo camunda/camunda` — don't trigger it yourself.
+- **Don't blame the diff blindly.** Verify the failing assertion/code is reachable from the
+  changeset before claiming "your PR broke this".
+- **Honor repo conventions.** Format/build via `./mvnw license:format spotless:apply -T1C` then
+  the module-scoped command from `AGENTS.md` — never recommend full-repo builds.
+- **Backports.** For bug fixes that need to land on `stable/*`, ask the user about backports per
+  `AGENTS.md` PR conventions — don't auto-tag.
+- **Flake handling.** Never disable, skip, or `@Disabled` a test. The repo policy is: file an
+  issue with `kind/flake` (via the `create-issue` skill), assign to the engineer, leave the test
+  enabled. If a flake gate auto-disabled it, that's the gate's job — not yours.
+
+## Compose with other skills
+
+- `ci-validation` — run after any workflow file edit before committing.
+- `ci-workflow-authoring` — consult when proposing non-trivial workflow changes.
+- `create-issue` — use to file a flaky-test issue.
+- `ci-incident` — escalate to this if the failure is part of a declared incident, not a single job.

--- a/.claude/skills/ci-fix-failure/references/code-test-failures.md
+++ b/.claude/skills/ci-fix-failure/references/code-test-failures.md
@@ -1,0 +1,95 @@
+# Category A — Code / Test Failures
+
+The change under test is genuinely broken. Goal: name the smallest edit that turns the job green and is in line with best practices from [docs/monorepo-docs/ci.md](../../../../docs/monorepo-docs/ci.md).
+
+## Sub-types and how to dig in
+
+### Java compile error
+
+The log names the file and line. Read that file at `headSha` (`gh api repos/camunda/camunda/contents/<path>?ref=<sha>` or just `git show <sha>:<path>` if checked out). Common shapes:
+
+- Missing import after a refactor in a dependency module — check sibling modules for the new symbol location.
+- Method signature changed in an upstream module — find callers with `grep -r <method>` and update them.
+- Generic/nullness issue — check whether the file uses `@NullMarked` (the repo is mid-migration to jspecify).
+
+### Spotless / license / format failure
+
+Log will include "spotless" or "license-maven-plugin". The fix is always:
+
+```bash
+./mvnw license:format spotless:apply -T1C
+```
+
+Recommend exactly this — do not propose hand-edits.
+
+### JUnit / AssertJ test failure
+
+From the log, get the test class FQN, method, and the assertion message. Then:
+
+1. Read the failing test file at `headSha`.
+2. Read the production class under test.
+3. Determine whether the test is asserting the right thing for the new behavior, or whether the production change broke an invariant.
+
+If the diff changed production code: the test is usually correct and the production code needs fixing. If the diff changed only the test: the test is wrong. If the diff is unrelated, treat as a candidate flake (Category B) — but first verify it really is unrelated, not a hidden coupling.
+
+To re-run that single test locally:
+
+```bash
+./mvnw verify -pl <module> -Dtest=<TestClassName>#<methodName> -DskipTests=false -DskipITs -Dquickly
+```
+
+For integration tests:
+
+```bash
+./mvnw verify -pl <module> -Dit.test=<ITClassName> -DskipTests=false -DskipUTs -Dquickly
+```
+
+Use the module from the test's path (e.g. `zeebe/engine`, not `zeebe`).
+
+### Frontend test failure (Vitest / Playwright)
+
+Tests live under `webapp/client/`, `operate/client/`, `tasklist/client/`. The log will reference a `.test.ts(x)` or `.spec.ts` file. Read the test and the source it imports.
+
+- Vitest unit test: invoke the `frontend-unit-test` skill for conventions.
+- Playwright: invoke the `frontend-integration-test` skill.
+- Migrated to OC webapp: see `frontend-migrator`.
+
+### GHA per-job timeout (cancelled job)
+
+Job conclusion is `cancelled`, annotations contain `The job has exceeded the maximum execution
+time of <N>m<S>s` plus a `<TestClass.method> -- Time elapsed: <N> s <<< ERROR!` entry naming the
+offending test. The test hung or ran too slowly to complete within the workflow's
+`timeout-minutes`.
+
+Treat this as a code/test failure. The fix is one of:
+
+- A genuine bug in the test or the production code under test (deadlock, infinite loop,
+  missing termination condition) → diagnose like any other test failure.
+- Test is doing too much work (oversized fixture, exhaustive sweep where a property test would
+  do) → reshape the test.
+- The whole test job is now over budget — split it.
+
+Re-run that test locally first to confirm it reproduces:
+
+```bash
+./mvnw verify -pl <module> -Dtest=<TestClassName>#<methodName> -DskipTests=false -DskipITs -Dquickly
+```
+
+If it does not reproduce locally and the test has prior timeout history, it may be flaky —
+consult Category B before proposing a fix.
+
+### Maven build / dependency error
+
+"Could not resolve dependencies", "module not found", or a snapshot version mismatch. Often a sibling module wasn't installed locally. Recommend:
+
+```bash
+./mvnw install -pl <module> -am -Dquickly -T1C
+```
+
+…to rebuild dependencies, then re-run the failing step.
+
+## Propose the fix
+
+Be specific: name the file, the line range, and the exact change. Show a short snippet of the
+edit if helpful. Then offer the verification command from the section above. Wait for the user's
+go-ahead before editing.

--- a/.claude/skills/ci-fix-failure/references/flaky-tests.md
+++ b/.claude/skills/ci-fix-failure/references/flaky-tests.md
@@ -1,0 +1,51 @@
+# Category B — Flaky Tests
+
+A flake is a test that fails non-deterministically. Don't reach for this label without evidence —
+"unrelated to my diff" is necessary but not sufficient. Repo policy is to **keep the test enabled**
+and file a tracking issue.
+
+## Confirming flake (do this before claiming it)
+
+1. The failing assertion is unrelated to the diff (no file overlap, no transitive call path).
+2. At least one of:
+   - The same test has a recent passing run on the same `headSha` (`gh run list --workflow <name> --commit <sha>`).
+   - The test or a sibling test has prior failures with a different cause (`gh issue list --label kind/flake --search "<test name>"`).
+   - The stack trace shows known flake shapes: timeout, awaitility wait expired, "expected port to be free", container/network race, eventual-consistency assertion without retry.
+3. A rerun of just the failed jobs passes:
+   ```bash
+   gh run rerun --failed <run-id> --repo camunda/camunda
+   ```
+   Recommend this to the user — don't trigger it yourself.
+
+## Repo policy
+
+From `AGENTS.md`:
+
+> If it is flaky (non-deterministic):
+> 1. Search for an existing open issue in camunda/camunda. If none exists, raise one using
+>    the `create-issue` skill (use the bug template; also add the `kind/flake` label).
+> 2. Assign the issue to the engineer.
+> 3. Treat the baseline as passed and proceed — do not disable the test.
+
+There is also an automated **flaky-test gate** documented at
+[docs/monorepo-docs/flaky-test-gate.md](../../../../docs/monorepo-docs/flaky-test-gate.md). Read
+it before proposing manual mitigation — the gate may already be doing the work.
+
+The broader repo policy on flakes is in the "flaky tests" section of
+[docs/monorepo-docs/ci.md](../../../../docs/monorepo-docs/ci.md): tests should retry 3–5 times
+within the configured timeout and report via the detailed test statistics API into CI health
+metrics. Any in-test retry change must follow this pattern, not invent its own.
+
+## What to propose to the user
+
+```
+Likely flake: <Test FQN> — <one-line reason>.
+Existing issue: <link or "none found">.
+Recommended next steps:
+  1. Rerun the failed jobs: gh run rerun --failed <run-id> --repo camunda/camunda
+  2. If no tracking issue exists, file one with the `create-issue` skill (label kind/flake).
+  3. Do NOT disable, @Disabled, or skip the test.
+```
+
+If the test is genuinely racy and there's a clean fix (e.g. replace `Thread.sleep` with
+Awaitility, or add a retry on an eventually-consistent assertion), offer that as follow-up — but separate from the rerun.

--- a/.claude/skills/ci-fix-failure/references/infra-transient.md
+++ b/.claude/skills/ci-fix-failure/references/infra-transient.md
@@ -1,0 +1,95 @@
+# Category D — Infra / Transient Failures
+
+Genuine infra/transient failures are rare in this repo and the bar for classifying as D is
+**high**. Nothing in the diff or workflow is wrong, and the annotations (Step 4 of SKILL.md) name
+an infra signal — not a test, step, or timeout caused by code.
+
+## Branch sensitivity decides the fix
+
+Classifying as D does **not** mean "recommend rerun and stop." The right disposition depends on
+the branch the run is on:
+
+### Strict-bar branches: `main`, `stable/*`, and any `schedule` and `merge_group` run
+
+These must always succeed. Transient failures on these branches are not acceptable — the response
+is **hardening the workflow** so the same class of failure can't break the branch again. Rerun is
+an immediate unblock only, not the fix.
+
+Propose the smallest concrete hardening change. **Always cross-check the proposal against**
+[docs/monorepo-docs/ci.md](../../../../docs/monorepo-docs/ci.md) — it defines the prescribed
+actions and the caching policy for this repo. Common shapes:
+
+- **Network-touching steps** (artifact upload to Nexus, package install, image pull, registry
+  fetch): wrap in `nick-fields/retry@<sha>` (allowlisted in `ci.md`). Set 2–3 attempts with
+  backoff. Pin to a SHA per `ci-security-compliance`. Many actions also expose a built-in `retry`
+  input — prefer that over wrapping when available.
+- **Slow `npm` / `yarn` install**: use the
+  [`setup-yarn-cache`](https://github.com/camunda/infra-global-github-actions/tree/main/setup-yarn-cache)
+  action. **Do not** use `actions/setup-node`'s `cache: 'npm'` field — that is not the repo's
+  prescribed pattern. Per `ci.md`, NPM/Yarn caches are written only on `main` / `stable*` builds.
+- **Slow Maven**: use the local
+  [`setup-maven-cache`](../../../../.github/actions/setup-maven-cache) action. Same write rules
+  apply.
+- **Docker builds**: do **not** add `cache-from: type=gha` / `cache-to: type=gha` to
+  `docker/build-push-action` — `ci.md` explicitly forbids it.
+- **External registry / dependency that has caused outages**: configure a mirror or fallback URL
+  if one exists, or pin to a known-good version. Coordinate with monorepo-devops if the change
+  touches `Artifactory` / `DockerHub` integration.
+- **Right-sizing / Splitting** (runner class): only justified when the timeout is the
+  actual constraint *and* the slowdown is intrinsic. Don't bump timeouts. Use
+  `ci-runner-utilization` for sizing decisions.
+
+Run the `ci-validation` skill after any workflow edit. Consult `ci-workflow-authoring` for
+conventions and `ci-security-compliance` for action pinning.
+
+### Looser-bar branches: `pull_request` (feature branches)
+
+The PR author can re-trigger and the cost of one flaky failure is bounded to their PR. Rerun is
+acceptable for a one-off transient:
+
+```
+gh run rerun --failed <run-id> --repo camunda/camunda
+```
+
+Only propose hardening if:
+
+- The signal has recurred across runs (check `gh run list --workflow <name> --branch <branch>`).
+- The same root cause is also hitting `main` / `stable/*` / `schedule` / `merge_group`.
+
+## Cancellations are NOT automatically transient
+
+`cancelled` is almost always a real failure here since we set high timeouts:
+
+- **GHA per-job timeout** → the job ran longer than its `timeout-minutes` and was killed.
+  Annotation: `The job has exceeded the maximum execution time of <N>m<S>s`. This is Category A
+  (a slow/hung test or step is the root cause), **not** D.
+- **Merge-queue dequeue or cancellation** → blocks merges and costs a re-queue. Still a real
+  failure on a strict-bar context.
+
+## Genuine Category D shapes
+
+Use this category only when the annotations / log lines clearly point at infra:
+
+- `Error waiting for runner to pick up the job` (and the runner pool is known to have capacity)
+- `failed to pull image ...: 5xx` from a registry
+- HTTP 5xx from Nexus / artifact registry / package mirror during upload or download
+- `connection reset` or DNS failure mid-build, with no test signal
+- `The runner has received a shutdown signal` from the host platform
+- A GitHub status-page incident that overlapped the run window (GitHub announces incidents late sometimes, recheck)
+
+`OOMKilled` deserves care: if it killed the JVM running tests, that's usually Category A (memory
+leak or oversized fixture in code under test). Only treat OOM as D if it killed an unrelated
+process (e.g. the runner agent itself).
+
+## Don't
+
+- Don't close out a `main` / `stable/*` / `schedule` / `merge_group` brief with just "rerun." Propose
+  hardening as the primary fix.
+- Don't claim "GitHub was down" without a corroborating reference — say "looks transient,
+  recommend hardening X" instead.
+- Don't escalate to an incident from a single job failure. The `ci-incident` skill is for
+  declared incidents.
+- Don't reflexively recommend `gh run rerun` for cancellations. Most cancellations are
+  timeouts — rerunning won't fix a slow test.
+- Don't bump `timeout-minutes` or runner class to mask a flake — that hides real cost
+  (`ci-runner-utilization` exists for sizing decisions).

--- a/.claude/skills/ci-fix-failure/references/infra-transient.md
+++ b/.claude/skills/ci-fix-failure/references/infra-transient.md
@@ -81,6 +81,23 @@ Use this category only when the annotations / log lines clearly point at infra:
 leak or oversized fixture in code under test). Only treat OOM as D if it killed an unrelated
 process (e.g. the runner agent itself).
 
+## "Install dependencies" / setup step timed out
+
+Common shape: a setup step (`npm ci`, `mvn dependency:resolve`, image pull) hit its `timeout-minutes` and the job was cancelled. **This is NOT Category D by default** and **never** an excuse to extend the timeout (Hard Rule 1 in `SKILL.md`).
+
+Diagnose in this order:
+
+1. **Cache hit or miss?** Search the log for `Cache restored`, `Cache hit`, `Cache miss`, `Found in cache`. Per `ci.md` §"GitHub Actions Cache", NPM/Maven/Go caches are written **only** from `main`/`stable*` builds; a PR run against a recent lockfile change will see a miss and that is expected.
+2. **Is the prescribed composite action in use?** NPM → `setup-yarn-cache`; Maven → `setup-maven-cache`. If the workflow rolls its own cache step, that's the fix — switch to the composite action. Quote the `ci.md` line in the brief.
+3. **Cache is on and warm but `npm ci` still slow?** Likely a registry slowness; check status pages. On `pull_request` rerun. On `push`/`merge_group` propose a recurring hardening only if the metric trend shows this isn't a one-off — see CI Health dashboard.
+4. **Lockfile churn?** Frequent lockfile updates invalidate the cache on every push. The fix is upstream (group Renovate updates), not in this workflow.
+
+What NOT to propose:
+
+- ❌ Bumping `timeout-minutes`.
+- ❌ `actions/cache` with hand-rolled keys when `setup-yarn-cache` / `setup-maven-cache` exists.
+- ❌ `cache-from: type=gha` for Docker images (forbidden by `ci.md` §caching).
+
 ## Don't
 
 - Don't close out a `main` / `stable/*` / `schedule` / `merge_group` brief with just "rerun." Propose

--- a/.claude/skills/ci-fix-failure/references/workflow-config.md
+++ b/.claude/skills/ci-fix-failure/references/workflow-config.md
@@ -1,0 +1,64 @@
+# Category C — Workflow / CI Config Errors
+
+The workflow YAML itself, an action it calls, or a policy check is the problem.
+
+## Common shapes
+
+### actionlint / yaml syntax
+
+Error names a workflow file and line. Read the file under `.github/workflows/`. Fix locally and
+run:
+
+```bash
+actionlint .github/workflows/<file>.yml
+```
+
+### conftest / policy violation
+
+The repo enforces policy via conftest:
+
+```bash
+conftest test --rego-version v0 -o github --policy .github .github/workflows/*.yml
+```
+
+Common violations: missing `permissions:`, unpinned action (must be a SHA), forbidden third-party
+action. See the `ci-security-compliance` skill for the policy rationale.
+
+### Missing or wrong secret
+
+Log: `Error: Input required and not supplied: <name>` or `Bad credentials`. The secret is
+referenced in the workflow but not set, or set at the wrong scope (env vs repo vs org). Do **not**
+propose putting the secret value in the diff — flag it for the engineer to add via repo settings.
+
+### Runner label typo / unavailable
+
+Log: `Waiting for a runner...` or `No runner matching the specified labels`. Cross-check the
+`runs-on:` against known labels (`gcp-*`, `aws-*`, `ubuntu-slim`, `ubuntu-latest`). Note that
+self-hosted runners cost money; GitHub-hosted are free in this public repo.
+
+### Action input contract changed
+
+Log: `Unexpected input(s) ...` or `Required input '<x>' not provided`. The pinned action SHA
+predates a breaking change, or vice versa. Read the action's release notes via `gh release view`
+on its repo and update the inputs or SHA accordingly. Consult `ci-workflow-authoring` for pinning
+conventions.
+
+### Composite action error
+
+If the failing step calls a local composite action (under `.github/actions/`), follow the same
+flow into that action's `action.yml`.
+
+### New third-party action blocked
+
+If the GitHub Actions run does not start because a newly introduced third-party action is not allowed,
+follow the instructions in `ci.md` for getting an approval.
+
+## Proposing a workflow fix
+
+1. Name the exact file and YAML key to change.
+2. Show the before/after snippet.
+3. Recommend running the `ci-validation` skill after the edit — it runs actionlint, conftest,
+   spotless, and act assessment in the required order.
+
+Do **not** edit workflow files without the user's go-ahead, and do not commit them without
+running `ci-validation` first.

--- a/.claude/skills/ci-incident/SKILL.md
+++ b/.claude/skills/ci-incident/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ci-incident
+description: Drive response for a CI incident in camunda/camunda by combining incident.io state, Slack channel history, and the repo CI runbooks and incident process docs. Use when asked to resolve a CI incident, respond to an incident, or drive an incident by ID. Full incidents only, not alerts.
+---
+
+# CI Incident Response
+
+Guides a responder through a CI incident in `camunda/camunda`. Pulls live state from incident.io,
+context from the incident's Slack channel, the matching runbook from
+[docs/monorepo-docs/ci-runbooks.md](../../../docs/monorepo-docs/ci-runbooks.md), and the process
+from [docs/monorepo-docs/processes.md](../../../docs/monorepo-docs/processes.md).
+
+## Prerequisites
+
+- **incident.io MCP** — required. Verify the `mcp__incident-io__incident_show` tool is available.
+  If not, tell the user to [configure the incident.io MCP server](https://docs.incident.io/ai/remote-mcp) and stop.
+- **Slack MCP** — preferred but optional. If `mcp__*__slack_read_channel` is not available, warn
+  the user that Slack context will be skipped and continue.
+
+Throughout this skill, MCP tools are referenced by their short verb (`incident_show`,
+`slack_read_channel`); the actual identifier depends on which MCP server is configured.
+
+## Scope
+
+Full incidents only. If the user passes an alert ID (or anything that isn't an incident),
+stop and ask for the incident ID.
+
+## Procedure
+
+### Step 1 — Parse the incident ID
+
+The incident ID comes from `$ARGUMENTS`. If empty, ask the user for it before proceeding. Do not
+guess from recent context.
+
+### Step 2 — Pull incident state
+
+Call `incident_show` with the ID and `include: ["investigation", "postmortem", "roles", "custom_fields"]`.
+
+Extract and remember:
+
+- Title, severity, status, opened-at
+- Role assignments (lead, comms, etc.)
+- Active alert name(s)
+- Incident's Slack channel reference (channel ID or name)
+- Any existing investigation / postmortem content
+
+### Step 3 — Pull Slack context
+
+If the Slack MCP is available, read recent messages from the incident's Slack channel
+(`slack_read_channel`, ~50 most recent). Summarize for yourself:
+
+- What has already been tried
+- Who is actively engaged
+- Timestamp of the last status update
+- Any blockers or open questions raised
+
+If the Slack MCP is not available, note this in the brief and continue.
+
+### Step 4 — Match a runbook
+
+Read [docs/monorepo-docs/ci-runbooks.md](../../../docs/monorepo-docs/ci-runbooks.md).
+
+Match the incident title and active alert name(s) against the `###` headings under both
+**Alert Runbooks** and **Incident Runbooks** sections. Fuzzy match is fine (e.g. alert
+"Merge Queue High Failure Rate" → runbook heading of the same name).
+
+- **One match**: load its Troubleshooting and Solutions subsections.
+- **Multiple matches**: list them and ask the user which applies.
+- **No match**: list the available runbook headings and ask which applies, or confirm this is a
+  novel incident with no runbook.
+
+### Step 5 — Locate the current process step
+
+Read the **CI Incident Management** section of
+[docs/monorepo-docs/processes.md](../../../docs/monorepo-docs/processes.md).
+
+Based on incident status + Slack history, determine which step the incident is in:
+
+1. Identification
+2. Response
+3. Follow-Up
+
+This tells you what action is expected next (e.g. assign roles, post update, create follow-ups).
+
+### Step 6 — Brief the responder
+
+In a single concise message, give the responder:
+
+- **State**: title, severity, status, lead, opened-at
+- **Slack TL;DR**: what's been tried, who's active, last update time
+- **Runbook**: matched heading + the Troubleshooting steps
+- **Process step**: which of the three steps the incident is in, and what's expected
+- **Next action**: one concrete recommendation
+
+Then wait for the responder to direct the next move.
+
+### Step 7 — Drive the response
+
+Work through the runbook with the responder. Prioritize mitigation (stopping the bleeding) over root causing and resolution. Use relevant CI skills from this repository, e.g. for troubleshooting. Specific rules:
+
+- **Status updates**: always use `incident_update` from the incident.io MCP. Do not post directly
+  to the incident's Slack channel — incident.io syndicates updates to Slack.
+- **Slack MCP usage**: read-only by default. Only post via Slack MCP if the responder explicitly
+  asks to message a channel *other than* the incident channel (e.g. `#top-monorepo-ci`).
+- **Confirm wording**: never send an `incident_update` without showing the draft to the responder
+  and getting explicit confirmation.
+- **Don't change state silently**: never change severity, status, or role assignments without the
+  responder explicitly instructing it.
+
+### Step 8 — Wrap-up
+
+When the incident moves to resolved or closed:
+
+- Re-read the **Follow-Up** subsection of `processes.md`.
+- Prompt the responder to create follow-ups via `follow_up_create` for each action item raised
+  during response (postmortem tasks, runbook updates, fixes deferred during the incident).
+- Offer to draft each follow-up's title and description from the Slack history and runbook gaps.
+
+## Guardrails
+
+- Do not invent runbook content. If no runbook matches, say so.
+- Do not assume the responder has tried something just because it's in the runbook — ask.
+- If the runbook references commands or links that no longer exist in the repo, flag it as a
+  follow-up rather than improvising.


### PR DESCRIPTION
## Description

Adds two Claude Code agent skills to help engineers and incident medics respond to CI problems in `camunda/camunda`.

**New skills:**

- `.claude/skills/ci-incident/` — drives high-level response for a full CI incident by combining incident.io state, Slack channel history, and the CI runbooks/process docs to guide the medic/responder, work quite nicely thanks to our docs.
- `.claude/skills/ci-fix-failure/` — diagnoses a failing GitHub Actions run from a run/job URL: fetches jobs and logs via `gh`, classifies the failure (code/test, flake, workflow config, infra), and proposes a concrete fix. Diagnose-and-propose only; the engineer confirms before any fix is applied. Includes reference notes for each failure class (to be expanded over time).

**Review:**

Can be tried by `/ci-incident INC-6018` and `/ci-fix-failure https://github.com/camunda/camunda/actions/runs/27692969710/job/81908578909` or `/ci-fix-failure https://github.com/camunda/camunda/actions/runs/27698749975`

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to https://github.com/camunda/camunda/issues/52873