### PR TITLE
deps: bump camunda-security-library to 0.1.0-alpha33

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha31</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha33</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Description

Bumps the `camunda-security-library` pin from `0.1.0-alpha31` to `0.1.0-alpha33`.

This release brings in:
- per-scope **webapp** security chains (camunda/camunda-security-library#427)
- per-scope session honoured on the scoped **API** chain (camunda/camunda-security-library#432)

## Why this is the only change needed

The existing `PhysicalTenantScopeProvider` already emits one `ScopedSecurityDescriptor` per physical tenant. CSL's `ScopedSecurityChainRegistrar` now registers **both** an API and a webapp `SecurityFilterChain` per descriptor, so consuming this release activates the per-PT webapp security chains through the same descriptor interface that already feeds the API chains — no OC wiring change required.

This is the foundation for the PT webapp slice: serving webapp routes/static assets under the physical-tenant prefix (#55313) sits behind these now-active per-PT webapp chains. Part of Physical Tenants Identity, Slice 3 (#54897).

## Verification

Full-repo `./mvnw install -Dquickly -T1C` compiles green against alpha33 — the alpha31→alpha33 API surface broke no OC consumer. Runtime/e2e validation of the per-PT webapp chains is covered by PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)