### PR TITLE
feat: add latest agent message to status section

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.test.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import type {ReactNode} from 'react';
+import {mockSearchAgentInstanceHistory} from 'modules/mocks/api/v2/agentInstances/searchAgentInstanceHistory';
+import {LatestAgentMessage} from './LatestAgentMessage';
+import {searchResult} from 'modules/testUtils';
+import {mockAgentInstanceHistoryItem} from 'modules/mocks/mockAgentInstanceHistoryItem';
+
+const AGENT_INSTANCE_KEY = '2251799813851828';
+
+function createWrapper() {
+  const queryClient = getMockQueryClient();
+  return ({children}: {children: ReactNode}) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+        <Routes>
+          <Route path={Paths.processInstance()} element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('<LatestAgentMessage />', () => {
+  it('should render skeleton while loading', () => {
+    mockSearchAgentInstanceHistory(AGENT_INSTANCE_KEY).withDelay(
+      searchResult([]),
+    );
+
+    render(
+      <LatestAgentMessage
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    expect(
+      screen.getByTestId('latest-agent-message-skeleton'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render a hint when no agent message exists yet', async () => {
+    mockSearchAgentInstanceHistory(AGENT_INSTANCE_KEY).withSuccess(
+      searchResult([]),
+    );
+
+    render(
+      <LatestAgentMessage
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('latest-agent-message-skeleton'),
+    );
+
+    expect(
+      screen.getByText('The agent has not produced a message yet.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render an error hint when loading fails', async () => {
+    mockSearchAgentInstanceHistory(AGENT_INSTANCE_KEY).withServerError(500);
+
+    render(
+      <LatestAgentMessage
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('latest-agent-message-skeleton'),
+    );
+
+    expect(
+      screen.getByText('Failed to load latest agent message.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render the latest assistant message', async () => {
+    mockSearchAgentInstanceHistory(AGENT_INSTANCE_KEY).withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: 'msg-1',
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'I will help you with that.'}],
+        }),
+      ]),
+    );
+
+    render(
+      <LatestAgentMessage
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('latest-agent-message-skeleton'),
+    );
+
+    const message = within(screen.getByTestId('conversation-message-msg-1'));
+    expect(
+      message.getByRole('heading', {name: 'Assistant'}),
+    ).toBeInTheDocument();
+    expect(message.getByText('I will help you with that.')).toBeInTheDocument();
+  });
+
+  it('should render tool call buttons for a message with tool calls', async () => {
+    mockSearchAgentInstanceHistory(AGENT_INSTANCE_KEY).withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: 'msg-2',
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'Calling a tool.'}],
+          toolCalls: [
+            {
+              toolCallId: 'tc-1',
+              toolName: 'doSomething',
+              elementId: 'element-1',
+              arguments: {},
+            },
+            {
+              toolCallId: 'tc-2',
+              toolName: 'noElement',
+              elementId: null,
+              arguments: {},
+            },
+          ],
+        }),
+      ]),
+    );
+
+    render(
+      <LatestAgentMessage
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('latest-agent-message-skeleton'),
+    );
+
+    const message = within(screen.getByTestId('conversation-message-msg-2'));
+    expect(
+      message.getByRole('button', {
+        name: '"doSomething" tool call. Click to open details.',
+      }),
+    ).toBeEnabled();
+    expect(
+      message.getByRole('button', {name: '"noElement" tool call.'}),
+    ).toBeDisabled();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {SkeletonText} from '@carbon/react';
+import {useLatestAgentMessage} from 'modules/queries/agentInstances/useLatestAgentMessage';
+import {ConversationMessage} from '../ConversationMessage';
+import {StatusHint} from './styled';
+
+type LatestAgentMessageProps = {
+  agentInstanceKey: string;
+  enablePeriodicRefetch: boolean;
+};
+
+const LatestAgentMessage: React.FC<LatestAgentMessageProps> = ({
+  agentInstanceKey,
+  enablePeriodicRefetch,
+}) => {
+  const {data, status} = useLatestAgentMessage(agentInstanceKey, {
+    enablePeriodicRefetch,
+  });
+
+  if (status === 'pending') {
+    return (
+      <div data-testid="latest-agent-message-skeleton">
+        <SkeletonText heading paragraph lineCount={3} />
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return <StatusHint>Failed to load latest agent message.</StatusHint>;
+  }
+
+  if (data === null) {
+    return <StatusHint>The agent has not produced a message yet.</StatusHint>;
+  }
+
+  return (
+    <ConversationMessage
+      actor={data.role}
+      content={data.content}
+      toolCalls={data.toolCalls}
+      historyItemKey={data.historyItemKey}
+    />
+  );
+};
+
+export {LatestAgentMessage};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -22,6 +22,7 @@ import {searchResult} from 'modules/testUtils';
 import {Paths} from 'modules/Routes';
 import {AgentDetails} from './index';
 import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import {mockAgentInstanceHistoryItem} from 'modules/mocks/mockAgentInstanceHistoryItem';
 
 vi.mock('modules/feature-flags', () => ({
   IS_CONVERSATION_HISTORY_ENABLED: true,
@@ -72,6 +73,10 @@ const mockAgentInstance: AgentInstance = {
 };
 
 describe('<AgentDetails />', () => {
+  beforeEach(() => {
+    mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
+  });
+
   it('should render AI Agent heading and status for TOOL_CALLING', () => {
     render(
       <AgentDetails
@@ -195,6 +200,36 @@ describe('<AgentDetails />', () => {
     ).toBeInTheDocument();
   });
 
+  it('should open the status accordion item by default and display the latest agent message', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([mockAgentInstanceHistoryItem({role: 'ASSISTANT'})]),
+    );
+
+    render(
+      <AgentDetails
+        agentInstance={mockAgentInstance}
+        isLoading={false}
+        isError={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('latest-agent-message-skeleton'),
+    );
+
+    const statusSection = within(screen.getByTestId('agent-status-section'));
+    expect(
+      statusSection.getByRole('button', {
+        name: 'Status: Calling tools',
+        expanded: true,
+      }),
+    ).toBeVisible();
+    expect(
+      statusSection.getByRole('article', {name: 'Assistant message'}),
+    ).toBeVisible();
+  });
+
   it('should render usage metrics', () => {
     render(
       <AgentDetails
@@ -276,6 +311,8 @@ describe('<AgentDetails />', () => {
     mockSearchAgentInstanceHistory(
       mockAgentInstance.agentInstanceKey,
     ).withSuccess(searchResult([]), {mockResolverFn: historySpy});
+    // Latest message is always fetched. Handle first before history spy handler.
+    mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
 
     const {user} = render(
       <AgentDetails

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -36,6 +36,7 @@ import {ToolsCalledMetric} from './AgentMetrics/ToolsCalledMetric';
 import {SectionTitle} from './SectionTitle';
 import {ConversationMessage} from './ConversationMessage';
 import {ConversationHistory} from './ConversationHistory';
+import {LatestAgentMessage} from './ConversationHistory/LatestAgentMessage';
 import {IS_CONVERSATION_HISTORY_ENABLED} from 'modules/feature-flags';
 import {isAgentInstanceRunning} from 'modules/queries/agentInstances/useAgentInstance';
 
@@ -122,13 +123,21 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
       <Accordion align="start">
         <AccordionItem
           data-testid="agent-status-section"
-          disabled
+          open
+          disabled={!IS_CONVERSATION_HISTORY_ENABLED}
           title={
             <SectionTitle icon={<StatusIcon status={agentInstance.status} />}>
               Status: {statusLabel}
             </SectionTitle>
           }
-        ></AccordionItem>
+        >
+          {IS_CONVERSATION_HISTORY_ENABLED && (
+            <LatestAgentMessage
+              agentInstanceKey={agentInstance.agentInstanceKey}
+              enablePeriodicRefetch={isAgentInstanceRunning(agentInstance)}
+            />
+          )}
+        </AccordionItem>
         <AccordionItem
           data-testid="agent-usage-section"
           title={

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -38,7 +38,7 @@ import {ConversationMessage} from './ConversationMessage';
 import {ConversationHistory} from './ConversationHistory';
 import {LatestAgentMessage} from './ConversationHistory/LatestAgentMessage';
 import {IS_CONVERSATION_HISTORY_ENABLED} from 'modules/feature-flags';
-import {isAgentInstanceRunning} from 'modules/queries/agentInstances/useAgentInstance';
+import {isAgentInstanceActive} from 'modules/queries/agentInstances/agentInstanceStatus';
 
 const STATUS_LABELS: Record<AgentInstanceStatus, string> = {
   INITIALIZING: 'Initializing',
@@ -134,7 +134,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
           {IS_CONVERSATION_HISTORY_ENABLED && (
             <LatestAgentMessage
               agentInstanceKey={agentInstance.agentInstanceKey}
-              enablePeriodicRefetch={isAgentInstanceRunning(agentInstance)}
+              enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
             />
           )}
         </AccordionItem>
@@ -174,7 +174,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
             <ConversationHistory
               agentInstanceKey={agentInstance.agentInstanceKey}
               isVisible={isConversationHistoryOpen}
-              enablePeriodicRefetch={isAgentInstanceRunning(agentInstance)}
+              enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
             />
           </AccordionItem>
         )}

--- a/operate/client/src/modules/queries/agentInstances/agentInstanceStatus.ts
+++ b/operate/client/src/modules/queries/agentInstances/agentInstanceStatus.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {
+  AgentInstance,
+  AgentInstanceStatus,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const RUNNING_STATUSES: ReadonlySet<AgentInstanceStatus> = new Set([
+  'INITIALIZING',
+  'TOOL_DISCOVERY',
+  'THINKING',
+  'TOOL_CALLING',
+  'IDLE',
+]);
+
+const ACTIVE_STATUSES: ReadonlySet<AgentInstanceStatus> = new Set([
+  'INITIALIZING',
+  'TOOL_DISCOVERY',
+  'THINKING',
+  'TOOL_CALLING',
+]);
+
+const isAgentInstanceRunning = (agentInstance: AgentInstance): boolean => {
+  return RUNNING_STATUSES.has(agentInstance.status);
+};
+
+const isAgentInstanceActive = (agentInstance: AgentInstance): boolean => {
+  return ACTIVE_STATUSES.has(agentInstance.status);
+};
+
+const ACTIVE_STATUSES_ARRAY: AgentInstanceStatus[] =
+  Array.from(ACTIVE_STATUSES);
+
+export {isAgentInstanceRunning, isAgentInstanceActive, ACTIVE_STATUSES_ARRAY};

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstance.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstance.ts
@@ -10,18 +10,7 @@ import {skipToken, useQuery} from '@tanstack/react-query';
 import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import {fetchAgentInstance} from 'modules/api/v2/agentInstances/fetchAgentInstance';
 import {queryKeys} from '../queryKeys';
-
-const RUNNING_STATUSES: ReadonlySet<AgentInstance['status']> = new Set([
-  'INITIALIZING',
-  'TOOL_DISCOVERY',
-  'THINKING',
-  'TOOL_CALLING',
-  'IDLE',
-]);
-
-const isAgentInstanceRunning = (agentInstance: AgentInstance): boolean => {
-  return RUNNING_STATUSES.has(agentInstance.status);
-};
+import {isAgentInstanceRunning} from './agentInstanceStatus';
 
 const useAgentInstance = <T = AgentInstance>(
   agentInstanceKey: string | undefined,
@@ -56,4 +45,4 @@ const useAgentInstance = <T = AgentInstance>(
   });
 };
 
-export {useAgentInstance, isAgentInstanceRunning};
+export {useAgentInstance};

--- a/operate/client/src/modules/queries/agentInstances/useLatestAgentMessage.ts
+++ b/operate/client/src/modules/queries/agentInstances/useLatestAgentMessage.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import type {SearchAgentInstanceHistoryRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import {searchAgentInstanceHistory} from 'modules/api/v2/agentInstances/searchAgentInstanceHistory';
+import {queryKeys} from '../queryKeys';
+
+const REQUEST_BODY: SearchAgentInstanceHistoryRequestBody = {
+  sort: [{field: 'producedAt', order: 'desc'}],
+  filter: {commitStatus: 'COMMITTED', role: 'ASSISTANT'},
+  page: {limit: 1},
+};
+
+const useLatestAgentMessage = (
+  agentInstanceKey: string,
+  options?: {enablePeriodicRefetch?: boolean},
+) => {
+  return useQuery({
+    queryKey:
+      queryKeys.agentInstanceHistory.latestAgentMessage(agentInstanceKey),
+    queryFn: async ({signal}) => {
+      const {response, error} = await searchAgentInstanceHistory(
+        agentInstanceKey,
+        REQUEST_BODY,
+        signal,
+      );
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
+    select: (data) => data.items[0] ?? null,
+    refetchInterval: options?.enablePeriodicRefetch ? 5000 : undefined,
+  });
+};
+
+export {useLatestAgentMessage};

--- a/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
+++ b/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
@@ -6,16 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
 import {useAgentInstancesSearch} from './useAgentInstancesSearch';
-
-const ACTIVE_STATUSES: AgentInstance['status'][] = [
-  'INITIALIZING',
-  'TOOL_DISCOVERY',
-  'THINKING',
-  'TOOL_CALLING',
-];
+import {ACTIVE_STATUSES_ARRAY} from './agentInstanceStatus';
 
 const useProcessInstanceAgentInstances = () => {
   const {processInstanceId} = useProcessInstancePageParams();
@@ -24,7 +17,7 @@ const useProcessInstanceAgentInstances = () => {
     {
       filter: {
         processInstanceKey: processInstanceId ?? '',
-        status: {$in: ACTIVE_STATUSES},
+        status: {$in: ACTIVE_STATUSES_ARRAY},
       },
     },
     {

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -46,6 +46,11 @@ const queryKeys = {
       agentInstanceKey: string,
       payload?: SearchAgentInstanceHistoryRequestBody,
     ) => ['agentInstanceHistorySearch', agentInstanceKey, payload],
+    latestAgentMessage: (agentInstanceKey: string) => [
+      'agentInstanceHistorySearch',
+      'latestAgentMessage',
+      agentInstanceKey,
+    ],
   },
   variables: {
     search: () => ['searchVariables'],


### PR DESCRIPTION
## Description

This PR adds a new query hook for fetching the latest agent instance history message produced by an agent, and displays it as a `ConversationMessage` in the agent status section. The accordion is now enabled (when feature flag active), and open by default.

_Side Note: The latest message currently does nothing when a tool is clicked. I want to wait until we decided on our approach to tool call handling, before adding functionality there._

## Related issues

closes #52969
