### PR TITLE
fix: fix tomcat config for optimize https

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
@@ -191,7 +191,6 @@ public class OptimizeTomcatConfig {
 
   private SSLHostConfig getSslHostConfig() {
     final SSLHostConfig sslHostConfig = new SSLHostConfig();
-    sslHostConfig.setHostName(configurationService.getContainerHost());
 
     final SSLHostConfigCertificate cert =
         new SSLHostConfigCertificate(sslHostConfig, Type.UNDEFINED);
@@ -232,6 +231,7 @@ public class OptimizeTomcatConfig {
     applyCommonConfiguration(connector);
     connector.setPort(getPort(EnvironmentPropertiesConstants.HTTPS_PORT_KEY));
     connector.setScheme("https");
+    connector.setProperty("SSLEnabled", "true");
     connector.setSecure(true);
 
     connector.setProperty("protocol", HTTP11_NIO_PROTOCOL);

--- a/optimize/backend/src/test/java/io/camunda/optimize/OptimizeTomcatConfigTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/OptimizeTomcatConfigTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.EnvironmentPropertiesConstants;
 import org.apache.catalina.connector.Connector;
+import org.apache.tomcat.util.net.SSLHostConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -47,7 +48,6 @@ public class OptimizeTomcatConfigTest {
     when(environment.getProperty(EnvironmentPropertiesConstants.HTTP_PORT_KEY)).thenReturn("8090");
     when(environment.getProperty(EnvironmentPropertiesConstants.HTTPS_PORT_KEY)).thenReturn("8091");
 
-    when(configurationService.getContainerHost()).thenReturn("localhost");
     // then
     optimizeTomcatConfig.tomcatFactoryCustomizer().customize(factory);
 
@@ -65,6 +65,7 @@ public class OptimizeTomcatConfigTest {
     final Connector httpConnector = connectorCaptor.getValue();
     assertThat(httpConnector.getPort()).isEqualTo(8090);
     assertThat(httpConnector.getScheme()).isEqualTo("http");
+    assertThat(httpsConnector.getProperty("SSLEnabled")).isEqualTo(true);
     assertThat(httpConnector.getSecure()).isFalse();
   }
 
@@ -75,7 +76,6 @@ public class OptimizeTomcatConfigTest {
     when(environment.getProperty(EnvironmentPropertiesConstants.HTTP_PORT_KEY)).thenReturn("");
     when(environment.getProperty(EnvironmentPropertiesConstants.HTTPS_PORT_KEY)).thenReturn("8091");
 
-    when(configurationService.getContainerHost()).thenReturn("localhost");
     // then
     optimizeTomcatConfig.tomcatFactoryCustomizer().customize(factory);
 
@@ -89,6 +89,23 @@ public class OptimizeTomcatConfigTest {
     assertThat(httpsConnector.getPort()).isEqualTo(8091);
     assertThat(httpsConnector.getScheme()).isEqualTo("https");
     assertThat(httpsConnector.getSecure()).isTrue();
+    assertThat(httpsConnector.getProperty("SSLEnabled")).isEqualTo(true);
+  }
+
+  @Test
+  public void shouldNotSetHostNameOnSslHostConfig() {
+    // given
+    when(environment.getProperty(anyString())).thenReturn("property");
+    when(environment.getProperty(EnvironmentPropertiesConstants.HTTPS_PORT_KEY)).thenReturn("8091");
+
+    // when
+    final Connector httpsConnector = new Connector();
+    optimizeTomcatConfig.configureHttpsConnector(httpsConnector);
+
+    // then - hostname on the SSLHostConfig should not be set to the container host
+    final SSLHostConfig[] sslHostConfigs = httpsConnector.findSslHostConfigs();
+    assertThat(sslHostConfigs).hasSize(1);
+    assertThat(sslHostConfigs[0].getHostName()).isEqualTo("_default_");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Performs the two bugfixes to allow Optimize to serve HTTPS configurations correctly. The bugfixes are:

1. SSLEnabled never set on the connector (configureHttpsConnector) – connector was never switched into TLS mode.
2. Wrong hostname on SSLHostConfig (getSslHostConfig) – should not be set as Tomcat's connector looks for `_default_` hostname (i.e. not set).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55403
