### PR TITLE
Expose businessId on correlated message subscription search, filter, and sort

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/CorrelatedMessageSubscriptionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/CorrelatedMessageSubscriptionFilter.java
@@ -26,6 +26,24 @@ import java.util.function.Consumer;
 public interface CorrelatedMessageSubscriptionFilter extends SearchRequestFilter {
 
   /**
+   * Filter by business id.
+   *
+   * @param businessId the business id of the correlated message subscription
+   * @return the updated filter
+   */
+  CorrelatedMessageSubscriptionFilter businessId(String businessId);
+
+  /**
+   * Filter by business id using a {@link StringProperty} consumer. Supports advanced string
+   * operators including {@code $like} with wildcards.
+   *
+   * @param fn the business id {@link StringProperty} consumer for the correlated message
+   *     subscription
+   * @return the updated filter
+   */
+  CorrelatedMessageSubscriptionFilter businessId(Consumer<StringProperty> fn);
+
+  /**
    * Filter by correlation key.
    *
    * @param correlationKey the correlation key of the correlated message subscription

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/CorrelatedMessageSubscription.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/CorrelatedMessageSubscription.java
@@ -53,4 +53,15 @@ public interface CorrelatedMessageSubscription {
   Long getSubscriptionKey();
 
   String getTenantId();
+
+  /**
+   * Returns the business id of the correlated message. The business id enforces uniqueness of the
+   * process instance created by a message start event.
+   *
+   * <p><strong>Note:</strong> This field is {@code null} when the correlating message did not
+   * provide a business id, or for correlations to a catch, boundary, or intermediate event.
+   *
+   * @return the business id, or {@code null} if none was provided
+   */
+  String getBusinessId();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/CorrelatedMessageSubscription.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/CorrelatedMessageSubscription.java
@@ -55,13 +55,17 @@ public interface CorrelatedMessageSubscription {
   String getTenantId();
 
   /**
-   * Returns the business id of the correlated message. The business id enforces uniqueness of the
-   * process instance created by a message start event.
+   * Returns the business id associated with this correlated message subscription.
    *
-   * <p><strong>Note:</strong> This field is {@code null} when the correlating message did not
-   * provide a business id, or for correlations to a catch, boundary, or intermediate event.
+   * <p>For a message start event correlation, this is the business id carried by the correlating
+   * message, which was stamped on the started process instance to enforce its uniqueness. For a
+   * catch, boundary, or intermediate event correlation, this is the business id of the subscribing
+   * process instance, captured when the subscription was opened.
    *
-   * @return the business id, or {@code null} if none was provided
+   * <p><strong>Note:</strong> This field is {@code null} when the relevant process instance has no
+   * business id.
+   *
+   * @return the business id, or {@code null} if none applies
    */
   String getBusinessId();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/CorrelatedMessageSubscriptionSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/CorrelatedMessageSubscriptionSort.java
@@ -20,6 +20,8 @@ import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSo
 public interface CorrelatedMessageSubscriptionSort
     extends SearchRequestSort<CorrelatedMessageSubscriptionSort> {
 
+  CorrelatedMessageSubscriptionSort businessId();
+
   CorrelatedMessageSubscriptionSort correlationKey();
 
   CorrelatedMessageSubscriptionSort correlationTime();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/CorrelatedMessageSubscriptionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/CorrelatedMessageSubscriptionFilterImpl.java
@@ -40,6 +40,19 @@ public class CorrelatedMessageSubscriptionFilterImpl
   }
 
   @Override
+  public CorrelatedMessageSubscriptionFilter businessId(final String businessId) {
+    return businessId(f -> f.eq(businessId));
+  }
+
+  @Override
+  public CorrelatedMessageSubscriptionFilter businessId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setBusinessId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public CorrelatedMessageSubscriptionFilter correlationKey(final String correlationKey) {
     return correlationKey(f -> f.eq(correlationKey));
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/CorrelatedMessageSubscriptionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/CorrelatedMessageSubscriptionImpl.java
@@ -36,6 +36,7 @@ public class CorrelatedMessageSubscriptionImpl implements CorrelatedMessageSubsc
   private final Long rootProcessInstanceKey;
   private final Long subscriptionKey;
   private final String tenantId;
+  private final String businessId;
 
   public CorrelatedMessageSubscriptionImpl(final CorrelatedMessageSubscriptionResult item) {
     correlationKey = item.getCorrelationKey();
@@ -51,6 +52,7 @@ public class CorrelatedMessageSubscriptionImpl implements CorrelatedMessageSubsc
     rootProcessInstanceKey = ParseUtil.parseLongOrNull(item.getRootProcessInstanceKey());
     subscriptionKey = ParseUtil.parseLongOrNull(item.getSubscriptionKey());
     tenantId = item.getTenantId();
+    businessId = item.getBusinessId();
   }
 
   @Override
@@ -119,6 +121,11 @@ public class CorrelatedMessageSubscriptionImpl implements CorrelatedMessageSubsc
   }
 
   @Override
+  public String getBusinessId() {
+    return businessId;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(
         correlationKey,
@@ -133,7 +140,8 @@ public class CorrelatedMessageSubscriptionImpl implements CorrelatedMessageSubsc
         processInstanceKey,
         rootProcessInstanceKey,
         subscriptionKey,
-        tenantId);
+        tenantId,
+        businessId);
   }
 
   @Override
@@ -159,6 +167,7 @@ public class CorrelatedMessageSubscriptionImpl implements CorrelatedMessageSubsc
         && Objects.equals(
             rootProcessInstanceKey, correlatedMessageSubscription.rootProcessInstanceKey)
         && Objects.equals(subscriptionKey, correlatedMessageSubscription.subscriptionKey)
-        && Objects.equals(tenantId, correlatedMessageSubscription.tenantId);
+        && Objects.equals(tenantId, correlatedMessageSubscription.tenantId)
+        && Objects.equals(businessId, correlatedMessageSubscription.businessId);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/CorrelatedMessageSubscriptionSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/CorrelatedMessageSubscriptionSortImpl.java
@@ -23,6 +23,11 @@ public class CorrelatedMessageSubscriptionSortImpl
     implements CorrelatedMessageSubscriptionSort {
 
   @Override
+  public CorrelatedMessageSubscriptionSort businessId() {
+    return field("businessId");
+  }
+
+  @Override
   public CorrelatedMessageSubscriptionSort correlationKey() {
     return field("correlationKey");
   }

--- a/clients/java/src/test/java/io/camunda/client/message/SearchCorrelatedMessageSubscriptionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/message/SearchCorrelatedMessageSubscriptionTest.java
@@ -165,7 +165,9 @@ public class SearchCorrelatedMessageSubscriptionTest extends ClientRestTest {
                     .subscriptionKey()
                     .asc()
                     .tenantId()
-                    .desc())
+                    .desc()
+                    .businessId()
+                    .asc())
         .send()
         .join();
 
@@ -175,7 +177,7 @@ public class SearchCorrelatedMessageSubscriptionTest extends ClientRestTest {
     final List<SearchRequestSort> sorts =
         SearchRequestSortMapper.fromCorrelatedMessageSubscriptionSearchQuerySortRequest(
             Objects.requireNonNull(request.getSort()));
-    assertThat(sorts).hasSize(12);
+    assertThat(sorts).hasSize(13);
     assertSort(sorts.get(0), "correlationKey", SortOrderEnum.ASC);
     assertSort(sorts.get(1), "correlationTime", SortOrderEnum.ASC);
     assertSort(sorts.get(2), "elementId", SortOrderEnum.ASC);
@@ -188,6 +190,7 @@ public class SearchCorrelatedMessageSubscriptionTest extends ClientRestTest {
     assertSort(sorts.get(9), "processInstanceKey", SortOrderEnum.DESC);
     assertSort(sorts.get(10), "subscriptionKey", SortOrderEnum.ASC);
     assertSort(sorts.get(11), "tenantId", SortOrderEnum.DESC);
+    assertSort(sorts.get(12), "businessId", SortOrderEnum.ASC);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/message/SearchCorrelatedMessageSubscriptionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/message/SearchCorrelatedMessageSubscriptionTest.java
@@ -77,6 +77,7 @@ public class SearchCorrelatedMessageSubscriptionTest extends ClientRestTest {
                     .processDefinitionKey(654L)
                     .processInstanceKey(456L)
                     .subscriptionKey(987L)
+                    .businessId("business-id")
                     .tenantId("tenant-id"))
         .send()
         .join();
@@ -111,6 +112,27 @@ public class SearchCorrelatedMessageSubscriptionTest extends ClientRestTest {
     assertThat(request.getFilter().getSubscriptionKey().get$Eq()).isEqualTo("987");
     assertThat(request.getFilter().getTenantId()).isNotNull();
     assertThat(request.getFilter().getTenantId().get$Eq()).isEqualTo("tenant-id");
+    assertThat(request.getFilter().getBusinessId()).isNotNull();
+    assertThat(request.getFilter().getBusinessId().get$Eq()).isEqualTo("business-id");
+  }
+
+  @Test
+  void shouldSearchWithAdvancedBusinessIdFilter() {
+    // When
+    client
+        .newCorrelatedMessageSubscriptionSearchRequest()
+        .filter(f -> f.businessId(b -> b.like("order-*").neq("order-0").exists(true)))
+        .send()
+        .join();
+
+    // Then
+    final CorrelatedMessageSubscriptionSearchQuery request =
+        gatewayService.getLastRequest(CorrelatedMessageSubscriptionSearchQuery.class);
+    assertThat(request.getFilter()).isNotNull();
+    assertThat(request.getFilter().getBusinessId()).isNotNull();
+    assertThat(request.getFilter().getBusinessId().get$Like()).isEqualTo("order-*");
+    assertThat(request.getFilter().getBusinessId().get$Neq()).isEqualTo("order-0");
+    assertThat(request.getFilter().getBusinessId().get$Exists()).isTrue();
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/message/SearchCorrelatedMessageSubscriptionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/message/SearchCorrelatedMessageSubscriptionTest.java
@@ -19,15 +19,21 @@ import static io.camunda.client.util.assertions.SortAssert.assertSort;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import io.camunda.client.api.search.response.CorrelatedMessageSubscription;
+import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
+import io.camunda.client.protocol.rest.CorrelatedMessageSubscriptionResult;
 import io.camunda.client.protocol.rest.CorrelatedMessageSubscriptionSearchQuery;
+import io.camunda.client.protocol.rest.CorrelatedMessageSubscriptionSearchQueryResult;
+import io.camunda.client.protocol.rest.SearchQueryPageResponse;
 import io.camunda.client.protocol.rest.SortOrderEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
@@ -160,5 +166,53 @@ public class SearchCorrelatedMessageSubscriptionTest extends ClientRestTest {
     assertSort(sorts.get(9), "processInstanceKey", SortOrderEnum.DESC);
     assertSort(sorts.get(10), "subscriptionKey", SortOrderEnum.ASC);
     assertSort(sorts.get(11), "tenantId", SortOrderEnum.DESC);
+  }
+
+  @Test
+  void shouldMapBusinessIdInResponse() {
+    // Given
+    final CorrelatedMessageSubscriptionResult item = new CorrelatedMessageSubscriptionResult();
+    item.setMessageKey("123");
+    item.setSubscriptionKey("987");
+    item.setBusinessId("order-12345");
+    gatewayService.onSearchCorrelatedMessageSubscriptionsRequest(buildResponseWith(item));
+
+    // When
+    final SearchResponse<CorrelatedMessageSubscription> response =
+        client.newCorrelatedMessageSubscriptionSearchRequest().send().join();
+
+    // Then
+    assertThat(response.items()).hasSize(1);
+    assertThat(response.items().get(0).getBusinessId()).isEqualTo("order-12345");
+  }
+
+  @Test
+  void shouldMapNullBusinessIdInResponse() {
+    // Given
+    final CorrelatedMessageSubscriptionResult item = new CorrelatedMessageSubscriptionResult();
+    item.setMessageKey("123");
+    item.setSubscriptionKey("987");
+    item.setBusinessId(null);
+    gatewayService.onSearchCorrelatedMessageSubscriptionsRequest(buildResponseWith(item));
+
+    // When
+    final SearchResponse<CorrelatedMessageSubscription> response =
+        client.newCorrelatedMessageSubscriptionSearchRequest().send().join();
+
+    // Then
+    assertThat(response.items()).hasSize(1);
+    assertThat(response.items().get(0).getBusinessId()).isNull();
+  }
+
+  private static CorrelatedMessageSubscriptionSearchQueryResult buildResponseWith(
+      final CorrelatedMessageSubscriptionResult item) {
+    final CorrelatedMessageSubscriptionSearchQueryResult response =
+        new CorrelatedMessageSubscriptionSearchQueryResult();
+    final SearchQueryPageResponse page = new SearchQueryPageResponse();
+    page.setTotalItems(1L);
+    response.setPage(page);
+    response.setItems(new ArrayList<>());
+    response.addItemsItem(item);
+    return response;
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -118,6 +118,8 @@ public class RestGatewayPaths {
   private static final String URL_AUDIT_LOG_SEARCH = REST_API_PATH + "/audit-logs/search";
   private static final String URL_ELEMENT_INSTANCE_WAIT_STATE_SEARCH =
       REST_API_PATH + "/element-instances/wait-states/search";
+  private static final String URL_CORRELATED_MESSAGE_SUBSCRIPTIONS_SEARCH =
+      REST_API_PATH + "/correlated-message-subscriptions/search";
   private static final String URL_PROCESS_DEFINITION_INSTANCE_STATISTICS =
       REST_API_PATH + "/process-definitions/statistics/process-instances";
   private static final String URL_PROCESS_DEFINITION_INSTANCE_VERSION_STATISTICS =
@@ -442,6 +444,10 @@ public class RestGatewayPaths {
 
   public static String getElementInstanceWaitStateSearchUrl() {
     return URL_ELEMENT_INSTANCE_WAIT_STATE_SEARCH;
+  }
+
+  public static String getCorrelatedMessageSubscriptionsSearchUrl() {
+    return URL_CORRELATED_MESSAGE_SUBSCRIPTIONS_SEARCH;
   }
 
   public static String getUserTaskAuditLogSearchUrl(final long userTaskKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -489,6 +489,12 @@ public class RestGatewayService {
     registerPost(RestGatewayPaths.getElementInstanceWaitStateSearchUrl(), response);
   }
 
+  public void onSearchCorrelatedMessageSubscriptionsRequest(
+      final io.camunda.client.protocol.rest.CorrelatedMessageSubscriptionSearchQueryResult
+          response) {
+    registerPost(RestGatewayPaths.getCorrelatedMessageSubscriptionsSearchUrl(), response);
+  }
+
   public void onSearchUserTaskAuditLogRequest(
       final long userTaskKey, final AuditLogSearchQueryResult response) {
     registerPost(RestGatewayPaths.getUserTaskAuditLogSearchUrl(userTaskKey), response);

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -403,4 +403,15 @@
     </createTable>
   </changeSet>
 
+  <changeSet id="add_business_id_to_correlated_message_subscription" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}CORRELATED_MESSAGE_SUBSCRIPTION" columnName="BUSINESS_ID"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}CORRELATED_MESSAGE_SUBSCRIPTION">
+      <column name="BUSINESS_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapper.java
@@ -31,6 +31,7 @@ public class CorrelatedMessageSubscriptionEntityMapper {
         .subscriptionKey(dbModel.subscriptionKey())
         .subscriptionType(dbModel.subscriptionType())
         .tenantId(nullToEmpty(dbModel.tenantId()))
+        .businessId(dbModel.businessId())
         .build();
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/CorrelatedMessageSubscriptionSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/CorrelatedMessageSubscriptionSearchColumn.java
@@ -11,6 +11,7 @@ import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 
 public enum CorrelatedMessageSubscriptionSearchColumn
     implements SearchColumn<CorrelatedMessageSubscriptionEntity> {
+  BUSINESS_ID("businessId"),
   CORRELATION_KEY("correlationKey"),
   CORRELATION_TIME("correlationTime"),
   FLOW_NODE_ID("flowNodeId"),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/CorrelatedMessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/CorrelatedMessageSubscriptionDbModel.java
@@ -26,7 +26,8 @@ public record CorrelatedMessageSubscriptionDbModel(
     Long rootProcessInstanceKey,
     Long subscriptionKey,
     MessageSubscriptionType subscriptionType,
-    String tenantId)
+    String tenantId,
+    String businessId)
     implements DbModel<CorrelatedMessageSubscriptionDbModel> {
 
   @Override
@@ -51,7 +52,8 @@ public record CorrelatedMessageSubscriptionDbModel(
                 .rootProcessInstanceKey(rootProcessInstanceKey)
                 .subscriptionKey(subscriptionKey)
                 .subscriptionType(subscriptionType)
-                .tenantId(tenantId))
+                .tenantId(tenantId)
+                .businessId(businessId))
         .build();
   }
 
@@ -70,6 +72,7 @@ public record CorrelatedMessageSubscriptionDbModel(
     private Long subscriptionKey;
     private MessageSubscriptionType subscriptionType;
     private String tenantId;
+    private String businessId;
 
     public Builder() {}
 
@@ -143,6 +146,11 @@ public record CorrelatedMessageSubscriptionDbModel(
       return this;
     }
 
+    public Builder businessId(final String businessId) {
+      this.businessId = businessId;
+      return this;
+    }
+
     @Override
     public CorrelatedMessageSubscriptionDbModel build() {
       return new CorrelatedMessageSubscriptionDbModel(
@@ -159,7 +167,8 @@ public record CorrelatedMessageSubscriptionDbModel(
           rootProcessInstanceKey,
           subscriptionKey,
           subscriptionType,
-          tenantId);
+          tenantId,
+          businessId);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
@@ -28,6 +28,7 @@
       <idArg column="SUBSCRIPTION_KEY" javaType="java.lang.Long"/>
       <arg column="SUBSCRIPTION_TYPE" javaType="io.camunda.search.entities.CorrelatedMessageSubscriptionEntity$MessageSubscriptionType" />
       <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="BUSINESS_ID" javaType="java.lang.String"/>
     </constructor>
   </resultMap>
 
@@ -46,7 +47,8 @@
       ROOT_PROCESS_INSTANCE_KEY,
       SUBSCRIPTION_KEY,
       SUBSCRIPTION_TYPE,
-      TENANT_ID
+      TENANT_ID,
+      BUSINESS_ID
     )
     VALUES (
       #{correlationKey},
@@ -62,7 +64,8 @@
       #{rootProcessInstanceKey},
       #{subscriptionKey},
       #{subscriptionType},
-      #{tenantId}
+      #{tenantId},
+      #{businessId}
     )
   </insert>
 
@@ -92,7 +95,8 @@
         ROOT_PROCESS_INSTANCE_KEY,
         SUBSCRIPTION_KEY,
         SUBSCRIPTION_TYPE,
-        TENANT_ID
+        TENANT_ID,
+        BUSINESS_ID
       FROM ${prefix}CORRELATED_MESSAGE_SUBSCRIPTION
     <include refid="io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper.searchAndAuthFilter"/>
     ) t

--- a/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
@@ -126,6 +126,12 @@
 
   <sql id="searchFilter">
     <!-- basic filter -->
+    <if test="filter.businessIdOperations != null and !filter.businessIdOperations.isEmpty()">
+      <foreach collection="filter.businessIdOperations" item="operation">
+        AND BUSINESS_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
     <if test="filter.correlationKeyOperations != null and !filter.correlationKeyOperations.isEmpty()">
       <foreach collection="filter.correlationKeyOperations" item="operation">
         AND CORRELATION_KEY

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapperTest.java
@@ -35,6 +35,7 @@ public class CorrelatedMessageSubscriptionEntityMapperTest {
             .subscriptionKey(321L)
             .subscriptionType(MessageSubscriptionType.PROCESS_EVENT)
             .tenantId("tenantId")
+            .businessId("testBusinessId")
             .build();
 
     // When
@@ -80,5 +81,6 @@ public class CorrelatedMessageSubscriptionEntityMapperTest {
         .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
     assertThat(entity.tenantId())
         .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.businessId()).isNull(); // nullable field is passed through unchanged
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -1161,6 +1161,9 @@ public class SearchQueryFilterMapper {
     final List<String> validationErrors = new ArrayList<>();
 
     if (filter != null) {
+      ofNullable(filter.getBusinessId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::businessIdOperations);
       ofNullable(filter.getCorrelationKey())
           .map(mapToStringOperations())
           .ifPresent(builder::correlationKeyOperations);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1280,6 +1280,7 @@ public final class SearchQueryResponseMapper {
   private static CorrelatedMessageSubscriptionResult toCorrelatedMessageSubscription(
       final CorrelatedMessageSubscriptionEntity correlatedMessageSubscription) {
     return CorrelatedMessageSubscriptionResult.Builder.create()
+        .businessId(correlatedMessageSubscription.businessId())
         .correlationKey(correlatedMessageSubscription.correlationKey())
         .correlationTime(formatDate(correlatedMessageSubscription.correlationTime()))
         .elementId(correlatedMessageSubscription.flowNodeId())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -930,6 +930,7 @@ public class SearchQuerySortRequestMapper {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
+        case BUSINESS_ID -> builder.businessId();
         case CORRELATION_KEY -> builder.correlationKey();
         case CORRELATION_TIME -> builder.correlationTime();
         case ELEMENT_ID -> builder.flowNodeId();

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -556,6 +556,66 @@ class SearchQueryResponseMapperTest {
   }
 
   @Test
+  void shouldMapBusinessIdForCorrelatedMessageSubscription() {
+    // given
+    final var entity =
+        CorrelatedMessageSubscriptionEntity.builder()
+            .correlationKey("corrKey")
+            .correlationTime(OffsetDateTime.now())
+            .flowNodeId("messageCatch")
+            .flowNodeInstanceKey(111L)
+            .messageKey(222L)
+            .messageName("testMessage")
+            .partitionId(1)
+            .processDefinitionId("processId")
+            .processDefinitionKey(456L)
+            .processInstanceKey(789L)
+            .rootProcessInstanceKey(999L)
+            .subscriptionKey(333L)
+            .tenantId("tenant")
+            .businessId("order-12345")
+            .build();
+
+    // when
+    final var subscriptions =
+        SearchQueryResponseMapper.toCorrelatedMessageSubscriptionSearchQueryResponse(
+            new SearchQueryResult<CorrelatedMessageSubscriptionEntity>(
+                1, false, List.of(entity), null, null));
+
+    // then
+    assertThat(subscriptions.getItems().getFirst().getBusinessId()).isEqualTo("order-12345");
+  }
+
+  @Test
+  void shouldMapNullBusinessIdForCorrelatedMessageSubscription() {
+    // given
+    final var entity =
+        CorrelatedMessageSubscriptionEntity.builder()
+            .correlationKey("corrKey")
+            .correlationTime(OffsetDateTime.now())
+            .flowNodeId("flowNode")
+            .messageKey(222L)
+            .messageName("testMessage")
+            .partitionId(1)
+            .processDefinitionId("processId")
+            .processDefinitionKey(456L)
+            .processInstanceKey(789L)
+            .subscriptionKey(333L)
+            .tenantId("tenant")
+            .businessId(null)
+            .build();
+
+    // when
+    final var subscriptions =
+        SearchQueryResponseMapper.toCorrelatedMessageSubscriptionSearchQueryResponse(
+            new SearchQueryResult<CorrelatedMessageSubscriptionEntity>(
+                1, false, List.of(entity), null, null));
+
+    // then
+    assertThat(subscriptions.getItems().getFirst().getBusinessId()).isNull();
+  }
+
+  @Test
   void shouldMapRootProcessInstanceKeyForSequenceFlow() {
     // given
     final var entity =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CorrelatedMessageSubscriptionBusinessIdSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CorrelatedMessageSubscriptionBusinessIdSearchIT.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Verifies the businessId carried by a message-start-event correlation flows end to end (engine ->
- * exporter -> secondary storage -> search API) and can be read back and filtered on every secondary
- * storage backend.
+ * exporter -> secondary storage -> search API) and can be read back, filtered, and sorted on every
+ * secondary storage backend.
  *
  * <p>Intentionally a plain {@code @MultiDbTest} (not {@code @CompatibilityTest}): the start-event
  * businessId is new in 8.10, so it cannot be asserted against an older broker that does not emit
@@ -108,6 +108,33 @@ public class CorrelatedMessageSubscriptionBusinessIdSearchIT {
 
     // then
     assertThat(searchResponse.items()).isEmpty();
+  }
+
+  @Test
+  void shouldSortByBusinessId() {
+    // when ascending
+    final var ascending =
+        camundaClient
+            .newCorrelatedMessageSubscriptionSearchRequest()
+            .sort(s -> s.businessId().asc())
+            .send()
+            .join();
+
+    // when descending
+    final var descending =
+        camundaClient
+            .newCorrelatedMessageSubscriptionSearchRequest()
+            .sort(s -> s.businessId().desc())
+            .send()
+            .join();
+
+    // then
+    assertThat(ascending.items())
+        .extracting(CorrelatedMessageSubscription::getBusinessId)
+        .containsExactly(BUSINESS_ID_A, BUSINESS_ID_B);
+    assertThat(descending.items())
+        .extracting(CorrelatedMessageSubscription::getBusinessId)
+        .containsExactly(BUSINESS_ID_B, BUSINESS_ID_A);
   }
 
   private static void startProcessViaMessageStartWithBusinessId(final String businessId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CorrelatedMessageSubscriptionBusinessIdSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CorrelatedMessageSubscriptionBusinessIdSearchIT.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.waitForCorrelatedMessageSubscriptions;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.CorrelatedMessageSubscription;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the businessId carried by a message-start-event correlation flows end to end (engine ->
+ * exporter -> secondary storage -> search API) and can be read back and filtered on every secondary
+ * storage backend.
+ *
+ * <p>Intentionally a plain {@code @MultiDbTest} (not {@code @CompatibilityTest}): the start-event
+ * businessId is new in 8.10, so it cannot be asserted against an older broker that does not emit
+ * it.
+ */
+@MultiDbTest
+public class CorrelatedMessageSubscriptionBusinessIdSearchIT {
+
+  private static final String START_MESSAGE_NAME = "Start";
+  private static final String BUSINESS_ID_A = "order-100";
+  private static final String BUSINESS_ID_B = "order-200";
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    deployResource(
+        camundaClient, "process/process_with_message_start_and_parallel_receive_tasks.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    // start two instances through the message start event, each carrying a distinct business id
+    startProcessViaMessageStartWithBusinessId(BUSINESS_ID_A);
+    startProcessViaMessageStartWithBusinessId(BUSINESS_ID_B);
+
+    waitForProcessInstancesToStart(camundaClient, 2);
+    // only the two start-event correlations are CORRELATED; the receive-task subscriptions stay
+    // CREATED and therefore do not show up in the correlated-message search
+    waitForCorrelatedMessageSubscriptions(camundaClient, 2);
+  }
+
+  @Test
+  void shouldExposeBusinessIdOnStartEventCorrelation() {
+    // when
+    final var searchResponse =
+        camundaClient.newCorrelatedMessageSubscriptionSearchRequest().send().join();
+
+    // then
+    assertThat(searchResponse.items())
+        .extracting(CorrelatedMessageSubscription::getBusinessId)
+        .containsExactlyInAnyOrder(BUSINESS_ID_A, BUSINESS_ID_B);
+  }
+
+  @Test
+  void shouldFilterByBusinessIdEquals() {
+    // when
+    final var searchResponse =
+        camundaClient
+            .newCorrelatedMessageSubscriptionSearchRequest()
+            .filter(f -> f.businessId(BUSINESS_ID_A))
+            .send()
+            .join();
+
+    // then
+    assertThat(searchResponse.items()).hasSize(1);
+    assertThat(searchResponse.items().getFirst().getBusinessId()).isEqualTo(BUSINESS_ID_A);
+  }
+
+  @Test
+  void shouldFilterByBusinessIdLikeWildcard() {
+    // when
+    final var searchResponse =
+        camundaClient
+            .newCorrelatedMessageSubscriptionSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("order-*")))
+            .send()
+            .join();
+
+    // then
+    assertThat(searchResponse.items())
+        .extracting(CorrelatedMessageSubscription::getBusinessId)
+        .containsExactlyInAnyOrder(BUSINESS_ID_A, BUSINESS_ID_B);
+  }
+
+  @Test
+  void shouldReturnEmptyForNonMatchingBusinessId() {
+    // when
+    final var searchResponse =
+        camundaClient
+            .newCorrelatedMessageSubscriptionSearchRequest()
+            .filter(f -> f.businessId("does-not-exist"))
+            .send()
+            .join();
+
+    // then
+    assertThat(searchResponse.items()).isEmpty();
+  }
+
+  private static void startProcessViaMessageStartWithBusinessId(final String businessId) {
+    camundaClient
+        .newCorrelateMessageCommand()
+        .messageName(START_MESSAGE_NAME)
+        .withoutCorrelationKey()
+        .businessId(businessId)
+        .execute();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CorrelatedMessageSubscriptionCatchEventBusinessIdSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CorrelatedMessageSubscriptionCatchEventBusinessIdSearchIT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.waitForCorrelatedMessageSubscriptions;
+import static io.camunda.it.util.TestHelper.waitForMessageSubscriptions;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.CorrelatedMessageSubscription;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the businessId of the subscribing process instance flows end to end (engine ->
+ * exporter -> secondary storage -> search API) for non-start correlations to a catch / boundary /
+ * intermediate event, not only for message-start-event correlations. The businessId is captured
+ * from the process instance at subscription-open time and carried onto the {@code
+ * ProcessMessageSubscription:CORRELATED} event, so the correlated-message search exposes it for
+ * these correlations too.
+ *
+ * <p>Intentionally a plain {@code @MultiDbTest} (not {@code @CompatibilityTest}): carrying the
+ * subscribing instance's businessId onto the catch-event correlation is new in 8.10, so it cannot
+ * be asserted against an older broker that does not emit it.
+ */
+@MultiDbTest
+public class CorrelatedMessageSubscriptionCatchEventBusinessIdSearchIT {
+
+  private static final String START_MESSAGE_NAME = "Start";
+  private static final String BUSINESS_ID = "catch-order-1";
+  private static final int RECEIVE_TASK_COUNT = 3;
+  // one start-event correlation + one per correlated receive task
+  private static final int EXPECTED_CORRELATIONS = RECEIVE_TASK_COUNT + 1;
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    deployResource(
+        camundaClient, "process/process_with_message_start_and_parallel_receive_tasks.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    // start a single instance through the message start event carrying a business id; the instance
+    // then waits on the three parallel receive tasks, whose subscriptions capture that business id
+    camundaClient
+        .newCorrelateMessageCommand()
+        .messageName(START_MESSAGE_NAME)
+        .withoutCorrelationKey()
+        .businessId(BUSINESS_ID)
+        .execute();
+    waitForProcessInstancesToStart(camundaClient, 1);
+    waitForMessageSubscriptions(camundaClient, RECEIVE_TASK_COUNT);
+
+    // correlate each receive-task message to the waiting instance
+    for (int i = 1; i <= RECEIVE_TASK_COUNT; i++) {
+      camundaClient
+          .newCorrelateMessageCommand()
+          .messageName("Test" + i)
+          .correlationKey("correlation_key_" + i)
+          .send()
+          .join();
+    }
+
+    waitForCorrelatedMessageSubscriptions(camundaClient, EXPECTED_CORRELATIONS);
+  }
+
+  @Test
+  void shouldExposeBusinessIdOnCatchEventCorrelations() {
+    // when
+    final var searchResponse =
+        camundaClient.newCorrelatedMessageSubscriptionSearchRequest().send().join();
+
+    // then every correlation — the start event and the three catch events — carries the subscribing
+    // instance's business id
+    assertThat(searchResponse.items())
+        .hasSize(EXPECTED_CORRELATIONS)
+        .allSatisfy(s -> assertThat(s.getBusinessId()).isEqualTo(BUSINESS_ID));
+
+    // and specifically the catch-event correlations (identified by a non-null elementInstanceKey,
+    // which start-event correlations do not have) carry it — this is the path that previously
+    // dropped the business id
+    assertThat(searchResponse.items())
+        .filteredOn(s -> s.getElementInstanceKey() != null)
+        .hasSize(RECEIVE_TASK_COUNT)
+        .allSatisfy(s -> assertThat(s.getBusinessId()).isEqualTo(BUSINESS_ID));
+  }
+
+  @Test
+  void shouldFilterCatchEventCorrelationsByBusinessId() {
+    // when
+    final var searchResponse =
+        camundaClient
+            .newCorrelatedMessageSubscriptionSearchRequest()
+            .filter(f -> f.businessId(BUSINESS_ID))
+            .send()
+            .join();
+
+    // then all correlations are returned, including the catch-event ones
+    assertThat(searchResponse.items())
+        .hasSize(EXPECTED_CORRELATIONS)
+        .extracting(CorrelatedMessageSubscription::getBusinessId)
+        .containsOnly(BUSINESS_ID);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
@@ -81,6 +81,31 @@ public class CorrelatedMessageSubscriptionIT {
   }
 
   @TestTemplate
+  public void shouldFindCorrelatedMessageSubscriptionByBusinessId(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final CorrelatedMessageSubscriptionDbReader reader =
+        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+
+    final var original = CorrelatedMessageSubscriptionFixtures.createRandomized(b -> b);
+    createAndSaveCorrelatedMessageSubscription(rdbmsWriters, original);
+    createAndSaveRandomCorrelatedMessageSubscriptions(rdbmsWriters);
+
+    final var searchResult =
+        reader.search(
+            CorrelatedMessageSubscriptionQuery.of(
+                b ->
+                    b.filter(f -> f.businessIds(original.businessId()))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(10))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().businessId()).isEqualTo(original.businessId());
+  }
+
+  @TestTemplate
   public void shouldFindCorrelatedMessageSubscriptionByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -206,6 +231,7 @@ public class CorrelatedMessageSubscriptionIT {
                                     .processDefinitionIds(original.processDefinitionId())
                                     .processDefinitionKeys(original.processDefinitionKey())
                                     .subscriptionKeys(original.subscriptionKey())
+                                    .businessIds(original.businessId())
                                     .tenantIds(original.tenantId()))
                         .sort(s -> s)
                         .page(p -> p.from(0).size(5))));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
@@ -286,6 +286,61 @@ public class CorrelatedMessageSubscriptionIT {
   }
 
   @TestTemplate
+  public void shouldFindCorrelatedMessageSubscriptionWithSearchAfterByNullableBusinessId(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final CorrelatedMessageSubscriptionDbReader reader =
+        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+
+    final var processDefinitionKey = nextKey();
+    // 16 subscriptions without a businessId and 4 with one. Sorted ascending, businessId is
+    // NULLS FIRST on every database, so the 15-row page boundary (and therefore the keyset
+    // cursor) falls on a null businessId - exercising the nullable keyset path.
+    createAndSaveRandomCorrelatedMessageSubscriptions(
+        rdbmsWriters, 16, b -> b.processDefinitionKey(processDefinitionKey).businessId(null));
+    createAndSaveRandomCorrelatedMessageSubscriptions(
+        rdbmsWriters, 4, b -> b.processDefinitionKey(processDefinitionKey));
+
+    final var sort = CorrelatedMessageSubscriptionSort.of(s -> s.businessId().asc());
+    final var allItems =
+        reader.search(
+            CorrelatedMessageSubscriptionQuery.of(
+                b ->
+                    b.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                        .sort(sort)
+                        .page(p -> p.from(0).size(20))));
+
+    final var firstPage =
+        reader.search(
+            CorrelatedMessageSubscriptionQuery.of(
+                b ->
+                    b.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                        .sort(sort)
+                        .page(p -> p.size(15))));
+
+    final var nextPage =
+        reader.search(
+            CorrelatedMessageSubscriptionQuery.of(
+                b ->
+                    b.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                        .sort(sort)
+                        .page(p -> p.size(5).after(firstPage.endCursor()))));
+
+    // the whole result is ordered nulls-first by businessId
+    assertThat(allItems.items())
+        .extracting(CorrelatedMessageSubscriptionEntity::businessId)
+        .isSortedAccordingTo(Comparator.nullsFirst(Comparator.naturalOrder()));
+    // the cursor boundary sits on a null businessId
+    assertThat(firstPage.items()).hasSize(15);
+    assertThat(firstPage.items().get(14).businessId()).isNull();
+    // paging continues correctly across the null -> non-null boundary from a null cursor
+    assertThat(nextPage.total()).isEqualTo(20);
+    assertThat(nextPage.items()).hasSize(5);
+    assertThat(nextPage.items()).isEqualTo(allItems.items().subList(15, 20));
+  }
+
+  @TestTemplate
   public void shouldSortByBusinessId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
@@ -362,5 +362,6 @@ public class CorrelatedMessageSubscriptionIT {
     assertThat(actual.rootProcessInstanceKey()).isEqualTo(expected.rootProcessInstanceKey());
     assertThat(actual.subscriptionKey()).isEqualTo(expected.subscriptionKey());
     assertThat(actual.tenantId()).isEqualTo(expected.tenantId());
+    assertThat(actual.businessId()).isEqualTo(expected.businessId());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
@@ -24,6 +24,7 @@ import io.camunda.search.sort.CorrelatedMessageSubscriptionSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
@@ -282,6 +283,41 @@ public class CorrelatedMessageSubscriptionIT {
     assertThat(nextPage.total()).isEqualTo(20);
     assertThat(nextPage.items()).hasSize(5);
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
+  }
+
+  @TestTemplate
+  public void shouldSortByBusinessId(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final CorrelatedMessageSubscriptionDbReader reader =
+        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+
+    final var processDefinitionKey = nextKey();
+    createAndSaveRandomCorrelatedMessageSubscriptions(
+        rdbmsWriters, b -> b.processDefinitionKey(processDefinitionKey));
+
+    final var ascending =
+        reader.search(
+            CorrelatedMessageSubscriptionQuery.of(
+                b ->
+                    b.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                        .sort(s -> s.businessId().asc())
+                        .page(p -> p.from(0).size(20))));
+
+    final var descending =
+        reader.search(
+            CorrelatedMessageSubscriptionQuery.of(
+                b ->
+                    b.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                        .sort(s -> s.businessId().desc())
+                        .page(p -> p.from(0).size(20))));
+
+    assertThat(ascending.items())
+        .extracting(CorrelatedMessageSubscriptionEntity::businessId)
+        .isSortedAccordingTo(String::compareTo);
+    assertThat(descending.items())
+        .extracting(CorrelatedMessageSubscriptionEntity::businessId)
+        .isSortedAccordingTo(Comparator.reverseOrder());
   }
 
   @TestTemplate

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CorrelatedMessageSubscriptionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CorrelatedMessageSubscriptionFixtures.java
@@ -37,7 +37,8 @@ public final class CorrelatedMessageSubscriptionFixtures extends CommonFixtures 
             .processDefinitionKey(nextKey())
             .processInstanceKey(nextKey())
             .rootProcessInstanceKey(nextKey())
-            .tenantId("tenant-" + generateRandomString(10));
+            .tenantId("tenant-" + generateRandomString(10))
+            .businessId("biz-" + generateRandomString(10));
     return builderFunction.apply(builder).build();
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -1024,6 +1024,8 @@ class RdbmsExporterIT {
         .isEqualTo(recordValue.getProcessInstanceKey());
     assertThat(correlatedMessageSubscription.get().rootProcessInstanceKey())
         .isEqualTo(recordValue.getRootProcessInstanceKey());
+    assertThat(correlatedMessageSubscription.get().businessId())
+        .isEqualTo(recordValue.getBusinessId());
   }
 
   @Test
@@ -1052,6 +1054,8 @@ class RdbmsExporterIT {
         .isEqualTo(processInstanceKey);
     assertThat(correlatedMessageSubscription.get().rootProcessInstanceKey())
         .isEqualTo(processInstanceKey);
+    assertThat(correlatedMessageSubscription.get().businessId())
+        .isEqualTo(recordValue.getBusinessId());
   }
 
   @Test

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/CorrelatedMessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/CorrelatedMessageSubscriptionEntityTransformer.java
@@ -33,7 +33,8 @@ public class CorrelatedMessageSubscriptionEntityTransformer
         value.getRootProcessInstanceKey(),
         value.getSubscriptionKey(),
         toMessageSubscriptionType(value.getSubscriptionType()),
-        value.getTenantId());
+        value.getTenantId(),
+        value.getBusinessId());
   }
 
   private MessageSubscriptionType toMessageSubscriptionType(final String value) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/CorrelatedMessageSubscriptionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/CorrelatedMessageSubscriptionFilterTransformer.java
@@ -30,6 +30,7 @@ public class CorrelatedMessageSubscriptionFilterTransformer
   @Override
   public SearchQuery toSearchQuery(final CorrelatedMessageSubscriptionFilter filter) {
     return and(
+        stringOperations(BUSINESS_ID, filter.businessIdOperations()),
         stringOperations(CORRELATION_KEY, filter.correlationKeyOperations()),
         dateTimeOperations(CORRELATION_TIME, filter.correlationTimeOperations()),
         stringOperations(FLOW_NODE_ID, filter.flowNodeIdOperations()),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/CorrelatedMessageSubscriptionFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/CorrelatedMessageSubscriptionFieldSortingTransformer.java
@@ -15,6 +15,7 @@ public class CorrelatedMessageSubscriptionFieldSortingTransformer
   @Override
   public String apply(final String domainField) {
     return switch (domainField) {
+      case "businessId" -> BUSINESS_ID;
       case "correlationKey" -> CORRELATION_KEY;
       case "correlationTime" -> CORRELATION_TIME;
       case "flowNodeId" -> FLOW_NODE_ID;

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/CorrelatedMessageSubscriptionQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/CorrelatedMessageSubscriptionQueryTransformerTest.java
@@ -69,6 +69,13 @@ public class CorrelatedMessageSubscriptionQueryTransformerTest extends AbstractT
             (Function<
                     CorrelatedMessageSubscriptionFilter.Builder,
                     ObjectBuilder<CorrelatedMessageSubscriptionFilter>>)
+                b -> b.businessIds("biz1"),
+            "businessId",
+            "biz1"),
+        Arguments.of(
+            (Function<
+                    CorrelatedMessageSubscriptionFilter.Builder,
+                    ObjectBuilder<CorrelatedMessageSubscriptionFilter>>)
                 b -> b.correlationKeys("key1"),
             "correlationKey",
             "key1"),

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/CorrelatedMessageSubscriptionSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/CorrelatedMessageSubscriptionSortTest.java
@@ -24,6 +24,7 @@ public class CorrelatedMessageSubscriptionSortTest extends AbstractSortTransform
 
   private static Stream<Arguments> provideSortParameters() {
     return Stream.of(
+        new TestArguments("businessId", SortOrder.ASC, s -> s.businessId().asc()),
         new TestArguments("correlationKey", SortOrder.ASC, s -> s.correlationKey().asc()),
         new TestArguments("correlationTime", SortOrder.ASC, s -> s.correlationTime().asc()),
         new TestArguments("flowNodeId", SortOrder.ASC, s -> s.flowNodeId().asc()),

--- a/search/search-domain/src/main/java/io/camunda/search/entities/CorrelatedMessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/CorrelatedMessageSubscriptionEntity.java
@@ -27,7 +27,8 @@ public record CorrelatedMessageSubscriptionEntity(
     @Nullable Long rootProcessInstanceKey,
     Long subscriptionKey,
     @Nullable MessageSubscriptionType subscriptionType,
-    String tenantId)
+    String tenantId,
+    @Nullable String businessId)
     implements TenantOwnedEntity {
 
   public CorrelatedMessageSubscriptionEntity {
@@ -62,6 +63,7 @@ public record CorrelatedMessageSubscriptionEntity(
     private @Nullable Long subscriptionKey;
     private @Nullable MessageSubscriptionType subscriptionType;
     private @Nullable String tenantId;
+    private @Nullable String businessId;
 
     public Builder correlationKey(final String correlationKey) {
       this.correlationKey = correlationKey;
@@ -133,6 +135,11 @@ public record CorrelatedMessageSubscriptionEntity(
       return this;
     }
 
+    public Builder businessId(final String businessId) {
+      this.businessId = businessId;
+      return this;
+    }
+
     @SuppressWarnings("NullAway")
     public CorrelatedMessageSubscriptionEntity build() {
       return new CorrelatedMessageSubscriptionEntity(
@@ -149,7 +156,8 @@ public record CorrelatedMessageSubscriptionEntity(
           rootProcessInstanceKey,
           subscriptionKey,
           subscriptionType,
-          tenantId);
+          tenantId,
+          businessId);
     }
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/CorrelatedMessageSubscriptionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/CorrelatedMessageSubscriptionFilter.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 
 public record CorrelatedMessageSubscriptionFilter(
+    List<Operation<String>> businessIdOperations,
     List<Operation<String>> correlationKeyOperations,
     List<Operation<OffsetDateTime>> correlationTimeOperations,
     List<Operation<String>> flowNodeIdOperations,
@@ -36,6 +37,7 @@ public record CorrelatedMessageSubscriptionFilter(
       new CorrelatedMessageSubscriptionFilter.Builder().build();
 
   public static final class Builder implements ObjectBuilder<CorrelatedMessageSubscriptionFilter> {
+    private List<Operation<String>> businessIdOperations;
     private List<Operation<String>> correlationKeyOperations;
     private List<Operation<OffsetDateTime>> correlationTimeOperations;
     private List<Operation<String>> flowNodeIdOperations;
@@ -48,6 +50,21 @@ public record CorrelatedMessageSubscriptionFilter(
     private List<Operation<Long>> processInstanceKeyOperations;
     private List<Operation<Long>> subscriptionKeyOperations;
     private List<Operation<String>> tenantIdOperations;
+
+    public Builder businessIdOperations(final List<Operation<String>> operations) {
+      businessIdOperations = addValuesToList(businessIdOperations, operations);
+      return this;
+    }
+
+    public Builder businessIds(final String value, final String... values) {
+      return businessIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder businessIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return businessIdOperations(collectValues(operation, operations));
+    }
 
     public Builder correlationKeyOperations(final List<Operation<String>> operations) {
       correlationKeyOperations = addValuesToList(correlationKeyOperations, operations);
@@ -232,6 +249,7 @@ public record CorrelatedMessageSubscriptionFilter(
     @Override
     public CorrelatedMessageSubscriptionFilter build() {
       return new CorrelatedMessageSubscriptionFilter(
+          Objects.requireNonNullElse(businessIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(correlationKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(correlationTimeOperations, Collections.emptyList()),
           Objects.requireNonNullElse(flowNodeIdOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/sort/CorrelatedMessageSubscriptionSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/CorrelatedMessageSubscriptionSort.java
@@ -31,6 +31,11 @@ public record CorrelatedMessageSubscriptionSort(List<FieldSorting> orderings)
       extends SortOption.AbstractBuilder<CorrelatedMessageSubscriptionSort.Builder>
       implements ObjectBuilder<CorrelatedMessageSubscriptionSort> {
 
+    public Builder businessId() {
+      currentOrdering = new FieldSorting("businessId", null);
+      return this;
+    }
+
     public Builder correlationKey() {
       currentOrdering = new FieldSorting("correlationKey", null);
       return this;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/CorrelatedMessageSubscriptionTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/CorrelatedMessageSubscriptionTemplate.java
@@ -22,6 +22,7 @@ public class CorrelatedMessageSubscriptionTemplate extends AbstractTemplateDescr
   public static final String ID = "id";
 
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
+  public static final String BUSINESS_ID = "businessId";
   public static final String CORRELATION_KEY = "correlationKey";
   public static final String CORRELATION_TIME = "correlationTime";
   public static final String FLOW_NODE_ID = "flowNodeId";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/CorrelatedMessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/CorrelatedMessageSubscriptionEntity.java
@@ -37,6 +37,10 @@ public class CorrelatedMessageSubscriptionEntity
   @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long rootProcessInstanceKey;
 
+  /** Attention! This field will be filled in only for data imported after v. 8.10.0. */
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String businessId;
+
   @Override
   public String getId() {
     return id;
@@ -190,6 +194,15 @@ public class CorrelatedMessageSubscriptionEntity
     return this;
   }
 
+  public String getBusinessId() {
+    return businessId;
+  }
+
+  public CorrelatedMessageSubscriptionEntity setBusinessId(final String businessId) {
+    this.businessId = businessId;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -207,7 +220,8 @@ public class CorrelatedMessageSubscriptionEntity
         processInstanceKey,
         subscriptionKey,
         subscriptionType,
-        tenantId);
+        tenantId,
+        businessId);
   }
 
   @Override
@@ -234,7 +248,8 @@ public class CorrelatedMessageSubscriptionEntity
         && Objects.equals(processInstanceKey, that.processInstanceKey)
         && Objects.equals(subscriptionType, that.subscriptionType)
         && Objects.equals(tenantId, that.tenantId)
-        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey);
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey)
+        && Objects.equals(businessId, that.businessId);
   }
 
   @Override
@@ -278,6 +293,9 @@ public class CorrelatedMessageSubscriptionEntity
         + '\''
         + ", rootProcessInstanceKey="
         + rootProcessInstanceKey
+        + ", businessId='"
+        + businessId
+        + '\''
         + '}';
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-correlated-message-subscription.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-correlated-message-subscription.json
@@ -50,6 +50,9 @@
       },
       "rootProcessInstanceKey": {
         "type": "long"
+      },
+      "businessId": {
+        "type": "keyword"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-correlated-message-subscription.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-correlated-message-subscription.json
@@ -50,6 +50,9 @@
       },
       "rootProcessInstanceKey": {
         "type": "long"
+      },
+      "businessId": {
+        "type": "keyword"
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -205,6 +205,7 @@ public final class EventHandle {
         .setCorrelationKey(correlationKey)
         .setMessageKey(messageKey)
         .setMessageName(messageName)
+        .setBusinessId(businessId)
         .setVariables(variables)
         .setTenantId(subscription.getTenantId());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
@@ -111,6 +111,7 @@ public final class MessageStartProcessInstanceRequestStartProcessor
           .setCorrelationKey(reply.getCorrelationKeyBuffer())
           .setMessageKey(reply.getMessageKey())
           .setMessageName(reply.getMessageNameBuffer())
+          .setBusinessId(reply.getBusinessIdBuffer())
           .setVariables(reply.getVariablesBuffer())
           .setTenantId(reply.getTenantId());
       stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -128,7 +128,13 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
     record
         .setElementId(subscriptionRecord.getElementIdBuffer())
         .setInterrupting(subscriptionRecord.isInterrupting())
-        .setRootProcessInstanceKey(subscriptionRecord.getRootProcessInstanceKey());
+        .setRootProcessInstanceKey(subscriptionRecord.getRootProcessInstanceKey())
+        // The correlate command sent from the message partition does not carry the businessId; it
+        // was captured from the subscribing process instance at subscription-open time and
+        // persisted on the subscription.
+        // Copy it onto the CORRELATED event so the correlated-message read path can expose the
+        // businessId for catch / boundary / intermediate correlations too.
+        .setBusinessId(subscriptionRecord.getBusinessIdBuffer());
 
     stateWriter.appendFollowUpEvent(
         subscription.getKey(), ProcessMessageSubscriptionIntent.CORRELATED, record);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationBusinessIdTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
@@ -312,6 +313,59 @@ public final class MessageCorrelationBusinessIdTest {
         .withBusinessId("biz-42")
         .publish();
     assertProcessCompleted(processInstanceKey);
+  }
+
+  // --- Pinning: the process instance's businessId (captured at OPEN) is carried onto the
+  // --- ProcessMessageSubscription:CORRELATED event, so the correlated-message read path can expose
+  // --- it for non-start correlations. The correlate command itself carries no businessId.
+
+  @Test
+  public void shouldRecordProcessInstanceBusinessIdOnCatchCorrelation() {
+    // given a PI with businessId "biz-42" waiting on an intermediate catch event
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-10")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when a message without a businessId correlates (asymmetric rule: it still correlates)
+    engine.message().withName("message").withCorrelationKey("order-10").publish();
+
+    // then the CORRELATED event carries the subscribing PI's businessId, not the message's (empty)
+    final var correlated =
+        RecordingExporter.processMessageSubscriptionRecords(
+                ProcessMessageSubscriptionIntent.CORRELATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(correlated.getValue().getBusinessId()).isEqualTo("biz-42");
+  }
+
+  @Test
+  public void shouldRecordEmptyBusinessIdOnCatchCorrelationWhenProcessInstanceHasNone() {
+    // given a PI without a businessId waiting on an intermediate catch event
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("key", "order-11")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when a message correlates
+    engine.message().withName("message").withCorrelationKey("order-11").publish();
+
+    // then the CORRELATED event carries an empty businessId (no regression for the none path)
+    final var correlated =
+        RecordingExporter.processMessageSubscriptionRecords(
+                ProcessMessageSubscriptionIntent.CORRELATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(correlated.getValue().getBusinessId()).isEmpty();
   }
 
   private static BpmnModelInstance processWithIntermediateCatch(final String processId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventCorrelatedBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventCorrelatedBusinessIdTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Pins that the {@code businessId} carried by a message is recorded on the {@code
+ * MessageStartEventSubscription:CORRELATED} event when the message correlates to a start event
+ * locally (single partition, so {@code P_B == P_K} and the start is triggered through {@link
+ * io.camunda.zeebe.engine.processing.common.EventHandle#triggerMessageStartEvent}). The recorded
+ * value is what the secondary-storage read path later exposes for start-event correlations.
+ */
+public final class MessageStartEventCorrelatedBusinessIdTest {
+
+  private static final String PROCESS_ID = "wf";
+  private static final String MESSAGE_NAME = "start-msg";
+
+  private static final BpmnModelInstance MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("start")
+          .message(MESSAGE_NAME)
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .done();
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Test
+  public void shouldRecordBusinessIdOnStartEventCorrelation() {
+    // given
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+
+    // when
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-1")
+        .publish();
+
+    // then
+    final var correlated =
+        RecordingExporter.messageStartEventSubscriptionRecords(
+                MessageStartEventSubscriptionIntent.CORRELATED)
+            .withMessageName(MESSAGE_NAME)
+            .getFirst();
+    assertThat(correlated.getValue().getBusinessId()).isEqualTo("biz-1");
+  }
+
+  @Test
+  public void shouldRecordEmptyBusinessIdWhenMessageHasNone() {
+    // given
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+
+    // when
+    engine.message().withName(MESSAGE_NAME).withCorrelationKey("").publish();
+
+    // then
+    final var correlated =
+        RecordingExporter.messageStartEventSubscriptionRecords(
+                MessageStartEventSubscriptionIntent.CORRELATED)
+            .withMessageName(MESSAGE_NAME)
+            .getFirst();
+    assertThat(correlated.getValue().getBusinessId()).isEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionCorrelatedBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceCrossPartitionCorrelatedBusinessIdTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Cross-partition counterpart of {@link MessageStartEventCorrelatedBusinessIdTest}: when a
+ * message-start publish lands on {@code P_K} but its {@code businessId} hashes to a different
+ * partition {@code P_B}, the start is delegated to {@code P_B} and the {@code
+ * MessageStartEventSubscription:CORRELATED} event is written back on {@code P_K} by {@link
+ * io.camunda.zeebe.engine.processing.message.MessageStartProcessInstanceRequestStartProcessor}.
+ * This pins that the delegated reply still carries the published {@code businessId} onto that
+ * event.
+ *
+ * <p>The constants are chosen so {@code hash(correlationKey) != hash(businessId)}; an
+ * {@code @Before} precondition fails loudly if a future hash change degenerates the scenario into a
+ * single-partition path.
+ */
+public final class MessageStartProcessInstanceCrossPartitionCorrelatedBusinessIdTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  // hash("ck-1") -> P_K=1 and hash("biz-1") -> P_B=3 under PARTITION_COUNT=3, re-asserted in
+  // @Before.
+  private static final String CORRELATION_KEY = "ck-1";
+  private static final String BUSINESS_ID = "biz-1";
+
+  private static final String PROCESS_ID = "wf-cross";
+  private static final String MESSAGE_NAME = "start-msg-cross";
+
+  private static final BpmnModelInstance MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("start")
+          .message(MESSAGE_NAME)
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .done();
+
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+
+  @Before
+  public void assertCrossPartitionRouting() {
+    assertThat(partitionFor(CORRELATION_KEY))
+        .as("CORRELATION_KEY and BUSINESS_ID must hash to different partitions")
+        .isNotEqualTo(partitionFor(BUSINESS_ID));
+  }
+
+  @Test
+  public void shouldRecordBusinessIdOnCrossPartitionStartCorrelation() {
+    // given
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CREATED)
+        .withMessageName(MESSAGE_NAME)
+        .limit(PARTITION_COUNT)
+        .asList();
+
+    // when a message-start publish lands on P_K but its businessId hashes to P_B
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .publish();
+
+    // then the CORRELATED event written back on P_K by the reply processor carries the businessId
+    final var correlated =
+        RecordingExporter.messageStartEventSubscriptionRecords(
+                MessageStartEventSubscriptionIntent.CORRELATED)
+            .withMessageName(MESSAGE_NAME)
+            .getFirst();
+    assertThat(correlated.getValue().getBusinessId()).isEqualTo(BUSINESS_ID);
+  }
+
+  private static int partitionFor(final String key) {
+    return SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString(key), PARTITION_COUNT);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.exporter.utils.ExporterUtil.emptyToNull;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.webapps.schema.entities.CorrelatedMessageSubscriptionEntity;
@@ -65,6 +66,7 @@ public class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandl
         .setMessageName(value.getMessageName())
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
         .setProcessInstanceKey(value.getProcessInstanceKey())
+        .setBusinessId(emptyToNull(value.getBusinessId()))
         .setSubscriptionType("START_EVENT")
         .setTenantId(tenantOrDefault(value.getTenantId()));
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.exporter.utils.ExporterUtil.emptyToNull;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.webapps.schema.entities.CorrelatedMessageSubscriptionEntity;
@@ -65,6 +66,7 @@ public class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler
         .setMessageName(value.getMessageName())
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
         .setProcessInstanceKey(value.getProcessInstanceKey())
+        .setBusinessId(emptyToNull(value.getBusinessId()))
         .setSubscriptionType("PROCESS_EVENT")
         .setTenantId(tenantOrDefault(value.getTenantId()));
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -137,6 +137,7 @@ final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandle
     final String tenantId = "tenantId";
     final String messageName = "messageName";
     final String correlationKey = "correlationKey";
+    final String businessId = "businessId";
     final Intent intent = MessageStartEventSubscriptionIntent.CORRELATED;
     final var recordValue =
         ImmutableMessageStartEventSubscriptionRecordValue.builder()
@@ -148,6 +149,7 @@ final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandle
             .withProcessInstanceKey(processInstanceKey)
             .withProcessDefinitionKey(processDefinitionKey)
             .withTenantId(tenantId)
+            .withBusinessId(businessId)
             .build();
     final Record<MessageStartEventSubscriptionRecordValue> record =
         factory.generateRecord(
@@ -183,6 +185,7 @@ final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandle
     assertThat(entity.getSubscriptionKey()).isEqualTo(recordKey);
     assertThat(entity.getSubscriptionType()).isEqualTo("START_EVENT");
     assertThat(entity.getTenantId()).isEqualTo(tenantId);
+    assertThat(entity.getBusinessId()).isEqualTo(businessId);
   }
 
   @Test
@@ -209,6 +212,28 @@ final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandle
 
     // then
     assertThat(entity.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  void shouldMapEmptyBusinessIdToNull() {
+    // given
+    final var recordValue =
+        ImmutableMessageStartEventSubscriptionRecordValue.builder().withBusinessId("").build();
+    final Record<MessageStartEventSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
+            r ->
+                r.withIntent(MessageStartEventSubscriptionIntent.CORRELATED)
+                    .withValue(recordValue));
+
+    final CorrelatedMessageSubscriptionEntity entity =
+        underTest.createNewEntity(underTest.generateIds(record).getFirst());
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getBusinessId()).isNull();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -138,6 +138,7 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
     final String tenantId = "tenantId";
     final String messageName = "messageName";
     final String correlationKey = "correlationKey";
+    final String businessId = "businessId";
     final Intent intent = ProcessMessageSubscriptionIntent.CORRELATED;
     final var recordValue =
         ImmutableProcessMessageSubscriptionRecordValue.builder()
@@ -151,6 +152,7 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
             .withProcessInstanceKey(processInstanceKey)
             .withTenantId(tenantId)
             .withRootProcessInstanceKey(rootProcessInstanceKey)
+            .withBusinessId(businessId)
             .build();
     final Record<ProcessMessageSubscriptionRecordValue> record =
         factory.generateRecord(
@@ -187,6 +189,27 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
     assertThat(entity.getSubscriptionType()).isEqualTo("PROCESS_EVENT");
     assertThat(entity.getTenantId()).isEqualTo(tenantId);
     assertThat(entity.getRootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
+    assertThat(entity.getBusinessId()).isEqualTo(businessId);
+  }
+
+  @Test
+  void shouldMapEmptyBusinessIdToNull() {
+    // given
+    final var recordValue =
+        ImmutableProcessMessageSubscriptionRecordValue.builder().withBusinessId("").build();
+    final Record<ProcessMessageSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+            r -> r.withIntent(ProcessMessageSubscriptionIntent.CORRELATED).withValue(recordValue));
+
+    final CorrelatedMessageSubscriptionEntity entity =
+        underTest.createNewEntity(underTest.generateIds(record).getFirst());
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getBusinessId()).isNull();
   }
 
   @Test

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-start-event-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-start-event-subscription-template.json
@@ -40,6 +40,9 @@
             "messageKey": {
               "type": "long"
             },
+            "businessId": {
+              "type": "keyword"
+            },
             "variables": {
               "enabled": false
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-start-event-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-start-event-subscription-template.json
@@ -46,6 +46,9 @@
             "messageKey": {
               "type": "long"
             },
+            "businessId": {
+              "type": "keyword"
+            },
             "variables": {
               "enabled": false
             },

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.rdbms.handlers;
 
+import static io.camunda.exporter.rdbms.utils.ExportUtil.emptyToNull;
 import static io.camunda.exporter.rdbms.utils.ExportUtil.tenantOrDefault;
 
 import io.camunda.db.rdbms.write.domain.CorrelatedMessageSubscriptionDbModel.Builder;
@@ -46,6 +47,7 @@ public class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionExpor
         // processes started via message are always root process instances
         .rootProcessInstanceKey(value.getProcessInstanceKey())
         .subscriptionType(MessageSubscriptionType.START_EVENT)
+        .businessId(emptyToNull(value.getBusinessId()))
         .tenantId(tenantOrDefault(value.getTenantId()));
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionExportHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.rdbms.handlers;
 
+import static io.camunda.exporter.rdbms.utils.ExportUtil.emptyToNull;
 import static io.camunda.exporter.rdbms.utils.ExportUtil.tenantOrDefault;
 
 import io.camunda.db.rdbms.write.domain.CorrelatedMessageSubscriptionDbModel.Builder;
@@ -45,6 +46,7 @@ public class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionExportHa
         .processInstanceKey(value.getProcessInstanceKey())
         .rootProcessInstanceKey(value.getRootProcessInstanceKey())
         .subscriptionType(MessageSubscriptionType.PROCESS_EVENT)
+        .businessId(emptyToNull(value.getBusinessId()))
         .tenantId(tenantOrDefault(value.getTenantId()));
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -96,6 +96,7 @@ final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandle
     final String tenantId = "tenantId";
     final String messageName = "messageName";
     final String correlationKey = "correlationKey";
+    final String businessId = "businessId";
     final Intent intent = MessageStartEventSubscriptionIntent.CORRELATED;
     final var recordValue =
         ImmutableMessageStartEventSubscriptionRecordValue.builder()
@@ -107,6 +108,7 @@ final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandle
             .withProcessInstanceKey(processInstanceKey)
             .withProcessDefinitionKey(processDefinitionKey)
             .withTenantId(tenantId)
+            .withBusinessId(businessId)
             .build();
     final Record<MessageStartEventSubscriptionRecordValue> record =
         factory.generateRecord(
@@ -141,6 +143,7 @@ final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandle
     assertThat(entity.subscriptionKey()).isEqualTo(recordKey);
     assertThat(entity.subscriptionType()).isEqualTo(MessageSubscriptionType.START_EVENT);
     assertThat(entity.tenantId()).isEqualTo(tenantId);
+    assertThat(entity.businessId()).isEqualTo(businessId);
   }
 
   @Test
@@ -167,5 +170,32 @@ final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandle
     verify(correlatedMessageSubscriptionWriter).create(itemCaptor.capture());
     final CorrelatedMessageSubscriptionDbModel entity = itemCaptor.getValue();
     assertThat(entity.tenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  void shouldMapEmptyBusinessIdToNull() {
+    // given
+    final long recordKey = 789;
+    final long messageKey = 555;
+    final Intent intent = MessageStartEventSubscriptionIntent.CORRELATED;
+
+    final var recordValue =
+        ImmutableMessageStartEventSubscriptionRecordValue.builder()
+            .withMessageKey(messageKey)
+            .withBusinessId("")
+            .build();
+    final Record<MessageStartEventSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
+            r -> r.withIntent(intent).withKey(recordKey).withValue(recordValue));
+
+    // when
+    underTest.export(record);
+
+    // then
+    final var itemCaptor = ArgumentCaptor.forClass(CorrelatedMessageSubscriptionDbModel.class);
+    verify(correlatedMessageSubscriptionWriter).create(itemCaptor.capture());
+    final CorrelatedMessageSubscriptionDbModel entity = itemCaptor.getValue();
+    assertThat(entity.businessId()).isNull();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -96,6 +96,7 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
     final String tenantId = "tenantId";
     final String messageName = "messageName";
     final String correlationKey = "correlationKey";
+    final String businessId = "businessId";
     final Intent intent = ProcessMessageSubscriptionIntent.CORRELATED;
     final var recordValue =
         ImmutableProcessMessageSubscriptionRecordValue.builder()
@@ -108,6 +109,7 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
             .withMessageName(messageName)
             .withProcessInstanceKey(processInstanceKey)
             .withTenantId(tenantId)
+            .withBusinessId(businessId)
             .build();
     final Record<ProcessMessageSubscriptionRecordValue> record =
         factory.generateRecord(
@@ -142,6 +144,7 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
     assertThat(entity.subscriptionKey()).isEqualTo(recordKey);
     assertThat(entity.subscriptionType()).isEqualTo(MessageSubscriptionType.PROCESS_EVENT);
     assertThat(entity.tenantId()).isEqualTo(tenantId);
+    assertThat(entity.businessId()).isEqualTo(businessId);
   }
 
   @Test
@@ -166,5 +169,32 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
     verify(correlatedMessageSubscriptionWriter).create(itemCaptor.capture());
     final CorrelatedMessageSubscriptionDbModel entity = itemCaptor.getValue();
     assertThat(entity.tenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  void shouldMapEmptyBusinessIdToNull() {
+    // given
+    final long recordKey = 789;
+    final long messageKey = 555;
+    final Intent intent = ProcessMessageSubscriptionIntent.CORRELATED;
+
+    final var recordValue =
+        ImmutableProcessMessageSubscriptionRecordValue.builder()
+            .withMessageKey(messageKey)
+            .withBusinessId("")
+            .build();
+    final Record<ProcessMessageSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+            r -> r.withIntent(intent).withKey(recordKey).withValue(recordValue));
+
+    // when
+    underTest.export(record);
+
+    // then
+    final var itemCaptor = ArgumentCaptor.forClass(CorrelatedMessageSubscriptionDbModel.class);
+    verify(correlatedMessageSubscriptionWriter).create(itemCaptor.capture());
+    final CorrelatedMessageSubscriptionDbModel entity = itemCaptor.getValue();
+    assertThat(entity.businessId()).isNull();
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -701,6 +701,7 @@ components:
           description: The field to sort by.
           type: string
           enum:
+            - businessId
             - correlationKey
             - correlationTime
             - elementId

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -608,10 +608,12 @@ components:
       properties:
         businessId:
           description: |
-            The business id of the correlated message. It enforces uniqueness of the process
-            instance created by a message start event. It is `null` when the correlating message
-            did not provide a business id, or for correlations to a catch, boundary, or
-            intermediate event.
+            The business id associated with this correlated message subscription. For a message
+            start event correlation, it is the business id carried by the correlating message that
+            was stamped on the started process instance to enforce its uniqueness. For a catch,
+            boundary, or intermediate event correlation, it is the business id of the subscribing
+            process instance, captured when the subscription was opened. It is `null` when the
+            relevant process instance has no business id.
           nullable: true
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
@@ -757,8 +759,10 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: |
-            The business id of the correlated message. Supports advanced string filtering, including
-            `$like` with `*`/`?` wildcards.
+            Filter by the business id stored on the correlated message subscription — for message
+            start event correlations the correlating message's business id, and for catch, boundary,
+            or intermediate event correlations the subscribing process instance's business id.
+            Supports advanced string filtering, including `$like` with `*`/`?` wildcards.
         correlationKey:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -752,6 +752,12 @@ components:
       description: Correlated message subscriptions search filter.
       type: object
       properties:
+        businessId:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: |
+            The business id of the correlated message. Supports advanced string filtering, including
+            `$like` with `*`/`?` wildcards.
         correlationKey:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
@@ -800,6 +806,9 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The tenant ID associated with this correlated message subscription.
+      x-properties-added-in-version:
+        - propertyName: businessId
+          addedInVersion: "8.10"
 
     MessageSubscriptionTypeFilterProperty:
       description: MessageSubscriptionTypeEnum with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -591,6 +591,7 @@ components:
     CorrelatedMessageSubscriptionResult:
       type: object
       required:
+        - businessId
         - correlationKey
         - correlationTime
         - elementId
@@ -605,6 +606,15 @@ components:
         - elementInstanceKey
         - processDefinitionKey
       properties:
+        businessId:
+          description: |
+            The business id of the correlated message. It enforces uniqueness of the process
+            instance created by a message start event. It is `null` when the correlating message
+            did not provide a business id, or for correlations to a catch, boundary, or
+            intermediate event.
+          nullable: true
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
         correlationKey:
           description: The correlation key of the message.
           nullable: true
@@ -665,6 +675,8 @@ components:
       x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
+        - propertyName: businessId
+          addedInVersion: "8.10"
 
     CorrelatedMessageSubscriptionSearchQuery:
       type: object

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.query.CorrelatedMessageSubscriptionQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -108,7 +109,8 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                   "processInstanceKey": "2251799813685849",
                   "subscriptionKey": "2251799813685860",
                   "tenantId": "test-tenant",
-                  "rootProcessInstanceKey": null
+                  "rootProcessInstanceKey": null,
+                  "businessId": "order-12345"
                 }
             ],
             "page": {
@@ -140,6 +142,7 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                           .processInstanceKey(2251799813685849L)
                           .subscriptionKey(2251799813685860L)
                           .tenantId("test-tenant")
+                          .businessId("order-12345")
                           .build()))
               .startCursor("WzIyNTE3OTk4MTM2ODU4Mjld")
               .endCursor("WzIyNTE3OTk4MTM2ODU4NjZd")
@@ -453,6 +456,7 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
             """
             {
               "filter": {
+                "businessId": "order-12345",
                 "correlationKey": "test",
                   "correlationTime": "2025-07-05T12:11:00.975Z",
                   "elementId": "Activity_1ludhs2",
@@ -481,7 +485,8 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                 new CorrelatedMessageSubscriptionQuery.Builder()
                     .filter(
                         f ->
-                            f.correlationKeys("test")
+                            f.businessIds("order-12345")
+                                .correlationKeys("test")
                                 .correlationTimes(OffsetDateTime.parse("2025-07-05T12:11:00.975Z"))
                                 .flowNodeIds("Activity_1ludhs2")
                                 .flowNodeInstanceKeys(2251799813685853L)
@@ -493,6 +498,46 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                                 .processInstanceKeys(2251799813685849L)
                                 .subscriptionKeys(2251799813685860L)
                                 .tenantIds("test-tenant"))
+                    .build()),
+            any());
+  }
+
+  @Test
+  public void shouldSearchCorrelatedWithAdvancedBusinessIdFilter() {
+    // given
+    when(services.searchCorrelated(any(), any())).thenReturn(SEARCH_CORRELATED_QUERY_RESULT);
+
+    // when / then
+    webClient
+        .post()
+        .uri(CORRELATED_MESSAGE_SUBSCRIPTIONS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "businessId": { "$like": "order-*", "$neq": "order-0", "$exists": true }
+              }
+            }""")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_CORRELATED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(services)
+        .searchCorrelated(
+            eq(
+                new CorrelatedMessageSubscriptionQuery.Builder()
+                    .filter(
+                        f ->
+                            f.businessIdOperations(
+                                Operation.neq("order-0"),
+                                Operation.exists(true),
+                                Operation.like("order-*")))
                     .build()),
             any());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -558,6 +558,10 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
             {
               "sort": [
                 {
+                  "field": "businessId",
+                  "order": "asc"
+                },
+                {
                   "field": "correlationKey",
                   "order": "asc"
                 },
@@ -621,7 +625,9 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                 new CorrelatedMessageSubscriptionQuery.Builder()
                     .sort(
                         s ->
-                            s.correlationKey()
+                            s.businessId()
+                                .asc()
+                                .correlationKey()
                                 .asc()
                                 .correlationTime()
                                 .desc()

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
@@ -33,6 +33,7 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue MESSAGE_KEY_KEY = new StringValue("messageKey");
   private static final StringValue CORRELATION_KEY_KEY = new StringValue("correlationKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
 
@@ -46,12 +47,13 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty messageKeyProp = new LongProperty(MESSAGE_KEY_KEY, -1L);
   private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY, "");
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
   private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageStartEventSubscriptionRecord() {
-    super(9);
+    super(10);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(startEventIdProp)
@@ -59,6 +61,7 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
         .declareProperty(processInstanceKeyProp)
         .declareProperty(messageKeyProp)
         .declareProperty(correlationKeyProp)
+        .declareProperty(businessIdProp)
         .declareProperty(variablesProp)
         .declareProperty(tenantIdProp);
   }
@@ -71,6 +74,7 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
     processInstanceKeyProp.setValue(record.getProcessInstanceKey());
     messageKeyProp.setValue(record.getMessageKey());
     correlationKeyProp.setValue(record.getCorrelationKeyBuffer());
+    businessIdProp.setValue(record.getBusinessIdBuffer());
     variablesProp.setValue(record.getVariablesBuffer());
     tenantIdProp.setValue(record.getTenantId());
   }
@@ -127,6 +131,21 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
 
   public MessageStartEventSubscriptionRecord setCorrelationKey(final DirectBuffer correlationKey) {
     correlationKeyProp.setValue(correlationKey);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+  public MessageStartEventSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1354,6 +1354,7 @@ final class JsonSerializableToJsonTest {
                   .setProcessInstanceKey(2L)
                   .setMessageKey(3L)
                   .setCorrelationKey(wrapString("test-key"))
+                  .setBusinessId(wrapString("test-business-id"))
                   .setVariables(VARIABLES_MSGPACK);
             },
         """
@@ -1365,6 +1366,7 @@ final class JsonSerializableToJsonTest {
                   "processInstanceKey": 2,
                   "messageKey": 3,
                   "correlationKey": "test-key",
+                  "businessId": "test-business-id",
                   "variables": {
                     "foo": "bar"
                   },
@@ -1396,6 +1398,7 @@ final class JsonSerializableToJsonTest {
                   "processInstanceKey": -1,
                   "messageKey": -1,
                   "correlationKey": "",
+                  "businessId": "",
                   "variables": {},
                   "tenantId": "<default>"
                 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageStartEventSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageStartEventSubscriptionRecord.golden
@@ -33,6 +33,7 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue MESSAGE_KEY_KEY = new StringValue("messageKey");
   private static final StringValue CORRELATION_KEY_KEY = new StringValue("correlationKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
 
@@ -46,12 +47,13 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty messageKeyProp = new LongProperty(MESSAGE_KEY_KEY, -1L);
   private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY, "");
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
   private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageStartEventSubscriptionRecord() {
-    super(9);
+    super(10);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(startEventIdProp)
@@ -59,6 +61,7 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
         .declareProperty(processInstanceKeyProp)
         .declareProperty(messageKeyProp)
         .declareProperty(correlationKeyProp)
+        .declareProperty(businessIdProp)
         .declareProperty(variablesProp)
         .declareProperty(tenantIdProp);
   }
@@ -71,6 +74,7 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
     processInstanceKeyProp.setValue(record.getProcessInstanceKey());
     messageKeyProp.setValue(record.getMessageKey());
     correlationKeyProp.setValue(record.getCorrelationKeyBuffer());
+    businessIdProp.setValue(record.getBusinessIdBuffer());
     variablesProp.setValue(record.getVariablesBuffer());
     tenantIdProp.setValue(record.getTenantId());
   }
@@ -127,6 +131,21 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
 
   public MessageStartEventSubscriptionRecord setCorrelationKey(final DirectBuffer correlationKey) {
     correlationKeyProp.setValue(correlationKey);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+  public MessageStartEventSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageStartEventSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageStartEventSubscriptionRecordValue.java
@@ -67,4 +67,12 @@ public interface MessageStartEventSubscriptionRecordValue
    *     subscription. Otherwise, it returns -1.
    */
   long getMessageKey();
+
+  /**
+   * @return the business id carried by the message that correlated to this subscription. It is only
+   *     set when a message is correlated to this subscription, and it becomes the business id of
+   *     the process instance created by the start event. Otherwise, it returns an empty string.
+   * @since 8.10
+   */
+  String getBusinessId();
 }


### PR DESCRIPTION
## Description

Extends the correlated message subscription search API to expose, filter, and sort by `businessId` — the identifier that enforces uniqueness of process instances created via message start events.

### What changed

**Protocol & engine layer**
- Added `businessId` to `MessageStartEventSubscriptionRecord` (protocol version bumped from 9 to 10).
- `EventHandle#triggerMessageStartEvent` and `MessageStartProcessInstanceRequestStartProcessor` now forward the message's `businessId` onto the `MessageStartEventSubscription:CORRELATED` record, covering both single-partition and cross-partition correlation paths.
- `ProcessMessageSubscriptionCorrelateProcessor` now copies the subscribing instance's `businessId` (captured at subscription-open time) onto the `ProcessMessageSubscription:CORRELATED` event, so non-start correlations (catch, boundary, intermediate) also expose `businessId` on the search API.

**Exporter layer (Elasticsearch / OpenSearch / RDBMS)**
- Both `CorrelatedMessageSubscription` export handlers (start-event and process-event) map `businessId` from the protocol record onto the persisted entity. Empty strings are normalized to `null`.
- Index templates updated with a new `businessId` keyword field.
- Liquibase changeset adds a `BUSINESS_ID` column to the `CORRELATED_MESSAGE_SUBSCRIPTION` RDBMS table.

**Search / query layer**
- `CorrelatedMessageSubscriptionEntity` (domain model) and the webapps schema entity gain a nullable `businessId` field.
- `CorrelatedMessageSubscriptionFilter` supports the full advanced string operation set (`$eq`, `$neq`, `$exists`, `$like` with `*`/`?` wildcards`) via `businessIds(...)` and `businessIdOperations(...)`.
- `CorrelatedMessageSubscriptionSort` gains a `businessId()` sort field.
- Filter and sort transformers (Elasticsearch/OpenSearch) and the RDBMS MyBatis mapper updated accordingly.

**REST API (OpenAPI & gateway)**
- `messages.yaml` adds `businessId` to `CorrelatedMessageSubscriptionResult`, the search filter, and the sort enum (versioned as `8.10`).
- HTTP gateway mapper wires `businessId` through filter, sort, and response mapping.

**Java client**
- `CorrelatedMessageSubscriptionFilter`, `CorrelatedMessageSubscriptionSort`, and `CorrelatedMessageSubscription` updated with `businessId` support.

### Notes
- `businessId` is the correlating message's business id for start-event correlations, and the subscribing process instance's business id (captured at subscription-open time) for catch/boundary/intermediate correlations. It is `null` only when the relevant process instance has no business id.
- Field is available only for data imported after v8.10.0 (annotated `@SinceVersion("8.10.0")`).
- Nullable keyset pagination (where the cursor sits on a `null` businessId) is explicitly covered by RDBMS integration tests.

## Related issues

closes #51687