### PR TITLE
fix: Add Routing for Reindex by ID Deletion

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
@@ -125,11 +125,13 @@ public final class ReschedulingTask implements RunnableTask {
   }
 
   private void logError(final Throwable error) {
+    final var cause = error.getCause();
+    final var msg = cause != null ? cause.getMessage() : error.getMessage();
     periodicLogger.logError(
         "Error occurred while performing a background task {}; error message {}; operation will be retried",
         error,
         task.getCaption(),
-        error.getCause().getMessage());
+        msg);
   }
 
   private void reschedule(final long delay) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -33,8 +33,8 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
   private final String destinationIdx;
   private final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
       idsSupplier;
-  private final TriFunction<String, String, List<String>, CompletableFuture<Long>> reindexer;
-  private final BiFunction<String, List<String>, CompletableFuture<Long>> deleter;
+  private final TriFunction<String, String, List<IdWithRouting>, CompletableFuture<Long>> reindexer;
+  private final BiFunction<String, List<IdWithRouting>, CompletableFuture<Long>> deleter;
   private final Executor executor;
   private final CamundaExporterMetrics metrics;
   private final Logger logger;
@@ -53,8 +53,8 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
       final String destinationIdx,
       final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
           idsSupplier,
-      final TriFunction<String, String, List<String>, CompletableFuture<Long>> reindexer,
-      final BiFunction<String, List<String>, CompletableFuture<Long>> deleter,
+      final TriFunction<String, String, List<IdWithRouting>, CompletableFuture<Long>> reindexer,
+      final BiFunction<String, List<IdWithRouting>, CompletableFuture<Long>> deleter,
       final Executor executor,
       final CamundaExporterMetrics metrics,
       final Logger logger) {
@@ -152,16 +152,18 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
 
   private CompletableFuture<Long> reindex(final ArchiveDocIdsBatch<SortFieldType> response) {
     return reindexer
-        .apply(sourceIdx, destinationIdx, response.ids())
+        .apply(sourceIdx, destinationIdx, response.documents())
         .thenApply(
-            reindexCount -> validateProcessedCount("reindex", reindexCount, response.ids().size()));
+            reindexCount ->
+                validateProcessedCount("reindex", reindexCount, response.documents().size()));
   }
 
   private CompletableFuture<Long> delete(final ArchiveDocIdsBatch<SortFieldType> response) {
     return deleter
-        .apply(sourceIdx, response.ids())
+        .apply(sourceIdx, response.documents())
         .thenApply(
-            deleteCount -> validateProcessedCount("delete", deleteCount, response.ids().size()));
+            deleteCount ->
+                validateProcessedCount("delete", deleteCount, response.documents().size()));
   }
 
   private long validateProcessedCount(
@@ -187,17 +189,24 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
     return false;
   }
 
-  public record ArchiveDocIdsBatch<T>(List<String> ids, List<T> searchAfter) {
+  public record ArchiveDocIdsBatch<T>(List<IdWithRouting> documents, List<T> searchAfter) {
     static <T> ArchiveDocIdsBatch<T> empty() {
       return new ArchiveDocIdsBatch<>(List.of(), List.of());
     }
 
-    static <T> ArchiveDocIdsBatch<T> from(final List<String> ids, final List<T> searchAfter) {
-      return new ArchiveDocIdsBatch<>(ids, searchAfter);
+    static <T> ArchiveDocIdsBatch<T> from(
+        final List<IdWithRouting> documents, final List<T> searchAfter) {
+      return new ArchiveDocIdsBatch<>(documents, searchAfter);
     }
 
     public boolean isEmpty() {
-      return ids.isEmpty();
+      return documents.isEmpty();
+    }
+  }
+
+  public record IdWithRouting(String id, String routing) {
+    public static IdWithRouting of(final String id) {
+      return new IdWithRouting(id, null);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -44,6 +44,7 @@ import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -447,17 +448,21 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
                 return ArchiveDocIdsBatch.empty();
               }
               return ArchiveDocIdsBatch.from(
-                  hits.stream().map(Hit::id).toList(), hits.getLast().sort());
+                  hits.stream().map(h -> new IdWithRouting(h.id(), h.routing())).toList(),
+                  hits.getLast().sort());
             });
   }
 
   @VisibleForTesting
   CompletableFuture<Long> reindexDocumentsById(
-      final String sourceIndexName, final String destinationIndexName, final List<String> docIds) {
-    if (docIds.isEmpty()) {
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final List<IdWithRouting> docs) {
+    if (docs.isEmpty()) {
       return CompletableFuture.completedFuture(0L);
     }
 
+    final var docIds = docs.stream().map(IdWithRouting::id).toList();
     final var query = QueryBuilders.bool(q -> q.filter(b -> b.ids(id -> id.values(docIds))));
     final var request =
         new ReindexRequest.Builder()
@@ -496,14 +501,18 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
 
   @VisibleForTesting
   CompletableFuture<Long> deleteDocumentsById(
-      final String sourceIndexName, final List<String> docIds) {
-    if (docIds.isEmpty()) {
+      final String sourceIndexName, final List<IdWithRouting> docs) {
+    if (docs.isEmpty()) {
       return CompletableFuture.completedFuture(0L);
     }
 
     final var operations =
-        docIds.stream()
-            .map(docId -> new BulkOperation.Builder().delete(d -> d.id(docId)).build())
+        docs.stream()
+            .map(
+                d ->
+                    new BulkOperation.Builder()
+                        .delete(del -> del.id(d.id()).routing(d.routing()))
+                        .build())
             .toList();
 
     final var request =
@@ -525,7 +534,9 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
           "Deleting reindexed documents from %s index completed with %d failures"
               .formatted(sourceIndex, errorCount));
     }
-    return response.items().size();
+
+    // only count DELETE bulk operation where result was `deleted`
+    return response.items().stream().filter(i -> "deleted".equals(i.result())).count();
   }
 
   private CompletableFuture<ArchivingStatus> withArchivingStatus() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -364,12 +364,13 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             taskSupplier::moveNextBatch, count -> taskSupplier.isComplete())
         .thenComposeAsync(
             ignored -> {
-              // don't set the lifecycle if nothing was moved
-              // as it also might mean the index does not exist anyway
-              if (taskSupplier.getTotalArchived() > 0L) {
-                return setIndexLifeCycle(destinationIndexName);
-              }
-              return CompletableFuture.completedFuture(null);
+              // always trigger set life cycle, which checks whether the policy was previously
+              // applied and, if so, skips it. If nothing moved and the destination index is
+              // not present, we already set .allowNoIndices(true), which prevents it from erroring.
+              // However, if nothing moved because we previously moved them, but the call errored
+              // at the put policy stage, this will reapply the policy and ensure no index is
+              // left without the ILM policy.
+              return setIndexLifeCycle(destinationIndexName);
             },
             executor)
         .thenApply(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -61,6 +61,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -479,7 +480,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .thenApplyAsync(
             response -> {
               validateReindexResponse(sourceIndexName, response);
-              return response.total();
+              return getReindexedDocumentsCount(response);
             },
             executor)
         .whenCompleteAsync(
@@ -497,6 +498,12 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
           "Reindex request from %s index completed with %d failures"
               .formatted(sourceIndex, failures.size()));
     }
