### PR TITLE
fix: load-test: recreate port-forward during the verification script

### DIFF
--- a/load-tests/docs/scripts/verify-test.sh
+++ b/load-tests/docs/scripts/verify-test.sh
@@ -55,13 +55,13 @@ wait_for_pods() {
     wait_output=$(kubectl wait --for=condition=ready pod \
         -l "$label" \
         --timeout="${POD_TIMEOUT}s" -n "$NAMESPACE" 2>&1) && {
-      echo "::group::Wait output"
+      echo "::group::⇒ kubectl wait output"
       echo "$wait_output"
       echo "::endgroup::"
       echo "${description} are ready in $NAMESPACE"
       return 0
     }
-    echo "::group::Wait output"
+    echo "::group::⇒ kubectl wait output"
     echo "$wait_output"
     echo "::endgroup::"
 
@@ -107,45 +107,54 @@ if ! wait_for_pods "app.kubernetes.io/component=zeebe-client" "load test client 
   exit 1
 fi
 
-# Port-forward to the clients service metrics endpoint
-local_port=$((METRICS_PORT + RANDOM % 1000))
-kubectl port-forward "svc/clients" "${local_port}:${METRICS_PORT}" -n "$NAMESPACE" &
-pf_pid=$!
-trap 'kill "$pf_pid" 2>/dev/null || true; wait "$pf_pid" 2>/dev/null || true' EXIT
-sleep 5  # wait for port-forward to establish
-
 # Check that the client has successfully connected to the gateway.
 # app_connected >= 1 confirms that the topology was received (i.e. the
 # client authenticated and connected successfully, regardless of REST or gRPC).
-interval=30
+interval=10
 max_attempts=$((CONNECTIVITY_TIMEOUT / interval))
 attempts=0
 verified=false
+app_connected=""
 
 while [[ $attempts -lt $max_attempts ]]; do
-  count=$( { curl -s "http://localhost:${local_port}/metrics" 2>/dev/null || true; } \
+  echo "::group::⇒ connectivity checks $attempts/$max_attempts"
+  echo "Checking clients connectivity: $attempts/$max_attempts"
+  # Port-forward to the clients service metrics endpoint
+  local_port=$((METRICS_PORT + RANDOM % 1000))
+  service="svc/clients"
+  echo "Opening port-forward to $service via port $local_port..."
+  kubectl port-forward "$service" "${local_port}:${METRICS_PORT}" -n "$NAMESPACE" &
+  pf_pid=$!
+  trap 'kill "$pf_pid" 2>/dev/null || true; wait "$pf_pid" 2>/dev/null || true' EXIT
+  sleep 2  # wait for port-forward to establish
+
+  app_connected=$( { curl -s "http://localhost:${local_port}/metrics" 2>/dev/null || true; } \
     | { grep '^app_connected ' || true; } \
     | awk '{print $2}' \
     | cut -d. -f1)
 
-  if [[ -n "$count" ]] && [[ "$count" -ge 1 ]]; then
-    echo "Namespace $NAMESPACE: client connected to gateway (app.connected=$count)"
+  echo "Stopping the port-forward..."
+  kill $pf_pid 2>/dev/null || true
+  wait $pf_pid 2>/dev/null || true
+  attempts=$((attempts + 1))
+
+  if [[ -n "$app_connected" ]] && [[ "$app_connected" -ge 1 ]]; then
     verified=true
+    echo "::endgroup::"
     break
   fi
 
-  attempts=$((attempts + 1))
   echo "Namespace $NAMESPACE: waiting for gateway connectivity (attempt $attempts/$max_attempts)"
+  echo "::endgroup::"
   sleep "$interval"
 done
-
-kill $pf_pid 2>/dev/null || true
-wait $pf_pid 2>/dev/null || true
 
 if [[ "$verified" != "true" ]]; then
   echo "::error::Namespace $NAMESPACE client did not connect to gateway within timeout (app.connected metric never reached 1)"
   echo "status=failure" >> "$GITHUB_OUTPUT"
   exit 1
+else
+  echo "Namespace $NAMESPACE: client connected to gateway (app.connected=$app_connected)"
 fi
 
 echo "status=success" >> "$GITHUB_OUTPUT"

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -5,7 +5,7 @@ Welcome to the manual setup of a load test. :wave:
 There are two targets to run a load test against:
 
 * [Self-Managed Zeebe Cluster](#load-testing-self-managed-zeebe-cluster)
-* [Camunda Cloud Cluster](#load-testing-camunda-cloud-saas)
+* [Camunda SaaS Cluster](#load-testing-camunda-cloud-saas)
 
 All guides are targeted at a Linux system.
 


### PR DESCRIPTION
## Description

Closes #55363: in the load tests, when we verify the connectivity between the client applications and the rest of the system:

1. we create a port-forward
2. we assume if it's created, it will stay up
3. we poll the client metrics endpoint until we have the value we expect

If the port-forward dies in the middle, we wait on an invalid port-forward for several minutes then give up.

Instead, the port-forwarding is deleted and recreated for each iteration, until the connection succeeds. This prevents the casese where:

1. A port-forward has been successfully created but the connected pod dies in the middle
2. The pod reports healthy too early, allowing the port-forward to complete but before it becomes ready

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* #55363
