### PR TITLE
feat: resolve per-physical-tenant CamundaSecurityLibraryProperties

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/security/PhysicalTenantSecurityProperties.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/PhysicalTenantSecurityProperties.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.security;
+
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import java.util.Map;
+
+/**
+ * Holds the {@link CamundaSecurityLibraryProperties} for every physical tenant, keyed by physical
+ * tenant id.
+ *
+ * <p>A typed wrapper is required because injecting a bare {@code Map<String,
+ * CamundaSecurityLibraryProperties>} would trigger Spring's collection-injection semantics: Spring
+ * would look for beans of type {@code CamundaSecurityLibraryProperties} and key them by bean name
+ * rather than by physical tenant id.
+ */
+public record PhysicalTenantSecurityProperties(
+    Map<String, CamundaSecurityLibraryProperties> propertiesByPhysicalTenant) {}

--- a/dist/src/main/java/io/camunda/application/commons/security/PhysicalTenantSecurityPropertiesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/PhysicalTenantSecurityPropertiesConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.security;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class PhysicalTenantSecurityPropertiesConfiguration {
+
+  @Bean
+  public PhysicalTenantSecurityProperties physicalTenantSecurityProperties(
+      final PhysicalTenantResolver physicalTenantResolver) {
+    final Map<String, CamundaSecurityLibraryProperties> props =
+        physicalTenantResolver.<CamundaSecurityLibraryProperties>mapValues(Camunda::getSecurity);
+    return new PhysicalTenantSecurityProperties(props);
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/security/PhysicalTenantSecurityPropertiesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/PhysicalTenantSecurityPropertiesConfigurationTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Drives the real {@link PhysicalTenantResolver} so the per-tenant {@link
+ * CamundaSecurityLibraryProperties} values come from actual config binding of {@code
+ * camunda.physical-tenants.<id>.security.*} overrides — not from stubs.
+ *
+ * <p>Only {@code security.authorizations.*} is exercised here: {@code security.multi-tenancy.*} is
+ * intentionally non-overridable per physical tenant (it is on the {@code
+ * PhysicalTenantOverridePolicyValidation} deny-list — multi-tenancy enablement is cluster-wide).
+ */
+class PhysicalTenantSecurityPropertiesConfigurationTest {
+
+  private final PhysicalTenantSecurityPropertiesConfiguration configuration =
+      new PhysicalTenantSecurityPropertiesConfiguration();
+
+  private MockEnvironment environment;
+
+  @BeforeEach
+  void setUp() {
+    environment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(environment);
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldResolveAuthorizationsEnabledPerTenantFromRealBinding() {
+    // given authorizations enabled at the root, overridden to disabled for tenanta
+    setProperties(
+        Map.of(
+            "camunda.security.authorizations.enabled", "true",
+            "camunda.physical-tenants.tenanta.security.authorizations.enabled", "false",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta"),
+        "tenanta");
+
+    // when
+    final var properties = resolve();
+
+    // then the override is bound per tenant; default keeps the root value
+    assertThat(
+            propertiesOf(properties, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .getAuthorizations()
+                .isEnabled())
+        .isTrue();
+    assertThat(propertiesOf(properties, "tenanta").getAuthorizations().isEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldResolveAuthorizationsIndependentlyForTwoTenants() {
+    // given two tenants with opposite authorization-enabled flags
+    setProperties(
+        Map.of(
+            "camunda.physical-tenants.tenanta.security.authorizations.enabled", "true",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta",
+            "camunda.physical-tenants.tenantb.security.authorizations.enabled", "false",
+            "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
+                "tenantb"),
+        "tenanta",
+        "tenantb");
+
+    // when
+    final var properties = resolve();
+
+    // then each tenant resolves its own flag independently
+    assertThat(propertiesOf(properties, "tenanta").getAuthorizations().isEnabled()).isTrue();
+    assertThat(propertiesOf(properties, "tenantb").getAuthorizations().isEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldAlwaysContainDefaultEntryReflectingRoot() {
+    // given only root configuration is set (no tenants declared)
+    setProperties(Map.of("camunda.security.authorizations.enabled", "true"));
+
+    // when
+    final var properties = resolve();
+
+    // then a default entry is synthesized from the root and reflects its values
+    assertThat(properties.propertiesByPhysicalTenant())
+        .containsOnlyKeys(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(
+            propertiesOf(properties, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .getAuthorizations()
+                .isEnabled())
+        .isTrue();
+  }
+
+  private PhysicalTenantSecurityProperties resolve() {
+    final Camunda camunda = new Camunda();
+    Binder.get(environment).bind(Camunda.PREFIX, Bindable.ofInstance(camunda));
+    final PhysicalTenantResolver resolver = PhysicalTenantResolver.of(environment, camunda);
+    return configuration.physicalTenantSecurityProperties(resolver);
+  }
+
+  private static CamundaSecurityLibraryProperties propertiesOf(
+      final PhysicalTenantSecurityProperties properties, final String physicalTenantId) {
+    final var resolved = properties.propertiesByPhysicalTenant().get(physicalTenantId);
+    assertThat(resolved).as("properties for physical tenant '%s'", physicalTenantId).isNotNull();
+    return resolved;
+  }
+
+  /**
+   * Sets {@code properties} and, for each given non-default tenant, adds the minimal {@code
+   * security.initialization} block that every explicitly-configured tenant requires to pass
+   * resolver validation.
+   */
+  private void setProperties(final Map<String, Object> properties, final String... tenantIds) {
+    final Map<String, Object> all = new HashMap<>(properties);
+    for (final String tenantId : tenantIds) {
+      all.put(
+          "camunda.physical-tenants."
+              + tenantId
+              + ".security.initialization.default-roles.admin.users[0]",
+          tenantId + "-admin");
+    }
+    environment.getPropertySources().addFirst(new MapPropertySource("test", all));
+  }
+}


### PR DESCRIPTION
## Description

Slice S6 of the physical-tenant (PT) routing of the authorization layer (ADR-0005, #55252).

Exposes a host-layer holder that resolves `CamundaSecurityLibraryProperties` **per physical tenant**, so a later slice (S2, #55438) can branch the per-PT authorization decision on each tenant's `authorizations.enabled`. This slice is the foundational resolution mechanism only — it has no consumer yet (like the S1 fail-fast guardrail), and it is purely additive and non-breaking.

No new config surface: per-PT properties resolve through the existing `PhysicalTenantResolver`, which already overlays `camunda.physical-tenants.<id>.*` onto a fresh `Camunda` (whose `Security` extends `CamundaSecurityLibraryProperties`). So per-PT `security.authorizations.enabled` is just the existing `camunda.security.*` key under the existing per-PT overlay.

## What changed

- `PhysicalTenantSecurityProperties` — a typed record wrapping `Map<String, CamundaSecurityLibraryProperties>` keyed by PT id (typed wrapper to avoid Spring's bare-`Map` collection-injection semantics, mirroring `PhysicalTenantSearchClientReaders`).
- `PhysicalTenantSecurityPropertiesConfiguration` — a `@Bean` building the holder via `physicalTenantResolver.mapValues(Camunda::getSecurity)`.
- Tests drive the **real** `PhysicalTenantResolver` (MockEnvironment + Binder) so per-PT values come from actual `camunda.physical-tenants.<id>.security.*` binding, not stubs.

## Scope: authorizations only (multi-tenancy is cluster-wide)

`authorizations.enabled` is the only per-PT security flag. `security.multi-tenancy` is intentionally on the `PhysicalTenantOverridePolicyValidation` deny-list — multi-tenancy enablement applies uniformly cluster-wide and cannot be overridden per PT (a per-PT override fails resolution at boot). The holder still carries each tenant's full `CamundaSecurityLibraryProperties`; the multi-tenancy flag simply resolves to the uniform root value for every tenant.

## Acceptance criteria → confirming tests

| Acceptance criterion | Confirming test(s) |
| --- | --- |
| Per-PT `CamundaSecurityLibraryProperties` resolvable via `PhysicalTenantResolver` | `PhysicalTenantSecurityPropertiesConfigurationTest.shouldResolveAuthorizationsEnabledPerTenantFromRealBinding` (real binding of a per-PT `security.authorizations.enabled` override) |
| `authorizations.enabled` honored per PT | `…shouldResolveAuthorizationsEnabledPerTenantFromRealBinding` (root true, `tenanta` false) + `…shouldResolveAuthorizationsIndependentlyForTwoTenants` |
| `default` entry always present, reflecting root | `…shouldAlwaysContainDefaultEntryReflectingRoot` |

Closes #55442