+  }
+
+  private static long getReindexedDocumentsCount(final ReindexResponse response) {
+    return Math.addExact(
+        Objects.requireNonNullElse(response.created(), 0L),
+        Objects.requireNonNullElse(response.updated(), 0L));
   }
 
   @VisibleForTesting

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -250,8 +250,13 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
 
     return applyPolicyToIndices(policyName, destinationIndexName)
         .thenApply(
-            ok -> {
-              lifeCyclePolicyApplied.put(destinationIndexName, policyName);
+            applied -> {
+              // Only cache when the policy was actually applied to a real index. If the dest
+              // didn't exist yet (applied=false), we deliberately skip the cache update so a
+              // later call (after the index is created by reindex) re-applies the policy.
+              if (Boolean.TRUE.equals(applied)) {
+                lifeCyclePolicyApplied.put(destinationIndexName, policyName);
+              }
               return null;
             });
   }
@@ -412,6 +417,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
                             config.getArchivingTimePoint(), partitionId)));
 
     return client.count(countRequest).thenApplyAsync(res -> Math.toIntExact(res.count()));
+  }
+
+  @VisibleForTesting
+  void invalidateLifeCycleCache(final String indexName) {
+    lifeCyclePolicyApplied.invalidate(indexName);
   }
 
   @VisibleForTesting
@@ -585,11 +595,39 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         ListViewTemplate.END_DATE);
   }
 
