### PR TITLE
Expose Business ID across gRPC, REST, and clients

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CorrelateMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CorrelateMessageCommandStep1.java
@@ -59,6 +59,22 @@ public interface CorrelateMessageCommandStep1 {
           CommandWithVariables<CorrelateMessageCommandStep3> {
 
     /**
+     * Set the business id of the message.
+     *
+     * <p>The business id is an optional, user-defined string identifier used to enforce uniqueness
+     * of the process instance that a message start event would create. If provided and uniqueness
+     * enforcement is enabled, the engine rejects starting a new process instance when another root
+     * process instance with the same business id is already active for the same process definition.
+     *
+     * <p>It has no effect when the message correlates to a catch, boundary, or intermediate event.
+     *
+     * @param businessId the business id of the message
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CorrelateMessageCommandStep3 businessId(String businessId);
+
+    /**
      * Set the variables of the message.
      *
      * @param variables the variables (JSON) as String

--- a/clients/java/src/main/java/io/camunda/client/api/command/PublishMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/PublishMessageCommandStep1.java
@@ -86,6 +86,22 @@ public interface PublishMessageCommandStep1
     PublishMessageCommandStep3 timeToLive(Duration timeToLive);
 
     /**
+     * Set the business id of the message.
+     *
+     * <p>The business id is an optional, user-defined string identifier used to enforce uniqueness
+     * of the process instance that a message start event would create. If provided and uniqueness
+     * enforcement is enabled, the engine rejects starting a new process instance when another root
+     * process instance with the same business id is already active for the same process definition.
+     *
+     * <p>It has no effect when the message correlates to a catch, boundary, or intermediate event.
+     *
+     * @param businessId the business id of the message
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    PublishMessageCommandStep3 businessId(String businessId);
+
+    /**
      * Set the variables of the message.
      *
      * @param variables the variables (JSON) as String

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CorrelateMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CorrelateMessageCommandImpl.java
@@ -72,6 +72,12 @@ public class CorrelateMessageCommandImpl extends CommandWithVariables<CorrelateM
   }
 
   @Override
+  public CorrelateMessageCommandStep3 businessId(final String businessId) {
+    request.setBusinessId(businessId);
+    return this;
+  }
+
+  @Override
   public CorrelateMessageCommandStep3 withoutCorrelationKey() {
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/PublishMessageCommandImpl.java
@@ -127,6 +127,13 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
   }
 
   @Override
+  public PublishMessageCommandStep3 businessId(final String businessId) {
+    grpcRequestObjectBuilder.setBusinessId(businessId);
+    httpRequestObject.setBusinessId(businessId);
+    return this;
+  }
+
+  @Override
   public FinalCommandStep<PublishMessageResponse> requestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/clients/java/src/test/java/io/camunda/client/process/CorrelateMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CorrelateMessageTest.java
@@ -88,6 +88,28 @@ final class CorrelateMessageTest extends ClientRestTest {
   }
 
   @Test
+  void shouldCorrelateMessageWithBusinessId() {
+    // given
+    final String messageName = "name";
+    final String correlationKey = "correlationKey";
+    gatewayService.onCorrelateMessageRequest(DUMMY_RESPONSE);
+
+    // when
+    client
+        .newCorrelateMessageCommand()
+        .messageName(messageName)
+        .correlationKey(correlationKey)
+        .businessId("order-12345")
+        .send()
+        .join();
+
+    // then
+    final MessageCorrelationRequest request =
+        gatewayService.getLastRequest(MessageCorrelationRequest.class);
+    assertThat(request.getBusinessId()).isEqualTo("order-12345");
+  }
+
+  @Test
   void shouldThrowExceptionWhenVariablesAreNotInMapStructure() {
     // given
     final String messageName = "name";

--- a/clients/java/src/test/java/io/camunda/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/PublishMessageTest.java
@@ -81,6 +81,26 @@ public final class PublishMessageTest extends ClientTest {
   }
 
   @Test
+  public void shouldPublishMessageWithBusinessId() {
+    // given
+    final long messageKey = 123L;
+    gatewayService.onPublishMessageRequest(messageKey);
+
+    // when
+    client
+        .newPublishMessageCommand()
+        .messageName("name")
+        .correlationKey("key")
+        .businessId("order-12345")
+        .send()
+        .join();
+
+    // then
+    final PublishMessageRequest request = gatewayService.getLastRequest();
+    assertThat(request.getBusinessId()).isEqualTo("order-12345");
+  }
+
+  @Test
   public void shouldPublishMessageWithStringVariables() {
     // when
     client

--- a/clients/java/src/test/java/io/camunda/client/process/rest/PublishMessageRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/PublishMessageRestTest.java
@@ -80,6 +80,26 @@ public class PublishMessageRestTest extends ClientRestTest {
   }
 
   @Test
+  public void shouldPublishMessageWithBusinessId() {
+    // given
+    gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);
+
+    // when
+    client
+        .newPublishMessageCommand()
+        .messageName("name")
+        .correlationKey("key")
+        .businessId("order-12345")
+        .send()
+        .join();
+
+    // then
+    final MessagePublicationRequest request =
+        gatewayService.getLastRequest(MessagePublicationRequest.class);
+    assertThat(request.getBusinessId()).isEqualTo("order-12345");
+  }
+
+  @Test
   public void shouldPublishMessageWithStringVariables() {
     // given
     gatewayService.onPublishMessageRequest(DUMMY_RESPONSE);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -285,7 +285,8 @@ public class RequestMapper {
                 correlationRequest.getName(),
                 correlationRequest.getCorrelationKey(),
                 correlationRequest.getVariables(),
-                tenantId));
+                tenantId,
+                correlationRequest.getBusinessId()));
   }
 
   public static CompleteJobRequest toJobCompletionRequest(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -551,7 +551,8 @@ public class RequestMapper {
                 getStringOrEmpty(
                     messagePublicationRequest, MessagePublicationRequest::getMessageId),
                 getMapOrEmpty(messagePublicationRequest, MessagePublicationRequest::getVariables),
-                tenantId));
+                tenantId,
+                messagePublicationRequest.getBusinessId()));
   }
 
   public static Either<ProblemDetail, ResourceDeletionRequest> toResourceDeletion(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/MessageRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/MessageRequestValidator.java
@@ -10,6 +10,7 @@ package io.camunda.gateway.mapping.http.validator;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateBusinessId;
 
 import io.camunda.gateway.protocol.model.MessageCorrelationRequest;
 import io.camunda.gateway.protocol.model.MessagePublicationRequest;
@@ -41,6 +42,7 @@ public final class MessageRequestValidator {
           }
           validateCorrelationKeyLength(
               publicationRequest.getCorrelationKey(), maxNameFieldLength, violations);
+          validateBusinessId(publicationRequest.getBusinessId(), violations);
         });
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/MessageRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/MessageRequestValidator.java
@@ -30,6 +30,7 @@ public final class MessageRequestValidator {
           }
           validateCorrelationKeyLength(
               correlationRequest.getCorrelationKey(), maxNameFieldLength, violations);
+          validateBusinessId(correlationRequest.getBusinessId(), violations);
         });
   }
 

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/MessageRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/MessageRequestValidatorTest.java
@@ -74,6 +74,39 @@ class MessageRequestValidatorTest {
   }
 
   @Test
+  void shouldRejectCorrelationRequestWhenBusinessIdExceedsMaxLength() {
+    // given
+    final var request =
+        MessageCorrelationRequest.Builder.create()
+            .name("message-name")
+            .businessId("a".repeat(257))
+            .build();
+
+    // when
+    final var validationResult = validateMessageCorrelationRequest(request, MAX_NAME_FIELD_LENGTH);
+
+    // then
+    assertThat(validationResult).isPresent();
+    assertThat(validationResult.get().getDetail()).contains("businessId").contains("256");
+  }
+
+  @Test
+  void shouldAcceptCorrelationRequestWhenBusinessIdAtMaxLength() {
+    // given
+    final var request =
+        MessageCorrelationRequest.Builder.create()
+            .name("message-name")
+            .businessId("a".repeat(256))
+            .build();
+
+    // when
+    final var validationResult = validateMessageCorrelationRequest(request, MAX_NAME_FIELD_LENGTH);
+
+    // then
+    assertThat(validationResult).isEmpty();
+  }
+
+  @Test
   void shouldAcceptPublicationRequestWhenCorrelationKeyAtMaxLength() {
     // given
     final var request =

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/MessageRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/MessageRequestValidatorTest.java
@@ -88,4 +88,37 @@ class MessageRequestValidatorTest {
     // then
     assertThat(validationResult).isEmpty();
   }
+
+  @Test
+  void shouldRejectPublicationRequestWhenBusinessIdExceedsMaxLength() {
+    // given
+    final var request =
+        MessagePublicationRequest.Builder.create()
+            .name("message-name")
+            .businessId("a".repeat(257))
+            .build();
+
+    // when
+    final var validationResult = validateMessagePublicationRequest(request, MAX_NAME_FIELD_LENGTH);
+
+    // then
+    assertThat(validationResult).isPresent();
+    assertThat(validationResult.get().getDetail()).contains("businessId").contains("256");
+  }
+
+  @Test
+  void shouldAcceptPublicationRequestWhenBusinessIdAtMaxLength() {
+    // given
+    final var request =
+        MessagePublicationRequest.Builder.create()
+            .name("message-name")
+            .businessId("a".repeat(256))
+            .build();
+
+    // when
+    final var validationResult = validateMessagePublicationRequest(request, MAX_NAME_FIELD_LENGTH);
+
+    // then
+    assertThat(validationResult).isEmpty();
+  }
 }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
@@ -26,6 +26,7 @@ import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecifi
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -45,8 +46,23 @@ public class ProcessesToolRepository implements ToolRepository {
   protected static final String LABEL_RESULTS = "## Results";
   protected static final String LABEL_WHEN_NOT_TO_USE = "## When not to use";
   protected static final String LABEL_WHEN_TO_USE = "## When to use";
-
+  protected static final String BUSINESS_ID_ARGUMENT = "businessId";
   private static final char TOOL_NAME_DELIMITER = '_';
+  private static final Map<String, Object> TOOL_INPUT_SCHEMA =
+      Map.of(
+          "type",
+          "object",
+          "properties",
+          Map.of(
+              BUSINESS_ID_ARGUMENT,
+              Map.of(
+                  "type",
+                  "string",
+                  "description",
+                  "Optional business id that enforces uniqueness of the started process instance. "
+                      + "While another instance of this process started with the same business id is "
+                      + "active, starting another one is rejected. All other arguments are passed as "
+                      + "process variables.")));
   private static final Map<String, Object> TOOL_OUTPUT_SCHEMA =
       Map.of(
           "type",
@@ -164,6 +180,8 @@ public class ProcessesToolRepository implements ToolRepository {
     final String toolName = entity.toolName();
     return (ctx, req) -> {
       final Map<String, Object> arguments = req.arguments() != null ? req.arguments() : Map.of();
+      final String businessId = businessIdFrom(arguments);
+      final Map<String, Object> variables = processVariablesFrom(arguments);
       return CallToolResultMapper.from(
           serviceRegistry
               .messageServices(PhysicalTenantContext.current())
@@ -173,8 +191,9 @@ public class ProcessesToolRepository implements ToolRepository {
                       // UUID: distribute messages across partitions, support parallel process
                       // instances
                       UUID.randomUUID().toString(),
-                      arguments,
-                      entity.tenantId()),
+                      variables,
+                      entity.tenantId(),
+                      businessId),
                   authenticationProvider.getCamundaAuthentication(),
                   ChannelType.MCP,
                   toolName),
@@ -182,10 +201,27 @@ public class ProcessesToolRepository implements ToolRepository {
     };
   }
 
+  private static String businessIdFrom(final Map<String, Object> arguments) {
+    return arguments.get(BUSINESS_ID_ARGUMENT) instanceof final String businessId
+            && !businessId.isBlank()
+        ? businessId
+        : null;
+  }
+
+  private static Map<String, Object> processVariablesFrom(final Map<String, Object> arguments) {
+    if (!arguments.containsKey(BUSINESS_ID_ARGUMENT)) {
+      return arguments;
+    }
+    // businessId is a reserved tool argument, not a process variable
+    final Map<String, Object> variables = new HashMap<>(arguments);
+    variables.remove(BUSINESS_ID_ARGUMENT);
+    return variables;
+  }
+
   private static Tool buildTool(final MessageSubscriptionEntity entity) {
     final var name = buildToolName(entity);
     final var description = buildDescription(entity.toolProperties());
-    return Tool.builder(name, Map.of("type", "object"))
+    return Tool.builder(name, TOOL_INPUT_SCHEMA)
         .title(entity.toolName())
         .description(description)
         .outputSchema(TOOL_OUTPUT_SCHEMA)

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -213,7 +213,13 @@ class ProcessesToolRepositoryTest {
           "title": "orderProcess",
           "description": "Core purpose",
           "inputSchema": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+              "businessId": {
+                "type": "string",
+                "description": "Optional business id that enforces uniqueness of the started process instance. While another instance of this process started with the same business id is active, starting another one is rejected. All other arguments are passed as process variables."
+              }
+            }
           },
           "outputSchema": {
             "type": "object",
@@ -347,8 +353,78 @@ class ProcessesToolRepositoryTest {
       assertThatCode(() -> UUID.fromString(reqCaptor.getValue().correlationKey()))
           .doesNotThrowAnyException();
       assertThat(reqCaptor.getValue().variables()).containsExactly(entry("foo", "bar"));
+      assertThat(reqCaptor.getValue().businessId()).isNull();
       assertThat(channelTypeCaptor.getValue()).isEqualTo(ChannelType.MCP);
       assertThat(toolNameCaptor.getValue()).isEqualTo("deploy");
+    }
+
+    @Test
+    void shouldForwardBusinessIdAndExcludeItFromVariables() {
+      // given
+      final var entity =
+          buildStartSubscriptionEntity(
+              77L,
+              "deploy",
+              Map.of(),
+              "deploy.start",
+              "tenant-a",
+              MessageSubscriptionState.CREATED);
+      when(messageSubscriptionServices.getByKey(eq(77L), any())).thenReturn(entity);
+      when(messageServices.correlateMessage(any(), any(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new MessageCorrelationRecord()));
+
+      final var result = repository.findTool(transportContext, "deploy_77");
+
+      // when
+      result
+          .get()
+          .callHandler()
+          .apply(
+              transportContext,
+              CallToolRequest.builder("deploy_77")
+                  .arguments(Map.of("businessId", "order-42", "foo", "bar"))
+                  .build());
+
+      // then
+      final var reqCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
+      verify(messageServices).correlateMessage(reqCaptor.capture(), any(), any(), any());
+      assertThat(reqCaptor.getValue().businessId()).isEqualTo("order-42");
+      assertThat(reqCaptor.getValue().variables()).containsExactly(entry("foo", "bar"));
+    }
+
+    @Test
+    void shouldTreatBlankBusinessIdAsAbsent() {
+      // given
+      final var entity =
+          buildStartSubscriptionEntity(
+              77L,
+              "deploy",
+              Map.of(),
+              "deploy.start",
+              "tenant-a",
+              MessageSubscriptionState.CREATED);
+      when(messageSubscriptionServices.getByKey(eq(77L), any())).thenReturn(entity);
+      when(messageServices.correlateMessage(any(), any(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new MessageCorrelationRecord()));
+
+      final var result = repository.findTool(transportContext, "deploy_77");
+
+      // when
+      result
+          .get()
+          .callHandler()
+          .apply(
+              transportContext,
+              CallToolRequest.builder("deploy_77")
+                  .arguments(Map.of("businessId", "   ", "foo", "bar"))
+                  .build());
+
+      // then
+      final var reqCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
+      verify(messageServices).correlateMessage(reqCaptor.capture(), any(), any(), any());
+      assertThat(reqCaptor.getValue().businessId()).isNull();
+      // a blank businessId is still a reserved argument and not forwarded as a variable
+      assertThat(reqCaptor.getValue().variables()).containsExactly(entry("foo", "bar"));
     }
 
     @Test

--- a/service/src/main/java/io/camunda/service/MessageServices.java
+++ b/service/src/main/java/io/camunda/service/MessageServices.java
@@ -88,7 +88,8 @@ public final class MessageServices extends PhysicalTenantScopedApiServices<Messa
             .setTimeToLive(request.timeToLive)
             .setMessageId(request.messageId)
             .setVariables(getDocumentOrEmpty(request.variables))
-            .setTenantId(request.tenantId);
+            .setTenantId(request.tenantId)
+            .setBusinessId(request.businessId);
     return sendBrokerRequestWithFullResponse(brokerRequest, authentication);
   }
 
@@ -101,5 +102,6 @@ public final class MessageServices extends PhysicalTenantScopedApiServices<Messa
       Long timeToLive,
       String messageId,
       Map<String, Object> variables,
-      String tenantId) {}
+      String tenantId,
+      @Nullable String businessId) {}
 }

--- a/service/src/main/java/io/camunda/service/MessageServices.java
+++ b/service/src/main/java/io/camunda/service/MessageServices.java
@@ -71,7 +71,8 @@ public final class MessageServices extends PhysicalTenantScopedApiServices<Messa
         new BrokerCorrelateMessageRequest(
                 correlationRequest.name, correlationRequest.correlationKey, maxVariableNameLength)
             .setVariables(getDocumentOrEmpty(correlationRequest.variables))
-            .setTenantId(correlationRequest.tenantId);
+            .setTenantId(correlationRequest.tenantId)
+            .setBusinessId(correlationRequest.businessId);
     if (channelType != null) {
       brokerRequest.setChannelType(channelType);
     }
@@ -94,7 +95,19 @@ public final class MessageServices extends PhysicalTenantScopedApiServices<Messa
   }
 
   public record CorrelateMessageRequest(
-      String name, String correlationKey, Map<String, Object> variables, String tenantId) {}
+      String name,
+      String correlationKey,
+      Map<String, Object> variables,
+      String tenantId,
+      @Nullable String businessId) {
+    public CorrelateMessageRequest(
+        final String name,
+        final String correlationKey,
+        final Map<String, Object> variables,
+        final String tenantId) {
+      this(name, correlationKey, variables, tenantId, null);
+    }
+  }
 
   public record PublicationMessageRequest(
       String name,

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -129,6 +129,10 @@ public final class RequestMapper extends RequestUtil {
 
   public static BrokerPublishMessageRequest toPublishMessageRequest(
       final PublishMessageRequest grpcRequest) {
+    if (StringUtils.isBlank(grpcRequest.getName())) {
+      throw new IllegalArgumentException(
+          "Expected to publish message with a non-empty name, but no name was provided");
+    }
     final BrokerPublishMessageRequest brokerRequest =
         new BrokerPublishMessageRequest(grpcRequest.getName(), grpcRequest.getCorrelationKey());
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -140,7 +140,8 @@ public final class RequestMapper extends RequestUtil {
         .setMessageId(grpcRequest.getMessageId())
         .setTimeToLive(grpcRequest.getTimeToLive())
         .setVariables(ensureJsonSet(grpcRequest.getVariables()))
-        .setTenantId(ensureTenantIdSet("PublishMessage", grpcRequest.getTenantId()));
+        .setTenantId(ensureTenantIdSet("PublishMessage", grpcRequest.getTenantId()))
+        .setBusinessId(ensureBusinessIdValid(grpcRequest.getBusinessId()));
 
     return brokerRequest;
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -850,4 +850,69 @@ public class RequestMapperTest {
           .hasMessageContaining("non-empty name");
     }
   }
+
+  @Nested
+  class PublishMessageRequestBusinessIdTest {
+
+    @Test
+    public void shouldAcceptValidBusinessId() {
+      // given
+      final var grpcRequest =
+          PublishMessageRequest.newBuilder()
+              .setName("message")
+              .setBusinessId("order-12345")
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toPublishMessageRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEqualTo("order-12345");
+    }
+
+    @Test
+    public void shouldAcceptBusinessIdAtMaxLength() {
+      // given
+      final String maxLengthBusinessId = "a".repeat(256);
+      final var grpcRequest =
+          PublishMessageRequest.newBuilder()
+              .setName("message")
+              .setBusinessId(maxLengthBusinessId)
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toPublishMessageRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEqualTo(maxLengthBusinessId);
+    }
+
+    @Test
+    public void shouldRejectBusinessIdExceedingMaxLength() {
+      // given
+      final var grpcRequest =
+          PublishMessageRequest.newBuilder()
+              .setName("message")
+              .setBusinessId("a".repeat(257))
+              .build();
+
+      // when/then
+      assertThatThrownBy(() -> RequestMapper.toPublishMessageRequest(grpcRequest))
+          .isInstanceOf(InvalidBusinessIdException.class)
+          .hasMessageContaining("business id")
+          .hasMessageContaining("256");
+    }
+
+    @Test
+    public void shouldAcceptEmptyBusinessId() {
+      // given
+      final var grpcRequest = PublishMessageRequest.newBuilder().setName("message").build();
+
+      // when
+      final var brokerRequest = RequestMapper.toPublishMessageRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEmpty();
+    }
+  }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeleteResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
 import io.camunda.zeebe.gateway.validation.VariableNameLengthValidator;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
@@ -809,6 +810,44 @@ public class RequestMapperTest {
           .isInstanceOf(InvalidVariableRequestException.class)
           .hasMessageContaining("Expected variable names to be no longer than 5 characters")
           .hasMessageContaining("length 6");
+    }
+  }
+
+  @Nested
+  class PublishMessageRequestNameValidationTest {
+
+    @Test
+    public void shouldAcceptNonBlankName() {
+      // given
+      final var grpcRequest = PublishMessageRequest.newBuilder().setName("message").build();
+
+      // when
+      final var brokerRequest = RequestMapper.toPublishMessageRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getName()).isEqualTo("message");
+    }
+
+    @Test
+    public void shouldRejectMissingName() {
+      // given
+      final var grpcRequest = PublishMessageRequest.newBuilder().build();
+
+      // when/then
+      assertThatThrownBy(() -> RequestMapper.toPublishMessageRequest(grpcRequest))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("non-empty name");
+    }
+
+    @Test
+    public void shouldRejectBlankName() {
+      // given
+      final var grpcRequest = PublishMessageRequest.newBuilder().setName("   ").build();
+
+      // when/then
+      assertThatThrownBy(() -> RequestMapper.toPublishMessageRequest(grpcRequest))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("non-empty name");
     }
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/PublishMessageTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/PublishMessageTest.java
@@ -40,6 +40,7 @@ public final class PublishMessageTest extends GatewayTest {
             .setMessageId("unique")
             .setTimeToLive(123)
             .setVariables(variables)
+            .setBusinessId("order-12345")
             .build();
 
     // when
@@ -62,5 +63,6 @@ public final class PublishMessageTest extends GatewayTest {
     assertThat(brokerRequestValue.getTimeToLive()).isEqualTo(request.getTimeToLive());
     MsgPackUtil.assertEqualityExcluding(brokerRequestValue.getVariablesBuffer(), variables);
     assertThat(brokerRequestValue.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(brokerRequestValue.getBusinessId()).isEqualTo(request.getBusinessId());
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -652,6 +652,11 @@ message PublishMessageRequest {
   string variables = 5;
   // the tenant id of the message
   string tenantId = 6;
+  // an optional business id used to enforce uniqueness of the process instance that a message
+  // start event would create. If provided and uniqueness enforcement is enabled, the engine
+  // rejects starting a new process instance when another root process instance with the same
+  // business id is already active for the same process definition.
+  optional string businessId = 7;
 }
 
 message PublishMessageResponse {

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -190,6 +190,18 @@ components:
           description: the tenant for which the message is published
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+        businessId:
+          description: |
+            An optional business id used to enforce uniqueness of the process instance that a
+            message start event would create. If provided and uniqueness enforcement is enabled,
+            the engine rejects starting a new process instance when another root process instance
+            with the same business id is already active for the same process definition. It has no
+            effect when the message correlates to a catch, boundary, or intermediate event.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
+      x-properties-added-in-version:
+        - propertyName: businessId
+          addedInVersion: "8.10"
 
     MessageCorrelationResult:
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -246,8 +246,20 @@ components:
           description: The tenant of the message sender.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+        businessId:
+          description: |
+            An optional business id used to enforce uniqueness of the process instance that a
+            message start event would create. If provided and uniqueness enforcement is enabled,
+            the engine rejects starting a new process instance when another root process instance
+            with the same business id is already active for the same process definition. It has no
+            effect when the message correlates to a catch, boundary, or intermediate event.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
       required:
         - name
+      x-properties-added-in-version:
+        - propertyName: businessId
+          addedInVersion: "8.10"
 
     MessagePublicationResult:
       description: The message key of the published message.

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
@@ -90,7 +90,8 @@ public class MessageControllerTest extends RestControllerTest {
               "variables": {
                 "key": "value"
               },
-              "tenantId": "<default>"
+              "tenantId": "<default>",
+              "businessId": "order-12345"
             }""";
 
     // when then
@@ -111,6 +112,7 @@ public class MessageControllerTest extends RestControllerTest {
     assertThat(capturedRequest.correlationKey()).isEqualTo("correlationKey");
     assertThat(capturedRequest.variables()).containsExactly(Map.entry("key", "value"));
     assertThat(capturedRequest.tenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(capturedRequest.businessId()).isEqualTo("order-12345");
 
     response
         .expectBody()

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
@@ -417,7 +417,8 @@ public class MessageControllerTest extends RestControllerTest {
               "variables": {
                 "key": "value"
               },
-              "tenantId": "<default>"
+              "tenantId": "<default>",
+              "businessId": "order-12345"
             }""";
 
     // when then
@@ -441,6 +442,7 @@ public class MessageControllerTest extends RestControllerTest {
     assertThat(capturedRequest.messageId()).isEqualTo("messageId");
     assertThat(capturedRequest.variables()).containsExactly(Map.entry("key", "value"));
     assertThat(capturedRequest.tenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(capturedRequest.businessId()).isEqualTo("order-12345");
   }
 
   @Test

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCorrelateMessageRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCorrelateMessageRequest.java
@@ -48,6 +48,11 @@ public final class BrokerCorrelateMessageRequest
     return this;
   }
 
+  public BrokerCorrelateMessageRequest setBusinessId(final String businessId) {
+    requestDto.setBusinessId(businessId != null ? businessId : "");
+    return this;
+  }
+
   @Override
   public BufferWriter getRequestWriter() {
     return requestDto;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPublishMessageRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPublishMessageRequest.java
@@ -51,6 +51,11 @@ public final class BrokerPublishMessageRequest extends BrokerExecuteCommand<Mess
     return this;
   }
 
+  public BrokerPublishMessageRequest setBusinessId(final String businessId) {
+    requestDto.setBusinessId(businessId != null ? businessId : "");
+    return this;
+  }
+
   @Override
   public MessageRecord getRequestWriter() {
     return requestDto;


### PR DESCRIPTION
## Description

Exposes the `businessId` field end-to-end across the Camunda message APIs, enabling clients to supply a business ID for uniqueness enforcement when starting a process instance via a message start event.

### What changed

**gRPC (`PublishMessage`)**
- Added an optional `businessId` field (field 7) to `PublishMessageRequest` in `gateway.proto`, preserving wire compatibility.
- Added non-empty `name` validation on the gRPC publish path (aligns with REST behavior).
- `RequestMapper` maps `businessId` from the gRPC request into broker request objects, with max-length (256 chars) validation via `ensureBusinessIdValid`.

**REST (`publishMessage` and `correlateMessage`)**
- Added optional `businessId` property to both `messages.yaml` OpenAPI schemas (publish and correlate), versioned as added in `8.10`.
- Updated `MessagePublicationRequest` and `MessageCorrelationRequest` REST models, `RequestMapper`, and `MessageRequestValidator` to accept, validate, and forward `businessId`.

**Java client**
- Exposed `businessId(String)` on `PublishMessageCommandStep3` and `CorrelateMessageCommandStep3` builder interfaces.
- Implemented in `PublishMessageCommandImpl` (both gRPC and HTTP request objects) and `CorrelateMessageCommandImpl`.

**MCP gateway**
- Added `businessId` as a reserved, documented tool input argument in `ProcessesToolRepository`.
- `businessId` is forwarded to the correlate message request and explicitly excluded from process variables. Blank values are treated as absent.

**Service layer**
- Extended `CorrelateMessageRequest` and `PublicationMessageRequest` records with a nullable `businessId` field (backward-compatible constructor overload added for `CorrelateMessageRequest`).
- Broker requests (`BrokerCorrelateMessageRequest`, `BrokerPublishMessageRequest`) now forward `businessId` to the engine.

### Behavior
- `businessId` is **optional**. Omitting it applies no uniqueness constraint.
- When provided, the engine rejects starting a new process instance if another root instance with the same `businessId` is already active for the same process definition.
- Has **no effect** when the message correlates to a catch, boundary, or intermediate event.
- Max length: **256 characters** (validated at the gRPC, REST, and client layers).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53726
