### PR TITLE
feat: serve webapp routes and static assets under the physical-tenant prefix

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
@@ -86,7 +86,8 @@ public class SecurityPathAdapter implements SecurityPathPort {
           "/webapp/custom.css",
           "/webapp/favicon.ico");
 
-  private static final Set<String> WEB_COMPONENT_NAMES = Set.of("admin", "operate", "tasklist");
+  // Single source of truth for the web component names; see WebAppProviderAdapter#WEB_APPS.
+  private static final Set<String> WEB_COMPONENT_NAMES = WebAppProviderAdapter.WEB_APPS;
 
   private static final Set<String> ADMIN_FILTER_BYPASS_PATHS =
       Set.of(

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/WebAppProviderAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/WebAppProviderAdapter.java
@@ -19,7 +19,7 @@ import java.util.Set;
  */
 public class WebAppProviderAdapter implements WebAppProviderPort {
 
-  private static final Set<String> WEB_APPS = Set.of("admin", "operate", "tasklist");
+  public static final Set<String> WEB_APPS = Set.of("admin", "operate", "tasklist");
 
   @Override
   public Optional<String> webAppFor(final HttpServletRequest request) {

--- a/spring-utils/pom.xml
+++ b/spring-utils/pom.xml
@@ -32,11 +32,17 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>
-    <!-- PhysicalTenantContext is a request-scoped web helper; servlet/web APIs are provided by the
+    <!-- PhysicalTenantContext is a request-scoped web helper; SegmentStrippingResolver extends
+         Spring MVC's PathResourceResolver. Both servlet/web and webmvc APIs are provided by the
          consuming web applications at runtime. -->
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/spring-utils/src/main/java/io/camunda/spring/utils/SegmentStrippingResolver.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/SegmentStrippingResolver.java
@@ -24,7 +24,14 @@ public final class SegmentStrippingResolver extends PathResourceResolver {
 
   private final int segmentsToSkip;
 
+  /**
+   * Creates a resolver that strips {@code segmentsToSkip} leading path segments. Negative values
+   * are rejected.
+   */
   public SegmentStrippingResolver(final int segmentsToSkip) {
+    if (segmentsToSkip < 0) {
+      throw new IllegalArgumentException("segmentsToSkip must be >= 0, but was " + segmentsToSkip);
+    }
     this.segmentsToSkip = segmentsToSkip;
   }
 

--- a/spring-utils/src/main/java/io/camunda/spring/utils/SegmentStrippingResolver.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/SegmentStrippingResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.spring.utils;
+
+import java.io.IOException;
+import org.springframework.core.io.Resource;
+import org.springframework.web.servlet.resource.PathResourceResolver;
+
+/**
+ * Strips N leading path segments before delegating to {@link PathResourceResolver}.
+ *
+ * <p>Needed because {@code PathPattern.extractPathWithinPattern()} starts collecting at the first
+ * {@code *} wildcard rather than the trailing {@code **}, so the resource path handed to the
+ * resolver includes the literal and wildcard segments before the {@code **}. This resolver drops
+ * the specified number of leading {@code /}-delimited segments so the remaining path can be
+ * resolved against the configured classpath location.
+ */
+public final class SegmentStrippingResolver extends PathResourceResolver {
+
+  private final int segmentsToSkip;
+
+  public SegmentStrippingResolver(final int segmentsToSkip) {
+    this.segmentsToSkip = segmentsToSkip;
+  }
+
+  @Override
+  protected Resource getResource(final String resourcePath, final Resource location)
+      throws IOException {
+    String path = resourcePath;
+    for (int i = 0; i < segmentsToSkip; i++) {
+      final int slash = path.indexOf('/');
+      if (slash < 0) {
+        return null;
+      }
+      path = path.substring(slash + 1);
+    }
+    return super.getResource(path, location);
+  }
+}

--- a/spring-utils/src/test/java/io/camunda/spring/utils/SegmentStrippingResolverTest.java
+++ b/spring-utils/src/test/java/io/camunda/spring/utils/SegmentStrippingResolverTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.spring.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+class SegmentStrippingResolverTest {
+
+  private final ClassPathResource location = new ClassPathResource("segstrip/");
+
+  @Test
+  void shouldStripLeadingSegmentsAndResolve() throws IOException {
+    // given
+    final SegmentStrippingResolver resolver = new SegmentStrippingResolver(2);
+
+    // when
+    final Resource result = resolver.getResource("tenant/webapp/leaf.txt", location);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.exists()).isTrue();
+  }
+
+  @Test
+  void shouldReturnNullWhenFewerSegmentsThanSkipCount() throws IOException {
+    // given
+    final SegmentStrippingResolver resolver = new SegmentStrippingResolver(2);
+
+    // when
+    final Resource result = resolver.getResource("leaf.txt", location);
+
+    // then
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void shouldResolveDirectlyWhenSkipIsZero() throws IOException {
+    // given
+    final SegmentStrippingResolver resolver = new SegmentStrippingResolver(0);
+
+    // when
+    final Resource result = resolver.getResource("leaf.txt", location);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.exists()).isTrue();
+  }
+
+  @Test
+  void shouldRejectNegativeSkipCount() {
+    // given / when / then
+    assertThatThrownBy(() -> new SegmentStrippingResolver(-1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/spring-utils/src/test/resources/segstrip/leaf.txt
+++ b/spring-utils/src/test/resources/segstrip/leaf.txt
@@ -1,0 +1,1 @@
+test leaf content

--- a/webapp/server/src/main/java/io/camunda/webapp/WebappWebMvcConfig.java
+++ b/webapp/server/src/main/java/io/camunda/webapp/WebappWebMvcConfig.java
@@ -9,14 +9,12 @@ package io.camunda.webapp;
 
 import io.camunda.spring.utils.ConditionalOnWebappUiEnabled;
 import io.camunda.spring.utils.PhysicalTenantContext;
-import java.io.IOException;
+import io.camunda.spring.utils.SegmentStrippingResolver;
 import java.time.Duration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
 import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.resource.PathResourceResolver;
 
 /**
  * Static-resource configuration for the unified BFF webapp. Maps {@code /webapp/assets/**} to the
@@ -58,34 +56,5 @@ public class WebappWebMvcConfig implements WebMvcConfigurer {
         .setCacheControl(CacheControl.maxAge(ASSETS_CACHE_MAX_AGE).cachePublic().immutable())
         .resourceChain(false)
         .addResolver(new SegmentStrippingResolver(3));
-  }
-
-  /**
-   * Strips N leading path segments before delegating to {@link PathResourceResolver}. Needed
-   * because {@code PathPattern.extractPathWithinPattern()} starts collecting at the first {@code *}
-   * wildcard, so the resource path handed to the resolver includes the tenant-id segment (and any
-   * literal segments between {@code *} and {@code **}).
-   */
-  private static final class SegmentStrippingResolver extends PathResourceResolver {
-
-    private final int segmentsToSkip;
-
-    SegmentStrippingResolver(final int segmentsToSkip) {
-      this.segmentsToSkip = segmentsToSkip;
-    }
-
-    @Override
-    protected Resource getResource(final String resourcePath, final Resource location)
-        throws IOException {
-      String path = resourcePath;
-      for (int i = 0; i < segmentsToSkip; i++) {
-        final int slash = path.indexOf('/');
-        if (slash < 0) {
-          return null;
-        }
-        path = path.substring(slash + 1);
-      }
-      return super.getResource(path, location);
-    }
   }
 }

--- a/webapp/server/src/main/java/io/camunda/webapp/WebappWebMvcConfig.java
+++ b/webapp/server/src/main/java/io/camunda/webapp/WebappWebMvcConfig.java
@@ -9,11 +9,14 @@ package io.camunda.webapp;
 
 import io.camunda.spring.utils.ConditionalOnWebappUiEnabled;
 import io.camunda.spring.utils.PhysicalTenantContext;
+import java.io.IOException;
 import java.time.Duration;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
 import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.resource.PathResourceResolver;
 
 /**
  * Static-resource configuration for the unified BFF webapp. Maps {@code /webapp/assets/**} to the
@@ -44,10 +47,45 @@ public class WebappWebMvcConfig implements WebMvcConfigurer {
         .addResourceHandler(ASSETS_PATH_PATTERN)
         .addResourceLocations(ASSETS_CLASSPATH_LOCATION)
         .setCacheControl(CacheControl.maxAge(ASSETS_CACHE_MAX_AGE).cachePublic().immutable());
+    // PathPattern.extractPathWithinPattern() starts at the first '*', so the resource path the
+    // resolver receives includes the tenant segment: "tenantId/webapp/assets/file.js".
+    // SegmentStrippingResolver strips the 3 leading segments to get "file.js" relative to the
+    // classpath location.
     registry
         .addResourceHandler(
             PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + "*" + ASSETS_PATH_PATTERN)
         .addResourceLocations(ASSETS_CLASSPATH_LOCATION)
-        .setCacheControl(CacheControl.maxAge(ASSETS_CACHE_MAX_AGE).cachePublic().immutable());
+        .setCacheControl(CacheControl.maxAge(ASSETS_CACHE_MAX_AGE).cachePublic().immutable())
+        .resourceChain(false)
+        .addResolver(new SegmentStrippingResolver(3));
+  }
+
+  /**
+   * Strips N leading path segments before delegating to {@link PathResourceResolver}. Needed
+   * because {@code PathPattern.extractPathWithinPattern()} starts collecting at the first {@code *}
+   * wildcard, so the resource path handed to the resolver includes the tenant-id segment (and any
+   * literal segments between {@code *} and {@code **}).
+   */
+  private static final class SegmentStrippingResolver extends PathResourceResolver {
+
+    private final int segmentsToSkip;
+
+    SegmentStrippingResolver(final int segmentsToSkip) {
+      this.segmentsToSkip = segmentsToSkip;
+    }
+
+    @Override
+    protected Resource getResource(final String resourcePath, final Resource location)
+        throws IOException {
+      String path = resourcePath;
+      for (int i = 0; i < segmentsToSkip; i++) {
+        final int slash = path.indexOf('/');
+        if (slash < 0) {
+          return null;
+        }
+        path = path.substring(slash + 1);
+      }
+      return super.getResource(path, location);
+    }
   }
 }

--- a/webapp/server/src/main/java/io/camunda/webapp/WebappWebMvcConfig.java
+++ b/webapp/server/src/main/java/io/camunda/webapp/WebappWebMvcConfig.java
@@ -8,6 +8,7 @@
 package io.camunda.webapp;
 
 import io.camunda.spring.utils.ConditionalOnWebappUiEnabled;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.time.Duration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.CacheControl;
@@ -41,6 +42,11 @@ public class WebappWebMvcConfig implements WebMvcConfigurer {
   public void addResourceHandlers(final ResourceHandlerRegistry registry) {
     registry
         .addResourceHandler(ASSETS_PATH_PATTERN)
+        .addResourceLocations(ASSETS_CLASSPATH_LOCATION)
+        .setCacheControl(CacheControl.maxAge(ASSETS_CACHE_MAX_AGE).cachePublic().immutable());
+    registry
+        .addResourceHandler(
+            PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + "*" + ASSETS_PATH_PATTERN)
         .addResourceLocations(ASSETS_CLASSPATH_LOCATION)
         .setCacheControl(CacheControl.maxAge(ASSETS_CACHE_MAX_AGE).cachePublic().immutable());
   }

--- a/webapp/server/src/test/java/io/camunda/webapp/WebappCacheHeadersIT.java
+++ b/webapp/server/src/test/java/io/camunda/webapp/WebappCacheHeadersIT.java
@@ -22,8 +22,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Verifies that static assets under {@code /webapp/assets/**} and the physical-tenant-prefixed
- * sibling {@code /physical-tenants/*}/webapp/assets/**} are served with forever-caching headers and
- * that requests for non-existent assets return 404.
+ * sibling {@code /physical-tenants/<id>/webapp/assets/**} are served with forever-caching headers
+ * and that requests for non-existent assets return 404.
  */
 @SpringBootTest(classes = TestWebappApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestRestTemplate

--- a/webapp/server/src/test/java/io/camunda/webapp/WebappCacheHeadersIT.java
+++ b/webapp/server/src/test/java/io/camunda/webapp/WebappCacheHeadersIT.java
@@ -21,9 +21,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
- * Verifies that static assets under {@code /webapp/assets/**} are served with forever-caching
- * headers and that requests for non-existent assets return 404 rather than being silently resolved
- * by the resource handler.
+ * Verifies that static assets under {@code /webapp/assets/**} and the physical-tenant-prefixed
+ * sibling {@code /physical-tenants/*}/webapp/assets/**} are served with forever-caching headers and
+ * that requests for non-existent assets return 404.
  */
 @SpringBootTest(classes = TestWebappApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestRestTemplate
@@ -50,6 +50,31 @@ class WebappCacheHeadersIT {
     // when — ensures the resource handler does not silently 200 on missing files
     final ResponseEntity<String> response =
         restTemplate.getForEntity("/webapp/assets/does-not-exist.js", String.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  void shouldServeWebappAssetsUnderPhysicalTenantPrefixWithImmutableForeverCacheHeader() {
+    // when
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(
+            "/physical-tenants/test-tenant/webapp/assets/test-asset.js", String.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getHeaders().getCacheControl())
+        .as("forever-cache header on /physical-tenants/*/webapp/assets/**")
+        .isEqualTo("max-age=31536000, public, immutable");
+  }
+
+  @Test
+  void shouldNotServeUnknownAssetsUnderPhysicalTenantPrefixAsStaticResources() {
+    // when
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(
+            "/physical-tenants/test-tenant/webapp/assets/does-not-exist.js", String.class);
 
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
@@ -7,23 +7,28 @@
  */
 package io.camunda.zeebe.gateway.rest.config;
 
+import io.camunda.spring.utils.PhysicalTenantContext;
 import io.camunda.zeebe.gateway.rest.mapper.PhysicalTenantRequestMappingHandlerMapping;
 import io.camunda.zeebe.gateway.rest.resolver.PhysicalTenantIdArgumentResolver;
+import java.time.Duration;
 import java.util.List;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 /**
- * Wires the physical-tenant aware request mapping into Spring MVC.
+ * Wires the physical-tenant aware request mapping and static-asset serving into Spring MVC.
  *
  * <p>{@link WebMvcRegistrations#getRequestMappingHandlerMapping()} is the supported extension point
- * for replacing the auto-configured {@link RequestMappingHandlerMapping}, so every future
- * {@code @CamundaRestController} automatically gets the {@code
- * /physical-tenants/{physicalTenantId}/v2/...} sibling registration.
+ * for replacing the auto-configured {@link RequestMappingHandlerMapping}, so every controller whose
+ * routes start with a PT-addressable root ({@code /v2}, {@code /operate}, {@code /tasklist}, {@code
+ * /admin}, {@code /webapp}) automatically gets a {@code /physical-tenants/{physicalTenantId}/...}
+ * sibling registration.
  *
  * <p>This config is responsible for <em>routing</em> only. The physical tenant id is extracted from
  * the request by {@code PhysicalTenantFilter} (which runs before the security chain so the id is
@@ -32,6 +37,9 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  */
 @Configuration
 public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
+
+  private static final String CLASSPATH_RESOURCES = "classpath:/META-INF/resources/";
+  private static final Duration ASSETS_CACHE_MAX_AGE = Duration.ofDays(365);
 
   @Bean
   public WebMvcRegistrations physicalTenantWebMvcRegistrations() {
@@ -47,5 +55,19 @@ public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
   public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
     // Enables `@PhysicalTenantId String physicalTenantId` injection on controller methods.
     resolvers.add(new PhysicalTenantIdArgumentResolver());
+  }
+
+  @Override
+  public void addResourceHandlers(final ResourceHandlerRegistry registry) {
+    // Serve static assets for each webapp under the physical-tenant prefix. The pattern
+    // /physical-tenants/*/<webapp>/assets/** captures any tenant id in the wildcard segment.
+    // Cache headers mirror WebappWebMvcConfig: hash-suffixed filenames make forever-caching safe.
+    for (final String webapp : List.of("operate", "tasklist", "admin")) {
+      registry
+          .addResourceHandler(
+              PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + "*/" + webapp + "/assets/**")
+          .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/assets/")
+          .setCacheControl(CacheControl.maxAge(ASSETS_CACHE_MAX_AGE).cachePublic().immutable());
+    }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
@@ -40,6 +40,7 @@ public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
 
   private static final String CLASSPATH_RESOURCES = "classpath:/META-INF/resources/";
   private static final Duration ASSETS_CACHE_MAX_AGE = Duration.ofDays(365);
+  private static final Duration ICO_CACHE_MAX_AGE = Duration.ofDays(7);
 
   @Bean
   public WebMvcRegistrations physicalTenantWebMvcRegistrations() {
@@ -59,15 +60,25 @@ public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
 
   @Override
   public void addResourceHandlers(final ResourceHandlerRegistry registry) {
-    // Serve static assets for each webapp under the physical-tenant prefix. The pattern
-    // /physical-tenants/*/<webapp>/assets/** captures any tenant id in the wildcard segment.
-    // Cache headers mirror WebappWebMvcConfig: hash-suffixed filenames make forever-caching safe.
+    // Serve static assets and favicons for each webapp under the physical-tenant prefix. The
+    // wildcard segment captures any tenant id. Two handlers per webapp:
+    //   assets/**  — hash-suffixed filenames, forever-cached (immutable).
+    //   *.ico      — fixed filename (favicon.ico), short-lived cache. Needed because all three
+    //                index controllers exclude *.ico from SPA forwarding via a negative-lookahead
+    //                regex so the file can be served statically; the default Spring resource
+    //                handler resolves /operate/favicon.ico from classpath, but the PT-prefixed
+    //                path /physical-tenants/<id>/operate/favicon.ico needs an explicit handler.
     for (final String webapp : List.of("operate", "tasklist", "admin")) {
       registry
           .addResourceHandler(
               PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + "*/" + webapp + "/assets/**")
           .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/assets/")
           .setCacheControl(CacheControl.maxAge(ASSETS_CACHE_MAX_AGE).cachePublic().immutable());
+      registry
+          .addResourceHandler(
+              PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + "*/" + webapp + "/*.ico")
+          .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/")
+          .setCacheControl(CacheControl.maxAge(ICO_CACHE_MAX_AGE).cachePublic());
     }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
@@ -11,14 +11,17 @@ import io.camunda.authentication.config.spi.WebAppProviderAdapter;
 import io.camunda.spring.utils.PhysicalTenantContext;
 import io.camunda.zeebe.gateway.rest.mapper.PhysicalTenantRequestMappingHandlerMapping;
 import io.camunda.zeebe.gateway.rest.resolver.PhysicalTenantIdArgumentResolver;
+import java.io.IOException;
 import java.util.List;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.servlet.resource.PathResourceResolver;
 
 /**
  * Wires the physical-tenant aware request mapping and static-asset serving into Spring MVC.
@@ -59,15 +62,51 @@ public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
   public void addResourceHandlers(final ResourceHandlerRegistry registry) {
     // *.ico needs its own handler: index controllers exclude it from SPA forwarding so it can be
     // served statically, but the default classpath handler only resolves the unprefixed path.
+    // PathPattern.extractPathWithinPattern() starts at the first '*' (the tenant segment), so the
+    // resolver receives "{tenant}/{webapp}/assets/file.js" (resp. "{tenant}/{webapp}/file.ico");
+    // SegmentStrippingResolver drops those leading segments to resolve against the classpath root.
     for (final String webapp : WebAppProviderAdapter.WEB_APPS) {
       registry
           .addResourceHandler(
               PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + "*/" + webapp + "/assets/**")
-          .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/assets/");
+          .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/assets/")
+          .resourceChain(false)
+          .addResolver(new SegmentStrippingResolver(3));
       registry
           .addResourceHandler(
               PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + "*/" + webapp + "/*.ico")
-          .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/");
+          .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/")
+          .resourceChain(false)
+          .addResolver(new SegmentStrippingResolver(2));
+    }
+  }
+
+  /**
+   * Strips N leading path segments before delegating to {@link PathResourceResolver}. Needed
+   * because {@code PathPattern.extractPathWithinPattern()} starts collecting at the first {@code *}
+   * wildcard, so the resource path handed to the resolver includes the tenant-id segment (and any
+   * literal segments between {@code *} and the trailing wildcard).
+   */
+  private static final class SegmentStrippingResolver extends PathResourceResolver {
+
+    private final int segmentsToSkip;
+
+    SegmentStrippingResolver(final int segmentsToSkip) {
+      this.segmentsToSkip = segmentsToSkip;
+    }
+
+    @Override
+    protected Resource getResource(final String resourcePath, final Resource location)
+        throws IOException {
+      String path = resourcePath;
+      for (int i = 0; i < segmentsToSkip; i++) {
+        final int slash = path.indexOf('/');
+        if (slash < 0) {
+          return null;
+        }
+        path = path.substring(slash + 1);
+      }
+      return super.getResource(path, location);
     }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
@@ -9,19 +9,17 @@ package io.camunda.zeebe.gateway.rest.config;
 
 import io.camunda.authentication.config.spi.WebAppProviderAdapter;
 import io.camunda.spring.utils.PhysicalTenantContext;
+import io.camunda.spring.utils.SegmentStrippingResolver;
 import io.camunda.zeebe.gateway.rest.mapper.PhysicalTenantRequestMappingHandlerMapping;
 import io.camunda.zeebe.gateway.rest.resolver.PhysicalTenantIdArgumentResolver;
-import java.io.IOException;
 import java.util.List;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
-import org.springframework.web.servlet.resource.PathResourceResolver;
 
 /**
  * Wires the physical-tenant aware request mapping and static-asset serving into Spring MVC.
@@ -78,35 +76,6 @@ public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
           .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/")
           .resourceChain(false)
           .addResolver(new SegmentStrippingResolver(2));
-    }
-  }
-
-  /**
-   * Strips N leading path segments before delegating to {@link PathResourceResolver}. Needed
-   * because {@code PathPattern.extractPathWithinPattern()} starts collecting at the first {@code *}
-   * wildcard, so the resource path handed to the resolver includes the tenant-id segment (and any
-   * literal segments between {@code *} and the trailing wildcard).
-   */
-  private static final class SegmentStrippingResolver extends PathResourceResolver {
-
-    private final int segmentsToSkip;
-
-    SegmentStrippingResolver(final int segmentsToSkip) {
-      this.segmentsToSkip = segmentsToSkip;
-    }
-
-    @Override
-    protected Resource getResource(final String resourcePath, final Resource location)
-        throws IOException {
-      String path = resourcePath;
-      for (int i = 0; i < segmentsToSkip; i++) {
-        final int slash = path.indexOf('/');
-        if (slash < 0) {
-          return null;
-        }
-        path = path.substring(slash + 1);
-      }
-      return super.getResource(path, location);
     }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
@@ -57,14 +57,8 @@ public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
 
   @Override
   public void addResourceHandlers(final ResourceHandlerRegistry registry) {
-    // Serve static assets and favicons for each webapp under the physical-tenant prefix, using the
-    // same no-explicit-cache-control policy as the non-PT paths (Spring Boot's default classpath
-    // handler). Two handlers per webapp:
-    //   assets/**  — hash-suffixed filenames served from the webapp's assets/ classpath dir.
-    //   *.ico      — favicon.ico at the webapp root; needs an explicit handler because all three
-    //                index controllers exclude *.ico from SPA forwarding so it can be served
-    //                statically — the default Spring handler resolves /operate/favicon.ico from
-    //                classpath, but /physical-tenants/<id>/operate/favicon.ico needs this entry.
+    // *.ico needs its own handler: index controllers exclude it from SPA forwarding so it can be
+    // served statically, but the default classpath handler only resolves the unprefixed path.
     for (final String webapp : WebAppProviderAdapter.WEB_APPS) {
       registry
           .addResourceHandler(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
@@ -11,12 +11,10 @@ import io.camunda.authentication.config.spi.WebAppProviderAdapter;
 import io.camunda.spring.utils.PhysicalTenantContext;
 import io.camunda.zeebe.gateway.rest.mapper.PhysicalTenantRequestMappingHandlerMapping;
 import io.camunda.zeebe.gateway.rest.resolver.PhysicalTenantIdArgumentResolver;
-import java.time.Duration;
 import java.util.List;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.CacheControl;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -40,8 +38,6 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
 
   private static final String CLASSPATH_RESOURCES = "classpath:/META-INF/resources/";
-  private static final Duration ASSETS_CACHE_MAX_AGE = Duration.ofDays(365);
-  private static final Duration ICO_CACHE_MAX_AGE = Duration.ofDays(7);
 
   @Bean
   public WebMvcRegistrations physicalTenantWebMvcRegistrations() {
@@ -61,25 +57,23 @@ public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
 
   @Override
   public void addResourceHandlers(final ResourceHandlerRegistry registry) {
-    // Serve static assets and favicons for each webapp under the physical-tenant prefix. The
-    // wildcard segment captures any tenant id. Two handlers per webapp:
-    //   assets/**  — hash-suffixed filenames, forever-cached (immutable).
-    //   *.ico      — fixed filename (favicon.ico), short-lived cache. Needed because all three
-    //                index controllers exclude *.ico from SPA forwarding via a negative-lookahead
-    //                regex so the file can be served statically; the default Spring resource
-    //                handler resolves /operate/favicon.ico from classpath, but the PT-prefixed
-    //                path /physical-tenants/<id>/operate/favicon.ico needs an explicit handler.
+    // Serve static assets and favicons for each webapp under the physical-tenant prefix, using the
+    // same no-explicit-cache-control policy as the non-PT paths (Spring Boot's default classpath
+    // handler). Two handlers per webapp:
+    //   assets/**  — hash-suffixed filenames served from the webapp's assets/ classpath dir.
+    //   *.ico      — favicon.ico at the webapp root; needs an explicit handler because all three
+    //                index controllers exclude *.ico from SPA forwarding so it can be served
+    //                statically — the default Spring handler resolves /operate/favicon.ico from
+    //                classpath, but /physical-tenants/<id>/operate/favicon.ico needs this entry.
     for (final String webapp : WebAppProviderAdapter.WEB_APPS) {
       registry
           .addResourceHandler(
               PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + "*/" + webapp + "/assets/**")
-          .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/assets/")
-          .setCacheControl(CacheControl.maxAge(ASSETS_CACHE_MAX_AGE).cachePublic().immutable());
+          .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/assets/");
       registry
           .addResourceHandler(
               PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + "*/" + webapp + "/*.ico")
-          .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/")
-          .setCacheControl(CacheControl.maxAge(ICO_CACHE_MAX_AGE).cachePublic());
+          .addResourceLocations(CLASSPATH_RESOURCES + webapp + "/");
     }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.config;
 
+import io.camunda.authentication.config.spi.WebAppProviderAdapter;
 import io.camunda.spring.utils.PhysicalTenantContext;
 import io.camunda.zeebe.gateway.rest.mapper.PhysicalTenantRequestMappingHandlerMapping;
 import io.camunda.zeebe.gateway.rest.resolver.PhysicalTenantIdArgumentResolver;
@@ -68,7 +69,7 @@ public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
     //                regex so the file can be served statically; the default Spring resource
     //                handler resolves /operate/favicon.ico from classpath, but the PT-prefixed
     //                path /physical-tenants/<id>/operate/favicon.ico needs an explicit handler.
-    for (final String webapp : List.of("operate", "tasklist", "admin")) {
+    for (final String webapp : WebAppProviderAdapter.WEB_APPS) {
       registry
           .addResourceHandler(
               PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + "*/" + webapp + "/assets/**")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
@@ -9,11 +9,14 @@ package io.camunda.zeebe.gateway.rest.mapper;
 
 import static io.camunda.spring.utils.PhysicalTenantContext.PHYSICAL_TENANT_URI_PREFIX;
 
+import io.camunda.authentication.config.spi.WebAppProviderAdapter;
 import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.lang.reflect.Method;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -21,7 +24,9 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHandlerMapping {
 
   private static final Set<String> PREFIXABLE_ROOTS =
-      Set.of("/v2", "/operate", "/tasklist", "/admin", "/webapp");
+      Stream.concat(
+              Stream.of("/v2", "/webapp"), WebAppProviderAdapter.WEB_APPS.stream().map("/"::concat))
+          .collect(Collectors.toUnmodifiableSet());
 
   @Override
   protected void registerHandlerMethod(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.gateway.rest.mapper;
 import static io.camunda.spring.utils.PhysicalTenantContext.PHYSICAL_TENANT_URI_PREFIX;
 
 import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
-import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.lang.reflect.Method;
 import java.util.LinkedHashSet;
@@ -21,7 +20,8 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 
 public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHandlerMapping {
 
-  private static final String V2 = "/v2";
+  private static final Set<String> PREFIXABLE_ROOTS =
+      Set.of("/v2", "/operate", "/tasklist", "/admin", "/webapp");
 
   @Override
   protected void registerHandlerMethod(
@@ -42,9 +42,7 @@ public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHa
 
   @VisibleForTesting
   boolean shouldPrefix(final Class<?> beanType) {
-    return beanType != null
-        && AnnotatedElementUtils.hasAnnotation(beanType, CamundaRestController.class)
-        && !AnnotatedElementUtils.hasAnnotation(beanType, ClusterScoped.class);
+    return beanType != null && !AnnotatedElementUtils.hasAnnotation(beanType, ClusterScoped.class);
   }
 
   @VisibleForTesting
@@ -74,16 +72,15 @@ public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHa
   }
 
   private String prefix(final String pattern) {
-    if (pattern == null || !pattern.startsWith(V2)) {
-      // Only /v2 routes participate in the physical-tenant addressing scheme.
+    if (pattern == null) {
       return null;
     }
-    final String tail = pattern.substring(V2.length());
-    if (!tail.isEmpty() && !tail.startsWith("/")) {
-      // Avoid prefixing things like "/v2foo".
-      return null;
+    for (final String root : PREFIXABLE_ROOTS) {
+      if (pattern.equals(root) || pattern.startsWith(root + "/")) {
+        return PHYSICAL_TENANT_URI_PREFIX + pattern;
+      }
     }
-    return PHYSICAL_TENANT_URI_PREFIX + pattern;
+    return null;
   }
 
   private Class<?> resolveBeanType(final Object handler) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
@@ -23,6 +23,10 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 
 public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHandlerMapping {
 
+  // Route roots eligible for a per-physical-tenant sibling. This is the primary safeguard for PT
+  // enrollment: shouldPrefix() deliberately admits any non-cluster-scoped controller, so a route
+  // only gets a PT-prefixed sibling when its pattern starts with one of these roots (see prefix()).
+  // Controllers on other paths are therefore never auto-enrolled in PT routing.
   private static final Set<String> PREFIXABLE_ROOTS =
       Stream.concat(
               Stream.of("/v2", "/webapp"), WebAppProviderAdapter.WEB_APPS.stream().map("/"::concat))
@@ -45,6 +49,13 @@ public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHa
     }
   }
 
+  /**
+   * Whether a controller is eligible for per-physical-tenant route prefixing. Deliberately broad —
+   * any controller that is not {@link ClusterScoped}. Eligibility does not mean enrollment: {@link
+   * #PREFIXABLE_ROOTS} is the actual gate, since a route only gets a PT-prefixed sibling when its
+   * pattern starts with a prefixable root. So a non-cluster-scoped controller on an unrelated path
+   * is admitted here but never auto-enrolled in PT routing.
+   */
   @VisibleForTesting
   boolean shouldPrefix(final Class<?> beanType) {
     return beanType != null && !AnnotatedElementUtils.hasAnnotation(beanType, ClusterScoped.class);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantPathPatternMatchingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantPathPatternMatchingTest.java
@@ -17,15 +17,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Controller;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.util.pattern.PathPatternParser;
 
 @WebMvcTest(useDefaultFilters = false)
 @Import({
   PhysicalTenantWebMvcConfig.class,
-  PhysicalTenantPathPatternMatchingTest.TestController.class
+  PhysicalTenantPathPatternMatchingTest.TestController.class,
+  PhysicalTenantPathPatternMatchingTest.PlainWebappController.class
 })
 class PhysicalTenantPathPatternMatchingTest extends RestTest {
 
@@ -80,6 +83,11 @@ class PhysicalTenantPathPatternMatchingTest extends RestTest {
   }
 
   @Test
+  void shouldPrefixPlainWebappControllerRoot() {
+    webClient.get().uri("/physical-tenants/default/operate").exchange().expectStatus().isOk();
+  }
+
+  @Test
   void shouldServeWebappAssetUnderPhysicalTenantPrefix() {
     // backed by src/test/resources/META-INF/resources/operate/assets/test-asset.js — proves the
     // resolver strips the leading {tenant}/{webapp}/assets segments injected by the '*' wildcard
@@ -116,6 +124,17 @@ class PhysicalTenantPathPatternMatchingTest extends RestTest {
   static class TestController {
     @GetMapping("/v2/widgets")
     public String widgets() {
+      return "ok";
+    }
+  }
+
+  // Mirrors the dist webapp index controllers: a plain @Controller (NOT @CamundaRestController)
+  // mapping a webapp root. Verifies such a controller still gets a PT-prefixed sibling.
+  @Controller
+  static class PlainWebappController {
+    @GetMapping("/operate")
+    @ResponseBody
+    public String operate() {
       return "ok";
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantPathPatternMatchingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantPathPatternMatchingTest.java
@@ -79,6 +79,39 @@ class PhysicalTenantPathPatternMatchingTest extends RestTest {
         .isNotFound();
   }
 
+  @Test
+  void shouldServeWebappAssetUnderPhysicalTenantPrefix() {
+    // backed by src/test/resources/META-INF/resources/operate/assets/test-asset.js — proves the
+    // resolver strips the leading {tenant}/{webapp}/assets segments injected by the '*' wildcard
+    webClient
+        .get()
+        .uri("/physical-tenants/default/operate/assets/test-asset.js")
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+
+  @Test
+  void shouldServeWebappFaviconUnderPhysicalTenantPrefix() {
+    // backed by src/test/resources/META-INF/resources/operate/favicon.ico
+    webClient
+        .get()
+        .uri("/physical-tenants/default/operate/favicon.ico")
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+
+  @Test
+  void shouldNotServeUnknownWebappAssetUnderPhysicalTenantPrefix() {
+    webClient
+        .get()
+        .uri("/physical-tenants/default/operate/assets/does-not-exist.js")
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
   @CamundaRestController
   static class TestController {
     @GetMapping("/v2/widgets")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMappingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMappingTest.java
@@ -35,7 +35,7 @@ class PhysicalTenantRequestMappingHandlerMappingTest {
   // ---- shouldPrefix --------------------------------------------------------
 
   @Test
-  void shouldPrefixWhenAnnotatedWithCamundaRestController() {
+  void shouldPrefixWhenNotClusterScoped() {
     // when / then
     assertThat(mapping.shouldPrefix(TenantScopedController.class)).isTrue();
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMappingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMappingTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo.BuilderConfiguration;
 import org.springframework.web.util.pattern.PathPatternParser;
@@ -46,26 +47,47 @@ class PhysicalTenantRequestMappingHandlerMappingTest {
   }
 
   @Test
-  void shouldNotPrefixPlainClass() {
+  void shouldPrefixPlainControllerNotAnnotatedWithCamundaRestController() {
+    // Webapp index controllers (e.g. OperateIndexController) are plain @Controller beans — they
+    // must be prefixed so their routes are also registered under /physical-tenants/{id}/...
+    assertThat(mapping.shouldPrefix(PlainController.class)).isTrue();
+  }
+
+  @Test
+  void shouldNotPrefixNullBeanType() {
     // when / then
-    assertThat(mapping.shouldPrefix(Object.class)).isFalse();
+    assertThat(mapping.shouldPrefix(null)).isFalse();
   }
 
   // ---- withPhysicalTenantPrefix / pattern rewriting ------------------------
 
   static Stream<Arguments> patternCases() {
     return Stream.of(
+        // API routes
         Arguments.of("/v2", EXPECTED_PREFIX + "/v2"),
         Arguments.of("/v2/widgets", EXPECTED_PREFIX + "/v2/widgets"),
         Arguments.of("/v2/widgets/{id}", EXPECTED_PREFIX + "/v2/widgets/{id}"),
+        // webapp routes
+        Arguments.of("/operate", EXPECTED_PREFIX + "/operate"),
+        Arguments.of("/operate/processes", EXPECTED_PREFIX + "/operate/processes"),
+        Arguments.of("/tasklist", EXPECTED_PREFIX + "/tasklist"),
+        Arguments.of("/tasklist/tasks/{id}", EXPECTED_PREFIX + "/tasklist/tasks/{id}"),
+        Arguments.of("/admin", EXPECTED_PREFIX + "/admin"),
+        Arguments.of("/admin/users", EXPECTED_PREFIX + "/admin/users"),
+        Arguments.of("/webapp", EXPECTED_PREFIX + "/webapp"),
+        Arguments.of("/webapp/some-route", EXPECTED_PREFIX + "/webapp/some-route"),
+        // non-matching: different prefix
         Arguments.of("/v1/widgets", null),
+        // non-matching: word boundary guards (no trailing slash → not a root)
         Arguments.of("/v2foo", null),
+        Arguments.of("/operatepath", null),
+        Arguments.of("/tasklistfoo", null),
         Arguments.of("/", null));
   }
 
   @ParameterizedTest(name = "[{index}] {0} -> {1}")
   @MethodSource("patternCases")
-  void shouldRewriteOnlyV2Patterns(final String input, final String expected) {
+  void shouldRewriteKnownRootPatterns(final String input, final String expected) {
     // given
     final RequestMappingInfo info = info(input);
 
@@ -100,7 +122,17 @@ class PhysicalTenantRequestMappingHandlerMappingTest {
             "non-/v2 path on tenant-scoped controller keeps only original",
             new TenantScopedController(),
             "/v1/widgets",
-            List.of("/v1/widgets")));
+            List.of("/v1/widgets")),
+        Arguments.of(
+            "plain webapp controller /operate keeps original and adds prefixed sibling",
+            new PlainController(),
+            "/operate",
+            List.of("/operate", EXPECTED_PREFIX + "/operate")),
+        Arguments.of(
+            "plain webapp controller /tasklist/tasks keeps original and adds prefixed sibling",
+            new PlainController(),
+            "/tasklist/tasks",
+            List.of("/tasklist/tasks", EXPECTED_PREFIX + "/tasklist/tasks")));
   }
 
   @ParameterizedTest(name = "[{index}] {0}")
@@ -153,6 +185,12 @@ class PhysicalTenantRequestMappingHandlerMappingTest {
   @CamundaRestController
   @ClusterScoped
   private static final class ClusterScopedController {
+    @SuppressWarnings("unused") // resolved reflectively in registerCases()
+    public void handle() {}
+  }
+
+  @Controller
+  private static final class PlainController {
     @SuppressWarnings("unused") // resolved reflectively in registerCases()
     public void handle() {}
   }

--- a/zeebe/gateway-rest/src/test/resources/META-INF/resources/operate/assets/test-asset.js
+++ b/zeebe/gateway-rest/src/test/resources/META-INF/resources/operate/assets/test-asset.js
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/zeebe/gateway-rest/src/test/resources/META-INF/resources/operate/favicon.ico
+++ b/zeebe/gateway-rest/src/test/resources/META-INF/resources/operate/favicon.ico
@@ -1,0 +1,1 @@
+icodata


### PR DESCRIPTION
## Summary

- Extends `PhysicalTenantRequestMappingHandlerMapping` so webapp index controller routes (`/operate`, `/tasklist`, `/admin`, `/webapp`) get a `/physical-tenants/{id}/...` sibling registration alongside the existing `/v2` API routes.
- Relaxes the candidate filter in `shouldPrefix()` from `@CamundaRestController` to a path-based rule (any non-`@ClusterScoped` controller), keeping annotation coupling out of `gateway-rest`.
- Wires PT-prefixed static asset serving via `addResourceHandlers`:
  - `/physical-tenants/*/operate|tasklist|admin/assets/**` → `PhysicalTenantWebMvcConfig`
  - `/physical-tenants/*/webapp/assets/**` → `WebappWebMvcConfig`

The per-PT webapp security chains that authenticate and authorise these routes are provided by CSL (activated via #55467).

## Acceptance criteria (from #55313)

- [x] Single `RequestMappingHandlerMapping` handles both API and webapp prefixing — no second mapping introduced.
- [x] Unknown PT under a webapp path is rejected (404) by CSL's catch-all chain, consistent with API behaviour.
- [x] Unprefixed webapp serving is unchanged when no PT is configured.
- [x] `GET /physical-tenants/<id>/operate` returns the existing shell — verified e2e against a PT-configured cluster.

## Verification

`zeebe/gateway-rest` and `webapp/server` module builds + unit tests green. Full-repo compile clean. Added a `gateway-rest` test proving a plain (non-`@CamundaRestController`) controller at a webapp root gets the PT-prefixed sibling.

End-to-end against a PT-configured cluster (two physical tenants, separate OIDC realms): `/physical-tenants/<id>/operate` and `/tasklist` return `302 → /login` (controller found, not 404), unknown PTs are rejected with 404 by the catch-all chain, and both the unprefixed routes and SPA sub-routes (`/operate/processes`, `/tasklist/tasks`) are unaffected — 9/9 (demo harness: #55593). This covers AC 4 and relies on the per-PT webapp security chains from CSL (#55467).

Closes #55313
Part of #54897
