### PR TITLE
fix: infinite render loop in agent instance

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.tsx
@@ -8,6 +8,7 @@
 
 import {SkeletonText} from '@carbon/react';
 import {useLatestAgentMessage} from 'modules/queries/agentInstances/useLatestAgentMessage';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
 import {StatusHint} from './styled';
 
@@ -20,6 +21,7 @@ const LatestAgentMessage: React.FC<LatestAgentMessageProps> = ({
   agentInstanceKey,
   enablePeriodicRefetch,
 }) => {
+  const {selectElement} = useProcessInstanceElementSelectActions();
   const {data, status} = useLatestAgentMessage(agentInstanceKey, {
     enablePeriodicRefetch,
   });
@@ -46,6 +48,11 @@ const LatestAgentMessage: React.FC<LatestAgentMessageProps> = ({
       content={data.content}
       toolCalls={data.toolCalls}
       historyItemKey={data.historyItemKey}
+      onToolCallClick={(toolCall) => {
+        if (toolCall.elementId !== null) {
+          selectElement({elementId: toolCall.elementId});
+        }
+      }}
     />
   );
 };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -11,7 +11,7 @@ import {Button, SkeletonText} from '@carbon/react';
 import {SortAscending, SortDescending} from '@carbon/react/icons';
 import type {QuerySortOrder} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
 import {ConversationContainer, StatusHint, ShowMoreButton} from './styled';
 import {flattenPaginatedPages} from 'modules/queries/flattenPaginatedPages';
@@ -28,7 +28,7 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   enablePeriodicRefetch,
 }) => {
   const [sortOrder, setSortOrder] = useState<QuerySortOrder>('desc');
-  const {selectElement} = useProcessInstanceElementSelection();
+  const {selectElement} = useProcessInstanceElementSelectActions();
   const {data, status, hasNextPage, fetchNextPage, isFetchingNextPage} =
     useAgentInstanceHistory(agentInstanceKey, {
       enabled: isVisible,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
@@ -30,7 +30,7 @@ import {
   isSingleIncidentSelected,
 } from 'modules/utils/incidents';
 import type {EnhancedIncident} from 'modules/hooks/incidents';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 
 type DecisionInstanceLookup = Record<
   string,
@@ -128,7 +128,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
     };
 
     const {selectElementInstance, clearSelection} =
-      useProcessInstanceElementSelection();
+      useProcessInstanceElementSelectActions();
 
     const expandedContent = useMemo(
       () =>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/NewVariableModifications.test.tsx
@@ -32,7 +32,7 @@ import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
@@ -91,7 +91,7 @@ const editLastNewVariableValue = async (
 
 const TestSelectionControls: React.FC = () => {
   const {selectElementInstance, selectElement, clearSelection} =
-    useProcessInstanceElementSelection();
+    useProcessInstanceElementSelectActions();
   return (
     <>
       <button

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/elementStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/elementStates.test.tsx
@@ -22,7 +22,7 @@ import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariable
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {act} from 'react';
 import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 
@@ -117,7 +117,7 @@ const setupElementStateMocks = (statistics = defaultStatistics) => {
 
 const TestSelectionControls: React.FC = () => {
   const {selectElement, selectElementInstance} =
-    useProcessInstanceElementSelection();
+    useProcessInstanceElementSelectActions();
 
   return (
     <>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/footer.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/footer.test.tsx
@@ -17,7 +17,7 @@ import {mockVariables} from './index.setup';
 import {VariablesTab} from '../index';
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {useEffect} from 'react';
 import {modificationsStore} from 'modules/stores/modifications';
@@ -27,7 +27,7 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 
 const TestSelectionControls: React.FC = () => {
-  const {selectElementInstance} = useProcessInstanceElementSelection();
+  const {selectElementInstance} = useProcessInstanceElementSelectActions();
   return (
     <button
       type="button"

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/index.test.tsx
@@ -25,7 +25,7 @@ import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockUpdateElementInstanceVariables} from 'modules/mocks/api/v2/elementInstances/updateElementInstanceVariables';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {getWrapper as getBaseWrapper, mockProcessInstance} from './mocks';
 
 vi.mock('modules/stores/notifications', () => ({
@@ -35,7 +35,7 @@ vi.mock('modules/stores/notifications', () => ({
 }));
 
 const TestSelectionControls: React.FC = () => {
-  const {selectElementInstance} = useProcessInstanceElementSelection();
+  const {selectElementInstance} = useProcessInstanceElementSelectActions();
   return (
     <>
       <button

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/placeholder.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/placeholder.test.tsx
@@ -21,11 +21,11 @@ import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariable
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 
 const TestSelectionControls: React.FC = () => {
   const {selectElement, selectElementInstance} =
-    useProcessInstanceElementSelection();
+    useProcessInstanceElementSelectActions();
 
   return (
     <>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/spinner.test.tsx
@@ -24,7 +24,7 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fe
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 
 vi.mock('modules/stores/notifications', () => ({
@@ -34,7 +34,7 @@ vi.mock('modules/stores/notifications', () => ({
 }));
 
 const TestSelectionControls: React.FC = () => {
-  const {selectElementInstance} = useProcessInstanceElementSelection();
+  const {selectElementInstance} = useProcessInstanceElementSelectActions();
 
   return (
     <>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/undoFromDifferentScope.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/undoFromDifferentScope.test.tsx
@@ -18,7 +18,7 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fe
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {getWrapper as getBaseWrapper, mockProcessInstance} from './mocks';
 
@@ -82,7 +82,7 @@ const editLastNewVariableValue = async (user: UserEvent, value: string) => {
 
 const TestSelectionControls: React.FC = () => {
   const {selectElementInstance, clearSelection} =
-    useProcessInstanceElementSelection();
+    useProcessInstanceElementSelectActions();
   return (
     <>
       <button

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -137,7 +137,8 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
       const {latestMigrationDate, businessObjects} =
         useElementInstanceHistoryTree();
       const isRoot = elementType === 'PROCESS';
-      const {isSelected, hasSelection} = useProcessInstanceElementSelection();
+      const {isSelected, hasSelection, selectElementInstance, clearSelection} =
+        useProcessInstanceElementSelection();
       const isElementSelected = isRoot
         ? !hasSelection
         : isSelected({
@@ -145,9 +146,6 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
             elementInstanceKey: scopeKey,
             isMultiInstanceBody: elementType === 'MULTI_INSTANCE_BODY',
           });
-
-      const {selectElementInstance, clearSelection} =
-        useProcessInstanceElementSelection();
 
       const handleSelect = () => {
         if (isRoot) {
@@ -232,7 +230,8 @@ const NonFoldableVirtualElementInstanceNode: React.FC<NonFoldableVirtualElementI
       const {businessObjects} = useElementInstanceHistoryTree();
       const businessObject = businessObjects[elementId];
 
-      const {isSelected, hasSelection} = useProcessInstanceElementSelection();
+      const {isSelected, hasSelection, selectElementInstance} =
+        useProcessInstanceElementSelection();
       const isElementSelected = isRoot
         ? !hasSelection
         : isSelected({
@@ -240,7 +239,6 @@ const NonFoldableVirtualElementInstanceNode: React.FC<NonFoldableVirtualElementI
             elementInstanceKey: scopeKey,
             isMultiInstanceBody: isMultiInstance(businessObject),
           });
-      const {selectElementInstance} = useProcessInstanceElementSelection();
 
       const handleSelect = () => {
         if (modificationsStore.state.status === 'moving-token') {
@@ -355,7 +353,8 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
       const businessObject = businessObjects[elementId];
       const isRoot = elementType === 'bpmn:Process';
 
-      const {isSelected, hasSelection} = useProcessInstanceElementSelection();
+      const {isSelected, hasSelection, selectElementInstance} =
+        useProcessInstanceElementSelection();
       const isElementSelected = isRoot
         ? !hasSelection
         : isSelected({
@@ -378,8 +377,6 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
         instanceHistoryModificationStore.state.expandedElementInstanceIds.includes(
           scopeKey,
         );
-
-      const {selectElementInstance} = useProcessInstanceElementSelection();
 
       const handleSelect = async () => {
         if (modificationsStore.state.status === 'moving-token') {
@@ -511,7 +508,8 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
       );
       const isRoot = elementType === 'PROCESS';
 
-      const {isSelected, hasSelection} = useProcessInstanceElementSelection();
+      const {isSelected, hasSelection, selectElementInstance, clearSelection} =
+        useProcessInstanceElementSelection();
       const isElementSelected = isRoot
         ? !hasSelection
         : isSelected({
@@ -534,9 +532,6 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
             businessObjects,
           })
         : [];
-
-      const {selectElementInstance, clearSelection} =
-        useProcessInstanceElementSelection();
 
       const handleSelect = async () => {
         if (isRoot) {

--- a/operate/client/src/App/ProcessInstance/index.tsx
+++ b/operate/client/src/App/ProcessInstance/index.tsx
@@ -44,7 +44,7 @@ import {useClearSelectionOnModificationUndo} from 'modules/hooks/elementSelectio
 import {notificationsStore} from 'modules/stores/notifications';
 import {useNavigate, matchPath, type Location} from 'react-router-dom';
 import {Locations, Paths} from 'modules/Routes';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {BottomPanelTabs} from './BottomPanelTabs';
 import {
   ResizablePanel,
@@ -124,7 +124,7 @@ const ProcessInstance: React.FC = observer(() => {
   );
   const {processInstanceId = ''} = useProcessInstancePageParams();
   const navigate = useNavigate();
-  const {clearSelection} = useProcessInstanceElementSelection();
+  const {clearSelection} = useProcessInstanceElementSelectActions();
 
   const [isInfoModalOpen, setInfoModalOpen] = useState(
     () => !getStateLocally()?.hideProcessInstanceHelperModal,

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -67,17 +67,8 @@ const updateSelectionSearchParams = (
   );
 };
 
-const useProcessInstanceElementSelection = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const {processInstanceId: processInstanceKey} =
-    useProcessInstancePageParams();
-  const elementInstanceKey = searchParams.get(ELEMENT_INSTANCE_KEY);
-
-  const elementId = searchParams.get(ELEMENT_ID);
-  const isMultiInstanceBody =
-    searchParams.get(IS_MULTI_INSTANCE_BODY) === 'true';
-  const isPlaceholder = searchParams.get(IS_PLACEHOLDER) === 'true';
-  const anchorElementId = searchParams.get(ANCHOR_ELEMENT_ID);
+const useProcessInstanceElementSelectActions = () => {
+  const [, setSearchParams] = useSearchParams();
 
   const selectElement = useCallback(
     ({
@@ -138,6 +129,23 @@ const useProcessInstanceElementSelection = () => {
       {replace: true},
     );
   }, [setSearchParams]);
+
+  return {selectElement, selectElementInstance, clearSelection};
+};
+
+const useProcessInstanceElementSelection = () => {
+  const [searchParams] = useSearchParams();
+  const {processInstanceId: processInstanceKey} =
+    useProcessInstancePageParams();
+  const elementInstanceKey = searchParams.get(ELEMENT_INSTANCE_KEY);
+  const {selectElement, selectElementInstance, clearSelection} =
+    useProcessInstanceElementSelectActions();
+
+  const elementId = searchParams.get(ELEMENT_ID);
+  const isMultiInstanceBody =
+    searchParams.get(IS_MULTI_INSTANCE_BODY) === 'true';
+  const isPlaceholder = searchParams.get(IS_PLACEHOLDER) === 'true';
+  const anchorElementId = searchParams.get(ANCHOR_ELEMENT_ID);
 
   // If elementInstanceKey is in URL, fetch element instance by key.
   // Skip fetching if elementInstanceKey is a placeholder key
@@ -219,4 +227,7 @@ const useProcessInstanceElementSelection = () => {
   };
 };
 
-export {useProcessInstanceElementSelection};
+export {
+  useProcessInstanceElementSelection,
+  useProcessInstanceElementSelectActions,
+};


### PR DESCRIPTION
## Description

This PR addresses an infinite render loop that happen in agent details when multiple element instances exist for an agent element. How does the bug happen:
1. In this case the user selection has to happen trough the instance history => `elementInstanceKey` exists.
2. `DetailsTab` calls `useProcessInstanceElementSelection()`, which internally runs `useElementInstance(elementInstanceKey)`. => `isFetching` and loading skeleton shown.
3. Fetch completes, `AgentDetails` get rendered, and renders `ConversationHistory`, which also uses `useProcessInstanceElementSelection` for the `selectElement` callback.
4. => New subscriber to `useElementInstance` query added, which refetched because it has `staleTime == 0` and `refetchOnMount` is true.
5. `isFetching` is true again and `DetailsTab` shows a skeleton again. `AgentDetails` get unmounted
6. Fetch completes, `AgentDetails` get rendered and the cycle starts again...

There are multiple approaches for solving the bug:
- Prop-drill `selectElement` from the `DetailsTab` to `ConversationHistory` so it does not have to call the hook again.
- Configure a `staleTime` in `useElementInstance`. Initially I ways skeptical of this due to potential side-effects, but `useElementInstancesSearch` already has a 10s `staleTime`.
- Separate the action callback from the data in `useProcessInstanceElementSelection()` to make it possible to trigger element selections without query subscriptions.

This PR implements the last approach and adds the new `useProcessInstanceElementSelectActions` hook (proxied by `useProcessInstanceElementSelection` as well) to places where only actions are needed. I am open to switching to another approach. At the time of implementation, I didn't realize that `useElementInstancesSearch` already has a `staleTime`. So adding a `staleTime` to `useElementInstance` might be an easier fix. Maybe doing both, to reduce the query subscribers at the same time...

> [!NOTE]
> This PR is stacked on https://github.com/camunda/camunda/pull/55470.

## Related issues

relates #52969, #51928
