### PR TITLE
fix: remove broken negation logic for SM nightly

### DIFF
--- a/optimize/client/package.json
+++ b/optimize/client/package.json
@@ -46,7 +46,7 @@
     "e2e:visual:compare": "testcafe-blink-diff e2e/screenshots e2e/screenshots --compare base:actual --open --threshold 0.4 || exit 1",
     "e2e:ci:cloud:headless": "testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/cloud-tests/smokeTest.js -e",
     "e2e:ci:sm:smoke:headless": "DEBUG=testcafe* FORCE_COLOR=1 stdbuf -oL -eL testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks --no-sandbox --disable-dev-shm-usage --disable-gpu' e2e/sm-tests/*.js --test-meta type=smoke -e --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
-    "e2e:ci:sm:nightly:headless": "testcafe -c 3 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/sm-tests/*.js --test-meta type!=smoke -e --disable-screenshots --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
+    "e2e:ci:sm:nightly:headless": "testcafe -c 3 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/sm-tests/*.js -e --disable-screenshots --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
     "e2e:cloud": "testcafe chrome e2e/cloud-tests/smokeTest.js",
     "eject": "react-scripts eject",
     "postinstall": "node scripts/wireModules && patch-package",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Testcafe does not have this functionality for `test-meta`. I'm removing the negation and accepting the 9 extra test runs per nightly, which shouldn't be too much of a problem.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55509