-  private CompletableFuture<PutIndicesSettingsResponse> applyPolicyToIndices(
+  private CompletableFuture<Boolean> applyPolicyToIndices(
       final String policyName, final String indexNamePattern) {
 
-    logger.debug("Applying policy '{}' to indices: {}", policyName, indexNamePattern);
+    // Guard against `PUT _settings` with `allowNoIndices(true)` silently succeeding when no
+    // matching index exists. That silent success would otherwise let the caller mark its cache as
+    // "applied" for an index that hasn't been created yet, and a later real application against
+    // the freshly-created index would be skipped. We only do this check for single-index names —
+    // wildcard/multi-index patterns (used by setLifeCycleToAllIndexes) are not cached and exists
+    // semantics with negation / wildcards are not portable enough to gate on.
+    if (isPattern(indexNamePattern)) {
+      return doPutSettings(policyName, indexNamePattern).thenApply(r -> true);
+    }
 
+    return client
+        .indices()
+        .exists(b -> b.index(indexNamePattern))
+        .thenComposeAsync(
+            exists -> {
+              if (!exists.value()) {
+                logger.debug(
+                    "Skipping policy '{}' for '{}': index does not exist yet",
+                    policyName,
+                    indexNamePattern);
+                return CompletableFuture.completedFuture(false);
+              }
+              return doPutSettings(policyName, indexNamePattern).thenApply(r -> true);
+            },
+            executor);
+  }
+
+  private CompletableFuture<PutIndicesSettingsResponse> doPutSettings(
+      final String policyName, final String indexNamePattern) {
+    logger.debug("Applying policy '{}' to indices: {}", policyName, indexNamePattern);
     final var settingsRequest =
         new PutIndicesSettingsRequest.Builder()
             .settings(settings -> settings.lifecycle(lifecycle -> lifecycle.name(policyName)))
@@ -597,8 +635,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             .allowNoIndices(true)
             .ignoreUnavailable(true)
             .build();
-
     return client.indices().putSettings(settingsRequest);
+  }
+
+  private static boolean isPattern(final String indexNameOrPattern) {
+    return indexNameOrPattern.indexOf('*') >= 0 || indexNameOrPattern.indexOf(',') >= 0;
   }
 
   private ArchiveBatch createArchiveBatch(final SearchResponse<?> response, final String field) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -366,12 +366,13 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             taskSupplier::moveNextBatch, count -> taskSupplier.isComplete())
         .thenComposeAsync(
             ignored -> {
-              // don't set the lifecycle if nothing was moved
-              // as it also might mean the index does not exist anyway
-              if (taskSupplier.getTotalArchived() > 0L) {
-                return setIndexLifeCycle(destinationIndexName);
-              }
-              return CompletableFuture.completedFuture(null);
+              // always trigger set life cycle, which checks whether the policy was previously
+              // applied and, if so, skips it. If nothing moved and the destination index is
+              // not present, we already set .allowNoIndices(true), which prevents it from erroring.
+              // However, if nothing moved because we previously moved them, but the call errored
+              // at the put policy stage, this will reapply the policy and ensure no index is
+              // left without the ILM policy.
+              return setIndexLifeCycle(destinationIndexName);
             },
             executor)
         .thenApply(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -18,6 +18,7 @@ import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -452,17 +453,21 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
                 return ArchiveDocIdsBatch.empty();
               }
               return ArchiveDocIdsBatch.from(
-                  hits.stream().map(Hit::id).toList(), hits.getLast().sortVals());
+                  hits.stream().map(h -> new IdWithRouting(h.id(), h.routing())).toList(),
+                  hits.getLast().sortVals());
             });
   }
 
   @VisibleForTesting
   CompletableFuture<Long> reindexDocumentsById(
-      final String sourceIndexName, final String destinationIndexName, final List<String> docIds) {
-    if (docIds.isEmpty()) {
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final List<IdWithRouting> docs) {
+    if (docs.isEmpty()) {
       return CompletableFuture.completedFuture(0L);
     }
 
+    final var docIds = docs.stream().map(IdWithRouting::id).toList();
     final var query = QueryBuilders.bool().filter(b -> b.ids(id -> id.values(docIds))).build();
     final var request =
         new ReindexRequest.Builder()
@@ -500,13 +505,15 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
   @VisibleForTesting
   CompletableFuture<Long> deleteDocumentsById(
-      final String sourceIndexName, final List<String> docIds) {
-    if (docIds.isEmpty()) {
+      final String sourceIndexName, final List<IdWithRouting> docs) {
+    if (docs.isEmpty()) {
       return CompletableFuture.completedFuture(0L);
     }
 
     final var operations =
-        docIds.stream().map(docId -> BulkOperation.of(b -> b.delete(d -> d.id(docId)))).toList();
+        docs.stream()
+            .map(d -> BulkOperation.of(b -> b.delete(del -> del.id(d.id()).routing(d.routing()))))
+            .toList();
 
     final BulkRequest request =
         BulkRequest.of(b -> b.index(sourceIndexName).operations(operations));
@@ -526,7 +533,9 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
           "Deleting reindexed documents from %s index completed with %d failures"
               .formatted(sourceIndex, errorCount));
     }
-    return response.items().size();
+
+    // only count DELETE bulk operation where result was `deleted`
+    return response.items().stream().filter(i -> "deleted".equals(i.result())).count();
   }
 
   private SearchRequest createUsageMetricSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -254,8 +254,13 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     return applyPolicyToIndices(policyName, destinationIndexName)
         .thenApply(
-            ignored -> {
-              lifeCyclePolicyApplied.put(destinationIndexName, policyName);
+            applied -> {
+              // Only cache when the policy was actually applied to a real index. If the dest
+              // didn't exist yet (applied=false), we deliberately skip the cache update so a
+              // later call (after the index is created by reindex) re-applies the policy.
+              if (Boolean.TRUE.equals(applied)) {
+                lifeCyclePolicyApplied.put(destinationIndexName, policyName);
+              }
               return null;
             });
   }
@@ -418,6 +423,11 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     } catch (final IOException e) {
       return CompletableFuture.failedFuture(e);
     }
+  }
+
+  @VisibleForTesting
+  void invalidateLifeCycleCache(final String indexName) {
+    lifeCyclePolicyApplied.invalidate(indexName);
   }
 
   @VisibleForTesting
@@ -620,10 +630,37 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .toQuery();
   }
 
