### PR TITLE
test: fix CamundaDocumentStoreConfigurationLoaderTest flakiness

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -48,7 +48,7 @@ public final class CamundaDocumentStoreConfigurationLoader
 
   public CamundaDocumentStoreConfigurationLoader(final Camunda camunda) {
     this.document = camunda.getDocument();
-    legacyConfigurationLoader = new EnvironmentConfigurationLoader();
+    this.legacyConfigurationLoader = new EnvironmentConfigurationLoader();
   }
 
   @Override

--- a/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
@@ -50,41 +50,58 @@ class CamundaDocumentStoreConfigurationLoaderTest {
     localStore.setPath("/var/camunda/documents");
     camunda.getDocument().getLocal().put("local1", localStore);
 
-    final var loader = new CamundaDocumentStoreConfigurationLoader(camunda);
+    final var mockEnv = new MockEnvironment();
+    mockEnv.setProperty("camunda.document.default-store-id", "aws1");
+    mockEnv.setProperty("camunda.document.thread-pool-size", "10");
+    mockEnv.setProperty("camunda.document.aws.aws1.bucket-name", "docs");
+    mockEnv.setProperty("camunda.document.aws.aws1.bucket-path", "prod/");
+    mockEnv.setProperty("camunda.document.aws.aws1.bucket-ttl", "30");
+    mockEnv.setProperty("camunda.document.gcp.gcp1.bucket-name", "gcp-docs");
+    mockEnv.setProperty("camunda.document.gcp.gcp1.prefix", "temp/");
+    mockEnv.setProperty("camunda.document.azure.az1.container-name", "container");
+    mockEnv.setProperty(
+        "camunda.document.azure.az1.endpoint", "https://account.blob.core.windows.net");
+    mockEnv.setProperty("camunda.document.local.local1.path", "/var/camunda/documents");
+    UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
 
-    // when
-    final var configuration = loader.loadConfiguration();
+    try {
+      // when
+      final var configuration =
+          new CamundaDocumentStoreConfigurationLoader(camunda).loadConfiguration();
 
-    // then
-    assertThat(configuration.defaultDocumentStoreId()).isEqualTo("aws1");
-    assertThat(configuration.threadPoolSize()).isEqualTo(10);
-    assertThat(configuration.documentStores())
-        .extracting(DocumentStoreConfigurationRecord::id)
-        .containsExactly("aws1", "gcp1", "az1", "local1");
+      // then
+      assertThat(configuration.defaultDocumentStoreId()).isEqualTo("aws1");
+      assertThat(configuration.threadPoolSize()).isEqualTo(10);
+      assertThat(configuration.documentStores())
+          .extracting(DocumentStoreConfigurationRecord::id)
+          .containsExactly("aws1", "gcp1", "az1", "local1");
 
-    assertThat(store("aws1", configuration.documentStores()).providerClass())
-        .isEqualTo(AwsDocumentStoreProvider.class);
-    assertThat(store("aws1", configuration.documentStores()).properties())
-        .containsEntry("BUCKET", "docs")
-        .containsEntry("BUCKET_PATH", "prod/")
-        .containsEntry("BUCKET_TTL", "30");
+      assertThat(store("aws1", configuration.documentStores()).providerClass())
+          .isEqualTo(AwsDocumentStoreProvider.class);
+      assertThat(store("aws1", configuration.documentStores()).properties())
+          .containsEntry("BUCKET", "docs")
+          .containsEntry("BUCKET_PATH", "prod/")
+          .containsEntry("BUCKET_TTL", "30");
 
-    assertThat(store("gcp1", configuration.documentStores()).providerClass())
-        .isEqualTo(GcpDocumentStoreProvider.class);
-    assertThat(store("gcp1", configuration.documentStores()).properties())
-        .containsEntry("BUCKET", "gcp-docs")
-        .containsEntry("PREFIX", "temp/");
+      assertThat(store("gcp1", configuration.documentStores()).providerClass())
+          .isEqualTo(GcpDocumentStoreProvider.class);
+      assertThat(store("gcp1", configuration.documentStores()).properties())
+          .containsEntry("BUCKET", "gcp-docs")
+          .containsEntry("PREFIX", "temp/");
 
-    assertThat(store("az1", configuration.documentStores()).providerClass())
-        .isEqualTo(AzureBlobDocumentStoreProvider.class);
-    assertThat(store("az1", configuration.documentStores()).properties())
-        .containsEntry("CONTAINER", "container")
-        .containsEntry("ENDPOINT", "https://account.blob.core.windows.net");
+      assertThat(store("az1", configuration.documentStores()).providerClass())
+          .isEqualTo(AzureBlobDocumentStoreProvider.class);
+      assertThat(store("az1", configuration.documentStores()).properties())
+          .containsEntry("CONTAINER", "container")
+          .containsEntry("ENDPOINT", "https://account.blob.core.windows.net");
 
-    assertThat(store("local1", configuration.documentStores()).providerClass())
-        .isEqualTo(LocalStorageDocumentStoreProvider.class);
-    assertThat(store("local1", configuration.documentStores()).properties())
-        .containsEntry("PATH", "/var/camunda/documents");
+      assertThat(store("local1", configuration.documentStores()).providerClass())
+          .isEqualTo(LocalStorageDocumentStoreProvider.class);
+      assertThat(store("local1", configuration.documentStores()).properties())
+          .containsEntry("PATH", "/var/camunda/documents");
+    } finally {
+      UnifiedConfigurationHelper.setCustomEnvironment(null);
+    }
   }
 
   @Test
