### PR TITLE
ci: enable stable branch coverage for optimize nightly CIs

### DIFF
--- a/.github/workflows/optimize-ci-data-upgrade-nightly.yml
+++ b/.github/workflows/optimize-ci-data-upgrade-nightly.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/paths-filter
 
   upgrade-tests:
-    name: "Database Upgrade [${{ matrix.branch }}]"
+    name: "Database Upgrade [${{ matrix.database }}][${{ matrix.branch }}]"
     runs-on: gcp-core-8-default
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/optimize-ci-data-upgrade-nightly.yml
+++ b/.github/workflows/optimize-ci-data-upgrade-nightly.yml
@@ -38,17 +38,24 @@ jobs:
         uses: ./.github/actions/paths-filter
 
   upgrade-tests:
-    name: "Database Upgrade"
+    name: "Database Upgrade [${{ matrix.branch }}]"
     runs-on: gcp-core-8-default
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         database: [ elasticsearch, opensearch ]
+        branch: [ main, stable/8.8, stable/8.9 ]
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.backend-changes == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Set branch slug
+        run: echo "BRANCH_SLUG=$(echo '${{ matrix.branch }}' | tr '/' '-')" >> "$GITHUB_ENV"
       - name: Setup Maven
         uses: ./.github/actions/setup-build
         with:
@@ -100,7 +107,7 @@ jobs:
         if: always()
         uses: ./.github/actions/collect-test-artifacts
         with:
-          name: upgrade-${{ matrix.database }}-junit
+          name: upgrade-${{ matrix.database }}-${{ env.BRANCH_SLUG }}-junit
           path: |
             **/failsafe-reports/**/*.xml
             **/*.log
@@ -109,13 +116,13 @@ jobs:
         uses: ./.github/actions/docker-logs
         if: always()
         with:
-          archive_name: upgrade-docker-${{ matrix.database }}
+          archive_name: upgrade-docker-${{ matrix.database }}-${{ env.BRANCH_SLUG }}
       - name: Observe build status
         if: always()
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "upgrade-tests/${{ matrix.database }}"
+          job_name: "upgrade-tests/${{ matrix.database }}/${{ matrix.branch }}"
           build_status: ${{ job.status }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -19,6 +19,8 @@ defaults:
 
 env:
   TEST_OWNER: '@camunda/core-features'
+  TEST_PRODUCT: 'optimize'
+  TEST_TYPE: 'E2E Self-Managed'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 permissions:
@@ -146,6 +148,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          job_name: ${{ github.job }}-${{ env.BRANCH_SLUG }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -27,7 +27,11 @@ permissions:
 
 jobs:
   e2e-full:
-    name: "E2E Self-Managed (Full + Visual)"
+    name: "E2E Self-Managed (Full + Visual) [${{ matrix.branch }}]"
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, stable/8.8, stable/8.9]
     permissions:
       contents: read
       id-token: write # for authenticating with GCP
@@ -39,6 +43,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Set branch slug
+        run: echo "BRANCH_SLUG=$(echo '${{ matrix.branch }}' | tr '/' '-')" >> "$GITHUB_ENV"
 
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -115,21 +124,21 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: optimize-e2e-nightly-logs
+          name: optimize-e2e-nightly-logs-${{ env.BRANCH_SLUG }}
           path: ./optimize/client/build/*.log
 
       - name: Upload diff images as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: visual-regression-report
+          name: visual-regression-report-${{ env.BRANCH_SLUG }}
           path: ./optimize/client/e2e/screenshots/
 
       - name: Docker log dump
         uses: ./.github/actions/docker-logs
         if: always()
         with:
-          archive_name: optimize-e2e-nightly-docker-logs
+          archive_name: optimize-e2e-nightly-docker-logs-${{ env.BRANCH_SLUG }}
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -99,13 +99,14 @@ jobs:
 
       - name: Wait for import to complete
         run: |
+          expected=${{ matrix.branch == 'stable/8.8' && '49' || '17' }}
           while : ; do
             count=$(curl -s -X GET "http://localhost:9200/optimize-process-definition/_count" | jq '.count')
-            if [[ $count -eq 49 ]]; then
+            if [[ $count -eq $expected ]]; then
               echo "Import Completed"
               break
             fi
-            echo "Index has $count entities. Waiting for 49..."
+            echo "Index has $count entities. Waiting for $expected..."
             sleep 10
           done
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Enables stable branch coverage for 8.8 and 8.9 for Optimize nightly CIs. 8.7 does not have these nightly tests and thus is not included.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54790