### PR TITLE
feat: Enable Reindex by ID as Default Archiver

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -692,6 +692,7 @@ public class BatchOperationIT {
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
+                        .batchOperationKeys(batchOperation.batchOperationKey())
                         .states(BatchOperationState.ACTIVE.name())
                         .build(),
                     BatchOperationSort.of(b -> b),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -197,12 +197,17 @@ public class ExporterConfiguration {
   }
 
   public static class HistoryConfiguration {
+    /* This should be kept in sync with BackgroundTaskManagerFactory.DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE */
+    private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
+    /* This should be kept in sync with BackgroundTaskManagerFactory.DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE */
+    private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE = 500;
+
     private boolean processInstanceEnabled = true;
-    private boolean archiveByIdEnabled = false;
+    private boolean archiveByIdEnabled = true;
     private String elsRolloverDateFormat = "date";
     private String rolloverInterval = "1d";
     private String usageMetricsRolloverInterval = "1M";
-    private int rolloverBatchSize = 100;
+    private Integer rolloverBatchSize;
     private int reindexBatchSize = 2500;
     private int archiveByIdMaxRetryAttempts = 3;
     private int archiveByIdRetryDelayMs = 1000;
@@ -257,6 +262,12 @@ public class ExporterConfiguration {
     }
 
     public int getRolloverBatchSize() {
+      if (rolloverBatchSize == null) {
+        rolloverBatchSize =
+            archiveByIdEnabled
+                ? DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE
+                : DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE;
+      }
       return rolloverBatchSize;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
@@ -60,6 +61,11 @@ import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.slf4j.Logger;
 
 public final class BackgroundTaskManagerFactory {
+  /* This should be kept in sync with HistoryConfiguration.DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE */
+  private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE = 500;
+  /* This should be kept in sync with HistoryConfiguration.DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE */
+  private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
+
   private final int partitionId;
   private final String exporterId;
   private final ExporterConfiguration config;
@@ -318,11 +324,20 @@ public final class BackgroundTaskManagerFactory {
         .map(ProcessInstanceDependant.class::cast)
         .forEach(dependantTemplates::add);
 
+    final HistoryConfiguration history = config.getHistory();
     final ProcessInstanceArchiverJob piArchiverJob;
-    if (config.getHistory().isArchiveByIdEnabled()) {
+    if (history.isArchiveByIdEnabled()) {
+      if (history.getRolloverBatchSize() < DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE) {
+        logger.warn(
+            "Creating process instance archiver job with a roll-over batch size lower than "
+                + "recommended (recommended minimum: {}, configured batch size:{}) ",
+            DEFAULT_HISTORY_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE,
+            history.getRolloverBatchSize());
+      }
+
       piArchiverJob =
           new ProcessInstanceByIdArchiverJob(
-              config.getHistory(),
+              history,
               archiverRepository,
               resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
               dependantTemplates,
@@ -330,9 +345,17 @@ public final class BackgroundTaskManagerFactory {
               logger,
               executor);
     } else {
+      if (history.getRolloverBatchSize() > DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE) {
+        logger.warn(
+            "Creating process instance archiver job with a roll-over batch size higher than "
+                + "recommended (recommended: {}, configured batch size:{}) ",
+            DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE,
+            history.getRolloverBatchSize());
+      }
+
       piArchiverJob =
           new ProcessInstanceArchiverJob(
-              config.getHistory(),
+              history,
               archiverRepository,
               resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
               dependantTemplates,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
@@ -18,10 +18,10 @@ import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 
 /**
- * This is an experimental archiver job for handling process instance data where we reindex
- * documents by id. Similar to the {@link ProcessInstanceArchiverJob} this job handles the archiving
- * of the process instance records itself and also delegates to the repository to move dependent
- * records (decisions, flow node instances, variable updates, etc).
+ * This is an archiver job for archiving process instance data where we reindex documents by id.
+ * Similar to the {@link ProcessInstanceArchiverJob} this job handles the archiving of the process
+ * instance records itself and also delegates to the repository to move dependent records
+ * (decisions, flow node instances, variable updates, etc).
  */
 public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
@@ -17,6 +17,7 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
 import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
+import io.camunda.exporter.tasks.archiver.ProcessInstanceByIdArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
 import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricsArchiverJob;
@@ -57,6 +58,7 @@ class BackgroundTaskManagerFactoryTest {
   void shouldScheduleProcessInstanceArchiverTaskWhenConfigEnabled() {
     // given
     config.getHistory().setProcessInstanceEnabled(true);
+    config.getHistory().setArchiveByIdEnabled(false);
 
     // when
     final var taskManager = factory.build();
@@ -66,6 +68,22 @@ class BackgroundTaskManagerFactoryTest {
     assertThat(tasks)
         .as("Should contain ProcessInstancesArchiverJob when config is enabled")
         .anyMatch(task -> isProcessInstanceArchiverTask(task));
+  }
+
+  @Test
+  void shouldScheduleProcessInstanceByIdArchiverJobTaskWhenConfigEnabled() {
+    // given
+    config.getHistory().setProcessInstanceEnabled(true);
+    config.getHistory().setArchiveByIdEnabled(true);
+
+    // when
+    final var taskManager = factory.build();
+
+    // then
+    final var tasks = getTasksFromManager(taskManager);
+    assertThat(tasks)
+        .as("Should contain ProcessInstanceByIdArchiverJob when config is enabled")
+        .anyMatch(task -> isProcessInstanceByIdArchiverTask(task));
   }
 
   @Test
@@ -145,8 +163,8 @@ class BackgroundTaskManagerFactoryTest {
     // then
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
-        .as("Should contain both PI archiver and count tasks when all configs are enabled")
-        .anyMatch(task -> isProcessInstanceArchiverTask(task))
+        .as("Should contain both PI by ID archiver and count tasks when all configs are enabled")
+        .anyMatch(task -> isProcessInstanceByIdArchiverTask(task))
         .anyMatch(task -> isProcessInstanceToBeArchivedCountTask(task));
   }
 
@@ -218,6 +236,10 @@ class BackgroundTaskManagerFactoryTest {
 
   private boolean isProcessInstanceArchiverTask(final RunnableTask task) {
     return isTaskOfType(task, ProcessInstanceArchiverJob.class);
+  }
+
+  private boolean isProcessInstanceByIdArchiverTask(final RunnableTask task) {
+    return isTaskOfType(task, ProcessInstanceByIdArchiverJob.class);
   }
 
   private boolean isProcessInstanceToBeArchivedCountTask(final RunnableTask task) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -35,7 +35,7 @@ final class ProcessInstanceArchiverJobTest {
       LoggerFactory.getLogger(ProcessInstanceArchiverJobTest.class);
 
   private final Executor executor = Runnable::run;
-  private final HistoryConfiguration historyConfiguration = new HistoryConfiguration();
+  private final HistoryConfiguration historyConfiguration = nonReindexByIdHistoryConfig();
   private final TestRepository repository = spy(new TestRepository());
   private final ListViewTemplate processInstanceTemplate = new ListViewTemplate("", true);
   private final DecisionInstanceTemplate decisionInstanceTemplate =
@@ -317,6 +317,12 @@ final class ProcessInstanceArchiverJobTest {
     assertThat(archiverTimer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
 
     verify(repository, times(2)).getProcessInstancesNextBatch(1_000);
+  }
+
+  private static HistoryConfiguration nonReindexByIdHistoryConfig() {
+    final var config = new HistoryConfiguration();
+    config.setArchiveByIdEnabled(false);
+    return config;
   }
 
   private static final class WeirdlyNamedDependant implements ProcessInstanceDependant {


### PR DESCRIPTION


## Description

Enable the reindex by ID as the default archiving mode for process instances.

This will also set the default rollover batch size based on the process instance archive mode. It will set a higher value if using reindex by ID, or previous lower value if using the older style archiver.

Also add logging to indicate that app is running with a batch size lower than recommended for reindex by id, and when higher than default for old archive jobs.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