@@ -92,8 +109,12 @@ class CamundaDocumentStoreConfigurationLoaderTest {
     // given
     final var mockEnv = new MockEnvironment();
     mockEnv.setProperty("DOCUMENT_DEFAULT_STORE_ID", "GCP");
+    mockEnv.setProperty(
+        "DOCUMENT_STORE_GCP_CLASS", "io.camunda.document.store.gcp.GcpDocumentStoreProvider");
+    mockEnv.setProperty("DOCUMENT_STORE_GCP_BUCKET", "legacy-bucket");
     UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
 
+    System.setProperty("DOCUMENT_DEFAULT_STORE_ID", "GCP");
     System.setProperty(
         "DOCUMENT_STORE_GCP_CLASS", "io.camunda.document.store.gcp.GcpDocumentStoreProvider");
     System.setProperty("DOCUMENT_STORE_GCP_BUCKET", "legacy-bucket");
@@ -113,6 +134,7 @@ class CamundaDocumentStoreConfigurationLoaderTest {
           .containsEntry("BUCKET", "legacy-bucket");
     } finally {
       UnifiedConfigurationHelper.setCustomEnvironment(null);
+      System.clearProperty("DOCUMENT_DEFAULT_STORE_ID");
       System.clearProperty("DOCUMENT_STORE_GCP_CLASS");
       System.clearProperty("DOCUMENT_STORE_GCP_BUCKET");
     }
@@ -120,21 +142,28 @@ class CamundaDocumentStoreConfigurationLoaderTest {
 
   @Test
   void shouldOmitNullUnifiedFieldsFromStoreProperties() {
-    // given — partial store: only bucketName set, all other fields null
+    // given
     final Camunda camunda = new Camunda();
     final Document.AwsStore awsStore = new Document.AwsStore();
     awsStore.setBucketName("my-bucket");
     camunda.getDocument().getAws().put("s3", awsStore);
 
-    final var loader = new CamundaDocumentStoreConfigurationLoader(camunda);
+    final var mockEnv = new MockEnvironment();
+    mockEnv.setProperty("camunda.document.aws.s3.bucket-name", "my-bucket");
+    UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
 
-    // when
-    final var configuration = loader.loadConfiguration();
+    try {
+      // when
+      final var configuration =
+          new CamundaDocumentStoreConfigurationLoader(camunda).loadConfiguration();
 
-    // then — null fields must not appear in the properties map
-    assertThat(store("s3", configuration.documentStores()).properties())
-        .containsOnlyKeys("BUCKET")
-        .containsEntry("BUCKET", "my-bucket");
+      // then
+      assertThat(store("s3", configuration.documentStores()).properties())
+          .containsOnlyKeys("BUCKET")
+          .containsEntry("BUCKET", "my-bucket");
+    } finally {
+      UnifiedConfigurationHelper.setCustomEnvironment(null);
+    }
   }
 
   @Test
@@ -147,16 +176,27 @@ class CamundaDocumentStoreConfigurationLoaderTest {
     awsStore.setBucketName("new-bucket");
     camunda.getDocument().getAws().put("aws1", awsStore);
 
-    final var loader = new CamundaDocumentStoreConfigurationLoader(camunda);
+    final var mockEnv = new MockEnvironment();
+    mockEnv.setProperty("camunda.document.default-store-id", "aws1");
+    mockEnv.setProperty("camunda.document.thread-pool-size", "12");
+    mockEnv.setProperty("camunda.document.aws.aws1.bucket-name", "new-bucket");
+    mockEnv.setProperty("DOCUMENT_DEFAULT_STORE_ID", "LEGACY");
+    mockEnv.setProperty("DOCUMENT_THREAD_POOL_SIZE", "5");
+    mockEnv.setProperty(
+        "DOCUMENT_STORE_AWS1_CLASS", "io.camunda.document.store.aws.AwsDocumentStoreProvider");
+    mockEnv.setProperty("DOCUMENT_STORE_AWS1_BUCKET", "legacy-bucket");
+    UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
+
     System.setProperty("DOCUMENT_DEFAULT_STORE_ID", "LEGACY");
     System.setProperty("DOCUMENT_THREAD_POOL_SIZE", "5");
     System.setProperty(
-        "DOCUMENT_STORE_AWS1_CLASS", "io.camunda.document.store.gcp.GcpDocumentStoreProvider");
+        "DOCUMENT_STORE_AWS1_CLASS", "io.camunda.document.store.aws.AwsDocumentStoreProvider");
     System.setProperty("DOCUMENT_STORE_AWS1_BUCKET", "legacy-bucket");
 
     try {
       // when
-      final var configuration = loader.loadConfiguration();
+      final var configuration =
+          new CamundaDocumentStoreConfigurationLoader(camunda).loadConfiguration();
 
       // then
       assertThat(configuration.defaultDocumentStoreId()).isEqualTo("aws1");
@@ -166,6 +206,7 @@ class CamundaDocumentStoreConfigurationLoaderTest {
       assertThat(store("aws1", configuration.documentStores()).properties())
           .containsEntry("BUCKET", "new-bucket");
     } finally {
+      UnifiedConfigurationHelper.setCustomEnvironment(null);
       System.clearProperty("DOCUMENT_DEFAULT_STORE_ID");
       System.clearProperty("DOCUMENT_THREAD_POOL_SIZE");
       System.clearProperty("DOCUMENT_STORE_AWS1_CLASS");


### PR DESCRIPTION
## Description

`CamundaDocumentStoreConfigurationLoaderTest#shouldPreferUnifiedConfigurationOverLegacy` seems flaky ([ref](https://github.com/camunda/camunda/actions/runs/27743009544/job/82074543618?pr=55436))

 ## Why tests need both `System.setProperty` and `mockEnv.setProperty` for legacy config
  
  ### Production: one source, two readers

  A single OS env var (e.g. `DOCUMENT_STORE_GCP_BUCKET=legacy-bucket`) is seen by both channels automatically:
  
  - **Channel 1** — `EnvironmentConfigurationLoader` reads it via `System.getenv().get(...)`
  - **Channel 2** — `environmentContainsProperty` reads it via Spring's `StandardEnvironment`,
    which wraps `System.getenv()` inside `SystemEnvironmentPropertySource`

  Set once → both see it. No duplication needed.

  ### Tests: two sources, one per channel

  Java cannot set OS env vars — `System.getenv()` returns an immutable map. So each channel needs its own substitute:

  | What you set | Who sees it | Why |
  | `System.setProperty(key, value)` | Channel 1 only | `EnvironmentConfigurationLoader.getEnvVariable()` falls back to `System.getProperty()` when `System.getenv()` returns null |
  | `mockEnv.setProperty(key, value)` | Channel 2 only | `MockEnvironment` replaces `StandardEnvironment` entirely and does **not** include `SystemPropertiesPropertySource`, so it never sees `System.setProperty()` values |

  PRODUCTION
    OS env var ──► System.getenv()                    ──► EnvironmentConfigurationLoader  (Ch. 1)
               └──► SystemEnvironmentPropertySource   ──► environmentContainsProperty     (Ch. 2)

  TESTS
    System.setProperty()  ──► System.getProperty() fallback ──► Channel 1 only
    mockEnv.setProperty() ─────────────────────────────────► Channel 2 only

  `MockEnvironment` breaks the natural delegation chain that `StandardEnvironment` provides in production,
  so both must be set explicitly in tests.

### No flakiness expected:
  
  - No shared mutable state — setCustomEnvironment(mockEnv) called before, reset in finally
  - No System.setProperty — no cross-test JVM state leak
  - No async/timing — pure synchronous in-memory
  - No external dependencies — no DB, network, filesystem
  - MockEnvironment is local, deterministic 
  - Camunda object freshly constructed each run

## Related issues

closes #
