### PR TITLE
fix: retry transient GCS manifest listing failures

### DIFF
--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -33,6 +33,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
     </dependency>

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -28,6 +28,8 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
+import io.camunda.zeebe.util.retry.RetryConfiguration;
+import io.camunda.zeebe.util.retry.RetryDecorator;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
@@ -57,6 +59,9 @@ public final class ManifestManager {
   private static final int MAX_LIST_ATTEMPTS = 6;
   private static final Duration INITIAL_LIST_RETRY_DELAY = Duration.ofMillis(100);
   private static final Duration MAX_LIST_RETRY_DELAY = Duration.ofSeconds(2);
+  private static final RetryDecorator MANIFEST_LIST_RETRY =
+      new RetryDecorator(manifestListRetryConfiguration())
+          .withRetryOnException(ManifestManager::shouldRetryListOperation);
   private static final Logger LOG = LoggerFactory.getLogger(ManifestManager.class);
 
   /**
@@ -223,42 +228,42 @@ public final class ManifestManager {
   }
 
   private List<Blob> listManifestBlobsWithRetry(final String prefix) {
-    for (int attempt = 1; ; attempt++) {
-      try {
-        final var blobs = new ArrayList<Blob>();
-        client
-            .list(bucketInfo.getName(), BlobListOption.prefix(prefix))
-            .iterateAll()
-            .forEach(blobs::add);
-        return blobs;
-      } catch (final StorageException e) {
-        if (attempt >= MAX_LIST_ATTEMPTS || !shouldRetryListOperation(e)) {
-          throw e;
-        }
-
-        LOG.warn(
-            "Failed to list GCS backup manifests from bucket '{}' with prefix '{}' on attempt {}/{}. Retrying.",
-            bucketInfo.getName(),
-            prefix,
-            attempt,
-            MAX_LIST_ATTEMPTS,
-            e);
-        waitBeforeListRetry(attempt);
-      }
+    try {
+      return MANIFEST_LIST_RETRY.decorate(
+          "list GCS backup manifests from bucket '%s' with prefix '%s'"
+              .formatted(bucketInfo.getName(), prefix),
+          () -> listManifestBlobs(prefix),
+          ignored -> false);
+    } catch (final RuntimeException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to list GCS backup manifests", e);
     }
   }
 
-  private boolean shouldRetryListOperation(final StorageException e) {
-    return e.isRetryable() || isServerError(e) || isTransientComputeEngineMetadataError(e);
+  private List<Blob> listManifestBlobs(final String prefix) {
+    final var blobs = new ArrayList<Blob>();
+    client
+        .list(bucketInfo.getName(), BlobListOption.prefix(prefix))
+        .iterateAll()
+        .forEach(blobs::add);
+    return blobs;
   }
 
-  private boolean isServerError(final StorageException e) {
+  private static boolean shouldRetryListOperation(final Throwable error) {
+    return error instanceof StorageException storageException
+        && (storageException.isRetryable()
+            || isServerError(storageException)
+            || isTransientComputeEngineMetadataError(storageException));
+  }
+
+  private static boolean isServerError(final StorageException e) {
     final var statusCode = e.getCode();
     return statusCode >= 500 && statusCode < 600;
   }
 
-  private boolean isTransientComputeEngineMetadataError(final StorageException e) {
-    for (Throwable current = e; current != null; current = current.getCause()) {
+  private static boolean isTransientComputeEngineMetadataError(final Throwable error) {
+    for (Throwable current = error; current != null; current = current.getCause()) {
       final var message = current.getMessage();
       if (message != null
           && message.contains("Unexpected Error code 500")
@@ -269,18 +274,12 @@ public final class ManifestManager {
     return false;
   }
 
-  private void waitBeforeListRetry(final int attempt) {
-    final var delay =
-        Duration.ofMillis(
-            Math.min(
-                MAX_LIST_RETRY_DELAY.toMillis(),
-                INITIAL_LIST_RETRY_DELAY.toMillis() << (attempt - 1)));
-    try {
-      Thread.sleep(delay);
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new StorageException(0, "Interrupted while retrying GCS backup manifest listing", e);
-    }
+  private static RetryConfiguration manifestListRetryConfiguration() {
+    final var retryConfiguration = new RetryConfiguration();
+    retryConfiguration.setMaxRetries(MAX_LIST_ATTEMPTS);
+    retryConfiguration.setMinRetryDelay(INITIAL_LIST_RETRY_DELAY);
+    retryConfiguration.setMaxRetryDelay(MAX_LIST_RETRY_DELAY);
+    return retryConfiguration;
   }
 
   private CompletableFuture<BackupStatus> downloadManifestStatus(final Blob blob) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -30,8 +30,10 @@ import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
@@ -52,6 +54,9 @@ public final class ManifestManager {
           .disable(WRITE_DATES_AS_TIMESTAMPS)
           .setSerializationInclusion(Include.NON_ABSENT);
   public static final int PRECONDITION_FAILED = 412;
+  private static final int MAX_LIST_ATTEMPTS = 6;
+  private static final Duration INITIAL_LIST_RETRY_DELAY = Duration.ofMillis(100);
+  private static final Duration MAX_LIST_RETRY_DELAY = Duration.ofSeconds(2);
   private static final Logger LOG = LoggerFactory.getLogger(ManifestManager.class);
 
   /**
@@ -193,10 +198,7 @@ public final class ManifestManager {
   public Collection<BackupStatus> listBackupStatuses(final BackupIdentifierWildcard wildcard) {
     final var blobFilter = filterBlobsByWildcard(wildcard);
     LOG.debug("Listing backup statuses for wildcard {}", wildcard);
-    final var listing =
-        client
-            .list(bucketInfo.getName(), BlobListOption.prefix(wildcardPrefix(wildcard)))
-            .iterateAll();
+    final var listing = listManifestBlobsWithRetry(wildcardPrefix(wildcard));
     final var statusFutures = new ArrayList<CompletableFuture<BackupStatus>>();
     for (final var blob : listing) {
       if (!blobFilter.test(blob)) {
@@ -218,6 +220,67 @@ public final class ManifestManager {
         .map(CompletableFuture::join)
         .filter(status -> wildcard.matches(status.id()))
         .toList();
+  }
+
+  private List<Blob> listManifestBlobsWithRetry(final String prefix) {
+    for (int attempt = 1; ; attempt++) {
+      try {
+        final var blobs = new ArrayList<Blob>();
+        client
+            .list(bucketInfo.getName(), BlobListOption.prefix(prefix))
+            .iterateAll()
+            .forEach(blobs::add);
+        return blobs;
+      } catch (final StorageException e) {
+        if (attempt >= MAX_LIST_ATTEMPTS || !shouldRetryListOperation(e)) {
+          throw e;
+        }
+
+        LOG.warn(
+            "Failed to list GCS backup manifests from bucket '{}' with prefix '{}' on attempt {}/{}. Retrying.",
+            bucketInfo.getName(),
+            prefix,
+            attempt,
+            MAX_LIST_ATTEMPTS,
+            e);
+        waitBeforeListRetry(attempt);
+      }
+    }
+  }
+
+  private boolean shouldRetryListOperation(final StorageException e) {
+    return e.isRetryable() || isServerError(e) || isTransientComputeEngineMetadataError(e);
+  }
+
+  private boolean isServerError(final StorageException e) {
+    final var statusCode = e.getCode();
+    return statusCode >= 500 && statusCode < 600;
+  }
+
+  private boolean isTransientComputeEngineMetadataError(final StorageException e) {
+    for (Throwable current = e; current != null; current = current.getCause()) {
+      final var message = current.getMessage();
+      if (message != null
+          && message.contains("Unexpected Error code 500")
+          && message.contains("Compute Engine metadata")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void waitBeforeListRetry(final int attempt) {
+    final var delay =
+        Duration.ofMillis(
+            Math.min(
+                MAX_LIST_RETRY_DELAY.toMillis(),
+                INITIAL_LIST_RETRY_DELAY.toMillis() << (attempt - 1)));
+    try {
+      Thread.sleep(delay);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new StorageException(0, "Interrupted while retrying GCS backup manifest listing", e);
+    }
   }
 
   private CompletableFuture<BackupStatus> downloadManifestStatus(final Blob blob) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -56,8 +56,8 @@ public final class ManifestManager {
           .disable(WRITE_DATES_AS_TIMESTAMPS)
           .setSerializationInclusion(Include.NON_ABSENT);
   public static final int PRECONDITION_FAILED = 412;
-  private static final int MAX_LIST_ATTEMPTS = 6;
-  private static final Duration INITIAL_LIST_RETRY_DELAY = Duration.ofMillis(100);
+  private static final int LIST_MAX_RETRIES = 6;
+  private static final Duration MIN_LIST_RETRY_DELAY = Duration.ofMillis(100);
   private static final Duration MAX_LIST_RETRY_DELAY = Duration.ofSeconds(2);
   private static final RetryDecorator MANIFEST_LIST_RETRY =
       new RetryDecorator(manifestListRetryConfiguration())
@@ -203,7 +203,8 @@ public final class ManifestManager {
   public Collection<BackupStatus> listBackupStatuses(final BackupIdentifierWildcard wildcard) {
     final var blobFilter = filterBlobsByWildcard(wildcard);
     LOG.debug("Listing backup statuses for wildcard {}", wildcard);
-    final var listing = listManifestBlobsWithRetry(wildcardPrefix(wildcard));
+    final var prefix = wildcardPrefix(wildcard);
+    final var listing = listManifestBlobsWithRetry(prefix);
     final var statusFutures = new ArrayList<CompletableFuture<BackupStatus>>();
     for (final var blob : listing) {
       if (!blobFilter.test(blob)) {
@@ -229,15 +230,18 @@ public final class ManifestManager {
 
   private List<Blob> listManifestBlobsWithRetry(final String prefix) {
     try {
-      return MANIFEST_LIST_RETRY.decorate(
+      final var operationName =
           "list GCS backup manifests from bucket '%s' with prefix '%s'"
-              .formatted(bucketInfo.getName(), prefix),
-          () -> listManifestBlobs(prefix),
-          ignored -> false);
+              .formatted(bucketInfo.getName(), prefix);
+      return MANIFEST_LIST_RETRY.decorate(
+          operationName, () -> listManifestBlobs(prefix), ignored -> false);
     } catch (final RuntimeException e) {
       throw e;
     } catch (final Exception e) {
-      throw new RuntimeException("Failed to list GCS backup manifests", e);
+      throw new RuntimeException(
+          "Failed to list GCS backup manifests from bucket '%s' with prefix '%s'"
+              .formatted(bucketInfo.getName(), prefix),
+          e);
     }
   }
 
@@ -251,10 +255,19 @@ public final class ManifestManager {
   }
 
   private static boolean shouldRetryListOperation(final Throwable error) {
-    return error instanceof StorageException storageException
-        && (storageException.isRetryable()
-            || isServerError(storageException)
-            || isTransientComputeEngineMetadataError(storageException));
+    for (var current = error; current != null; current = current.getCause()) {
+      if (current instanceof final StorageException storageException
+          && shouldRetryStorageException(storageException)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean shouldRetryStorageException(final StorageException storageException) {
+    return storageException.isRetryable()
+        || isServerError(storageException)
+        || isNonHttpIoError(storageException);
   }
 
   private static boolean isServerError(final StorageException e) {
@@ -262,12 +275,14 @@ public final class ManifestManager {
     return statusCode >= 500 && statusCode < 600;
   }
 
-  private static boolean isTransientComputeEngineMetadataError(final Throwable error) {
-    for (Throwable current = error; current != null; current = current.getCause()) {
-      final var message = current.getMessage();
-      if (message != null
-          && message.contains("Unexpected Error code 500")
-          && message.contains("Compute Engine metadata")) {
+  private static boolean isNonHttpIoError(final StorageException e) {
+    return e.getCode() == 0 && hasCause(e, IOException.class);
+  }
+
+  private static boolean hasCause(
+      final Throwable error, final Class<? extends Throwable> causeType) {
+    for (var current = error; current != null; current = current.getCause()) {
+      if (causeType.isInstance(current)) {
         return true;
       }
     }
@@ -276,8 +291,8 @@ public final class ManifestManager {
 
   private static RetryConfiguration manifestListRetryConfiguration() {
     final var retryConfiguration = new RetryConfiguration();
-    retryConfiguration.setMaxRetries(MAX_LIST_ATTEMPTS);
-    retryConfiguration.setMinRetryDelay(INITIAL_LIST_RETRY_DELAY);
+    retryConfiguration.setMaxRetries(LIST_MAX_RETRIES);
+    retryConfiguration.setMinRetryDelay(MIN_LIST_RETRY_DELAY);
     retryConfiguration.setMaxRetryDelay(MAX_LIST_RETRY_DELAY);
     return retryConfiguration;
   }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -36,10 +36,12 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +59,7 @@ public final class ManifestManager {
           .setSerializationInclusion(Include.NON_ABSENT);
   public static final int PRECONDITION_FAILED = 412;
   private static final int LIST_MAX_RETRIES = 6;
+  private static final int MAX_CAUSE_DEPTH = 20;
   private static final Duration MIN_LIST_RETRY_DELAY = Duration.ofMillis(100);
   private static final Duration MAX_LIST_RETRY_DELAY = Duration.ofSeconds(2);
   private static final RetryDecorator MANIFEST_LIST_RETRY =
@@ -255,13 +258,11 @@ public final class ManifestManager {
   }
 
   private static boolean shouldRetryListOperation(final Throwable error) {
-    for (var current = error; current != null; current = current.getCause()) {
-      if (current instanceof final StorageException storageException
-          && shouldRetryStorageException(storageException)) {
-        return true;
-      }
-    }
-    return false;
+    return causes(error)
+        .anyMatch(
+            current ->
+                current instanceof final StorageException storageException
+                    && shouldRetryStorageException(storageException));
   }
 
   private static boolean shouldRetryStorageException(final StorageException storageException) {
@@ -281,12 +282,11 @@ public final class ManifestManager {
 
   private static boolean hasCause(
       final Throwable error, final Class<? extends Throwable> causeType) {
-    for (var current = error; current != null; current = current.getCause()) {
-      if (causeType.isInstance(current)) {
-        return true;
-      }
-    }
-    return false;
+    return causes(error).anyMatch(causeType::isInstance);
+  }
+
+  private static Stream<Throwable> causes(final Throwable error) {
+    return Stream.iterate(error, Objects::nonNull, Throwable::getCause).limit(MAX_CAUSE_DEPTH);
   }
 
   private static RetryConfiguration manifestListRetryConfiguration() {

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -14,8 +15,11 @@ import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobTargetOption;
 import com.google.cloud.storage.StorageException;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
@@ -25,7 +29,9 @@ import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
@@ -225,6 +231,70 @@ final class ManifestManagerTest {
     Assertions.assertThatThrownBy(() -> manager.completeManifest(persisted))
         .isInstanceOf(StorageException.class)
         .hasMessageContaining("expected but unhandled");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void shouldRetryListBackupStatusesWhenTransientMetadataErrorOccurs() {
+    // given
+    final var client = Mockito.mock(Storage.class);
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
+    final var backup =
+        new BackupImpl(
+            new BackupIdentifierImpl(1, 2, 3),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new NamedFileSetImpl(Map.of()),
+            new NamedFileSetImpl(Map.of()));
+    final var manifest = Manifest.createInProgress(backup).complete();
+    final var blob = Mockito.mock(Blob.class);
+    Mockito.when(blob.getName()).thenReturn("basePathmanifests/2/3/1/manifest.json");
+    Mockito.when(blob.getMetadata()).thenReturn(ManifestMetadata.fromManifest(manifest));
+    final var page = Mockito.mock(Page.class);
+    Mockito.when(page.iterateAll()).thenReturn(List.of(blob));
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+        .thenThrow(
+            new StorageException(
+                new IOException(
+                    "Unexpected Error code 500 trying to get universe domain from Compute Engine metadata")))
+        .thenReturn(page);
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.empty(), BackupIdentifierWildcard.CheckpointPattern.any());
+
+    // when
+    final var statuses = manager.listBackupStatuses(wildcard);
+
+    // then
+    Assertions.assertThat(statuses)
+        .singleElement()
+        .satisfies(
+            status -> {
+              Assertions.assertThat(status.id()).isEqualTo(backup.id());
+              Assertions.assertThat(status.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
+            });
+    Mockito.verify(client, Mockito.times(2)).list(Mockito.eq("bucket"), Mockito.any());
+  }
+
+  @Test
+  void shouldNotRetryListBackupStatusesWhenErrorIsNotTransient() {
+    // given
+    final var client = Mockito.mock(Storage.class);
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+        .thenThrow(new StorageException(400, "bad request"));
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.empty(), BackupIdentifierWildcard.CheckpointPattern.any());
+
+    // when/then
+    Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
+        .isInstanceOf(StorageException.class)
+        .hasMessageContaining("bad request");
+    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
   }
 
   @Nested

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -233,9 +233,8 @@ final class ManifestManagerTest {
         .hasMessageContaining("expected but unhandled");
   }
 
-  @SuppressWarnings("unchecked")
   @Test
-  void shouldRetryListBackupStatusesWhenTransientMetadataErrorOccurs() {
+  void shouldRetryListBackupStatusesWhenNonHttpIoStorageExceptionOccurs() {
     // given
     final var client = Mockito.mock(Storage.class);
     final var manager =
@@ -251,13 +250,13 @@ final class ManifestManagerTest {
     final var blob = Mockito.mock(Blob.class);
     Mockito.when(blob.getName()).thenReturn("basePathmanifests/2/3/1/manifest.json");
     Mockito.when(blob.getMetadata()).thenReturn(ManifestMetadata.fromManifest(manifest));
-    final var page = Mockito.mock(Page.class);
+    final var page = mockBlobPage(blob);
     Mockito.when(page.iterateAll()).thenReturn(List.of(blob));
     Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
         .thenThrow(
             new StorageException(
                 new IOException(
-                    "Unexpected Error code 500 trying to get universe domain from Compute Engine metadata")))
+                    "universe domain metadata request failed while listing manifests")))
         .thenReturn(page);
     final var wildcard =
         new BackupIdentifierWildcardImpl(
@@ -278,6 +277,70 @@ final class ManifestManagerTest {
   }
 
   @Test
+  void shouldRetryListBackupStatusesWhenNonHttpIoStorageExceptionIsWrapped() {
+    // given
+    final var client = Mockito.mock(Storage.class);
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
+    final var backup =
+        new BackupImpl(
+            new BackupIdentifierImpl(1, 2, 3),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new NamedFileSetImpl(Map.of()),
+            new NamedFileSetImpl(Map.of()));
+    final var manifest = Manifest.createInProgress(backup).complete();
+    final var blob = Mockito.mock(Blob.class);
+    Mockito.when(blob.getName()).thenReturn("basePathmanifests/2/3/1/manifest.json");
+    Mockito.when(blob.getMetadata()).thenReturn(ManifestMetadata.fromManifest(manifest));
+    final var page = mockBlobPage(blob);
+    Mockito.when(page.iterateAll()).thenReturn(List.of(blob));
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+        .thenThrow(
+            new RuntimeException(
+                new StorageException(
+                    new IOException(
+                        "universe domain metadata request failed while listing manifests"))))
+        .thenReturn(page);
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.empty(), BackupIdentifierWildcard.CheckpointPattern.any());
+
+    // when
+    final var statuses = manager.listBackupStatuses(wildcard);
+
+    // then
+    Assertions.assertThat(statuses)
+        .singleElement()
+        .satisfies(
+            status -> {
+              Assertions.assertThat(status.id()).isEqualTo(backup.id());
+              Assertions.assertThat(status.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
+            });
+    Mockito.verify(client, Mockito.times(2)).list(Mockito.eq("bucket"), Mockito.any());
+  }
+
+  @Test
+  void shouldNotRetryListBackupStatusesWhenStorageExceptionIsNotIoBacked() {
+    // given
+    final var client = Mockito.mock(Storage.class);
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+        .thenThrow(new StorageException(0, "not an I/O failure"));
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.empty(), BackupIdentifierWildcard.CheckpointPattern.any());
+
+    // when/then
+    Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
+        .isInstanceOf(StorageException.class)
+        .hasMessageContaining("not an I/O failure");
+    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
+  }
+
+  @Test
   void shouldNotRetryListBackupStatusesWhenErrorIsNotTransient() {
     // given
     final var client = Mockito.mock(Storage.class);
@@ -295,6 +358,13 @@ final class ManifestManagerTest {
         .isInstanceOf(StorageException.class)
         .hasMessageContaining("bad request");
     Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Page<Blob> mockBlobPage(final Blob blob) {
+    final var page = Mockito.mock(Page.class);
+    Mockito.when(page.iterateAll()).thenReturn(List.of(blob));
+    return page;
   }
 
   @Nested

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -255,8 +255,7 @@ final class ManifestManagerTest {
     Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
         .thenThrow(
             new StorageException(
-                new IOException(
-                    "universe domain metadata request failed while listing manifests")))
+                new IOException("universe domain metadata request failed while listing manifests")))
         .thenReturn(page);
     final var wildcard =
         new BackupIdentifierWildcardImpl(

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
 import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -28,6 +30,7 @@ import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -340,6 +343,26 @@ final class ManifestManagerTest {
   }
 
   @Test
+  void shouldNotLoopWhenListBackupStatusesStorageExceptionCauseChainCycles() {
+    // given
+    final var client = Mockito.mock(Storage.class);
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+        .thenThrow(new StorageException(0, "cyclic cause", new CyclicCauseException()));
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.empty(), BackupIdentifierWildcard.CheckpointPattern.any());
+
+    // when/then
+    Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
+        .isInstanceOf(StorageException.class)
+        .hasMessageContaining("cyclic cause");
+    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
+  }
+
+  @Test
   void shouldNotRetryListBackupStatusesWhenErrorIsNotTransient() {
     // given
     final var client = Mockito.mock(Storage.class);
@@ -359,11 +382,49 @@ final class ManifestManagerTest {
     Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
   }
 
+  @Test
+  void shouldNotLoopForeverWhenRetryCauseChainIsCyclic() {
+    // given
+    final var client = Mockito.mock(Storage.class);
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.empty(), BackupIdentifierWildcard.CheckpointPattern.any());
+
+    final var firstCause = new Exception("first cause");
+    final var secondCause = new Exception("second cause");
+    firstCause.initCause(secondCause);
+    secondCause.initCause(firstCause);
+
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+        .thenThrow(new RuntimeException("cyclic failure", firstCause));
+
+    // when / then
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(1),
+        () -> {
+          Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
+              .isInstanceOf(RuntimeException.class)
+              .hasMessageContaining("cyclic failure");
+        });
+    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
+  }
+
   @SuppressWarnings("unchecked")
   private static Page<Blob> mockBlobPage(final Blob blob) {
     final var page = Mockito.mock(Page.class);
     Mockito.when(page.iterateAll()).thenReturn(List.of(blob));
     return page;
+  }
+
+  private static final class CyclicCauseException extends RuntimeException {
+
+    @Override
+    public synchronized Throwable getCause() {
+      return this;
+    }
   }
 
   @Nested

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
-
 import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -356,7 +354,7 @@ final class ManifestManagerTest {
             Optional.empty(), Optional.empty(), BackupIdentifierWildcard.CheckpointPattern.any());
 
     // when/then
-    assertTimeoutPreemptively(
+    org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(
         Duration.ofSeconds(5),
         () ->
             Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
@@ -405,7 +403,7 @@ final class ManifestManagerTest {
         .thenThrow(new RuntimeException("cyclic failure", firstCause));
 
     // when / then
-    assertTimeoutPreemptively(
+    org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(
         Duration.ofSeconds(5),
         () -> {
           Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -356,9 +356,12 @@ final class ManifestManagerTest {
             Optional.empty(), Optional.empty(), BackupIdentifierWildcard.CheckpointPattern.any());
 
     // when/then
-    Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
-        .isInstanceOf(StorageException.class)
-        .hasMessageContaining("cyclic cause");
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () ->
+            Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
+                .isInstanceOf(StorageException.class)
+                .hasMessageContaining("cyclic cause"));
     Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
   }
 
@@ -403,7 +406,7 @@ final class ManifestManagerTest {
 
     // when / then
     assertTimeoutPreemptively(
-        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
         () -> {
           Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
               .isInstanceOf(RuntimeException.class)


### PR DESCRIPTION
## Description

GCS backup list operations currently fail immediately when the Google auth layer turns a transient Compute Engine metadata HTTP 500 into a non-retryable `StorageException`. That bypasses the GCS client's configured retry budget for the list call.

This change wraps manifest listing in a bounded retry for idempotent list operations. It retries retryable storage exceptions, server-side storage errors, and the metadata 500 path reported in #50304, then keeps the existing fail-fast behavior for permanent errors. The listing is materialized inside the retry boundary so failures from page iteration are retried as part of the same operation.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #50304

## Verification

- `.\mvnw.cmd -pl zeebe/backup-stores/gcs spotless:check -DskipTests`
- `.\mvnw.cmd -pl zeebe/backup-stores/gcs -Dtest=ManifestManagerTest -DskipTests=false -DskipITs -Dquickly test`
- `git diff --check`