### PR TITLE
fix: Introduce `BEFORE_ALL` listener event type in `camunda-api-zod-schemas`

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -18,7 +18,7 @@
 		"lint:knip": "knip --tsConfig tsconfig.browser.json"
 	},
 	"dependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.72",
+		"@camunda/camunda-api-zod-schemas": "0.0.73",
 		"@camunda/camunda-composite-components": "0.24.0",
 		"@carbon/react": "1.109.0",
 		"@carbon/type": "11.61.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -27,7 +27,7 @@
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.72",
+				"@camunda/camunda-api-zod-schemas": "0.0.73",
 				"@camunda/camunda-composite-components": "0.24.0",
 				"@carbon/react": "1.109.0",
 				"@carbon/type": "11.61.0",
@@ -10872,13 +10872,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.72",
+				"@camunda/camunda-api-zod-schemas": "0.0.73",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.72",
+			"version": "0.0.73",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.9.3",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.72",
+		"@camunda/camunda-api-zod-schemas": "0.0.73",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Introduce `BEFORE_ALL` listener event type
 
+### ❤️ Contributors
+
+- Konstantinos Mylosis ([@konstantinos-mylosis](https://github.com/konstantinos-mylosis))
+
 ## v0.0.72
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.0.73
+
+### 🚀 Enhancements
+
+- Introduce `BEFORE_ALL` listener event type
+
 ## v0.0.72
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/job.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/job.ts
@@ -35,6 +35,7 @@ type JobKind = z.infer<typeof jobKindSchema>;
 
 const listenerEventTypeSchema = z.enum([
 	'UNSPECIFIED',
+	'BEFORE_ALL',
 	'START',
 	'END',
 	'CANCEL',

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.72",
+	"version": "0.0.73",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

Introduce `BEFORE_ALL` listener event type in camunda api zod schemas

## Related issues

relates #55120
