### PR TITLE
test: stabilize flow node filter selection in process instances filters

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -205,7 +205,9 @@ export class OperateFiltersPanelPage {
 
   async selectFlowNode(option: string) {
     await this.flowNodeFilter.click();
-    await this.getOptionByName(option, false).click();
+    const flowNodeOption = this.getOptionByName(option, false);
+    await flowNodeOption.waitFor({state: 'visible'});
+    await flowNodeOption.click();
   }
 
   async fillVariableNameFilter(name: string) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -581,9 +581,12 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.selectVersion('1');
       await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('');
 
-      await operateFiltersPanelPage.selectFlowNode('StartEvent_1');
+      // Selecting the version asynchronously resets the flow node filter, which
+      // can wipe a flow node selected too early. Re-apply the flow node on every
+      // retry so a reload settles the page before selecting it again.
       await waitForAssertion({
         assertion: async () => {
+          await operateFiltersPanelPage.selectFlowNode('StartEvent_1');
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
           ).toBeVisible({timeout: 60000});


### PR DESCRIPTION
## Summary

Fixes the flaky `Process Instances Filters › Interaction between diagram and filters` E2E test in the **stable/8.8** nightly run.

Changing the process version asynchronously resets the **Flow Node** filter. The test selected `StartEvent_1` immediately after switching to version 1, so the selection could be:
- **wiped** by the late-firing version-change reset (the failure trace shows the combobox value set to `StartEvent_1` then cleared ~20ms later), or
- **not applied at all** because the dropdown options had not reloaded yet (`option 'StartEvent_1' not found` timeout).

The step's `onFailure` only reloaded the page and never re-applied the flow node, so retries could never recover once the filter was lost (the page came back showing 1 instance instead of the empty state).

This is a **test-side timing issue specific to 8.8** — the product correctly filtered to 0 instances while the flow node was applied. It is **unrelated to bug #45156**, which the issue explicitly states affects only 8.9/8.10 (those branches skipped the test; skipping is not permitted here).

## Changes

- `selectFlowNode` waits for the option to be visible before clicking (only used by this test).
- The flow node selection is moved **inside** `waitForAssertion`, so each retry re-selects the flow node on a settled page after `page.reload()`.

## Test plan

- [ ] On-demand run of this branch against stable/8.8 (Operate E2E)

Nightly run: https://github.com/camunda/camunda/actions/runs/27800243457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/27808240817
