### PR TITLE
fix: update Optimize base image digest for CVE-2026-5450

### DIFF
--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:5b3b542628551e21bda68a0a51c91820da43638aa69eae1557ca81c2e562de76"
+ARG BASE_DIGEST="sha256:a8ff2aa9ea257f0809e30915462e56e300b9d189b9f115086d6558661fe54085"
 ARG WAITFORIT_CHECKSUM="b7a04f38de1e51e7455ecf63151c8c7e405bd2d45a2d4e16f6419db737a125d6"
 
 # If you don't have access to Minimus hardened base images, you can use public


### PR DESCRIPTION
## Description

Update `openjre-base-compat:21-dev` digest in `optimize.Dockerfile` to address CVE-2026-5450.

## Checklist

## Related issues