### PR TITLE
fix: switch tasklist migration reindex to async to avoid socket timeout

### DIFF
--- a/migration/task-migration/pom.xml
+++ b/migration/task-migration/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>elasticsearch-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opensearch.client</groupId>
       <artifactId>opensearch-java</artifactId>
     </dependency>

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/ReindexTaskStatus.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/ReindexTaskStatus.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.task.adapter;
+
+public record ReindexTaskStatus(
+    String taskId,
+    boolean found,
+    boolean completed,
+    long total,
+    long created,
+    long updated,
+    long deleted) {
+
+  public static ReindexTaskStatus notFound() {
+    return new ReindexTaskStatus("", false, false, 0, 0, 0, 0);
+  }
+}

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -709,7 +709,12 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
       }
       if (failures != null && !failures.isEmpty()) {
         throw new MigrationException(
-            "Reindex task " + taskId + " completed with " + failures.size() + " failures");
+            "Reindex task "
+                + taskId
+                + " completed with "
+                + failures.size()
+                + " failures; first: "
+                + failures.get(0));
       }
     }
     final boolean completed = res.completed() && (created + updated + deleted + conflicts) >= total;

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -35,11 +35,14 @@ import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutMappingRequest;
 import co.elastic.clients.elasticsearch.indices.UpdateAliasesRequest;
+import co.elastic.clients.elasticsearch.tasks.GetTasksResponse;
 import co.elastic.clients.json.JsonData;
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.commons.configuration.MigrationConfiguration;
+import io.camunda.migration.commons.configuration.MigrationConfiguration.MigrationRetryConfiguration;
 import io.camunda.migration.commons.storage.ProcessorStep;
 import io.camunda.migration.commons.storage.TasklistMigrationRepositoryIndex;
+import io.camunda.migration.task.adapter.ReindexTaskStatus;
 import io.camunda.migration.task.adapter.TaskEntityPair;
 import io.camunda.migration.task.adapter.TaskLegacyIndex;
 import io.camunda.migration.task.adapter.TaskMigrationAdapter;
@@ -55,9 +58,13 @@ import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.retry.RetryDecorator;
+import jakarta.json.JsonObject;
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -70,6 +77,10 @@ import org.slf4j.LoggerFactory;
 public class ElasticsearchAdapter implements TaskMigrationAdapter {
 
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchAdapter.class);
+
+  private static final String MAIN_REINDEX_STEP_ID = VersionUtil.getVersion() + "-reindex-main";
+  private static final String DATED_REINDEX_STEP_PREFIX =
+      VersionUtil.getVersion() + "-reindex-dated-";
 
   private final ElasticsearchClient client;
   private final MigrationConfiguration migrationConfiguration;
