### PR TITLE
feat: route data-plane authorization to the per-physical-tenant ResourceAccessController

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -28,13 +28,17 @@ import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.search.clients.CamundaSearchClients;
+import io.camunda.search.clients.auth.AnonymousResourceAccessController;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.SearchClientReaders;
+import io.camunda.security.core.authz.ResourceAccessController;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,10 +118,21 @@ public class RdbmsConfiguration {
   @Bean
   public CamundaSearchClients camundaSearchClients(
       final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
-      final PhysicalTenantResourceAccessControllers physicalTenantResourceAccessControllers) {
+      final Optional<PhysicalTenantResourceAccessControllers>
+          physicalTenantResourceAccessControllers) {
     return new CamundaSearchClients(
         physicalTenantSearchClientReaders.readersByPhysicalTenant(),
-        physicalTenantResourceAccessControllers.controllersByPhysicalTenant());
+        physicalTenantResourceAccessControllers
+            .map(PhysicalTenantResourceAccessControllers::controllersByPhysicalTenant)
+            .orElseGet(() -> anonymousControllers(physicalTenantSearchClientReaders)));
+  }
+
+  private static Map<String, ResourceAccessController> anonymousControllers(
+      final PhysicalTenantSearchClientReaders readers) {
+    return readers.readersByPhysicalTenant().entrySet().stream()
+        .collect(
+            Collectors.toUnmodifiableMap(
+                Map.Entry::getKey, e -> new AnonymousResourceAccessController()));
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.rdbms;
 
 import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 
+import io.camunda.application.commons.search.PhysicalTenantResourceAccessControllers;
 import io.camunda.application.commons.search.PhysicalTenantSearchClientReaders;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
@@ -27,15 +28,12 @@ import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.search.clients.CamundaSearchClients;
-import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.SearchClientReaders;
-import io.camunda.security.core.authz.ResourceAccessController;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
@@ -116,10 +114,10 @@ public class RdbmsConfiguration {
   @Bean
   public CamundaSearchClients camundaSearchClients(
       final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
-      final List<ResourceAccessController> resourceAccessControllers) {
+      final PhysicalTenantResourceAccessControllers physicalTenantResourceAccessControllers) {
     return new CamundaSearchClients(
         physicalTenantSearchClientReaders.readersByPhysicalTenant(),
-        new ResourceAccessDelegatingController(resourceAccessControllers));
+        physicalTenantResourceAccessControllers.controllersByPhysicalTenant());
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -28,7 +28,7 @@ import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.search.clients.CamundaSearchClients;
-import io.camunda.search.clients.auth.AnonymousResourceAccessController;
+import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.security.core.authz.ResourceAccessController;
@@ -36,6 +36,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -124,15 +125,22 @@ public class RdbmsConfiguration {
         physicalTenantSearchClientReaders.readersByPhysicalTenant(),
         physicalTenantResourceAccessControllers
             .map(PhysicalTenantResourceAccessControllers::controllersByPhysicalTenant)
-            .orElseGet(() -> anonymousControllers(physicalTenantSearchClientReaders)));
+            .orElseGet(() -> failFastControllers(physicalTenantSearchClientReaders)));
   }
 
-  private static Map<String, ResourceAccessController> anonymousControllers(
+  /**
+   * Fallback for non-web contexts (e.g. Restore, engine-only integration tests) where the per-PT
+   * {@link PhysicalTenantResourceAccessControllers} bean is not created. Such contexts do not
+   * perform authorized data-plane reads; an empty delegating controller keeps the context startable
+   * while failing fast on any accidental read.
+   */
+  private static Map<String, ResourceAccessController> failFastControllers(
       final PhysicalTenantSearchClientReaders readers) {
-    return readers.readersByPhysicalTenant().entrySet().stream()
+    return readers.readersByPhysicalTenant().keySet().stream()
         .collect(
             Collectors.toUnmodifiableMap(
-                Map.Entry::getKey, e -> new AnonymousResourceAccessController()));
+                tenantId -> tenantId,
+                tenantId -> new ResourceAccessDelegatingController(List.of())));
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantResourceAccessControllers.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantResourceAccessControllers.java
@@ -14,8 +14,10 @@ import java.util.Map;
  * Holds the {@link ResourceAccessController} for every physical tenant, keyed by physical tenant
  * id.
  *
- * <p>A typed wrapper is required because injecting a bare {@code Map<String,
- * ResourceAccessController>} would trigger Spring's collection-injection semantics.
+ * <p>A dedicated wrapper type is used so the map stays keyed by physical tenant id. Injecting a
+ * bare {@code Map<String, ResourceAccessController>} would otherwise require a qualifier — without
+ * one, Spring resolves it via bean-collection autowiring, keyed by bean name rather than by
+ * physical tenant id.
  */
 public record PhysicalTenantResourceAccessControllers(
     Map<String, ResourceAccessController> controllersByPhysicalTenant) {}

--- a/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantResourceAccessControllers.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantResourceAccessControllers.java
@@ -14,10 +14,11 @@ import java.util.Map;
  * Holds the {@link ResourceAccessController} for every physical tenant, keyed by physical tenant
  * id.
  *
- * <p>A dedicated wrapper type is used so the map stays keyed by physical tenant id. Injecting a
- * bare {@code Map<String, ResourceAccessController>} would otherwise require a qualifier — without
- * one, Spring resolves it via bean-collection autowiring, keyed by bean name rather than by
- * physical tenant id.
+ * <p>This wrapper record is not strictly required — a dedicated bean of type {@code Map<String,
+ * ResourceAccessController>} would work just as well. It is used to keep the injection point
+ * explicit and unambiguous: it avoids any confusion with Spring's bean-collection autowiring, which
+ * for a bare {@code Map<String, ResourceAccessController>} injection point keys the map by bean
+ * name rather than by physical tenant id.
  */
 public record PhysicalTenantResourceAccessControllers(
     Map<String, ResourceAccessController> controllersByPhysicalTenant) {}

--- a/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantResourceAccessControllers.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantResourceAccessControllers.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import io.camunda.security.core.authz.ResourceAccessController;
+import java.util.Map;
+
+/**
+ * Holds the {@link ResourceAccessController} for every physical tenant, keyed by physical tenant
+ * id.
+ *
+ * <p>A typed wrapper is required because injecting a bare {@code Map<String,
+ * ResourceAccessController>} would trigger Spring's collection-injection semantics.
+ */
+public record PhysicalTenantResourceAccessControllers(
+    Map<String, ResourceAccessController> controllersByPhysicalTenant) {}

--- a/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.search;
 
+import io.camunda.application.commons.security.PhysicalTenantSecurityProperties;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.db.rdbms.read.security.RdbmsResourceAccessController;
@@ -16,12 +17,17 @@ import io.camunda.search.clients.auth.DefaultTenantAccessProvider;
 import io.camunda.search.clients.auth.DisabledResourceAccessProvider;
 import io.camunda.search.clients.auth.DisabledTenantAccessProvider;
 import io.camunda.search.clients.auth.DocumentBasedResourceAccessController;
+import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.security.core.authz.ResourceAccessController;
 import io.camunda.security.core.authz.ResourceAccessProvider;
 import io.camunda.security.core.authz.TenantAccessProvider;