-  private CompletableFuture<Void> applyPolicyToIndices(
+  private CompletableFuture<Boolean> applyPolicyToIndices(
+      final String policyName, final String indexNamePattern) {
+
+    // Guard against OS ISM endpoints silently succeeding for non-existent indices. That silent
+    // success would otherwise let the caller mark its cache as "applied" for an index that
+    // hasn't been created yet, and a later real application against the freshly-created index
+    // would be skipped. We only do this check for single-index names — wildcard/multi-index
+    // patterns (used by setLifeCycleToAllIndexes) are not cached and exists semantics with
+    // negation / wildcards are not portable enough to gate on.
+    if (isPattern(indexNamePattern)) {
+      return doApplyIsmPolicy(policyName, indexNamePattern).thenApply(ignored -> true);
+    }
+
+    return sendRequestAsync(() -> client.indices().exists(b -> b.index(indexNamePattern)))
+        .thenComposeAsync(
+            exists -> {
+              if (!exists.value()) {
+                logger.debug(
+                    "Skipping policy '{}' for '{}': index does not exist yet",
+                    policyName,
+                    indexNamePattern);
+                return CompletableFuture.completedFuture(false);
+              }
+              return doApplyIsmPolicy(policyName, indexNamePattern).thenApply(ignored -> true);
+            },
+            executor);
+  }
+
+  private CompletableFuture<Void> doApplyIsmPolicy(
       final String policyName, final String indexNamePattern) {
     logger.debug("Applying policy '{}' to indices: {}", policyName, indexNamePattern);
-
     final var jsonpMapper = genericClient._transport().jsonpMapper();
 
     return sendRequestAsync(
@@ -654,6 +691,10 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .thenComposeAsync(
             resp -> checkIsmResponse(resp, "change_policy", policyName, indexNamePattern),
             executor);
+  }
+
+  private static boolean isPattern(final String indexNameOrPattern) {
+    return indexNameOrPattern.indexOf('*') >= 0 || indexNameOrPattern.indexOf(',') >= 0;
   }
 
   private CompletableFuture<Void> checkIsmResponse(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -483,7 +484,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .thenApplyAsync(
             response -> {
               validateReindexResponse(sourceIndexName, response);
-              return response.total();
+              return getReindexedDocumentsCount(response);
             },
             executor)
         .whenCompleteAsync(
@@ -501,6 +502,12 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
           "Reindex request from %s index completed with %d failures"
               .formatted(sourceIndex, failures.size()));
     }
+  }
+
+  private static long getReindexedDocumentsCount(final ReindexResponse response) {
+    return Math.addExact(
+        Objects.requireNonNullElse(response.created(), 0L),
+        Objects.requireNonNullElse(response.updated(), 0L));
   }
 
   @VisibleForTesting

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -65,12 +65,7 @@ public class ProcessInstanceArchiverJob implements ArchiverJob {
         // the time it takes all in all, including searching, reindexing, deletion
         // There is some overhead with the scheduling at the executor, but this should be
         // negligible
-        .thenComposeAsync(
-            count -> {
-              metrics.measureArchivingDuration(timer);
-              return CompletableFuture.completedFuture(count);
-            },
-            executor);
+        .whenCompleteAsync((val, err) -> metrics.measureArchivingDuration(timer), executor);
   }
 
   @VisibleForTesting

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
@@ -86,7 +86,8 @@ public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
       final String finishDate, final List<String> processInstanceKeys) {
     // 1. First archive docs from dependent indices and `joinRelation={variable OR activity}`
     // from operate-list-view index (already done)
-    // 2. Then archive all docs except `joinRelation=processInstance` from operate-list-view index
+    // 2. Then archive all docs except `joinRelation=processInstance` from operate-list-view index;
+    // we use this as a catch-all clause to move all related documents.
     // 3. Then archive all `joinRelation=processInstance` docs from operate-list-view index
     return archive(
             getTemplateDescriptor().getFullQualifiedName(),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -47,7 +48,9 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             searchAfter ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(List.of("doc1", "doc2"), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(
+                        List.of(IdWithRouting.of("doc1"), IdWithRouting.of("doc2")),
+                        List.of("after1"))),
             (source, dest, ids) -> {
               if (reindexCallCount.incrementAndGet() <= 2) {
                 return CompletableFuture.failedFuture(retryableError);
@@ -94,7 +97,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             searchAfter ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> CompletableFuture.failedFuture(retryableError),
             (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
             DIRECT_EXECUTOR,
@@ -127,7 +130,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             searchAfter ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> CompletableFuture.failedFuture(nonRetryableError),
             (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
             DIRECT_EXECUTOR,
@@ -179,7 +182,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             searchAfter ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> {
               final int call = reindexCallCount.incrementAndGet();
               if (call != 2 && call != 7) {
@@ -238,7 +241,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             searchAfter ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> {
               if (reindexCallCount.incrementAndGet() == 1) {
                 return CompletableFuture.failedFuture(retryableError);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -118,6 +118,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob> {
   void withArchiverJob(final ExporterConfiguration config, final ArchiveJobConsumer<T> jobConsumer)
       throws Exception {
     config.getHistory().getRetention().setEnabled(true);
+    config.getIndex().setNumberOfShards(3);
     createSchemas(config);
 
     final ExporterResourceProvider exporterResourceProvider = exporterResourceProvider(config);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -868,7 +868,7 @@ final class ElasticsearchArchiverRepositoryIT {
     // when - first setting policy for indexName1 and indexName2
     repository
         .setIndexLifeCycle(indexName1)
-        .thenApply(
+        .thenCompose(
             ignore -> {
               // wait for the cache of indexName1 to expire
               Awaitility.await().pollDelay(Duration.ofSeconds(minimumAgeSeconds)).until(() -> true);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -28,6 +28,7 @@ import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
@@ -781,8 +782,13 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   private <T extends TDocument> void index(final String index, final T document) {
+    index(index, document, null);
+  }
+
+  private <T extends TDocument> void index(
+      final String index, final T document, final String routing) {
     try {
-      testClient.index(b -> b.index(index).document(document).id(document.id()));
+      testClient.index(b -> b.index(index).document(document).id(document.id()).routing(routing));
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -978,11 +984,12 @@ final class ElasticsearchArchiverRepositoryIT {
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
     createProcessInstanceIndex();
-    documents.forEach(doc -> index(processInstanceIndex, doc));
+    documents.forEach(
+        doc -> index(processInstanceIndex, doc, String.valueOf(doc.processInstanceKey())));
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when searching for process instance key 111
-    // then - we expect documents with IDs 1,2 and 4 to be returned
+    // then - we expect documents with IDs 1,2 and 4 to be returned with routing=111
     final var batch =
         repository
             .getArchiveDocIdsBatch(
@@ -994,7 +1001,10 @@ final class ElasticsearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2", "4");
+    assertThat(batch.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "2", "4");
+    assertThat(batch.documents()).extracting(IdWithRouting::routing).containsOnly("111");
     assertThat(batch.searchAfter()).hasSize(1);
     assertThat(batch.searchAfter().getFirst().stringValue()).isEqualTo("4");
 
@@ -1012,7 +1022,7 @@ final class ElasticsearchArchiverRepositoryIT {
             .join();
 
     assertThat(emptyBatch.isEmpty()).isTrue();
-    assertThat(emptyBatch.ids()).isEmpty();
+    assertThat(emptyBatch.documents()).isEmpty();
     assertThat(emptyBatch.searchAfter()).isEmpty();
 
     // when searching for process instance key 111 with reindex batch size of 2
@@ -1029,7 +1039,9 @@ final class ElasticsearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchPg1.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batchPg1.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "2");
     assertThat(batchPg1.searchAfter().getFirst().stringValue()).isEqualTo("2");
 
     // when searching for process instance key 111 with searchAfter from page 1
@@ -1046,7 +1058,7 @@ final class ElasticsearchArchiverRepositoryIT {
                 batchPg1.searchAfter())
             .join();
 
-    assertThat(batchPg2.ids()).containsExactlyInAnyOrder("4");
+    assertThat(batchPg2.documents()).extracting(IdWithRouting::id).containsExactlyInAnyOrder("4");
     assertThat(batchPg2.searchAfter().getFirst().stringValue()).isEqualTo("4");
 
     // when searching for process instance key 111 with searchAfter from page 2
@@ -1064,7 +1076,7 @@ final class ElasticsearchArchiverRepositoryIT {
             .join();
 
     assertThat(batchPg3.isEmpty()).isTrue();
-    assertThat(batchPg3.ids()).isEmpty();
+    assertThat(batchPg3.documents()).isEmpty();
     assertThat(batchPg3.searchAfter()).isEmpty();
 
     // when searching for process instance key 111 with exclusion filter for joinRelation=activity
@@ -1081,7 +1093,9 @@ final class ElasticsearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchExcluded.ids()).containsExactlyInAnyOrder("1", "4");
+    assertThat(batchExcluded.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "4");
 
     // when searching for process instance key 111 with inclusion filter for joinRelation=variable
     // and exclusion filter for joinRelation=activity
@@ -1097,7 +1111,9 @@ final class ElasticsearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchBothFilters.ids()).containsExactlyInAnyOrder("1", "4");
+    assertThat(batchBothFilters.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "4");
   }
 
   @Test
@@ -1114,7 +1130,8 @@ final class ElasticsearchArchiverRepositoryIT {
 
     // when - reindex the first two documents
     final var result =
-        repository.reindexDocumentsById(sourceIndexName, destIndexName, List.of("1", "2"));
+        repository.reindexDocumentsById(
+            sourceIndexName, destIndexName, List.of(IdWithRouting.of("1"), IdWithRouting.of("2")));
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -1146,7 +1163,9 @@ final class ElasticsearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(indexName));
 
     // when - delete the first two documents
-    final var result = repository.deleteDocumentsById(indexName, List.of("1", "2"));
+    final var result =
+        repository.deleteDocumentsById(
+            indexName, List.of(IdWithRouting.of("1"), IdWithRouting.of("2")));
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -1179,7 +1198,8 @@ final class ElasticsearchArchiverRepositoryIT {
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
     createProcessInstanceIndex();
-    documents.forEach(doc -> index(processInstanceIndex, doc));
+    documents.forEach(
+        doc -> index(processInstanceIndex, doc, String.valueOf(doc.processInstanceKey())));
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when moving documents by id

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -795,11 +795,17 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   @Test
-  void shouldCacheIndicesWhichHaveRetentionPolicyAppliedAndNotReapplyPointlessly() {
+  void shouldCacheIndicesWhichHaveRetentionPolicyAppliedAndNotReapplyPointlessly()
+      throws IOException {
     // given
     retention.setEnabled(true);
     final var indexName1 = processInstanceIndex + UUID.randomUUID();
     final var indexName2 = processInstanceIndex + UUID.randomUUID();
+    // setIndexLifeCycle now short-circuits when the target index doesn't exist (to avoid
+    // poisoning the applied-policy cache for indices that haven't been created yet), so the
+    // test must create both indices before exercising the cache behavior.
+    testClient.indices().create(r -> r.index(indexName1));
+    testClient.indices().create(r -> r.index(indexName2));
 
     final var clientSpy = spy(new ElasticsearchAsyncClient(transport));
     final var indicesClientSpy = spy(clientSpy.indices());
@@ -846,6 +852,11 @@ final class ElasticsearchArchiverRepositoryIT {
     retention.setMinimumAge("%ds".formatted(minimumAgeSeconds));
     final var indexName1 = processInstanceIndex + UUID.randomUUID();
     final var indexName2 = processInstanceIndex + UUID.randomUUID();
+    // setIndexLifeCycle now short-circuits when the target index doesn't exist (to avoid
+    // poisoning the applied-policy cache for indices that haven't been created yet), so the
+    // test must create both indices before exercising the cache behavior.
+    testClient.indices().create(r -> r.index(indexName1));
+    testClient.indices().create(r -> r.index(indexName2));
 
     final var clientSpy = spy(new ElasticsearchAsyncClient(transport));
     final var indicesClientSpy = spy(clientSpy.indices());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -1192,6 +1192,74 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   @Test
+  void shouldDeleteDocumentsByIdWithRoutingOnMultiShardIndex() throws IOException {
+    // given - a 3-shard index seeded with docs whose custom routing differs from their id.
+    // On a multi-shard index, a delete-by-id without routing is routed by hash(_id); for
+    // docs indexed with custom routing this lands on the wrong shard and ES silently
+    // returns result=not_found. This test proves the bulk delete carries routing through
+    // and that getDeletedDocCount only counts items actually deleted.
+    final var indexName = UUID.randomUUID().toString();
+    testClient
+        .indices()
+        .create(r -> r.index(indexName).settings(s -> s.numberOfShards("3").numberOfReplicas("0")));
+
+    final var repository = createRepository();
+    final int total = 50;
+    final var docs =
+        IntStream.rangeClosed(1, total).mapToObj(i -> new TestDocument(String.valueOf(i))).toList();
+    // routing is deliberately different from id, so hash(routing) != hash(id) for most
+    // docs across 3 shards.
+    docs.forEach(d -> index(indexName, d, "r-" + (Integer.parseInt(d.id()) % 7)));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete with the routing each doc was indexed under
+    final var idsWithRouting =
+        docs.stream()
+            .map(d -> new IdWithRouting(d.id(), "r-" + (Integer.parseInt(d.id()) % 7)))
+            .toList();
+    final var result = repository.deleteDocumentsById(indexName, idsWithRouting);
+
+    // then - every doc reports result=deleted, and the index is empty
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(result.join())
+        .as(
+            "all docs must report result=deleted on multi-shard index when routing is carried"
+                + " through; if this drops below %d the routing param is being ignored",
+            total)
+        .isEqualTo(total);
+    testClient.indices().refresh(r -> r.index(indexName));
+    assertThat(testClient.count(c -> c.index(indexName)).count()).isEqualTo(0L);
+  }
+
+  @Test
+  void shouldNotCountNotFoundResultsAsDeleted() throws IOException {
+    // given - an index with a single real doc; we will issue a bulk delete that mixes the
+    // real id with non-existent ids so ES returns result=not_found for the latter. The
+    // tightened getDeletedDocCount must exclude not_found items, otherwise the archiver
+    // loop would falsely report progress whenever a delete missed (wrong shard / wrong
+    // routing / already-deleted doc).
+    final var indexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    index(indexName, new TestDocument("1"));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete a mix of one existing id and two non-existent ids
+    final var result =
+        repository.deleteDocumentsById(
+            indexName,
+            List.of(
+                IdWithRouting.of("1"),
+                IdWithRouting.of("does-not-exist-a"),
+                IdWithRouting.of("does-not-exist-b")));
+
+    // then - only the existing doc counts as deleted
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(result.join()).as("not_found items must not be counted as deleted").isEqualTo(1L);
+    testClient.indices().refresh(r -> r.index(indexName));
+    assertThat(testClient.count(c -> c.index(indexName)).count()).isEqualTo(0L);
+  }
+
+  @Test
   void shouldMoveDocumentsById() throws IOException {
     final var repository = createRepository();
     final List<TestProcessDocument> documents = new ArrayList<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -33,6 +33,7 @@ import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesAsyncClient;
 import co.elastic.clients.elasticsearch.indices.GetIndexResponse;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.net.ConnectException;
@@ -44,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -211,6 +213,39 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
     inOrder.verifyNoMoreInteractions();
   }
 
+  @Test
+  void shouldPropagateRoutingForEachBulkDeleteOperation() {
+    // given
+    final var docs =
+        List.of(
+            new IdWithRouting("4", "routing-4"),
+            new IdWithRouting("5", "routing-5"),
+            new IdWithRouting("6", "routing-6"));
+    when(client.bulk(any(BulkRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(bulkResponse("4", "5", "6")));
+
+    // when
+    final var deleted =
+        ((ElasticsearchArchiverRepository) repository)
+            .deleteDocumentsById("from-index", docs)
+            .join();
+
+    // then
+    assertThat(deleted).isEqualTo(3L);
+
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(client).bulk(captor.capture());
+
+    final var operations = captor.getValue().operations();
+    assertThat(operations).hasSize(3);
+    assertThat(operations.get(0).delete().id()).isEqualTo("4");
+    assertThat(operations.get(0).delete().routing()).isEqualTo("routing-4");
+    assertThat(operations.get(1).delete().id()).isEqualTo("5");
+    assertThat(operations.get(1).delete().routing()).isEqualTo("routing-5");
+    assertThat(operations.get(2).delete().id()).isEqualTo("6");
+    assertThat(operations.get(2).delete().routing()).isEqualTo("routing-6");
+  }
+
   private SearchResponse<Object> searchResponse(final String... ids) {
     final var hits =
         Arrays.stream(ids).map(id -> Hit.of(h -> h.id(id).index("from-index"))).toList();
@@ -235,7 +270,8 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
                             h.id(id)
                                 .operationType(OperationType.Delete)
                                 .index("from-index")
-                                .status(200)))
+                                .status(200)
+                                .result("deleted")))
             .toList();
     return BulkResponse.of(b -> b.took(123L).errors(false).items(items));
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -187,7 +187,9 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
             CompletableFuture.completedFuture(searchResponse("4", "5", "6")),
             CompletableFuture.completedFuture(searchResponse()));
     when(client.reindex(any(ReindexRequest.class)))
-        .thenReturn(CompletableFuture.completedFuture(ReindexResponse.of(b -> b.total(3L))));
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                ReindexResponse.of(b -> b.total(3L).created(3L).updated(0L))));
     when(client.bulk(any(BulkRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(bulkResponse("4", "5", "6")));
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.verify;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
@@ -1079,11 +1080,12 @@ final class OpenSearchArchiverRepositoryIT {
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
     createProcessInstanceIndex();
-    documents.forEach(doc -> index(processInstanceIndex, doc));
+    documents.forEach(
+        doc -> index(processInstanceIndex, doc, String.valueOf(doc.processInstanceKey())));
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when searching for process instance key 111
-    // then - we expect documents with IDs 1,2 and 4 to be returned
+    // then - we expect documents with IDs 1,2 and 4 to be returned with routing=111
     final var batch =
         repository
             .getArchiveDocIdsBatch(
@@ -1095,7 +1097,10 @@ final class OpenSearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2", "4");
+    assertThat(batch.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "2", "4");
+    assertThat(batch.documents()).extracting(IdWithRouting::routing).containsOnly("111");
     assertThat(batch.searchAfter()).hasSize(1);
     assertThat(batch.searchAfter().getFirst().stringValue()).isEqualTo("4");
 
@@ -1113,7 +1118,7 @@ final class OpenSearchArchiverRepositoryIT {
             .join();
 
     assertThat(emptyBatch.isEmpty()).isTrue();
-    assertThat(emptyBatch.ids()).isEmpty();
+    assertThat(emptyBatch.documents()).isEmpty();
     assertThat(emptyBatch.searchAfter()).isEmpty();
 
     // when searching for process instance key 111 with reindex batch size of 2
@@ -1130,7 +1135,9 @@ final class OpenSearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchPg1.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batchPg1.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "2");
     assertThat(batchPg1.searchAfter().getFirst().stringValue()).isEqualTo("2");
 
     // when searching for process instance key 111 with searchAfter from page 1
@@ -1147,7 +1154,7 @@ final class OpenSearchArchiverRepositoryIT {
                 batchPg1.searchAfter())
             .join();
 
-    assertThat(batchPg2.ids()).containsExactlyInAnyOrder("4");
+    assertThat(batchPg2.documents()).extracting(IdWithRouting::id).containsExactlyInAnyOrder("4");
     assertThat(batchPg2.searchAfter().getFirst().stringValue()).isEqualTo("4");
 
     // when searching for process instance key 111 with searchAfter from page 2
@@ -1165,7 +1172,7 @@ final class OpenSearchArchiverRepositoryIT {
             .join();
 
     assertThat(batchPg3.isEmpty()).isTrue();
-    assertThat(batchPg3.ids()).isEmpty();
+    assertThat(batchPg3.documents()).isEmpty();
     assertThat(batchPg3.searchAfter()).isEmpty();
 
     // when searching for process instance key 111 with exclusion filter for joinRelation=activity
@@ -1182,7 +1189,9 @@ final class OpenSearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchExcluded.ids()).containsExactlyInAnyOrder("1", "4");
+    assertThat(batchExcluded.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "4");
 
     // when searching for process instance key 111 with inclusion filter for joinRelation=variable
     // and exclusion filter for joinRelation=activity
@@ -1198,7 +1207,9 @@ final class OpenSearchArchiverRepositoryIT {
                 null)
             .join();
 
-    assertThat(batchBothFilters.ids()).containsExactlyInAnyOrder("1", "4");
+    assertThat(batchBothFilters.documents())
+        .extracting(IdWithRouting::id)
+        .containsExactlyInAnyOrder("1", "4");
   }
 
   @Test
@@ -1215,7 +1226,8 @@ final class OpenSearchArchiverRepositoryIT {
 
     // when - reindex the first two documents
     final var result =
-        repository.reindexDocumentsById(sourceIndexName, destIndexName, List.of("1", "2"));
+        repository.reindexDocumentsById(
+            sourceIndexName, destIndexName, List.of(IdWithRouting.of("1"), IdWithRouting.of("2")));
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -1247,7 +1259,9 @@ final class OpenSearchArchiverRepositoryIT {
     testClient.indices().refresh(r -> r.index(indexName));
 
     // when - delete the first two documents
-    final var result = repository.deleteDocumentsById(indexName, List.of("1", "2"));
+    final var result =
+        repository.deleteDocumentsById(
+            indexName, List.of(IdWithRouting.of("1"), IdWithRouting.of("2")));
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -1280,7 +1294,8 @@ final class OpenSearchArchiverRepositoryIT {
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
     createProcessInstanceIndex();
-    documents.forEach(doc -> index(processInstanceIndex, doc));
+    documents.forEach(
+        doc -> index(processInstanceIndex, doc, String.valueOf(doc.processInstanceKey())));
     testClient.indices().refresh(r -> r.index(processInstanceIndex));
 
     // when moving documents by id
@@ -1509,8 +1524,13 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   private <T extends TDocument> void index(final String index, final T document) {
+    index(index, document, null);
+  }
+
+  private <T extends TDocument> void index(
+      final String index, final T document, final String routing) {
     try {
-      testClient.index(b -> b.index(index).document(document).id(document.id()));
+      testClient.index(b -> b.index(index).document(document).id(document.id()).routing(routing));
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1290,6 +1290,74 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   @Test
+  void shouldDeleteDocumentsByIdWithRoutingOnMultiShardIndex() throws IOException {
+    // given - a 3-shard index seeded with docs whose custom routing differs from their id.
+    // On a multi-shard index, a delete-by-id without routing is routed by hash(_id); for
+    // docs indexed with custom routing this lands on the wrong shard and OS silently
+    // returns result=not_found. This test proves the bulk delete carries routing through
+    // and that getDeletedDocCount only counts items actually deleted.
+    final var indexName = ARCHIVER_IDX_PREFIX + UUID.randomUUID().toString();
+    testClient
+        .indices()
+        .create(r -> r.index(indexName).settings(s -> s.numberOfShards("3").numberOfReplicas("0")));
+
+    final var repository = createRepository();
+    final int total = 50;
+    final var docs =
+        IntStream.rangeClosed(1, total).mapToObj(i -> new TestDocument(String.valueOf(i))).toList();
+    // routing is deliberately different from id, so hash(routing) != hash(id) for most
+    // docs across 3 shards.
+    docs.forEach(d -> index(indexName, d, "r-" + (Integer.parseInt(d.id()) % 7)));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete with the routing each doc was indexed under
+    final var idsWithRouting =
+        docs.stream()
+            .map(d -> new IdWithRouting(d.id(), "r-" + (Integer.parseInt(d.id()) % 7)))
+            .toList();
+    final var result = repository.deleteDocumentsById(indexName, idsWithRouting);
+
+    // then - every doc reports result=deleted, and the index is empty
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(result.join())
+        .as(
+            "all docs must report result=deleted on multi-shard index when routing is carried"
+                + " through; if this drops below %d the routing param is being ignored",
+            total)
+        .isEqualTo(total);
+    testClient.indices().refresh(r -> r.index(indexName));
+    assertThat(testClient.count(c -> c.index(indexName)).count()).isEqualTo(0L);
+  }
+
+  @Test
+  void shouldNotCountNotFoundResultsAsDeleted() throws IOException {
+    // given - an index with a single real doc; we will issue a bulk delete that mixes the
+    // real id with non-existent ids so OS returns result=not_found for the latter. The
+    // tightened getDeletedDocCount must exclude not_found items, otherwise the archiver
+    // loop would falsely report progress whenever a delete missed (wrong shard / wrong
+    // routing / already-deleted doc).
+    final var indexName = ARCHIVER_IDX_PREFIX + UUID.randomUUID().toString();
+    final var repository = createRepository();
+    index(indexName, new TestDocument("1"));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete a mix of one existing id and two non-existent ids
+    final var result =
+        repository.deleteDocumentsById(
+            indexName,
+            List.of(
+                IdWithRouting.of("1"),
+                IdWithRouting.of("does-not-exist-a"),
+                IdWithRouting.of("does-not-exist-b")));
+
+    // then - only the existing doc counts as deleted
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    assertThat(result.join()).as("not_found items must not be counted as deleted").isEqualTo(1L);
+    testClient.indices().refresh(r -> r.index(indexName));
+    assertThat(testClient.count(c -> c.index(indexName)).count()).isEqualTo(0L);
+  }
+
+  @Test
   void shouldMoveDocumentsById() throws IOException {
     final var repository = createRepository();
     final List<TestProcessDocument> documents = new ArrayList<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -889,7 +889,7 @@ final class OpenSearchArchiverRepositoryIT {
     // when - first setting policy for indexName1 and indexName2
     repository
         .setIndexLifeCycle(indexName1)
-        .thenApply(
+        .thenCompose(
             ignore -> {
               // wait for the cache of indexName1 to expire
               Awaitility.await().pollDelay(Duration.ofSeconds(minimumAgeSeconds)).until(() -> true);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -809,11 +809,18 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   @Test
-  void shouldCacheIndicesWhichHaveRetentionPolicyAppliedAndNotReapplyPointlessly() {
+  void shouldCacheIndicesWhichHaveRetentionPolicyAppliedAndNotReapplyPointlessly()
+      throws IOException {
     // given
     retention.setEnabled(true);
     final var indexName1 = processInstanceIndex + UUID.randomUUID();
     final var indexName2 = processInstanceIndex + UUID.randomUUID();
+    // setIndexLifeCycle now short-circuits when the target index doesn't exist (to avoid
+    // poisoning the applied-policy cache for indices that haven't been created yet), so the
+    // test must create both the policy and the indices before exercising the cache behavior.
+    createLifeCyclePolicies();
+    testClient.indices().create(r -> r.index(indexName1));
+    testClient.indices().create(r -> r.index(indexName2));
 
     final var asyncClient = createOpenSearchAsyncClient();
     final var genericClientSpy =
@@ -865,6 +872,12 @@ final class OpenSearchArchiverRepositoryIT {
     retention.setMinimumAge("%ds".formatted(minimumAgeSeconds));
     final var indexName1 = processInstanceIndex + UUID.randomUUID();
     final var indexName2 = processInstanceIndex + UUID.randomUUID();
+    // setIndexLifeCycle now short-circuits when the target index doesn't exist (to avoid
+    // poisoning the applied-policy cache for indices that haven't been created yet), so the
+    // test must create both the policy and the indices before exercising the cache behavior.
+    createLifeCyclePolicies();
+    testClient.indices().create(r -> r.index(indexName1));
+    testClient.indices().create(r -> r.index(indexName2));
 
     final var asyncClient = createOpenSearchAsyncClient();
     final var genericClientSpy =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
@@ -29,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.core.BulkRequest;
@@ -250,9 +252,41 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
                             h.id(id)
                                 .operationType(OperationType.Delete)
                                 .index("from-index")
-                                .status(200)))
+                                .status(200)
+                                .result("deleted")))
             .toList();
     return BulkResponse.of(b -> b.took(123L).errors(false).items(items));
+  }
+
+  @Test
+  void shouldPropagateRoutingForEachBulkDeleteOperation() throws IOException {
+    // given
+    final var docs =
+        List.of(
+            new IdWithRouting("4", "routing-4"),
+            new IdWithRouting("5", "routing-5"),
+            new IdWithRouting("6", "routing-6"));
+    when(client.bulk(any(BulkRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(bulkResponse("4", "5", "6")));
+
+    // when
+    final var deleted =
+        ((OpenSearchArchiverRepository) repository).deleteDocumentsById("from-index", docs).join();
+
+    // then
+    assertThat(deleted).isEqualTo(3L);
+
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(client).bulk(captor.capture());
+
+    final var operations = captor.getValue().operations();
+    assertThat(operations).hasSize(3);
+    assertThat(operations.get(0).delete().id()).isEqualTo("4");
+    assertThat(operations.get(0).delete().routing()).isEqualTo("routing-4");
+    assertThat(operations.get(1).delete().id()).isEqualTo("5");
+    assertThat(operations.get(1).delete().routing()).isEqualTo("routing-5");
+    assertThat(operations.get(2).delete().id()).isEqualTo("6");
+    assertThat(operations.get(2).delete().routing()).isEqualTo("routing-6");
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -200,7 +200,9 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
             CompletableFuture.completedFuture(searchResponse("4", "5", "6")),
             CompletableFuture.completedFuture(searchResponse()));
     when(client.reindex(any(ReindexRequest.class)))
-        .thenReturn(CompletableFuture.completedFuture(ReindexResponse.of(b -> b.total(3L))));
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                ReindexResponse.of(b -> b.total(3L).created(3L).updated(0L))));
     when(client.bulk(any(BulkRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(bulkResponse("4", "5", "6")));
 


### PR DESCRIPTION
## Description

Delete by ID (unlike the query) require routing hints unlike to route the delete operation to the right shard and we missed adding that. This was not caught in our testing as we almost always run tests with single shard.

Adding the routing by reading routing info provided when getting the IDs. Also switching archiver ITs to run with a few shards so that we can spot this sort of things earlier.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
