### PR TITLE
fix: RDBMS acceptance tests for DeployedResourceEntity + PostgreSQL bytea fix

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -34,6 +34,9 @@
     <modifySql dbms="h2">
       <replace replace="BLOB" with="BINARY LARGE OBJECT"/>
     </modifySql>
+    <modifySql dbms="postgresql">
+      <replace replace="OID" with="bytea"/>
+    </modifySql>
   </changeSet>
 
   <changeSet id="add_message_subscription_type_column" author="camunda">

--- a/db/rdbms/src/main/resources/mapper/DeployedResourceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DeployedResourceMapper.xml
@@ -25,7 +25,7 @@
       <arg column="DEPLOYMENT_KEY" javaType="java.lang.Long"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
         typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
-      <arg column="RESOURCE_CONTENT" javaType="[B" jdbcType="BLOB"/>
+      <arg column="RESOURCE_CONTENT" javaType="[B" jdbcType="BINARY"/>
     </constructor>
   </resultMap>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceIT.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.deployedresource;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.resourceAccessChecksFromResourceIds;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.resourceAccessChecksFromTenantIds;
+import static io.camunda.it.rdbms.db.fixtures.DeployedResourceFixtures.createAndSaveDeployedResource;
+import static io.camunda.it.rdbms.db.fixtures.DeployedResourceFixtures.createAndSaveRandomDeployedResources;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DeployedResourceDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.DeployedResourceDbModel;
+import io.camunda.it.rdbms.db.fixtures.DeployedResourceFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.DeployedResourceEntity;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.sort.DeployedResourceSort;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class DeployedResourceIT {
+
+  public static final int PARTITION_ID = 0;
+
+  @TestTemplate
+  public void shouldSaveAndFindDeployedResourceByKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final DeployedResourceDbModel resource = DeployedResourceFixtures.createRandomized(b -> b);
+    createAndSaveDeployedResource(rdbmsWriters, resource);
+
+    // when
+    final var entity = reader.getByKey(resource.resourceKey(), ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(entity).isNotNull();
+    assertThat(entity.resourceKey()).isEqualTo(resource.resourceKey());
+    assertThat(entity.resourceId()).isEqualTo(resource.resourceId());
+    assertThat(entity.resourceName()).isEqualTo(resource.resourceName());
+    assertThat(entity.resourceType()).isEqualTo(resource.resourceType());
+    assertThat(entity.version()).isEqualTo(resource.version());
+    assertThat(entity.versionTag()).isEqualTo(resource.versionTag());
+    assertThat(entity.deploymentKey()).isEqualTo(resource.deploymentKey());
+    assertThat(entity.tenantId()).isEqualTo(resource.tenantId());
+    assertThat(entity.resourceContent()).isEqualTo(resource.resourceContent());
+  }
+
+  @TestTemplate
+  public void shouldSaveAndFindDeployedResourceMetadataByKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final DeployedResourceDbModel resource = DeployedResourceFixtures.createRandomized(b -> b);
+    createAndSaveDeployedResource(rdbmsWriters, resource);
+
+    // when
+    final var entity =
+        reader.getByKeyMetadata(resource.resourceKey(), ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(entity).isNotNull();
+    assertThat(entity.resourceKey()).isEqualTo(resource.resourceKey());
+    assertThat(entity.resourceId()).isEqualTo(resource.resourceId());
+    assertThat(entity.resourceName()).isEqualTo(resource.resourceName());
+    assertThat(entity.resourceType()).isEqualTo(resource.resourceType());
+    assertThat(entity.version()).isEqualTo(resource.version());
+    assertThat(entity.versionTag()).isEqualTo(resource.versionTag());
+    assertThat(entity.deploymentKey()).isEqualTo(resource.deploymentKey());
+    assertThat(entity.tenantId()).isEqualTo(resource.tenantId());
+    assertThat(entity.resourceContent()).isNull();
+  }
+
+  @TestTemplate
+  public void shouldFindDeployedResourceByResourceId(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final DeployedResourceDbModel resource = DeployedResourceFixtures.createRandomized(b -> b);
+    createAndSaveDeployedResource(rdbmsWriters, resource);
+    createAndSaveRandomDeployedResources(rdbmsWriters);
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.resourceIds(resource.resourceId()))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(10))));
+
+    // then
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().resourceId()).isEqualTo(resource.resourceId());
+  }
+
+  @TestTemplate
+  public void shouldFindDeployedResourceByResourceType(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final String uniqueType = "FORM-" + nextKey();
+    final DeployedResourceDbModel resource =
+        createAndSaveDeployedResource(rdbmsWriters, b -> b.resourceType(uniqueType));
+    createAndSaveRandomDeployedResources(rdbmsWriters);
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.resourceTypes(uniqueType))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
+  }
+
+  @TestTemplate
+  public void shouldFindDeployedResourceByDeploymentKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final Long deploymentKey = nextKey();
+    final DeployedResourceDbModel resource =
+        createAndSaveDeployedResource(rdbmsWriters, b -> b.deploymentKey(deploymentKey));
+    createAndSaveRandomDeployedResources(rdbmsWriters);
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.deploymentKeyOperations(Operation.eq(deploymentKey)))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
+  }
+
+  @TestTemplate
+  public void shouldFindDeployedResourceByVersion(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final Long deploymentKey = nextKey();
+    final DeployedResourceDbModel resource =
+        createAndSaveDeployedResource(
+            rdbmsWriters, b -> b.deploymentKey(deploymentKey).version(42));
+    createAndSaveRandomDeployedResources(
+        rdbmsWriters, b -> b.deploymentKey(deploymentKey).version(1));
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(
+                            f ->
+                                f.deploymentKeyOperations(Operation.eq(deploymentKey)).versions(42))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
+  }
+
+  @TestTemplate
+  public void shouldFindDeployedResourceByVersionTag(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final String versionTag = "v-unique-" + nextKey();
+    final DeployedResourceDbModel resource =
+        createAndSaveDeployedResource(rdbmsWriters, b -> b.versionTag(versionTag));
+    createAndSaveRandomDeployedResources(rdbmsWriters);
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.versionTags(versionTag))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
+  }
+
+  @TestTemplate
+  public void shouldFindDeployedResourceByTenantId(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final String tenantId = "tenant-unique-" + nextKey();
+    final DeployedResourceDbModel resource =
+        createAndSaveDeployedResource(rdbmsWriters, b -> b.tenantId(tenantId));
+    createAndSaveRandomDeployedResources(rdbmsWriters);
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.tenantIds(tenantId))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
+  }
+
+  @TestTemplate
+  public void shouldFindDeployedResourceWithFullFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final DeployedResourceDbModel resource = DeployedResourceFixtures.createRandomized(b -> b);
+    createAndSaveDeployedResource(rdbmsWriters, resource);
+    createAndSaveRandomDeployedResources(rdbmsWriters);
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(
+                            f ->
+                                f.resourceKeyOperations(Operation.eq(resource.resourceKey()))
+                                    .resourceIds(resource.resourceId())
+                                    .resourceNames(resource.resourceName())
+                                    .resourceTypes(resource.resourceType())
+                                    .versions(resource.version())
+                                    .versionTags(resource.versionTag())
+                                    .deploymentKeyOperations(Operation.eq(resource.deploymentKey()))
+                                    .tenantIds(resource.tenantId()))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(5))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
+  }
+
+  @TestTemplate
+  public void shouldFindAllDeployedResourcesPaged(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final Long deploymentKey = nextKey();
+    createAndSaveRandomDeployedResources(rdbmsWriters, b -> b.deploymentKey(deploymentKey));
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.deploymentKeyOperations(Operation.eq(deploymentKey)))
+                        .sort(s -> s.resourceKey().asc())
+                        .page(p -> p.from(0).size(5))));
+
+    // then
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldFindAllDeployedResourcesPagedWithHasMoreHits(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final Long deploymentKey = nextKey();
+    createAndSaveRandomDeployedResources(rdbmsWriters, 120, b -> b.deploymentKey(deploymentKey));
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.deploymentKeyOperations(Operation.eq(deploymentKey)))
+                        .sort(s -> s.resourceKey().asc())
+                        .page(p -> p.from(0).size(5))));
+
+    // then
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isTrue();
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldFindDeployedResourceWithSearchAfter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final Long deploymentKey = nextKey();
+    createAndSaveRandomDeployedResources(rdbmsWriters, b -> b.deploymentKey(deploymentKey));
+
+    final var sort = DeployedResourceSort.of(s -> s.resourceName().asc().resourceKey().asc());
+
+    final var fullResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.deploymentKeyOperations(Operation.eq(deploymentKey)))
+                        .sort(sort)
+                        .page(p -> p.from(0).size(20))));
+
+    final var firstPage =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.deploymentKeyOperations(Operation.eq(deploymentKey)))
+                        .sort(sort)
+                        .page(p -> p.from(0).size(10))));
+
+    // when
+    final var nextPage =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.deploymentKeyOperations(Operation.eq(deploymentKey)))
+                        .sort(sort)
+                        .page(p -> p.size(10).after(firstPage.endCursor()))));
+
+    // then
+    assertThat(nextPage.total()).isEqualTo(20);
+    assertThat(nextPage.items()).hasSize(10);
+    assertThat(nextPage.items()).isEqualTo(fullResult.items().subList(10, 20));
+  }
+
+  @TestTemplate
+  public void shouldDeleteDeployedResource(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final Long deploymentKey = nextKey();
+    final var resource1 =
+        createAndSaveDeployedResource(rdbmsWriters, b -> b.deploymentKey(deploymentKey));
+    final var resource2 =
+        createAndSaveDeployedResource(rdbmsWriters, b -> b.deploymentKey(deploymentKey));
+    final var resource3 =
+        createAndSaveDeployedResource(rdbmsWriters, b -> b.deploymentKey(deploymentKey));
+
+    // when
+    rdbmsWriters.getResourceWriter().delete(resource2.resourceKey());
+    rdbmsWriters.flush();
+
+    // then
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(
+                b ->
+                    b.filter(f -> f.deploymentKeyOperations(Operation.eq(deploymentKey)))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(20))));
+
+    assertThat(searchResult.total()).isEqualTo(2);
+    assertThat(searchResult.items()).hasSize(2);
+    assertThat(searchResult.items().stream().map(DeployedResourceEntity::resourceKey))
+        .containsExactlyInAnyOrder(resource1.resourceKey(), resource3.resourceKey());
+  }
+
+  @TestTemplate
+  public void shouldFindDeployedResourceByAuthorizedResourceId(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final DeployedResourceDbModel resource = createAndSaveDeployedResource(rdbmsWriters, b -> b);
+    createAndSaveRandomDeployedResources(rdbmsWriters);
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(b -> b),
+            resourceAccessChecksFromResourceIds(
+                AuthorizationResourceType.RESOURCE, resource.resourceId()));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
+  }
+
+  @TestTemplate
+  public void shouldFindDeployedResourceByAuthorizedTenantId(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+
+    final DeployedResourceDbModel resource = createAndSaveDeployedResource(rdbmsWriters, b -> b);
+    createAndSaveRandomDeployedResources(rdbmsWriters);
+
+    // when
+    final var searchResult =
+        reader.search(
+            DeployedResourceQuery.of(b -> b),
+            resourceAccessChecksFromTenantIds(resource.tenantId()));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceSortIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.deployedresource;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.DeployedResourceFixtures.createAndSaveRandomDeployedResources;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DeployedResourceDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.DeployedResourceEntity;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.sort.DeployedResourceSort;
+import io.camunda.search.sort.DeployedResourceSort.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class DeployedResourceSortIT {
+
+  @TestTemplate
+  public void shouldSortByResourceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourceKey().asc(),
+        Comparator.comparing(DeployedResourceEntity::resourceKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByResourceKeyDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourceKey().desc(),
+        Comparator.comparing(DeployedResourceEntity::resourceKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByResourceIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourceId().asc(),
+        Comparator.comparing(DeployedResourceEntity::resourceId));
+  }
+
+  @TestTemplate
+  public void shouldSortByResourceNameAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourceName().asc(),
+        Comparator.comparing(DeployedResourceEntity::resourceName));
+  }
+
+  @TestTemplate
+  public void shouldSortByVersionAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.version().asc(),
+        Comparator.comparing(DeployedResourceEntity::version));
+  }
+
+  @TestTemplate
+  public void shouldSortByVersionDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.version().desc(),
+        Comparator.comparing(DeployedResourceEntity::version).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByVersionTagAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.versionTag().asc(),
+        Comparator.comparing(
+            DeployedResourceEntity::versionTag, Comparator.nullsFirst(Comparator.naturalOrder())));
+  }
+
+  @TestTemplate
+  public void shouldSortByDeploymentKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.deploymentKey().asc(),
+        Comparator.comparing(DeployedResourceEntity::deploymentKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.tenantId().asc(),
+        Comparator.comparing(DeployedResourceEntity::tenantId));
+  }
+
+  private void testSorting(
+      final RdbmsService rdbmsService,
+      final Function<Builder, ObjectBuilder<DeployedResourceSort>> sortBuilder,
+      final Comparator<DeployedResourceEntity> comparator) {
+    final Long deploymentKey = nextKey();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(0L);
+    createAndSaveRandomDeployedResources(rdbmsWriters, 20, b -> b.deploymentKey(deploymentKey));
+
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final var results =
+        reader
+            .search(
+                DeployedResourceQuery.of(
+                    b ->
+                        b.filter(f -> f.deploymentKeyOperations(Operation.eq(deploymentKey)))
+                            .sort(DeployedResourceSort.of(sortBuilder))
+                            .page(p -> p.from(0).size(20))))
+            .items();
+
+    assertThat(results.size()).isGreaterThanOrEqualTo(20);
+    assertThat(results).isSortedAccordingTo(comparator);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DeployedResourceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DeployedResourceFixtures.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.DeployedResourceDbModel;
+import io.camunda.db.rdbms.write.domain.DeployedResourceDbModel.DeployedResourceDbModelBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public final class DeployedResourceFixtures extends CommonFixtures {
+
+  private DeployedResourceFixtures() {}
+
+  public static DeployedResourceDbModel createRandomized(
+      final Function<DeployedResourceDbModelBuilder, DeployedResourceDbModelBuilder>
+          builderFunction) {
+    final var builder =
+        new DeployedResourceDbModelBuilder()
+            .resourceKey(nextKey())
+            .resourceId("resource-id-" + generateRandomString(20))
+            .resourceName("resource-" + generateRandomString(20) + ".bpmn")
+            .resourceType("PROCESS")
+            .version(RANDOM.nextInt(1, 100))
+            .versionTag("v" + generateRandomString(5))
+            .deploymentKey(nextKey())
+            .tenantId("tenant-" + generateRandomString(20))
+            .resourceContent(generateRandomString(50).getBytes());
+    return builderFunction.apply(builder).build();
+  }
+
+  public static void createAndSaveRandomDeployedResources(final RdbmsWriters rdbmsWriters) {
+    createAndSaveRandomDeployedResources(rdbmsWriters, b -> b);
+  }
+
+  public static void createAndSaveRandomDeployedResources(
+      final RdbmsWriters rdbmsWriters,
+      final Function<DeployedResourceDbModelBuilder, DeployedResourceDbModelBuilder>
+          builderFunction) {
+    createAndSaveRandomDeployedResources(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomDeployedResources(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<DeployedResourceDbModelBuilder, DeployedResourceDbModelBuilder>
+          builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
+      rdbmsWriters.getResourceWriter().create(createRandomized(builderFunction));
+    }
+    rdbmsWriters.flush();
+  }
+
+  public static DeployedResourceDbModel createAndSaveDeployedResource(
+      final RdbmsWriters rdbmsWriters,
+      final Function<DeployedResourceDbModelBuilder, DeployedResourceDbModelBuilder>
+          builderFunction) {
+    final DeployedResourceDbModel model = createRandomized(builderFunction);
+    createAndSaveDeployedResources(rdbmsWriters, List.of(model));
+    return model;
+  }
+
+  public static void createAndSaveDeployedResource(
+      final RdbmsWriters rdbmsWriters, final DeployedResourceDbModel resource) {
+    createAndSaveDeployedResources(rdbmsWriters, List.of(resource));
+  }
+
+  public static void createAndSaveDeployedResources(
+      final RdbmsWriters rdbmsWriters, final List<DeployedResourceDbModel> resources) {
+    for (final DeployedResourceDbModel resource : resources) {
+      rdbmsWriters.getResourceWriter().create(resource);
+    }
+    rdbmsWriters.flush();
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes a type mismatch in the `DEPLOYED_RESOURCE` schema for PostgreSQL: Liquibase maps `BLOB` to `OID` (large object), but the MyBatis mapper sends `byte[]` via `setBytes()` which PostgreSQL treats as `bytea`. Added a `modifySql` override in `8.10.0.xml` to use `bytea` instead, and changed the resultMap `jdbcType` from `BLOB` to `BINARY` so reads use `getBytes()` (compatible with `bytea`) rather than the LOB API.
- Adds `DeployedResourceIT` covering the full read/write/filter/auth lifecycle across all 6 supported database engines (H2, PostgreSQL, MariaDB, MySQL, Oracle, MSSQL).
- Adds `DeployedResourceSortIT` covering all sortable fields.
- Adds `DeployedResourceFixtures` as the companion test-data builder.

## Test plan

- [ ] `./mvnw verify -pl qa/acceptance-tests -Prdbms -Dit.test="DeployedResourceIT,DeployedResourceSortIT" -DskipTests=false -DskipUTs -Dquickly` — 144 tests, all pass across all 6 DB engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)