### PR TITLE
fix: introduce synthetic active overlay for multi instance beforeAll execution listeners

### DIFF
--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.3",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.72",
+        "@camunda/camunda-api-zod-schemas": "0.0.73",
         "@camunda/camunda-composite-components": "0.23.3",
         "@carbon/elements": "11.90.0",
         "@carbon/react": "1.108.0",
@@ -459,9 +459,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.72",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.72.tgz",
-      "integrity": "sha512-ZZmQHnvO2QCjq4sARIdcjNub94mKWKJx2xWfjPGuSjWRaRnZKilhqHLLYVBSvjPla9VgIi6lnYj6QT6iKOR/AQ==",
+      "version": "0.0.73",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.73.tgz",
+      "integrity": "sha512-l23X/+obOpLMwO9ZsveZX0WeDPTGZpzO+97MtCKt7iBnaW0kKOWqfq3Sg7GU57X7pGTPt+DIP2SNqIAnkxD0nw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.3",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.72",
+    "@camunda/camunda-api-zod-schemas": "0.0.73",
     "@camunda/camunda-composite-components": "0.23.3",
     "@carbon/elements": "11.90.0",
     "@carbon/react": "1.108.0",

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -10,6 +10,7 @@ import {
   render,
   waitForElementToBeRemoved,
   screen,
+  waitFor,
 } from 'modules/testing-library';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {TopPanel} from './index';
@@ -37,6 +38,8 @@ import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstance
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
 import {mockSearchAgentInstances} from 'modules/mocks/api/v2/agentInstances/searchAgentInstances';
