### PR TITLE
test: stabilize tenant assignment and cluster variable search API tests on stable/8.9

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-search-api.spec.ts
@@ -409,7 +409,7 @@ test.describe.parallel('Search Cluster Variables API Tests', () => {
         },
         body,
       );
-      assertPaginatedRequest(res, {
+      await assertPaginatedRequest(res, {
         itemLengthGreaterThan: 1,
         totalItemGreaterThan: 1,
       });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/tenant-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/tenant-requestHelpers.ts
@@ -20,7 +20,7 @@ import {
   jsonHeaders,
 } from '../http';
 import {expect} from '@playwright/test';
-import {generateUniqueId} from '../constants';
+import {defaultAssertionOptions, generateUniqueId} from '../constants';
 import {
   CREATE_NEW_TENANT,
   roleRequiredFields,
@@ -48,11 +48,15 @@ export async function assignUsersToTenant(
       userId: user.username,
       tenantId: tenantId,
     };
-    const res = await request.put(
-      buildUrl('/tenants/{tenantId}/users/{userId}', p),
-      {headers: jsonHeaders()},
-    );
-    await assertStatusCode(res, 204);
+    // Retry: the freshly created user/tenant may not yet be visible to the
+    // assignment command, which surfaces as a transient 404.
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/users/{userId}', p),
+        {headers: jsonHeaders()},
+      );
+      await assertStatusCode(res, 204);
+    }).toPass(defaultAssertionOptions);
     state[`username${tenantId}${i}`] = user.username;
   }
 }
@@ -158,13 +162,17 @@ export async function assignRolesToTenant(
       roleId: roleIdValueUsingKey(tenantIdKey, state, i) as string,
       tenantId: tenantId as string,
     };
-    const res = await request.put(
-      buildUrl('/tenants/{tenantId}/roles/{roleId}', p),
-      {
-        headers: jsonHeaders(),
-      },
-    );
-    await assertStatusCode(res, 204);
+    // Retry: the freshly created role/tenant may not yet be visible to the
+    // assignment command, which surfaces as a transient 404.
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/roles/{roleId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertStatusCode(res, 204);
+    }).toPass(defaultAssertionOptions);
   }
 }
 


### PR DESCRIPTION
## Description

Fixes three failing nightly E2E/API tests (Elasticsearch, `stable/8.9`) that share an eventual-consistency root cause.

### `tenant-role-api-tests` / `tenant-users-api-tests` — 404 in `beforeAll`
The reporter attributed the failures to `Assign Already Added Role To Tenant - Conflict` and `Assign User To Tenant`, but the stack traces point at the `beforeAll` setup helpers (`assignRolesToTenant`, `assignUsersToTenant`). These helpers PUT the tenant assignment immediately after creating the role/user — before the new entity is visible to the assignment command — which returns a transient `404`. `beforeAll` is not wrapped in a retry, so the whole describe block fails.

**Fix:** wrap the assignment PUTs in `expect(...).toPass(defaultAssertionOptions)`, matching the retry pattern already used by `createMappingRule` and the cluster-variable helpers.

### `Search Cluster Variables Finds Created Variables` — missing `await`
The test failed in ~90ms (no retry) even though it is wrapped in `toPass`. The cause: `assertPaginatedRequest` is `async` but was called **without `await`** on the `totalItemGreaterThan: 1` assertion, so its rejection escaped the `toPass` callback as a floating promise and failed the test immediately. Every other call site already awaits it.

**Fix:** add the missing `await` so the retry window absorbs index-propagation lag while the second global variable becomes searchable.

### Scope
- Test-only change (commit type `test:`).
- No product code touched; no skips/fixmes introduced.
- Pre-existing unrelated `tsc` error in `v2-stateless-tests/request-validation-test-generator/scripts/sync-tests.ts` is present on the clean branch and is out of scope.

Originating nightly run: https://github.com/camunda/camunda/actions/runs/27731390133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/27739216608
