### PR TITLE
deps: bump opensearch-rest-client from 2.17.0 to 2.19.5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,7 +88,7 @@
     <version.netty>4.2.14.Final</version.netty>
     <version.objenesis>3.5</version.objenesis>
     <version.opentelemetry>1.62.0</version.opentelemetry>
-    <version.opensearch>2.17.0</version.opensearch>
+    <version.opensearch>2.19.5</version.opensearch>
     <version.opensearch-java>3.5.0</version.opensearch-java>
     <version.opensearch.testcontainers>4.1.0</version.opensearch.testcontainers>
     <version.prometheus>1.3.5</version.prometheus>


### PR DESCRIPTION
## Summary

- Bumps `opensearch-rest-client` (`org.opensearch.client`) from 2.17.0 to 2.19.5
- Closes #55334