### PR TITLE
fix: match integer variable values against Zeebe's double string format

### DIFF
--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -217,7 +217,7 @@
           VAR_VALUE = #{operation.value}
         </if>
         <if test="operation.type.toString == 'LONG'">
-          LONG_VALUE = #{operation.value}
+          (LONG_VALUE = #{operation.value} OR DOUBLE_VALUE = #{operation.value})
         </if>
         <if test="operation.type.toString == 'DOUBLE'">
           DOUBLE_VALUE = #{operation.value}
@@ -228,7 +228,7 @@
           VAR_VALUE != #{operation.value}
         </if>
         <if test="operation.type.toString == 'LONG'">
-          LONG_VALUE != #{operation.value}
+          (LONG_VALUE != #{operation.value} OR DOUBLE_VALUE != #{operation.value})
         </if>
         <if test="operation.type.toString == 'DOUBLE'">
           DOUBLE_VALUE != #{operation.value}
@@ -267,18 +267,29 @@
         </if>
       </when>
       <when test="operation.operator.name().equals('IN')">
-        <if test="operation.type.toString == 'STRING'">
+        <if test="operation.type.toString == 'STRING' or operation.type.toString == 'BOOLEAN'">
           VAR_VALUE IN
+          <foreach collection="operation.values" item="value" open="(" separator=", " close=")">
+            #{value}
+          </foreach>
         </if>
         <if test="operation.type.toString == 'LONG'">
-          LONG_VALUE IN
+          (LONG_VALUE IN
+          <foreach collection="operation.values" item="value" open="(" separator=", " close=")">
+            #{value}
+          </foreach>
+          OR DOUBLE_VALUE IN
+          <foreach collection="operation.values" item="value" open="(" separator=", " close=")">
+            #{value}
+          </foreach>
+          )
         </if>
         <if test="operation.type.toString == 'DOUBLE'">
           DOUBLE_VALUE IN
+          <foreach collection="operation.values" item="value" open="(" separator=", " close=")">
+            #{value}
+          </foreach>
         </if>
-        <foreach collection="operation.values" item="value" open="(" separator=", " close=")">
-          #{value}
-        </foreach>
       </when>
       <when test="operation.operator.name().equals('LIKE')">
         VAR_VALUE LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.WildcardTransformingStringTypeHandler}

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -213,6 +213,9 @@
   <sql id="variableOperationCondition">
     <choose>
       <when test="operation.operator.name().equals('EQUALS')">
+        <if test="operation.type.toString == 'NULL'">
+          VAR_VALUE = 'null'
+        </if>
         <if test="operation.type.toString == 'STRING' or operation.type.toString == 'BOOLEAN'">
           VAR_VALUE = #{operation.value}
         </if>
@@ -224,6 +227,9 @@
         </if>
       </when>
       <when test="operation.operator.name().equals('NOT_EQUALS')">
+        <if test="operation.type.toString == 'NULL'">
+          VAR_VALUE != 'null'
+        </if>
         <if test="operation.type.toString == 'STRING' or operation.type.toString == 'BOOLEAN'">
           VAR_VALUE != #{operation.value}
         </if>
@@ -267,6 +273,9 @@
         </if>
       </when>
       <when test="operation.operator.name().equals('IN')">
+        <if test="operation.type.toString == 'NULL'">
+          VAR_VALUE = 'null'
+        </if>
         <if test="operation.type.toString == 'STRING' or operation.type.toString == 'BOOLEAN'">
           VAR_VALUE IN
           <foreach collection="operation.values" item="value" open="(" separator=", " close=")">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableNullValueSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableNullValueSearchIT.java
@@ -63,4 +63,66 @@ public class VariableNullValueSearchIT {
               assertThat(searchResult.items().getFirst().getValue()).isEqualTo("null");
             });
   }
