### PR TITLE
fix: adjust load test ES/OS index replicas

### DIFF
--- a/load-tests/setup/main/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-elasticsearch.yaml
@@ -33,6 +33,32 @@ orchestration:
     secondaryStorage:
       type: elasticsearch
 
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
+
+    ## The values below are duplicated from
+    ## camunda-platform-values-defaults.yaml. Keep them in sync.
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
 ########################################################################################
 ################################################### Elasticsearch cluster configuration
 ########################################################################################

--- a/load-tests/setup/main/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-opensearch.yaml
@@ -22,6 +22,32 @@ orchestration:
     secondaryStorage:
       type: opensearch
 
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
+
+    ## The values below are duplicated from
+    ## camunda-platform-values-defaults.yaml. Keep them in sync.
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
 #################################################################################################
 ################################################### Disable Elasticsearch when using OpenSearch
 #################################################################################################

--- a/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
@@ -210,6 +210,9 @@ operate:
     # https://docs.camunda.io/docs/8.7/self-managed/operate-deployment/operate-configuration/#json-logging-configuration
     - name: OPERATE_LOG_APPENDER
       value: Stackdriver
+    # https://docs.camunda.io/docs/8.7/self-managed/operate-deployment/operate-configuration/#settings-for-shards-and-replicas
+    - name: CAMUNDA_OPERATE_ELASTICSEARCH_NUMBER_OF_REPLICAS
+      value: "1"
   nodeSelector:
     topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:
@@ -235,6 +238,9 @@ tasklist:
     # https://docs.camunda.io/docs/8.7/self-managed/tasklist-deployment/tasklist-configuration/#json-logging-configuration
     - name: TASKLIST_LOG_APPENDER
       value: Stackdriver
+    # https://docs.camunda.io/docs/8.7/self-managed/tasklist-deployment/tasklist-configuration/#settings-for-shards-and-replicas
+    - name: CAMUNDA_TASKLIST_ELASTICSEARCH_NUMBER_OF_REPLICAS
+      value: "1"
   nodeSelector:
     topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:
@@ -383,6 +389,9 @@ zeebe:
       # application-override.yml is listed second so it has higher priority and can override application.yml.
       # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
       value: "/usr/local/zeebe/config/application.yml,optional:/usr/local/zeebe/config/application-override.yml"
+
+    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
 
 zeebeGateway:
   # Replicas defines how many standalone gateways are deployed

--- a/load-tests/setup/stable-89/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-elasticsearch.yaml
@@ -33,6 +33,33 @@ orchestration:
     secondaryStorage:
       type: elasticsearch
 
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
+
+    ## The values below are duplicated from
+    ## camunda-platform-values-defaults.yaml. Keep them in sync.
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
+
 ########################################################################################
 ################################################### Elasticsearch cluster configuration
 ########################################################################################

--- a/load-tests/setup/stable-89/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-opensearch.yaml
@@ -22,6 +22,32 @@ orchestration:
     secondaryStorage:
       type: opensearch
 
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
+
+    ## The values below are duplicated from
+    ## camunda-platform-values-defaults.yaml. Keep them in sync.
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
 #################################################################################################
 ################################################### Disable Elasticsearch when using OpenSearch
 #################################################################################################

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -88,6 +88,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -88,6 +88,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -88,6 +88,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -88,6 +88,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/operate/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/operate/deployment.yaml
@@ -62,6 +62,8 @@ spec:
           env:
             - name: OPERATE_LOG_APPENDER
               value: Stackdriver
+            - name: CAMUNDA_OPERATE_ELASTICSEARCH_NUMBER_OF_REPLICAS
+              value: "1"
           resources:
             limits:
               cpu: 2000m
@@ -137,6 +139,8 @@ spec:
               value: zeebe:26502
             - name: OPERATE_LOG_APPENDER
               value: Stackdriver
+            - name: CAMUNDA_OPERATE_ELASTICSEARCH_NUMBER_OF_REPLICAS
+              value: "1"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-87-elasticsearch-stable-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/tasklist/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/tasklist/deployment.yaml
@@ -111,6 +111,8 @@ spec:
               value: zeebe:26502
             - name: TASKLIST_LOG_APPENDER
               value: Stackdriver
+            - name: CAMUNDA_TASKLIST_ELASTICSEARCH_NUMBER_OF_REPLICAS
+              value: "1"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-87-elasticsearch-stable-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/statefulset.yaml
@@ -115,6 +115,8 @@ spec:
               value: INFO
             - name: SPRING_CONFIG_ADDITIONALLOCATION
               value: /usr/local/zeebe/config/application.yml,optional:/usr/local/zeebe/config/application-override.yml
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-87-elasticsearch-stable-camunda-platform-documentstore-env-vars

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/operate/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/operate/deployment.yaml
@@ -62,6 +62,8 @@ spec:
           env:
             - name: OPERATE_LOG_APPENDER
               value: Stackdriver
+            - name: CAMUNDA_OPERATE_ELASTICSEARCH_NUMBER_OF_REPLICAS
+              value: "1"
           resources:
             limits:
               cpu: 2000m
@@ -137,6 +139,8 @@ spec:
               value: zeebe:26502
             - name: OPERATE_LOG_APPENDER
               value: Stackdriver
+            - name: CAMUNDA_OPERATE_ELASTICSEARCH_NUMBER_OF_REPLICAS
+              value: "1"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-87-elasticsearch-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/tasklist/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/tasklist/deployment.yaml
@@ -111,6 +111,8 @@ spec:
               value: zeebe:26502
             - name: TASKLIST_LOG_APPENDER
               value: Stackdriver
+            - name: CAMUNDA_TASKLIST_ELASTICSEARCH_NUMBER_OF_REPLICAS
+              value: "1"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-87-elasticsearch-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/statefulset.yaml
@@ -115,6 +115,8 @@ spec:
               value: INFO
             - name: SPRING_CONFIG_ADDITIONALLOCATION
               value: /usr/local/zeebe/config/application.yml,optional:/usr/local/zeebe/config/application-override.yml
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-87-elasticsearch-camunda-platform-documentstore-env-vars

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -87,6 +87,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -87,6 +87,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -87,6 +87,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -87,6 +87,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME


### PR DESCRIPTION
## Description

Closes: https://github.com/camunda/camunda/issues/55404

This changes the Elasticsearch + OpenSearch settings so that all the indices we create always have (at least) a single replica configured.

In our default configuration, some indices have 0 replicas configured: when an Elasticsearch node holding the one of the primary shard is unavailable, some parts of the index become unavailable for read/write:

1. Elasticsearch health status turns `red` :red_circle: , which may alert or page operators
2. Reads/writes to the affected portion of the indices will fail, returning errors to the clients

For the implementation: since we are overriding the environment variables and that:

1. There are already predefined environment variables in the `camunda-platform-values-defaults.yaml` file
2. The environment variables are configured as an array: adding new ones in another Helm values file override the original array from the default file

... we have to duplicate the whole environment variables. It's also not possible to set both Elasticsearch and OpenSearch at the same time: if the exporter is not loaded but the configuration is set, the process doesn't start and crash complaining about the configuration for the missing exporter.

The defaults will be changed in 8.10+: https://github.com/camunda/camunda/issues/55366

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/55404
