### PR TITLE
ci: route matrix.owner through job-level TEST_OWNER env in zeebe-aws-os-dispatch-tests.yml

### DIFF
--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -81,6 +81,8 @@ jobs:
       actions: write
     timeout-minutes: 60
     runs-on: ${{ matrix.runs-on }}
+    env:
+      TEST_OWNER: ${{ matrix.owner }}
     strategy:
       fail-fast: false
       matrix:
@@ -99,7 +101,7 @@ jobs:
             maven-test-fork-count: 7
             maven-test-profiles: multi-db-test-client
             runs-on: aws-core-8-default
-            owner: "General"
+            owner: '@camunda/monorepo-devops-team'
           - group: camunda-qa-acceptance-tests-non-client
             name: "Camunda QA Module Non-Client Tests"
             maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
@@ -107,7 +109,7 @@ jobs:
             maven-test-fork-count: 7
             maven-test-profiles: multi-db-test-non-client
             runs-on: aws-core-8-default
-            owner: "General"
+            owner: '@camunda/monorepo-devops-team'
           - group: search-client-opensearch
             name: "Search Client OpenSearch ITs"
             maven-modules: "'io.camunda:camunda-search-client-connect,io.camunda:camunda-search-client-opensearch'"
@@ -115,7 +117,7 @@ jobs:
             maven-test-fork-count: 7
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
-            owner: "Core Features"
+            owner: '@camunda/core-features'
           - group: camunda-exporter
             name: "Camunda Exporter ITs"
             maven-modules: "'io.camunda:camunda-exporter'"
@@ -123,7 +125,7 @@ jobs:
             maven-test-fork-count: 7
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
-            owner: "Data Layer"
+            owner: '@camunda/data-layer'
           - group: zeebe-opensearch-exporter
             name: "Zeebe OpenSearch Exporter ITs"
             maven-modules: "'io.camunda:zeebe-opensearch-exporter'"
@@ -131,7 +133,7 @@ jobs:
             maven-test-fork-count: 7
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
-            owner: "Data Layer"
+            owner: '@camunda/data-layer'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup AWS OpenSearch
@@ -187,7 +189,6 @@ jobs:
           job_name: "integration-tests/${{ matrix.group }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: ${{ matrix.owner }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
## Description

Follow-up to [#55040](https://github.com/camunda/camunda/pull/55040). The `zeebe-aws-os-dispatch-tests.yml` scheduled workflow still submits non-canonical CI Analytics ownership for its `integration-tests` matrix even though the workflow-level `TEST_OWNER: '@camunda/core-features'` is set.

Two related issues, both fixed in this PR:

1. **Non-canonical matrix `owner:` values.** The 5 matrix entries use old free-text labels (`"General"`, `"Core Features"`, `"Data Layer"`). Canonicalized to `@camunda/...` handles, matching the convention established by #55040 and the matching changes already shipped via the stable/8.8 and stable/8.9 backports.

2. **Inline `user_description: ${{ matrix.owner }}` override.** This overrides the workflow-level handle on a per-entry basis but bypasses the `observe-build-status` env fallback. Replaced with a job-level `env: TEST_OWNER: ${{ matrix.owner }}` and the inline dropped — matching the pattern used by `ci.yml`'s `integration-tests` and `zeebe-unit-tests` jobs (where per-entry routing already goes through env).

### Effective mapping

| Matrix group | Owner |
|---|---|
| `camunda-qa-acceptance-tests-client` | `@camunda/monorepo-devops-team` |
| `camunda-qa-acceptance-tests-non-client` | `@camunda/monorepo-devops-team` |
| `search-client-opensearch` | `@camunda/core-features` |
| `camunda-exporter` | `@camunda/data-layer` |
| `zeebe-opensearch-exporter` | `@camunda/data-layer` |

Same mapping as the stable/8.8 and stable/8.9 backports of #55040.

### Why it was overlooked

The original bulk sweep added workflow-level `TEST_OWNER` to push/schedule workflows but didn't audit per-job matrix `owner:` fields within those files. The inline `user_description` override is invisible if you only check the workflow-level env. I caught and fixed this pattern on the stable backports but the same fix never propagated back to main.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Contributes to #52873. Follow-up to #55040.