### PR TITLE
test: unskip 4 test(s) referencing closed bugs (main)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
@@ -16,8 +16,7 @@ import {
 import {deploy} from '../../../../utils/zeebeClient';
 import {createProcessInstanceAndRetrieveTimeStamp} from '@requestHelpers';
 
-//Skipped due to bug 48562: https://github.com/camunda/camunda/issues/48562
-test.describe.skip('Pin Clock API Tests', () => {
+test.describe('Pin Clock API Tests', () => {
   let processDefinitionId: string;
 
   test.beforeAll(async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
@@ -184,8 +184,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     );
   });
 
-  //Skipped due to bug 50945: https://github.com/camunda/camunda/issues/50945
-  test.skip('Get process instance statistics sort by processDefinitionId - Success', async ({
+  test('Get process instance statistics sort by processDefinitionId - Success', async ({
     request,
   }) => {
     const res = await request.post(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
@@ -142,7 +142,6 @@ test.describe.parallel('Process instance statistics by version', () => {
     request,
   }) => {
     const sort = [
-      //Skipped due to bug 50976: https://github.com/camunda/camunda/issues/50976
       // {field: "processDefinitionId", order: "ASC"},
       // {field: "processDefinitionKey", order: "ASC"},
       // {field: "processDefinitionName", order: "ASC"},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -79,8 +79,7 @@ test.describe('Process Instances Filters', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // skipped due to bug 45156: https://github.com/camunda/camunda/issues/45156
-  test.skip('Interaction between diagram and filters', async ({
+  test('Interaction between diagram and filters', async ({
     operateProcessesPage,
     operateFiltersPanelPage,
     page,


### PR DESCRIPTION
## Auto-Unskip: Tests with Closed Bug References

> Opened automatically by the [auto-unskip workflow](https://github.com/camunda/qa-metrics-exporter/actions/runs/27817153314).

**4** test(s) in `main` were unskipped because their referenced bugs are now closed.

### Closed Bugs

- [camunda/camunda#48562](https://github.com/camunda/camunda/issues/48562) Diagrams not visible after clock reset or clock update — closed 2026-04-08
- [camunda/camunda#50945](https://github.com/camunda/camunda/issues/50945) Get process instance statistics API returns 500 when sorting by processDefinitionId — closed 2026-05-28
- [camunda/camunda#50976](https://github.com/camunda/camunda/issues/50976) Get process instance statistics by version returns 500 when sorting — closed 2026-05-11
- [camunda/camunda#45156](https://github.com/camunda/camunda/issues/45156) Operate – Incorrect process instances count when selecting flow node without active token — closed 2026-05-29

### Files Changed (4)

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts`: 1 skip(s) removed (camunda/camunda#48562)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts`: 1 skip(s) removed (camunda/camunda#50945)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts`: 1 skip(s) removed (camunda/camunda#50976)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts`: 1 skip(s) removed (camunda/camunda#45156)

### Checklist

- [ ] On-demand test run passes on this branch
- [ ] No regressions in adjacent tests
