### PR TITLE
Implement AgentHistory ES/OS secondary-storage search reader

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AgentHistoryDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AgentHistoryDocumentReader.java
@@ -24,7 +24,10 @@ public class AgentHistoryDocumentReader extends DocumentBasedReader implements A
   @Override
   public SearchQueryResult<AgentInstanceHistoryEntity> search(
       final AgentInstanceHistoryQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException(
-        "AgentHistoryDocumentReader is not yet implemented. Tracked in #55268.");
+    return getSearchExecutor()
+        .search(
+            query,
+            io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.class,
+            resourceAccessChecks);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -111,6 +111,7 @@ import io.camunda.search.clients.transformers.entity.UserEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserTaskEntityTransformer;
 import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
 import io.camunda.search.clients.transformers.entity.WaitStateEntityTransformer;
+import io.camunda.search.clients.transformers.filter.AgentHistoryFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AgentInstanceFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AuditLogFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AuthorizationFilterTransformer;
@@ -194,6 +195,7 @@ import io.camunda.search.clients.transformers.sort.UserTaskFieldSortingTransform
 import io.camunda.search.clients.transformers.sort.VariableFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.WaitStateFieldSortingTransformer;
 import io.camunda.search.filter.AgentInstanceFilter;
+import io.camunda.search.filter.AgentInstanceHistoryFilter;
 import io.camunda.search.filter.AuditLogFilter;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
@@ -335,6 +337,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate;
 import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
@@ -575,6 +578,9 @@ public final class ServiceTransformers {
     mappers.put(WaitStateSort.class, new WaitStateFieldSortingTransformer());
 
     // filters -> search query
+    mappers.put(
+        AgentInstanceHistoryFilter.class,
+        new AgentHistoryFilterTransformer(indexDescriptors.get(AgentHistoryTemplate.class)));
     mappers.put(
         AgentInstanceFilter.class,
         new AgentInstanceFilterTransformer(indexDescriptors.get(AgentInstanceTemplate.class)));

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -79,6 +79,7 @@ import io.camunda.search.clients.transformers.aggregation.result.ProcessDefiniti
 import io.camunda.search.clients.transformers.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsTUAggregationResultTransformer;
+import io.camunda.search.clients.transformers.entity.AgentHistoryEntityTransformer;
 import io.camunda.search.clients.transformers.entity.AgentInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.AuditLogEntityTransformer;
 import io.camunda.search.clients.transformers.entity.AuthorizationEntityTransformer;
@@ -357,6 +358,7 @@ import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity;
 import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
@@ -496,6 +498,7 @@ public final class ServiceTransformers {
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
+    mappers.put(AgentHistoryEntity.class, new AgentHistoryEntityTransformer());
     mappers.put(AgentInstanceEntity.class, new AgentInstanceEntityTransformer());
     mappers.put(AuthorizationEntity.class, new AuthorizationEntityTransformer());
     mappers.put(BatchOperationEntity.class, new BatchOperationEntityTransformer());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -162,6 +162,7 @@ import io.camunda.search.clients.transformers.result.DecisionRequirementsResultC
 import io.camunda.search.clients.transformers.result.DeployedResourceResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.ProcessDefinitionResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.ProcessInstanceResultConfigTransformer;
+import io.camunda.search.clients.transformers.sort.AgentHistoryFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.AgentInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.AuditLogSortTransformer;
 import io.camunda.search.clients.transformers.sort.AuthorizationFieldSortingTransformer;
@@ -239,6 +240,7 @@ import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
@@ -290,6 +292,7 @@ import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
 import io.camunda.search.result.DeployedResourceQueryResultConfig;
 import io.camunda.search.result.ProcessDefinitionQueryResultConfig;
 import io.camunda.search.result.ProcessInstanceQueryResultConfig;
+import io.camunda.search.sort.AgentInstanceHistorySort;
 import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.search.sort.AuditLogSort;
 import io.camunda.search.sort.AuthorizationSort;
@@ -453,6 +456,7 @@ public final class ServiceTransformers {
         new TypedSearchQueryTransformer<>(mappers);
     // query -> request
     Stream.of(
+            AgentInstanceHistoryQuery.class,
             AgentInstanceQuery.class,
             AuthorizationQuery.class,
             BatchOperationQuery.class,
@@ -539,6 +543,7 @@ public final class ServiceTransformers {
     mappers.put(DeployedResourceEntity.class, new DeployedResourceEntityTransformer());
 
     // domain field sorting -> database field sorting
+    mappers.put(AgentInstanceHistorySort.class, new AgentHistoryFieldSortingTransformer());
     mappers.put(AgentInstanceSort.class, new AgentInstanceFieldSortingTransformer());
     mappers.put(AuthorizationSort.class, new AuthorizationFieldSortingTransformer());
     mappers.put(BatchOperationSort.class, new BatchOperationFieldSortingTransformer());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformer.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentMetadata;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentReference;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Metrics;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryContentValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryEmbeddedToolCallValue;
+import io.camunda.webapps.schema.entities.document.DocumentReferenceEntity;
+import java.util.List;
+
+public class AgentHistoryEntityTransformer
+    implements ServiceTransformer<AgentHistoryEntity, AgentInstanceHistoryEntity> {
+
+  @Override
+  public AgentInstanceHistoryEntity apply(final AgentHistoryEntity source) {
+    return new AgentInstanceHistoryEntity(
+        source.getKey(),
+        source.getAgentInstanceKey(),
+        source.getElementInstanceKey(),
+        source.getProcessInstanceKey(),
+        source.getProcessDefinitionKey(),
+        source.getBpmnProcessId(),
+        source.getTenantId(),
+        source.getJobKey(),
+        source.getJobLease(),
+        source.getIteration(),
+        toRole(source.getRole()),
+        toContent(source.getContent()),
+        toToolCalls(source.getToolCalls()),
+        new Metrics(source.getInputTokens(), source.getOutputTokens(), source.getDurationMs()),
+        toCommitStatus(source.getCommitStatus()),
+        source.getProducedAt());
+  }
+
+  private static AgentInstanceHistoryRole toRole(
+      final io.camunda.webapps.schema.entities.agenthistory.AgentHistoryRole role) {
+    return switch (role) {
+      case USER -> AgentInstanceHistoryRole.USER;
+      case ASSISTANT -> AgentInstanceHistoryRole.ASSISTANT;
+      case TOOL_RESULT -> AgentInstanceHistoryRole.TOOL_RESULT;
+    };
+  }
+
+  private static AgentInstanceHistoryCommitStatus toCommitStatus(
+      final io.camunda.webapps.schema.entities.agenthistory.AgentHistoryCommitStatus status) {
+    return switch (status) {
+      case PENDING -> AgentInstanceHistoryCommitStatus.PENDING;
+      case COMMITTED -> AgentInstanceHistoryCommitStatus.COMMITTED;
+      case DISCARDED -> AgentInstanceHistoryCommitStatus.DISCARDED;
+    };
+  }
+
+  private static List<ContentItem> toContent(final List<AgentHistoryContentValue> content) {
+    if (content == null) {
+      return List.of();
+    }
+    return content.stream().map(AgentHistoryEntityTransformer::toContentItem).toList();
+  }
+
+  private static ContentItem toContentItem(final AgentHistoryContentValue value) {
+    return switch (value.contentType()) {
+      case TEXT -> new ContentItem(ContentType.TEXT, value.text(), null, null);
+      case DOCUMENT ->
+          new ContentItem(
+              ContentType.DOCUMENT, null, toDocumentReference(value.documentReference()), null);
+      case OBJECT -> new ContentItem(ContentType.OBJECT, null, null, value.object());
+    };
+  }
+
+  private static DocumentReference toDocumentReference(final DocumentReferenceEntity entity) {
+    if (entity == null) {
+      return null;
+    }
+    final var meta = entity.metadata();
+    return new DocumentReference(
+        entity.storeId(),
+        entity.documentId(),
+        entity.contentHash(),
+        new DocumentMetadata(
+            meta.contentType(),
+            meta.fileName(),
+            meta.expiresAt(),
+            meta.size(),
+            meta.processDefinitionId(),
+            meta.processInstanceKey(),
+            meta.customProperties()));
+  }
+
+  private static List<ToolCall> toToolCalls(
+      final List<AgentHistoryEmbeddedToolCallValue> toolCalls) {
+    if (toolCalls == null) {
+      return List.of();
+    }
+    return toolCalls.stream()
+        .map(t -> new ToolCall(t.toolCallId(), t.toolName(), t.elementId(), t.arguments()))
+        .toList();
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentHistoryFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentHistoryFilterTransformer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.intOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.AGENT_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.COMMIT_STATUS;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.ELEMENT_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.ITERATION;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.JOB_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.PRODUCED_AT;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.ROLE;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.AgentInstanceHistoryFilter;
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.ArrayList;
+
+public class AgentHistoryFilterTransformer
+    extends IndexFilterTransformer<AgentInstanceHistoryFilter> {
+
+  public AgentHistoryFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final AgentInstanceHistoryFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+    queries.addAll(longOperations(AGENT_INSTANCE_KEY, filter.agentInstanceKeyOperations()));
+    queries.addAll(longOperations(KEY, filter.historyItemKeyOperations()));
+    queries.addAll(stringOperations(ROLE, filter.roleOperations()));
+    queries.addAll(longOperations(ELEMENT_INSTANCE_KEY, filter.elementInstanceKeyOperations()));
+    queries.addAll(longOperations(JOB_KEY, filter.jobKeyOperations()));
+    queries.addAll(intOperations(ITERATION, filter.iterationOperations()));
+    queries.addAll(stringOperations(COMMIT_STATUS, filter.commitStatusOperations()));
+    queries.addAll(dateTimeOperations(PRODUCED_AT, filter.producedAtOperations()));
+    return and(queries);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(
+      final RequiredAuthorization<?> authorization) {
+    return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentHistoryFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentHistoryFieldSortingTransformer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.ITERATION;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.PRODUCED_AT;
+
+public class AgentHistoryFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "historyItemKey" -> KEY;
+      case "iteration" -> ITERATION;
+      case "producedAt" -> PRODUCED_AT;
+      default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformerTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryCommitStatus;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryContentValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryEmbeddedToolCallValue;
+import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryRole;
+import io.camunda.webapps.schema.entities.document.DocumentReferenceEntity;
+import io.camunda.webapps.schema.entities.document.DocumentReferenceMetadataEntity;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class AgentHistoryEntityTransformerTest {
+
+  private final AgentHistoryEntityTransformer transformer = new AgentHistoryEntityTransformer();
+
+  private AgentHistoryEntity buildSource() {
+    final var source = new AgentHistoryEntity();
+    source.setId("1");
+    source.setKey(100L);
+    source.setAgentInstanceKey(50L);
+    source.setElementInstanceKey(200L);
+    source.setProcessInstanceKey(300L);
+    source.setRootProcessInstanceKey(250L);
+    source.setBpmnProcessId("my-process");
+    source.setProcessDefinitionKey(400L);
+    source.setTenantId("<default>");
+    source.setPartitionId(1);
+    source.setJobKey(500L);
+    source.setJobLease("lease-token");
+    source.setIteration(3);
+    source.setRole(AgentHistoryRole.ASSISTANT);
+    source.setCommitStatus(AgentHistoryCommitStatus.COMMITTED);
+    source.setProducedAt(OffsetDateTime.parse("2024-06-01T12:00:00Z"));
+    source.setInputTokens(50L);
+    source.setOutputTokens(30L);
+    source.setDurationMs(1200L);
+    source.setContent(List.of(AgentHistoryContentValue.text("Hello, world!")));
+    source.setToolCalls(
+        List.of(
+            new AgentHistoryEmbeddedToolCallValue(
+                "tc-1", "search", "elem-1", Map.of("query", "weather"))));
+    return source;
+  }
+
+  @Test
+  void shouldMapAllFields() {
+    // given
+    final var source = buildSource();
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.historyItemKey()).isEqualTo(100L);
+    assertThat(result.agentInstanceKey()).isEqualTo(50L);
+    assertThat(result.elementInstanceKey()).isEqualTo(200L);
+    assertThat(result.processInstanceKey()).isEqualTo(300L);
+    assertThat(result.processDefinitionKey()).isEqualTo(400L);
+    assertThat(result.processDefinitionId()).isEqualTo("my-process");
+    assertThat(result.tenantId()).isEqualTo("<default>");
+    assertThat(result.jobKey()).isEqualTo(500L);
+    assertThat(result.jobLease()).isEqualTo("lease-token");
+    assertThat(result.iteration()).isEqualTo(3);
+    assertThat(result.role()).isEqualTo(AgentInstanceHistoryRole.ASSISTANT);
+    assertThat(result.commitStatus()).isEqualTo(AgentInstanceHistoryCommitStatus.COMMITTED);
+    assertThat(result.producedAt()).isEqualTo(OffsetDateTime.parse("2024-06-01T12:00:00Z"));
+    assertThat(result.metrics().inputTokens()).isEqualTo(50L);
+    assertThat(result.metrics().outputTokens()).isEqualTo(30L);
+    assertThat(result.metrics().durationMs()).isEqualTo(1200L);
+    assertThat(result.content()).hasSize(1);
+    assertThat(result.content().get(0).contentType()).isEqualTo(ContentType.TEXT);
+    assertThat(result.content().get(0).text()).isEqualTo("Hello, world!");
+    assertThat(result.toolCalls()).hasSize(1);
+    assertThat(result.toolCalls().get(0).toolCallId()).isEqualTo("tc-1");
+    assertThat(result.toolCalls().get(0).toolName()).isEqualTo("search");
+    assertThat(result.toolCalls().get(0).elementId()).isEqualTo("elem-1");
+    assertThat(result.toolCalls().get(0).arguments()).isEqualTo(Map.of("query", "weather"));
+  }
+
+  @Test
+  void shouldMapNullContentToEmptyList() {
+    // given
+    final var source = buildSource();
+    source.setContent(null);
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.content()).isEmpty();
+  }
+
+  @Test
+  void shouldMapNullToolCallsToEmptyList() {
+    // given
+    final var source = buildSource();
+    source.setToolCalls(null);
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.toolCalls()).isEmpty();
+  }
+
+  @Test
+  void shouldMapNullIterationAsNull() {
+    // given
+    final var source = buildSource();
+    source.setIteration(null);
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.iteration()).isNull();
+  }
+
+  @Test
+  void shouldMapTextContent() {
+    // given
+    final var source = buildSource();
+    source.setContent(List.of(AgentHistoryContentValue.text("some text")));
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.content()).hasSize(1);
+    final var item = result.content().get(0);
+    assertThat(item.contentType()).isEqualTo(ContentType.TEXT);
+    assertThat(item.text()).isEqualTo("some text");
+    assertThat(item.documentReference()).isNull();
+    assertThat(item.object()).isEmpty();
+  }
+
+  @Test
+  void shouldMapDocumentContent() {
+    // given
+    final var metadata =
+        new DocumentReferenceMetadataEntity(
+            "application/pdf", "report.pdf", null, 2048L, null, null, Map.of());
+    final var docRefEntity = new DocumentReferenceEntity("doc-1", "store-1", "hash123", metadata);
+    final var source = buildSource();
+    source.setContent(List.of(AgentHistoryContentValue.document(docRefEntity)));
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.content()).hasSize(1);
+    final var item = result.content().get(0);
+    assertThat(item.contentType()).isEqualTo(ContentType.DOCUMENT);
+    assertThat(item.text()).isNull();
+    final var docRef = item.documentReference();
+    assertThat(docRef).isNotNull();
+    assertThat(docRef.storeId()).isEqualTo("store-1");
+    assertThat(docRef.documentId()).isEqualTo("doc-1");
+    assertThat(docRef.contentHash()).isEqualTo("hash123");
+    assertThat(docRef.metadata().contentType()).isEqualTo("application/pdf");
+    assertThat(docRef.metadata().fileName()).isEqualTo("report.pdf");
+    assertThat(docRef.metadata().size()).isEqualTo(2048L);
+  }
+
+  @Test
+  void shouldMapObjectContent() {
+    // given
+    final var objectData = Map.<String, Object>of("result", "42");
+    final var source = buildSource();
+    source.setContent(List.of(AgentHistoryContentValue.object(objectData)));
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.content()).hasSize(1);
+    final var item = result.content().get(0);
+    assertThat(item.contentType()).isEqualTo(ContentType.OBJECT);
+    assertThat(item.object()).isEqualTo(objectData);
+  }
+
+  @ParameterizedTest
+  @EnumSource(AgentHistoryRole.class)
+  void shouldMapEveryRole(final AgentHistoryRole schemaRole) {
+    // given
+    final var source = buildSource();
+    source.setRole(schemaRole);
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then — 1:1 name mapping
+    assertThat(result.role()).isNotNull();
+    assertThat(result.role().name()).isEqualTo(schemaRole.name());
+  }
+
+  @ParameterizedTest
+  @EnumSource(AgentHistoryCommitStatus.class)
+  void shouldMapEveryCommitStatus(final AgentHistoryCommitStatus schemaStatus) {
+    // given
+    final var source = buildSource();
+    source.setCommitStatus(schemaStatus);
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then — 1:1 name mapping
+    assertThat(result.commitStatus()).isNotNull();
+    assertThat(result.commitStatus().name()).isEqualTo(schemaStatus.name());
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentHistoryFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentHistoryFilterTransformerTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.Operation;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class AgentHistoryFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldQueryByAgentInstanceKey() {
+    // given
+    final var filter = FilterBuilders.agentInstanceHistory(f -> f.agentInstanceKeys(50L));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("agentInstanceKey");
+              assertThat(t.value().longValue()).isEqualTo(50L);
+            });
+  }
+
+  @Test
+  void shouldQueryByHistoryItemKey() {
+    // given
+    final var filter = FilterBuilders.agentInstanceHistory(f -> f.historyItemKeys(100L));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("key");
+              assertThat(t.value().longValue()).isEqualTo(100L);
+            });
+  }
+
+  @Test
+  void shouldQueryByRole() {
+    // given
+    final var filter =
+        FilterBuilders.agentInstanceHistory(f -> f.roles(AgentInstanceHistoryRole.ASSISTANT));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("role");
+              assertThat(t.value().stringValue()).isEqualTo("ASSISTANT");
+            });
+  }
+
+  @Test
+  void shouldQueryByElementInstanceKey() {
+    // given
+    final var filter = FilterBuilders.agentInstanceHistory(f -> f.elementInstanceKeys(200L));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("elementInstanceKey");
+              assertThat(t.value().longValue()).isEqualTo(200L);
+            });
+  }
+
+  @Test
+  void shouldQueryByJobKey() {
+    // given
+    final var filter = FilterBuilders.agentInstanceHistory(f -> f.jobKeys(300L));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("jobKey");
+              assertThat(t.value().longValue()).isEqualTo(300L);
+            });
+  }
+
+  @Test
+  void shouldQueryByIteration() {
+    // given
+    final var filter = FilterBuilders.agentInstanceHistory(f -> f.iterations(3));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("iteration");
+              assertThat(t.value().intValue()).isEqualTo(3);
+            });
+  }
+
+  @Test
+  void shouldQueryByCommitStatus() {
+    // given
+    final var filter =
+        FilterBuilders.agentInstanceHistory(
+            f -> f.commitStatuses(AgentInstanceHistoryCommitStatus.COMMITTED));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("commitStatus");
+              assertThat(t.value().stringValue()).isEqualTo("COMMITTED");
+            });
+  }
+
+  @Test
+  void shouldQueryByProducedAt() {
+    // given
+    final var date = OffsetDateTime.parse("2024-06-01T00:00:00Z");
+    final var filter =
+        FilterBuilders.agentInstanceHistory(f -> f.producedAtOperations(Operation.eq(date)));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("producedAt");
+              assertThat(t.value().stringValue()).contains("2024-06-01");
+            });
+  }
+
+  @Test
+  void shouldQueryByAllFields() {
+    // given
+    final var filter =
+        FilterBuilders.agentInstanceHistory(
+            f ->
+                f.agentInstanceKeys(50L)
+                    .historyItemKeys(100L)
+                    .roles(AgentInstanceHistoryRole.USER)
+                    .elementInstanceKeys(200L)
+                    .jobKeys(300L)
+                    .iterations(2)
+                    .commitStatuses(AgentInstanceHistoryCommitStatus.PENDING)
+                    .producedAtOperations(
+                        Operation.eq(OffsetDateTime.parse("2024-06-01T00:00:00Z"))));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption()).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) searchRequest.queryOption()).must()).hasSize(8);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentHistoryFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentHistoryFieldSortingTransformerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.AgentInstanceHistorySort;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.util.ObjectBuilder;
+import io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class AgentHistoryFieldSortingTransformerTest extends AbstractSortTransformerTest {
+
+  private static Stream<Arguments> provideSortParameters() {
+    return Stream.of(
+        new TestArguments(AgentHistoryTemplate.KEY, SortOrder.DESC, s -> s.historyItemKey().desc()),
+        new TestArguments(AgentHistoryTemplate.ITERATION, SortOrder.ASC, s -> s.iteration().asc()),
+        new TestArguments(
+            AgentHistoryTemplate.PRODUCED_AT, SortOrder.DESC, s -> s.producedAt().desc()));
+  }
+
+  @ParameterizedTest(name = "should sort by {0} in ''{1}'' direction")
+  @MethodSource("provideSortParameters")
+  void shouldSortByField(
+      final String expectedField,
+      final SortOrder sortOrder,
+      final Function<AgentInstanceHistorySort.Builder, ObjectBuilder<AgentInstanceHistorySort>>
+          fn) {
+    // given
+    final var request = SearchQueryBuilders.agentInstanceHistorySearchQuery(q -> q.sort(fn));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort).hasSize(2);
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(expectedField);
+              assertThat(t.field().order()).isEqualTo(sortOrder);
+            });
+    assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(AgentHistoryTemplate.KEY);
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  @Test
+  void shouldUseHistoryItemKeyAsDefaultTiebreakerWhenNoSortSpecified() {
+    // given — query with no explicit sort
+    final var request = SearchQueryBuilders.agentInstanceHistorySearchQuery(q -> q);
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then — only the implicit default tiebreaker is appended
+    assertThat(sort).hasSize(1);
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(AgentHistoryTemplate.KEY);
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  @Test
+  void shouldThrowForUnknownSortField() {
+    // given
+    final var transformer = new AgentHistoryFieldSortingTransformer();
+
+    // when / then
+    assertThatThrownBy(() -> transformer.apply("unknownField"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknownField");
+  }
+
+  private record TestArguments(
+      String expectedField,
+      SortOrder sortOrder,
+      Function<AgentInstanceHistorySort.Builder, ObjectBuilder<AgentInstanceHistorySort>> fn)
+      implements Arguments {
+
+    @Override
+    public Object[] get() {
+      return new Object[] {expectedField, sortOrder, fn};
+    }
+
+    @Override
+    public String toString() {
+      return expectedField + " " + sortOrder;
+    }
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentHistoryTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentHistoryTemplate.java
@@ -27,6 +27,7 @@ public class AgentHistoryTemplate extends AbstractTemplateDescriptor
   public static final String INDEX_VERSION = "8.10.0";
 
   public static final String KEY = "key";
+  public static final String AGENT_INSTANCE_KEY = "agentInstanceKey";
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String ELEMENT_INSTANCE_KEY = "elementInstanceKey";
   public static final String TENANT_ID = "tenantId";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryCommitStatus.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryCommitStatus.java
@@ -9,7 +9,6 @@ package io.camunda.webapps.schema.entities.agenthistory;
 
 /** Entity-layer enum for the commit status of a history entry. */
 public enum AgentHistoryCommitStatus {
-  UNKNOWN,
   PENDING,
   COMMITTED,
   DISCARDED

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryContentType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryContentType.java
@@ -7,13 +7,8 @@
  */
 package io.camunda.webapps.schema.entities.agenthistory;
 
-/**
- * Entity-layer enum for the content type of a history entry content block. {@code UNKNOWN} is used
- * for any protocol value that has no explicit mapping (e.g. {@code UNSPECIFIED} or future types);
- * the content is still stored with all available fields so data is not silently discarded.
- */
+/** Entity-layer enum for the content type of a history entry content block. */
 public enum AgentHistoryContentType {
-  UNKNOWN,
   TEXT,
   DOCUMENT,
   OBJECT

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
@@ -399,8 +399,7 @@ public final class AgentHistoryEntity
 
   /**
    * A single content block in a history entry message. {@code text}, {@code documentReference}, and
-   * {@code object} are mutually exclusive based on {@code contentType}; for {@code UNKNOWN} types
-   * all available fields are populated as-is.
+   * {@code object} are mutually exclusive based on {@code contentType}.
    */
   public record AgentHistoryContentValue(
       AgentHistoryContentType contentType,

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryRole.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryRole.java
@@ -9,7 +9,6 @@ package io.camunda.webapps.schema.entities.agenthistory;
 
 /** Entity-layer enum for the role of a history entry author. */
 public enum AgentHistoryRole {
-  UNKNOWN,
   USER,
   ASSISTANT,
   TOOL_RESULT

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -105,9 +105,9 @@ public class AgentHistoryHandler
         .setRole(mapRole(value.getRole()))
         .setCommitStatus(mapCommitStatusFromIntent(intent))
         .setProducedAt(
-            value.getProducedAt() > 0
-                ? DateUtil.toOffsetDateTime(Instant.ofEpochMilli(value.getProducedAt()))
-                : null)
+            DateUtil.toOffsetDateTime(
+                Instant.ofEpochMilli(
+                    value.getProducedAt() > 0 ? value.getProducedAt() : record.getTimestamp())))
         .setInputTokens(value.getMetrics().getInputTokens())
         .setOutputTokens(value.getMetrics().getOutputTokens())
         .setDurationMs(value.getMetrics().getDurationMs())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -12,7 +12,6 @@ import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplat
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryCommitStatus;
-import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryContentType;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryEntity.AgentHistoryContentValue;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryRole;
@@ -30,8 +29,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * CamundaExporter handler for {@code AGENT_HISTORY} records.
@@ -45,8 +42,6 @@ import org.slf4j.LoggerFactory;
  */
 public class AgentHistoryHandler
     implements ExportHandler<AgentHistoryEntity, AgentHistoryRecordValue> {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(AgentHistoryHandler.class);
 
   private static final Set<AgentHistoryIntent> HANDLED_INTENTS =
       Set.of(
@@ -134,25 +129,23 @@ public class AgentHistoryHandler
       case USER -> AgentHistoryRole.USER;
       case ASSISTANT -> AgentHistoryRole.ASSISTANT;
       case TOOL_RESULT -> AgentHistoryRole.TOOL_RESULT;
-      default -> {
-        LOGGER.warn(
-            "Received unexpected AgentHistoryRole: {}, will be mapped to UNKNOWN", protocolRole);
-        yield AgentHistoryRole.UNKNOWN;
-      }
+      // should never happen — protocol UNSPECIFIED is always overwritten before export
+      case UNSPECIFIED ->
+          throw new IllegalStateException(
+              "Unexpected UNSPECIFIED AgentHistoryRole on an exported record");
     };
   }
 
   private static AgentHistoryCommitStatus mapCommitStatusFromIntent(
       final AgentHistoryIntent intent) {
+    // should never happen — handlesRecord() gates updateEntity() to the three event intents
     return switch (intent) {
       case CREATED -> AgentHistoryCommitStatus.PENDING;
       case COMMITTED -> AgentHistoryCommitStatus.COMMITTED;
       case DISCARDED -> AgentHistoryCommitStatus.DISCARDED;
-      default -> {
-        LOGGER.warn(
-            "Received unexpected AgentHistoryIntent: {}, will be mapped to UNKNOWN", intent);
-        yield AgentHistoryCommitStatus.UNKNOWN;
-      }
+      default ->
+          throw new IllegalStateException(
+              "Unexpected AgentHistoryIntent on an exported record: " + intent);
     };
   }
 
@@ -167,16 +160,10 @@ public class AgentHistoryHandler
                       AgentHistoryContentValue.document(
                           mapDocumentReference(c.getDocumentReference()));
                   case OBJECT -> AgentHistoryContentValue.object(c.getObject());
-                  default -> {
-                    LOGGER.warn(
-                        "Received unexpected AgentHistoryContentType: {}, will be mapped to UNKNOWN",
-                        c.getContentType());
-                    yield new AgentHistoryContentValue(
-                        AgentHistoryContentType.UNKNOWN,
-                        ExporterUtil.emptyToNull(c.getText()),
-                        mapDocumentReference(c.getDocumentReference()),
-                        c.getObject().isEmpty() ? null : c.getObject());
-                  }
+                  // should never happen — protocol UNSPECIFIED is always overwritten before export
+                  case UNSPECIFIED ->
+                      throw new IllegalStateException(
+                          "Unexpected UNSPECIFIED AgentHistoryContentType on an exported record");
                 })
         .toList();
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -547,9 +547,9 @@ final class AgentHistoryHandlerTest {
   }
 
   @Test
-  void shouldConvertNonPositiveProducedAtToNull() {
-    // given — producedAt == -1 is the protocol default for "unset"; Instant.ofEpochMilli(-1)
-    // would produce a 1969 timestamp, which is invalid for this field
+  void shouldFallBackToRecordTimestampWhenProducedAtNonPositive() {
+    // given — producedAt == -1 is the protocol default for "unset"; fall back to the record
+    // timestamp so the non-nullable API contract is preserved
     final var recordValue =
         ImmutableAgentHistoryRecordValue.builder()
             .from(buildMinimalRecordValue(1L, 1))
@@ -565,7 +565,8 @@ final class AgentHistoryHandlerTest {
     underTest.updateEntity(record, entity);
 
     // then
-    assertThat(entity.getProducedAt()).isNull();
+    assertThat(entity.getProducedAt())
+        .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
   }
 
   // --- helpers ---

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.COMMIT_STATUS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
@@ -255,7 +256,7 @@ final class AgentHistoryHandlerTest {
   }
 
   @Test
-  void shouldMapUnspecifiedRoleToUnknown() {
+  void shouldThrowOnUnspecifiedRole() {
     // given
     final var recordValue =
         ImmutableAgentHistoryRecordValue.builder()
@@ -268,11 +269,12 @@ final class AgentHistoryHandlerTest {
             r -> r.withIntent(AgentHistoryIntent.CREATED).withValue(recordValue));
     final var entity = new AgentHistoryEntity().setId("1");
 
-    // when
-    underTest.updateEntity(record, entity);
-
-    // then
-    assertThat(entity.getRole()).isEqualTo(AgentHistoryRole.UNKNOWN);
+    // when / then
+    assertThatThrownBy(() -> underTest.updateEntity(record, entity))
+        .as(
+            "If a new AgentHistoryRole is added, add an explicit case to AgentHistoryHandler.mapRole()")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Unexpected UNSPECIFIED AgentHistoryRole on an exported record");
   }
 
   @ParameterizedTest(name = "[{index}] Intent ''{0}'' should map to the expected commitStatus")
@@ -300,12 +302,12 @@ final class AgentHistoryHandlerTest {
     assertThat(entity.getCommitStatus()).isEqualTo(expected);
   }
 
-  @ParameterizedTest(name = "[{index}] Unexpected ''{0}'' should map to ''UNKNOWN'' commitStatus")
+  @ParameterizedTest(name = "[{index}] Unexpected ''{0}'' should throw")
   @EnumSource(
       value = AgentHistoryIntent.class,
       names = {"CREATED", "COMMITTED", "DISCARDED"},
       mode = Mode.EXCLUDE)
-  void shouldMapUnexpectedIntentToUnknownCommitStatus(final AgentHistoryIntent intent) {
+  void shouldThrowForUnexpectedIntent(final AgentHistoryIntent intent) {
     // given
     final Record<AgentHistoryRecordValue> record =
         factory.generateRecord(
@@ -313,11 +315,12 @@ final class AgentHistoryHandlerTest {
             r -> r.withIntent(intent).withValue(buildMinimalRecordValue(1L, 1)));
     final var entity = new AgentHistoryEntity().setId("1");
 
-    // when
-    underTest.updateEntity(record, entity);
-
-    // then
-    assertThat(entity.getCommitStatus()).isEqualTo(AgentHistoryCommitStatus.UNKNOWN);
+    // when / then
+    assertThatThrownBy(() -> underTest.updateEntity(record, entity))
+        .as(
+            "If a new AgentHistoryIntent is handled, add an explicit case to AgentHistoryHandler.mapCommitStatusFromIntent()")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Unexpected AgentHistoryIntent on an exported record: " + intent);
   }
 
   @Test
@@ -357,8 +360,8 @@ final class AgentHistoryHandlerTest {
   }
 
   @Test
-  void shouldMapUnspecifiedContentTypeToUnknown() {
-    // given — UNSPECIFIED is the protocol sentinel; it should survive as UNKNOWN (not be dropped)
+  void shouldThrowOnUnspecifiedContentType() {
+    // given — UNSPECIFIED is the protocol sentinel; it cannot occur for a real exported record
     final var unspecifiedItem =
         ImmutableAgentHistoryMessageContentValue.builder()
             .withContentType(
@@ -377,18 +380,12 @@ final class AgentHistoryHandlerTest {
             r -> r.withIntent(AgentHistoryIntent.CREATED).withValue(recordValue));
     final var entity = new AgentHistoryEntity().setId("1");
 
-    // when
-    underTest.updateEntity(record, entity);
-
-    // then — UNSPECIFIED is preserved as UNKNOWN with all available fields
-    assertThat(entity.getContent())
-        .singleElement()
-        .satisfies(
-            content -> {
-              assertThat(content.contentType()).isEqualTo(AgentHistoryContentType.UNKNOWN);
-              assertThat(content.text()).isEqualTo("some text");
-              assertThat(content.object()).isEqualTo(Map.of("key", "value"));
-            });
+    // when / then
+    assertThatThrownBy(() -> underTest.updateEntity(record, entity))
+        .as(
+            "If a new AgentHistoryContentType is added, add an explicit case to AgentHistoryHandler.mapContent()")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Unexpected UNSPECIFIED AgentHistoryContentType on an exported record");
   }
 
   @ParameterizedTest(


### PR DESCRIPTION
## Overview

Implements the Elasticsearch/OpenSearch secondary-storage search reader for agent history records, closing the gap between the exporter (which writes `AgentHistoryEntity` documents to the `agent-history` index) and the REST layer (which needs `AgentInstanceHistoryEntity` search results).

## What changed

**Fix: `producedAt` fallback in the exporter**
`AgentHistoryHandler` was returning `null` for `producedAt` when the protocol value was non-positive. Changed to fall back to the enclosing record's timestamp, which is always set. The matching test is updated to assert on the timestamp value instead of null.

**Schema cleanup: remove `UNKNOWN` enum variants**
`AgentHistoryRole`, `AgentHistoryCommitStatus`, and `AgentHistoryContentType` had `UNKNOWN` variants that are never written to the index. Removing them makes the enums a faithful mirror of the protocol enums and lets switch statements be exhaustive without a default arm. The exporter handler now throws `IllegalStateException` on `UNSPECIFIED`/unexpected values rather than silently mapping them to `UNKNOWN`.

**Entity transformer (`AgentHistoryEntityTransformer`)**
Maps `AgentHistoryEntity` (schema) → `AgentInstanceHistoryEntity` (domain) with exhaustive enum switches (3-arm, no default), null-safe collection handling (returns empty lists for null content/toolCalls), and correct `DocumentReference` field order — the schema record is `(documentId, storeId, …)` while the domain record is `(storeId, documentId, …)`.

**Filter transformer (`AgentHistoryFilterTransformer`) + `AGENT_INSTANCE_KEY` constant**
Translates all eight `AgentInstanceHistoryFilter` field-operation lists to ES/OS queries. Authorization check uses `bpmnProcessId` terms, matching the pattern established by `AgentInstanceFilterTransformer`. Added `AGENT_INSTANCE_KEY = "agentInstanceKey"` to `AgentHistoryTemplate` to support the agent-instance-key filter.

**Sort transformer (`AgentHistoryFieldSortingTransformer`)**
Maps the three domain sort fields (`historyItemKey`, `iteration`, `producedAt`) to index constants. Default tiebreaker inherits `"key"` from `FieldSortingTransformer`. Also registers `AgentInstanceHistoryQuery` in the `ServiceTransformers` query stream.

**Document reader (`AgentHistoryDocumentReader.search()`)**
Replaces the `UnsupportedOperationException` stub with a real `SearchClientBasedQueryExecutor.search()` call that deserialises into `AgentHistoryEntity` and relies on the registered `AgentHistoryEntityTransformer` to convert results.

## Design decisions

- **No `UNKNOWN` fallback on enums:** throwing on `UNSPECIFIED`/unexpected values is intentional — these cases indicate a programming error in the exporter, not a valid data state. Letting them surface as exceptions is safer than silently corrupting records.
- **`AgentInstanceHistoryQuery` added in C5 (sort commit) rather than C6:** the sort integration test (`AbstractSortTransformerTest`) needs the query registered; pulling it forward avoids a test-only stub.
- **`producedAt` fallback uses record timestamp:** the protocol guarantees every record has a valid timestamp, so the exporter's `producedAt` can always be non-null without guessing.

## Test coverage

Each commit includes a unit test class exercising all mapped fields and edge cases:
- `AgentHistoryEntityTransformerTest` — 13 tests (all fields, null collections, per-enum parameterised)
- `AgentHistoryFilterTransformerTest` — 9 tests (all filter fields + all-fields compound)
- `AgentHistoryFieldSortingTransformerTest` — 5 tests (all sort fields + default tiebreaker + unknown throws)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Closes #55268