### PR TITLE
feat: fail-fast PhysicalTenantContext.current() outside request scope

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/config/spi/BasicAuthUserDetailsAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/BasicAuthUserDetailsAdapterTest.java
@@ -46,8 +46,9 @@ class BasicAuthUserDetailsAdapterTest {
                 b.userServices("default", defaultUserServices)
                     .userServices("tenanta", tenantAUserServices));
     adapter = new BasicAuthUserDetailsAdapter(serviceRegistry);
-    // Ensure no stale request context from a previous test
-    RequestContextHolder.resetRequestAttributes();
+    // Bind a plain request with no PT attribute — models a non-prefixed /v2/... cluster request
+    RequestContextHolder.setRequestAttributes(
+        new ServletRequestAttributes(new MockHttpServletRequest()));
   }
 
   @AfterEach
@@ -57,7 +58,7 @@ class BasicAuthUserDetailsAdapterTest {
 
   @Test
   void shouldMapUserEntityToCamundaUserDetails() {
-    // given — no request context: defaults to "default" tenant
+    // given — request bound with no PT attribute: resolves to the "default" tenant
     when(defaultUserServices.getUser(any(), any()))
         .thenReturn(new UserEntity(100L, TEST_USER_ID, "Foo Bar", "email@tested", "password1"));
 
@@ -90,8 +91,8 @@ class BasicAuthUserDetailsAdapterTest {
   }
 
   @Test
-  void shouldFallBackToDefaultTenantWhenNoRequestContextBound() {
-    // given — no request context at all
+  void shouldUseDefaultTenantWhenRequestHasNoPhysicalTenantPrefix() {
+    // given — request bound (set in setUp) but no PT attribute stamped (non-prefixed /v2/... path)
     when(defaultUserServices.getUser(any(), any()))
         .thenReturn(new UserEntity(100L, TEST_USER_ID, "Foo Bar", "email@tested", "password1"));
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -71,7 +71,9 @@ class ProcessesToolRepositoryTest {
         .when(serviceRegistry.messageSubscriptionServices(any()))
         .thenReturn(messageSubscriptionServices);
     lenient().when(serviceRegistry.messageServices(any())).thenReturn(messageServices);
-    // Bind a plain request with no PT attribute — models a non-prefixed /mcp/... cluster request
+    // Bind a request so current() resolves on the request thread; with no PT attribute it falls
+    // back to the default tenant. (A real /mcp/... request differs — the MCP filter stamps the
+    // default explicitly — but exercising current()'s fallback is sufficient for these tests.)
     RequestContextHolder.setRequestAttributes(
         new ServletRequestAttributes(new MockHttpServletRequest()));
   }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
@@ -67,6 +71,14 @@ class ProcessesToolRepositoryTest {
         .when(serviceRegistry.messageSubscriptionServices(any()))
         .thenReturn(messageSubscriptionServices);
     lenient().when(serviceRegistry.messageServices(any())).thenReturn(messageServices);
+    // Bind a plain request with no PT attribute — models a non-prefixed /mcp/... cluster request
+    RequestContextHolder.setRequestAttributes(
+        new ServletRequestAttributes(new MockHttpServletRequest()));
+  }
+
+  @AfterEach
+  void clearRequestContext() {
+    RequestContextHolder.resetRequestAttributes();
   }
 
   private static MessageSubscriptionEntity buildStartSubscriptionEntity(

--- a/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantContext.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantContext.java
@@ -53,10 +53,12 @@ public final class PhysicalTenantContext {
   /**
    * Returns the resolved physical tenant id for the request being processed on the current thread.
    *
-   * <p>When the request carries the {@code /physical-tenants/{physicalTenantId}/...} prefix, the id
-   * stamped by {@code PhysicalTenantFilter} (gateway-rest) or the MCP {@code defaultTenantFilter}
-   * is returned. For non-prefixed requests (plain {@code /v2/...} or {@code /mcp/...}) the filter
-   * stamps {@link PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} and that value is returned.
+   * <p>For prefixed {@code /physical-tenants/{physicalTenantId}/...} requests the id is stamped on
+   * the request by {@code PhysicalTenantFilter} (gateway-rest) or by the MCP gateway filter, and
+   * that value is returned. Non-prefixed requests resolve to {@link
+   * PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} via different mechanisms: for REST {@code
+   * /v2/...} {@code PhysicalTenantFilter} stamps nothing and this method falls back to the default;
+   * for MCP {@code /mcp/...} the MCP autoconfiguration stamps the default explicitly.
    *
    * @return the physical tenant id for the current request; never {@code null}
    * @throws IllegalStateException if called outside a servlet-request scope (i.e. {@link

--- a/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantContext.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantContext.java
@@ -51,14 +51,23 @@ public final class PhysicalTenantContext {
   }
 
   /**
-   * @return the resolved physical tenant id for the request being processed on this thread, or
-   *     {@link PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} when no request context is bound or
-   *     the attribute is not set.
+   * Returns the resolved physical tenant id for the request being processed on the current thread.
+   *
+   * <p>When the request carries the {@code /physical-tenants/{physicalTenantId}/...} prefix, the id
+   * stamped by {@code PhysicalTenantFilter} (gateway-rest) or the MCP {@code defaultTenantFilter}
+   * is returned. For non-prefixed requests (plain {@code /v2/...} or {@code /mcp/...}) the filter
+   * stamps {@link PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} and that value is returned.
+   *
+   * @return the physical tenant id for the current request; never {@code null}
+   * @throws IllegalStateException if called outside a servlet-request scope (i.e. {@link
+   *     RequestContextHolder#getRequestAttributes()} returns {@code null})
    */
   public static String current() {
     final RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
     if (attributes == null) {
-      return PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+      throw new IllegalStateException(
+          "PhysicalTenantContext.current() called outside a request scope; "
+              + "the physical tenant must be resolved on the request thread (or supplied explicitly).");
     }
     final String value =
         asString(

--- a/spring-utils/src/test/java/io/camunda/spring/utils/PhysicalTenantContextTest.java
+++ b/spring-utils/src/test/java/io/camunda/spring/utils/PhysicalTenantContextTest.java
@@ -8,6 +8,7 @@
 package io.camunda.spring.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import jakarta.servlet.http.HttpServletRequest;
@@ -49,9 +50,21 @@ class PhysicalTenantContextTest {
   }
 
   @Test
-  void shouldReturnDefaultFromCurrentWhenNoRequestBound() {
+  void shouldThrowWhenNoRequestBound() {
     // given: no RequestContextHolder bound
     RequestContextHolder.resetRequestAttributes();
+
+    // when / then
+    assertThatThrownBy(PhysicalTenantContext::current)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("request scope");
+  }
+
+  @Test
+  void shouldReturnDefaultFromCurrentWhenRequestBoundButNoPtAttribute() {
+    // given: request bound but no PT attribute set (non-prefixed /v2/... cluster request)
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
     // when / then
     assertThat(PhysicalTenantContext.current())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/resolver/PhysicalTenantIdArgumentResolverTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/resolver/PhysicalTenantIdArgumentResolverTest.java
@@ -40,7 +40,10 @@ class PhysicalTenantIdArgumentResolverTest {
 
   @Test
   void defaultsForClusterPathWithoutStampedId() {
-    // given a cluster (non-prefixed) request — no PT id is stamped
+    // given a cluster (non-prefixed) request — request is bound but no PT id is stamped
+    RequestContextHolder.setRequestAttributes(
+        new ServletRequestAttributes(new MockHttpServletRequest()));
+
     // when / then: must default, never null (a null id breaks command building downstream)
     assertThat(resolver.resolveArgument(null, null, null, null))
         .isEqualTo(DEFAULT_PHYSICAL_TENANT_ID);


### PR DESCRIPTION
## Description

Slice 1 of the physical-tenant (PT) routing of the authorization layer (ADR-0005).

`PhysicalTenantContext.current()` previously returned the **default** physical tenant whenever it was called off the request thread (no `RequestContextHolder` attributes bound). That silently masks a missing PT resolution as a legitimate `"default"` read — exactly the failure mode the later slices must not allow, since a read resolving to the wrong PT's storage leaks data across tenants.

This change makes `current()` **fail loudly**: it throws `IllegalStateException` when called outside a servlet-request scope, so a misrouted read surfaces at its call site instead of quietly reading the wrong storage. Subsequent slices route per-PT reads on the request thread and rely on this guardrail to catch any caller that escapes the request scope.

The contract for legitimate non-prefixed traffic is unchanged: a request that **is** bound but carries no stamped PT attribute still resolves to the default tenant.

## What changed

- `PhysicalTenantContext.current()` throws `IllegalStateException` when `RequestContextHolder.getRequestAttributes()` is `null`; javadoc updated with `@throws` and clarified per-gateway default resolution.
- Test fallout fixed across modules whose unit tests exercised `current()` without binding a request — they now bind a plain `MockHttpServletRequest` (no PT attribute), which exercises `current()`'s attribute-absent fallback to the default tenant:
  - `BasicAuthUserDetailsAdapterTest` (authentication)
  - `PhysicalTenantIdArgumentResolverTest` (gateway-rest)
  - `ProcessesToolRepositoryTest` (gateway-mcp)

All production callers were audited: each runs on the request thread (request attributes are bound by the gateway filters / MVC / MCP transport before `current()` is reachable), so none is affected.

## Acceptance criteria → confirming tests

| Acceptance criterion | Confirming test(s) |
| --- | --- |
| `current()` throws a clear exception when no request context is bound | `PhysicalTenantContextTest.shouldThrowWhenNoRequestBound` (spring-utils) |
| `current()` returns `default` when a request is bound without a PT prefix | `PhysicalTenantContextTest.shouldReturnDefaultFromCurrentWhenRequestBoundButNoPtAttribute` (spring-utils); end-to-end on the consuming paths via `BasicAuthUserDetailsAdapterTest.shouldUseDefaultTenantWhenRequestHasNoPhysicalTenantPrefix` (authentication) and `PhysicalTenantIdArgumentResolverTest.defaultsForClusterPathWithoutStampedId` (gateway-rest) |
| All `current()` callers audited; no legitimate off-request, non-authz caller relies on the old `default` fallback | Audit documented above (all callers run on the request thread). Regression-confirmed by the updated request-binding suites passing: `BasicAuthUserDetailsAdapterTest`, `PhysicalTenantIdArgumentResolverTest`, `ProcessesToolRepositoryTest` |
| Unit tests cover both branches (no request → throws; request, no prefix → `default`) | `PhysicalTenantContextTest.shouldThrowWhenNoRequestBound` + `PhysicalTenantContextTest.shouldReturnDefaultFromCurrentWhenRequestBoundButNoPtAttribute`; the stamped-prefix branch is covered by `PhysicalTenantContextTest.shouldReturnBoundValueFromCurrent` |

Closes #55437
