### PR TITLE
refactor: remove redundant instanceof guard in per-group baseline count retrieval

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterES.java
@@ -19,7 +19,6 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessRepor
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
 import io.camunda.optimize.service.db.es.filter.ProcessQueryFilterEnhancerES;
-import io.camunda.optimize.service.db.es.report.interpreter.groupby.process.ProcessGroupByInterpreterES;
 import io.camunda.optimize.service.db.es.report.interpreter.groupby.process.ProcessGroupByInterpreterFacadeES;
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
@@ -94,12 +93,8 @@ public class GenericProcessExecutionPlanInterpreterES
   protected Map<String, Long> retrievePerGroupBaselineCounts(
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
       final String[] indices) {
-    if (!(getGroupByInterpreter()
-        instanceof final ProcessGroupByInterpreterES groupByInterpreter)) {
-      return Map.of();
-    }
     final Optional<String> baselineField =
-        groupByInterpreter.getBaselineCountAggregationField(context);
+        getGroupByInterpreter().getBaselineCountAggregationField(context);
     if (baselineField.isEmpty()) {
       return Map.of();
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterOS.java
@@ -14,7 +14,6 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessRepor
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.report.filter.ProcessQueryFilterEnhancerOS;
 import io.camunda.optimize.service.db.os.report.interpreter.groupby.process.ProcessGroupByInterpreterFacadeOS;
-import io.camunda.optimize.service.db.os.report.interpreter.groupby.process.ProcessGroupByInterpreterOS;
 import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.report.ExecutionContext;
@@ -92,12 +91,8 @@ public class GenericProcessExecutionPlanInterpreterOS
   protected Map<String, Long> retrievePerGroupBaselineCounts(
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
       final String[] indices) {
-    if (!(getGroupByInterpreter()
-        instanceof final ProcessGroupByInterpreterOS groupByInterpreter)) {
-      return Map.of();
-    }
     final Optional<String> baselineField =
-        groupByInterpreter.getBaselineCountAggregationField(context);
+        getGroupByInterpreter().getBaselineCountAggregationField(context);
     if (baselineField.isEmpty()) {
       return Map.of();
     }


### PR DESCRIPTION
related to #55294

## Description
Follow up PR to address https://github.com/camunda/camunda/pull/55295#discussion_r3429211439

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related #55294
