### PR TITLE
test: add reusable PhysicalTenantsITHelper and fold isolation IT onto it

### DIFF
--- a/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
+++ b/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
@@ -322,12 +322,23 @@ public class ExtendedConfigurationBuilder {
    * List elements are emitted as {@code key[i]}; map entries as {@code key.entryKey}.
    */
   public static Map<String, Object> flatPropertiesFor(final Camunda config) {
+    return flatPropertiesFor(config, CAMUNDA_HEADER);
+  }
+
+  /**
+   * Same as {@link #flatPropertiesFor(Camunda)} but emits the keys under an arbitrary {@code
+   * prefix} instead of the top-level {@code camunda} header — e.g. {@code
+   * camunda.physical-tenants.<id>} so a physical-tenant {@link Camunda} can be flattened into the
+   * very keys the broker binds it from (see {@code
+   * io.camunda.configuration.physicaltenants.PhysicalTenantResolver}).
+   */
+  public static Map<String, Object> flatPropertiesFor(final Camunda config, final String prefix) {
     final Map<String, Object> defaultMap = flatten(new Camunda());
     final Map<String, Object> configuredMap = flatten(config);
     final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
     putLegacyNodeIdPropertyIfNeeded(diff);
     final Map<String, Object> flat = new LinkedHashMap<>();
-    flattenInto(diff, CAMUNDA_HEADER, flat);
+    flattenInto(diff, prefix, flat);
     return flat;
   }
 

--- a/qa/testcontainer/src/test/java/io/camunda/container/ExtendedConfigurationBuilderTest.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/ExtendedConfigurationBuilderTest.java
@@ -167,4 +167,36 @@ final class ExtendedConfigurationBuilderTest {
         .noneMatch(k -> k.endsWith(".prefix"))
         .noneMatch(k -> k.endsWith(".database-name"));
   }
+
+  @Test
+  void shouldEmitKeysUnderProvidedPrefix() {
+    // given
+    final var config = new Camunda();
+    config.getData().getSecondaryStorage().setType(SecondaryStorageType.rdbms);
+
+    // when — flattened under a physical-tenant prefix instead of the top-level `camunda` header
+    final var flat =
+        ExtendedConfigurationBuilder.flatPropertiesFor(config, "camunda.physical-tenants.tenanta");
+
+    // then — every key carries the given prefix and none leak under the root `camunda.data.*` form
+    assertThat(flat)
+        .containsEntry("camunda.physical-tenants.tenanta.data.secondary-storage.type", "rdbms");
+    assertThat(flat.keySet()).noneMatch(k -> k.startsWith("camunda.data."));
+  }
+
+  @Test
+  void shouldNotEmitNodeIdForPhysicalTenantConfig() {
+    // given — physical-tenant configs carry storage/security only and never a node id, which is a
+    // root-config concern
+    final var config = new Camunda();
+    config.getData().getSecondaryStorage().setType(SecondaryStorageType.rdbms);
+
+    // when — flattened under a physical-tenant prefix
+    final var flat =
+        ExtendedConfigurationBuilder.flatPropertiesFor(config, "camunda.physical-tenants.tenanta");
+
+    // then — with no node id set neither the fixed nor the legacy node-id key is emitted, which is
+    // why legacy-node-id mirroring needs no prefix-specific special-casing
+    assertThat(flat.keySet()).noneMatch(k -> k.contains("node-id"));
+  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantIsolationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantIsolationIT.java
@@ -14,9 +14,10 @@ import static org.awaitility.Awaitility.await;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.response.ActivateJobsResponse;
-import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
@@ -39,27 +40,26 @@ final class PhysicalTenantIsolationIT {
   private static final String TENANT_A = "tenanta";
   private static final String JOB_TYPE = "task";
 
+  // the default tenant and tenant A both run broker-only (no secondary storage, M1 scope);
+  // declaring tenant A starts a second, fully isolated partition group / engine for it
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
   @TestZeebe
   private final TestStandaloneBroker broker =
-      new TestStandaloneBroker()
-          .withUnauthenticatedAccess()
-          // the cluster uses no secondary storage (broker-only) ...
-          .withDataConfig(
-              dataCfg -> dataCfg.getSecondaryStorage().setType(SecondaryStorageType.none))
-          // each explicitly-configured physical tenant must provide its own initialization block
-          .withProperty(
-              "camunda.physical-tenants."
-                  + TENANT_A
-                  + ".security.initialization.default-roles.admin.users[0]",
-              TENANT_A + "-admin");
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
 
   @AutoClose private CamundaClient defaultClient;
   @AutoClose private CamundaClient tenantAClient;
 
   @BeforeEach
   void beforeEach() {
-    defaultClient = broker.newClientBuilder().build();
-    tenantAClient = broker.newClientBuilder().physicalTenantId(TENANT_A).build();
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
   }
 
   @Test
@@ -120,9 +120,8 @@ final class PhysicalTenantIsolationIT {
             .send()
             .join();
     assertThat(tenantAJobs.getJobs()).hasSize(1);
-    assertThat(tenantAJobs.getJobs().getFirst().getProcessInstanceKey())
-        .isEqualTo(processInstanceKey);
-    tenantAClient.newCompleteCommand(tenantAJobs.getJobs().getFirst().getKey()).send().join();
+    assertThat(tenantAJobs.getJobs().get(0).getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    tenantAClient.newCompleteCommand(tenantAJobs.getJobs().get(0).getKey()).send().join();
 
     // and - the process was never deployed to the default tenant
     assertThatThrownBy(

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.camunda.client.CamundaClientBuilder;
+import io.camunda.configuration.SecondaryStorage;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Reusable helper for booting a single {@link TestStandaloneBroker} that serves several physical
+ * tenants, and for addressing each of them over gRPC and REST. Every physical tenant, including the
+ * {@code default} one, must be declared explicitly with its {@link Storage}. The helper only emits
+ * configuration and builds clients / REST base URLs; the broker lifecycle stays with the existing
+ * {@code @ZeebeIntegration} / {@code @TestZeebe} extension:
+ *
+ * <pre>{@code
+ * @ZeebeIntegration
+ * final class MyIsolationIT {
+ *   private static final PhysicalTenantsITHelper TENANTS =
+ *       PhysicalTenantsITHelper.builder()
+ *           .withTenant("default", Storage.rdbmsH2("default"))
+ *           .withTenant("tenanta", Storage.rdbmsH2("tenanta"))
+ *           .build();
+ *
+ *   @TestZeebe
+ *   private final TestStandaloneBroker broker =
+ *       TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+ *
+ *   @Test
+ *   void shouldIsolate() {
+ *     try (final var client = TENANTS.newClientBuilder(broker, "tenanta").build()) {
+ *       // gRPC scoped to tenanta
+ *     }
+ *     final URI restBase = TENANTS.restBaseFor(broker, "tenanta"); // .../physical-tenants/tenanta/v2
+ *   }
+ * }
+ * }</pre>
+ */
+public final class PhysicalTenantsITHelper {
+
+  public static final String DEFAULT_TENANT_ID = "default";
+
+  private final Map<String, Storage> tenants;
+
+  private PhysicalTenantsITHelper(final Map<String, Storage> tenants) {
+    this.tenants = Collections.unmodifiableMap(new LinkedHashMap<>(tenants));
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public TestStandaloneBroker configure(final TestStandaloneBroker broker) {
+    tenants.forEach(
+        (tenant, storage) -> {
+          storage.applyTo(broker, tenant);
+          if (!DEFAULT_TENANT_ID.equals(tenant)) {
+            broker.withPtConfig(
+                tenant,
+                camunda ->
+                    camunda
+                        .getSecurity()
+                        .getInitialization()
+                        .setDefaultRoles(
+                            Map.of("admin", Map.of("users", List.of(tenant + "-admin")))));
+          }
+        });
+    return broker;
+  }
+
+  public CamundaClientBuilder newClientBuilder(
+      final TestGateway<?> gateway, final String tenantId) {
+    final CamundaClientBuilder builder = gateway.newClientBuilder();
+    if (!DEFAULT_TENANT_ID.equals(tenantId)) {
+      // gRPC is scoped via the header; REST is scoped by pointing the client at the tenant-prefixed
+      // root (the client appends /v2). Workaround until the client applies physicalTenantId to
+      // REST.
+      builder.physicalTenantId(tenantId).restAddress(restRootFor(gateway, tenantId));
+    }
+    return builder;
+  }
+
+  public URI restBaseFor(final TestGateway<?> gateway, final String tenantId) {
+    return URI.create(restRootFor(gateway, tenantId) + "/v2");
+  }
+
+  private static URI restRootFor(final TestGateway<?> gateway, final String tenantId) {
+    final String base = gateway.restAddress().toString().replaceAll("/+$", "");
+    final String tenantPrefix =
+        DEFAULT_TENANT_ID.equals(tenantId) ? "" : "/physical-tenants/" + tenantId;
+    return URI.create(base + tenantPrefix);
+  }
+
+  public Set<String> tenantIds() {
+    return new LinkedHashSet<>(tenants.keySet());
+  }
+
+  public static final class Builder {
+
+    private final Map<String, Storage> tenants = new LinkedHashMap<>();
+
+    private Builder() {}
+
+    public Builder withTenant(final String tenantId, final Storage storage) {
+      if (tenantId == null || tenantId.isBlank()) {
+        throw new IllegalArgumentException("tenantId must not be null or blank");
+      }
+      Objects.requireNonNull(storage, "storage must not be null for tenant '" + tenantId + "'");
+      if (tenants.putIfAbsent(tenantId, storage) != null) {
+        throw new IllegalArgumentException(
+            "physical tenant '" + tenantId + "' is already declared");
+      }
+      return this;
+    }
+
+    public PhysicalTenantsITHelper build() {
+      // the default tenant carries the broker's root config and is addressed without a header, so
+      // it must be declared explicitly (see class javadoc); enforcing it also rejects an empty set
+      if (!tenants.containsKey(DEFAULT_TENANT_ID)) {
+        throw new IllegalStateException(
+            "the '" + DEFAULT_TENANT_ID + "' physical tenant must be declared explicitly");
+      }
+      return new PhysicalTenantsITHelper(tenants);
+    }
+  }
+
+  private record NoneStorage() implements Storage {
+
+    @Override
+    public void applyTo(final TestStandaloneBroker broker, final String tenantId) {
+      if (DEFAULT_TENANT_ID.equals(tenantId)) {
+        broker.withSecondaryStorageType(SecondaryStorageType.none);
+      } else {
+        broker.withPtConfig(
+            tenantId,
+            camunda -> camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.none));
+      }
+    }
+  }
+
+  private record RdbmsStorage(String url, String username, String password) implements Storage {
+
+    @Override
+    public void applyTo(final TestStandaloneBroker broker, final String tenantId) {
+      if (DEFAULT_TENANT_ID.equals(tenantId)) {
+        broker.withSecondaryStorageType(SecondaryStorageType.rdbms);
+        broker.withDataConfig(data -> applyRdbms(data.getSecondaryStorage()));
+      } else {
+        broker.withPtConfig(
+            tenantId, camunda -> applyRdbms(camunda.getData().getSecondaryStorage()));
+      }
+    }
+
+    private void applyRdbms(final SecondaryStorage secondaryStorage) {
+      secondaryStorage.setType(SecondaryStorageType.rdbms);
+      final var rdbms = secondaryStorage.getRdbms();
+      rdbms.setUrl(url);
+      rdbms.setUsername(username);
+      rdbms.setPassword(password);
+    }
+  }
+
+  public interface Storage {
+
+    void applyTo(TestStandaloneBroker broker, String tenantId);
+
+    static Storage none() {
+      return new NoneStorage();
+    }
+
+    static Storage rdbms(final String url, final String username, final String password) {
+      return new RdbmsStorage(url, username, password);
+    }
+
+    static Storage rdbmsH2(final String dbName) {
+      return rdbms(
+          "jdbc:h2:mem:" + dbName + "-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+          "sa",
+          "");
+    }
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -53,6 +54,7 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   private final Collection<ApplicationContextInitializer> additionalInitializers;
   private final ReactorResourceFactory reactorResourceFactory = new ReactorResourceFactory();
   private final Set<String> refreshableKeys = new HashSet<>();
+  private final Map<String, Camunda> ptConfigs = new LinkedHashMap<>();
 
   public TestSpringApplication(final Class<?>... springApplications) {
     this(new Camunda(), springApplications);
@@ -221,6 +223,23 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   /**
+   * Mutates the unified configuration for a single physical tenant. The per-tenant {@link Camunda}
+   * is flattened into {@code camunda.physical-tenants.<tenantId>.*} properties at {@link
+   * #createSpringBuilder()} time, mirroring how {@code
+   * io.camunda.configuration.physicaltenants.PhysicalTenantResolver} binds a physical tenant from
+   * those same keys. Use {@link #withUnifiedConfig(Consumer)} for the root ({@code default})
+   * tenant.
+   *
+   * @param tenantId the physical tenant id
+   * @param modifier a configuration function that accepts the tenant's Camunda configuration object
+   * @return itself for chaining
+   */
+  public T withPtConfig(final String tenantId, final Consumer<Camunda> modifier) {
+    modifier.accept(ptConfigs.computeIfAbsent(tenantId, id -> new Camunda()));
+    return self();
+  }
+
+  /**
    * Replaces a set of properties that should be re-derived from in-memory builder state on every
    * {@link #start()}. Keys set in a previous call are removed before the new {@code properties} are
    * applied, so fields that disappear between restarts (e.g. an exporter cleared from the unified
@@ -311,7 +330,16 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     // Flatten the in-memory unified config into camunda.* properties at the latest possible point,
     // so every with*Config / withUnifiedConfig call made up to now is captured. Refreshable so that
     // fields cleared between stop/start (e.g. an exporter removed) don't remain.
-    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
+    final Map<String, Object> flatProperties =
+        new LinkedHashMap<>(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
+    // withRefreshableProperties replaces (not accumulates) the refreshable set, so the root config
+    // and every physical tenant must be merged into a single map before registering them.
+    ptConfigs.forEach(
+        (tenantId, ptConfig) ->
+            flatProperties.putAll(
+                ExtendedConfigurationBuilder.flatPropertiesFor(
+                    ptConfig, "camunda.physical-tenants." + tenantId)));
+    withRefreshableProperties(flatProperties);
     return MainSupport.createDefaultApplicationBuilder()
         .bannerMode(Mode.OFF)
         .registerShutdownHook(false)


### PR DESCRIPTION
## What

M1 of the physical-tenant IT plan (#55350): a reusable `PhysicalTenantsITHelper` for booting a single broker that serves several physical tenants and for building per-tenant clients. The seed `PhysicalTenantIsolationIT` from #55344 is folded onto it.

- `builder().withTenant(tenantId, storageType)` — every physical tenant, including `default`, is declared explicitly with its secondary-storage type.
- `configure(broker)` emits the top-level `camunda.data.*` config for the `default` tenant and the `camunda.physical-tenants.<id>.*` storage + security-init properties for the others.
- `newClientBuilder(gateway, tenantId)` scopes a client to a tenant (no header for the `default` tenant).
- Reuses the existing `@ZeebeIntegration` / `@TestZeebe` lifecycle unchanged — no new JUnit extension.

## Base

Stacked on **#55344** (`ls/50532-physical-tenant-e2e`) — it carries the boot recipe + IT seed this builds on. Merge into / after that branch.

Relates to #55350. Part of epic #50532.