### PR TITLE
feat(monitoring): test submission of new workflow_ref to build_status_v2

### DIFF
--- a/.github/actions/observe-aborted-jobs/action.yml
+++ b/.github/actions/observe-aborted-jobs/action.yml
@@ -41,7 +41,8 @@ runs:
         secrets: |
           secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
 
-    - uses: camunda/infra-global-github-actions/submit-aborted-gha-status@main
+    - uses: camunda/infra-global-github-actions/submit-aborted-gha-status@infra-1080-add-workflow-ref-to-build-status-v2
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
+        big_query_table_name: "ci-30-162810:dev_ci_analytics.build_status_v2"

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -95,7 +95,7 @@ runs:
         job_name_override: "${{ inputs.job_name }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
    ######################## Report build result #############################
-    - uses: camunda/infra-global-github-actions/submit-build-status@main
+    - uses: camunda/infra-global-github-actions/submit-build-status@infra-1080-add-workflow-ref-to-build-status-v2
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         job_name_override: "${{ inputs.job_name }}"
@@ -104,3 +104,4 @@ runs:
         user_reason: "${{ inputs.user_reason }}"
         user_description: "${{ inputs.user_description != '' && inputs.user_description || env.TEST_OWNER }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
+        big_query_table_name: "ci-30-162810:dev_ci_analytics.build_status_v2"

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -55,7 +55,7 @@ runs:
         secretId: ${{ inputs.secret_vault_secretId }}
         exportEnv: false # we rely on step outputs, no need for environment variables
         secrets: |
-          secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
+          secret/data/products/zeebe/ci/ci-analytics-dev gcloud_sa_key;
 
     - name: Check secrets availability
       if: ${{ steps.secrets.outputs.gcloud_sa_key == '' }}

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -13,6 +13,7 @@ on:
 env:
   TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
+  TEST_SUBMIT_STATUS: true
 
 jobs:
   utils-get-snapshot-docker-tag:


### PR DESCRIPTION
## Description

Tests the composite action to extract workflow_ref (workflow path basically) and add it to build_status_v2

This is related to camunda/team-infrastructure#1080

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
