### PR TITLE
fix: Optimize DefinitionService throws NPE on missing processDefinitionVersion

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/DefinitionService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/DefinitionService.java
@@ -447,7 +447,7 @@ public class DefinitionService implements ConfigurationReloadable {
                     getDefinition(
                         DefinitionType.PROCESS,
                         processDefinition.getLeft(),
-                        List.of(processDefinition.getRight()),
+                        Stream.ofNullable(processDefinition.getRight()).toList(),
                         Collections.emptyList()))
             .filter(Optional::isPresent)
             .map(Optional::get)

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/DefinitionServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/DefinitionServiceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.service.db.reader.DefinitionReader;
+import io.camunda.optimize.service.security.util.definition.DataSourceDefinitionAuthorizationService;
+import io.camunda.optimize.service.tenant.TenantService;
+import io.camunda.optimize.service.util.configuration.CacheConfiguration;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.GlobalCacheConfiguration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefinitionServiceTest {
+
+  @Mock private DefinitionReader definitionReader;
+  @Mock private DataSourceDefinitionAuthorizationService definitionAuthorizationService;
+  @Mock private TenantService tenantService;
+  @Mock private ConfigurationService configurationService;
+
+  private DefinitionService underTest;
+
+  @BeforeEach
+  void setUp() {
+    final CacheConfiguration cacheConfiguration = new CacheConfiguration();
+    cacheConfiguration.setMaxSize(10);
+    cacheConfiguration.setDefaultTtlMillis(10_000);
+    final GlobalCacheConfiguration globalCacheConfiguration = new GlobalCacheConfiguration();
+    globalCacheConfiguration.setDefinitions(cacheConfiguration);
+    when(configurationService.getCaches()).thenReturn(globalCacheConfiguration);
+    underTest =
+        new DefinitionService(
+            definitionReader, definitionAuthorizationService, tenantService, configurationService);
+  }
+
+  @Test
+  void shouldReturnEmptyFlowNodeNamesWhenProcessDefinitionVersionIsNull() {
+    // given
+    final ProcessInstanceDto instance = new ProcessInstanceDto();
+    instance.setProcessDefinitionKey("my-process");
+    instance.setProcessDefinitionVersion(null);
+
+    // when
+    final Map<String, String> result =
+        underTest.fetchDefinitionFlowNodeNamesAndIdsForProcessInstances(List.of(instance));
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyFlowNodeNamesWhenProcessInstanceListIsEmpty() {
+    // when
+    final Map<String, String> result =
+        underTest.fetchDefinitionFlowNodeNamesAndIdsForProcessInstances(Collections.emptyList());
+
+    // then
+    assertThat(result).isEmpty();
+  }
+}


### PR DESCRIPTION
## Description

Since the downstream code `getFirstFullyImportedDefinitionFromTenantsIfAvailable` already treats the empty versions case,  handle the case in `DefinitionService` with `Stream.ofNullable(processDefinition.getRight()).toList()` which would not throw NPE.

Maybe we should consider adding a debug log mentioning `definitionType`, `definitionKey` or `definitionVersions` in a common place like: 
- `DefinitionReaderES.getFirstFullyImportedDefinitionFromTenantsIfAvailable`
- `DefinitionReaderOS.getFirstFullyImportedDefinitionFromTenantsIfAvailable`

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues
relative discussion ([ref](https://camunda.slack.com/archives/C0B79MV2K8Q/p1781688617836959?thread_ts=1781687800.937969&cid=C0B79MV2K8Q))
closes #54800