+import {mockSearchElementInstanceInspection} from 'modules/mocks/api/v2/elementInstanceInspection/searchElementInstanceInspection';
+import {diagramOverlaysStore} from 'modules/stores/diagramOverlays';
 import {
   SearchParamsUpdater,
   updateSearchParams,
@@ -231,10 +234,13 @@ describe('TopPanel', () => {
     mockSearchElementInstances().withSuccess(searchResult([]));
 
     mockSearchAgentInstances().withSuccess(searchResult([]));
+
+    mockSearchElementInstanceInspection().withSuccess(searchResult([]));
   });
 
   afterEach(() => {
     modificationsStore.reset();
+    diagramOverlaysStore.reset();
   });
 
   it('should render spinner while loading', async () => {
@@ -472,5 +478,51 @@ describe('TopPanel', () => {
     expect(
       screen.queryByTestId(/^agent-shine-overlay-/),
     ).not.toBeInTheDocument();
+  });
+
+  it('should add an active overlay for a multi-instance body waiting for a beforeAll execution listener', async () => {
+    // given: MULTI_INSTANCE_BODY element in inspection data only —
+    // excluded from statistics to avoid double-counting body + inner instances
+    mockSearchElementInstanceInspection().withSuccess(
+      searchResult([
+        {
+          rootProcessInstanceKey: 'instance_id',
+          processInstanceKey: 'instance_id',
+          elementInstanceKey: '9999',
+          elementId: 'multi-instance-task',
+          elementType: 'MULTI_INSTANCE_BODY',
+          waitStateType: 'JOB',
+          details: {
+            waitStateType: 'JOB',
+            jobType: 'io.camunda:execution-listener:1',
+            jobKind: 'EXECUTION_LISTENER',
+            listenerEventType: 'BEFORE_ALL',
+          },
+        },
+      ]),
+    );
+
+    render(<TopPanel />, {wrapper: getWrapper()});
+
+    // when: diagram finishes loading
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('diagram-spinner'),
+    );
+
+    // then: a synthetic active overlay was added without a count (instance
+    // count is unknown until the beforeAll listener completes and the body activates)
+    await waitFor(() => {
+      const activeOverlay = diagramOverlaysStore.state.overlays.find(
+        (o) =>
+          o.elementId === 'multi-instance-task' && o.type === 'elementState',
+      );
+      expect(activeOverlay).toBeDefined();
+      const payload = activeOverlay?.payload as {
+        elementState: string;
+        count?: number;
+      };
+      expect(payload?.elementState).toBe('active');
+      expect(payload?.count).toBeUndefined();
+    });
   });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -505,19 +505,25 @@ describe('TopPanel', () => {
     await waitForElementToBeRemoved(() =>
       screen.queryByTestId('diagram-spinner'),
     );
-
     await waitFor(() => {
-      const activeOverlay = diagramOverlaysStore.state.overlays.find(
-        (o) =>
-          o.elementId === 'multi-instance-task' && o.type === 'elementState',
-      );
-      expect(activeOverlay).toBeDefined();
-      const payload = activeOverlay?.payload as {
-        elementState: string;
-        count?: number;
-      };
-      expect(payload?.elementState).toBe('active');
-      expect(payload?.count).toBeUndefined();
+      expect(
+        diagramOverlaysStore.state.overlays.find(
+          ({elementId, type}) =>
+            elementId === 'multi-instance-task' && type === 'elementState',
+        ),
+      ).toBeDefined();
     });
+
+    const activeOverlay = diagramOverlaysStore.state.overlays.find(
+      ({elementId, type}) =>
+        elementId === 'multi-instance-task' && type === 'elementState',
+    );
+
+    const payload = activeOverlay?.payload as {
+      elementState: string;
+      count?: number;
+    };
+    expect(payload?.elementState).toBe('active');
+    expect(payload?.count).toBeUndefined();
   });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -481,8 +481,6 @@ describe('TopPanel', () => {
   });
 
   it('should add an active overlay for a multi-instance body waiting for a beforeAll execution listener', async () => {
-    // given: MULTI_INSTANCE_BODY element in inspection data only —
-    // excluded from statistics to avoid double-counting body + inner instances
     mockSearchElementInstanceInspection().withSuccess(
       searchResult([
         {
@@ -504,13 +502,10 @@ describe('TopPanel', () => {
 
     render(<TopPanel />, {wrapper: getWrapper()});
 
-    // when: diagram finishes loading
     await waitForElementToBeRemoved(() =>
       screen.queryByTestId('diagram-spinner'),
     );
 
-    // then: a synthetic active overlay was added without a count (instance
-    // count is unknown until the beforeAll listener completes and the body activates)
     await waitFor(() => {
       const activeOverlay = diagramOverlaysStore.state.overlays.find(
         (o) =>

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -60,7 +60,10 @@ import {useProcessSequenceFlows} from 'modules/queries/sequenceFlows/useProcessS
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useElementInstanceInspection} from 'modules/queries/elementInstanceInspection/useElementInstanceInspection';
 import {getSubprocessOverlayFromIncidentElements} from 'modules/utils/elements';
-import {getWaitStateLabel} from 'modules/utils/waitStates';
+import {
+  getWaitStateLabel,
+  isBeforeAllExecutionListenerWaitState,
+} from 'modules/utils/waitStates';
 import type {
   AgentShinePayload,
   AgentStatusPayload,
@@ -183,6 +186,26 @@ const TopPanel: React.FC = observer(() => {
       })) || []),
       ...subprocessOverlays,
     ];
+
+    // Multi-instance bodies waiting for beforeAll execution listeners are
+    // excluded from the statistics query to avoid double-counting the body
+    // Add a synthetic active overlay for each such element so the diagram badge still appears.
+    if (inspectionData?.items?.length) {
+      const elementIdsInStats = new Set(statistics?.map(({id}) => id) ?? []);
+      for (const item of inspectionData.items) {
+        if (
+          isBeforeAllExecutionListenerWaitState(item) &&
+          !elementIdsInStats.has(item.elementId)
+        ) {
+          allElementStateOverlays.push({
+            payload: {elementState: 'active' as const},
+            type: OVERLAY_TYPE_STATE,
+            elementId: item.elementId,
+            position: overlayPositions.active,
+          });
+        }
+      }
+    }
 
     const notCompletedElementStateOverlays = allElementStateOverlays?.filter(
       (stateOverlay) => stateOverlay.payload.elementState !== 'completed',

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -187,9 +187,6 @@ const TopPanel: React.FC = observer(() => {
       ...subprocessOverlays,
     ];
 
-    // Multi-instance bodies waiting for beforeAll execution listeners are
-    // excluded from the statistics query to avoid double-counting the body
-    // Add a synthetic active overlay for each such element so the diagram badge still appears.
     if (inspectionData?.items?.length) {
       const elementIdsInStats = new Set(statistics?.map(({id}) => id) ?? []);
       for (const item of inspectionData.items) {

--- a/operate/client/src/modules/utils/waitStates.ts
+++ b/operate/client/src/modules/utils/waitStates.ts
@@ -6,7 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {ElementInstanceInspection} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {
+  ElementInstanceInspection,
+  ElementInstanceType,
+  JobKind,
+  WaitStateType,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 import {formatDate} from 'modules/utils/date';
 
 function getWaitStateLabel(
@@ -135,4 +140,21 @@ function getEarliestTimerDueDate(
   return earliestDueDate;
 }
 
-export {getWaitStateLabel, getWaitStateStatusItems, getEarliestTimerDueDate};
+function isBeforeAllExecutionListenerWaitState(
+  item: ElementInstanceInspection,
+): boolean {
+  return (
+    (item.elementType as ElementInstanceType) === 'MULTI_INSTANCE_BODY' &&
+    (item.details['waitStateType'] as WaitStateType) === 'JOB' &&
+    (item.details['jobKind'] as JobKind) === 'EXECUTION_LISTENER' &&
+    item.details['listenerEventType'] === 'BEFORE_ALL'
+    // TODO use ListenerEventType from camunda-api-zod-schemas/8.10 when published
+  );
+}
+
+export {
+  getWaitStateLabel,
+  getWaitStateStatusItems,
+  getEarliestTimerDueDate,
+  isBeforeAllExecutionListenerWaitState,
+};

--- a/operate/client/src/modules/utils/waitStates.ts
+++ b/operate/client/src/modules/utils/waitStates.ts
@@ -6,12 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {
-  ElementInstanceInspection,
-  ElementInstanceType,
-  JobKind,
-  WaitStateType,
-} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {ElementInstanceInspection} from '@camunda/camunda-api-zod-schemas/8.10';
 import {formatDate} from 'modules/utils/date';
 
 function getWaitStateLabel(
@@ -42,8 +37,7 @@ function getWaitStateStatusItems(
   return waitStates.flatMap((waitState) => {
     switch (waitState.waitStateType) {
       case 'MESSAGE': {
-        const messageName =
-          (waitState.details['messageName'] as string) ?? 'unknown';
+        const messageName = waitState.details['messageName'] ?? 'unknown';
         return {
           key: `${waitState.elementInstanceKey}-MESSAGE-${messageName}`,
           text: `Waiting for message: ${messageName}`,
@@ -68,8 +62,7 @@ function getWaitStateStatusItems(
         };
       }
       case 'SIGNAL': {
-        const signalName =
-          (waitState.details['signalName'] as string) ?? 'unknown';
+        const signalName = waitState.details['signalName'] ?? 'unknown';
         return {
           key: `${waitState.elementInstanceKey}-SIGNAL-${signalName}`,
           text: `Waiting for signal: ${signalName}`,
@@ -82,8 +75,8 @@ function getWaitStateStatusItems(
         };
       }
       case 'JOB': {
-        const jobType = (waitState.details['jobType'] as string) ?? 'unknown';
-        const jobKind = waitState.details['jobKind'] as string | undefined;
+        const jobType = waitState.details['jobType'] ?? 'unknown';
+        const jobKind = waitState.details['jobKind'];
         if (jobKind === 'EXECUTION_LISTENER' || jobKind === 'TASK_LISTENER') {
           return {
             key: `${waitState.elementInstanceKey}-JOB-${jobKind}-${jobType}`,
@@ -144,11 +137,10 @@ function isBeforeAllExecutionListenerWaitState(
   item: ElementInstanceInspection,
 ): boolean {
   return (
-    (item.elementType as ElementInstanceType) === 'MULTI_INSTANCE_BODY' &&
-    (item.details['waitStateType'] as WaitStateType) === 'JOB' &&
-    (item.details['jobKind'] as JobKind) === 'EXECUTION_LISTENER' &&
+    item.elementType === 'MULTI_INSTANCE_BODY' &&
+    item.details['waitStateType'] === 'JOB' &&
+    item.details['jobKind'] === 'EXECUTION_LISTENER' &&
     item.details['listenerEventType'] === 'BEFORE_ALL'
-    // TODO use ListenerEventType from camunda-api-zod-schemas/8.10 when published
   );
 }
 


### PR DESCRIPTION
## Description

Introduce synthetic active overlay for multi instance beforeAll execution listeners as discussed in slack [discussion](https://camunda.slack.com/archives/C0AGYRL4KD3/p1781851200414279?thread_ts=1780666419.374459&cid=C0AGYRL4KD3).

No count yet, since `In Progress` job worker for `beforeAll` is going to resolve multi instance count.

<img width="1103" height="709" alt="image" src="https://github.com/user-attachments/assets/e063b5a7-bc83-416f-8706-4575dddf9198" />

## Related issues
Part of [#prj-pdp-3458-multi-instance-activity-execution-listeners](https://camunda.slack.com/archives/C0AGYRL4KD3)
closes #55120
