### PR TITLE
fix: route physical-tenant commands via partition group on handler send paths

### DIFF
--- a/service/src/main/java/io/camunda/service/ApiServices.java
+++ b/service/src/main/java/io/camunda/service/ApiServices.java
@@ -52,8 +52,22 @@ public abstract class ApiServices<T extends ApiServices<T>> {
 
   protected final <R> CompletableFuture<BrokerResponse<R>> sendBrokerRequestWithFullResponse(
       final BrokerRequest<R> brokerRequest, final CamundaAuthentication authentication) {
-    brokerRequestMutators().forEach(mutator -> mutator.accept(brokerRequest, authentication));
+    applyBrokerRequestMutators(brokerRequest, authentication);
     return brokerClient.sendRequest(brokerRequest).handleAsync(handleBrokerResponse(), executor);
+  }
+
+  /**
+   * Applies every {@link #brokerRequestMutators() mutator} to the given request. Send paths that
+   * cannot use {@link #sendBrokerRequest} / {@link #sendBrokerRequestWithFullResponse} (e.g.
+   * because they dispatch via a partition-retry or job-activation handler and therefore bypass
+   * these helpers) must call this so they get the full mutator set (authorization <em>and</em>, for
+   * physical-tenant-scoped services, the partition group). Hand-applying a subset (e.g. only
+   * authorization) silently drops newer mutators and is the bug class this method exists to
+   * prevent.
+   */
+  protected final void applyBrokerRequestMutators(
+      final BrokerRequest<?> brokerRequest, final CamundaAuthentication authentication) {
+    brokerRequestMutators().forEach(mutator -> mutator.accept(brokerRequest, authentication));
   }
 
   protected List<BiConsumer<BrokerRequest, CamundaAuthentication>> brokerRequestMutators() {

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -103,9 +103,10 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
             .setTimeout(request.timeout())
             .setWorker(request.worker())
             .setVariables(request.fetchVariable());
-    final var brokerRequestAuthorization =
-        brokerRequestAuthorizationConverter.convert(authentication);
-    brokerRequest.setAuthorization(brokerRequestAuthorization);
+    // Apply the full mutator set (authorization AND, for physical-tenant-scoped services, the
+    // partition group) so job activation round-robins over the tenant's partition group. The
+    // handler reads brokerRequest.getPartitionGroup() when selecting partitions.
+    applyBrokerRequestMutators(brokerRequest, authentication);
     activateJobsHandler.activateJobs(
         brokerRequest, responseObserver, cancelationHandlerConsumer, request.requestTimeout());
   }

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -574,9 +574,10 @@ public final class ProcessInstanceServices
       final CamundaAuthentication authentication,
       final Duration requestTimeout,
       final RequestRetryHandler handler) {
-    final var brokerRequestAuthorization =
-        brokerRequestAuthorizationConverter.convert(authentication);
-    brokerRequest.setAuthorization(brokerRequestAuthorization);
+    // Apply the full mutator set (authorization AND, for physical-tenant-scoped services, the
+    // partition group) so the retry handler dispatches to the tenant's partition group. The handler
+    // reads brokerRequest.getPartitionGroup() when selecting partitions.
+    applyBrokerRequestMutators(brokerRequest, authentication);
     final CompletableFuture<R> responseFuture = new CompletableFuture<>();
     if (requestTimeout != null) {
       handler.sendRequest(

--- a/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
@@ -78,6 +78,29 @@ final class ProcessInstanceRoundRobinDispatchTest {
   }
 
   @Test
+  void shouldStampPhysicalTenantPartitionGroupOnDispatchedRequests() {
+    // given
+    final var sentRequests = new ArrayList<BrokerCreateProcessInstanceRequest>();
+    when(brokerClient.sendRequest(any(BrokerCreateProcessInstanceRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              sentRequests.add(invocation.getArgument(0, BrokerCreateProcessInstanceRequest.class));
+              return CompletableFuture.completedFuture(
+                  new BrokerResponse<>(new ProcessInstanceCreationRecord()));
+            });
+
+    // when
+    services.createProcessInstance(createRequest(100L), authentication).join();
+
+    // then — the retry-partition dispatch path must apply the physical-tenant mutator so the
+    // request carries the tenant's partition group; otherwise it would route to the default group
+    assertThat(sentRequests)
+        .isNotEmpty()
+        .allSatisfy(
+            request -> assertThat(request.getPartitionGroup()).isEqualTo(PHYSICAL_TENANT_ID));
+  }
+
+  @Test
   void shouldDistributeIndependentlyPerDefinitionKey() {
     // given — warm up per-definition handlers for both definition keys
     final var partitions = capturePartitions();


### PR DESCRIPTION
## Description

Process-instance creation and job activation dispatch through the partition-retry and job-activation handlers rather than `BrokerClient#sendRequest`. Those paths hand-applied **only** the authorization mutator and never ran the full `brokerRequestMutators()` set, so the `setPartitionGroup(physicalTenantId)` mutator added by `PhysicalTenantScopedApiServices` was silently dropped. As a result every create-process-instance and activate-jobs command was dispatched to the **default** partition group regardless of the physical tenant in the request path — writing into the wrong tenant's engine and secondary storage.

Deployment was unaffected because it uses the standard `sendBrokerRequest` path, which already applies all mutators.

## Changes

- Add `ApiServices#applyBrokerRequestMutators(...)` as the single point that runs all mutators, and route `sendBrokerRequestWithFullResponse` through it.
- Call it from `ProcessInstanceServices.sendRequestWithRetryPartitions` (covers all four create paths — create / create-with-result × businessId / round-robin) and `JobServices.activateJobs`.
- Add a regression test asserting the retry-partition dispatch stamps the tenant's partition group.

related to https://github.com/camunda/camunda/pull/55351
