### PR TITLE
test: unskip 11 test(s) referencing closed bugs (stable/8.8)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
@@ -159,8 +159,7 @@ test.describe.parallel('Search Batch Operation Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Batch Operations Invalid Pagination', async ({request}) => {
+  test('Search Batch Operations Invalid Pagination', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl('/batch-operations/search'), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -132,8 +132,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  // Skipped due to bug 43097: https://github.com/camunda/camunda/issues/43097
-  test.skip('Suspend active batch operation returns 204 and status becomes SUSPENDED without resume', async ({
+  test('Suspend active batch operation returns 204 and status becomes SUSPENDED without resume', async ({
     request,
   }) => {
     const key = await test.step('Create cancel batch operation', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
@@ -291,8 +291,7 @@ test.describe('Element Instance Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Element Instances - with invalid pagination parameters', async ({
+  test('Search Element Instances - with invalid pagination parameters', async ({
     request,
   }) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
@@ -162,8 +162,7 @@ test.describe.parallel('Process Definition Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Process Definitions - with invalid pagination parameters', async ({
+  test('Search Process Definitions - with invalid pagination parameters', async ({
     request,
   }) => {
     const res = await request.post(buildUrl('/process-definitions/search'), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-resolve-incidents-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-resolve-incidents-api.spec.ts
@@ -48,8 +48,7 @@ test.describe
     await assertUnauthorizedRequest(res);
   });
 
-  // Skipped due to bug 41209:  https://github.com/camunda/camunda/issues/41209
-  test.skip('Create a Batch Operation to Resolve Incidents - Success', async ({
+  test('Create a Batch Operation to Resolve Incidents - Success', async ({
     request,
   }) => {
     const localState: Record<string, string> = {
@@ -151,8 +150,7 @@ test.describe
     );
   });
 
-  // Skipped due to bug 41209: https://github.com/camunda/camunda/issues/41209
-  test.skip('Create a Batch Operation to Resolve Incidents - With Multiple Filters', async ({
+  test('Create a Batch Operation to Resolve Incidents - With Multiple Filters', async ({
     request,
   }) => {
     const localState: Record<string, string> = {
@@ -245,8 +243,7 @@ test.describe
     await cancelProcessInstance(localState.processInstanceKey2);
   });
 
-  // Skipped due to bug 41209: https://github.com/camunda/camunda/issues/41209
-  test.skip('Create a Batch Operation to Resolve Incidents - With Or Filters', async ({
+  test('Create a Batch Operation to Resolve Incidents - With Or Filters', async ({
     request,
   }) => {
     const localState: Record<string, string> = {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
@@ -237,8 +237,7 @@ test.describe.parallel('Search Variables API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Variables with invalid pagination parameters', async ({
+  test('Search Variables with invalid pagination parameters', async ({
     request,
   }) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -97,9 +97,8 @@ test.describe('Operations', () => {
     });
   });
 
-  // Skipped due to bug 42375: https://github.com/camunda/camunda/issues/42375
   // !Note: assert the code after the bug is fixed as it was dicoverd during the test implementation
-  test.skip('Retry and cancel single instance', async ({
+  test('Retry and cancel single instance', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -202,10 +202,8 @@ test.describe('Process Instance Modifications', () => {
     });
   });
 
-  // Skipped due to bug 42546: https://github.com/camunda/camunda/issues/42546
   // !Note: assert the code after the bug is fixed as it was discoverd during the test implementation
-  // eslint-disable-next-line playwright/no-skipped-test
-  test.skip('Should apply/remove add variable modifications', async ({
+  test('Should apply/remove add variable modifications', async ({
     page,
     operateProcessInstancePage,
     operateProcessModificationModePage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -74,8 +74,7 @@ test.describe('Process Instances Table', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // Skipped due to bug 38103: https://github.com/camunda/camunda/issues/38103
-  test.skip('Sorting of process instances', async ({
+  test('Sorting of process instances', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,


### PR DESCRIPTION
## Auto-Unskip: Tests with Closed Bug References

> Opened automatically by the [auto-unskip workflow](https://github.com/camunda/qa-metrics-exporter/actions/runs/27818360385).

**11** test(s) in `stable/8.8` were unskipped because their referenced bugs are now closed.

### Closed Bugs

- [camunda/camunda#39372](https://github.com/camunda/camunda/issues/39372) No validation of page limit attribute in Search Request — closed 2026-03-09
- [camunda/camunda#43097](https://github.com/camunda/camunda/issues/43097) Suspend Batch Operation unexpectedly blocks further Batch Operation progress — closed 2026-03-09
- [camunda/camunda#41209](https://github.com/camunda/camunda/issues/41209) Process instance is still shown with incident after successfully resolving the incident — closed 2026-04-15
- [camunda/camunda#42375](https://github.com/camunda/camunda/issues/42375) Cancel operation is not added to operations panel when triggered for single instance — closed 2026-03-24
- [camunda/camunda#42546](https://github.com/camunda/camunda/issues/42546) Undo operation in modification mode removes incorrect modification when performed from different flow node scope — closed 2026-03-03
- [camunda/camunda#38103](https://github.com/camunda/camunda/issues/38103) Sort by Version fails after applying Process Instance filter — closed 2026-03-25

### Files Changed (9)

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts`: 1 skip(s) removed (camunda/camunda#43097)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-resolve-incidents-api.spec.ts`: 3 skip(s) removed (camunda/camunda#41209)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts`: 1 skip(s) removed (camunda/camunda#42375)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts`: 1 skip(s) removed (camunda/camunda#42546)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts`: 1 skip(s) removed (camunda/camunda#38103)

### ⚠️ Needs manual review (4)

These markers reference closed bugs but could **not** be safely auto-unskipped, so they were left untouched:

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts` L65 (camunda/camunda#42165) — marker precedes commented-out code (uncomment manually)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts` L23 (camunda/camunda#48562) — conditional/ternary skip expression
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts` L22 (camunda/camunda#48562) — conditional/ternary skip expression
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts` L157 (camunda/camunda#42546) — marker precedes commented-out code (uncomment manually)

### Checklist

- [ ] On-demand test run passes on this branch
- [ ] No regressions in adjacent tests
