### PR TITLE
test: verify physical tenant REST isolation for process definitions and instances

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantRestIsolationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantRestIsolationIT.java
@@ -8,11 +8,11 @@
 package io.camunda.zeebe.it.physicaltenant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
@@ -20,11 +20,8 @@ import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Duration;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
@@ -47,9 +44,6 @@ final class PhysicalTenantRestIsolationIT {
   private final TestStandaloneBroker broker =
       TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
 
-  private final HttpClient httpClient = HttpClient.newHttpClient();
-  private final ObjectMapper objectMapper = new ObjectMapper();
-
   @Test
   void shouldIsolateProcessDefinitionsAndInstancesAcrossPhysicalTenantsOverRest() throws Exception {
     // given
@@ -62,7 +56,8 @@ final class PhysicalTenantRestIsolationIT {
 
     final long processDefinitionKey;
     final long processInstanceKey;
-    try (final CamundaClient tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build()) {
+    try (final CamundaClient tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+        final CamundaClient defaultClient = TENANTS.newClientBuilder(broker, DEFAULT).build()) {
       processDefinitionKey =
           await("deployment to tenant A succeeds")
               .atMost(Duration.ofSeconds(30))
@@ -87,51 +82,39 @@ final class PhysicalTenantRestIsolationIT {
               .send()
               .join()
               .getProcessInstanceKey();
+
+      // when
+      await("tenant A's process definition and instance are queryable over REST")
+          .atMost(Duration.ofSeconds(60))
+          .pollInterval(Duration.ofMillis(500))
+          .untilAsserted(
+              () -> {
+                assertThat(tenantAClient.newProcessDefinitionSearchRequest().send().join().items())
+                    .hasSize(1);
+                assertThat(tenantAClient.newProcessInstanceSearchRequest().send().join().items())
+                    .hasSize(1);
+              });
+
+      // then - the process definition is readable in tenant A but invisible to the default tenant
+      assertThat(tenantAClient.newProcessDefinitionGetRequest(processDefinitionKey).send().join())
+          .isNotNull();
+      assertNotFound(
+          () -> defaultClient.newProcessDefinitionGetRequest(processDefinitionKey).send().join());
+      assertThat(defaultClient.newProcessDefinitionSearchRequest().send().join().items()).isEmpty();
+
+      // and - the process instance is readable in tenant A but invisible to the default tenant
+      assertThat(tenantAClient.newProcessInstanceGetRequest(processInstanceKey).send().join())
+          .isNotNull();
+      assertNotFound(
+          () -> defaultClient.newProcessInstanceGetRequest(processInstanceKey).send().join());
+      assertThat(defaultClient.newProcessInstanceSearchRequest().send().join().items()).isEmpty();
     }
-
-    // when
-    await("tenant A's process definition and instance are queryable over REST")
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofMillis(500))
-        .untilAsserted(
-            () -> {
-              assertThat(searchCount(TENANT_A, "process-definitions")).isEqualTo(1);
-              assertThat(searchCount(TENANT_A, "process-instances")).isEqualTo(1);
-            });
-
-    // then - the process definition is readable in tenant A but invisible to the default tenant
-    assertThat(getStatus(TENANT_A, "process-definitions/" + processDefinitionKey)).isEqualTo(200);
-    assertThat(getStatus(DEFAULT, "process-definitions/" + processDefinitionKey)).isEqualTo(404);
-    assertThat(searchCount(DEFAULT, "process-definitions")).isZero();
-
-    // and - the process instance is readable in tenant A but invisible to the default tenant
-    assertThat(getStatus(TENANT_A, "process-instances/" + processInstanceKey)).isEqualTo(200);
-    assertThat(getStatus(DEFAULT, "process-instances/" + processInstanceKey)).isEqualTo(404);
-    assertThat(searchCount(DEFAULT, "process-instances")).isZero();
   }
 
-  private int getStatus(final String tenantId, final String path) throws Exception {
-    final HttpResponse<Void> response =
-        httpClient.send(
-            HttpRequest.newBuilder(uri(tenantId, path)).GET().build(),
-            HttpResponse.BodyHandlers.discarding());
-    return response.statusCode();
-  }
-
-  private int searchCount(final String tenantId, final String resource) throws Exception {
-    final HttpResponse<String> response =
-        httpClient.send(
-            HttpRequest.newBuilder(uri(tenantId, resource + "/search"))
-                .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString("{}"))
-                .build(),
-            HttpResponse.BodyHandlers.ofString());
-    assertThat(response.statusCode()).isEqualTo(200);
-    final JsonNode items = objectMapper.readTree(response.body()).get("items");
-    return items == null ? 0 : items.size();
-  }
-
-  private URI uri(final String tenantId, final String path) {
-    return URI.create(TENANTS.restBaseFor(broker, tenantId) + "/" + path);
+  private void assertNotFound(final ThrowingCallable callable) {
+    assertThatThrownBy(callable)
+        .isInstanceOf(ProblemException.class)
+        .extracting(t -> ((ProblemException) t).code())
+        .isEqualTo(404);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantRestIsolationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantRestIsolationIT.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+final class PhysicalTenantRestIsolationIT {
+
+  private static final String DEFAULT = PhysicalTenantsITHelper.DEFAULT_TENANT_ID;
+  private static final String TENANT_A = "tenanta";
+  private static final String JOB_TYPE = "task";
+  private static final String PROCESS_ID = "rest-isolation-process";
+
+  // both tenants use an isolated in-memory RDBMS so the REST query endpoints (which read from
+  // secondary storage) can serve process definitions and instances per tenant
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(DEFAULT, Storage.rdbmsH2("pt-default"))
+          .withTenant(TENANT_A, Storage.rdbmsH2("pt-tenanta"))
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  private final HttpClient httpClient = HttpClient.newHttpClient();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void shouldIsolateProcessDefinitionsAndInstancesAcrossPhysicalTenantsOverRest() throws Exception {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+
+    final long processDefinitionKey;
+    final long processInstanceKey;
+    try (final CamundaClient tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build()) {
+      processDefinitionKey =
+          await("deployment to tenant A succeeds")
+              .atMost(Duration.ofSeconds(30))
+              .ignoreExceptions()
+              .until(
+                  () ->
+                      tenantAClient
+                          .newDeployResourceCommand()
+                          .addProcessModel(process, PROCESS_ID + ".bpmn")
+                          .send()
+                          .join()
+                          .getProcesses()
+                          .get(0)
+                          .getProcessDefinitionKey(),
+                  key -> key > 0);
+
+      processInstanceKey =
+          tenantAClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId(PROCESS_ID)
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+    }
+
+    // when
+    await("tenant A's process definition and instance are queryable over REST")
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              assertThat(searchCount(TENANT_A, "process-definitions")).isEqualTo(1);
+              assertThat(searchCount(TENANT_A, "process-instances")).isEqualTo(1);
+            });
+
+    // then - the process definition is readable in tenant A but invisible to the default tenant
+    assertThat(getStatus(TENANT_A, "process-definitions/" + processDefinitionKey)).isEqualTo(200);
+    assertThat(getStatus(DEFAULT, "process-definitions/" + processDefinitionKey)).isEqualTo(404);
+    assertThat(searchCount(DEFAULT, "process-definitions")).isZero();
+
+    // and - the process instance is readable in tenant A but invisible to the default tenant
+    assertThat(getStatus(TENANT_A, "process-instances/" + processInstanceKey)).isEqualTo(200);
+    assertThat(getStatus(DEFAULT, "process-instances/" + processInstanceKey)).isEqualTo(404);
+    assertThat(searchCount(DEFAULT, "process-instances")).isZero();
+  }
+
+  private int getStatus(final String tenantId, final String path) throws Exception {
+    final HttpResponse<Void> response =
+        httpClient.send(
+            HttpRequest.newBuilder(uri(tenantId, path)).GET().build(),
+            HttpResponse.BodyHandlers.discarding());
+    return response.statusCode();
+  }
+
+  private int searchCount(final String tenantId, final String resource) throws Exception {
+    final HttpResponse<String> response =
+        httpClient.send(
+            HttpRequest.newBuilder(uri(tenantId, resource + "/search"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+    final JsonNode items = objectMapper.readTree(response.body()).get("items");
+    return items == null ? 0 : items.size();
+  }
+
+  private URI uri(final String tenantId, final String path) {
+    return URI.create(TENANTS.restBaseFor(broker, tenantId) + "/" + path);
+  }
+}


### PR DESCRIPTION
## What

M2 + M3 of the physical-tenant IT plan (#55350): a new `PhysicalTenantRestIsolationIT` proving process **definitions** and **instances** are isolated across physical tenants over the **REST API**.

A process is deployed and instantiated only in tenant A; then:
- Tenant A's scoped REST path (`/physical-tenants/tenanta/v2/...`) reads the definition and instance — by key (200) and via search (1 item).
- The default tenant's REST path cannot see them — `404` by key, empty search.

Covers both **M2** (REST correctly scopes operations to the requested physical tenant) and **M3** (cross-tenant isolation for process definitions and instances).

## Why it needs secondary storage

The REST query endpoints (`/v2/process-definitions`, `/v2/process-instances`) are `@RequiresSecondaryStorage` — they read from the exporter-populated store, not the broker. So each tenant is configured with its **own isolated in-memory RDBMS (H2)**, and the test awaits each tenant's exporter to populate before asserting.

The Java client can't scope REST calls to a physical tenant yet (`physicalTenantId` only affects gRPC), so the test issues **raw HTTP** against the `/physical-tenants/{id}/v2` path prefix.

## Helper changes

`PhysicalTenantsITHelper` gains:
- a `Storage` value object (`none()` / `rdbmsH2(name)`) so each tenant declares its own secondary storage, and
- `restBaseFor(gateway, tenantId)` to resolve a tenant's REST base URL.

The default tenant's storage is applied via the **typed** config API (`withSecondaryStorageType` + `withDataConfig`) because a raw property does not override the broker's default; non-default tenants are configured via `camunda.physical-tenants.<id>.*` properties.

## Base

Stacked on **#55469** (`el-55350-reusable-pt-cluster`, the M1 helper). Merge after / into that branch.

Relates to #55350. Part of epic #50532.

## Tech debt

Minor tech debt is added for the manual rest calls to tenant endpoints when CamundaClient supports physical tenant over rest then it can be migrated over https://github.com/camunda/camunda/issues/55498