### PR TITLE
55128 token outlier bands

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -17,6 +17,7 @@ import static io.camunda.optimize.service.dashboard.AgenticControlDashboardServi
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_CONSUMERS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_OUTLIER_BANDS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_TREND_REPORT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -939,6 +940,39 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
             .mapToDouble(MapResultEntryDto::getValue)
             .sum();
     assertThat(totalOutput).isCloseTo(300.0, within(1.0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Token outlier bands report (weekly P5/P50/P95 token line chart)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldReturnThreePercentileMeasures_forTokenOutlierBands() {
+    // given — 5 instances sharing an end date with total tokens [100, 200, 300, 400, 500]
+    final OffsetDateTime sharedEnd = OffsetDateTime.now().minusDays(2);
+    persistProcessInstances(
+        List.of(
+            agenticInstanceWithTokens(PROC_KEY, 100L, 0L).endDate(sharedEnd).build(),
+            agenticInstanceWithTokens(PROC_KEY, 200L, 0L).endDate(sharedEnd).build(),
+            agenticInstanceWithTokens(PROC_KEY, 300L, 0L).endDate(sharedEnd).build(),
+            agenticInstanceWithTokens(PROC_KEY, 400L, 0L).endDate(sharedEnd).build(),
+            agenticInstanceWithTokens(PROC_KEY, 500L, 0L).endDate(sharedEnd).build()));
+
+    // when
+    final MapCommandResult result = evaluateMap(TOKEN_OUTLIER_BANDS_REPORT_ID, noExtraFilters());
+
+    // then — exactly three measures, ordered p5, p50, p95
+    final List<MeasureDto<List<MapResultEntryDto>>> measures = result.getMeasures();
+    assertThat(measures).hasSize(3);
+    assertThat(measures.get(0).getAggregationType())
+        .isEqualTo(new AggregationDto(AggregationType.PERCENTILE, 5.0));
+    assertThat(measures.get(1).getAggregationType())
+        .isEqualTo(new AggregationDto(AggregationType.PERCENTILE, 50.0));
+    assertThat(measures.get(2).getAggregationType())
+        .isEqualTo(new AggregationDto(AggregationType.PERCENTILE, 95.0));
+
+    // and the p50 band reflects the median total tokens (300) — ES percentile approximation
+    assertThat(measures.get(1).getData().getFirst().getValue()).isCloseTo(300.0, within(50.0));
   }
 
   // ---------------------------------------------------------------------------

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -85,6 +85,13 @@ public class AgenticControlDashboardService {
   public static final String KPI_TOKEN_TREND_FOOTNOTE = "agenticKpiTokenTrendFootnote";
   public static final String KPI_TOKEN_TREND_FOOTNOTE_KEY =
       "agenticControl.report." + KPI_TOKEN_TREND_FOOTNOTE;
+  public static final String KPI_TOKEN_OUTLIER_BANDS_NAME = "agenticKpiTokenOutlierBandsName";
+  public static final String KPI_TOKEN_OUTLIER_BANDS_DESCRIPTION =
+      "agenticKpiTokenOutlierBandsDescription";
+  public static final String KPI_TOKEN_OUTLIER_BANDS_FOOTNOTE =
+      "agenticKpiTokenOutlierBandsFootnote";
+  public static final String KPI_TOKEN_OUTLIER_BANDS_FOOTNOTE_KEY =
+      "agenticControl.report." + KPI_TOKEN_OUTLIER_BANDS_FOOTNOTE;
   public static final String KPI_TOKEN_CONSUMERS_NAME = "agenticKpiTokenConsumersName";
   public static final String KPI_TOKEN_CONSUMERS_FOOTNOTE = "agenticKpiTokenConsumersFootnote";
   public static final String KPI_TOKEN_CONSUMERS_FOOTNOTE_KEY =
@@ -126,6 +133,9 @@ public class AgenticControlDashboardService {
       UUID.nameUUIDFromBytes("agentic-token-trend".getBytes(StandardCharsets.UTF_8)).toString();
   public static final String TOKEN_CONSUMERS_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-token-consumers".getBytes(StandardCharsets.UTF_8)).toString();
+  public static final String TOKEN_OUTLIER_BANDS_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-token-outlier-bands".getBytes(StandardCharsets.UTF_8))
+          .toString();
   public static final String KPI_DURATION_P50_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-duration-p50".getBytes(StandardCharsets.UTF_8)).toString();
   public static final String KPI_DURATION_P95_REPORT_ID =
@@ -186,6 +196,7 @@ public class AgenticControlDashboardService {
     tiles.add(buildMedianTokensReport());
     tiles.add(buildDurationStabilityReport());
     tiles.add(buildTokenTrendReport());
+    tiles.add(buildTokenOutlierBandsReport());
     tiles.add(buildTopTokenConsumersReport());
     tiles.add(buildP50DurationReport());
     tiles.add(buildP95DurationReport());
@@ -392,6 +403,53 @@ public class AgenticControlDashboardService {
                 .buildList())
         .agenticControlReport(true)
         .build();
+  }
+
+  // Token consumption stability: p5/p50/p95 total tokens per execution over time, rendered as
+  // shaded outlier bands. Reuses the multi-percentile-in-one-report support (see the duration
+  // stability report) and mirrors the token-trend tile's weekly date grouping.
+  private DashboardReportTileDto buildTokenOutlierBandsReport() {
+    final EndDateGroupByDto groupBy = new EndDateGroupByDto();
+    groupBy.setValue(new DateGroupByValueDto(AggregateByDateUnit.WEEK));
+
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.AGENT_INSTANCE, ViewProperty.TOTAL_TOKENS))
+            .groupBy(groupBy)
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.OUTLIER_BAND)
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .aggregationTypes(
+                        new LinkedHashSet<>(
+                            List.of(
+                                new AggregationDto(AggregationType.PERCENTILE, 5.0),
+                                new AggregationDto(AggregationType.PERCENTILE, 50.0),
+                                new AggregationDto(AggregationType.PERCENTILE, 95.0))))
+                    .build())
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .buildList())
+            .agenticControlReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        TOKEN_OUTLIER_BANDS_REPORT_ID,
+        null,
+        reportData,
+        KPI_TOKEN_OUTLIER_BANDS_NAME,
+        KPI_TOKEN_OUTLIER_BANDS_DESCRIPTION,
+        null);
+    return buildTile(
+        TOKEN_OUTLIER_BANDS_REPORT_ID,
+        // sits in the right half of the token-trend row, mirroring its size
+        new PositionDto(9, 6),
+        new DimensionDto(9, 4),
+        Map.of("section", "token", "footnote", KPI_TOKEN_OUTLIER_BANDS_FOOTNOTE_KEY));
   }
 
   private DashboardReportTileDto buildTopTokenConsumersReport() {

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -223,6 +223,10 @@
   "report": {
     "label": "Bericht",
     "label-plural": "Berichte",
+    "outlierBand": {
+      "percentile": "p{value}",
+      "yAxis": "Token pro Ausführung"
+    },
     "textTile": "Textkachel",
     "externalUrl": "Externe URL",
     "create": "Bericht Erstellen",

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -224,7 +224,7 @@
     "label": "Bericht",
     "label-plural": "Berichte",
     "outlierBand": {
-      "percentile": "p{value}",
+      "percentile": "P{value}",
       "yAxis": "Token pro Ausführung"
     },
     "textTile": "Textkachel",
@@ -1575,6 +1575,9 @@
       "agenticDurationStabilityDescription": "P50- und P95-Ausführungsdauer abgeschlossener agentischer Prozessinstanzen über die Zeit im gewählten Zeitraum.",
       "agenticKpiTokenTrendName": "Token-Trend",
       "agenticKpiTokenTrendFootnote": "Wenn die Token-Nutzung ohne mehr Ausführungen steigt, wachsen möglicherweise die Prompts oder das Modell erzeugt längere Ausgaben. Engineering informieren.",
+      "agenticKpiTokenOutlierBandsName": "Token-Ausreißerbänder (P5 / P50 / P95)",
+      "agenticKpiTokenOutlierBandsDescription": "P5, P50 und P95 der insgesamt verbrauchten Token pro abgeschlossener agentischer Prozessinstanz im ausgewählten Zeitraum.",
+      "agenticKpiTokenOutlierBandsFootnote": "Eine größer werdende Lücke zwischen P5 und P95 bedeutet, dass sich Ausführungen inkonsistent verhalten. Achten Sie auf Prompt-Variabilität oder Nicht-Determinismus.",
       "agenticKpiTokenConsumersName": "Top-Token-Verbraucher nach Prozess",
       "agenticKpiTokenConsumersFootnote": "Die Reduzierung des größten Verbrauchers hat die größte Auswirkung auf die gesamten Token-Kosten.",
       "agenticKpiDurationP50Name": "P50-Ausführungsdauer",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -224,7 +224,7 @@
     "label": "Report",
     "label-plural": "Reports",
     "outlierBand": {
-      "percentile": "p{value}",
+      "percentile": "P{value}",
       "yAxis": "Tokens per execution"
     },
     "textTile": "Text tile",
@@ -1575,6 +1575,9 @@
       "agenticDurationStabilityDescription": "P50 and P95 execution duration of completed agentic process instances over time in the selected period.",
       "agenticKpiTokenTrendName": "Token Trend",
       "agenticKpiTokenTrendFootnote": "If token use rises without more executions, prompts may be growing or the model is producing longer outputs. Raise with engineering.",
+      "agenticKpiTokenOutlierBandsName": "Token outlier bands (P5 / P50 / P95)",
+      "agenticKpiTokenOutlierBandsDescription": "P5, P50 and P95 total tokens consumed per completed agentic process instance over time in the selected period.",
+      "agenticKpiTokenOutlierBandsFootnote": "A widening gap between P5 and P95 means executions are behaving inconsistently. Look for prompt variability or non-determinism.",
       "agenticKpiTokenConsumersName": "Top token consumers by process",
       "agenticKpiTokenConsumersFootnote": "Reducing the top consumer will have the biggest impact on overall token spend.",
       "agenticKpiDurationP50Name": "P50 execution duration",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -223,6 +223,10 @@
   "report": {
     "label": "Report",
     "label-plural": "Reports",
+    "outlierBand": {
+      "percentile": "p{value}",
+      "yAxis": "Tokens per execution"
+    },
     "textTile": "Text tile",
     "externalUrl": "External URL",
     "create": "Create report",

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -93,7 +93,7 @@ public class AgenticControlDashboardServiceTest {
     assertThat(saved.isAgenticControlDashboard()).isTrue();
     assertThat(saved.isManagementDashboard()).isFalse();
     assertThat(saved.getCollectionId()).isNull();
-    assertThat(saved.getTiles()).hasSize(11);
+    assertThat(saved.getTiles()).hasSize(12);
   }
 
   @Test
@@ -175,6 +175,7 @@ public class AgenticControlDashboardServiceTest {
             AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID,
             AgenticControlDashboardService.DURATION_STABILITY_REPORT_ID,
             AgenticControlDashboardService.TOKEN_TREND_REPORT_ID,
+            AgenticControlDashboardService.TOKEN_OUTLIER_BANDS_REPORT_ID,
             AgenticControlDashboardService.TOKEN_CONSUMERS_REPORT_ID,
             AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID,
             AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID,
@@ -239,7 +240,7 @@ public class AgenticControlDashboardServiceTest {
     underTest.reconcile();
 
     // then reports are upserted and dashboard tiles are updated, but dashboard is not recreated
-    verify(reportWriter, times(11))
+    verify(reportWriter, times(12))
         .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
     verify(dashboardWriter, never()).saveDashboard(any());
     verify(dashboardWriter).updateDashboard(any(), any());
@@ -330,6 +331,10 @@ public class AgenticControlDashboardServiceTest {
               AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_NAME,
               AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION,
               AgenticControlDashboardService.KPI_TOKEN_TREND_NAME,
+              AgenticControlDashboardService.KPI_TOKEN_TREND_FOOTNOTE,
+              AgenticControlDashboardService.KPI_TOKEN_OUTLIER_BANDS_NAME,
+              AgenticControlDashboardService.KPI_TOKEN_OUTLIER_BANDS_FOOTNOTE,
+              AgenticControlDashboardService.KPI_TOKEN_OUTLIER_BANDS_DESCRIPTION,
               AgenticControlDashboardService.KPI_TOKEN_TREND_FOOTNOTE,
               AgenticControlDashboardService.KPI_TOKEN_CONSUMERS_NAME,
               AgenticControlDashboardService.KPI_TOKEN_CONSUMERS_FOOTNOTE,
@@ -428,6 +433,36 @@ public class AgenticControlDashboardServiceTest {
     assertThat(stabilityTile.getDimensions().getWidth()).isEqualTo(18);
     assertThat(stabilityTile.getDimensions().getHeight()).isEqualTo(2);
     assertThat(stabilityTile.getConfiguration()).isEqualTo(Map.of("section", "duration"));
+  }
+
+  @Test
+  void shouldSeedTokenOutlierBandsTileNextToTokenTrend() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then — placed in the right half of the token-trend row, matching its size
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    final var outlierTile =
+        saved.getTiles().stream()
+            .filter(
+                t -> t.getId().equals(AgenticControlDashboardService.TOKEN_OUTLIER_BANDS_REPORT_ID))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(outlierTile.getPosition().getX()).isEqualTo(9);
+    assertThat(outlierTile.getPosition().getY()).isEqualTo(6);
+    assertThat(outlierTile.getDimensions().getWidth()).isEqualTo(9);
+    assertThat(outlierTile.getDimensions().getHeight()).isEqualTo(4);
+    assertThat(outlierTile.getConfiguration())
+        .isEqualTo(
+            Map.of(
+                "section",
+                "token",
+                "footnote",
+                AgenticControlDashboardService.KPI_TOKEN_OUTLIER_BANDS_FOOTNOTE_KEY));
   }
 
   @Test

--- a/optimize/client/src/modules/components/ReportRenderer/ProcessReportRenderer.js
+++ b/optimize/client/src/modules/components/ReportRenderer/ProcessReportRenderer.js
@@ -39,6 +39,7 @@ function getComponent(visualization) {
     case 'line':
     case 'pie':
     case 'barLine':
+    case 'outlierBand':
       return Chart;
     case 'heat':
       return Heatmap;

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/Chart.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/Chart.js
@@ -11,6 +11,7 @@ import ChartRenderer from './ChartRenderer';
 import createDefaultChartConfig from './defaultChart';
 import createHyperChartConfig from './hyperChart';
 import createTargetLineConfig from './targetLineChart';
+import createOutlierBandConfig from './outlierBandChart';
 import {themed} from 'theme';
 
 export function Chart(props) {
@@ -30,7 +31,9 @@ export function Chart(props) {
     configuration.targetValue.active && configuration.targetValue[targetValueType];
 
   let createConfig;
-  if (targetValue && visualization === 'line') {
+  if (visualization === 'outlierBand') {
+    createConfig = createOutlierBandConfig;
+  } else if (targetValue && visualization === 'line') {
     createConfig = createTargetLineConfig;
   } else if (hyper) {
     createConfig = createHyperChartConfig;

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/Chart.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/Chart.test.js
@@ -12,10 +12,12 @@ import {Chart} from './Chart';
 import createDefaultChartConfig from './defaultChart';
 import createHyperChartConfig from './hyperChart';
 import createTargetLineConfig from './targetLineChart';
+import createOutlierBandConfig from './outlierBandChart';
 
 jest.mock('./targetLineChart', () => jest.fn());
 jest.mock('./hyperChart', () => jest.fn());
 jest.mock('./defaultChart', () => jest.fn());
+jest.mock('./outlierBandChart', () => jest.fn());
 
 const report = {
   data: {
@@ -75,4 +77,18 @@ it('should render default normal chart if report is a single report', () => {
   );
 
   expect(createDefaultChartConfig).toHaveBeenCalled();
+});
+
+it('should use the outlier band config when visualization is outlierBand', () => {
+  shallow(
+    <Chart
+      report={{
+        ...report,
+        result: {data: {}, measures: []},
+        data: {...report.data, visualization: 'outlierBand'},
+      }}
+    />
+  );
+
+  expect(createOutlierBandConfig).toHaveBeenCalled();
 });

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/colorsUtils.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/colorsUtils.js
@@ -6,6 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {color} from 'chart.js/helpers';
+
 import {formatters} from 'services';
 
 const {convertToMilliseconds} = formatters;
@@ -77,4 +79,8 @@ function getStripedColor(color) {
   canvasPattern.color = color;
 
   return canvasPattern;
+}
+
+export function addAlpha(colorString, opacity) {
+  return color(colorString).alpha(opacity).rgbString();
 }

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/fadeOnHover.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/fadeOnHover.js
@@ -6,8 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {color} from 'chart.js/helpers';
 import deepEqual from 'fast-deep-equal';
+
+import {addAlpha} from './colorsUtils';
 
 const COLOR_FADE_OPACITY = 0.15;
 
@@ -133,8 +134,4 @@ export default function fadeOnHover({visualization, isStacked}) {
       }
     },
   };
-}
-
-function addAlpha(colorString, opacity) {
-  return color(colorString).alpha(opacity).rgbString();
 }

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/outlierBandChart/createOutlierBandConfig.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/outlierBandChart/createOutlierBandConfig.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import createPlugins from '../createPlugins';
+
+import createOutlierBandData from './createOutlierBandData';
+import createOutlierBandOptions from './createOutlierBandOptions';
+
+// Renders a report with three percentile measures (p5/p50/p95) as stacked shaded bands. Uses the
+// native Chart.js line type plus the Filler plugin (already registered) — no custom controller
+// needed, unlike targetLineChart.
+export default function createOutlierBandConfig(props) {
+  return {
+    type: 'line',
+    data: createOutlierBandData(props),
+    options: createOutlierBandOptions(props),
+    plugins: createPlugins(props),
+  };
+}

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/outlierBandChart/createOutlierBandData.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/outlierBandChart/createOutlierBandData.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ColorPicker} from 'components';
+import {t} from 'translation';
+
+import {extractDefaultChartData} from '../defaultChart/createDefaultChartData';
+import {addAlpha} from '../colorsUtils';
+
+const BAND_FILL_OPACITY = 0.35;
+
+// Builds one line dataset per percentile measure, ordered low → high (p5 → p50 → p95) so Chart.js
+// fill-between renders stacked bands: the lowest band fills down to the axis origin and every
+// higher band fills down to the band directly below it. Colours come from Optimize's standard
+// series palette (ColorPicker), consistent with every other multi-series chart.
+export default function createOutlierBandData(props) {
+  const {
+    report: {result},
+  } = props;
+  const measures = result?.measures ?? [];
+
+  if (!measures.length) {
+    return {labels: [], datasets: []};
+  }
+
+  // Order measure indices by percentile ascending, independent of the response order.
+  const orderedIdx = measures
+    .map((_measure, idx) => idx)
+    .sort((a, b) => percentileOf(measures[a]) - percentileOf(measures[b]));
+
+  const colors = ColorPicker.getGeneratedColors(orderedIdx.length);
+  const {labels, labelsMap} = extractDefaultChartData(props, orderedIdx[0]);
+
+  const datasets = orderedIdx.map((measureIdx, bandIdx) => {
+    const {formattedResult} = extractDefaultChartData(props, measureIdx);
+    const color = colors[bandIdx];
+
+    return {
+      yAxisID: 'axis-0',
+      label: bandLabel(measures[measureIdx]),
+      // align every band on the reference (lowest-percentile) date buckets
+      data: alignToBuckets(labelsMap, formattedResult),
+      borderColor: color,
+      backgroundColor: addAlpha(color, BAND_FILL_OPACITY),
+      legendColor: color,
+      pointBackgroundColor: color,
+      borderWidth: 1,
+      fill: bandIdx === 0 ? 'origin' : '-1',
+      tension: 0,
+    };
+  });
+
+  return {labels, datasets};
+}
+
+// Looks up each band's value by the reference bucket key so all bands share one x-axis. A band
+// missing a bucket yields null (rendered as a gap) rather than throwing.
+function alignToBuckets(refLabelsMap, formattedResult) {
+  return refLabelsMap.map(
+    ({key}) => formattedResult.find((entry) => entry.key === key)?.value ?? null
+  );
+}
+
+function percentileOf(measure) {
+  return measure?.aggregationType?.value ?? 0;
+}
+
+function bandLabel(measure) {
+  return t('report.outlierBand.percentile', {value: percentileOf(measure)});
+}

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/outlierBandChart/createOutlierBandData.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/outlierBandChart/createOutlierBandData.test.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import createOutlierBandData from './createOutlierBandData';
+
+function percentileMeasure(value, data) {
+  return {property: 'totalTokens', aggregationType: {type: 'percentile', value}, data};
+}
+
+function buildProps(measures) {
+  return {
+    report: {
+      result: {measures},
+      data: {
+        configuration: {color: 'blue'},
+        visualization: 'outlierBand',
+        groupBy: {type: '', value: ''},
+        view: {properties: ['totalTokens'], entity: 'processInstance'},
+      },
+    },
+    theme: 'light',
+  };
+}
+
+it('should build three bands ordered P5, P50, P95 regardless of the measure order', () => {
+  // given measures in a non-ascending order
+  const measures = [
+    percentileMeasure(95, [
+      {key: 'wk1', value: 3000},
+      {key: 'wk2', value: 3100},
+    ]),
+    percentileMeasure(5, [
+      {key: 'wk1', value: 500},
+      {key: 'wk2', value: 520},
+    ]),
+    percentileMeasure(50, [
+      {key: 'wk1', value: 1300},
+      {key: 'wk2', value: 1320},
+    ]),
+  ];
+
+  // when
+  const {labels, datasets} = createOutlierBandData(buildProps(measures));
+
+  // then — ordered low → high, aligned on shared buckets
+  expect(datasets).toHaveLength(3);
+  expect(datasets.map((dataset) => dataset.label)).toEqual(['P5', 'P50', 'P95']);
+  expect(datasets[0].data).toEqual([500, 520]);
+  expect(datasets[1].data).toEqual([1300, 1320]);
+  expect(datasets[2].data).toEqual([3000, 3100]);
+  expect(labels).toEqual(['wk1', 'wk2']);
+});
+
+it('should fill the lowest band to the origin and higher bands to the band below', () => {
+  // given
+  const measures = [
+    percentileMeasure(5, [{key: 'wk1', value: 500}]),
+    percentileMeasure(50, [{key: 'wk1', value: 1300}]),
+    percentileMeasure(95, [{key: 'wk1', value: 3000}]),
+  ];
+
+  // when
+  const {datasets} = createOutlierBandData(buildProps(measures));
+
+  // then
+  expect(datasets[0].fill).toBe('origin');
+  expect(datasets[1].fill).toBe('-1');
+  expect(datasets[2].fill).toBe('-1');
+});
+
+it('should apply a semi-transparent fill derived from the band border colour', () => {
+  // given
+  const measures = [
+    percentileMeasure(5, [{key: 'wk1', value: 500}]),
+    percentileMeasure(50, [{key: 'wk1', value: 1300}]),
+    percentileMeasure(95, [{key: 'wk1', value: 3000}]),
+  ];
+
+  // when
+  const {datasets} = createOutlierBandData(buildProps(measures));
+
+  // then — fill is an rgba derived from the (solid) border colour, so the two differ
+  datasets.forEach((dataset) => {
+    expect(dataset.borderColor).toBeTruthy();
+    expect(dataset.backgroundColor).toContain('rgba');
+    expect(dataset.backgroundColor).not.toEqual(dataset.borderColor);
+    expect(dataset.legendColor).toEqual(dataset.borderColor);
+  });
+});
+
+it('should return empty data when there are no measures', () => {
+  expect(createOutlierBandData(buildProps([]))).toEqual({labels: [], datasets: []});
+});

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/outlierBandChart/createOutlierBandOptions.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/outlierBandChart/createOutlierBandOptions.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {t} from 'translation';
+
+import createDefaultChartOptions from '../defaultChart/createDefaultChartOptions';
+
+// Reuses the standard line-chart option machinery (axes, ticks, tooltips) by treating the report
+// as a line chart, then layers on the band-specific tweaks: a fixed Y-axis title and a reversed
+// legend so it reads p95 → p50 → p5 (top band first), matching the visual stack order.
+export default function createOutlierBandOptions(props) {
+  const lineProps = {
+    ...props,
+    report: {
+      ...props.report,
+      data: {...props.report.data, visualization: 'line'},
+    },
+  };
+
+  const options = createDefaultChartOptions(lineProps);
+
+  const measuresAxis = options.scales?.['axis-0'];
+  if (measuresAxis) {
+    measuresAxis.title = {
+      ...measuresAxis.title,
+      display: true,
+      text: t('report.outlierBand.yAxis'),
+    };
+  }
+
+  options.plugins.legend = {
+    ...options.plugins.legend,
+    display: true,
+    reverse: true,
+  };
+
+  return options;
+}

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/outlierBandChart/index.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/outlierBandChart/index.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import createOutlierBandConfig from './createOutlierBandConfig';
+
+export default createOutlierBandConfig;

--- a/optimize/client/src/modules/types.ts
+++ b/optimize/client/src/modules/types.ts
@@ -156,7 +156,15 @@ interface DistributedBy {
   value: GroupByValue | null;
 }
 
-type ProcessReportVisualization = 'number' | 'table' | 'bar' | 'barLine' | 'line' | 'pie' | 'heat';
+type ProcessReportVisualization =
+  | 'number'
+  | 'table'
+  | 'bar'
+  | 'barLine'
+  | 'line'
+  | 'pie'
+  | 'heat'
+  | 'outlierBand';
 
 type AggregationTypeType = 'avg' | 'min' | 'max' | 'sum' | 'percentile';
 
@@ -313,8 +321,10 @@ export interface SingleProcessReportResultData {
   value: string | number;
 }
 
-export interface Report<Data extends object = SingleProcessReportData, Result = unknown | undefined>
-  extends GenericEntity<Data> {
+export interface Report<
+  Data extends object = SingleProcessReportData,
+  Result = unknown | undefined,
+> extends GenericEntity<Data> {
   id: string;
   collectionId?: string | null;
   description: string | null;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ReportConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ReportConstants.java
@@ -67,6 +67,7 @@ public final class ReportConstants {
   public static final String BADGE_VISUALIZATION = "badge";
   public static final String PIE_VISUALIZATION = "pie";
   public static final String BAR_LINE_VISUALIZATION = "barLine";
+  public static final String OUTLIER_BAND_VISUALIZATION = "outlierBand";
 
   public static final String DEFAULT_CONFIGURATION_COLOR = "#1991c8";
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessVisualization.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessVisualization.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.dto.optimize.ReportConstants.BAR_LINE_VISUALIZ
 import static io.camunda.optimize.dto.optimize.ReportConstants.BAR_VISUALIZATION;
 import static io.camunda.optimize.dto.optimize.ReportConstants.HEAT_VISUALIZATION;
 import static io.camunda.optimize.dto.optimize.ReportConstants.LINE_VISUALIZATION;
+import static io.camunda.optimize.dto.optimize.ReportConstants.OUTLIER_BAND_VISUALIZATION;
 import static io.camunda.optimize.dto.optimize.ReportConstants.PIE_VISUALIZATION;
 import static io.camunda.optimize.dto.optimize.ReportConstants.SINGLE_NUMBER_VISUALIZATION;
 import static io.camunda.optimize.dto.optimize.ReportConstants.TABLE_VISUALIZATION;
@@ -26,7 +27,8 @@ public enum ProcessVisualization {
   LINE(LINE_VISUALIZATION),
   PIE(PIE_VISUALIZATION),
   BADGE(BADGE_VISUALIZATION),
-  HEAT(HEAT_VISUALIZATION);
+  HEAT(HEAT_VISUALIZATION),
+  OUTLIER_BAND(OUTLIER_BAND_VISUALIZATION);
 
   private final String id;
 

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessVisualizationSerializationTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessVisualizationSerializationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.report.single.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.service.util.mapper.ObjectMapperFactory;
+import org.junit.jupiter.api.Test;
+
+class ProcessVisualizationSerializationTest {
+
+  private final ObjectMapper objectMapper = ObjectMapperFactory.OPTIMIZE_MAPPER;
+
+  @Test
+  void shouldSerializeOutlierBandToItsWireId() throws Exception {
+    // given / when
+    final String json = objectMapper.writeValueAsString(ProcessVisualization.OUTLIER_BAND);
+
+    // then — the @JsonValue id is the contract shared with the frontend
+    assertThat(json).isEqualTo("\"outlierBand\"");
+  }
+
+  @Test
+  void shouldDeserializeOutlierBandFromItsWireId() throws Exception {
+    // given / when
+    final ProcessVisualization result =
+        objectMapper.readValue("\"outlierBand\"", ProcessVisualization.class);
+
+    // then
+    assertThat(result).isEqualTo(ProcessVisualization.OUTLIER_BAND);
+  }
+}


### PR DESCRIPTION
## Description

Adds a **"Token outlier bands (p5 / p50 / p95)"** tile to the *Token usage* section of
the agentic control plane dashboard (Optimize). It renders a shaded-area line chart with
three stacked bands — p5, p50 and p95 of total tokens consumed per execution — bucketed
weekly over the active date window.


## How

The chart reuses Optimize's existing multi-percentile support — the report is evaluated
**once** and returns three percentile measures (the same mechanism the duration-stability
tile already uses), so no new backend aggregation/query code was needed.

1. Moved the private `addAlpha` colour helper out of `fadeOnHover.js` into its natural home,
`colorsUtils.js`, so it can be shared.

2. Added a typed `outlierBand` value end to end (backend enum + frontend union) so a report
can declare itself as a band chart. Only `HEAT` is special-cased in evaluation, so
`outlierBand` evaluates like a line report.

3. New `outlierBandChart/` config module. Datasets are ordered p5→p50→p95 so Chart.js
fill-between stacks correctly

4. Wired the report + tile into `AgenticControlDashboardService`

## Screenshot
<img width="2996" height="989" alt="Screenshot 2026-06-17 at 3 56 28 PM" src="https://github.com/user-attachments/assets/4bd796b8-4e97-4b38-bf7a-914c475727e7" />


Closes #55128