+import io.camunda.security.impl.SearchAuthorizationScopeRepository;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -69,5 +75,71 @@ public class ResourceAccessControllerConfiguration {
       final ResourceAccessProvider resourceAccessProvider,
       final TenantAccessProvider tenantAccessProvider) {
     return new RdbmsResourceAccessController(resourceAccessProvider, tenantAccessProvider);
+  }
+
+  @Bean
+  @ConditionalOnSecondaryStorageType({
+    SecondaryStorageType.elasticsearch,
+    SecondaryStorageType.opensearch
+  })
+  public PhysicalTenantResourceAccessControllers
+      documentBasedPhysicalTenantResourceAccessControllers(
+          final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
+          final PhysicalTenantSecurityProperties physicalTenantSecurityProperties,
+          final TenantAccessProvider tenantAccessProvider) {
+    final Map<String, ResourceAccessController> controllers = new LinkedHashMap<>();
+    physicalTenantSearchClientReaders
+        .readersByPhysicalTenant()
+        .forEach(
+            (tenantId, searchClientReaders) -> {
+              final var cslProps =
+                  physicalTenantSecurityProperties.propertiesByPhysicalTenant().get(tenantId);
+              final var checker =
+                  new AuthorizationChecker(
+                      new SearchAuthorizationScopeRepository(
+                          searchClientReaders.authorizationReader()));
+              final ResourceAccessProvider provider =
+                  cslProps.getAuthorizations().isEnabled()
+                      ? new DefaultResourceAccessProvider(checker)
+                      : new DisabledResourceAccessProvider();
+              final ResourceAccessController rac =
+                  new DocumentBasedResourceAccessController(provider, tenantAccessProvider);
+              controllers.put(
+                  tenantId,
+                  new ResourceAccessDelegatingController(
+                      List.of(new AnonymousResourceAccessController(), rac)));
+            });
+    return new PhysicalTenantResourceAccessControllers(Map.copyOf(controllers));
+  }
+
+  @Bean
+  @ConditionalOnSecondaryStorageType(SecondaryStorageType.rdbms)
+  public PhysicalTenantResourceAccessControllers rdbmsPhysicalTenantResourceAccessControllers(
+      final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
+      final PhysicalTenantSecurityProperties physicalTenantSecurityProperties,
+      final TenantAccessProvider tenantAccessProvider) {
+    final Map<String, ResourceAccessController> controllers = new LinkedHashMap<>();
+    physicalTenantSearchClientReaders
+        .readersByPhysicalTenant()
+        .forEach(
+            (tenantId, searchClientReaders) -> {
+              final var cslProps =
+                  physicalTenantSecurityProperties.propertiesByPhysicalTenant().get(tenantId);
+              final var checker =
+                  new AuthorizationChecker(
+                      new SearchAuthorizationScopeRepository(
+                          searchClientReaders.authorizationReader()));
+              final ResourceAccessProvider provider =
+                  cslProps.getAuthorizations().isEnabled()
+                      ? new DefaultResourceAccessProvider(checker)
+                      : new DisabledResourceAccessProvider();
+              final ResourceAccessController rac =
+                  new RdbmsResourceAccessController(provider, tenantAccessProvider);
+              controllers.put(
+                  tenantId,
+                  new ResourceAccessDelegatingController(
+                      List.of(new AnonymousResourceAccessController(), rac)));
+            });
+    return new PhysicalTenantResourceAccessControllers(Map.copyOf(controllers));
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
@@ -28,6 +28,7 @@ import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -87,29 +88,11 @@ public class ResourceAccessControllerConfiguration {
           final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
           final PhysicalTenantSecurityProperties physicalTenantSecurityProperties,
           final TenantAccessProvider tenantAccessProvider) {
-    final Map<String, ResourceAccessController> controllers = new LinkedHashMap<>();
-    physicalTenantSearchClientReaders
-        .readersByPhysicalTenant()
-        .forEach(
-            (tenantId, searchClientReaders) -> {
-              final var cslProps =
-                  physicalTenantSecurityProperties.propertiesByPhysicalTenant().get(tenantId);
-              final var checker =
-                  new AuthorizationChecker(
-                      new SearchAuthorizationScopeRepository(
-                          searchClientReaders.authorizationReader()));
-              final ResourceAccessProvider provider =
-                  cslProps.getAuthorizations().isEnabled()
-                      ? new DefaultResourceAccessProvider(checker)
-                      : new DisabledResourceAccessProvider();
-              final ResourceAccessController rac =
-                  new DocumentBasedResourceAccessController(provider, tenantAccessProvider);
-              controllers.put(
-                  tenantId,
-                  new ResourceAccessDelegatingController(
-                      List.of(new AnonymousResourceAccessController(), rac)));
-            });
-    return new PhysicalTenantResourceAccessControllers(Map.copyOf(controllers));
+    return buildPerTenantControllers(
+        physicalTenantSearchClientReaders,
+        physicalTenantSecurityProperties,
+        tenantAccessProvider,
+        DocumentBasedResourceAccessController::new);
   }
 
   @Bean
@@ -118,6 +101,19 @@ public class ResourceAccessControllerConfiguration {
       final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
       final PhysicalTenantSecurityProperties physicalTenantSecurityProperties,
       final TenantAccessProvider tenantAccessProvider) {
+    return buildPerTenantControllers(
+        physicalTenantSearchClientReaders,
+        physicalTenantSecurityProperties,
+        tenantAccessProvider,
+        RdbmsResourceAccessController::new);
+  }
+
+  private static PhysicalTenantResourceAccessControllers buildPerTenantControllers(
+      final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
+      final PhysicalTenantSecurityProperties physicalTenantSecurityProperties,
+      final TenantAccessProvider tenantAccessProvider,
+      final BiFunction<ResourceAccessProvider, TenantAccessProvider, ResourceAccessController>
+          controllerFactory) {
     final Map<String, ResourceAccessController> controllers = new LinkedHashMap<>();
     physicalTenantSearchClientReaders
         .readersByPhysicalTenant()
@@ -133,12 +129,12 @@ public class ResourceAccessControllerConfiguration {
                   cslProps.getAuthorizations().isEnabled()
                       ? new DefaultResourceAccessProvider(checker)
                       : new DisabledResourceAccessProvider();
-              final ResourceAccessController rac =
-                  new RdbmsResourceAccessController(provider, tenantAccessProvider);
+              final ResourceAccessController resourceAccessController =
+                  controllerFactory.apply(provider, tenantAccessProvider);
               controllers.put(
                   tenantId,
                   new ResourceAccessDelegatingController(
-                      List.of(new AnonymousResourceAccessController(), rac)));
+                      List.of(new AnonymousResourceAccessController(), resourceAccessController)));
             });
     return new PhysicalTenantResourceAccessControllers(Map.copyOf(controllers));
   }

--- a/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
@@ -55,30 +55,6 @@ public class ResourceAccessControllerConfiguration {
   }
 
   @Bean
-  public ResourceAccessController anonymousResourceAccessController() {
-    return new AnonymousResourceAccessController();
-  }
-
-  @Bean
-  @ConditionalOnSecondaryStorageType({
-    SecondaryStorageType.elasticsearch,
-    SecondaryStorageType.opensearch
-  })
-  public ResourceAccessController documentBasedResourceAccessController(
-      final ResourceAccessProvider resourceAccessProvider,
-      final TenantAccessProvider tenantAccessProvider) {
-    return new DocumentBasedResourceAccessController(resourceAccessProvider, tenantAccessProvider);
-  }
-
-  @Bean
-  @ConditionalOnSecondaryStorageType(SecondaryStorageType.rdbms)
-  public ResourceAccessController rdbmsResourceAccessController(
-      final ResourceAccessProvider resourceAccessProvider,
-      final TenantAccessProvider tenantAccessProvider) {
-    return new RdbmsResourceAccessController(resourceAccessProvider, tenantAccessProvider);
-  }
-
-  @Bean
   @ConditionalOnSecondaryStorageType({
     SecondaryStorageType.elasticsearch,
     SecondaryStorageType.opensearch

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -11,7 +11,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.search.clients.CamundaSearchClients;
-import io.camunda.search.clients.auth.AnonymousResourceAccessController;
+import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.impl.NoDBSearchClientsProxy;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.impl.NoopAuthorizationReader;
@@ -19,6 +19,7 @@ import io.camunda.search.es.clients.ElasticsearchSearchClient;
 import io.camunda.search.os.clients.OpensearchSearchClient;
 import io.camunda.security.core.authz.ResourceAccessController;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -67,14 +68,21 @@ public class SearchClientConfiguration {
         physicalTenantSearchClientReaders.readersByPhysicalTenant(),
         physicalTenantResourceAccessControllers
             .map(PhysicalTenantResourceAccessControllers::controllersByPhysicalTenant)
-            .orElseGet(() -> anonymousControllers(physicalTenantSearchClientReaders)));
+            .orElseGet(() -> failFastControllers(physicalTenantSearchClientReaders)));
   }
 
-  private static Map<String, ResourceAccessController> anonymousControllers(
+  /**
+   * Fallback for non-web contexts (e.g. Restore, engine-only integration tests) where the per-PT
+   * {@link PhysicalTenantResourceAccessControllers} bean is not created. Such contexts do not
+   * perform authorized data-plane reads; an empty delegating controller keeps the context startable
+   * while failing fast on any accidental read.
+   */
+  private static Map<String, ResourceAccessController> failFastControllers(
       final PhysicalTenantSearchClientReaders readers) {
-    return readers.readersByPhysicalTenant().entrySet().stream()
+    return readers.readersByPhysicalTenant().keySet().stream()
         .collect(
             Collectors.toUnmodifiableMap(
-                Map.Entry::getKey, e -> new AnonymousResourceAccessController()));
+                tenantId -> tenantId,
+                tenantId -> new ResourceAccessDelegatingController(List.of())));
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -11,15 +11,12 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.search.clients.CamundaSearchClients;
-import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.impl.NoDBSearchClientsProxy;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.impl.NoopAuthorizationReader;
 import io.camunda.search.es.clients.ElasticsearchSearchClient;
 import io.camunda.search.os.clients.OpensearchSearchClient;
