### PR TITLE
feat: prevent override of security.session* and security.transport-layer-security.* per PT

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidation.java
@@ -97,7 +97,9 @@ final class PhysicalTenantOverridePolicyValidation {
               "security.http-headers",
               // forward declaration — property lands with #54898
               "security.cluster-admin",
-              "security.multi-tenancy")
+              "security.multi-tenancy",
+              "security.session",
+              "security.transport-layer-security.cluster")
           .map(ConfigurationPropertyName::of)
           .toList();
 

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidationTest.java
@@ -237,11 +237,51 @@ class PhysicalTenantOverridePolicyValidationTest {
   void shouldAllowTenantOverridingOtherSecurityProperties() {
     // given a tenant overriding a security property that is not on the deny-list
     final MockEnvironment environment =
-        environmentWith(Map.of("camunda.physical-tenants.tenanta.security.session.timeout", "30m"));
+        environmentWith(
+            Map.of("camunda.physical-tenants.tenanta.security.authorizations.enabled", true));
 
     // when / then freely overridable security properties are allowed
     assertThatCode(() -> PhysicalTenantOverridePolicyValidation.validate(environment))
         .doesNotThrowAnyException();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "security.session",
+        "security.session.persistent.enabled",
+      })
+  void shouldRejectTenantOverridingSessionProperties(final String relativeKey) {
+    // given a tenant overriding a session property (installation-wide, must not vary per tenant)
+    final MockEnvironment environment =
+        environmentWith(Map.of("camunda.physical-tenants.tenanta." + relativeKey, "somevalue"));
+
+    // when / then the entire session subtree is blocked
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantOverridePolicyValidation.validate(environment))
+        .withMessageContaining("may not be overridden per physical tenant")
+        .withMessageContaining("tenanta")
+        .withMessageContaining(relativeKey);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "security.transport-layer-security.cluster.enabled",
+        "security.transport-layer-security.cluster.certificate-chain-path",
+        "security.transport-layer-security.cluster.key-store.password",
+      })
+  void shouldRejectTenantOverridingClusterTlsProperties(final String relativeKey) {
+    // given a tenant overriding a cluster TLS property (installation-level infrastructure)
+    final MockEnvironment environment =
+        environmentWith(Map.of("camunda.physical-tenants.tenanta." + relativeKey, "somevalue"));
+
+    // when / then the entire cluster TLS subtree is blocked
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantOverridePolicyValidation.validate(environment))
+        .withMessageContaining("may not be overridden per physical tenant")
+        .withMessageContaining("tenanta")
+        .withMessageContaining(relativeKey);
   }
 
   @Test

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -97,6 +97,13 @@ security.http-headers.referrer-policy.value
 security.multi-tenancy
 security.multi-tenancy.api-enabled
 security.multi-tenancy.checks-enabled
+security.session
+security.session.persistent.enabled
+security.transport-layer-security.cluster.certificate-chain-path
+security.transport-layer-security.cluster.certificate-private-key-path
+security.transport-layer-security.cluster.enabled
+security.transport-layer-security.cluster.key-store.file-path
+security.transport-layer-security.cluster.key-store.password
 system.actor.idle.max-park-period
 system.actor.idle.max-spins
 system.actor.idle.max-yields

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -356,13 +356,6 @@ security.initialization.users
 security.saas
 security.saas.cluster-id
 security.saas.organization-id
-security.session
-security.session.persistent.enabled
-security.transport-layer-security.cluster.certificate-chain-path
-security.transport-layer-security.cluster.certificate-private-key-path
-security.transport-layer-security.cluster.enabled
-security.transport-layer-security.cluster.key-store.file-path
-security.transport-layer-security.cluster.key-store.password
 system.clock-controlled
 webapps.identity.enabled
 webapps.identity.ui-enabled


### PR DESCRIPTION
## Description

Config properties security.session.* and security.transport-layer-security.cluster.* are non overridable per PT and startup fails with a clear error when it happens 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #54731 (ac 4)
