### PR TITLE
ci: use temurin distribution in Operate workflows (stable/8.9)

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         name: Build setup
         with:
-          java-distribution: adopt
+          java-distribution: temurin
           maven-cache-key-modifier: operate
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-ci-build-observe-reusable.yml
+++ b/.github/workflows/operate-ci-build-observe-reusable.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         name: Build setup
         with:
-          java-distribution: adopt
+          java-distribution: temurin
           maven-cache-key-modifier: operate
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-ci-build-observe-reusable.yml
+++ b/.github/workflows/operate-ci-build-observe-reusable.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: refs/heads/${{ inputs.branch }}
           fetch-depth: 0 # fetches all history for all branches and tags
@@ -54,7 +54,7 @@ jobs:
       # Setup: import secrets from vault
       - name: Import Secrets
         id: secrets  # important to refer to it in later steps
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           dockerhub: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
           harbor: true
-          java-distribution: adopt
+          java-distribution: temurin
           maven-cache-key-modifier: operate
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -83,7 +83,7 @@ jobs:
       # Setup: import secrets from vault
       - name: Import Secrets
         id: secrets # important to refer to it in later steps
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         name: Build setup
         with:
-          java-distribution: adopt
+          java-distribution: temurin
           maven-cache-key-modifier: operate-tests
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -82,7 +82,7 @@ jobs:
       # Setup: import secrets from vault
       - name: Import Secrets
         id: secrets  # important to refer to it in later steps
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: "21"
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: "21"
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml

--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-build
         with:
-          java-distribution: adopt
+          java-distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
           maven-cache-key-modifier: operate
           vault-address: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
## Summary

- Replaces legacy `adopt` distribution alias with `temurin` in all Operate CI workflows
- Affects 7 workflow files: direct `setup-java` calls and callers of `.github/actions/setup-build` with `java-distribution` input
- `temurin` is the correct Adoptium distribution for `actions/setup-java@v5` and is used throughout the rest of the repo

## Context

Identified in PR review on [#55465](https://github.com/camunda/camunda/pull/55465#discussion_r3435613306). The `adopt` alias is legacy/ambiguous and risks breakage in future v5+ releases if the alias is removed or changes behavior.