### PR TITLE
fix: replace nested tools mapping with flat object in agent-instance index

### DIFF
--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-instance.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-instance.json
@@ -73,17 +73,21 @@
         "type": "integer"
       },
       "tools": {
-        "type": "nested",
+        "type": "object",
         "properties": {
           "name": {
-            "type": "keyword"
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
           },
           "description": {
             "type": "text",
             "index": false
           },
           "elementId": {
-            "type": "keyword"
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
           }
         }
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-instance.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-instance.json
@@ -73,17 +73,21 @@
         "type": "integer"
       },
       "tools": {
-        "type": "nested",
+        "type": "object",
         "properties": {
           "name": {
-            "type": "keyword"
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
           },
           "description": {
             "type": "text",
             "index": false
           },
           "elementId": {
-            "type": "keyword"
+            "type": "keyword",
+            "index": false,
+            "doc_values": false
           }
         }
       },


### PR DESCRIPTION
## Description

The `tools` field in the `camunda-agent-instance` Elasticsearch and OpenSearch index templates was mapped as `nested`. The `nested` type is designed exclusively for accurate cross-field queries within array elements (e.g. `tools.name = X AND tools.elementId = Y` referring to the same item). No such queries are planned — `tools` is written on creation, fully replaced on every update, and read back as a complete array for display purposes only.

Using `nested` for a display-only field adds unnecessary overhead:
- Each array element is stored as a hidden Lucene document, increasing index size
- Every upsert creates N hidden documents for N tools (write amplification)
- The 1000-element per-document hard limit applies with no benefit

This PR replaces `nested` with `"type": "object"` and adds `"index": false` + `"doc_values": false` to the `name` and `elementId` sub-fields, disabling both the inverted index and the column store since neither search, sort, nor aggregation on these fields is needed. The `description` field already had `"index": false` and requires no further change (`text` fields have no doc_values by default).

The write and read paths in `AgentInstanceHandler` and `AgentInstanceEntityTransformer` are unaffected — serialisation operates against `_source`, which is always stored regardless of indexing settings.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51512
related: #55188