### PR TITLE
feat: reject assigned providers sharing the same issuer URI at startup

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
@@ -10,8 +10,12 @@ package io.camunda.configuration.physicaltenants;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -52,6 +56,9 @@ import org.springframework.core.env.Environment;
  *       overlay.
  *   <li>A named provider literally called {@value #DEFAULT_SLOT_ASSIGNED_ID} collides with the
  *       reserved default-slot id and is rejected as unsupported.
+ *   <li>Among the effective provider set (the {@code assigned} list, or all providers for the
+ *       default tenant without a selection), no two providers may carry the same {@code
+ *       issuer-uri}: identical issuers produce an ambiguous token-validation chain at runtime.
  * </ul>
  */
 @NullMarked
@@ -85,9 +92,15 @@ final class PhysicalTenantAssignedProvidersValidation {
     final Set<String> rootNamedIds = childSegments(environment, ROOT_NAMED_PROVIDERS);
     final boolean rootDefaultSlotPresent = hasDescendant(environment, ROOT_DEFAULT_SLOT);
 
-    for (final String tenantId : childSegments(environment, PHYSICAL_TENANTS_NAME)) {
+    final Set<String> discoveredTenantIds = childSegments(environment, PHYSICAL_TENANTS_NAME);
+    boolean defaultTenantExplicitlyDiscovered = false;
+
+    for (final String tenantId : discoveredTenantIds) {
       final List<String> assigned = bindAssigned(binder, tenantId);
       final boolean isDefault = PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId);
+      if (isDefault) {
+        defaultTenantExplicitlyDiscovered = true;
+      }
 
       if (!oidcMethod) {
         if (assigned != null) {
@@ -117,6 +130,12 @@ final class PhysicalTenantAssignedProvidersValidation {
         // The default tenant may omit a selection (implicit full set); a non-default tenant must
         // declare one so its provider set is explicit.
         if (isDefault) {
+          // Build the implicit full-set and check it for issuer collisions.
+          final List<String> allProviderIds = new ArrayList<>(namedIds);
+          if (rootDefaultSlotPresent || hasTenantOverlayDefaultSlot(environment, tenantId)) {
+            allProviderIds.add(DEFAULT_SLOT_ASSIGNED_ID);
+          }
+          checkIssuerCollisions(binder, tenantId, allProviderIds);
           continue;
         }
         throw fail(
@@ -160,6 +179,21 @@ final class PhysicalTenantAssignedProvidersValidation {
                     DEFAULT_SLOT_ASSIGNED_ID,
                     ROOT_AUTH));
       }
+
+      checkIssuerCollisions(binder, tenantId, assigned);
+    }
+
+    // The default tenant is synthesized even when no physical tenants are configured at all (the
+    // common single-tenant deployment). If it was never explicitly discovered above, run the
+    // root-level full-set issuer collision check here so that duplicate issuers on cluster-level
+    // providers are still caught.
+    if (oidcMethod && !defaultTenantExplicitlyDiscovered) {
+      final List<String> rootProviderIds = new ArrayList<>(rootNamedIds);
+      if (rootDefaultSlotPresent) {
+        rootProviderIds.add(DEFAULT_SLOT_ASSIGNED_ID);
+      }
+      checkIssuerCollisions(
+          binder, PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID, rootProviderIds);
     }
   }
 
@@ -225,6 +259,60 @@ final class PhysicalTenantAssignedProvidersValidation {
       }
     }
     return false;
+  }
+
+  /**
+   * Resolves the effective {@code issuer-uri} for {@code providerId} under {@code tenantId},
+   * preferring the PT-overlay path and falling back to the root path. Returns {@code null} when
+   * neither path carries a value.
+   */
+  private static @Nullable String resolveIssuerUri(
+      final Binder binder, final String tenantId, final String providerId) {
+    final String ptPath;
+    final String rootPath;
+    if (DEFAULT_SLOT_ASSIGNED_ID.equals(providerId)) {
+      ptPath =
+          "%s.%s.security.authentication.oidc.issuer-uri"
+              .formatted(PHYSICAL_TENANTS_PREFIX, tenantId);
+      rootPath = ROOT_AUTH + ".oidc.issuer-uri";
+    } else {
+      ptPath =
+          "%s.%s.security.authentication.providers.oidc.%s.issuer-uri"
+              .formatted(PHYSICAL_TENANTS_PREFIX, tenantId, providerId);
+      rootPath = ROOT_AUTH + ".providers.oidc." + providerId + ".issuer-uri";
+    }
+    return binder
+        .bind(ptPath, Bindable.of(String.class))
+        .orElseGet(() -> binder.bind(rootPath, Bindable.of(String.class)).orElse(null));
+  }
+
+  /**
+   * Fails if any two provider ids in {@code providerIds} resolve to the same {@code issuer-uri}
+   * under {@code tenantId}. Provider ids whose issuer is {@code null} are skipped (not yet
+   * configured, or set elsewhere).
+   */
+  private static void checkIssuerCollisions(
+      final Binder binder, final String tenantId, final Collection<String> providerIds) {
+    final Map<String, List<String>> byIssuer = new LinkedHashMap<>();
+    // Deduplicate: a repeated id in `assigned` carries the same issuer twice, which would
+    // otherwise appear as a false collision. The distinct set preserves insertion order.
+    for (final String id : new LinkedHashSet<>(providerIds)) {
+      final String issuer = resolveIssuerUri(binder, tenantId, id);
+      if (issuer != null) {
+        byIssuer.computeIfAbsent(issuer, k -> new ArrayList<>()).add(id);
+      }
+    }
+    final List<String> collisions =
+        byIssuer.entrySet().stream()
+            .filter(e -> e.getValue().size() > 1)
+            .map(e -> "issuer '%s' is claimed by providers %s".formatted(e.getKey(), e.getValue()))
+            .toList();
+    if (!collisions.isEmpty()) {
+      throw fail(
+          ("physical tenant '%s' assigns providers sharing the same issuer URI — "
+                  + "each assigned provider must use a distinct issuer. Conflicts: %s")
+              .formatted(tenantId, collisions));
+    }
   }
 
   private static UnifiedConfigurationException fail(final String detail) {

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidationTest.java
@@ -316,6 +316,243 @@ class PhysicalTenantAssignedProvidersValidationTest {
         .doesNotThrowAnyException();
   }
 
+  @Test
+  void shouldRejectIssuerCollisionWhenNoPhysicalTenantsConfigured() {
+    // given an OIDC cluster with no physical tenants and two root-level providers sharing the same
+    // issuer — the synthesized default tenant uses the full set, so the collision must be caught
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri",
+                    "https://idp.example.com",
+                "camunda.security.authentication.providers.oidc.b.issuer-uri",
+                    "https://idp.example.com"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("default")
+        .withMessageContaining("same issuer URI")
+        .withMessageContaining("https://idp.example.com");
+  }
+
+  // -------------------------------------------------------------------------
+  // Issuer URI collision: assigned list
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldRejectTwoNamedProvidersWithSameIssuerInAssigned() {
+    // given two named providers sharing the same issuer-uri, both in a tenant's assigned list
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri",
+                    "https://idp.example.com",
+                "camunda.security.authentication.providers.oidc.b.issuer-uri",
+                    "https://idp.example.com",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[1]",
+                    "b"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("same issuer URI")
+        .withMessageContaining("https://idp.example.com");
+  }
+
+  @Test
+  void shouldRejectDefaultSlotAndNamedProviderSharingIssuerInAssigned() {
+    // given the default slot and a named provider both configured with the same issuer-uri,
+    // and a tenant assigning both via the reserved "oidc" id and the named id
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.issuer-uri", "https://idp.example.com",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri",
+                    "https://idp.example.com",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "oidc",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[1]",
+                    "a"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("same issuer URI")
+        .withMessageContaining("https://idp.example.com");
+  }
+
+  @Test
+  void shouldAcceptAssignedProvidersWithDistinctIssuers() {
+    // given two named providers with different issuers, both in a tenant's assigned list
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri",
+                    "https://idp-a.example.com",
+                "camunda.security.authentication.providers.oidc.b.issuer-uri",
+                    "https://idp-b.example.com",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[1]",
+                    "b"));
+
+    // when / then
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAcceptWhenTwoProvidersShareIssuerButOnlyOneIsAssigned() {
+    // given two cluster-level providers sharing the same issuer, but each tenant assigning only
+    // one — the collision check is scoped to each tenant's effective set, not the root set.
+    // The default tenant must also declare an explicit assigned to avoid seeing both colliding
+    // providers in its implicit full set.
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri",
+                    "https://idp.example.com",
+                "camunda.security.authentication.providers.oidc.b.issuer-uri",
+                    "https://idp.example.com",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "a",
+                // constrain the default tenant too so it does not see both colliding providers
+                "camunda.physical-tenants.default.security.authentication.providers.assigned[0]",
+                    "a"));
+
+    // when / then — no collision in the effective assigned set for either tenant
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldNotReportFalseCollisionForDuplicateIdInAssigned() {
+    // given a single named provider whose id appears twice in assigned (a config typo) — the same
+    // provider id resolves to the same issuer once, so there is no real collision
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri",
+                    "https://idp.example.com",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[1]",
+                    "a"));
+
+    // when / then — deduplication prevents a false issuer-collision report
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAcceptAssignedProvidersWithNullIssuers() {
+    // given assigned providers that have no issuer-uri configured (null issuers are not a
+    // collision)
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.client-id", "client-a",
+                "camunda.security.authentication.providers.oidc.b.client-id", "client-b",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[1]",
+                    "b"));
+
+    // when / then
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRespectTenantOverlayIssuerWhenCheckingCollisions() {
+    // given root providers "a" and "b" sharing the same issuer — a collision at root level.
+    // tenanta overrides "a" to a distinct issuer via its PT overlay, so its effective set has no
+    // collision. The default tenant is constrained to a single-provider assigned so it does not
+    // see the root-level collision.
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri",
+                    "https://idp.example.com",
+                "camunda.security.authentication.providers.oidc.b.issuer-uri",
+                    "https://idp.example.com",
+                // tenanta overrides provider "a" to a different issuer
+                "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.a.issuer-uri",
+                    "https://other-idp.example.com",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]",
+                    "a",
+                "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[1]",
+                    "b",
+                // constrain the default tenant so it does not see both colliding root providers
+                "camunda.physical-tenants.default.security.authentication.providers.assigned[0]",
+                    "a"));
+
+    // when / then — overlay makes the effective issuers distinct for tenanta
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  // -------------------------------------------------------------------------
+  // Issuer URI collision: default tenant with implicit full set (no assigned)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldRejectDefaultTenantWithoutAssignedWhenFullSetHasIssuerCollision() {
+    // given two cluster-level named providers sharing the same issuer, and the default tenant
+    // omitting providers.assigned (implicit full set) — the collision must fail fast
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri",
+                    "https://idp.example.com",
+                "camunda.security.authentication.providers.oidc.b.issuer-uri",
+                    "https://idp.example.com",
+                // trigger default tenant discovery with no assigned
+                "camunda.physical-tenants.default.security.authentication.providers.oidc.a.client-id",
+                    "client-a"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .withMessageContaining("default")
+        .withMessageContaining("same issuer URI")
+        .withMessageContaining("https://idp.example.com");
+  }
+
+  @Test
+  void shouldAcceptDefaultTenantWithoutAssignedWhenFullSetHasDistinctIssuers() {
+    // given two cluster-level named providers with distinct issuers, default tenant with no
+    // assigned
+    final Environment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.providers.oidc.a.issuer-uri",
+                    "https://idp-a.example.com",
+                "camunda.security.authentication.providers.oidc.b.issuer-uri",
+                    "https://idp-b.example.com",
+                "camunda.physical-tenants.default.security.authentication.providers.oidc.a.client-id",
+                    "client-a"));
+
+    // when / then
+    assertThatCode(() -> PhysicalTenantAssignedProvidersValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Config invariant is now enforced at startup: a PT does not assign two providers sharing the same issuer. camunda.security.authentication.oidc.issuer-uri and camunda.security.authentication.providers.oidc.[name].issuer-uri

Error message looks like this:

```
Caused by: io.camunda.configuration.UnifiedConfigurationException: Invalid physical-tenant provider selection: physical tenant 'tenanta' assigns providers sharing the same issuer URI — each assigned provider must use a distinct issuer. Conflicts: [issuer 'https://idp.example.com' is claimed by providers [providera, providerb]]
	at io.camunda.configuration.physicaltenants.PhysicalTenantAssignedProvidersValidation.fail(PhysicalTenantAssignedProvidersValidation.java:298)
	at io.camunda.configuration.physicaltenants.PhysicalTenantAssignedProvidersValidation.checkIssuerCollisions(PhysicalTenantAssignedProvidersValidation.java:290)
	at io.camunda.configuration.physicaltenants.PhysicalTenantAssignedProvidersValidation.validate(PhysicalTenantAssignedProvidersValidation.java:177)
	at io.camunda.configuration.physicaltenants.PhysicalTenantResolver.of(PhysicalTenantResolver.java:91)
	at io.camunda.application.commons.configuration.UnifiedConfigurationModule.physicalTenantResolver(UnifiedConfigurationModule.java:31)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.lambda$instantiate$0(SimpleInstantiationStrategy.java:155)
	... 50 more
```

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #54731 (AC3)