+
+  @Test
+  void shouldFindProcessVariableByNullValueEquals() {
+    // given
+    final var variableName = "nullVar_" + UUID.randomUUID().toString().replace("-", "");
+    final var processInstance =
+        startProcessInstance(
+            camundaClient, "bpmProcessVariable", "{\"%s\":null}".formatted(variableName));
+
+    // when / then
+    Awaitility.await("should find variable filtered by null value")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  camundaClient
+                      .newVariableSearchRequest()
+                      .filter(
+                          f ->
+                              f.name(variableName)
+                                  .processInstanceKey(processInstance.getProcessInstanceKey())
+                                  .value(v -> v.eq("null")))
+                      .send()
+                      .join();
+              assertThat(searchResult.items()).hasSize(1);
+              assertThat(searchResult.items().getFirst().getValue()).isEqualTo("null");
+            });
+  }
+
+  @Test
+  void shouldExcludeNullValuedProcessVariableByNotEqualsNull() {
+    // given
+    final var suffix = UUID.randomUUID().toString().replace("-", "");
+    final var nullVarName = "nullVar_" + suffix;
+    final var realVarName = "realVar_" + suffix;
+    final var processInstance =
+        startProcessInstance(
+            camundaClient,
+            "bpmProcessVariable",
+            "{\"%s\":null,\"%s\":\"hello\"}".formatted(nullVarName, realVarName));
+
+    // when / then
+    Awaitility.await("should exclude null-valued variable when filtering by neq null")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  camundaClient
+                      .newVariableSearchRequest()
+                      .filter(
+                          f ->
+                              f.name(b -> b.in(nullVarName, realVarName))
+                                  .processInstanceKey(processInstance.getProcessInstanceKey())
+                                  .value(v -> v.neq("null")))
+                      .send()
+                      .join();
+              assertThat(searchResult.items()).hasSize(1);
+              assertThat(searchResult.items().getFirst().getName()).isEqualTo(realVarName);
+            });
+  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableNumericValueSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableNumericValueSearchIT.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.io.InputStream;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+@CompatibilityTest
+public class VariableNumericValueSearchIT {
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    final InputStream process =
+        VariableNumericValueSearchIT.class.getResourceAsStream("/process/bpm_variable_test.bpmn");
+    deployProcessAndWaitForIt(
+        camundaClient, Bpmn.readModelFromStream(process), "bpm_variable_test.bpmn");
+  }
+
+  @Test
+  void shouldFindProcessVariableByIntegerValueEquals() {
+    // given
+    final var variableName = "intVar_" + UUID.randomUUID().toString().replace("-", "");
+    final var processInstance =
+        startProcessInstance(
+            camundaClient, "bpmProcessVariable", "{\"%s\":356}".formatted(variableName));
+
+    // when / then
+    Awaitility.await("should find integer variable filtered by its integer value")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  camundaClient
+                      .newVariableSearchRequest()
+                      .filter(
+                          f ->
+                              f.name(variableName)
+                                  .processInstanceKey(processInstance.getProcessInstanceKey())
+                                  .value(v -> v.eq("356")))
+                      .send()
+                      .join();
+              assertThat(searchResult.items()).hasSize(1);
+            });
+  }
+
+  @Test
+  void shouldFindProcessVariableByNegativeIntegerValueEquals() {
+    // given
+    final var variableName = "negIntVar_" + UUID.randomUUID().toString().replace("-", "");
+    final var processInstance =
+        startProcessInstance(
+            camundaClient, "bpmProcessVariable", "{\"%s\":-42000}".formatted(variableName));
+
+    // when / then
+    Awaitility.await("should find negative integer variable filtered by its integer value")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  camundaClient
+                      .newVariableSearchRequest()
+                      .filter(
+                          f ->
+                              f.name(variableName)
+                                  .processInstanceKey(processInstance.getProcessInstanceKey())
+                                  .value(v -> v.eq("-42000")))
+                      .send()
+                      .join();
+              assertThat(searchResult.items()).hasSize(1);
+            });
+  }
+
+  @Test
+  void shouldExcludeMatchingIntegerVariableByNotEquals() {
+    // given
+    final var suffix = UUID.randomUUID().toString().replace("-", "");
+    final var matchVarName = "matchVar_" + suffix;
+    final var otherVarName = "otherVar_" + suffix;
+    final var processInstance =
+        startProcessInstance(
+            camundaClient,
+            "bpmProcessVariable",
+            "{\"%s\":356,\"%s\":999}".formatted(matchVarName, otherVarName));
+
+    // when / then
+    Awaitility.await("should exclude the matching integer variable when filtering by neq")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  camundaClient
+                      .newVariableSearchRequest()
+                      .filter(
+                          f ->
+                              f.name(b -> b.in(matchVarName, otherVarName))
+                                  .processInstanceKey(processInstance.getProcessInstanceKey())
+                                  .value(v -> v.neq("356")))
+                      .send()
+                      .join();
+              assertThat(searchResult.items()).hasSize(1);
+              assertThat(searchResult.items().getFirst().getName()).isEqualTo(otherVarName);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableValueFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableValueFilterIT.java
@@ -207,6 +207,24 @@ public class VariableValueFilterIT {
   }
 
   @TestTemplate
+  public void shouldFindVariableWithNameAndInNullValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    prepareRandomVariables(testApplication);
+    final String varName = "var-name-" + nextStringId();
+    final VariableDbModel randomizedVariable =
+        VariableFixtures.createRandomized(b -> b.name(varName).value("null"));
+    createAndSaveVariable(rdbmsService, randomizedVariable);
+
+    // and
+    final Operation<String> operation = Operation.in("null");
+
+    // when
+    searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
+  }
+
+  @TestTemplate
   public void shouldFindVariableWithNameAndEqBooleanValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableValueFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableValueFilterIT.java
