### PR TITLE
docs: update load-tests documentation for setup/main modernization

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -365,7 +365,7 @@ Select the `scenario` input in the workflow dispatch form:
 - `realistic` — complex, customer-like workload with multi-instance activities, call activities, and DMN; use this for release-like validation and broader functional realism. See [realistic load](../docs/testing/reliability-testing.md#realistic-load).
 - `typical` — straight-through baseline with a representative BPMN model and `50` PI/s target load; use it for sustained baseline comparisons. See [typical load](../docs/testing/reliability-testing.md#typical-load).
 - `latency` — low-throughput artificial workload (`1` PI/s, `1` worker) to isolate latency and reduce blast radius while debugging. See [latency load test](../docs/testing/reliability-testing.md#latency-load-test).
-- `archiver` — multi-instance archiver-focused scenario with no workers; use it when validating archiver or secondary-storage-related behavior. Its current wiring is defined in [`load-tests/setup/default/Makefile`](setup/default/Makefile).
+- `archiver` — multi-instance archiver-focused scenario with no workers; use it when validating archiver or secondary-storage-related behavior. Its current wiring is defined in [`load-tests/setup/main/Makefile`](setup/main/Makefile).
 
 For manual runs and deeper scenario details, see [`load-tests/setup/README.md`](setup/README.md#running-specific-scenarios).
 

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -85,18 +85,31 @@ Shared baseline platform config lives in `camunda-platform-values-defaults.yaml`
 ### How to set up a load test namespace
 
 The root `newLoadTest.sh` is a **version dispatcher** — it forwards to a version-specific script
-under `setup/<version>/newLoadTest.sh`, defaulting to `main`. This lets each stable branch carry
-its own setup without path conflicts. To target a specific version explicitly, pass
-`--target-version <version>` (or `-t <version>`) before the namespace argument:
+under `setup/<version>/newLoadTest.sh`. Available versions:
+
+| Version     | Targets             |
+|-------------|---------------------|
+| `main`      | current dev (default) |
+| `stable-89` | stable/8.9          |
+| `stable-88` | stable/8.8          |
+| `stable-87` | stable/8.7          |
+
+Pass `--target-version <version>` (or `-t <version>`) to select a version; omit it to use `main`:
 
 ```sh
-./newLoadTest.sh --target-version main my-load-test
+./newLoadTest.sh my-load-test                          # targets main (default)
+./newLoadTest.sh --target-version stable-89 my-test   # targets stable/8.9
 ```
 
-Running without `--target-version` targets `main` by default. The rest of this section documents
-the `main` setup.
+To see all available options for a version, pass `-h` after `--target-version`:
 
-If you run `newLoadTest.sh` without arguments, it will display the following help message.
+```sh
+./newLoadTest.sh --target-version stable-89 -h
+```
+
+The rest of this section documents the `main` setup.
+
+Running `newLoadTest.sh` without arguments shows the `main` help:
 
 ```sh
 Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -85,26 +85,14 @@ Shared baseline platform config lives in `camunda-platform-values-defaults.yaml`
 ### How to set up a load test namespace
 
 The root `newLoadTest.sh` is a **version dispatcher** — it forwards to a version-specific script
-under `setup/<version>/newLoadTest.sh`. Available versions:
+under `setup/<version>/newLoadTest.sh`, defaulting to `main`. Each stable version has its own
+subfolder (`stable-87`, `stable-88`, …) so all version setups live on `main` without backports.
 
-| Version     | Targets             |
-|-------------|---------------------|
-| `main`      | current dev (default) |
-| `stable-89` | stable/8.9          |
-| `stable-88` | stable/8.8          |
-| `stable-87` | stable/8.7          |
-
-Pass `--target-version <version>` (or `-t <version>`) to select a version; omit it to use `main`:
+Run `./newLoadTest.sh --help` to see currently available versions. To target a specific version:
 
 ```sh
-./newLoadTest.sh my-load-test                          # targets main (default)
-./newLoadTest.sh --target-version stable-89 my-test   # targets stable/8.9
-```
-
-To see all available options for a version, pass `-h` after `--target-version`:
-
-```sh
-./newLoadTest.sh --target-version stable-89 -h
+./newLoadTest.sh --target-version stable-89 my-test   # stable/8.9 setup
+./newLoadTest.sh --target-version stable-89 -h        # version-specific help
 ```
 
 The rest of this section documents the `main` setup.

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -84,6 +84,18 @@ Shared baseline platform config lives in `camunda-platform-values-defaults.yaml`
 
 ### How to set up a load test namespace
 
+The root `newLoadTest.sh` is a **version dispatcher** — it forwards to a version-specific script
+under `setup/<version>/newLoadTest.sh`, defaulting to `main`. This lets each stable branch carry
+its own setup without path conflicts. To target a specific version explicitly, pass
+`--target-version <version>` (or `-t <version>`) before the namespace argument:
+
+```sh
+./newLoadTest.sh --target-version main my-load-test
+```
+
+Running without `--target-version` targets `main` by default. The rest of this section documents
+the `main` setup.
+
 If you run `newLoadTest.sh` without arguments, it will display the following help message.
 
 ```sh
@@ -114,7 +126,7 @@ Example:
 
 This will source and run the `newLoadTest.sh` script. A new folder is created with the given name, containing a rendered Makefile, Helm values, and (under `resources/`) two Kubernetes manifests: `namespace.yaml` (labels, AZ pinning, TTL) and `camunda-credentials.yaml` (randomly generated passwords/tokens). The cluster itself is unchanged by this script — `make install` from inside the folder runs `kubectl apply -f resources/…` to create the namespace and secret. Reruns after a TTL deletion reapply the same manifests, so the orchestration secret stays in sync with `load-test-values.yaml` and you don't lose credentials.
 
-The template files live under `setup/default/`:
+The template files live under `setup/main/`:
 
 - `Makefile` — rendered into the namespace folder with placeholders substituted.
 - `values/` — Helm values files. All installs start from

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -2,8 +2,15 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+list_versions() {
+  find "$SCRIPT_DIR" -mindepth 2 -maxdepth 2 -name newLoadTest.sh 2>/dev/null \
+    | xargs -I{} dirname {} | xargs -I{} basename {} | sort | tr '\n' ' '
+}
+
 usage() {
-  cat <<'EOF'
+  local available
+  available=$(list_versions)
+  cat <<EOF
 Usage: newLoadTest.sh [--target-version|-t <version>] [options] <namespace>
 
 Options:
@@ -11,9 +18,9 @@ Options:
   -h                               Show this help message.
 
 All other options are forwarded to the target version's newLoadTest.sh.
-For version-specific help, run: ./newLoadTest.sh --target-version main -h
+For version-specific help, run: ./newLoadTest.sh --target-version <version> -h
 
-Available versions: main, stable-89, stable-88, stable-87
+Available versions: ${available:-main}
 EOF
 }
 
@@ -46,9 +53,7 @@ target_script="$SCRIPT_DIR/$target_version/newLoadTest.sh"
 
 if [[ ! -f "$target_script" ]]; then
   echo "Error: No setup found for version '$target_version'." >&2
-  available=$(find "$SCRIPT_DIR" -mindepth 2 -maxdepth 2 -name newLoadTest.sh 2>/dev/null \
-    | xargs -I{} dirname {} | xargs -I{} basename {} | tr '\n' ' ')
-  echo "Available versions: ${available:-none}" >&2
+  echo "Available versions: $(list_versions)" >&2
   exit 1
 fi
 

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -9,7 +9,7 @@ For the full operational reference (architecture, scenarios, scheduling, seconda
 Helm value typing pitfalls), see [`load-tests/README.md`](https://github.com/camunda/camunda/blob/main/load-tests/README.md). For metrics
 definitions, SLO targets, and Prometheus queries, see
 [`load-tests/docs/metrics.md`](https://github.com/camunda/camunda/blob/main/load-tests/docs/metrics.md). For the canonical schema of every
-available chart value (beyond what `load-tests/setup/default/values/camunda-platform-values-defaults.yaml` overrides), see
+available chart value (beyond what `load-tests/setup/main/values/camunda-platform-values-defaults.yaml` overrides), see
 the upstream chart at [`camunda/camunda-platform-helm`](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform).
 
 ## Prerequisites check
@@ -175,10 +175,10 @@ Configuration is driven by the values files at the setup folder which is created
 
 For example:
 
-- `load-tests/setup/default/values/camunda-platform-values-defaults.yaml` — platform chart overrides (image tag, resources,
+- `load-tests/setup/main/values/camunda-platform-values-defaults.yaml` — platform chart overrides (image tag, resources,
   exporters, secondary storage)
-- `load-tests/setup/default/values/camunda-platform-values-${storage}.yaml` — platform chart overrides for secondary storage-specific configuration (e.g. Elasticsearch JVM settings, OpenSearch auth)
-- `load-tests/setup/default/values/load-test-values.yaml` — load tester chart overrides (rate, scenario, worker)
+- `load-tests/setup/main/values/camunda-platform-values-${storage}.yaml` — platform chart overrides for secondary storage-specific configuration (e.g. Elasticsearch JVM settings, OpenSearch auth)
+- `load-tests/setup/main/values/load-test-values.yaml` — load tester chart overrides (rate, scenario, worker)
 
 Override individual keys by passing extra `--set` flags to the `make` calls (see Update / redeploy below). Full reference in
 `load-tests/setup/README.md`.
@@ -226,8 +226,8 @@ kubectl get namespaces -l camunda.io/purpose=load-test,camunda.io/created-by=$(g
 
 ```bash
 # Read default Helm values (know what keys to override)
-cat load-tests/setup/default/values/camunda-platform-values-defaults.yaml
-cat load-tests/setup/default/values/load-test-values.yaml
+cat load-tests/setup/main/values/camunda-platform-values-defaults.yaml
+cat load-tests/setup/main/values/load-test-values.yaml
 
 # What inputs were dispatched into a GHA run? The build/install jobs print
 # the resolved values and parameters into the GitHub Actions step summary.
@@ -269,7 +269,7 @@ gh workflow run camunda-load-test.yml --repo camunda/camunda \
 
 Faster than GHA for tweaking Helm values against an already-running deployments. See `load-tests/setup/README.md` for full manual setup documentation.
 
-**Always pin the image** — `load-tests/setup/default/values/camunda-platform-values-defaults.yaml` defaults to `tag: SNAPSHOT`,
+**Always pin the image** — `load-tests/setup/main/values/camunda-platform-values-defaults.yaml` defaults to `tag: SNAPSHOT`,
 which floats. For an iterative loop you usually want a specific tag (the one from the previous
 GHA build, or a released `orchestration-tag`):
 


### PR DESCRIPTION
## Summary

- Updates all `setup/default/` path references to `setup/main/` in `load-tests/README.md`, `load-tests/setup/README.md`, and the `load-test-ops` skill
- Documents the new `newLoadTest.sh` version dispatcher and its `--target-version` flag in `setup/README.md`

Closes #54235 (documentation part of the modernization)

## Test plan

- [ ] Verify all linked paths resolve correctly (no broken links to `setup/default/`)
- [ ] Confirm `setup/README.md` dispatcher section accurately reflects the wrapper behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)