-import io.camunda.security.core.authz.ResourceAccessController;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
-import java.util.List;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -59,9 +56,9 @@ public class SearchClientConfiguration {
   })
   public CamundaSearchClients camundaSearchClients(
       final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
-      final List<ResourceAccessController> resourceAccessControllers) {
+      final PhysicalTenantResourceAccessControllers physicalTenantResourceAccessControllers) {
     return new CamundaSearchClients(
         physicalTenantSearchClientReaders.readersByPhysicalTenant(),
-        new ResourceAccessDelegatingController(resourceAccessControllers));
+        physicalTenantResourceAccessControllers.controllersByPhysicalTenant());
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -11,12 +11,17 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.search.clients.CamundaSearchClients;
+import io.camunda.search.clients.auth.AnonymousResourceAccessController;
 import io.camunda.search.clients.impl.NoDBSearchClientsProxy;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.impl.NoopAuthorizationReader;
 import io.camunda.search.es.clients.ElasticsearchSearchClient;
 import io.camunda.search.os.clients.OpensearchSearchClient;
+import io.camunda.security.core.authz.ResourceAccessController;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -56,9 +61,20 @@ public class SearchClientConfiguration {
   })
   public CamundaSearchClients camundaSearchClients(
       final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
-      final PhysicalTenantResourceAccessControllers physicalTenantResourceAccessControllers) {
+      final Optional<PhysicalTenantResourceAccessControllers>
+          physicalTenantResourceAccessControllers) {
     return new CamundaSearchClients(
         physicalTenantSearchClientReaders.readersByPhysicalTenant(),
-        physicalTenantResourceAccessControllers.controllersByPhysicalTenant());
+        physicalTenantResourceAccessControllers
+            .map(PhysicalTenantResourceAccessControllers::controllersByPhysicalTenant)
+            .orElseGet(() -> anonymousControllers(physicalTenantSearchClientReaders)));
+  }
+
+  private static Map<String, ResourceAccessController> anonymousControllers(
+      final PhysicalTenantSearchClientReaders readers) {
+    return readers.readersByPhysicalTenant().entrySet().stream()
+        .collect(
+            Collectors.toUnmodifiableMap(
+                Map.Entry::getKey, e -> new AnonymousResourceAccessController()));
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsConfigurationPerTenantReadersIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsConfigurationPerTenantReadersIT.java
@@ -10,6 +10,8 @@ package io.camunda.application.commons.rdbms;
 import static io.camunda.configuration.physicaltenants.PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.application.commons.search.PhysicalTenantResourceAccessControllers;
+import io.camunda.application.commons.search.PhysicalTenantSearchClientReaders;
 import io.camunda.application.commons.search.SearchClientConfiguration;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
@@ -28,6 +30,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.OffsetDateTime;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -141,12 +144,19 @@ class RdbmsConfigurationPerTenantReadersIT {
     }
 
     /**
-     * Required only so that {@link CamundaSearchClients} can execute a read; access control is not
-     * under test here.
+     * Provides an anonymous controller per physical tenant so {@link CamundaSearchClients} can
+     * execute reads; access control is not under test here.
      */
     @Bean
-    ResourceAccessController testAnonymousResourceAccessController() {
-      return new AnonymousResourceAccessController();
+    PhysicalTenantResourceAccessControllers testPhysicalTenantResourceAccessControllers(
+        final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders) {
+      return new PhysicalTenantResourceAccessControllers(
+          physicalTenantSearchClientReaders.readersByPhysicalTenant().keySet().stream()
+              .collect(
+                  Collectors.toUnmodifiableMap(
+                      tenantId -> tenantId,
+                      tenantId ->
+                          (ResourceAccessController) new AnonymousResourceAccessController())));
     }
 
     private static void configureTenant(final MockEnvironment env, final String tenantId) {

--- a/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
@@ -9,20 +9,37 @@ package io.camunda.application.commons.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.camunda.application.commons.security.CamundaSecurityConfiguration;
+import io.camunda.application.commons.security.PhysicalTenantSecurityProperties;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.search.clients.auth.DefaultTenantAccessProvider;
 import io.camunda.search.clients.auth.DisabledTenantAccessProvider;
+import io.camunda.search.clients.reader.AuthorizationReader;
+import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.security.core.authz.ResourceAccessController;
 import io.camunda.security.core.authz.TenantAccessProvider;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 
 public class ResourceAccessControllerConfigurationTest {
 
   private WebApplicationContextRunner baseRunner() {
+    final var authReaderStub = mock(AuthorizationReader.class);
+    final var readersStub = mock(SearchClientReaders.class);
+    when(readersStub.authorizationReader()).thenReturn(authReaderStub);
+    final var defaultPtReaders =
+        new PhysicalTenantSearchClientReaders(Map.of("default", readersStub));
+    final var defaultPtSecProps =
+        new PhysicalTenantSecurityProperties(
+            Map.of("default", new CamundaSecurityLibraryProperties()));
+
     return new WebApplicationContextRunner()
         .withUserConfiguration(
             ResourceAccessControllerConfiguration.class,
@@ -30,6 +47,8 @@ public class ResourceAccessControllerConfigurationTest {
             UnifiedConfiguration.class,
             UnifiedConfigurationHelper.class)
         .withBean(AuthorizationChecker.class, () -> mock(AuthorizationChecker.class))
+        .withBean(PhysicalTenantSearchClientReaders.class, () -> defaultPtReaders)
+        .withBean(PhysicalTenantSecurityProperties.class, () -> defaultPtSecProps)
         // make REST gateway condition pass
         .withPropertyValues(
             "zeebe.broker.gateway.enable=true",
@@ -95,5 +114,74 @@ public class ResourceAccessControllerConfigurationTest {
               final var tap = context.getBean(TenantAccessProvider.class);
               assertThat(tap).isInstanceOf(DisabledTenantAccessProvider.class);
             });
+  }
+
+  @Nested
+  class PhysicalTenantResourceAccessControllersBean {
+
+    // Creates a dedicated runner with two PT entries — avoids bean-override conflict with
+    // baseRunner
+    private WebApplicationContextRunner twoTenantRunner(final String storageType) {
+      final var authReaderA = mock(AuthorizationReader.class);
+      final var authReaderB = mock(AuthorizationReader.class);
+      final var readersA = mock(SearchClientReaders.class);
+      final var readersB = mock(SearchClientReaders.class);
+      when(readersA.authorizationReader()).thenReturn(authReaderA);
+      when(readersB.authorizationReader()).thenReturn(authReaderB);
+      final var ptReaders =
+          new PhysicalTenantSearchClientReaders(Map.of("tenanta", readersA, "tenantb", readersB));
+      final var ptSecProps =
+          new PhysicalTenantSecurityProperties(
+              Map.of(
+                  "tenanta",
+                  new CamundaSecurityLibraryProperties(),
+                  "tenantb",
+                  new CamundaSecurityLibraryProperties()));
+
+      return new WebApplicationContextRunner()
+          .withUserConfiguration(
+              ResourceAccessControllerConfiguration.class,
+              CamundaSecurityConfiguration.class,
+              UnifiedConfiguration.class,
+              UnifiedConfigurationHelper.class)
+          .withBean(AuthorizationChecker.class, () -> mock(AuthorizationChecker.class))
+          .withBean(PhysicalTenantSearchClientReaders.class, () -> ptReaders)
+          .withBean(PhysicalTenantSecurityProperties.class, () -> ptSecProps)
+          .withPropertyValues(
+              "zeebe.broker.gateway.enable=true",
+              "camunda.rest.enabled=true",
+              "camunda.security.authorizations.enabled=false",
+              "camunda.data.secondary-storage.type=" + storageType);
+    }
+
+    @Test
+    void shouldContainEntryForEachPhysicalTenantForElasticsearch() {
+      twoTenantRunner("elasticsearch")
+          .run(
+              context -> {
+                assertThat(context).hasSingleBean(PhysicalTenantResourceAccessControllers.class);
+                final var controllers =
+                    context.getBean(PhysicalTenantResourceAccessControllers.class);
+                assertThat(controllers.controllersByPhysicalTenant())
+                    .containsOnlyKeys("tenanta", "tenantb");
+                assertThat(controllers.controllersByPhysicalTenant().values())
+                    .allSatisfy(c -> assertThat(c).isInstanceOf(ResourceAccessController.class));
+              });
+    }
+
+    @Test
+    void shouldContainEntryForEachPhysicalTenantForOpensearch() {
+      twoTenantRunner("opensearch")
+          .run(
+              context -> {
+                assertThat(context).hasSingleBean(PhysicalTenantResourceAccessControllers.class);
+                final var controllers =
+                    context.getBean(PhysicalTenantResourceAccessControllers.class);
+                assertThat(controllers.controllersByPhysicalTenant())
+                    .containsOnlyKeys("tenanta", "tenantb");
+                assertThat(controllers.controllersByPhysicalTenant().values())
+                    .allSatisfy(c -> assertThat(c).isInstanceOf(ResourceAccessController.class));
+              });
+    }
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/spring/PhysicalTenantSearchClientReadersConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/spring/PhysicalTenantSearchClientReadersConfigurationIT.java
@@ -15,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.camunda.application.commons.search.NativeSearchClientsConfiguration;
+import io.camunda.application.commons.search.PhysicalTenantResourceAccessControllers;
+import io.camunda.application.commons.search.PhysicalTenantSearchClientReaders;
 import io.camunda.application.commons.search.PhysicalTenantSearchClientReadersConfiguration;
 import io.camunda.application.commons.search.SearchClientConfiguration;
 import io.camunda.application.commons.search.SearchClientReaderConfiguration;
@@ -33,6 +35,7 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import jakarta.annotation.Resource;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -163,12 +166,19 @@ public class PhysicalTenantSearchClientReadersConfigurationIT {
     }
 
     /**
-     * Required only so that {@link CamundaSearchClients} can execute a read; access control is not
-     * under test here.
+     * Provides an anonymous controller per physical tenant so {@link CamundaSearchClients} can
+     * execute reads; access control is not under test here.
      */
     @Bean
-    ResourceAccessController testAnonymousResourceAccessController() {
-      return new AnonymousResourceAccessController();
+    PhysicalTenantResourceAccessControllers testPhysicalTenantResourceAccessControllers(
+        final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders) {
+      return new PhysicalTenantResourceAccessControllers(
+          physicalTenantSearchClientReaders.readersByPhysicalTenant().keySet().stream()
+              .collect(
+                  Collectors.toUnmodifiableMap(
+                      tenantId -> tenantId,
+                      tenantId ->
+                          (ResourceAccessController) new AnonymousResourceAccessController())));
     }
 
     private static void stubFakeEs(final WireMockServer wm, final long processInstanceKey) {

--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -15,8 +15,8 @@
   <dependencies>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>configuration-api</artifactId>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
     </dependency>
 
     <dependency>

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -191,7 +191,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<AgentInstanceHistoryEntity> searchAgentHistoryItems(
       final AgentInstanceHistoryQuery query) {
-    return doSearchWithReader(readers.agentHistoryReader(), query);
+    return doSearchWithReader(requireScopedReaders().agentHistoryReader(), query);
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -11,7 +11,6 @@ import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_ID_NOT_F
 import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_KEY_NOT_FOUND;
 import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_MULTIPLE_IDS_NOT_FOUND;
 
-import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.search.clients.reader.SearchEntityReader;
 import io.camunda.search.clients.reader.SearchQueryStatisticsReader;
@@ -127,6 +126,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -134,66 +134,58 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   private static final Logger LOG = LoggerFactory.getLogger(CamundaSearchClients.class);
 
-  private final SearchClientReaders readers;
+  @Nullable private final SearchClientReaders readers;
   private final Map<String, SearchClientReaders> tenantReaders;
-  private final String currentPhysicalTenantId;
-  private final ResourceAccessController resourceAccessController;
+  @Nullable private final String currentPhysicalTenantId;
+  @Nullable private final ResourceAccessController resourceAccessController;
   private final Map<String, ResourceAccessController> resourceAccessControllerByTenant;
-  private final SecurityContext securityContext;
-
-  public CamundaSearchClients(
-      final Map<String, SearchClientReaders> tenantReaders,
-      final ResourceAccessController resourceAccessController) {
-    this(
-        tenantReaders,
-        tenantReaders.keySet().stream()
-            .collect(Collectors.toUnmodifiableMap(k -> k, k -> resourceAccessController)));
-  }
+  @Nullable private final SecurityContext securityContext;
 
   public CamundaSearchClients(
       final Map<String, SearchClientReaders> tenantReaders,
       final Map<String, ResourceAccessController> resourceAccessControllerByTenant) {
-    this(
-        tenantReaders,
-        PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-        resourceAccessControllerByTenant,
-        null);
+    this(tenantReaders, null, resourceAccessControllerByTenant, null);
   }
 
   private CamundaSearchClients(
       final Map<String, SearchClientReaders> tenantReaders,
-      final String currentPhysicalTenantId,
+      final @Nullable String currentPhysicalTenantId,
       final Map<String, ResourceAccessController> resourceAccessControllerByTenant,
-      final SecurityContext securityContext) {
+      final @Nullable SecurityContext securityContext) {
     this.tenantReaders = Map.copyOf(tenantReaders);
-    readers = this.tenantReaders.get(currentPhysicalTenantId);
-    if (readers == null) {
-      throw new IllegalArgumentException(
-          "Missing readers for physical tenant '%s'. Known physical tenants: %s"
-              .formatted(currentPhysicalTenantId, this.tenantReaders.keySet()));
-    }
-    this.currentPhysicalTenantId = currentPhysicalTenantId;
     this.resourceAccessControllerByTenant = Map.copyOf(resourceAccessControllerByTenant);
-    this.resourceAccessController =
-        this.resourceAccessControllerByTenant.get(currentPhysicalTenantId);
-    if (this.resourceAccessController == null) {
-      throw new IllegalArgumentException(
-          ("Missing ResourceAccessController for physical tenant '%s'. Known physical tenants: %s")
-              .formatted(currentPhysicalTenantId, this.resourceAccessControllerByTenant.keySet()));
-    }
+    this.currentPhysicalTenantId = currentPhysicalTenantId;
     this.securityContext = securityContext;
+    if (currentPhysicalTenantId != null) {
+      readers = this.tenantReaders.get(currentPhysicalTenantId);
+      if (readers == null) {
+        throw new IllegalArgumentException(
+            "Unknown physical tenant: '%s'. Known physical tenants: %s"
+                .formatted(currentPhysicalTenantId, this.tenantReaders.keySet()));
+      }
+      resourceAccessController = this.resourceAccessControllerByTenant.get(currentPhysicalTenantId);
+      if (resourceAccessController == null) {
+        throw new IllegalArgumentException(
+            "Missing ResourceAccessController for physical tenant '%s'. Known physical tenants: %s"
+                .formatted(
+                    currentPhysicalTenantId, this.resourceAccessControllerByTenant.keySet()));
+      }
+    } else {
+      readers = null;
+      resourceAccessController = null;
+    }
   }
 
   @Override
   public AgentInstanceEntity getAgentInstance(final long key) {
-    return doGetWithReader(readers.agentInstanceReader(), key)
+    return doGetWithReader(requireScopedReaders().agentInstanceReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Agent Instance", key));
   }
 
   @Override
   public SearchQueryResult<AgentInstanceEntity> searchAgentInstances(
       final AgentInstanceQuery query) {
-    return doSearchWithReader(readers.agentInstanceReader(), query);
+    return doSearchWithReader(requireScopedReaders().agentInstanceReader(), query);
   }
 
   @Override
@@ -204,36 +196,37 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   @Override
   public AuthorizationEntity getAuthorization(final long key) {
-    return doGetWithReader(readers.authorizationReader(), key)
+    return doGetWithReader(requireScopedReaders().authorizationReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Authorization", key));
   }
 
   @Override
   public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
       final AuthorizationQuery query) {
-    return doSearchWithReader(readers.authorizationReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(
+        requireScopedReaders().authorizationReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(final SequenceFlowQuery query) {
-    return doSearchWithReader(readers.sequenceFlowReader(), query);
+    return doSearchWithReader(requireScopedReaders().sequenceFlowReader(), query);
   }
 
   @Override
   public SearchQueryResult<MessageSubscriptionEntity> searchMessageSubscriptions(
       final MessageSubscriptionQuery query) {
-    return doSearchWithReader(readers.messageSubscriptionReader(), query);
+    return doSearchWithReader(requireScopedReaders().messageSubscriptionReader(), query);
   }
 
   @Override
   public SearchQueryResult<CorrelatedMessageSubscriptionEntity>
       searchCorrelatedMessageSubscriptions(final CorrelatedMessageSubscriptionQuery query) {
-    return doSearchWithReader(readers.correlatedMessageSubscriptionReader(), query);
+    return doSearchWithReader(requireScopedReaders().correlatedMessageSubscriptionReader(), query);
   }
 
   @Override
   public MessageSubscriptionEntity getMessageSubscription(final long key) {
-    return doGetWithReader(readers.messageSubscriptionReader(), key)
+    return doGetWithReader(requireScopedReaders().messageSubscriptionReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Message Subscription", key));
   }
 
@@ -266,18 +259,18 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<ClusterVariableEntity> searchClusterVariables(
       final ClusterVariableQuery query) {
-    return doSearchWithReader(readers.clusterVariableReader(), query);
+    return doSearchWithReader(requireScopedReaders().clusterVariableReader(), query);
   }
 
   @Override
   public AuditLogEntity getAuditLog(final String id) {
-    return doGetWithReader(readers.auditLogReader(), id)
+    return doGetWithReader(requireScopedReaders().auditLogReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Audit log", id));
   }
 
   @Override
   public SearchQueryResult<AuditLogEntity> searchAuditLogs(final AuditLogQuery query) {
-    return doSearchWithReader(readers.auditLogReader(), query);
+    return doSearchWithReader(requireScopedReaders().auditLogReader(), query);
   }
 
   @Override
@@ -299,7 +292,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   @Override
   public MappingRuleEntity getMappingRule(final String id) {
-    return doGetWithReader(readers.mappingRuleReader(), id)
+    return doGetWithReader(requireScopedReaders().mappingRuleReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Mapping Rule", id));
   }
 
@@ -307,78 +300,79 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public SearchQueryResult<MappingRuleEntity> searchMappingRules(
       final MappingRuleQuery mappingRuleQuery) {
     return doSearchWithReader(
-        readers.mappingRuleReader(), mappingRuleQuery, this::disableTenantCheck);
+        requireScopedReaders().mappingRuleReader(), mappingRuleQuery, this::disableTenantCheck);
   }
 
   @Override
   public DecisionDefinitionEntity getDecisionDefinition(final long key) {
-    return doGetWithReader(readers.decisionDefinitionReader(), key)
+    return doGetWithReader(requireScopedReaders().decisionDefinitionReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Decision Definition", key));
   }
 
   @Override
   public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
       final DecisionDefinitionQuery query) {
-    return doSearchWithReader(readers.decisionDefinitionReader(), query);
+    return doSearchWithReader(requireScopedReaders().decisionDefinitionReader(), query);
   }
 
   @Override
   public DecisionInstanceEntity getDecisionInstance(final String id) {
-    return doGetWithReader(readers.decisionInstanceReader(), id)
+    return doGetWithReader(requireScopedReaders().decisionInstanceReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Decision Instance", id));
   }
 
   @Override
   public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
       final DecisionInstanceQuery query) {
-    return doSearchWithReader(readers.decisionInstanceReader(), query);
+    return doSearchWithReader(requireScopedReaders().decisionInstanceReader(), query);
   }
 
   @Override
   public DecisionRequirementsEntity getDecisionRequirements(
       final long key, final boolean includeXml) {
-    return doGet(a -> readers.decisionRequirementsReader().getByKey(key, a, includeXml))
+    return doGet(
+            a -> requireScopedReaders().decisionRequirementsReader().getByKey(key, a, includeXml))
         .orElseThrow(() -> entityByKeyNotFoundException("Decision Requirements", key));
   }
 
   @Override
   public SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
       final DecisionRequirementsQuery query) {
-    return doSearchWithReader(readers.decisionRequirementsReader(), query);
+    return doSearchWithReader(requireScopedReaders().decisionRequirementsReader(), query);
   }
 
   @Override
   public FlowNodeInstanceEntity getFlowNodeInstance(final long key) {
-    return doGetWithReader(readers.flowNodeInstanceReader(), key)
+    return doGetWithReader(requireScopedReaders().flowNodeInstanceReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Element Instance", key));
   }
 
   @Override
   public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
       final FlowNodeInstanceQuery query) {
-    return doSearchWithReader(readers.flowNodeInstanceReader(), query);
+    return doSearchWithReader(requireScopedReaders().flowNodeInstanceReader(), query);
   }
 
   @Override
   public FormEntity getForm(final long key) {
-    return doGetWithReader(readers.formReader(), key)
+    return doGetWithReader(requireScopedReaders().formReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Form", key));
   }
 
   @Override
   public SearchQueryResult<FormEntity> searchForms(final FormQuery query) {
-    return doSearchWithReader(readers.formReader(), query);
+    return doSearchWithReader(requireScopedReaders().formReader(), query);
   }
 
   @Override
   public IncidentEntity getIncident(final long key) {
-    return doGetWithReader(readers.incidentReader(), key)
+    return doGetWithReader(requireScopedReaders().incidentReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Incident", key));
   }
 
   @Override
   public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery query) {
-    return doSearchWithReader(readers.incidentReader(), query);
+    return doSearchWithReader(requireScopedReaders().incidentReader(), query);
   }
 
   @Override
@@ -386,7 +380,8 @@ public class CamundaSearchClients implements SearchClientsProxy {
       incidentProcessInstanceStatisticsByError(
           final IncidentProcessInstanceStatisticsByErrorQuery query) {
 
-    return doSearchWithReader(readers.incidentProcessInstanceStatisticsByErrorReader(), query);
+    return doSearchWithReader(
+        requireScopedReaders().incidentProcessInstanceStatisticsByErrorReader(), query);
   }
 
   @Override
@@ -394,19 +389,20 @@ public class CamundaSearchClients implements SearchClientsProxy {
       searchIncidentProcessInstanceStatisticsByDefinition(
           final IncidentProcessInstanceStatisticsByDefinitionQuery query) {
 
-    return doSearchWithReader(readers.incidentProcessInstanceStatisticsByDefinitionReader(), query);
+    return doSearchWithReader(
+        requireScopedReaders().incidentProcessInstanceStatisticsByDefinitionReader(), query);
   }
 
   @Override
   public ProcessDefinitionEntity getProcessDefinition(final long key) {
-    return doGetWithReader(readers.processDefinitionReader(), key)
+    return doGetWithReader(requireScopedReaders().processDefinitionReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Process Definition", key));
   }
 
   @Override
   public SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
       final ProcessDefinitionQuery query) {
-    return doSearchWithReader(readers.processDefinitionReader(), query);
+    return doSearchWithReader(requireScopedReaders().processDefinitionReader(), query);
   }
 
   @Override
@@ -422,7 +418,8 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity>
       processDefinitionInstanceStatistics(final ProcessDefinitionInstanceStatisticsQuery query) {
-    return doSearchWithReader(readers.processDefinitionInstanceStatisticsReader(), query);
+    return doSearchWithReader(
+        requireScopedReaders().processDefinitionInstanceStatisticsReader(), query);
   }
 
   @Override
@@ -430,26 +427,27 @@ public class CamundaSearchClients implements SearchClientsProxy {
       getProcessDefinitionMessageSubscriptionStatistics(
           final ProcessDefinitionMessageSubscriptionStatisticsQuery query) {
     return doSearchWithReader(
-        readers.processDefinitionMessageSubscriptionStatisticsReader(), query);
+        requireScopedReaders().processDefinitionMessageSubscriptionStatisticsReader(), query);
   }
 
   @Override
   public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity>
       processDefinitionInstanceVersionStatistics(
           final ProcessDefinitionInstanceVersionStatisticsQuery query) {
-    return doSearchWithReader(readers.processDefinitionInstanceVersionStatisticsReader(), query);
+    return doSearchWithReader(
+        requireScopedReaders().processDefinitionInstanceVersionStatisticsReader(), query);
   }
 
   @Override
   public ProcessInstanceEntity getProcessInstance(final long processInstanceKey) {
-    return doGetWithReader(readers.processInstanceReader(), processInstanceKey)
+    return doGetWithReader(requireScopedReaders().processInstanceReader(), processInstanceKey)
         .orElseThrow(() -> entityByKeyNotFoundException("Process Instance", processInstanceKey));
   }
 
   @Override
   public SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(
       final ProcessInstanceQuery query) {
-    return doSearchWithReader(readers.processInstanceReader(), query);
+    return doSearchWithReader(requireScopedReaders().processInstanceReader(), query);
   }
 
   @Override
@@ -467,152 +465,165 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<JobEntity> searchJobs(final JobQuery query) {
-    return doSearchWithReader(readers.jobReader(), query);
+    return doSearchWithReader(requireScopedReaders().jobReader(), query);
   }
 
   @Override
   public GlobalJobStatisticsEntity getGlobalJobStatistics(final GlobalJobStatisticsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.jobMetricsBatchReader().getGlobalJobStatistics(query, access));
+        access ->
+            requireScopedReaders().jobMetricsBatchReader().getGlobalJobStatistics(query, access));
   }
 
   @Override
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       final JobTypeStatisticsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.jobMetricsBatchReader().getJobTypeStatistics(query, access));
+        access ->
+            requireScopedReaders().jobMetricsBatchReader().getJobTypeStatistics(query, access));
   }
 
   @Override
   public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
       final JobWorkerStatisticsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.jobMetricsBatchReader().getJobWorkerStatistics(query, access));
+        access ->
+            requireScopedReaders().jobMetricsBatchReader().getJobWorkerStatistics(query, access));
   }
 
   @Override
   public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
       final JobTimeSeriesStatisticsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.jobMetricsBatchReader().getJobTimeSeriesStatistics(query, access));
+        access ->
+            requireScopedReaders()
+                .jobMetricsBatchReader()
+                .getJobTimeSeriesStatistics(query, access));
   }
 
   @Override
   public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
       final JobErrorStatisticsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.jobMetricsBatchReader().getJobErrorStatistics(query, access));
+        access ->
+            requireScopedReaders().jobMetricsBatchReader().getJobErrorStatistics(query, access));
   }
 
   @Override
   public RoleEntity getRole(final String id) {
-    return doGetWithReader(readers.roleReader(), id)
+    return doGetWithReader(requireScopedReaders().roleReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Role", id));
   }
 
   @Override
   public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery query) {
-    return doSearchWithReader(readers.roleReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(requireScopedReaders().roleReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public SearchQueryResult<RoleMemberEntity> searchRoleMembers(final RoleMemberQuery query) {
-    return doSearchWithReader(readers.roleMemberReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(
+        requireScopedReaders().roleMemberReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public TenantEntity getTenant(final String id) {
-    return doGetWithReader(readers.tenantReader(), id)
+    return doGetWithReader(requireScopedReaders().tenantReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Tenant", id));
   }
 
   @Override
   public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery query) {
-    return doSearchWithReader(readers.tenantReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(
+        requireScopedReaders().tenantReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public SearchQueryResult<TenantMemberEntity> searchTenantMembers(final TenantMemberQuery query) {
-    return doSearchWithReader(readers.tenantMemberReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(
+        requireScopedReaders().tenantMemberReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public GroupEntity getGroup(final String id) {
-    return doGetWithReader(readers.groupReader(), id)
+    return doGetWithReader(requireScopedReaders().groupReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Group", id));
   }
 
   @Override
   public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
-    return doSearchWithReader(readers.groupReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(
+        requireScopedReaders().groupReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupMemberQuery query) {
-    return doSearchWithReader(readers.groupMemberReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(
+        requireScopedReaders().groupMemberReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public UserEntity getUser(final String username) {
-    return doGetWithReader(readers.userReader(), username)
+    return doGetWithReader(requireScopedReaders().userReader(), username)
         .orElseThrow(() -> entityByUsernameNotFoundException(username));
   }
 
   @Override
   public SearchQueryResult<UserEntity> searchUsers(final UserQuery query) {
-    return doSearchWithReader(readers.userReader(), query, this::disableTenantCheck);
+    return doSearchWithReader(requireScopedReaders().userReader(), query, this::disableTenantCheck);
   }
 
   @Override
   public UserTaskEntity getUserTask(final long key) {
-    return doGetWithReader(readers.userTaskReader(), key)
+    return doGetWithReader(requireScopedReaders().userTaskReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("User Task", key));
   }
 
   @Override
   public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery query) {
-    return doSearchWithReader(readers.userTaskReader(), query);
+    return doSearchWithReader(requireScopedReaders().userTaskReader(), query);
   }
 
   @Override
   public VariableEntity getVariable(final long key) {
-    return doGetWithReader(readers.variableReader(), key)
+    return doGetWithReader(requireScopedReaders().variableReader(), key)
         .orElseThrow(() -> entityByKeyNotFoundException("Variable", key));
   }
 
   @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery query) {
-    return doSearchWithReader(readers.variableReader(), query);
+    return doSearchWithReader(requireScopedReaders().variableReader(), query);
   }
 
   @Override
   public UsageMetricStatisticsEntity usageMetricStatistics(final UsageMetricsQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.usageMetricsReader().usageMetricStatistics(query, access));
+        access -> requireScopedReaders().usageMetricsReader().usageMetricStatistics(query, access));
   }
 
   @Override
   public UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsTUQuery query) {
     return doReadWithResourceAccessController(
-        access -> readers.usageMetricsTUReader().usageMetricTUStatistics(query, access));
+        access ->
+            requireScopedReaders().usageMetricsTUReader().usageMetricTUStatistics(query, access));
   }
 
   @Override
   public BatchOperationEntity getBatchOperation(final String id) {
-    return doGetWithReader(readers.batchOperationReader(), id)
+    return doGetWithReader(requireScopedReaders().batchOperationReader(), id)
         .orElseThrow(() -> entityByIdNotFoundException("Batch Operation", id));
   }
 
   @Override
   public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
       final BatchOperationQuery query) {
-    return doSearchWithReader(readers.batchOperationReader(), query);
+    return doSearchWithReader(requireScopedReaders().batchOperationReader(), query);
   }
 
   @Override
   public SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
       final BatchOperationItemQuery query) {
-    return doSearchWithReader(readers.batchOperationItemReader(), query);
+    return doSearchWithReader(requireScopedReaders().batchOperationItemReader(), query);
   }
 
   @Override
@@ -635,25 +646,25 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<GlobalListenerEntity> searchGlobalListeners(
       final GlobalListenerQuery query) {
-    return doSearchWithReader(readers.globalListenerReader(), query);
+    return doSearchWithReader(requireScopedReaders().globalListenerReader(), query);
   }
 
   @Override
   public DeployedResourceEntity getDeployedResource(final long key) {
-    return doGet(a -> readers.deployedResourceReader().getByKey(key, a))
+    return doGet(a -> requireScopedReaders().deployedResourceReader().getByKey(key, a))
         .orElseThrow(() -> entityByKeyNotFoundException("Resource", key));
   }
 
   @Override
   public DeployedResourceEntity getDeployedResourceMetadata(final long key) {
-    return doGet(a -> readers.deployedResourceReader().getByKeyMetadata(key, a))
+    return doGet(a -> requireScopedReaders().deployedResourceReader().getByKeyMetadata(key, a))
         .orElseThrow(() -> entityByKeyNotFoundException("Resource", key));
   }
 
   @Override
   public SearchQueryResult<DeployedResourceEntity> searchDeployedResources(
       final DeployedResourceQuery query) {
-    return doSearchWithReader(readers.deployedResourceReader(), query);
+    return doSearchWithReader(requireScopedReaders().deployedResourceReader(), query);
   }
 
   protected <T, Q extends TypedSearchQuery<?, ?>> Optional<T> doGetWithReader(
@@ -764,6 +775,14 @@ public class CamundaSearchClients implements SearchClientsProxy {
     }
   }
 
+  private SearchClientReaders requireScopedReaders() {
+    if (currentPhysicalTenantId == null) {
+      throw new IllegalStateException(
+          "CamundaSearchClients must be scoped to a physical tenant via withPhysicalTenant() before performing reads");
+    }
+    return readers;
+  }
+
   protected <T> T doReadWithResourceAccessController(
       final Function<ResourceAccessChecks, T> applier) {
     return resourceAccessController.doSearch(securityContext, applier);
@@ -797,7 +816,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<WaitStateEntity> searchWaitStates(
       final ElementInstanceWaitStateQuery query) {
-    return doSearchWithReader(readers.waitStateReader(), query);
+    return doSearchWithReader(requireScopedReaders().waitStateReader(), query);
   }
 
   private CamundaSearchException entityByIdNotFoundException(

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -134,10 +134,8 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   private static final Logger LOG = LoggerFactory.getLogger(CamundaSearchClients.class);
 
-  @Nullable private final SearchClientReaders readers;
   private final Map<String, SearchClientReaders> tenantReaders;
   @Nullable private final String currentPhysicalTenantId;
-  @Nullable private final ResourceAccessController resourceAccessController;
   private final Map<String, ResourceAccessController> resourceAccessControllerByTenant;
   @Nullable private final SecurityContext securityContext;
 
@@ -157,22 +155,19 @@ public class CamundaSearchClients implements SearchClientsProxy {
     this.currentPhysicalTenantId = currentPhysicalTenantId;
     this.securityContext = securityContext;
     if (currentPhysicalTenantId != null) {
-      readers = this.tenantReaders.get(currentPhysicalTenantId);
-      if (readers == null) {
+      // eagerly validate that the scoped tenant exists in both maps so withPhysicalTenant fails on
+      // an unknown tenant rather than at read time
+      if (!this.tenantReaders.containsKey(currentPhysicalTenantId)) {
         throw new IllegalArgumentException(
             "Unknown physical tenant: '%s'. Known physical tenants: %s"
                 .formatted(currentPhysicalTenantId, this.tenantReaders.keySet()));
       }
-      resourceAccessController = this.resourceAccessControllerByTenant.get(currentPhysicalTenantId);
-      if (resourceAccessController == null) {
+      if (!this.resourceAccessControllerByTenant.containsKey(currentPhysicalTenantId)) {
         throw new IllegalArgumentException(
             "Missing ResourceAccessController for physical tenant '%s'. Known physical tenants: %s"
                 .formatted(
                     currentPhysicalTenantId, this.resourceAccessControllerByTenant.keySet()));
       }
-    } else {
-      readers = null;
-      resourceAccessController = null;
     }
   }
 
@@ -234,7 +229,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public ClusterVariableEntity getClusterVariable(final String name, final String tenant) {
     return doGet(
             resourceAccessChecks ->
-                readers
+                requireScopedReaders()
                     .clusterVariableReader()
                     .getTenantScopedClusterVariable(name, tenant, resourceAccessChecks))
         .orElseThrow(
@@ -247,7 +242,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public ClusterVariableEntity getClusterVariable(final String name) {
     return doGet(
             resourceAccessChecks ->
-                readers
+                requireScopedReaders()
                     .clusterVariableReader()
                     .getGloballyScopedClusterVariable(name, resourceAccessChecks))
         .orElseThrow(
@@ -275,11 +270,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   @Override
   public SearchClientsProxy withPhysicalTenant(final String physicalTenantId) {
-    if (!tenantReaders.containsKey(physicalTenantId)) {
-      throw new IllegalArgumentException(
-          "Unknown physical tenant: '%s'. Known tenants: %s"
-              .formatted(physicalTenantId, tenantReaders.keySet()));
-    }
+    // the private constructor validates that the tenant is known
     return new CamundaSearchClients(
         tenantReaders, physicalTenantId, resourceAccessControllerByTenant, securityContext);
   }
@@ -410,7 +401,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final ProcessDefinitionStatisticsFilter filter) {
     return doReadWithResourceAccessController(
         access ->
-            readers
+            requireScopedReaders()
                 .processDefinitionStatisticsReader()
                 .aggregate(new ProcessDefinitionFlowNodeStatisticsQuery(filter), access));
   }
@@ -455,7 +446,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final long processInstanceKey) {
     return doReadWithResourceAccessController(
         access ->
-            readers
+            requireScopedReaders()
                 .processInstanceStatisticsReader()
                 .aggregate(
                     new ProcessInstanceFlowNodeStatisticsQuery(
@@ -631,7 +622,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final String listenerId, final GlobalListenerType listenerType) {
     return doGet(
             resourceAccessChecks ->
-                readers
+                requireScopedReaders()
                     .globalListenerReader()
                     .getGlobalListener(listenerId, listenerType, resourceAccessChecks))
         .orElseThrow(
@@ -785,12 +776,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   private SearchClientReaders requireScopedReaders() {
     requireScoped();
-    return readers;
+    return tenantReaders.get(currentPhysicalTenantId);
   }
 
   private ResourceAccessController requireScopedResourceAccessController() {
     requireScoped();
-    return resourceAccessController;
+    return resourceAccessControllerByTenant.get(currentPhysicalTenantId);
   }
 
   protected <T> T doReadWithResourceAccessController(

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -762,6 +762,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   protected <T> Optional<T> doGet(final Function<ResourceAccessChecks, T> applier) {
+    requireScoped();
     try {
       return Optional.ofNullable(doGetWithResourceAccessController(applier));
     } catch (final TenantAccessDeniedException e) {
@@ -775,22 +776,31 @@ public class CamundaSearchClients implements SearchClientsProxy {
     }
   }
 
-  private SearchClientReaders requireScopedReaders() {
+  private void requireScoped() {
     if (currentPhysicalTenantId == null) {
       throw new IllegalStateException(
           "CamundaSearchClients must be scoped to a physical tenant via withPhysicalTenant() before performing reads");
     }
+  }
+
+  private SearchClientReaders requireScopedReaders() {
+    requireScoped();
     return readers;
+  }
+
+  private ResourceAccessController requireScopedResourceAccessController() {
+    requireScoped();
+    return resourceAccessController;
   }
 
   protected <T> T doReadWithResourceAccessController(
       final Function<ResourceAccessChecks, T> applier) {
-    return resourceAccessController.doSearch(securityContext, applier);
+    return requireScopedResourceAccessController().doSearch(securityContext, applier);
   }
 
   protected <T> T doGetWithResourceAccessController(
       final Function<ResourceAccessChecks, T> applier) {
-    return resourceAccessController.doGet(securityContext, applier);
+    return requireScopedResourceAccessController().doGet(securityContext, applier);
   }
 
   protected CamundaSearchException entityByKeyNotFoundException(

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -138,6 +138,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   private final Map<String, SearchClientReaders> tenantReaders;
   private final String currentPhysicalTenantId;
   private final ResourceAccessController resourceAccessController;
+  private final Map<String, ResourceAccessController> resourceAccessControllerByTenant;
   private final SecurityContext securityContext;
 
   public CamundaSearchClients(
@@ -145,15 +146,24 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final ResourceAccessController resourceAccessController) {
     this(
         tenantReaders,
+        tenantReaders.keySet().stream()
+            .collect(Collectors.toUnmodifiableMap(k -> k, k -> resourceAccessController)));
+  }
+
+  public CamundaSearchClients(
+      final Map<String, SearchClientReaders> tenantReaders,
+      final Map<String, ResourceAccessController> resourceAccessControllerByTenant) {
+    this(
+        tenantReaders,
         PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-        resourceAccessController,
+        resourceAccessControllerByTenant,
         null);
   }
 
   private CamundaSearchClients(
       final Map<String, SearchClientReaders> tenantReaders,
       final String currentPhysicalTenantId,
-      final ResourceAccessController resourceAccessController,
+      final Map<String, ResourceAccessController> resourceAccessControllerByTenant,
       final SecurityContext securityContext) {
     this.tenantReaders = Map.copyOf(tenantReaders);
     readers = this.tenantReaders.get(currentPhysicalTenantId);
@@ -163,7 +173,14 @@ public class CamundaSearchClients implements SearchClientsProxy {
               .formatted(currentPhysicalTenantId, this.tenantReaders.keySet()));
     }
     this.currentPhysicalTenantId = currentPhysicalTenantId;
-    this.resourceAccessController = resourceAccessController;
+    this.resourceAccessControllerByTenant = Map.copyOf(resourceAccessControllerByTenant);
+    this.resourceAccessController =
+        this.resourceAccessControllerByTenant.get(currentPhysicalTenantId);
+    if (this.resourceAccessController == null) {
+      throw new IllegalArgumentException(
+          ("Missing ResourceAccessController for physical tenant '%s'. Known physical tenants: %s")
+              .formatted(currentPhysicalTenantId, this.resourceAccessControllerByTenant.keySet()));
+    }
     this.securityContext = securityContext;
   }
 
@@ -271,13 +288,13 @@ public class CamundaSearchClients implements SearchClientsProxy {
               .formatted(physicalTenantId, tenantReaders.keySet()));
     }
     return new CamundaSearchClients(
-        tenantReaders, physicalTenantId, resourceAccessController, securityContext);
+        tenantReaders, physicalTenantId, resourceAccessControllerByTenant, securityContext);
   }
 
   @Override
   public CamundaSearchClients withSecurityContext(final SecurityContext securityContext) {
     return new CamundaSearchClients(
-        tenantReaders, currentPhysicalTenantId, resourceAccessController, securityContext);
+        tenantReaders, currentPhysicalTenantId, resourceAccessControllerByTenant, securityContext);
   }
 
   @Override

--- a/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsTest.java
+++ b/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsTest.java
@@ -47,7 +47,10 @@ class CamundaSearchClientsTest {
   @BeforeEach
   void setUp() {
     camundaSearchClients =
-        new CamundaSearchClients(Map.of("default", readers), resourceAccessController);
+        (CamundaSearchClients)
+            new CamundaSearchClients(
+                    Map.of("default", readers), Map.of("default", resourceAccessController))
+                .withPhysicalTenant("default");
 
     // Make the resource access controller simply invoke the applier with a no-op check
     when(resourceAccessController.doSearch(any(), any()))
@@ -218,7 +221,10 @@ class CamundaSearchClientsTest {
       final var clients =
           new CamundaSearchClients(
               Map.of(DEFAULT, readers, TENANT_A, tenantAReaders, TENANT_B, tenantBReaders),
-              resourceAccessController);
+              Map.of(
+                  DEFAULT, resourceAccessController,
+                  TENANT_A, resourceAccessController,
+                  TENANT_B, resourceAccessController));
 
       // when / then
       assertThatThrownBy(() -> clients.withPhysicalTenant("unknown"))
@@ -237,7 +243,10 @@ class CamundaSearchClientsTest {
       final var clients =
           new CamundaSearchClients(
               Map.of(DEFAULT, readers, TENANT_A, tenantAReaders, TENANT_B, tenantBReaders),
-              resourceAccessController);
+              Map.of(
+                  DEFAULT, resourceAccessController,
+                  TENANT_A, resourceAccessController,
+                  TENANT_B, resourceAccessController));
 
       // when
       clients.withPhysicalTenant(TENANT_A).searchProcessInstances(ProcessInstanceQuery.of(b -> b));
@@ -248,6 +257,20 @@ class CamundaSearchClientsTest {
     }
 
     @Test
+    void shouldThrowWhenReadIsAttemptedWithoutScopingToAPhysicalTenant() {
+      // given — an unscoped base instance (withPhysicalTenant not yet called)
+      final var unscopedClients =
+          new CamundaSearchClients(
+              Map.of(DEFAULT, readers), Map.of(DEFAULT, resourceAccessController));
+
+      // when / then
+      assertThatThrownBy(
+              () -> unscopedClients.searchProcessInstances(ProcessInstanceQuery.of(b -> b)))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("withPhysicalTenant");
+    }
+
+    @Test
     void shouldPreserveSecurityContextAndResourceAccessControllerOnTheReturnedInstance() {
       // given
       when(tenantAReaders.processInstanceReader()).thenReturn(tenantAProcessInstanceReader);
@@ -255,7 +278,8 @@ class CamundaSearchClientsTest {
       final var securityContext = SecurityContext.of(b -> b);
       final var clients =
           new CamundaSearchClients(
-              Map.of(DEFAULT, readers, TENANT_A, tenantAReaders), resourceAccessController);
+              Map.of(DEFAULT, readers, TENANT_A, tenantAReaders),
+              Map.of(DEFAULT, resourceAccessController, TENANT_A, resourceAccessController));
 
       // when
       clients

--- a/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsTest.java
+++ b/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsTest.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -265,6 +266,63 @@ class CamundaSearchClientsTest {
       // then — switching the security context must not reset the physical tenant scoping
       verify(tenantAProcessInstanceReader).search(any(), any());
       verifyNoInteractions(processInstanceReader);
+    }
+  }
+
+  @Nested
+  class WithPhysicalTenantSelectsPerTenantRac {
+
+    private static final String PT_A = "pt-a";
+    private static final String PT_B = "pt-b";
+
+    @Test
+    void shouldRouteReadToCorrectRac() {
+      // given — two PTs with distinct RAC mocks (plus the required "default" entry)
+      final ResourceAccessController racDefault = mock(ResourceAccessController.class);
+      final ResourceAccessController racA = mock(ResourceAccessController.class);
+      final ResourceAccessController racB = mock(ResourceAccessController.class);
+      final SearchClientReaders readersDefault = mock(SearchClientReaders.class);
+      final SearchClientReaders readersA = mock(SearchClientReaders.class);
+      final SearchClientReaders readersB = mock(SearchClientReaders.class);
+      final ProcessInstanceReader processInstanceReaderA = mock(ProcessInstanceReader.class);
+      final ProcessInstanceReader processInstanceReaderB = mock(ProcessInstanceReader.class);
+
+      // make each RAC call through its applier
+      when(racA.doSearch(any(), any()))
+          .thenAnswer(
+              inv -> {
+                final Function<ResourceAccessChecks, Object> applier = inv.getArgument(1);
+                return applier.apply(ResourceAccessChecks.disabled());
+              });
+      when(racB.doSearch(any(), any()))
+          .thenAnswer(
+              inv -> {
+                final Function<ResourceAccessChecks, Object> applier = inv.getArgument(1);
+                return applier.apply(ResourceAccessChecks.disabled());
+              });
+
+      when(readersA.processInstanceReader()).thenReturn(processInstanceReaderA);
+      when(readersB.processInstanceReader()).thenReturn(processInstanceReaderB);
+
+      final CamundaSearchClients clients =
+          new CamundaSearchClients(
+              Map.of("default", readersDefault, PT_A, readersA, PT_B, readersB),
+              Map.of("default", racDefault, PT_A, racA, PT_B, racB));
+
+      // when scoped to PT_A
+      clients.withPhysicalTenant(PT_A).searchProcessInstances(ProcessInstanceQuery.of(b -> b));
+
+      // then only racA is called
+      verify(racA).doSearch(any(), any());
+      verifyNoInteractions(racB);
+
+      // when scoped to PT_B
+      clearInvocations(racA, racB);
+      clients.withPhysicalTenant(PT_B).searchProcessInstances(ProcessInstanceQuery.of(b -> b));
+
+      // then only racB is called
+      verify(racB).doSearch(any(), any());
+      verifyNoInteractions(racA);
     }
   }
 }

--- a/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsTest.java
+++ b/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsTest.java
@@ -271,6 +271,33 @@ class CamundaSearchClientsTest {
     }
 
     @Test
+    void shouldThrowWhenStatisticsReadIsAttemptedWithoutScoping() {
+      // given — an unscoped base instance
+      final var unscopedClients =
+          new CamundaSearchClients(
+              Map.of(DEFAULT, readers), Map.of(DEFAULT, resourceAccessController));
+
+      // when / then — a ResourceAccessController-backed (non reader-first) path must also fail fast
+      assertThatThrownBy(() -> unscopedClients.processInstanceFlowNodeStatistics(1L))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("withPhysicalTenant");
+    }
+
+    @Test
+    void shouldThrowWhenGetViaResourceAccessControllerIsAttemptedWithoutScoping() {
+      // given — an unscoped base instance
+      final var unscopedClients =
+          new CamundaSearchClients(
+              Map.of(DEFAULT, readers), Map.of(DEFAULT, resourceAccessController));
+
+      // when / then — a doGet(...)-backed path must fail fast with ISE, not a wrapped
+      // CamundaSearchException
+      assertThatThrownBy(() -> unscopedClients.getDeployedResource(1L))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("withPhysicalTenant");
+    }
+
+    @Test
     void shouldPreserveSecurityContextAndResourceAccessControllerOnTheReturnedInstance() {
       // given
       when(tenantAReaders.processInstanceReader()).thenReturn(tenantAProcessInstanceReader);


### PR DESCRIPTION
## Context

Part of #55252 (PT authorization routing). ADR-0005.

Stacked on #55466 (S6 — per-PT `CamundaSecurityLibraryProperties`); merge that first.

> Originally split into S2a (additive map) + S2b (fail-fast flip). The delta turned out small, so both are combined here — this PR now fully implements #55438.

## Problem

`CamundaSearchClients` held a single `ResourceAccessController` shared across all PTs. `withPhysicalTenant(pt)` already scoped _readers_ per PT but left the RAC pinned to the global singleton, so data-plane result filtering ran against the wrong PT's authorization data for non-default PTs.

## What this PR does

- Adds `Map<String, ResourceAccessController> resourceAccessControllerByTenant` to `CamundaSearchClients`. `withPhysicalTenant(pt)`/`withSecurityContext` scope both readers _and_ the RAC to the in-context PT.
- The base instance is an **unscoped router** (`currentPhysicalTenantId = null`): any read before `withPhysicalTenant(...)` fails fast with `IllegalStateException`. The guard covers both reader-first paths and `ResourceAccessController`-backed paths (statistics, usage metrics, deployed resources).
- Builds the per-PT RAC map in `ResourceAccessControllerConfiguration` for ES/OS and RDBMS via a shared `buildPerTenantControllers(..., controllerFactory)` helper. Per-PT chain: per-PT `AuthorizationReader` → `SearchAuthorizationScopeRepository` → `AuthorizationChecker` → `Default/DisabledResourceAccessProvider` (from S6's per-PT `authorizations.enabled`) → `DocumentBased/RdbmsResourceAccessController`, wrapped Anonymous-first in `ResourceAccessDelegatingController`.
- Removes the orphaned shared singleton `ResourceAccessController` beans (`anonymous`/`documentBased`/`rdbms`); `AnonymousResourceAccessController` stays reused inside the per-PT chains.
- Introduces `PhysicalTenantResourceAccessControllers` — a typed wrapper record keeping the map keyed by physical tenant id (a bare `Map<String,…>` would be resolved by Spring's bean-collection autowiring, keyed by bean name).
- Non-web contexts (Restore, engine-only ITs) don't create the per-PT RAC bean; the `camundaSearchClients` bean injects it as `Optional` and falls back to an empty `ResourceAccessDelegatingController` per PT — startable context, fail-fast on any accidental authorized read.

`TenantAccessProvider` stays shared (stateless).

## Acceptance criteria (#55438)

- ✅ `withPhysicalTenant(pt)` selects the PT's RAC (and readers) — ES/OS and RDBMS.
- ✅ Unscoped read on the base `CamundaSearchClients` fails fast (`IllegalStateException`); no silent `default`.
- ✅ Per-PT RAC map built in `ResourceAccessControllerConfiguration` over each PT's `AuthorizationReader` (both backends).
- ✅ Orphaned shared `ResourceAccessController` singleton beans removed; `AnonymousResourceAccessController` reused.
- ✅ Single-PT behavior unchanged (scoped to `default` via the per-PT services).
- ✅ Unit tests: per-PT RAC selection; unscoped fail-fast (reader-first + RAC-backed paths); per-PT RAC map construction.

## Tests

- `CamundaSearchClientsTest`: per-PT RAC routing; unscoped fail-fast across `searchX`, statistics (`processInstanceFlowNodeStatistics`), and `doGet`-backed (`getDeployedResource`) paths.
- `ResourceAccessControllerConfigurationTest`: Spring-context slice; per-PT controller bean created with an entry per configured PT for ES and OS.

Closes #55438