@@ -103,6 +103,110 @@ public class VariableValueFilterIT {
   }
 
   @TestTemplate
+  public void shouldFindVariableWithNameAndEqWholeNumberStoredAsDouble(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String varName = "var-name-" + nextStringId();
+    final var randomizedVariable =
+        prepareRandomVariablesAndReturnOne(testApplication, varName, "42000.0");
+
+    // and
+    final Operation<String> operation = Operation.eq("42000");
+
+    // when
+    searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindVariableWithNameAndNeqWholeNumberStoredAsDouble(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    prepareRandomVariables(testApplication);
+    final String varName = "var-name-" + nextStringId();
+    final VariableDbModel randomizedVariable =
+        VariableFixtures.createRandomized(b -> b.name(varName).value("42000.0"));
+    createAndSaveVariable(rdbmsService, randomizedVariable);
+
+    // and
+    final Operation<String> operation = Operation.neq("99999");
+
+    // when
+    searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindVariableWithNameAndInWholeNumberStoredAsDouble(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String varName = "var-name-" + nextStringId();
+    final var randomizedVariable =
+        prepareRandomVariablesAndReturnOne(testApplication, varName, "42000.0");
+
+    // and
+    final Operation<String> operation = Operation.in("42000", "50000");
+
+    // when
+    searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindVariableWithNameAndInBooleanValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String varName = "var-name-" + nextStringId();
+    final var randomizedVariable =
+        prepareRandomVariablesAndReturnOne(testApplication, varName, "true");
+
+    // and
+    final Operation<String> operation = Operation.in("true", "false");
+
+    // when
+    searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindVariableWithNameAndEqNullValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    prepareRandomVariables(testApplication);
+
+    // and
+    final String varName = "var-name-" + nextStringId();
+    final VariableDbModel randomizedVariable =
+        VariableFixtures.createRandomized(b -> b.name(varName).value("null"));
+    createAndSaveVariable(rdbmsService, randomizedVariable);
+
+    // and
+    final Operation<String> operation = Operation.eq("null");
+
+    // when
+    searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindVariableWithNameAndNeqNullValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    prepareRandomVariables(testApplication);
+    final String varName = "var-name-" + nextStringId();
+    final VariableDbModel randomizedVariable =
+        VariableFixtures.createRandomized(b -> b.name(varName).value("some-value"));
+    createAndSaveVariable(rdbmsService, randomizedVariable);
+
+    // and
+    final Operation<String> operation = Operation.neq("null");
+
+    // when
+    searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
+  }
+
+  @TestTemplate
   public void shouldFindVariableWithNameAndEqBooleanValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -571,11 +571,40 @@ public final class SearchQueryBuilders {
     // Handle common operations
     final var res =
         switch (operation.operator()) {
-          case EQUALS -> term(field, TypedValue.toTypedValue(operation.value()));
-          case NOT_EQUALS -> mustNot(term(field, TypedValue.toTypedValue(operation.value())));
+          case EQUALS -> {
+            if (operation.type().equals(ValueTypeEnum.LONG)) {
+              // Zeebe serializes whole numbers as doubles (e.g. "356.0"), so match both the
+              // integer and double string representations on the keyword field.
+              yield or(
+                  term(field, TypedValue.of(String.valueOf(operation.value()))),
+                  term(field, TypedValue.of(operation.value() + ".0")));
+            }
+            yield term(field, TypedValue.toTypedValue(operation.value()));
+          }
+          case NOT_EQUALS -> {
+            if (operation.type().equals(ValueTypeEnum.LONG)) {
+              yield mustNot(
+                  or(
+                      term(field, TypedValue.of(String.valueOf(operation.value()))),
+                      term(field, TypedValue.of(operation.value() + ".0"))));
+            }
+            yield mustNot(term(field, TypedValue.toTypedValue(operation.value())));
+          }
           case EXISTS -> exists(field);
           case NOT_EXISTS -> mustNot(exists(field));
-          case IN -> objectTerms(field, operation.values());
+          case IN -> {
+            if (operation.type().equals(ValueTypeEnum.LONG)) {
+              // Zeebe serializes whole numbers as doubles (e.g. "356.0"), so match both the
+              // integer and double string representations on the keyword field.
+              final var expandedValues = new ArrayList<>();
+              for (final var value : operation.values()) {
+                expandedValues.add(String.valueOf(value));
+                expandedValues.add(value + ".0");
+              }
+              yield objectTerms(field, expandedValues);
+            }
+            yield objectTerms(field, operation.values());
+          }
           default -> null;
         };
     if (res != null) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -18,6 +18,7 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.Operator;
 import io.camunda.search.filter.UntypedOperation;
 import io.camunda.util.ObjectBuilder;
+import io.camunda.util.ValueTypeUtil;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -572,6 +573,11 @@ public final class SearchQueryBuilders {
     final var res =
         switch (operation.operator()) {
           case EQUALS -> {
+            if (operation.type().equals(ValueTypeEnum.NULL)) {
+              // A JSON null variable is stored as the literal string "null" (not as an absent
+              // field), so match that literal.
+              yield term(field, TypedValue.of(ValueTypeUtil.JSON_NULL));
+            }
             if (operation.type().equals(ValueTypeEnum.LONG)) {
               // Zeebe serializes whole numbers as doubles (e.g. "356.0"), so match both the
               // integer and double string representations on the keyword field.
@@ -582,6 +588,9 @@ public final class SearchQueryBuilders {
             yield term(field, TypedValue.toTypedValue(operation.value()));
           }
           case NOT_EQUALS -> {
+            if (operation.type().equals(ValueTypeEnum.NULL)) {
+              yield mustNot(term(field, TypedValue.of(ValueTypeUtil.JSON_NULL)));
+            }
             if (operation.type().equals(ValueTypeEnum.LONG)) {
               yield mustNot(
                   or(
@@ -593,6 +602,10 @@ public final class SearchQueryBuilders {
           case EXISTS -> exists(field);
           case NOT_EXISTS -> mustNot(exists(field));
           case IN -> {
+            if (operation.type().equals(ValueTypeEnum.NULL)) {
+              // A JSON null variable is stored as the literal string "null", so match that literal.
+              yield term(field, TypedValue.of(ValueTypeUtil.JSON_NULL));
+            }
             if (operation.type().equals(ValueTypeEnum.LONG)) {
               // Zeebe serializes whole numbers as doubles (e.g. "356.0"), so match both the
               // integer and double string representations on the keyword field.

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/VariableQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/VariableQueryTransformerTest.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.query.SearchTermsQuery;
 import io.camunda.search.clients.types.TypedValue;
 import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.Operation;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.AuthorizationCheck;
 import io.camunda.security.core.authz.ResourceAccessChecks;
@@ -166,6 +167,103 @@ public class VariableQueryTransformerTest extends AbstractTransformerTest {
                         assertThat(term.field()).isEqualTo("value");
                         assertThat(term.value().stringValue()).isEqualTo("testValue");
                       });
+            });
+  }
+
+  @Test
+  public void shouldQueryByIntegerValueEqualsWithBothNumericRepresentations() {
+    // given
+    final var filter = FilterBuilders.variable((f) -> f.valueOperations(Operation.eq("356")));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              assertThat(boolQuery.should()).hasSize(2);
+              final var terms =
+                  boolQuery.should().stream()
+                      .map(SearchQuery::queryOption)
+                      .map(SearchTermQuery.class::cast)
+                      .toList();
+              assertThat(terms).extracting(SearchTermQuery::field).containsOnly("value");
+              final var valueStrings =
+                  terms.stream()
+                      .map(
+                          t ->
+                              t.value().isString()
+                                  ? t.value().stringValue()
+                                  : String.valueOf(t.value().longValue()))
+                      .toList();
+              assertThat(valueStrings).containsExactlyInAnyOrder("356", "356.0");
+            });
+  }
+
+  @Test
+  public void shouldQueryByIntegerValueNotEqualsExcludesBothRepresentations() {
+    // given
+    final var filter = FilterBuilders.variable((f) -> f.valueOperations(Operation.neq("356")));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              assertThat(boolQuery.mustNot()).hasSize(1);
+              final var inner = boolQuery.mustNot().getFirst().queryOption();
+              assertThat(inner)
+                  .isInstanceOfSatisfying(
+                      SearchBoolQuery.class,
+                      shouldBool -> {
+                        assertThat(shouldBool.should()).hasSize(2);
+                        final var terms =
+                            shouldBool.should().stream()
+                                .map(SearchQuery::queryOption)
+                                .map(SearchTermQuery.class::cast)
+                                .toList();
+                        assertThat(terms).extracting(SearchTermQuery::field).containsOnly("value");
+                        final var valueStrings =
+                            terms.stream()
+                                .map(
+                                    t ->
+                                        t.value().isString()
+                                            ? t.value().stringValue()
+                                            : String.valueOf(t.value().longValue()))
+                                .toList();
+                        assertThat(valueStrings).containsExactlyInAnyOrder("356", "356.0");
+                      });
+            });
+  }
+
+  @Test
+  public void shouldQueryByIntegerValueInWithBothNumericRepresentations() {
+    // given
+    final var filter =
+        FilterBuilders.variable((f) -> f.valueOperations(Operation.in("356", "400")));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermsQuery.class,
+            termsQuery -> {
+              assertThat(termsQuery.field()).isEqualTo("value");
+              final var valueStrings =
+                  termsQuery.values().stream()
+                      .map(v -> v.isString() ? v.stringValue() : String.valueOf(v.longValue()))
+                      .toList();
+              assertThat(valueStrings).containsExactlyInAnyOrder("356", "356.0", "400", "400.0");
             });
   }
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/VariableQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/VariableQueryTransformerTest.java
@@ -171,6 +171,69 @@ public class VariableQueryTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
+  public void shouldQueryByNullValueEqualsAsLiteralNullTerm() {
+    // given
+    final var filter = FilterBuilders.variable((f) -> f.valueOperations(Operation.eq("null")));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            term -> {
+              assertThat(term.field()).isEqualTo("value");
+              assertThat(term.value().stringValue()).isEqualTo("null");
+            });
+  }
+
+  @Test
+  public void shouldQueryByNullValueNotEqualsAsNegatedLiteralNullTerm() {
+    // given
+    final var filter = FilterBuilders.variable((f) -> f.valueOperations(Operation.neq("null")));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              assertThat(boolQuery.mustNot()).hasSize(1);
+              assertThat(boolQuery.mustNot().getFirst().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      term -> {
+                        assertThat(term.field()).isEqualTo("value");
+                        assertThat(term.value().stringValue()).isEqualTo("null");
+                      });
+            });
+  }
+
+  @Test
+  public void shouldQueryByNullValueInAsLiteralNullTerm() {
+    // given
+    final var filter = FilterBuilders.variable((f) -> f.valueOperations(Operation.in("null")));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            term -> {
+              assertThat(term.field()).isEqualTo("value");
+              assertThat(term.value().stringValue()).isEqualTo("null");
+            });
+  }
+
+  @Test
   public void shouldQueryByIntegerValueEqualsWithBothNumericRepresentations() {
     // given
     final var filter = FilterBuilders.variable((f) -> f.valueOperations(Operation.eq("356")));


### PR DESCRIPTION
## Description

Fixes two related bugs in variable value filtering via the C8 REST API.

### Fix 1: Integer variables not matching with $eq / $neq (closes #54078)

Zeebe serializes whole-number variables as doubles — `356` becomes `"356.0"` in the index. Filtering with `{"$eq": "356"}` returned 0 results (and `$neq` wrongly included the instance) because:
- **ES/OS**: term query used numeric `Long(356)`, which does not match keyword string `"356.0"`
- **RDBMS**: `LONG_VALUE = 356` found no match because the variable was stored in `DOUBLE_VALUE`

**Fix**: `EQUALS`/`NOT_EQUALS`/`IN` with integer-typed values now match both the integer and double string representations — ES/OS emits an OR of `term("356")` + `term("356.0")`; RDBMS uses `(LONG_VALUE = x OR DOUBLE_VALUE = x)`. Range operators (`$gt`/`$gte`/`$lt`/`$lte`) are out of scope for this issue and unchanged.

### Fix 2: Filtering by `null` value causes HTTP 500 (closes #54636)

Filtering with `{"$eq": "null"}` caused a 500 because the NULL type was unhandled (invalid null term query on ES/OS; no SQL fragment generated on RDBMS).

A JSON-null variable is stored as the literal string `"null"` on both backends (matching the existing `VariableNullValueSearchIT` behavior), so the fix matches that literal:
- **ES/OS**: `NULL` EQUALS → `term(field, "null")`; NOT_EQUALS → `mustNot(term(field, "null"))`
- **RDBMS**: `NULL` EQUALS → `VAR_VALUE = 'null'`; NOT_EQUALS → `VAR_VALUE != 'null'`

No schema changes. No V2 API contract changes.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54078
closes #54636