@@ -152,8 +163,77 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
   @Override
   public void reindexLegacyDatedIndex(final String legacyDatedIndex) throws MigrationException {
     final String newDatedIndex = MigrationUtils.generateNewIndexNameFromLegacy(legacyDatedIndex);
-    final var documentsWereProcessed = reindex(legacyDatedIndex, newDatedIndex);
-    if (documentsWereProcessed) {
+    final String stepId = DATED_REINDEX_STEP_PREFIX + sanitizeIndexName(legacyDatedIndex);
+    final ProcessorStep existingStep = getReindexStep(stepId);
+
+    if (existingStep != null && existingStep.isApplied()) {
+      LOG.info("Dated index reindex for {} already completed, skipping", legacyDatedIndex);
+      return;
+    }
+
+    final String taskId;
+    if (existingStep != null) {
+      final ReindexTaskStatus status;
+      try {
+        status =
+            retryDecorator.decorate(
+                "Check reindex task status " + existingStep.getContent(),
+                () -> getReindexTaskStatus(existingStep.getContent()),
+                s -> false);
+      } catch (final MigrationException e) {
+        throw e;
+      } catch (final Exception e) {
+        throw new MigrationException(e);
+      }
+      if (status.found() && status.completed()) {
+        writeReindexStep(stepId, existingStep.getContent(), true);
+        if (status.total() > 0) {
+          updateIndexAlias(newDatedIndex);
+          setIndexLifecycle(newDatedIndex);
+        } else {
+          LOG.info(
+              "No documents were reindexed from {} to {}. {} was not created.",
+              legacyDatedIndex,
+              newDatedIndex,
+              newDatedIndex);
+        }
+        return;
+      } else if (status.found()) {
+        taskId = existingStep.getContent();
+      } else {
+        taskId = submitReindex(legacyDatedIndex, newDatedIndex);
+        writeReindexStep(stepId, taskId, false);
+      }
+    } else {
+      taskId = submitReindex(legacyDatedIndex, newDatedIndex);
+      writeReindexStep(stepId, taskId, false);
+    }
+
+    final ReindexTaskStatus finalStatus;
+    try {
+      finalStatus =
+          busyRetryDecorator()
+              .decorate(
+                  "Wait for dated index reindex " + legacyDatedIndex,
+                  () -> {
+                    final var status = getReindexTaskStatus(taskId);
+                    if (!status.found()) {
+                      throw new MigrationException(
+                          "Reindex task " + taskId + " disappeared; restart migration to resubmit");
+                    }
+                    if (status.completed()) {
+                      writeReindexStep(stepId, taskId, true);
+                    }
+                    return status;
+                  },
+                  status -> !status.completed());
+    } catch (final MigrationException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new MigrationException(e);
+    }
+
+    if (finalStatus.total() > 0) {
       updateIndexAlias(newDatedIndex);
       setIndexLifecycle(newDatedIndex);
     } else {
@@ -167,7 +247,74 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
 
   @Override
   public void reindexLegacyMainIndex() throws MigrationException {
-    reindex(legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
+    final String stepId = MAIN_REINDEX_STEP_ID;
+    final ProcessorStep existingStep = getReindexStep(stepId);
+
+    if (existingStep != null && existingStep.isApplied()) {
+      LOG.info("Main index reindex already completed, skipping");
+      if (retentionConfiguration.isEnabled()) {
+        applyLegacyIndexRetentionPolicy();
+      }
+      return;
+    }
+
+    final String taskId;
+    if (existingStep != null) {
+      final ReindexTaskStatus status;
+      try {
+        status =
+            retryDecorator.decorate(
+                "Check reindex task status " + existingStep.getContent(),
+                () -> getReindexTaskStatus(existingStep.getContent()),
+                s -> false);
+      } catch (final MigrationException e) {
+        throw e;
+      } catch (final Exception e) {
+        throw new MigrationException(e);
+      }
+      if (status.found() && status.completed()) {
+        writeReindexStep(stepId, existingStep.getContent(), true);
+        if (retentionConfiguration.isEnabled()) {
+          applyLegacyIndexRetentionPolicy();
+        }
+        return;
+      } else if (status.found()) {
+        taskId = existingStep.getContent();
+      } else {
+        taskId =
+            submitReindex(
+                legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
+        writeReindexStep(stepId, taskId, false);
+      }
+    } else {
+      taskId =
+          submitReindex(
+              legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
+      writeReindexStep(stepId, taskId, false);
+    }
+
+    try {
+      busyRetryDecorator()
+          .decorate(
+              "Wait for main index reindex",
+              () -> {
+                final var status = getReindexTaskStatus(taskId);
+                if (!status.found()) {
+                  throw new MigrationException(
+                      "Reindex task " + taskId + " disappeared; restart migration to resubmit");
+                }
+                if (status.completed()) {
+                  writeReindexStep(stepId, taskId, true);
+                }
+                return status;
+              },
+              status -> !status.completed());
+    } catch (final MigrationException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new MigrationException(e);
+    }
+
     if (retentionConfiguration.isEnabled()) {
       applyLegacyIndexRetentionPolicy();
     }
@@ -494,7 +641,8 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
     }
   }
 
-  private boolean reindex(final String source, final String destination) throws MigrationException {
+  private String submitReindex(final String source, final String destination)
+      throws MigrationException {
     final ReindexRequest createMissingRequest =
         new ReindexRequest.Builder()
             .source(
@@ -509,16 +657,129 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
                     .build())
             .conflicts(Conflicts.Proceed) // ignore version conflicts
             .refresh(true)
+            .waitForCompletion(false)
             .build();
 
     try {
-      final var reindexResponse = client.reindex(createMissingRequest);
-      return reindexResponse != null
-          && reindexResponse.total() != null
-          && reindexResponse.total() > 0;
-    } catch (final IOException e) {
+      final var response =
+          retryDecorator.decorate(
+              "Submit reindex from " + source,
+              () -> client.reindex(createMissingRequest),
+              res -> res == null || res.task() == null);
+      return response.task();
+    } catch (final Exception e) {
       throw new MigrationException(e);
     }
+  }
+
+  private ReindexTaskStatus getReindexTaskStatus(final String taskId)
+      throws IOException, ElasticsearchException {
+    final GetTasksResponse res;
+    try {
+      res = client.tasks().get(req -> req.taskId(taskId));
+    } catch (final ElasticsearchException e) {
+      if (e.status() == 404) {
+        return ReindexTaskStatus.notFound();
+      }
+      throw e;
+    }
+    if (res == null || res.task() == null) {
+      return ReindexTaskStatus.notFound();
+    }
+    final JsonData statusData = res.task().status();
+    if (statusData == null) {
+      LOG.warn("Status of reindex task {} is null", taskId);
+      return ReindexTaskStatus.notFound();
+    }
+    final JsonObject status = statusData.toJson().asJsonObject();
+    if (status == null) {
+      LOG.warn("Status of reindex task {} is null", taskId);
+      return ReindexTaskStatus.notFound();
+    }
+    final long created = status.getInt("created", 0);
+    final long updated = status.getInt("updated", 0);
+    final long deleted = status.getInt("deleted", 0);
+    final long conflicts = status.getInt("version_conflicts", 0);
+    final var failures = status.getJsonArray("failures");
+    final long total = status.getInt("total", 0);
+    if (res.completed()) {
+      if (res.error() != null) {
+        throw new MigrationException(
+            "Reindex task " + taskId + " failed with error: " + res.error());
+      }
+      if (failures != null && !failures.isEmpty()) {
+        throw new MigrationException(
+            "Reindex task " + taskId + " completed with " + failures.size() + " failures");
+      }
+    }
+    final boolean completed = res.completed() && (created + updated + deleted + conflicts) >= total;
+    return new ReindexTaskStatus(taskId, true, completed, total, created, updated, deleted);
+  }
+
+  private void writeReindexStep(final String stepId, final String taskId, final boolean completed) {
+    final ProcessorStep step = new ProcessorStep();
+    step.setContent(taskId);
+    step.setDescription("Reindex task step " + stepId);
+    step.setAppliedDate(OffsetDateTime.now(ZoneId.systemDefault()));
+    step.setIndexName(TaskTemplate.INDEX_NAME);
+    step.setVersion(VersionUtil.getVersion());
+    step.setApplied(completed);
+
+    final UpdateRequest<ProcessorStep, ProcessorStep> updateRequest =
+        new UpdateRequest.Builder<ProcessorStep, ProcessorStep>()
+            .index(migrationIndex.getFullQualifiedName())
+            .id(stepId)
+            .docAsUpsert(true)
+            .doc(step)
+            .refresh(Refresh.True)
+            .upsert(step)
+            .build();
+    try {
+      retryDecorator.decorate(
+          "Write reindex step " + stepId,
+          () -> client.update(updateRequest, ProcessorStep.class),
+          res -> res.result() != Result.Created && res.result() != Result.Updated);
+    } catch (final Exception e) {
+      throw new MigrationException("Failed to write reindex step " + stepId, e);
+    }
+  }
+
+  private ProcessorStep getReindexStep(final String stepId) {
+    final SearchRequest searchRequest =
+        new SearchRequest.Builder()
+            .index(migrationIndex.getFullQualifiedName())
+            .size(1)
+            .query(q -> q.term(t -> t.field(TasklistMigrationRepositoryIndex.ID).value(stepId)))
+            .build();
+    try {
+      final SearchResponse<ProcessorStep> response =
+          retryDecorator.decorate(
+              "Fetch reindex step " + stepId,
+              () -> client.search(searchRequest, ProcessorStep.class),
+              res -> res.timedOut() || Boolean.TRUE.equals(res.terminatedEarly()));
+      return response.hits().hits().stream()
+          .map(Hit::source)
+          .filter(Objects::nonNull)
+          .findFirst()
+          .orElse(null);
+    } catch (final Exception e) {
+      throw new MigrationException("Failed to fetch reindex step " + stepId, e);
+    }
+  }
+
+  private RetryDecorator busyRetryDecorator() {
+    final var retryConfiguration = new MigrationRetryConfiguration();
+    retryConfiguration.setMaxRetries(Integer.MAX_VALUE);
+    retryConfiguration.setMinRetryDelay(migrationConfiguration.getRetry().getMinRetryDelay());
+    retryConfiguration.setMaxRetryDelay(migrationConfiguration.getRetry().getMaxRetryDelay());
+    retryConfiguration.setRetryDelayMultiplier(
+        migrationConfiguration.getRetry().getRetryDelayMultiplier());
+    return new RetryDecorator(retryConfiguration)
+        .withRetryOnException(e -> !(e instanceof MigrationException));
+  }
+
+  private static String sanitizeIndexName(final String indexName) {
+    return indexName.replaceAll("[/\\s]", "-");
   }
 
   private void updateIndexAlias(final String newDatedIndex) throws MigrationException {

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -61,6 +61,7 @@ import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoin
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.retry.RetryDecorator;
+import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -696,12 +697,12 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
       LOG.warn("Status of reindex task {} is null", taskId);
       return ReindexTaskStatus.notFound();
     }
-    final long created = status.getInt("created", 0);
-    final long updated = status.getInt("updated", 0);
-    final long deleted = status.getInt("deleted", 0);
-    final long conflicts = status.getInt("version_conflicts", 0);
+    final long created = getLongField(status, "created");
+    final long updated = getLongField(status, "updated");
+    final long deleted = getLongField(status, "deleted");
+    final long conflicts = getLongField(status, "version_conflicts");
     final var failures = status.getJsonArray("failures");
-    final long total = status.getInt("total", 0);
+    final long total = getLongField(status, "total");
     if (res.completed()) {
       if (res.error() != null) {
         throw new MigrationException(
@@ -781,6 +782,11 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
         migrationConfiguration.getRetry().getRetryDelayMultiplier());
     return new RetryDecorator(retryConfiguration)
         .withRetryOnException(e -> !(e instanceof MigrationException));
+  }
+
+  private static long getLongField(final JsonObject obj, final String field) {
+    final JsonNumber n = obj.getJsonNumber(field);
+    return n != null ? n.longValue() : 0L;
   }
 
   private static String sanitizeIndexName(final String indexName) {

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -72,6 +72,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -166,10 +167,49 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
   public void reindexLegacyDatedIndex(final String legacyDatedIndex) throws MigrationException {
     final String newDatedIndex = MigrationUtils.generateNewIndexNameFromLegacy(legacyDatedIndex);
     final String stepId = DATED_REINDEX_STEP_PREFIX + sanitizeIndexName(legacyDatedIndex);
+    executeReindex(
+        legacyDatedIndex,
+        newDatedIndex,
+        stepId,
+        "dated index reindex " + legacyDatedIndex,
+        status -> {
+          if (status.total() > 0) {
+            updateIndexAlias(newDatedIndex);
+            setIndexLifecycle(newDatedIndex);
+          } else {
+            LOG.info(
+                "No documents were reindexed from {} to {}. {} was not created.",
+                legacyDatedIndex,
+                newDatedIndex,
+                newDatedIndex);
+          }
+        });
+  }
+
+  @Override
+  public void reindexLegacyMainIndex() throws MigrationException {
+    executeReindex(
+        legacyIndex.getFullQualifiedName(),
+        destinationIndex.getFullQualifiedName(),
+        MAIN_REINDEX_STEP_ID,
+        "main index reindex",
+        status -> {});
+    if (retentionConfiguration.isEnabled()) {
+      applyLegacyIndexRetentionPolicy();
+    }
+  }
+
+  private void executeReindex(
+      final String source,
+      final String destination,
+      final String stepId,
+      final String label,
+      final Consumer<ReindexTaskStatus> onComplete)
+      throws MigrationException {
     final ProcessorStep existingStep = getReindexStep(stepId);
 
     if (existingStep != null && existingStep.isApplied()) {
-      LOG.info("Dated index reindex for {} already completed, skipping", legacyDatedIndex);
+      LOG.info("Reindex {} already completed, skipping", label);
       return;
     }
 
@@ -189,25 +229,16 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
       }
       if (status.found() && status.completed()) {
         writeReindexStep(stepId, existingStep.getContent(), true);
-        if (status.total() > 0) {
-          updateIndexAlias(newDatedIndex);
-          setIndexLifecycle(newDatedIndex);
-        } else {
-          LOG.info(
-              "No documents were reindexed from {} to {}. {} was not created.",
-              legacyDatedIndex,
-              newDatedIndex,
-              newDatedIndex);
-        }
+        onComplete.accept(status);
         return;
       } else if (status.found()) {
         taskId = existingStep.getContent();
       } else {
-        taskId = submitReindex(legacyDatedIndex, newDatedIndex);
+        taskId = submitReindex(source, destination);
         writeReindexStep(stepId, taskId, false);
       }
     } else {
-      taskId = submitReindex(legacyDatedIndex, newDatedIndex);
+      taskId = submitReindex(source, destination);
       writeReindexStep(stepId, taskId, false);
     }
 
@@ -216,7 +247,7 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
       finalStatus =
           busyRetryDecorator()
               .decorate(
-                  "Wait for dated index reindex " + legacyDatedIndex,
+                  "Wait for " + label,
                   () -> {
                     final var status = getReindexTaskStatus(taskId);
                     if (!status.found()) {
@@ -235,91 +266,7 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
       throw new MigrationException(e);
     }
 
-    if (finalStatus.total() > 0) {
-      updateIndexAlias(newDatedIndex);
-      setIndexLifecycle(newDatedIndex);
-    } else {
-      LOG.info(
-          "No documents were reindexed from {} to {}. {} was not created.",
-          legacyDatedIndex,
-          newDatedIndex,
-          newDatedIndex);
-    }
-  }
-
-  @Override
-  public void reindexLegacyMainIndex() throws MigrationException {
-    final String stepId = MAIN_REINDEX_STEP_ID;
-    final ProcessorStep existingStep = getReindexStep(stepId);
-
-    if (existingStep != null && existingStep.isApplied()) {
-      LOG.info("Main index reindex already completed, skipping");
-      if (retentionConfiguration.isEnabled()) {
-        applyLegacyIndexRetentionPolicy();
-      }
-      return;
-    }
-
-    final String taskId;
-    if (existingStep != null) {
-      final ReindexTaskStatus status;
-      try {
-        status =
-            retryDecorator.decorate(
-                "Check reindex task status " + existingStep.getContent(),
-                () -> getReindexTaskStatus(existingStep.getContent()),
-                s -> false);
-      } catch (final MigrationException e) {
-        throw e;
-      } catch (final Exception e) {
-        throw new MigrationException(e);
-      }
-      if (status.found() && status.completed()) {
-        writeReindexStep(stepId, existingStep.getContent(), true);
-        if (retentionConfiguration.isEnabled()) {
-          applyLegacyIndexRetentionPolicy();
-        }
-        return;
-      } else if (status.found()) {
-        taskId = existingStep.getContent();
-      } else {
-        taskId =
-            submitReindex(
-                legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
-        writeReindexStep(stepId, taskId, false);
-      }
-    } else {
-      taskId =
-          submitReindex(
-              legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
-      writeReindexStep(stepId, taskId, false);
-    }
-
-    try {
-      busyRetryDecorator()
-          .decorate(
-              "Wait for main index reindex",
-              () -> {
-                final var status = getReindexTaskStatus(taskId);
-                if (!status.found()) {
-                  throw new MigrationException(
-                      "Reindex task " + taskId + " disappeared; restart migration to resubmit");
-                }
-                if (status.completed()) {
-                  writeReindexStep(stepId, taskId, true);
-                }
-                return status;
-              },
-              status -> !status.completed());
-    } catch (final MigrationException e) {
-      throw e;
-    } catch (final Exception e) {
-      throw new MigrationException(e);
-    }
-
-    if (retentionConfiguration.isEnabled()) {
-      applyLegacyIndexRetentionPolicy();
-    }
+    onComplete.accept(finalStatus);
   }
 
   @Override

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -63,6 +63,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -692,11 +693,12 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
       LOG.warn("Status of reindex task {} is null", taskId);
       return ReindexTaskStatus.notFound();
     }
-    final JsonObject status = statusData.toJson().asJsonObject();
-    if (status == null) {
-      LOG.warn("Status of reindex task {} is null", taskId);
-      return ReindexTaskStatus.notFound();
+    final JsonValue statusValue = statusData.toJson();
+    if (!(statusValue instanceof JsonObject)) {
+      throw new MigrationException(
+          "Unexpected task status format for task " + taskId + ": " + statusValue.getValueType());
     }
+    final JsonObject status = (JsonObject) statusValue;
     final long created = getLongField(status, "created");
     final long updated = getLongField(status, "updated");
     final long deleted = getLongField(status, "deleted");

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
@@ -178,10 +179,46 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
   public void reindexLegacyDatedIndex(final String legacyDatedIndex) throws MigrationException {
     final String newDatedIndex = MigrationUtils.generateNewIndexNameFromLegacy(legacyDatedIndex);
     final String stepId = DATED_REINDEX_STEP_PREFIX + sanitizeIndexName(legacyDatedIndex);
+    executeReindex(
+        legacyDatedIndex,
+        newDatedIndex,
+        stepId,
+        "dated index reindex " + legacyDatedIndex,
+        status -> {
+          if (status.total() > 0) {
+            updateIndexAlias(newDatedIndex);
+            setIndexLifecycle(newDatedIndex);
+          } else {
+            LOG.info(
+                "No documents were reindexed from {} to {}. {} was not created.",
+                legacyDatedIndex,
+                newDatedIndex,
+                newDatedIndex);
+          }
+        });
+  }
+
+  @Override
+  public void reindexLegacyMainIndex() throws MigrationException {
+    executeReindex(
+        legacyIndex.getFullQualifiedName(),
+        destinationIndex.getFullQualifiedName(),
+        MAIN_REINDEX_STEP_ID,
+        "main index reindex",
+        status -> {});
+  }
+
+  private void executeReindex(
+      final String source,
+      final String destination,
+      final String stepId,
+      final String label,
+      final Consumer<ReindexTaskStatus> onComplete)
+      throws MigrationException {
     final ProcessorStep existingStep = getReindexStep(stepId);
 
     if (existingStep != null && existingStep.isApplied()) {
-      LOG.info("Dated index reindex for {} already completed, skipping", legacyDatedIndex);
+      LOG.info("Reindex {} already completed, skipping", label);
       return;
     }
 
@@ -201,25 +238,16 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
       }
       if (status.found() && status.completed()) {
         writeReindexStep(stepId, existingStep.getContent(), true);
-        if (status.total() > 0) {
-          updateIndexAlias(newDatedIndex);
-          setIndexLifecycle(newDatedIndex);
-        } else {
-          LOG.info(
-              "No documents were reindexed from {} to {}. {} was not created.",
-              legacyDatedIndex,
-              newDatedIndex,
-              newDatedIndex);
-        }
+        onComplete.accept(status);
         return;
       } else if (status.found()) {
         taskId = existingStep.getContent();
       } else {
-        taskId = submitReindex(legacyDatedIndex, newDatedIndex);
+        taskId = submitReindex(source, destination);
         writeReindexStep(stepId, taskId, false);
       }
     } else {
-      taskId = submitReindex(legacyDatedIndex, newDatedIndex);
+      taskId = submitReindex(source, destination);
       writeReindexStep(stepId, taskId, false);
     }
 
@@ -228,7 +256,7 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
       finalStatus =
           busyRetryDecorator()
               .decorate(
-                  "Wait for dated index reindex " + legacyDatedIndex,
+                  "Wait for " + label,
                   () -> {
                     final var status = getReindexTaskStatus(taskId);
                     if (!status.found()) {
@@ -247,81 +275,7 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
       throw new MigrationException(e);
     }
 
-    if (finalStatus.total() > 0) {
-      updateIndexAlias(newDatedIndex);
-      setIndexLifecycle(newDatedIndex);
-    } else {
-      LOG.info(
-          "No documents were reindexed from {} to {}. {} was not created.",
-          legacyDatedIndex,
-          newDatedIndex,
-          newDatedIndex);
-    }
-  }
-
-  @Override
-  public void reindexLegacyMainIndex() throws MigrationException {
-    final String stepId = MAIN_REINDEX_STEP_ID;
-    final ProcessorStep existingStep = getReindexStep(stepId);
-
-    if (existingStep != null && existingStep.isApplied()) {
-      LOG.info("Main index reindex already completed, skipping");
-      return;
-    }
-
-    final String taskId;
-    if (existingStep != null) {
-      final ReindexTaskStatus status;
-      try {
-        status =
-            retryDecorator.decorate(
-                "Check reindex task status " + existingStep.getContent(),
-                () -> getReindexTaskStatus(existingStep.getContent()),
-                s -> false);
-      } catch (final MigrationException e) {
-        throw e;
-      } catch (final Exception e) {
-        throw new MigrationException(e);
-      }
-      if (status.found() && status.completed()) {
-        writeReindexStep(stepId, existingStep.getContent(), true);
-        return;
-      } else if (status.found()) {
-        taskId = existingStep.getContent();
-      } else {
-        taskId =
-            submitReindex(
-                legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
-        writeReindexStep(stepId, taskId, false);
-      }
-    } else {
-      taskId =
-          submitReindex(
-              legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
-      writeReindexStep(stepId, taskId, false);
-    }
-
-    try {
-      busyRetryDecorator()
-          .decorate(
-              "Wait for main index reindex",
-              () -> {
-                final var status = getReindexTaskStatus(taskId);
-                if (!status.found()) {
-                  throw new MigrationException(
-                      "Reindex task " + taskId + " disappeared; restart migration to resubmit");
-                }
-                if (status.completed()) {
-                  writeReindexStep(stepId, taskId, true);
-                }
-                return status;
-              },
-              status -> !status.completed());
-    } catch (final MigrationException e) {
-      throw e;
-    } catch (final Exception e) {
-      throw new MigrationException(e);
-    }
+    onComplete.accept(finalStatus);
   }
 
   @Override

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
@@ -14,8 +14,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.commons.configuration.MigrationConfiguration;
+import io.camunda.migration.commons.configuration.MigrationConfiguration.MigrationRetryConfiguration;
 import io.camunda.migration.commons.storage.ProcessorStep;
 import io.camunda.migration.commons.storage.TasklistMigrationRepositoryIndex;
+import io.camunda.migration.task.adapter.ReindexTaskStatus;
 import io.camunda.migration.task.adapter.TaskEntityPair;
 import io.camunda.migration.task.adapter.TaskLegacyIndex;
 import io.camunda.migration.task.adapter.TaskMigrationAdapter;
@@ -31,9 +33,12 @@ import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -71,6 +76,7 @@ import org.opensearch.client.opensearch.generic.Requests;
 import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
 import org.opensearch.client.opensearch.indices.PutMappingRequest;
 import org.opensearch.client.opensearch.indices.UpdateAliasesRequest;
+import org.opensearch.client.opensearch.tasks.GetTasksResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,6 +87,11 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
   private static final String LEGACY_RUNTIME_POLICY =
       "/opensearch-legacy-runtime-index-policy.json";
   private static final String ISM_POLICIES_ENDPOINT = "_plugins/_ism/policies";
+
+  private static final String MAIN_REINDEX_STEP_ID = VersionUtil.getVersion() + "-reindex-main";
+  private static final String DATED_REINDEX_STEP_PREFIX =
+      VersionUtil.getVersion() + "-reindex-dated-";
+
   private final OpenSearchClient client;
   private final OpenSearchGenericClient genericClient;
   private final MigrationConfiguration migrationConfiguration;
@@ -166,8 +177,77 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
   @Override
   public void reindexLegacyDatedIndex(final String legacyDatedIndex) throws MigrationException {
     final String newDatedIndex = MigrationUtils.generateNewIndexNameFromLegacy(legacyDatedIndex);
-    final var documentsWereProcessed = reindex(legacyDatedIndex, newDatedIndex);
-    if (documentsWereProcessed) {
+    final String stepId = DATED_REINDEX_STEP_PREFIX + sanitizeIndexName(legacyDatedIndex);
+    final ProcessorStep existingStep = getReindexStep(stepId);
+
+    if (existingStep != null && existingStep.isApplied()) {
+      LOG.info("Dated index reindex for {} already completed, skipping", legacyDatedIndex);
+      return;
+    }
+
+    final String taskId;
+    if (existingStep != null) {
+      final ReindexTaskStatus status;
+      try {
+        status =
+            retryDecorator.decorate(
+                "Check reindex task status " + existingStep.getContent(),
+                () -> getReindexTaskStatus(existingStep.getContent()),
+                s -> false);
+      } catch (final MigrationException e) {
+        throw e;
+      } catch (final Exception e) {
+        throw new MigrationException(e);
+      }
+      if (status.found() && status.completed()) {
+        writeReindexStep(stepId, existingStep.getContent(), true);
+        if (status.total() > 0) {
+          updateIndexAlias(newDatedIndex);
+          setIndexLifecycle(newDatedIndex);
+        } else {
+          LOG.info(
+              "No documents were reindexed from {} to {}. {} was not created.",
+              legacyDatedIndex,
+              newDatedIndex,
+              newDatedIndex);
+        }
+        return;
+      } else if (status.found()) {
+        taskId = existingStep.getContent();
+      } else {
+        taskId = submitReindex(legacyDatedIndex, newDatedIndex);
+        writeReindexStep(stepId, taskId, false);
+      }
+    } else {
+      taskId = submitReindex(legacyDatedIndex, newDatedIndex);
+      writeReindexStep(stepId, taskId, false);
+    }
+
+    final ReindexTaskStatus finalStatus;
+    try {
+      finalStatus =
+          busyRetryDecorator()
+              .decorate(
+                  "Wait for dated index reindex " + legacyDatedIndex,
+                  () -> {
+                    final var status = getReindexTaskStatus(taskId);
+                    if (!status.found()) {
+                      throw new MigrationException(
+                          "Reindex task " + taskId + " disappeared; restart migration to resubmit");
+                    }
+                    if (status.completed()) {
+                      writeReindexStep(stepId, taskId, true);
+                    }
+                    return status;
+                  },
+                  status -> !status.completed());
+    } catch (final MigrationException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new MigrationException(e);
+    }
+
+    if (finalStatus.total() > 0) {
       updateIndexAlias(newDatedIndex);
       setIndexLifecycle(newDatedIndex);
     } else {
@@ -181,7 +261,67 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
 
   @Override
   public void reindexLegacyMainIndex() throws MigrationException {
-    reindex(legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
+    final String stepId = MAIN_REINDEX_STEP_ID;
+    final ProcessorStep existingStep = getReindexStep(stepId);
+
+    if (existingStep != null && existingStep.isApplied()) {
+      LOG.info("Main index reindex already completed, skipping");
+      return;
+    }
+
+    final String taskId;
+    if (existingStep != null) {
+      final ReindexTaskStatus status;
+      try {
+        status =
+            retryDecorator.decorate(
+                "Check reindex task status " + existingStep.getContent(),
+                () -> getReindexTaskStatus(existingStep.getContent()),
+                s -> false);
+      } catch (final MigrationException e) {
+        throw e;
+      } catch (final Exception e) {
+        throw new MigrationException(e);
+      }
+      if (status.found() && status.completed()) {
+        writeReindexStep(stepId, existingStep.getContent(), true);
+        return;
+      } else if (status.found()) {
+        taskId = existingStep.getContent();
+      } else {
+        taskId =
+            submitReindex(
+                legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
+        writeReindexStep(stepId, taskId, false);
+      }
+    } else {
+      taskId =
+          submitReindex(
+              legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
+      writeReindexStep(stepId, taskId, false);
+    }
+
+    try {
+      busyRetryDecorator()
+          .decorate(
+              "Wait for main index reindex",
+              () -> {
+                final var status = getReindexTaskStatus(taskId);
+                if (!status.found()) {
+                  throw new MigrationException(
+                      "Reindex task " + taskId + " disappeared; restart migration to resubmit");
+                }
+                if (status.completed()) {
+                  writeReindexStep(stepId, taskId, true);
+                }
+                return status;
+              },
+              status -> !status.completed());
+    } catch (final MigrationException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new MigrationException(e);
+    }
   }
 
   @Override
@@ -550,7 +690,8 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
                                         FieldValue.of(TaskJoinRelationshipType.TASK.getType())))));
   }
 
-  private boolean reindex(final String source, final String destination) throws MigrationException {
+  private String submitReindex(final String source, final String destination)
+      throws MigrationException {
     final ReindexRequest createMissingRequest =
         new ReindexRequest.Builder()
             .source(
@@ -565,16 +706,133 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
                     .build())
             .conflicts(Conflicts.Proceed) // ignore version conflicts
             .refresh(true)
+            .waitForCompletion(false)
             .build();
 
     try {
-      final var reindexResponse = client.reindex(createMissingRequest);
-      return reindexResponse != null
-          && reindexResponse.total() != null
-          && reindexResponse.total() > 0;
-    } catch (final IOException e) {
+      final var response =
+          retryDecorator.decorate(
+              "Submit reindex from " + source,
+              () -> client.reindex(createMissingRequest),
+              res -> res == null || res.task() == null);
+      return response.task();
+    } catch (final Exception e) {
       throw new MigrationException(e);
     }
+  }
+
+  private ReindexTaskStatus getReindexTaskStatus(final String taskId)
+      throws IOException, OpenSearchException {
+    final GetTasksResponse res;
+    try {
+      res = client.tasks().get(req -> req.taskId(taskId));
+    } catch (final OpenSearchException e) {
+      if (e.status() == 404) {
+        return ReindexTaskStatus.notFound();
+      }
+      throw e;
+    }
+    if (res == null || res.task() == null) {
+      return ReindexTaskStatus.notFound();
+    }
+    final var status = res.task().status();
+    if (status == null) {
+      LOG.warn("Status of reindex task {} is null", taskId);
+      return ReindexTaskStatus.notFound();
+    }
+    if (res.completed()) {
+      if (res.error() != null) {
+        throw new MigrationException(
+            "Reindex task " + taskId + " failed with error: " + res.error());
+      }
+      if (status.failures() != null && !status.failures().isEmpty()) {
+        throw new MigrationException(
+            "Reindex task " + taskId + " completed with " + status.failures().size() + " failures");
+      }
+    }
+    final boolean completed =
+        res.completed()
+            && (status.created() + status.updated() + status.deleted() + status.versionConflicts()
+                >= status.total());
+    return new ReindexTaskStatus(
+        taskId,
+        true,
+        completed,
+        status.total(),
+        status.created(),
+        status.updated(),
+        status.deleted());
+  }
+
+  private void writeReindexStep(final String stepId, final String taskId, final boolean completed) {
+    final ProcessorStep step = new ProcessorStep();
+    step.setContent(taskId);
+    step.setDescription("Reindex task step " + stepId);
+    step.setAppliedDate(OffsetDateTime.now(ZoneId.systemDefault()));
+    step.setIndexName(TaskTemplate.INDEX_NAME);
+    step.setVersion(VersionUtil.getVersion());
+    step.setApplied(completed);
+
+    final UpdateRequest<ProcessorStep, ProcessorStep> updateRequest =
+        new UpdateRequest.Builder<ProcessorStep, ProcessorStep>()
+            .index(migrationIndex.getFullQualifiedName())
+            .id(stepId)
+            .docAsUpsert(true)
+            .doc(step)
+            .refresh(Refresh.True)
+            .upsert(step)
+            .build();
+    try {
+      retryDecorator.decorate(
+          "Write reindex step " + stepId,
+          () -> client.update(updateRequest, ProcessorStep.class),
+          res -> res.result() != Result.Created && res.result() != Result.Updated);
+    } catch (final Exception e) {
+      throw new MigrationException("Failed to write reindex step " + stepId, e);
+    }
+  }
+
+  private ProcessorStep getReindexStep(final String stepId) {
+    final SearchRequest searchRequest =
+        new SearchRequest.Builder()
+            .index(migrationIndex.getFullQualifiedName())
+            .size(1)
+            .query(
+                q ->
+                    q.term(
+                        t ->
+                            t.field(TasklistMigrationRepositoryIndex.ID)
+                                .value(FieldValue.of(stepId))))
+            .build();
+    try {
+      final SearchResponse<ProcessorStep> response =
+          retryDecorator.decorate(
+              "Fetch reindex step " + stepId,
+              () -> client.search(searchRequest, ProcessorStep.class),
+              res -> res.timedOut() || Boolean.TRUE.equals(res.terminatedEarly()));
+      return response.hits().hits().stream()
+          .map(Hit::source)
+          .filter(Objects::nonNull)
+          .findFirst()
+          .orElse(null);
+    } catch (final Exception e) {
+      throw new MigrationException("Failed to fetch reindex step " + stepId, e);
+    }
+  }
+
+  private RetryDecorator busyRetryDecorator() {
+    final var retryConfiguration = new MigrationRetryConfiguration();
+    retryConfiguration.setMaxRetries(Integer.MAX_VALUE);
+    retryConfiguration.setMinRetryDelay(migrationConfiguration.getRetry().getMinRetryDelay());
+    retryConfiguration.setMaxRetryDelay(migrationConfiguration.getRetry().getMaxRetryDelay());
+    retryConfiguration.setRetryDelayMultiplier(
+        migrationConfiguration.getRetry().getRetryDelayMultiplier());
+    return new RetryDecorator(retryConfiguration)
+        .withRetryOnException(e -> !(e instanceof MigrationException));
+  }
+
+  private static String sanitizeIndexName(final String indexName) {
+    return indexName.replaceAll("[/\\s]", "-");
   }
 
   private void updateIndexAlias(final String newDatedIndex) throws MigrationException {

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
@@ -747,7 +747,12 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
       }
       if (status.failures() != null && !status.failures().isEmpty()) {
         throw new MigrationException(
-            "Reindex task " + taskId + " completed with " + status.failures().size() + " failures");
+            "Reindex task "
+                + taskId
+                + " completed with "
+                + status.failures().size()
+                + " failures; first: "
+                + status.failures().get(0));
       }
     }
     final boolean completed =

--- a/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
+++ b/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
@@ -481,6 +481,64 @@ class ElasticsearchAdapterTest {
     verify(client, never()).indices();
   }
 
+  @Test
+  void shouldResumePollWhenExistingTaskStillRunning() throws Exception {
+    // given - persisted step with in-progress task
+    final SearchResponse<ProcessorStep> runningStep =
+        mockRunningProcessorStepResponse("es-running-task");
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(runningStep);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse runningTask = buildRunningGetTasksResponse();
+    final GetTasksResponse completedTask = buildCompletedGetTasksResponse(5, 5, 0, 0);
+    final ElasticsearchTasksClient tasksClient = mock(ElasticsearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(runningTask, completedTask);
+
+    // when
+    adapter.reindexLegacyMainIndex();
+
+    // then - no new reindex submitted; resumed polling existing task
+    verify(client, never()).reindex(any(ReindexRequest.class));
+    verify(tasksClient, atLeastOnce()).get(any(Function.class));
+  }
+
+  @Test
+  void shouldResubmitReindexWhenExistingTaskNotFound() throws Exception {
+    // given - persisted step with task that has disappeared from cluster
+    final SearchResponse<ProcessorStep> runningStep =
+        mockRunningProcessorStepResponse("es-gone-task");
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(runningStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("es-new-task");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse completedTask = buildCompletedGetTasksResponse(5, 5, 0, 0);
+    final ElasticsearchTasksClient tasksClient = mock(ElasticsearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    // pre-poll check returns null (notFound); poll loop returns completed
+    when(tasksClient.get(any(Function.class))).thenReturn(null, completedTask);
+
+    // when
+    adapter.reindexLegacyMainIndex();
+
+    // then - reindex resubmitted once; task polled to completion
+    verify(client).reindex(any(ReindexRequest.class));
+    verify(tasksClient, atLeastOnce()).get(any(Function.class));
+  }
+
   @SuppressWarnings("unchecked")
   private SearchResponse<ProcessorStep> mockEmptyProcessorStepResponse() {
     final SearchResponse<ProcessorStep> response = mock(SearchResponse.class);
@@ -546,6 +604,43 @@ class ElasticsearchAdapterTest {
     when(response.terminatedEarly()).thenReturn(false);
 
     return response;
+  }
+
+  @SuppressWarnings("unchecked")
+  private SearchResponse<ProcessorStep> mockRunningProcessorStepResponse(final String taskId) {
+    final SearchResponse<ProcessorStep> response = mock(SearchResponse.class);
+    final HitsMetadata<ProcessorStep> hitsMetadata = mock(HitsMetadata.class);
+    final Hit<ProcessorStep> hit = mock(Hit.class);
+    final ProcessorStep step = new ProcessorStep();
+    step.setApplied(false);
+    step.setContent(taskId);
+    when(hit.source()).thenReturn(step);
+    when(response.hits()).thenReturn(hitsMetadata);
+    when(hitsMetadata.hits()).thenReturn(List.of(hit));
+    when(response.timedOut()).thenReturn(false);
+    when(response.terminatedEarly()).thenReturn(false);
+    return response;
+  }
+
+  private GetTasksResponse buildRunningGetTasksResponse() {
+    final GetTasksResponse taskResponse = mock(GetTasksResponse.class);
+    when(taskResponse.completed()).thenReturn(false);
+    when(taskResponse.error()).thenReturn(null);
+    final TaskInfo taskInfo = mock(TaskInfo.class);
+    when(taskResponse.task()).thenReturn(taskInfo);
+    final JsonData jsonData = mock(JsonData.class);
+    when(taskInfo.status()).thenReturn(jsonData);
+    final JsonValue jsonValue = mock(JsonValue.class);
+    when(jsonData.toJson()).thenReturn(jsonValue);
+    final JsonObject jsonObject = mock(JsonObject.class);
+    when(jsonValue.asJsonObject()).thenReturn(jsonObject);
+    when(jsonObject.getInt("created", 0)).thenReturn(0);
+    when(jsonObject.getInt("updated", 0)).thenReturn(0);
+    when(jsonObject.getInt("deleted", 0)).thenReturn(0);
+    when(jsonObject.getInt("version_conflicts", 0)).thenReturn(0);
+    when(jsonObject.getInt("total", 0)).thenReturn(5);
+    when(jsonObject.getJsonArray("failures")).thenReturn(null);
+    return taskResponse;
   }
 
   @SuppressWarnings("unchecked")

--- a/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
+++ b/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
@@ -47,7 +47,6 @@ import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Function;
@@ -579,11 +578,8 @@ class ElasticsearchAdapterTest {
     final JsonData jsonData = mock(JsonData.class);
     when(taskInfo.status()).thenReturn(jsonData);
 
-    final JsonValue jsonValue = mock(JsonValue.class);
-    when(jsonData.toJson()).thenReturn(jsonValue);
-
     final JsonObject jsonObject = mock(JsonObject.class);
-    when(jsonValue.asJsonObject()).thenReturn(jsonObject);
+    when(jsonData.toJson()).thenReturn(jsonObject);
     mockJsonNumber(jsonObject, "created", created);
     mockJsonNumber(jsonObject, "updated", updated);
     mockJsonNumber(jsonObject, "deleted", 0);
@@ -638,10 +634,8 @@ class ElasticsearchAdapterTest {
     when(taskResponse.task()).thenReturn(taskInfo);
     final JsonData jsonData = mock(JsonData.class);
     when(taskInfo.status()).thenReturn(jsonData);
-    final JsonValue jsonValue = mock(JsonValue.class);
-    when(jsonData.toJson()).thenReturn(jsonValue);
     final JsonObject jsonObject = mock(JsonObject.class);
-    when(jsonValue.asJsonObject()).thenReturn(jsonObject);
+    when(jsonData.toJson()).thenReturn(jsonObject);
     mockJsonNumber(jsonObject, "created", 0);
     mockJsonNumber(jsonObject, "updated", 0);
     mockJsonNumber(jsonObject, "deleted", 0);

--- a/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
+++ b/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
@@ -482,6 +482,70 @@ class ElasticsearchAdapterTest {
   }
 
   @Test
+  void shouldThrowWhenTaskCompletesWithError() throws Exception {
+    // given
+    final SearchResponse<ProcessorStep> emptyStep = mockEmptyProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(emptyStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("es-task-err");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse errorTask = buildCompletedGetTasksResponse(5, 5, 0, 0);
+    when(errorTask.error())
+        .thenReturn(mock(co.elastic.clients.elasticsearch._types.ErrorCause.class));
+    final ElasticsearchTasksClient tasksClient = mock(ElasticsearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(errorTask);
+
+    // when/then
+    assertThatThrownBy(() -> adapter.reindexLegacyMainIndex())
+        .isInstanceOf(MigrationException.class)
+        .hasMessageContaining("failed with error");
+  }
+
+  @Test
+  void shouldThrowWhenTaskCompletesWithFailures() throws Exception {
+    // given
+    final SearchResponse<ProcessorStep> emptyStep = mockEmptyProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(emptyStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("es-task-fail");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse failTask = buildCompletedGetTasksResponse(5, 4, 0, 0);
+    final jakarta.json.JsonArray failures = mock(jakarta.json.JsonArray.class);
+    when(failures.isEmpty()).thenReturn(false);
+    when(failures.size()).thenReturn(1);
+    when(failures.get(0)).thenReturn(mock(jakarta.json.JsonValue.class));
+    // override the failures mock on the existing JsonObject
+    final ElasticsearchTasksClient tasksClient = mock(ElasticsearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(failTask);
+    // re-wire failures on the jsonObject used inside failTask
+    final JsonObject statusObj = (JsonObject) failTask.task().status().toJson();
+    when(statusObj.getJsonArray("failures")).thenReturn(failures);
+
+    // when/then
+    assertThatThrownBy(() -> adapter.reindexLegacyMainIndex())
+        .isInstanceOf(MigrationException.class)
+        .hasMessageContaining("completed with");
+  }
+
+  @Test
   void shouldResumePollWhenExistingTaskStillRunning() throws Exception {
     // given - persisted step with in-progress task
     final SearchResponse<ProcessorStep> runningStep =

--- a/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
+++ b/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
@@ -11,28 +11,45 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Result;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch.core.ReindexRequest;
+import co.elastic.clients.elasticsearch.core.ReindexResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.UpdateRequest;
+import co.elastic.clients.elasticsearch.core.UpdateResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
+import co.elastic.clients.elasticsearch.indices.UpdateAliasesResponse;
+import co.elastic.clients.elasticsearch.tasks.ElasticsearchTasksClient;
+import co.elastic.clients.elasticsearch.tasks.GetTasksResponse;
+import co.elastic.clients.elasticsearch.tasks.TaskInfo;
+import co.elastic.clients.json.JsonData;
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.commons.configuration.MigrationConfiguration;
+import io.camunda.migration.commons.storage.ProcessorStep;
 import io.camunda.migration.task.adapter.TaskEntityPair;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -345,6 +362,177 @@ class ElasticsearchAdapterTest {
     // Size should match the number of unique task keys from the destination query (12 tasks)
     // This ensures we exceed the default ES search size of 10
     assertThat(sourceRequest.size()).isEqualTo(12);
+  }
+
+  @Test
+  void shouldSubmitAsyncReindexAndPollForMainIndex() throws Exception {
+    // given - pre-create mocks before any when() calls to avoid Mockito unfinished stubbing
+    final SearchResponse<ProcessorStep> emptyStep = mockEmptyProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(emptyStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("es-task-123");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse completedTask = buildCompletedGetTasksResponse(5, 5, 0, 0);
+    final ElasticsearchTasksClient tasksClient = mock(ElasticsearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(completedTask);
+
+    // when
+    adapter.reindexLegacyMainIndex();
+
+    // then - async reindex submitted with waitForCompletion=false
+    final ArgumentCaptor<ReindexRequest> reindexCaptor =
+        ArgumentCaptor.forClass(ReindexRequest.class);
+    verify(client).reindex(reindexCaptor.capture());
+    assertThat(reindexCaptor.getValue().waitForCompletion()).isEqualTo(Boolean.FALSE);
+
+    // task was polled
+    verify(tasksClient, atLeastOnce()).get(any(Function.class));
+
+    // step persisted twice: pending then completed
+    verify(client, times(2)).update(any(UpdateRequest.class), eq(ProcessorStep.class));
+  }
+
+  @Test
+  void shouldSkipMainIndexReindexIfAlreadyCompleted() throws Exception {
+    // given - existing step with applied=true
+    final SearchResponse<ProcessorStep> completedStep = mockCompletedProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(completedStep);
+
+    // when
+    adapter.reindexLegacyMainIndex();
+
+    // then - no reindex submitted, no tasks polled
+    verify(client, never()).reindex(any(ReindexRequest.class));
+    verify(client, never()).tasks();
+  }
+
+  @Test
+  void shouldCallAliasUpdateWhenDatedIndexDocumentsCreated() throws Exception {
+    // given - pre-create mocks before any when() calls
+    final SearchResponse<ProcessorStep> emptyStep = mockEmptyProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(emptyStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("es-task-456");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse completedTask = buildCompletedGetTasksResponse(3, 3, 0, 0);
+    final ElasticsearchTasksClient tasksClient = mock(ElasticsearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(completedTask);
+
+    final UpdateAliasesResponse aliasResponse = mock(UpdateAliasesResponse.class);
+    final ElasticsearchIndicesClient indicesClient = mock(ElasticsearchIndicesClient.class);
+    when(client.indices()).thenReturn(indicesClient);
+    when(indicesClient.updateAliases(
+            any(co.elastic.clients.elasticsearch.indices.UpdateAliasesRequest.class)))
+        .thenReturn(aliasResponse);
+
+    // when
+    adapter.reindexLegacyDatedIndex(INDEX_PREFIX + "-tasklist-task-8.5.0_2024-01-01");
+
+    // then - alias update called because documents were created
+    verify(indicesClient)
+        .updateAliases(any(co.elastic.clients.elasticsearch.indices.UpdateAliasesRequest.class));
+  }
+
+  @Test
+  void shouldNotCallAliasUpdateWhenDatedIndexNoDocumentsCreated() throws Exception {
+    // given - pre-create mocks before any when() calls
+    final SearchResponse<ProcessorStep> emptyStep = mockEmptyProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(emptyStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("es-task-789");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    // total=0: source index had no documents
+    final GetTasksResponse completedTask = buildCompletedGetTasksResponse(0, 0, 0, 0);
+    final ElasticsearchTasksClient tasksClient = mock(ElasticsearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(completedTask);
+
+    // when
+    adapter.reindexLegacyDatedIndex(INDEX_PREFIX + "-tasklist-task-8.5.0_2024-01-01");
+
+    // then - alias update NOT called because source had no documents
+    verify(client, never()).indices();
+  }
+
+  @SuppressWarnings("unchecked")
+  private SearchResponse<ProcessorStep> mockEmptyProcessorStepResponse() {
+    final SearchResponse<ProcessorStep> response = mock(SearchResponse.class);
+    final HitsMetadata<ProcessorStep> hitsMetadata = mock(HitsMetadata.class);
+    when(response.hits()).thenReturn(hitsMetadata);
+    when(hitsMetadata.hits()).thenReturn(List.of());
+    when(response.timedOut()).thenReturn(false);
+    when(response.terminatedEarly()).thenReturn(false);
+    return response;
+  }
+
+  @SuppressWarnings("unchecked")
+  private SearchResponse<ProcessorStep> mockCompletedProcessorStepResponse() {
+    final SearchResponse<ProcessorStep> response = mock(SearchResponse.class);
+    final HitsMetadata<ProcessorStep> hitsMetadata = mock(HitsMetadata.class);
+    final Hit<ProcessorStep> hit = mock(Hit.class);
+    final ProcessorStep step = new ProcessorStep();
+    step.setApplied(true);
+    step.setContent("es-task-done");
+    when(hit.source()).thenReturn(step);
+    when(response.hits()).thenReturn(hitsMetadata);
+    when(hitsMetadata.hits()).thenReturn(List.of(hit));
+    when(response.timedOut()).thenReturn(false);
+    when(response.terminatedEarly()).thenReturn(false);
+    return response;
+  }
+
+  private GetTasksResponse buildCompletedGetTasksResponse(
+      final int total, final int created, final int updated, final int conflicts) {
+    final GetTasksResponse taskResponse = mock(GetTasksResponse.class);
+    when(taskResponse.completed()).thenReturn(true);
+    when(taskResponse.error()).thenReturn(null);
+
+    final TaskInfo taskInfo = mock(TaskInfo.class);
+    when(taskResponse.task()).thenReturn(taskInfo);
+
+    final JsonData jsonData = mock(JsonData.class);
+    when(taskInfo.status()).thenReturn(jsonData);
+
+    final JsonValue jsonValue = mock(JsonValue.class);
+    when(jsonData.toJson()).thenReturn(jsonValue);
+
+    final JsonObject jsonObject = mock(JsonObject.class);
+    when(jsonValue.asJsonObject()).thenReturn(jsonObject);
+    when(jsonObject.getInt("created", 0)).thenReturn(created);
+    when(jsonObject.getInt("updated", 0)).thenReturn(updated);
+    when(jsonObject.getInt("deleted", 0)).thenReturn(0);
+    when(jsonObject.getInt("version_conflicts", 0)).thenReturn(conflicts);
+    when(jsonObject.getInt("total", 0)).thenReturn(total);
+    when(jsonObject.getJsonArray("failures")).thenReturn(null);
+
+    return taskResponse;
   }
 
   @SuppressWarnings("unchecked")

--- a/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
+++ b/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
@@ -45,6 +45,7 @@ import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import java.io.IOException;
@@ -583,14 +584,21 @@ class ElasticsearchAdapterTest {
 
     final JsonObject jsonObject = mock(JsonObject.class);
     when(jsonValue.asJsonObject()).thenReturn(jsonObject);
-    when(jsonObject.getInt("created", 0)).thenReturn(created);
-    when(jsonObject.getInt("updated", 0)).thenReturn(updated);
-    when(jsonObject.getInt("deleted", 0)).thenReturn(0);
-    when(jsonObject.getInt("version_conflicts", 0)).thenReturn(conflicts);
-    when(jsonObject.getInt("total", 0)).thenReturn(total);
+    mockJsonNumber(jsonObject, "created", created);
+    mockJsonNumber(jsonObject, "updated", updated);
+    mockJsonNumber(jsonObject, "deleted", 0);
+    mockJsonNumber(jsonObject, "version_conflicts", conflicts);
+    mockJsonNumber(jsonObject, "total", total);
     when(jsonObject.getJsonArray("failures")).thenReturn(null);
 
     return taskResponse;
+  }
+
+  private static void mockJsonNumber(
+      final JsonObject jsonObject, final String field, final long value) {
+    final JsonNumber jsonNumber = mock(JsonNumber.class);
+    when(jsonNumber.longValue()).thenReturn(value);
+    when(jsonObject.getJsonNumber(field)).thenReturn(jsonNumber);
   }
 
   @SuppressWarnings("unchecked")
@@ -634,11 +642,11 @@ class ElasticsearchAdapterTest {
     when(jsonData.toJson()).thenReturn(jsonValue);
     final JsonObject jsonObject = mock(JsonObject.class);
     when(jsonValue.asJsonObject()).thenReturn(jsonObject);
-    when(jsonObject.getInt("created", 0)).thenReturn(0);
-    when(jsonObject.getInt("updated", 0)).thenReturn(0);
-    when(jsonObject.getInt("deleted", 0)).thenReturn(0);
-    when(jsonObject.getInt("version_conflicts", 0)).thenReturn(0);
-    when(jsonObject.getInt("total", 0)).thenReturn(5);
+    mockJsonNumber(jsonObject, "created", 0);
+    mockJsonNumber(jsonObject, "updated", 0);
+    mockJsonNumber(jsonObject, "deleted", 0);
+    mockJsonNumber(jsonObject, "version_conflicts", 0);
+    mockJsonNumber(jsonObject, "total", 5);
     when(jsonObject.getJsonArray("failures")).thenReturn(null);
     return taskResponse;
   }

--- a/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/os/OpensearchAdapterTest.java
+++ b/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/os/OpensearchAdapterTest.java
@@ -479,6 +479,64 @@ class OpensearchAdapterTest {
     verify(client, never()).indices();
   }
 
+  @Test
+  void shouldResumePollWhenExistingTaskStillRunning() throws Exception {
+    // given - persisted step with in-progress task
+    final SearchResponse<ProcessorStep> runningStep =
+        mockRunningProcessorStepResponse("os-running-task");
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(runningStep);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse runningTask = buildRunningGetTasksResponse();
+    final GetTasksResponse completedTask = buildCompletedGetTasksResponse(5L, 5L, 0L, 0L);
+    final OpenSearchTasksClient tasksClient = mock(OpenSearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(runningTask, completedTask);
+
+    // when
+    adapter.reindexLegacyMainIndex();
+
+    // then - no new reindex submitted; resumed polling existing task
+    verify(client, never()).reindex(any(ReindexRequest.class));
+    verify(tasksClient, atLeastOnce()).get(any(Function.class));
+  }
+
+  @Test
+  void shouldResubmitReindexWhenExistingTaskNotFound() throws Exception {
+    // given - persisted step with task that has disappeared from cluster
+    final SearchResponse<ProcessorStep> runningStep =
+        mockRunningProcessorStepResponse("os-gone-task");
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(runningStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("os-new-task");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse completedTask = buildCompletedGetTasksResponse(5L, 5L, 0L, 0L);
+    final OpenSearchTasksClient tasksClient = mock(OpenSearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    // pre-poll check returns null (notFound); poll loop returns completed
+    when(tasksClient.get(any(Function.class))).thenReturn(null, completedTask);
+
+    // when
+    adapter.reindexLegacyMainIndex();
+
+    // then - reindex resubmitted once; task polled to completion
+    verify(client).reindex(any(ReindexRequest.class));
+    verify(tasksClient, atLeastOnce()).get(any(Function.class));
+  }
+
   @SuppressWarnings("unchecked")
   private SearchResponse<ProcessorStep> mockEmptyProcessorStepResponse() {
     final SearchResponse<ProcessorStep> response = mock(SearchResponse.class);
@@ -538,6 +596,39 @@ class OpensearchAdapterTest {
     when(response.terminatedEarly()).thenReturn(false);
 
     return response;
+  }
+
+  @SuppressWarnings("unchecked")
+  private SearchResponse<ProcessorStep> mockRunningProcessorStepResponse(final String taskId) {
+    final SearchResponse<ProcessorStep> response = mock(SearchResponse.class);
+    final HitsMetadata<ProcessorStep> hitsMetadata = mock(HitsMetadata.class);
+    final Hit<ProcessorStep> hit = mock(Hit.class);
+    final ProcessorStep step = new ProcessorStep();
+    step.setApplied(false);
+    step.setContent(taskId);
+    when(hit.source()).thenReturn(step);
+    when(response.hits()).thenReturn(hitsMetadata);
+    when(hitsMetadata.hits()).thenReturn(List.of(hit));
+    when(response.timedOut()).thenReturn(false);
+    when(response.terminatedEarly()).thenReturn(false);
+    return response;
+  }
+
+  private GetTasksResponse buildRunningGetTasksResponse() {
+    final GetTasksResponse taskResponse = mock(GetTasksResponse.class);
+    when(taskResponse.completed()).thenReturn(false);
+    when(taskResponse.error()).thenReturn(null);
+    final Info taskInfo = mock(Info.class);
+    when(taskResponse.task()).thenReturn(taskInfo);
+    final Status status = mock(Status.class);
+    when(taskInfo.status()).thenReturn(status);
+    when(status.total()).thenReturn(5L);
+    when(status.created()).thenReturn(0L);
+    when(status.updated()).thenReturn(0L);
+    when(status.deleted()).thenReturn(0L);
+    when(status.versionConflicts()).thenReturn(0L);
+    when(status.failures()).thenReturn(null);
+    return taskResponse;
   }
 
   @SuppressWarnings("unchecked")

--- a/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/os/OpensearchAdapterTest.java
+++ b/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/os/OpensearchAdapterTest.java
@@ -480,6 +480,64 @@ class OpensearchAdapterTest {
   }
 
   @Test
+  void shouldThrowWhenTaskCompletesWithError() throws Exception {
+    // given
+    final SearchResponse<ProcessorStep> emptyStep = mockEmptyProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(emptyStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("os-task-err");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse errorTask = buildCompletedGetTasksResponse(5L, 5L, 0L, 0L);
+    when(errorTask.error())
+        .thenReturn(mock(org.opensearch.client.opensearch._types.ErrorCause.class));
+    final OpenSearchTasksClient tasksClient = mock(OpenSearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(errorTask);
+
+    // when/then
+    assertThatThrownBy(() -> adapter.reindexLegacyMainIndex())
+        .isInstanceOf(MigrationException.class)
+        .hasMessageContaining("failed with error");
+  }
+
+  @Test
+  void shouldThrowWhenTaskCompletesWithFailures() throws Exception {
+    // given
+    final SearchResponse<ProcessorStep> emptyStep = mockEmptyProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(emptyStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("os-task-fail");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse failTask = buildCompletedGetTasksResponse(5L, 4L, 0L, 0L);
+    final Status statusMock = failTask.task().status();
+    when(statusMock.failures()).thenReturn(List.of("shard 0 failed: version conflict"));
+    final OpenSearchTasksClient tasksClient = mock(OpenSearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(failTask);
+
+    // when/then
+    assertThatThrownBy(() -> adapter.reindexLegacyMainIndex())
+        .isInstanceOf(MigrationException.class)
+        .hasMessageContaining("completed with");
+  }
+
+  @Test
   void shouldResumePollWhenExistingTaskStillRunning() throws Exception {
     // given - persisted step with in-progress task
     final SearchResponse<ProcessorStep> runningStep =

--- a/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/os/OpensearchAdapterTest.java
+++ b/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/os/OpensearchAdapterTest.java
@@ -11,13 +11,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.commons.configuration.MigrationConfiguration;
+import io.camunda.migration.commons.storage.ProcessorStep;
 import io.camunda.migration.task.adapter.TaskEntityPair;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -26,6 +29,7 @@ import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,12 +40,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Result;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch.core.ReindexRequest;
+import org.opensearch.client.opensearch.core.ReindexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.UpdateRequest;
+import org.opensearch.client.opensearch.core.UpdateResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
+import org.opensearch.client.opensearch.indices.UpdateAliasesResponse;
+import org.opensearch.client.opensearch.tasks.GetTasksResponse;
+import org.opensearch.client.opensearch.tasks.Info;
+import org.opensearch.client.opensearch.tasks.OpenSearchTasksClient;
+import org.opensearch.client.opensearch.tasks.Status;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -345,6 +360,171 @@ class OpensearchAdapterTest {
     // Size should match the number of unique task keys from the destination query (12 tasks)
     // This ensures we exceed the default OS search size of 10
     assertThat(sourceRequest.size()).isEqualTo(12);
+  }
+
+  @Test
+  void shouldSubmitAsyncReindexAndPollForMainIndex() throws Exception {
+    // given - pre-create mocks before any when() calls to avoid Mockito unfinished stubbing
+    final SearchResponse<ProcessorStep> emptyStep = mockEmptyProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(emptyStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("os-task-123");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse completedTask = buildCompletedGetTasksResponse(5L, 5L, 0L, 0L);
+    final OpenSearchTasksClient tasksClient = mock(OpenSearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(completedTask);
+
+    // when
+    adapter.reindexLegacyMainIndex();
+
+    // then - async reindex submitted with waitForCompletion=false
+    final ArgumentCaptor<ReindexRequest> reindexCaptor =
+        ArgumentCaptor.forClass(ReindexRequest.class);
+    verify(client).reindex(reindexCaptor.capture());
+    assertThat(reindexCaptor.getValue().waitForCompletion()).isEqualTo(Boolean.FALSE);
+
+    // task was polled
+    verify(tasksClient, atLeastOnce()).get(any(Function.class));
+
+    // step persisted twice: pending then completed
+    verify(client, times(2)).update(any(UpdateRequest.class), eq(ProcessorStep.class));
+  }
+
+  @Test
+  void shouldSkipMainIndexReindexIfAlreadyCompleted() throws Exception {
+    // given - existing step with applied=true
+    final SearchResponse<ProcessorStep> completedStep = mockCompletedProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(completedStep);
+
+    // when
+    adapter.reindexLegacyMainIndex();
+
+    // then - no reindex submitted, no tasks polled
+    verify(client, never()).reindex(any(ReindexRequest.class));
+    verify(client, never()).tasks();
+  }
+
+  @Test
+  void shouldCallAliasUpdateWhenDatedIndexDocumentsCreated() throws Exception {
+    // given - pre-create mocks before any when() calls
+    final SearchResponse<ProcessorStep> emptyStep = mockEmptyProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(emptyStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("os-task-456");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    final GetTasksResponse completedTask = buildCompletedGetTasksResponse(3L, 3L, 0L, 0L);
+    final OpenSearchTasksClient tasksClient = mock(OpenSearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(completedTask);
+
+    final UpdateAliasesResponse aliasResponse = mock(UpdateAliasesResponse.class);
+    final OpenSearchIndicesClient indicesClient = mock(OpenSearchIndicesClient.class);
+    when(client.indices()).thenReturn(indicesClient);
+    when(indicesClient.updateAliases(
+            any(org.opensearch.client.opensearch.indices.UpdateAliasesRequest.class)))
+        .thenReturn(aliasResponse);
+
+    // when
+    adapter.reindexLegacyDatedIndex(INDEX_PREFIX + "-tasklist-task-8.5.0_2024-01-01");
+
+    // then - alias update called because documents were created
+    verify(indicesClient)
+        .updateAliases(any(org.opensearch.client.opensearch.indices.UpdateAliasesRequest.class));
+  }
+
+  @Test
+  void shouldNotCallAliasUpdateWhenDatedIndexNoDocumentsCreated() throws Exception {
+    // given - pre-create mocks before any when() calls
+    final SearchResponse<ProcessorStep> emptyStep = mockEmptyProcessorStepResponse();
+    when(client.search(any(SearchRequest.class), eq(ProcessorStep.class))).thenReturn(emptyStep);
+
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.task()).thenReturn("os-task-789");
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    @SuppressWarnings("unchecked")
+    final UpdateResponse<ProcessorStep> updateResponse = mock(UpdateResponse.class);
+    when(updateResponse.result()).thenReturn(Result.Created);
+    when(client.update(any(UpdateRequest.class), eq(ProcessorStep.class)))
+        .thenReturn(updateResponse);
+
+    // total=0: source index had no documents
+    final GetTasksResponse completedTask = buildCompletedGetTasksResponse(0L, 0L, 0L, 0L);
+    final OpenSearchTasksClient tasksClient = mock(OpenSearchTasksClient.class);
+    when(client.tasks()).thenReturn(tasksClient);
+    when(tasksClient.get(any(Function.class))).thenReturn(completedTask);
+
+    // when
+    adapter.reindexLegacyDatedIndex(INDEX_PREFIX + "-tasklist-task-8.5.0_2024-01-01");
+
+    // then - alias update NOT called because source had no documents
+    verify(client, never()).indices();
+  }
+
+  @SuppressWarnings("unchecked")
+  private SearchResponse<ProcessorStep> mockEmptyProcessorStepResponse() {
+    final SearchResponse<ProcessorStep> response = mock(SearchResponse.class);
+    final HitsMetadata<ProcessorStep> hitsMetadata = mock(HitsMetadata.class);
+    when(response.hits()).thenReturn(hitsMetadata);
+    when(hitsMetadata.hits()).thenReturn(List.of());
+    when(response.timedOut()).thenReturn(false);
+    when(response.terminatedEarly()).thenReturn(false);
+    return response;
+  }
+
+  @SuppressWarnings("unchecked")
+  private SearchResponse<ProcessorStep> mockCompletedProcessorStepResponse() {
+    final SearchResponse<ProcessorStep> response = mock(SearchResponse.class);
+    final HitsMetadata<ProcessorStep> hitsMetadata = mock(HitsMetadata.class);
+    final Hit<ProcessorStep> hit = mock(Hit.class);
+    final ProcessorStep step = new ProcessorStep();
+    step.setApplied(true);
+    step.setContent("os-task-done");
+    when(hit.source()).thenReturn(step);
+    when(response.hits()).thenReturn(hitsMetadata);
+    when(hitsMetadata.hits()).thenReturn(List.of(hit));
+    when(response.timedOut()).thenReturn(false);
+    when(response.terminatedEarly()).thenReturn(false);
+    return response;
+  }
+
+  private GetTasksResponse buildCompletedGetTasksResponse(
+      final long total, final long created, final long updated, final long conflicts) {
+    final GetTasksResponse taskResponse = mock(GetTasksResponse.class);
+    when(taskResponse.completed()).thenReturn(true);
+    when(taskResponse.error()).thenReturn(null);
+
+    final Info taskInfo = mock(Info.class);
+    when(taskResponse.task()).thenReturn(taskInfo);
+
+    final Status status = mock(Status.class);
+    when(taskInfo.status()).thenReturn(status);
+    when(status.total()).thenReturn(total);
+    when(status.created()).thenReturn(created);
+    when(status.updated()).thenReturn(updated);
+    when(status.deleted()).thenReturn(0L);
+    when(status.versionConflicts()).thenReturn(conflicts);
+    when(status.failures()).thenReturn(null);
+
+    return taskResponse;
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

- Synchronous ES/OS reindex calls in `TaskMigrator` block the open HTTP connection until the reindex completes; on large Tasklist 8.7 indices this exceeds the ~30s socket timeout and aborts migration with `MigrationException`
- Switches `ElasticsearchAdapter` and `OpensearchAdapter` to submit reindex with `waitForCompletion=false`, persist the returned task ID to `TasklistMigrationRepositoryIndex`, then poll with `busyRetryDecorator` until the task completes
- On restart, the persisted task ID is resumed; if the cluster no longer holds the task the reindex is resubmitted (safe because `opType=Create` makes it idempotent)
- Terminal reindex task failures (completed with error or failures list) throw `MigrationException` immediately rather than looping forever
- Mirrors the existing async pattern in `MetricMigrator` / `ElasticsearchUsageMetricMigrationClient`

Fixes #54193

## Test plan

- [ ] Unit tests extended: async submit/poll flow and dated-index alias-update behavior for both adapters (13 tests each, 28 total) -- all pass
- [ ] Full compile: `./mvnw install -Dquickly -T1C` -- BUILD SUCCESS
- [ ] "Resume from persisted step" and "task not found, resubmit" restart paths are unit-tested -- and also covered at the design level by `opType=Create` idempotency; manual QA on a large dataset is needed to validate end-to-end
- [ ] E2E: requires an ES/OS cluster with a Tasklist 8.7 index large enough to trigger a socket timeout; out of scope for automated testing