### PR TITLE
ci: detect Spring Boot starter module path dynamically in maven-snapshot workflow

### DIFF
--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -68,9 +68,9 @@ jobs:
       - name: Detect Spring Boot starter module path
         run: |
           if [ -d "clients/camunda-spring-boot-starter" ]; then
-            echo "SPRING_STARTER_MODULE=clients/camunda-spring-boot-starter" >> $GITHUB_ENV
+            echo "SPRING_STARTER_MODULE=clients/camunda-spring-boot-starter" >> "$GITHUB_ENV"
           elif [ -d "clients/spring-boot-starter-camunda-sdk" ]; then
-            echo "SPRING_STARTER_MODULE=clients/spring-boot-starter-camunda-sdk" >> $GITHUB_ENV
+            echo "SPRING_STARTER_MODULE=clients/spring-boot-starter-camunda-sdk" >> "$GITHUB_ENV"
           else
             echo "ERROR: neither clients/camunda-spring-boot-starter nor clients/spring-boot-starter-camunda-sdk found" >&2
             exit 1

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -64,12 +64,20 @@ jobs:
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       # Scope to shipped modules only (mirrors JAVA_PROJECTS in zeebe-snyk.yml).
       # -am resolves the full transitive tree including BOM-pinned versions.
+      # The Spring Boot starter was renamed between main and stable branches, so detect dynamically.
+      - name: Detect Spring Boot starter module path
+        run: |
+          if [ -d "clients/camunda-spring-boot-starter" ]; then
+            echo "SPRING_STARTER_MODULE=clients/camunda-spring-boot-starter" >> $GITHUB_ENV
+          else
+            echo "SPRING_STARTER_MODULE=clients/spring-boot-starter-camunda-sdk" >> $GITHUB_ENV
+          fi
       - name: Submit Maven dependency snapshot
         uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0
         with:
           token: ${{ github.token }}
           maven-args: >-
-            -pl bom,clients/java,clients/camunda-spring-boot-starter,zeebe/bpmn-model,zeebe/exporter-api,zeebe/gateway-protocol-impl,zeebe/protocol
+            -pl bom,clients/java,${{ env.SPRING_STARTER_MODULE }},zeebe/bpmn-model,zeebe/exporter-api,zeebe/gateway-protocol-impl,zeebe/protocol
             -am
             -Dquickly
           correlator: ${{ github.job }}-maven

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -69,8 +69,11 @@ jobs:
         run: |
           if [ -d "clients/camunda-spring-boot-starter" ]; then
             echo "SPRING_STARTER_MODULE=clients/camunda-spring-boot-starter" >> $GITHUB_ENV
-          else
+          elif [ -d "clients/spring-boot-starter-camunda-sdk" ]; then
             echo "SPRING_STARTER_MODULE=clients/spring-boot-starter-camunda-sdk" >> $GITHUB_ENV
+          else
+            echo "ERROR: neither clients/camunda-spring-boot-starter nor clients/spring-boot-starter-camunda-sdk found" >&2
+            exit 1
           fi
       - name: Submit Maven dependency snapshot
         uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0


### PR DESCRIPTION
## Summary

- `maven-dependency-snapshot.yml` hardcoded `clients/camunda-spring-boot-starter` in its `-pl` list
- This module doesn't exist on `stable/8.7` (or older stable branches) — it's `clients/spring-boot-starter-camunda-sdk` there
- Maven aborts with `Could not find the selected project in the reactor`
- Fix: add a detection step that checks which path exists at runtime before invoking the action

## Test plan

- [ ] Verify CI passes on this PR (runs on `main` where `clients/camunda-spring-boot-starter` exists)
- [ ] After merge, confirm backport to `stable/8.7` fixes the failing push run