### PR TITLE
Implement CamundaClient support for AgentHistory search

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -144,6 +144,7 @@ import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.request.AgentInstanceHistorySearchRequest;
 import io.camunda.client.api.search.request.AgentInstanceSearchRequest;
 import io.camunda.client.api.search.request.AuditLogSearchRequest;
 import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
@@ -3523,7 +3524,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *       .elementInstanceKey(elementInstanceKey)
    *       .jobKey(jobKey)
    *       .jobLease(jobLease)
-   *       .role(AgentHistoryRole.ASSISTANT)
+   *       .role(AgentInstanceHistoryRole.ASSISTANT)
    *       .content(contentList)
    *       .producedAt(OffsetDateTime.now())
    *       .send()
@@ -3660,4 +3661,20 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for searching agent instances
    */
   AgentInstanceSearchRequest newAgentInstanceSearchRequest();
+
+  /**
+   * Creates a request to search the conversation history of an agent instance.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+   *       .filter(f -> f.role(AgentInstanceHistoryRole.USER))
+   *       .sort(s -> s.producedAt().asc())
+   *       .send();
+   * </pre>
+   *
+   * @param agentInstanceKey the key of the agent instance whose history to search
+   * @return a builder for searching agent instance history
+   */
+  AgentInstanceHistorySearchRequest newAgentInstanceHistorySearchRequest(long agentInstanceKey);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryContent.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryContent.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.DocumentReferenceResponse;
+import java.util.Map;
+
+/**
+ * A content block in an agent instance history item. Use the static factory methods to create
+ * instances; downcast to {@link TextContent}, {@link DocumentContent}, or {@link ObjectContent} to
+ * access type-specific fields.
+ */
+public interface AgentInstanceHistoryContent {
+
+  String getContentType();
+
+  /**
+   * Creates a plain-text content block.
+   *
+   * @param text the text. Must not be null.
+   * @return an {@link AgentInstanceHistoryContent} of type TEXT
+   */
+  static AgentInstanceHistoryContent text(final String text) {
+    if (text == null) {
+      throw new IllegalArgumentException("text must not be null");
+    }
+    return new TextContent(text);
+  }
+
+  /**
+   * Creates an arbitrary-object content block.
+   *
+   * @param object the key-value map. Must not be null.
+   * @return an {@link AgentInstanceHistoryContent} of type OBJECT
+   */
+  static AgentInstanceHistoryContent object(final Map<String, Object> object) {
+    if (object == null) {
+      throw new IllegalArgumentException("object must not be null");
+    }
+    return new ObjectContent(object);
+  }
+
+  /**
+   * Creates a document-reference content block from a {@link DocumentReferenceResponse} returned by
+   * other document APIs (e.g. upload or create-link).
+   *
+   * @param documentReference the document reference. Must not be null.
+   * @return a {@link DocumentContent} of type DOCUMENT
+   */
+  static DocumentContent document(final DocumentReferenceResponse documentReference) {
+    if (documentReference == null) {
+      throw new IllegalArgumentException("documentReference must not be null");
+    }
+    return new DocumentContent(documentReference);
+  }
+
+  /** Plain-text content block ({@code contentType = "TEXT"}). */
+  final class TextContent implements AgentInstanceHistoryContent {
+    private final String text;
+
+    public TextContent(final String text) {
+      this.text = text;
+    }
+
+    @Override
+    public String getContentType() {
+      return "TEXT";
+    }
+
+    public String getText() {
+      return text;
+    }
+  }
+
+  /** Arbitrary structured content block ({@code contentType = "OBJECT"}). */
+  final class ObjectContent implements AgentInstanceHistoryContent {
+    private final Map<String, Object> object;
+
+    public ObjectContent(final Map<String, Object> object) {
+      this.object = object;
+    }
+
+    @Override
+    public String getContentType() {
+      return "OBJECT";
+    }
+
+    public Map<String, Object> getObject() {
+      return object;
+    }
+  }
+
+  /** Camunda Document Store reference content block ({@code contentType = "DOCUMENT"}). */
+  final class DocumentContent implements AgentInstanceHistoryContent {
+    private final DocumentReferenceResponse documentReference;
+
+    public DocumentContent(final DocumentReferenceResponse documentReference) {
+      this.documentReference = documentReference;
+    }
+
+    @Override
+    public String getContentType() {
+      return "DOCUMENT";
+    }
+
+    public DocumentReferenceResponse getDocumentReference() {
+      return documentReference;
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryContent.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryContent.java
@@ -116,6 +116,12 @@ public interface AgentInstanceHistoryContent {
       return "DOCUMENT";
     }
 
+    /**
+     * Returns the document reference, or {@code null} if the server omitted it.
+     *
+     * <p>The {@link #document(DocumentReferenceResponse)} factory method rejects null, so null can
+     * only be returned when this instance was deserialized from a server response.
+     */
     public DocumentReferenceResponse getDocumentReference() {
       return documentReference;
     }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryMetrics.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryMetrics.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+/** Per-call token and latency metrics for an ASSISTANT agent instance history item. */
+public final class AgentInstanceHistoryMetrics {
+  private Long inputTokens;
+  private Long outputTokens;
+  private Long durationMs;
+
+  public AgentInstanceHistoryMetrics inputTokens(final long inputTokens) {
+    this.inputTokens = inputTokens;
+    return this;
+  }
+
+  public AgentInstanceHistoryMetrics outputTokens(final long outputTokens) {
+    this.outputTokens = outputTokens;
+    return this;
+  }
+
+  public AgentInstanceHistoryMetrics durationMs(final long durationMs) {
+    this.durationMs = durationMs;
+    return this;
+  }
+
+  public Long getInputTokens() {
+    return inputTokens;
+  }
+
+  public Long getOutputTokens() {
+    return outputTokens;
+  }
+
+  public Long getDurationMs() {
+    return durationMs;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryToolCall.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryToolCall.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import java.util.Map;
+
+/** A tool call associated with an ASSISTANT agent instance history item. */
+public final class AgentInstanceHistoryToolCall {
+  private String toolCallId;
+  private String toolName;
+  private String elementId;
+  private Map<String, Object> arguments;
+
+  public AgentInstanceHistoryToolCall toolCallId(final String toolCallId) {
+    this.toolCallId = toolCallId;
+    return this;
+  }
+
+  public AgentInstanceHistoryToolCall toolName(final String toolName) {
+    this.toolName = toolName;
+    return this;
+  }
+
+  public AgentInstanceHistoryToolCall elementId(final String elementId) {
+    this.elementId = elementId;
+    return this;
+  }
+
+  public AgentInstanceHistoryToolCall arguments(final Map<String, Object> arguments) {
+    this.arguments = arguments;
+    return this;
+  }
+
+  public String getToolCallId() {
+    return toolCallId;
+  }
+
+  public String getToolName() {
+    return toolName;
+  }
+
+  public String getElementId() {
+    return elementId;
+  }
+
+  public Map<String, Object> getArguments() {
+    return arguments;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentHistoryItemCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentHistoryItemCommandStep1.java
@@ -16,10 +16,9 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.CreateAgentHistoryItemResponse;
-import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Represents a request to append a conversation history item to an agent instance.
@@ -31,8 +30,8 @@ import java.util.Map;
  *       .newCreateAgentHistoryItemCommand(agentInstanceKey)
  *       .elementInstanceKey(2251799813685248L)
  *       .jobKey(2251799813685249L)
- *       .role(AgentHistoryRole.USER)
- *       .content(List.of(AgentHistoryContent.text("Hello!")))
+ *       .role(AgentInstanceHistoryRole.USER)
+ *       .content(List.of(AgentInstanceHistoryContent.text("Hello!")))
  *       .producedAt(OffsetDateTime.now())
  *       .send()
  *       .join();
@@ -67,7 +66,7 @@ public interface CreateAgentHistoryItemCommandStep1 {
      * @param role the conversation role. Must not be null.
      * @return this builder for method chaining
      */
-    CreateAgentHistoryItemCommandStep4 role(AgentHistoryRole role);
+    CreateAgentHistoryItemCommandStep4 role(AgentInstanceHistoryRole role);
   }
 
   interface CreateAgentHistoryItemCommandStep4 {
@@ -78,7 +77,7 @@ public interface CreateAgentHistoryItemCommandStep1 {
      * @param content the list of content blocks. Must not be null; may be empty.
      * @return this builder for method chaining
      */
-    CreateAgentHistoryItemCommandStep5 content(List<AgentHistoryContent> content);
+    CreateAgentHistoryItemCommandStep5 content(List<AgentInstanceHistoryContent> content);
   }
 
   interface CreateAgentHistoryItemCommandStep5 {
@@ -119,7 +118,7 @@ public interface CreateAgentHistoryItemCommandStep1 {
      * @param toolCalls the list of tool calls. May be null.
      * @return this builder for method chaining
      */
-    CreateAgentHistoryItemFinalCommandStep toolCalls(List<AgentHistoryToolCall> toolCalls);
+    CreateAgentHistoryItemFinalCommandStep toolCalls(List<AgentInstanceHistoryToolCall> toolCalls);
 
     /**
      * Sets per-call token and latency metrics. Present on ASSISTANT items only.
@@ -127,187 +126,6 @@ public interface CreateAgentHistoryItemCommandStep1 {
      * @param metrics the metrics. May be null.
      * @return this builder for method chaining
      */
-    CreateAgentHistoryItemFinalCommandStep metrics(AgentHistoryMetrics metrics);
-  }
-
-  /** Role of a history item in the agent conversation. */
-  enum AgentHistoryRole {
-    USER,
-    ASSISTANT,
-    TOOL_RESULT
-  }
-
-  /**
-   * Factory for content blocks passed to {@link CreateAgentHistoryItemCommandStep4#content}. Use
-   * these instead of the generated protocol classes to avoid explicit casts.
-   *
-   * <p>Example:
-   *
-   * <pre>
-   *   .content(List.of(
-   *       AgentHistoryContent.text("I can help."),
-   *       AgentHistoryContent.object(Map.of("key", "value")),
-   *       AgentHistoryContent.document(documentReferenceResponse)
-   *   ))
-   * </pre>
-   */
-  interface AgentHistoryContent {
-
-    /**
-     * Creates a plain-text content block.
-     *
-     * @param text the text. Must not be null.
-     * @return an {@link AgentHistoryContent} of type TEXT
-     */
-    static AgentHistoryContent text(final String text) {
-      if (text == null) {
-        throw new IllegalArgumentException("text must not be null");
-      }
-      return new TextContent(text);
-    }
-
-    /**
-     * Creates an arbitrary-object content block.
-     *
-     * @param object the key-value map. Must not be null.
-     * @return an {@link AgentHistoryContent} of type OBJECT
-     */
-    static AgentHistoryContent object(final Map<String, Object> object) {
-      if (object == null) {
-        throw new IllegalArgumentException("object must not be null");
-      }
-      return new ObjectContent(object);
-    }
-
-    /**
-     * Creates a document-reference content block from a {@link DocumentReferenceResponse} returned
-     * by other document APIs (e.g. upload or create-link).
-     *
-     * @param documentReference the document reference. Must not be null.
-     * @return a {@link DocumentContent} of type DOCUMENT
-     */
-    static DocumentContent document(final DocumentReferenceResponse documentReference) {
-      if (documentReference == null) {
-        throw new IllegalArgumentException("documentReference must not be null");
-      }
-      return new DocumentContent(documentReference);
-    }
-
-    /** Plain-text content block. */
-    final class TextContent implements AgentHistoryContent {
-      private final String text;
-
-      TextContent(final String text) {
-        this.text = text;
-      }
-
-      public String getText() {
-        return text;
-      }
-    }
-
-    /** Arbitrary-object content block. */
-    final class ObjectContent implements AgentHistoryContent {
-      private final Map<String, Object> object;
-
-      ObjectContent(final Map<String, Object> object) {
-        this.object = object;
-      }
-
-      public Map<String, Object> getObject() {
-        return object;
-      }
-    }
-
-    /** Document-reference content block. Use {@link AgentHistoryContent#document} to create. */
-    final class DocumentContent implements AgentHistoryContent {
-      private final DocumentReferenceResponse documentReference;
-
-      DocumentContent(final DocumentReferenceResponse documentReference) {
-        this.documentReference = documentReference;
-      }
-
-      public DocumentReferenceResponse getDocumentReference() {
-        return documentReference;
-      }
-    }
-  }
-
-  /** Per-call token and latency metrics for an ASSISTANT history item. */
-  final class AgentHistoryMetrics {
-    private Long inputTokens;
-    private Long outputTokens;
-    private Long durationMs;
-
-    public AgentHistoryMetrics inputTokens(final long inputTokens) {
-      this.inputTokens = inputTokens;
-      return this;
-    }
-
-    public AgentHistoryMetrics outputTokens(final long outputTokens) {
-      this.outputTokens = outputTokens;
-      return this;
-    }
-
-    public AgentHistoryMetrics durationMs(final long durationMs) {
-      this.durationMs = durationMs;
-      return this;
-    }
-
-    public Long getInputTokens() {
-      return inputTokens;
-    }
-
-    public Long getOutputTokens() {
-      return outputTokens;
-    }
-
-    public Long getDurationMs() {
-      return durationMs;
-    }
-  }
-
-  /** A tool call associated with an ASSISTANT history item. */
-  final class AgentHistoryToolCall {
-    private String toolCallId;
-    private String toolName;
-    private String elementId;
-    private Map<String, Object> arguments;
-
-    public AgentHistoryToolCall toolCallId(final String toolCallId) {
-      this.toolCallId = toolCallId;
-      return this;
-    }
-
-    public AgentHistoryToolCall toolName(final String toolName) {
-      this.toolName = toolName;
-      return this;
-    }
-
-    public AgentHistoryToolCall elementId(final String elementId) {
-      this.elementId = elementId;
-      return this;
-    }
-
-    public AgentHistoryToolCall arguments(final Map<String, Object> arguments) {
-      this.arguments = arguments;
-      return this;
-    }
-
-    public String getToolCallId() {
-      return toolCallId;
-    }
-
-    public String getToolName() {
-      return toolName;
-    }
-
-    public String getElementId() {
-      return elementId;
-    }
-
-    public Map<String, Object> getArguments() {
-      return arguments;
-    }
+    CreateAgentHistoryItemFinalCommandStep metrics(AgentInstanceHistoryMetrics metrics);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceHistoryCommitStatus.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceHistoryCommitStatus.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum AgentInstanceHistoryCommitStatus {
+  COMMITTED,
+  PENDING,
+  DISCARDED,
+  UNKNOWN_ENUM_VALUE
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceHistoryCommitStatus.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceHistoryCommitStatus.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.search.enums;
 
+/** The commit status of an agent instance history item within its job lease. */
 public enum AgentInstanceHistoryCommitStatus {
   COMMITTED,
   PENDING,

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceHistoryRole.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceHistoryRole.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum AgentInstanceHistoryRole {
+  USER,
+  ASSISTANT,
+  TOOL_RESULT,
+  UNKNOWN_ENUM_VALUE
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceHistoryRole.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceHistoryRole.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.search.enums;
 
+/** The role of the participant who produced an agent instance history item. */
 public enum AgentInstanceHistoryRole {
   USER,
   ASSISTANT,

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceHistoryFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceHistoryFilter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.filter.builder.AgentInstanceHistoryCommitStatusProperty;
+import io.camunda.client.api.search.filter.builder.AgentInstanceHistoryRoleProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.DateTimeProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.util.function.Consumer;
+
+public interface AgentInstanceHistoryFilter extends SearchRequestFilter {
+
+  AgentInstanceHistoryFilter historyItemKey(long value);
+
+  AgentInstanceHistoryFilter historyItemKey(Consumer<BasicLongProperty> fn);
+
+  AgentInstanceHistoryFilter role(AgentInstanceHistoryRole value);
+
+  AgentInstanceHistoryFilter role(Consumer<AgentInstanceHistoryRoleProperty> fn);
+
+  AgentInstanceHistoryFilter elementInstanceKey(long value);
+
+  AgentInstanceHistoryFilter elementInstanceKey(Consumer<BasicLongProperty> fn);
+
+  AgentInstanceHistoryFilter jobKey(long value);
+
+  AgentInstanceHistoryFilter jobKey(Consumer<BasicLongProperty> fn);
+
+  AgentInstanceHistoryFilter iteration(int value);
+
+  AgentInstanceHistoryFilter iteration(Consumer<IntegerProperty> fn);
+
+  AgentInstanceHistoryFilter commitStatus(AgentInstanceHistoryCommitStatus value);
+
+  AgentInstanceHistoryFilter commitStatus(Consumer<AgentInstanceHistoryCommitStatusProperty> fn);
+
+  AgentInstanceHistoryFilter producedAt(Consumer<DateTimeProperty> fn);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceHistoryFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceHistoryFilter.java
@@ -25,6 +25,7 @@ import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
+/** Filter criteria for agent instance history search requests. */
 public interface AgentInstanceHistoryFilter extends SearchRequestFilter {
 
   AgentInstanceHistoryFilter historyItemKey(long value);

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentInstanceHistoryCommitStatusProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentInstanceHistoryCommitStatusProperty.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
+
+public interface AgentInstanceHistoryCommitStatusProperty
+    extends PropertyBase<
+        AgentInstanceHistoryCommitStatus, AgentInstanceHistoryCommitStatusProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentInstanceHistoryCommitStatusProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentInstanceHistoryCommitStatusProperty.java
@@ -17,6 +17,9 @@ package io.camunda.client.api.search.filter.builder;
 
 import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
 
+/**
+ * Filter property for {@link io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus}.
+ */
 public interface AgentInstanceHistoryCommitStatusProperty
     extends PropertyBase<
         AgentInstanceHistoryCommitStatus, AgentInstanceHistoryCommitStatusProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentInstanceHistoryRoleProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentInstanceHistoryRoleProperty.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+
+public interface AgentInstanceHistoryRoleProperty
+    extends PropertyBase<AgentInstanceHistoryRole, AgentInstanceHistoryRoleProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentInstanceHistoryRoleProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentInstanceHistoryRoleProperty.java
@@ -17,5 +17,6 @@ package io.camunda.client.api.search.filter.builder;
 
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 
+/** Filter property for {@link io.camunda.client.api.search.enums.AgentInstanceHistoryRole}. */
 public interface AgentInstanceHistoryRoleProperty
     extends PropertyBase<AgentInstanceHistoryRole, AgentInstanceHistoryRoleProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/AgentInstanceHistorySearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/AgentInstanceHistorySearchRequest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.AgentInstanceHistoryFilter;
+import io.camunda.client.api.search.page.AnyPage;
+import io.camunda.client.api.search.response.AgentInstanceHistory;
+import io.camunda.client.api.search.sort.AgentInstanceHistorySort;
+
+public interface AgentInstanceHistorySearchRequest
+    extends TypedSearchRequest<
+            AgentInstanceHistoryFilter,
+            AgentInstanceHistorySort,
+            AnyPage,
+            AgentInstanceHistorySearchRequest>,
+        TypedPageableRequest<AnyPage, AgentInstanceHistorySearchRequest>,
+        FinalSearchRequestStep<AgentInstanceHistory> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/AgentInstanceHistorySearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/AgentInstanceHistorySearchRequest.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.client.api.search.sort.AgentInstanceHistorySort;
 
+/** Request builder for searching agent instance history items. */
 public interface AgentInstanceHistorySearchRequest
     extends TypedSearchRequest<
             AgentInstanceHistoryFilter,

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.search.request;
 
 import io.camunda.client.api.search.filter.AgentInstanceFilter;
+import io.camunda.client.api.search.filter.AgentInstanceHistoryFilter;
 import io.camunda.client.api.search.filter.AuditLogFilter;
 import io.camunda.client.api.search.filter.AuthorizationFilter;
 import io.camunda.client.api.search.filter.BatchOperationFilter;
@@ -48,6 +49,7 @@ import io.camunda.client.api.search.page.CursorBackwardPage;
 import io.camunda.client.api.search.page.CursorForwardPage;
 import io.camunda.client.api.search.page.LimitPage;
 import io.camunda.client.api.search.page.OffsetPage;
+import io.camunda.client.api.search.sort.AgentInstanceHistorySort;
 import io.camunda.client.api.search.sort.AgentInstanceSort;
 import io.camunda.client.api.search.sort.AuditLogSort;
 import io.camunda.client.api.search.sort.AuthorizationSort;
@@ -84,6 +86,7 @@ import io.camunda.client.api.statistics.filter.JobErrorStatisticsFilter;
 import io.camunda.client.api.statistics.filter.JobTypeStatisticsFilter;
 import io.camunda.client.api.statistics.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.client.impl.search.filter.AgentInstanceFilterImpl;
+import io.camunda.client.impl.search.filter.AgentInstanceHistoryFilterImpl;
 import io.camunda.client.impl.search.filter.AuthorizationFilterImpl;
 import io.camunda.client.impl.search.filter.BatchOperationFilterImpl;
 import io.camunda.client.impl.search.filter.BatchOperationItemFilterImpl;
@@ -116,6 +119,7 @@ import io.camunda.client.impl.search.page.CursorForwardPageImpl;
 import io.camunda.client.impl.search.page.LimitPageImpl;
 import io.camunda.client.impl.search.page.OffsetPageImpl;
 import io.camunda.client.impl.search.request.SearchRequestPageImpl;
+import io.camunda.client.impl.search.sort.AgentInstanceHistorySortImpl;
 import io.camunda.client.impl.search.sort.AgentInstanceSortImpl;
 import io.camunda.client.impl.search.sort.AuditLogSortImpl;
 import io.camunda.client.impl.search.sort.AuthorizationSortImpl;
@@ -608,6 +612,20 @@ public final class SearchRequestBuilders {
 
   public static ResourceSort resourceSort(final Consumer<ResourceSort> fn) {
     final ResourceSort sort = new ResourceSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static AgentInstanceHistoryFilter agentInstanceHistoryFilter(
+      final Consumer<AgentInstanceHistoryFilter> fn) {
+    final AgentInstanceHistoryFilter filter = new AgentInstanceHistoryFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static AgentInstanceHistorySort agentInstanceHistorySort(
+      final Consumer<AgentInstanceHistorySort> fn) {
+    final AgentInstanceHistorySort sort = new AgentInstanceHistorySortImpl();
     fn.accept(sort);
     return sort;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstanceHistory.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstanceHistory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public interface AgentInstanceHistory {
+
+  long getHistoryItemKey();
+
+  long getAgentInstanceKey();
+
+  long getElementInstanceKey();
+
+  long getJobKey();
+
+  String getJobLease();
+
+  Integer getIteration();
+
+  AgentInstanceHistoryRole getRole();
+
+  List<AgentInstanceHistoryContent> getContent();
+
+  List<AgentInstanceHistoryToolCall> getToolCalls();
+
+  AgentInstanceHistoryMetrics getMetrics();
+
+  AgentInstanceHistoryCommitStatus getCommitStatus();
+
+  OffsetDateTime getProducedAt();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstanceHistory.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstanceHistory.java
@@ -23,6 +23,7 @@ import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+/** A single history item recorded for an agent instance. */
 public interface AgentInstanceHistory {
 
   long getHistoryItemKey();

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceHistorySort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceHistorySort.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
+
+public interface AgentInstanceHistorySort extends SearchRequestSort<AgentInstanceHistorySort> {
+  AgentInstanceHistorySort producedAt();
+
+  AgentInstanceHistorySort historyItemKey();
+
+  AgentInstanceHistorySort iteration();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceHistorySort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceHistorySort.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.sort;
 
 import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
+/** Sort criteria for agent instance history search requests. */
 public interface AgentInstanceHistorySort extends SearchRequestSort<AgentInstanceHistorySort> {
   AgentInstanceHistorySort producedAt();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -155,6 +155,7 @@ import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.request.AgentInstanceHistorySearchRequest;
 import io.camunda.client.api.search.request.AgentInstanceSearchRequest;
 import io.camunda.client.api.search.request.AuditLogSearchRequest;
 import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
@@ -341,6 +342,7 @@ import io.camunda.client.impl.fetch.UserTaskGetRequestImpl;
 import io.camunda.client.impl.fetch.VariableGetRequestImpl;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.http.HttpClientFactory;
+import io.camunda.client.impl.search.request.AgentInstanceHistorySearchRequestImpl;
 import io.camunda.client.impl.search.request.AgentInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.AuditLogSearchRequestImpl;
 import io.camunda.client.impl.search.request.AuthorizationsSearchRequestImpl;
@@ -1800,6 +1802,12 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public AgentInstanceSearchRequest newAgentInstanceSearchRequest() {
     return new AgentInstanceSearchRequestImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public AgentInstanceHistorySearchRequest newAgentInstanceHistorySearchRequest(
+      final long agentInstanceKey) {
+    return new AgentInstanceHistorySearchRequestImpl(agentInstanceKey, httpClient, jsonMapper);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
@@ -17,14 +17,13 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.DocumentContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.ObjectContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.TextContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent.DocumentContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent.ObjectContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent.TextContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryMetrics;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryToolCall;
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemCommandStep2;
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemCommandStep3;
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemCommandStep4;
@@ -33,6 +32,7 @@ import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAg
 import io.camunda.client.api.response.CreateAgentHistoryItemResponse;
 import io.camunda.client.api.response.DocumentMetadata;
 import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateAgentHistoryItemResponseImpl;
@@ -94,17 +94,23 @@ public class CreateAgentHistoryItemCommandImpl
   }
 
   @Override
-  public CreateAgentHistoryItemCommandStep4 role(final AgentHistoryRole role) {
+  public CreateAgentHistoryItemCommandStep4 role(final AgentInstanceHistoryRole role) {
     ArgumentUtil.ensureNotNull("role", role);
-    request.role(AgentInstanceHistoryRoleEnum.fromValue(role.name()));
+    final AgentInstanceHistoryRoleEnum protoRole =
+        AgentInstanceHistoryRoleEnum.fromValue(role.name());
+    if (protoRole == null) {
+      throw new IllegalArgumentException("Invalid role: " + role);
+    }
+    request.role(protoRole);
     return this;
   }
 
   @Override
-  public CreateAgentHistoryItemCommandStep5 content(final List<AgentHistoryContent> content) {
+  public CreateAgentHistoryItemCommandStep5 content(
+      final List<AgentInstanceHistoryContent> content) {
     ArgumentUtil.ensureNotNull("content", content);
     final List<AgentInstanceMessageContent> protocolContent = new ArrayList<>(content.size());
-    for (final AgentHistoryContent item : content) {
+    for (final AgentInstanceHistoryContent item : content) {
       if (item == null) {
         throw new IllegalArgumentException("content must not contain null elements");
       }
@@ -124,7 +130,7 @@ public class CreateAgentHistoryItemCommandImpl
       } else if (item instanceof DocumentContent) {
         protocolContent.add(toProtocolDocumentContent((DocumentContent) item));
       } else {
-        throw new IllegalArgumentException("Unsupported AgentHistoryContent type: " + item);
+        throw new IllegalArgumentException("Unsupported AgentInstanceHistoryContent type: " + item);
       }
     }
     request.content(protocolContent);
@@ -133,6 +139,9 @@ public class CreateAgentHistoryItemCommandImpl
 
   private AgentInstanceDocumentContent toProtocolDocumentContent(final DocumentContent item) {
     final DocumentReferenceResponse ref = item.getDocumentReference();
+    if (ref == null) {
+      throw new IllegalArgumentException("documentReference must not be null");
+    }
     if (ref.getDocumentId() == null || ref.getDocumentId().trim().isEmpty()) {
       throw new IllegalArgumentException("documentReference.documentId must not be null or blank");
     }
@@ -203,12 +212,12 @@ public class CreateAgentHistoryItemCommandImpl
 
   @Override
   public CreateAgentHistoryItemFinalCommandStep toolCalls(
-      final List<AgentHistoryToolCall> toolCalls) {
+      final List<AgentInstanceHistoryToolCall> toolCalls) {
     if (toolCalls == null) {
       return this;
     }
     final List<AgentInstanceToolCall> protocolToolCalls = new ArrayList<>(toolCalls.size());
-    for (final AgentHistoryToolCall tc : toolCalls) {
+    for (final AgentInstanceHistoryToolCall tc : toolCalls) {
       if (tc == null) {
         throw new IllegalArgumentException("toolCalls must not contain null elements");
       }
@@ -230,7 +239,7 @@ public class CreateAgentHistoryItemCommandImpl
   }
 
   @Override
-  public CreateAgentHistoryItemFinalCommandStep metrics(final AgentHistoryMetrics metrics) {
+  public CreateAgentHistoryItemFinalCommandStep metrics(final AgentInstanceHistoryMetrics metrics) {
     if (metrics == null) {
       return this;
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentInstanceHistoryFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentInstanceHistoryFilterImpl.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.filter.AgentInstanceHistoryFilter;
+import io.camunda.client.api.search.filter.builder.AgentInstanceHistoryCommitStatusProperty;
+import io.camunda.client.api.search.filter.builder.AgentInstanceHistoryRoleProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.DateTimeProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
+import io.camunda.client.impl.search.filter.builder.AgentInstanceHistoryCommitStatusPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.AgentInstanceHistoryRolePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.protocol.rest.AgentHistoryItemKeyFilterProperty;
+import io.camunda.client.protocol.rest.BasicStringFilterProperty;
+import java.util.function.Consumer;
+
+public class AgentInstanceHistoryFilterImpl
+    extends TypedSearchRequestPropertyProvider<
+        io.camunda.client.protocol.rest.AgentInstanceHistoryFilter>
+    implements AgentInstanceHistoryFilter {
+
+  private final io.camunda.client.protocol.rest.AgentInstanceHistoryFilter filter;
+
+  public AgentInstanceHistoryFilterImpl() {
+    filter = new io.camunda.client.protocol.rest.AgentInstanceHistoryFilter();
+  }
+
+  @Override
+  protected io.camunda.client.protocol.rest.AgentInstanceHistoryFilter getSearchRequestProperty() {
+    return filter;
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter historyItemKey(final long value) {
+    return historyItemKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter historyItemKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongPropertyImpl property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setHistoryItemKey(
+        toAgentHistoryItemKeyFilterProperty(provideSearchRequestProperty(property)));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter role(final AgentInstanceHistoryRole value) {
+    return role(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter role(final Consumer<AgentInstanceHistoryRoleProperty> fn) {
+    final AgentInstanceHistoryRoleProperty property = new AgentInstanceHistoryRolePropertyImpl();
+    fn.accept(property);
+    filter.setRole(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter elementInstanceKey(final long value) {
+    return elementInstanceKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter elementInstanceKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongPropertyImpl property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setElementInstanceKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter jobKey(final long value) {
+    return jobKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter jobKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongPropertyImpl property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setJobKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter iteration(final int value) {
+    return iteration(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter iteration(final Consumer<IntegerProperty> fn) {
+    final IntegerProperty property = new IntegerPropertyImpl();
+    fn.accept(property);
+    filter.setIteration(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter commitStatus(final AgentInstanceHistoryCommitStatus value) {
+    return commitStatus(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter commitStatus(
+      final Consumer<AgentInstanceHistoryCommitStatusProperty> fn) {
+    final AgentInstanceHistoryCommitStatusProperty property =
+        new AgentInstanceHistoryCommitStatusPropertyImpl();
+    fn.accept(property);
+    filter.setCommitStatus(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryFilter producedAt(final Consumer<DateTimeProperty> fn) {
+    final DateTimeProperty property = new DateTimePropertyImpl();
+    fn.accept(property);
+    filter.setProducedAt(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  private AgentHistoryItemKeyFilterProperty toAgentHistoryItemKeyFilterProperty(
+      final BasicStringFilterProperty src) {
+    final AgentHistoryItemKeyFilterProperty dest = new AgentHistoryItemKeyFilterProperty();
+    dest.set$Eq(src.get$Eq());
+    dest.set$Neq(src.get$Neq());
+    dest.set$Exists(src.get$Exists());
+    dest.set$In(src.get$In());
+    dest.set$NotIn(src.get$NotIn());
+    return dest;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/AgentInstanceHistoryCommitStatusPropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/AgentInstanceHistoryCommitStatusPropertyImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
+import io.camunda.client.api.search.filter.builder.AgentInstanceHistoryCommitStatusProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryCommitStatusEnum;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryCommitStatusFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AgentInstanceHistoryCommitStatusPropertyImpl
+    extends TypedSearchRequestPropertyProvider<AgentInstanceHistoryCommitStatusFilterProperty>
+    implements AgentInstanceHistoryCommitStatusProperty {
+
+  private final AgentInstanceHistoryCommitStatusFilterProperty filterProperty =
+      new AgentInstanceHistoryCommitStatusFilterProperty();
+
+  @Override
+  public AgentInstanceHistoryCommitStatusProperty eq(final AgentInstanceHistoryCommitStatus value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, AgentInstanceHistoryCommitStatusEnum.class));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryCommitStatusProperty neq(
+      final AgentInstanceHistoryCommitStatus value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, AgentInstanceHistoryCommitStatusEnum.class));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryCommitStatusProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryCommitStatusProperty in(
+      final List<AgentInstanceHistoryCommitStatus> values) {
+    filterProperty.set$In(
+        values.stream()
+            .map(status -> EnumUtil.convert(status, AgentInstanceHistoryCommitStatusEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryCommitStatusProperty in(
+      final AgentInstanceHistoryCommitStatus... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected AgentInstanceHistoryCommitStatusFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/AgentInstanceHistoryRolePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/AgentInstanceHistoryRolePropertyImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.filter.builder.AgentInstanceHistoryRoleProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AgentInstanceHistoryRolePropertyImpl
+    extends TypedSearchRequestPropertyProvider<AgentInstanceHistoryRoleFilterProperty>
+    implements AgentInstanceHistoryRoleProperty {
+
+  private final AgentInstanceHistoryRoleFilterProperty filterProperty =
+      new AgentInstanceHistoryRoleFilterProperty();
+
+  @Override
+  public AgentInstanceHistoryRoleProperty eq(final AgentInstanceHistoryRole value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, AgentInstanceHistoryRoleEnum.class));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryRoleProperty neq(final AgentInstanceHistoryRole value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, AgentInstanceHistoryRoleEnum.class));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryRoleProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryRoleProperty in(final List<AgentInstanceHistoryRole> values) {
+    filterProperty.set$In(
+        values.stream()
+            .map(role -> EnumUtil.convert(role, AgentInstanceHistoryRoleEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistoryRoleProperty in(final AgentInstanceHistoryRole... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected AgentInstanceHistoryRoleFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/AgentInstanceHistorySearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/AgentInstanceHistorySearchRequestImpl.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.agentInstanceHistoryFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.agentInstanceHistorySort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.anyPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.AgentInstanceHistoryFilter;
+import io.camunda.client.api.search.page.AnyPage;
+import io.camunda.client.api.search.request.AgentInstanceHistorySearchRequest;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.response.AgentInstanceHistory;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.AgentInstanceHistorySort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQuery;
+import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class AgentInstanceHistorySearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<AgentInstanceHistorySearchQuery>
+    implements AgentInstanceHistorySearchRequest {
+
+  private final AgentInstanceHistorySearchQuery request;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long agentInstanceKey;
+
+  public AgentInstanceHistorySearchRequestImpl(
+      final long agentInstanceKey, final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.agentInstanceKey = agentInstanceKey;
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new AgentInstanceHistorySearchQuery();
+  }
+
+  @Override
+  public FinalSearchRequestStep<AgentInstanceHistory> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<AgentInstanceHistory>> send() {
+    final HttpCamundaFuture<SearchResponse<AgentInstanceHistory>> result =
+        new HttpCamundaFuture<>();
+    httpClient.post(
+        "/agent-instances/" + agentInstanceKey + "/history/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        AgentInstanceHistorySearchQueryResult.class,
+        SearchResponseMapper::toAgentInstanceHistorySearchResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public AgentInstanceHistorySearchRequest filter(final AgentInstanceHistoryFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistorySearchRequest filter(final Consumer<AgentInstanceHistoryFilter> fn) {
+    return filter(agentInstanceHistoryFilter(fn));
+  }
+
+  @Override
+  public AgentInstanceHistorySearchRequest page(final AnyPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistorySearchRequest page(final Consumer<AnyPage> fn) {
+    return page(anyPage(fn));
+  }
+
+  @Override
+  public AgentInstanceHistorySearchRequest sort(final AgentInstanceHistorySort value) {
+    request.setSort(
+        SearchRequestSortMapper.toAgentInstanceHistorySearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistorySearchRequest sort(final Consumer<AgentInstanceHistorySort> fn) {
+    return sort(agentInstanceHistorySort(fn));
+  }
+
+  @Override
+  protected AgentInstanceHistorySearchQuery getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -682,6 +682,21 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
+  public static List<AgentInstanceHistorySearchQuerySortRequest>
+      toAgentInstanceHistorySearchQuerySortRequest(final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final AgentInstanceHistorySearchQuerySortRequest request =
+                  new AgentInstanceHistorySearchQuerySortRequest();
+              request.setField(
+                  AgentInstanceHistorySearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
   public static List<ResourceSearchQuerySortRequest> toResourceSearchQuerySortRequest(
       final List<SearchRequestSort> requests) {
     return requests.stream()

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.DocumentContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.ObjectContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.TextContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.response.AgentInstanceHistory;
+import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.impl.util.ParseUtil;
+import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetrics;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemResult;
+import io.camunda.client.protocol.rest.AgentInstanceMessageContent;
+import io.camunda.client.protocol.rest.AgentInstanceObjectContent;
+import io.camunda.client.protocol.rest.AgentInstanceTextContent;
+import io.camunda.client.protocol.rest.AgentInstanceToolCall;
+import io.camunda.client.protocol.rest.DocumentReference;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
+
+  private final long historyItemKey;
+  private final long agentInstanceKey;
+  private final long elementInstanceKey;
+  private final long jobKey;
+  private final String jobLease;
+  private final Integer iteration;
+  private final AgentInstanceHistoryRole role;
+  private final List<AgentInstanceHistoryContent> content;
+  private final List<AgentInstanceHistoryToolCall> toolCalls;
+  private final AgentInstanceHistoryMetrics metrics;
+  private final AgentInstanceHistoryCommitStatus commitStatus;
+  private final OffsetDateTime producedAt;
+
+  public AgentInstanceHistoryImpl(final AgentInstanceHistoryItemResult result) {
+    historyItemKey = Long.parseLong(result.getHistoryItemKey());
+    agentInstanceKey = Long.parseLong(result.getAgentInstanceKey());
+    elementInstanceKey = Long.parseLong(result.getElementInstanceKey());
+    jobKey = Long.parseLong(result.getJobKey());
+    jobLease = result.getJobLease();
+    iteration = result.getIteration();
+    role = EnumUtil.convert(result.getRole(), AgentInstanceHistoryRole.class);
+    content =
+        result.getContent() != null
+            ? result.getContent().stream()
+                .map(AgentInstanceHistoryImpl::toContent)
+                .collect(Collectors.toList())
+            : Collections.emptyList();
+    toolCalls =
+        result.getToolCalls() != null
+            ? result.getToolCalls().stream()
+                .map(AgentInstanceHistoryImpl::toToolCall)
+                .collect(Collectors.toList())
+            : Collections.emptyList();
+    metrics = toMetrics(result.getMetrics());
+    commitStatus =
+        EnumUtil.convert(result.getCommitStatus(), AgentInstanceHistoryCommitStatus.class);
+    producedAt = ParseUtil.parseOffsetDateTimeOrNull(result.getProducedAt());
+  }
+
+  @Override
+  public long getHistoryItemKey() {
+    return historyItemKey;
+  }
+
+  @Override
+  public long getAgentInstanceKey() {
+    return agentInstanceKey;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  @Override
+  public long getJobKey() {
+    return jobKey;
+  }
+
+  @Override
+  public String getJobLease() {
+    return jobLease;
+  }
+
+  @Override
+  public Integer getIteration() {
+    return iteration;
+  }
+
+  @Override
+  public AgentInstanceHistoryRole getRole() {
+    return role;
+  }
+
+  @Override
+  public List<AgentInstanceHistoryContent> getContent() {
+    return content;
+  }
+
+  @Override
+  public List<AgentInstanceHistoryToolCall> getToolCalls() {
+    return toolCalls;
+  }
+
+  @Override
+  public AgentInstanceHistoryMetrics getMetrics() {
+    return metrics;
+  }
+
+  @Override
+  public AgentInstanceHistoryCommitStatus getCommitStatus() {
+    return commitStatus;
+  }
+
+  @Override
+  public OffsetDateTime getProducedAt() {
+    return producedAt;
+  }
+
+  private static AgentInstanceHistoryContent toContent(final AgentInstanceMessageContent proto) {
+    if (proto instanceof AgentInstanceTextContent) {
+      return new TextContent(((AgentInstanceTextContent) proto).getText());
+    } else if (proto instanceof AgentInstanceDocumentContent) {
+      final Object ref = ((AgentInstanceDocumentContent) proto).getDocumentReference();
+      return new DocumentContent(
+          ref != null ? new DocumentReferenceResponseImpl((DocumentReference) ref) : null);
+    } else if (proto instanceof AgentInstanceObjectContent) {
+      @SuppressWarnings("unchecked")
+      final Map<String, Object> obj =
+          (Map<String, Object>) ((AgentInstanceObjectContent) proto).getObject();
+      return new ObjectContent(obj);
+    }
+    return new TextContent(proto.getContentType());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static AgentInstanceHistoryToolCall toToolCall(final AgentInstanceToolCall proto) {
+    return new AgentInstanceHistoryToolCall()
+        .toolCallId(proto.getToolCallId())
+        .toolName(proto.getToolName())
+        .elementId(proto.getElementId())
+        .arguments(
+            proto.getArguments() != null ? (Map<String, Object>) proto.getArguments() : null);
+  }
+
+  private static AgentInstanceHistoryMetrics toMetrics(
+      final AgentInstanceHistoryItemMetrics proto) {
+    if (proto == null) {
+      return null;
+    }
+    return new AgentInstanceHistoryMetrics()
+        .inputTokens(proto.getInputTokens())
+        .outputTokens(proto.getOutputTokens())
+        .durationMs(proto.getDurationMs());
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
@@ -155,7 +155,7 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
           (Map<String, Object>) ((AgentInstanceObjectContent) proto).getObject();
       return new ObjectContent(obj);
     }
-    return new TextContent(proto.getContentType());
+    return null;
   }
 
   @SuppressWarnings("unchecked")

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.client.api.search.response.AuditLogResult;
 import io.camunda.client.api.search.response.Authorization;
 import io.camunda.client.api.search.response.BatchOperation;
@@ -82,6 +83,14 @@ public final class SearchResponseMapper {
     final List<AgentInstance> instances =
         toSearchResponseInstances(response.getItems(), AgentInstanceImpl::new);
     return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static SearchResponse<AgentInstanceHistory> toAgentInstanceHistorySearchResponse(
+      final AgentInstanceHistorySearchQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<AgentInstanceHistory> items =
+        toSearchResponseInstances(response.getItems(), AgentInstanceHistoryImpl::new);
+    return new SearchResponseImpl<>(items, page);
   }
 
   public static SearchResponse<ProcessDefinition> toProcessDefinitionSearchResponse(

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentInstanceHistorySortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentInstanceHistorySortImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.AgentInstanceHistorySort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class AgentInstanceHistorySortImpl extends SearchRequestSortBase<AgentInstanceHistorySort>
+    implements AgentInstanceHistorySort {
+
+  @Override
+  protected AgentInstanceHistorySort self() {
+    return this;
+  }
+
+  @Override
+  public AgentInstanceHistorySort producedAt() {
+    return field("producedAt");
+  }
+
+  @Override
+  public AgentInstanceHistorySort historyItemKey() {
+    return field("historyItemKey");
+  }
+
+  @Override
+  public AgentInstanceHistorySort iteration() {
+    return field("iteration");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
@@ -20,10 +20,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryMetrics;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.response.CreateAgentHistoryItemResponse;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
 import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryItemCreationResult;
@@ -60,8 +60,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
         .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
         .elementInstanceKey(ELEMENT_INSTANCE_KEY)
         .jobKey(JOB_KEY)
-        .role(AgentHistoryRole.USER)
-        .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+        .role(AgentInstanceHistoryRole.USER)
+        .content(Collections.singletonList(AgentInstanceHistoryContent.text("hello")))
         .producedAt(PRODUCED_AT)
         .execute();
 
@@ -83,8 +83,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
         .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
         .elementInstanceKey(ELEMENT_INSTANCE_KEY)
         .jobKey(JOB_KEY)
-        .role(AgentHistoryRole.ASSISTANT)
-        .content(Collections.singletonList(AgentHistoryContent.text("I can help.")))
+        .role(AgentInstanceHistoryRole.ASSISTANT)
+        .content(Collections.singletonList(AgentInstanceHistoryContent.text("I can help.")))
         .producedAt(PRODUCED_AT)
         .execute();
 
@@ -113,12 +113,13 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
         .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
         .elementInstanceKey(ELEMENT_INSTANCE_KEY)
         .jobKey(JOB_KEY)
-        .role(AgentHistoryRole.USER)
-        .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+        .role(AgentInstanceHistoryRole.USER)
+        .content(Collections.singletonList(AgentInstanceHistoryContent.text("hello")))
         .producedAt(PRODUCED_AT)
         .jobLease("lease-token")
         .iteration(3)
-        .metrics(new AgentHistoryMetrics().inputTokens(100L).outputTokens(50L).durationMs(200L))
+        .metrics(
+            new AgentInstanceHistoryMetrics().inputTokens(100L).outputTokens(50L).durationMs(200L))
         .execute();
 
     // then
@@ -144,8 +145,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
             .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
             .elementInstanceKey(ELEMENT_INSTANCE_KEY)
             .jobKey(JOB_KEY)
-            .role(AgentHistoryRole.USER)
-            .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+            .role(AgentInstanceHistoryRole.USER)
+            .content(Collections.singletonList(AgentInstanceHistoryContent.text("hello")))
             .producedAt(PRODUCED_AT)
             .execute();
 
@@ -215,7 +216,7 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
                     .elementInstanceKey(ELEMENT_INSTANCE_KEY)
                     .jobKey(JOB_KEY)
-                    .role(AgentHistoryRole.USER)
+                    .role(AgentInstanceHistoryRole.USER)
                     .content(null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("content must not be null");
@@ -229,8 +230,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
                     .elementInstanceKey(ELEMENT_INSTANCE_KEY)
                     .jobKey(JOB_KEY)
-                    .role(AgentHistoryRole.USER)
-                    .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+                    .role(AgentInstanceHistoryRole.USER)
+                    .content(Collections.singletonList(AgentInstanceHistoryContent.text("hello")))
                     .producedAt(null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("producedAt must not be null");
@@ -247,8 +248,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
                     .elementInstanceKey(ELEMENT_INSTANCE_KEY)
                     .jobKey(JOB_KEY)
-                    .role(AgentHistoryRole.USER)
-                    .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+                    .role(AgentInstanceHistoryRole.USER)
+                    .content(Collections.singletonList(AgentInstanceHistoryContent.text("hello")))
                     .producedAt(PRODUCED_AT)
                     .jobLease(jobLease))
         .isInstanceOf(IllegalArgumentException.class)
@@ -268,7 +269,7 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
         .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
         .elementInstanceKey(ELEMENT_INSTANCE_KEY)
         .jobKey(JOB_KEY)
-        .role(AgentHistoryRole.USER)
+        .role(AgentInstanceHistoryRole.USER)
         .content(Collections.emptyList())
         .producedAt(PRODUCED_AT)
         .execute();
@@ -288,8 +289,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
                     .elementInstanceKey(ELEMENT_INSTANCE_KEY)
                     .jobKey(JOB_KEY)
-                    .role(AgentHistoryRole.USER)
-                    .content(Collections.singletonList(AgentHistoryContent.text(text))))
+                    .role(AgentInstanceHistoryRole.USER)
+                    .content(Collections.singletonList(AgentInstanceHistoryContent.text(text))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("text content value must not be null or blank");
   }
@@ -305,8 +306,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
                     .elementInstanceKey(ELEMENT_INSTANCE_KEY)
                     .jobKey(JOB_KEY)
-                    .role(AgentHistoryRole.USER)
-                    .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+                    .role(AgentInstanceHistoryRole.USER)
+                    .content(Collections.singletonList(AgentInstanceHistoryContent.text("hello")))
                     .producedAt(PRODUCED_AT)
                     .iteration(iteration))
         .isInstanceOf(IllegalArgumentException.class)
@@ -317,21 +318,21 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
 
   @Test
   void shouldRejectNullTextArg() {
-    assertThatThrownBy(() -> AgentHistoryContent.text(null))
+    assertThatThrownBy(() -> AgentInstanceHistoryContent.text(null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("text must not be null");
   }
 
   @Test
   void shouldRejectNullObjectArg() {
-    assertThatThrownBy(() -> AgentHistoryContent.object(null))
+    assertThatThrownBy(() -> AgentInstanceHistoryContent.object(null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("object must not be null");
   }
 
   @Test
   void shouldRejectNullDocumentReferenceArg() {
-    assertThatThrownBy(() -> AgentHistoryContent.document(null))
+    assertThatThrownBy(() -> AgentInstanceHistoryContent.document(null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("documentReference must not be null");
   }
@@ -349,8 +350,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
                     .elementInstanceKey(ELEMENT_INSTANCE_KEY)
                     .jobKey(JOB_KEY)
-                    .role(AgentHistoryRole.USER)
-                    .content(Collections.singletonList(AgentHistoryContent.document(doc))))
+                    .role(AgentInstanceHistoryRole.USER)
+                    .content(Collections.singletonList(AgentInstanceHistoryContent.document(doc))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("documentId must not be null or blank");
   }
@@ -365,8 +366,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
                     .elementInstanceKey(ELEMENT_INSTANCE_KEY)
                     .jobKey(JOB_KEY)
-                    .role(AgentHistoryRole.USER)
-                    .content(Collections.singletonList(AgentHistoryContent.text("hello")))
+                    .role(AgentInstanceHistoryRole.USER)
+                    .content(Collections.singletonList(AgentInstanceHistoryContent.text("hello")))
                     .producedAt(PRODUCED_AT)
                     .toolCalls(Collections.singletonList(null)))
         .isInstanceOf(IllegalArgumentException.class)
@@ -392,8 +393,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
         .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
         .elementInstanceKey(ELEMENT_INSTANCE_KEY)
         .jobKey(JOB_KEY)
-        .role(AgentHistoryRole.USER)
-        .content(Collections.singletonList(AgentHistoryContent.document(doc)))
+        .role(AgentInstanceHistoryRole.USER)
+        .content(Collections.singletonList(AgentInstanceHistoryContent.document(doc)))
         .producedAt(PRODUCED_AT)
         .execute();
 
@@ -438,8 +439,8 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
         .newCreateAgentHistoryItemCommand(AGENT_INSTANCE_KEY)
         .elementInstanceKey(ELEMENT_INSTANCE_KEY)
         .jobKey(JOB_KEY)
-        .role(AgentHistoryRole.USER)
-        .content(Collections.singletonList(AgentHistoryContent.document(doc)))
+        .role(AgentInstanceHistoryRole.USER)
+        .content(Collections.singletonList(AgentInstanceHistoryContent.document(doc)))
         .producedAt(PRODUCED_AT)
         .execute();
 

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.TextContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.response.AgentInstanceHistory;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryCommitStatusEnum;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetrics;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemResult;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
+import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQuery;
+import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQueryResult;
+import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQuerySortRequest;
+import io.camunda.client.protocol.rest.AgentInstanceMessageContent;
+import io.camunda.client.protocol.rest.AgentInstanceTextContent;
+import io.camunda.client.protocol.rest.AgentInstanceToolCall;
+import io.camunda.client.protocol.rest.SearchQueryPageResponse;
+import io.camunda.client.protocol.rest.SortOrderEnum;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+
+class SearchAgentInstanceHistoryTest extends ClientRestTest {
+
+  private static final long AGENT_INSTANCE_KEY = 42L;
+
+  @Test
+  void shouldSearchAgentInstanceHistory() {
+    // when
+    client.newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY).send().join();
+
+    // then
+    final LoggedRequest restRequest = RestGatewayService.getLastRequest();
+    assertThat(restRequest.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(restRequest.getUrl()).isEqualTo("/v2/agent-instances/42/history/search");
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getFilter()).isNull();
+  }
+
+  @Test
+  void shouldSearchWithRoleFilter() {
+    // when
+    client
+        .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
+        .filter(f -> f.role(AgentInstanceHistoryRole.USER))
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getFilter()).isNotNull();
+    assertThat(request.getFilter().getRole().get$Eq()).isEqualTo(AgentInstanceHistoryRoleEnum.USER);
+  }
+
+  @Test
+  void shouldSearchWithHistoryItemKeyFilter() {
+    // when
+    client
+        .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
+        .filter(f -> f.historyItemKey(100L))
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getFilter().getHistoryItemKey().get$Eq()).isEqualTo("100");
+  }
+
+  @Test
+  void shouldSearchWithElementInstanceKeyFilter() {
+    // when
+    client
+        .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
+        .filter(f -> f.elementInstanceKey(200L))
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getFilter().getElementInstanceKey().get$Eq()).isEqualTo("200");
+  }
+
+  @Test
+  void shouldSearchWithJobKeyFilter() {
+    // when
+    client
+        .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
+        .filter(f -> f.jobKey(300L))
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getFilter().getJobKey().get$Eq()).isEqualTo("300");
+  }
+
+  @Test
+  void shouldSearchWithCommitStatusFilter() {
+    // when
+    client
+        .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
+        .filter(f -> f.commitStatus(AgentInstanceHistoryCommitStatus.COMMITTED))
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getFilter().getCommitStatus().get$Eq())
+        .isEqualTo(AgentInstanceHistoryCommitStatusEnum.COMMITTED);
+  }
+
+  @Test
+  void shouldSearchWithIterationFilter() {
+    // when
+    client
+        .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
+        .filter(f -> f.iteration(1))
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getFilter().getIteration().get$Eq()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldSearchWithProducedAtFilter() {
+    // given
+    final OffsetDateTime from = OffsetDateTime.parse("2025-01-01T00:00:00Z");
+    final OffsetDateTime to = OffsetDateTime.parse("2025-12-31T23:59:59Z");
+
+    // when
+    client
+        .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
+        .filter(f -> f.producedAt(p -> p.gt(from).lt(to)))
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getFilter().getProducedAt().get$Gt()).isEqualTo(from.toString());
+    assertThat(request.getFilter().getProducedAt().get$Lt()).isEqualTo(to.toString());
+  }
+
+  @Test
+  void shouldSearchWithIterationSort() {
+    // when
+    client
+        .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
+        .sort(s -> s.iteration().asc())
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getSort())
+        .as("sort fields and orders")
+        .extracting(
+            AgentInstanceHistorySearchQuerySortRequest::getField,
+            AgentInstanceHistorySearchQuerySortRequest::getOrder)
+        .containsExactly(
+            tuple(
+                AgentInstanceHistorySearchQuerySortRequest.FieldEnum.ITERATION, SortOrderEnum.ASC));
+  }
+
+  @Test
+  void shouldSearchWithPage() {
+    // when
+    client
+        .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
+        .page(p -> p.limit(10).from(5))
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getPage()).isNotNull();
+    assertThat(request.getPage().getLimit()).isEqualTo(10);
+    assertThat(request.getPage().getFrom()).isEqualTo(5);
+  }
+
+  @Test
+  void shouldSearchWithFullSorting() {
+    // when
+    client
+        .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
+        .sort(s -> s.producedAt().asc().historyItemKey().desc())
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceHistorySearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
+    assertThat(request.getSort())
+        .as("sort fields and orders")
+        .extracting(
+            AgentInstanceHistorySearchQuerySortRequest::getField,
+            AgentInstanceHistorySearchQuerySortRequest::getOrder)
+        .containsExactly(
+            tuple(
+                AgentInstanceHistorySearchQuerySortRequest.FieldEnum.PRODUCED_AT,
+                SortOrderEnum.ASC),
+            tuple(
+                AgentInstanceHistorySearchQuerySortRequest.FieldEnum.HISTORY_ITEM_KEY,
+                SortOrderEnum.DESC));
+  }
+
+  @Test
+  void shouldMapSearchResponse() {
+    // given
+    final OffsetDateTime now = OffsetDateTime.now();
+    final AgentInstanceHistoryItemResult provided =
+        Instancio.create(AgentInstanceHistoryItemResult.class)
+            .historyItemKey("100")
+            .agentInstanceKey("42")
+            .elementInstanceKey("200")
+            .jobKey("300")
+            .role(AgentInstanceHistoryRoleEnum.USER)
+            .commitStatus(AgentInstanceHistoryCommitStatusEnum.COMMITTED)
+            .producedAt(now.toString())
+            .metrics(
+                new AgentInstanceHistoryItemMetrics()
+                    .inputTokens(10L)
+                    .outputTokens(20L)
+                    .durationMs(100L))
+            .toolCalls(
+                Collections.singletonList(
+                    new AgentInstanceToolCall()
+                        .toolCallId("tc1")
+                        .toolName("search")
+                        .elementId("searchTask")))
+            .content(
+                Collections.singletonList(
+                    (AgentInstanceMessageContent)
+                        new AgentInstanceTextContent().contentType("TEXT").text("hello")));
+
+    gatewayService.onAgentInstanceHistorySearchRequest(
+        AGENT_INSTANCE_KEY,
+        Instancio.create(AgentInstanceHistorySearchQueryResult.class)
+            .page(
+                Instancio.create(SearchQueryPageResponse.class)
+                    .totalItems(1L)
+                    .hasMoreTotalItems(false))
+            .items(Collections.singletonList(provided)));
+
+    // when
+    final io.camunda.client.api.search.response.SearchResponse<AgentInstanceHistory> result =
+        client.newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY).send().join();
+
+    // then
+    assertSoftly(
+        softly -> {
+          softly.assertThat(result.page().totalItems()).isEqualTo(1);
+          softly.assertThat(result.items()).hasSize(1);
+
+          final AgentInstanceHistory item = result.items().get(0);
+          softly.assertThat(item.getHistoryItemKey()).as("historyItemKey").isEqualTo(100L);
+          softly.assertThat(item.getAgentInstanceKey()).as("agentInstanceKey").isEqualTo(42L);
+          softly.assertThat(item.getElementInstanceKey()).as("elementInstanceKey").isEqualTo(200L);
+          softly.assertThat(item.getJobKey()).as("jobKey").isEqualTo(300L);
+          softly.assertThat(item.getRole()).as("role").isEqualTo(AgentInstanceHistoryRole.USER);
+          softly
+              .assertThat(item.getCommitStatus())
+              .as("commitStatus")
+              .isEqualTo(AgentInstanceHistoryCommitStatus.COMMITTED);
+          softly.assertThat(item.getProducedAt()).as("producedAt").isEqualTo(now);
+
+          final AgentInstanceHistoryMetrics metrics = item.getMetrics();
+          softly.assertThat(metrics.getInputTokens()).as("inputTokens").isEqualTo(10L);
+          softly.assertThat(metrics.getOutputTokens()).as("outputTokens").isEqualTo(20L);
+          softly.assertThat(metrics.getDurationMs()).as("durationMs").isEqualTo(100L);
+
+          softly.assertThat(item.getToolCalls()).as("toolCalls").hasSize(1);
+          final AgentInstanceHistoryToolCall toolCall = item.getToolCalls().get(0);
+          softly.assertThat(toolCall.getToolCallId()).as("toolCallId").isEqualTo("tc1");
+          softly.assertThat(toolCall.getToolName()).as("toolName").isEqualTo("search");
+          softly.assertThat(toolCall.getElementId()).as("elementId").isEqualTo("searchTask");
+
+          softly.assertThat(item.getContent()).as("content").hasSize(1);
+          final AgentInstanceHistoryContent content = item.getContent().get(0);
+          softly.assertThat(content.getContentType()).as("contentType").isEqualTo("TEXT");
+          softly.assertThat(content).as("content is TextContent").isInstanceOf(TextContent.class);
+          softly.assertThat(((TextContent) content).getText()).as("text").isEqualTo("hello");
+        });
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
@@ -22,12 +22,15 @@ import static org.assertj.core.groups.Tuple.tuple;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.DocumentContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.ObjectContent;
 import io.camunda.client.api.command.AgentInstanceHistoryContent.TextContent;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
+import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryCommitStatusEnum;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetrics;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryItemResult;
@@ -36,14 +39,17 @@ import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQuery;
 import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQueryResult;
 import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQuerySortRequest;
 import io.camunda.client.protocol.rest.AgentInstanceMessageContent;
+import io.camunda.client.protocol.rest.AgentInstanceObjectContent;
 import io.camunda.client.protocol.rest.AgentInstanceTextContent;
 import io.camunda.client.protocol.rest.AgentInstanceToolCall;
+import io.camunda.client.protocol.rest.DocumentReference;
 import io.camunda.client.protocol.rest.SearchQueryPageResponse;
 import io.camunda.client.protocol.rest.SortOrderEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.Map;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
@@ -252,6 +258,8 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
             .agentInstanceKey("42")
             .elementInstanceKey("200")
             .jobKey("300")
+            .jobLease("lease-abc")
+            .iteration(3)
             .role(AgentInstanceHistoryRoleEnum.USER)
             .commitStatus(AgentInstanceHistoryCommitStatusEnum.COMMITTED)
             .producedAt(now.toString())
@@ -265,7 +273,8 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
                     new AgentInstanceToolCall()
                         .toolCallId("tc1")
                         .toolName("search")
-                        .elementId("searchTask")))
+                        .elementId("searchTask")
+                        .arguments(Collections.<String, Object>singletonMap("query", "camunda"))))
             .content(
                 Collections.singletonList(
                     (AgentInstanceMessageContent)
@@ -295,6 +304,8 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
           softly.assertThat(item.getAgentInstanceKey()).as("agentInstanceKey").isEqualTo(42L);
           softly.assertThat(item.getElementInstanceKey()).as("elementInstanceKey").isEqualTo(200L);
           softly.assertThat(item.getJobKey()).as("jobKey").isEqualTo(300L);
+          softly.assertThat(item.getJobLease()).as("jobLease").isEqualTo("lease-abc");
+          softly.assertThat(item.getIteration()).as("iteration").isEqualTo(3);
           softly.assertThat(item.getRole()).as("role").isEqualTo(AgentInstanceHistoryRole.USER);
           softly
               .assertThat(item.getCommitStatus())
@@ -312,6 +323,10 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
           softly.assertThat(toolCall.getToolCallId()).as("toolCallId").isEqualTo("tc1");
           softly.assertThat(toolCall.getToolName()).as("toolName").isEqualTo("search");
           softly.assertThat(toolCall.getElementId()).as("elementId").isEqualTo("searchTask");
+          softly
+              .assertThat(toolCall.getArguments())
+              .as("arguments")
+              .containsEntry("query", "camunda");
 
           softly.assertThat(item.getContent()).as("content").hasSize(1);
           final AgentInstanceHistoryContent content = item.getContent().get(0);
@@ -319,5 +334,71 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
           softly.assertThat(content).as("content is TextContent").isInstanceOf(TextContent.class);
           softly.assertThat(((TextContent) content).getText()).as("text").isEqualTo("hello");
         });
+  }
+
+  @Test
+  void shouldMapDocumentContent() {
+    // given
+    final DocumentReference ref = new DocumentReference().documentId("doc-1").storeId("store-a");
+    gatewayService.onAgentInstanceHistorySearchRequest(
+        AGENT_INSTANCE_KEY,
+        Instancio.create(AgentInstanceHistorySearchQueryResult.class)
+            .items(
+                Collections.singletonList(
+                    Instancio.create(AgentInstanceHistoryItemResult.class)
+                        .historyItemKey("1")
+                        .agentInstanceKey("1")
+                        .elementInstanceKey("1")
+                        .jobKey("1")
+                        .producedAt(null)
+                        .content(
+                            Collections.singletonList(
+                                (AgentInstanceMessageContent)
+                                    new AgentInstanceDocumentContent()
+                                        .contentType("DOCUMENT")
+                                        .documentReference(ref))))));
+
+    // when
+    final io.camunda.client.api.search.response.SearchResponse<AgentInstanceHistory> result =
+        client.newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY).send().join();
+
+    // then
+    final AgentInstanceHistoryContent content = result.items().get(0).getContent().get(0);
+    assertThat(content).isInstanceOf(DocumentContent.class);
+    final DocumentContent docContent = (DocumentContent) content;
+    assertThat(docContent.getDocumentReference().getDocumentId()).isEqualTo("doc-1");
+    assertThat(docContent.getDocumentReference().getStoreId()).isEqualTo("store-a");
+  }
+
+  @Test
+  void shouldMapObjectContent() {
+    // given
+    final Map<String, Object> obj = Collections.<String, Object>singletonMap("key", "value");
+    gatewayService.onAgentInstanceHistorySearchRequest(
+        AGENT_INSTANCE_KEY,
+        Instancio.create(AgentInstanceHistorySearchQueryResult.class)
+            .items(
+                Collections.singletonList(
+                    Instancio.create(AgentInstanceHistoryItemResult.class)
+                        .historyItemKey("1")
+                        .agentInstanceKey("1")
+                        .elementInstanceKey("1")
+                        .jobKey("1")
+                        .producedAt(null)
+                        .content(
+                            Collections.singletonList(
+                                (AgentInstanceMessageContent)
+                                    new AgentInstanceObjectContent()
+                                        .contentType("OBJECT")
+                                        ._object(obj))))));
+
+    // when
+    final io.camunda.client.api.search.response.SearchResponse<AgentInstanceHistory> result =
+        client.newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY).send().join();
+
+    // then
+    final AgentInstanceHistoryContent content = result.items().get(0).getContent().get(0);
+    assertThat(content).isInstanceOf(ObjectContent.class);
+    assertThat(((ObjectContent) content).getObject()).containsEntry("key", "value");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -25,6 +25,8 @@ public class RestGatewayPaths {
   private static final String URL_AGENT_INSTANCE = REST_API_PATH + "/agent-instances/%s";
   private static final String URL_AGENT_HISTORY_ITEM =
       REST_API_PATH + "/agent-instances/%s/history";
+  private static final String URL_AGENT_HISTORY_SEARCH =
+      REST_API_PATH + "/agent-instances/%s/history/search";
   private static final String URL_AGENT_INSTANCES_SEARCH =
       REST_API_PATH + "/agent-instances/search";
   private static final String URL_BATCH_OPERATION = REST_API_PATH + "/batch-operations/%s";
@@ -514,6 +516,10 @@ public class RestGatewayPaths {
 
   public static String getAgentHistoryItemUrl(final long agentInstanceKey) {
     return String.format(URL_AGENT_HISTORY_ITEM, agentInstanceKey);
+  }
+
+  public static String getAgentHistorySearchUrl(final long agentInstanceKey) {
+    return String.format(URL_AGENT_HISTORY_SEARCH, agentInstanceKey);
   }
 
   public static String getAgentInstancesSearchUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.protocol.rest.AgentInstanceCreationResult;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryItemCreationResult;
+import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQueryResult;
 import io.camunda.client.protocol.rest.AgentInstanceResult;
 import io.camunda.client.protocol.rest.AgentInstanceSearchQueryResult;
 import io.camunda.client.protocol.rest.AuditLogResult;
@@ -376,6 +377,11 @@ public class RestGatewayService {
   public void onCreateAgentHistoryItemRequest(
       final long agentInstanceKey, final AgentInstanceHistoryItemCreationResult response) {
     registerPost(RestGatewayPaths.getAgentHistoryItemUrl(agentInstanceKey), response);
+  }
+
+  public void onAgentInstanceHistorySearchRequest(
+      final long agentInstanceKey, final AgentInstanceHistorySearchQueryResult response) {
+    registerPost(RestGatewayPaths.getAgentHistorySearchUrl(agentInstanceKey), response);
   }
 
   public void onUpdateAgentInstanceRequest(final long agentInstanceKey) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -18,18 +18,15 @@ import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
-import static io.camunda.it.util.TestHelper.waitForJobs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.api.search.response.AgentInstance;
-import io.camunda.client.api.search.response.Job;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
@@ -39,9 +36,11 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -117,6 +116,17 @@ class AgentInstanceAuthorizationIT {
     elementInstanceKey1 = result1.elementInstanceKey();
     jobKey1 = result1.jobKey();
 
+    // Create history item immediately while jobKey1 is still active, before waiting for
+    // other agents to be indexed (which can take long enough for the job to expire).
+    adminClient
+        .newCreateAgentHistoryItemCommand(agentInstanceKey1)
+        .elementInstanceKey(elementInstanceKey1)
+        .jobKey(jobKey1)
+        .role(AgentInstanceHistoryRole.USER)
+        .content(List.of(AgentInstanceHistoryContent.text("hello")))
+        .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
+        .execute();
+
     agentInstanceKey2 = createAgentInstance(adminClient, PROCESS_ID_2).agentInstanceKey();
     final var result3 = createAgentInstance(adminClient, PROCESS_ID_3);
 
@@ -126,6 +136,13 @@ class AgentInstanceAuthorizationIT {
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey1);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey2);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey3);
+    // Agent history search is not supported on RDBMS; searchHistory tests are already
+    // individually disabled via @DisabledIfSystemProperty for rdbms.* backends.
+    if (!System.getProperty("test.integration.camunda.database.type", "")
+        .toLowerCase()
+        .startsWith("rdbms")) {
+      waitForHistoryItemsToBeIndexed(adminClient, agentInstanceKey1, 1);
+    }
   }
 
   // ── search ────────────────────────────────────────────────────────────────
@@ -292,8 +309,8 @@ class AgentInstanceAuthorizationIT {
                 .newCreateAgentHistoryItemCommand(agentInstanceKey1)
                 .elementInstanceKey(elementInstanceKey1)
                 .jobKey(jobKey1)
-                .role(AgentHistoryRole.USER)
-                .content(List.of(AgentHistoryContent.text("hello")))
+                .role(AgentInstanceHistoryRole.USER)
+                .content(List.of(AgentInstanceHistoryContent.text("hello")))
                 .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
                 .execute();
 
@@ -307,23 +324,61 @@ class AgentInstanceAuthorizationIT {
   @Test
   void createHistoryItemShouldPassAuthorizationForAuthorizedUser(
       @Authenticated(USER3) final CamundaClient camundaClient) {
-    // given — user3 has UPDATE_PROCESS_INSTANCE on PROCESS_ID_3; there is no active job, so the
-    // engine rejects with 404 after authorization, not 403
-    assertThatThrownBy(
+    // user3 has UPDATE_PROCESS_INSTANCE on PROCESS_ID_3 and jobKey3 is activated in setUp,
+    // so the command should succeed without any exception
+    assertThatNoException()
+        .isThrownBy(
             () ->
                 camundaClient
                     .newCreateAgentHistoryItemCommand(agentInstanceKey3)
                     .elementInstanceKey(elementInstanceKey3)
                     .jobKey(jobKey3)
-                    .role(AgentHistoryRole.USER)
-                    .content(List.of(AgentHistoryContent.text("hello")))
+                    .role(AgentInstanceHistoryRole.USER)
+                    .content(List.of(AgentInstanceHistoryContent.text("hello")))
                     .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
-                    .execute())
-        .isInstanceOf(ProblemException.class)
-        .satisfies(ex -> assertThat(((ProblemException) ex).code()).isNotEqualTo(403));
+                    .execute());
+  }
+
+  // ── searchHistory ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+  void searchHistoryShouldReturnHistoryForAuthorizedUser(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // user1 has READ_PROCESS_INSTANCE on PROCESS_ID_1
+    final var result =
+        camundaClient.newAgentInstanceHistorySearchRequest(agentInstanceKey1).execute();
+
+    assertThat(result.items()).isNotEmpty();
+    assertThat(result.items())
+        .allSatisfy(item -> assertThat(item.getAgentInstanceKey()).isEqualTo(agentInstanceKey1));
+  }
+
+  @Test
+  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+  void searchHistoryShouldReturnEmptyForUnauthorizedUser(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // user1 has no READ_PROCESS_INSTANCE on PROCESS_ID_2
+    final var result =
+        camundaClient.newAgentInstanceHistorySearchRequest(agentInstanceKey2).execute();
+
+    assertThat(result.items()).isEmpty();
   }
 
   // ── helpers ───────────────────────────────────────────────────────────────
+
+  private static void waitForHistoryItemsToBeIndexed(
+      final CamundaClient client, final long agentInstanceKey, final int expectedCount) {
+    Awaitility.await("agent history indexed for key " + agentInstanceKey)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var response =
+                  client.newAgentInstanceHistorySearchRequest(agentInstanceKey).execute();
+              assertThat(response.items()).hasSizeGreaterThanOrEqualTo(expectedCount);
+            });
+  }
 
   private static AgentInstanceCreationResult createAgentInstance(
       final CamundaClient adminClient, final String processId) {
@@ -362,15 +417,19 @@ class AgentInstanceAuthorizationIT {
             .execute()
             .getAgentInstanceKey();
 
-    final long jobKey =
-        waitForJobs(adminClient, List.of(processInstanceKey)).stream()
-            .filter(j -> JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX.equals(j.getType()))
-            .findFirst()
-            .map(Job::getJobKey)
-            .orElseThrow(
-                () ->
-                    new AssertionError(
-                        "No agent job found for process instance " + processInstanceKey));
+    final var activatedJobs =
+        adminClient
+            .newActivateJobsCommand()
+            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .maxJobsToActivate(1)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs();
+    assertThat(activatedJobs)
+        .as("expected to activate one agent job for process instance %d", processInstanceKey)
+        .isNotEmpty();
+    final long jobKey = activatedJobs.get(0).getKey();
 
     return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey, jobKey);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.response.AgentInstanceHistory;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@CompatibilityTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+public class AgentInstanceHistorySearchIT {
+
+  private static final String AGENT_ELEMENT_ID = "agentHistorySearchElement";
+  private static final String PROCESS_ID = "agentHistorySearchProcess";
+
+  private static CamundaClient camundaClient;
+
+  private static long agentInstanceKey;
+  private static long elementInstanceKey;
+  private static long jobKey;
+  private static long historyItemKey1;
+  private static long historyItemKey2;
+  private static long historyItemKey3;
+
+  @BeforeAll
+  static void setup() {
+    final var processModel =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
+            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .endEvent("end")
+            .done();
+
+    final var process =
+        deployProcessAndWaitForIt(camundaClient, processModel, "agent-history-search.bpmn");
+
+    final var pi = startProcessInstance(camundaClient, process.getBpmnProcessId());
+    final long processInstanceKey = pi.getProcessInstanceKey();
+
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey),
+        1);
+
+    elementInstanceKey =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    agentInstanceKey =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(elementInstanceKey)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are a helpful assistant.")
+            .send()
+            .join()
+            .getAgentInstanceKey();
+
+    waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey);
+
+    final var activatedJobs =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .maxJobsToActivate(1)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs();
+    assertThat(activatedJobs)
+        .as("expected to activate one agent job for process instance %d", processInstanceKey)
+        .isNotEmpty();
+    jobKey = activatedJobs.get(0).getKey();
+
+    // Create 3 history items with different roles
+    historyItemKey1 =
+        camundaClient
+            .newCreateAgentHistoryItemCommand(agentInstanceKey)
+            .elementInstanceKey(elementInstanceKey)
+            .jobKey(jobKey)
+            .role(AgentInstanceHistoryRole.USER)
+            .content(List.of(AgentInstanceHistoryContent.text("Hello, what can you do?")))
+            .producedAt(OffsetDateTime.parse("2025-06-01T10:00:00Z"))
+            .send()
+            .join()
+            .getHistoryItemKey();
+
+    historyItemKey2 =
+        camundaClient
+            .newCreateAgentHistoryItemCommand(agentInstanceKey)
+            .elementInstanceKey(elementInstanceKey)
+            .jobKey(jobKey)
+            .role(AgentInstanceHistoryRole.ASSISTANT)
+            .content(List.of(AgentInstanceHistoryContent.text("I can help with many tasks.")))
+            .producedAt(OffsetDateTime.parse("2025-06-01T10:01:00Z"))
+            .send()
+            .join()
+            .getHistoryItemKey();
+
+    historyItemKey3 =
+        camundaClient
+            .newCreateAgentHistoryItemCommand(agentInstanceKey)
+            .elementInstanceKey(elementInstanceKey)
+            .jobKey(jobKey)
+            .role(AgentInstanceHistoryRole.TOOL_RESULT)
+            .content(List.of(AgentInstanceHistoryContent.text("Search results: ...")))
+            .producedAt(OffsetDateTime.parse("2025-06-01T10:02:00Z"))
+            .send()
+            .join()
+            .getHistoryItemKey();
+
+    waitForHistoryItemsToBeIndexed(camundaClient, agentInstanceKey, 3);
+  }
+
+  @Test
+  void shouldReturnAllHistoryItems() {
+    // when
+    final var response =
+        camundaClient.newAgentInstanceHistorySearchRequest(agentInstanceKey).execute();
+
+    // then
+    assertThat(response.items())
+        .extracting(AgentInstanceHistory::getHistoryItemKey)
+        .containsExactlyInAnyOrder(historyItemKey1, historyItemKey2, historyItemKey3);
+  }
+
+  @Test
+  void shouldFilterByRole() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .filter(f -> f.role(AgentInstanceHistoryRole.USER))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.getHistoryItemKey()).isEqualTo(historyItemKey1);
+              assertThat(item.getRole()).isEqualTo(AgentInstanceHistoryRole.USER);
+            });
+  }
+
+  @Test
+  void shouldFilterByHistoryItemKey() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .filter(f -> f.historyItemKey(historyItemKey1))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .singleElement()
+        .satisfies(item -> assertThat(item.getHistoryItemKey()).isEqualTo(historyItemKey1));
+  }
+
+  @Test
+  void shouldSortByProducedAtAscending() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .sort(s -> s.producedAt().asc())
+            .execute();
+
+    // then — items should come back in producedAt order: item1 < item2 < item3
+    assertThat(response.items())
+        .extracting(AgentInstanceHistory::getHistoryItemKey)
+        .containsExactly(historyItemKey1, historyItemKey2, historyItemKey3);
+  }
+
+  @Test
+  void shouldPaginateResults() {
+    // when — page 1: limit 1
+    final var page1 =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .sort(s -> s.producedAt().asc())
+            .page(p -> p.limit(1))
+            .execute();
+
+    assertThat(page1.items()).hasSize(1);
+
+    // when — page 2: limit 1, from 1
+    final var page2 =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .sort(s -> s.producedAt().asc())
+            .page(p -> p.limit(1).from(1))
+            .execute();
+
+    assertThat(page2.items()).hasSize(1);
+
+    // then — pages do not overlap
+    final var page1Keys =
+        page1.items().stream().map(AgentInstanceHistory::getHistoryItemKey).toList();
+    final var page2Keys =
+        page2.items().stream().map(AgentInstanceHistory::getHistoryItemKey).toList();
+    assertThat(page1Keys).doesNotContainAnyElementsOf(page2Keys);
+  }
+
+  private static void waitForHistoryItemsToBeIndexed(
+      final CamundaClient client, final long agentKey, final int expectedCount) {
+    Awaitility.await("agent history indexed")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var response = client.newAgentInstanceHistorySearchRequest(agentKey).execute();
+              assertThat(response.items()).hasSizeGreaterThanOrEqualTo(expectedCount);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -171,6 +171,7 @@ public class AgentInstanceHistorySearchIT {
             item -> {
               assertThat(item.getHistoryItemKey()).isEqualTo(historyItemKey1);
               assertThat(item.getRole()).isEqualTo(AgentInstanceHistoryRole.USER);
+              assertThat(item.getCommitStatus()).isNotNull();
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -10,15 +10,13 @@ package io.camunda.it.tenancy;
 import static io.camunda.it.util.TestHelper.deployProcessForTenantAndWaitForIt;
 import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
-import static io.camunda.it.util.TestHelper.waitForJobs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.ProblemException;
-import io.camunda.client.api.search.response.Job;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
@@ -28,8 +26,10 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -66,7 +66,9 @@ public class AgentInstanceTenancyIT {
 
   private static long agentInstanceKeyA;
   private static long agentInstanceKeyB;
+  private static long elementInstanceKeyA;
   private static long elementInstanceKeyB;
+  private static long jobKeyA;
   private static long jobKeyB;
 
   @BeforeAll
@@ -89,14 +91,47 @@ public class AgentInstanceTenancyIT {
     deployProcessForTenant(adminClient, processModel, TENANT_A);
     deployProcessForTenant(adminClient, processModel, TENANT_B);
 
-    agentInstanceKeyA = createAgentInstance(adminClient, TENANT_A);
+    final var resultA = createAgentInstanceWithResult(adminClient, TENANT_A);
+    agentInstanceKeyA = resultA.agentInstanceKey();
+    elementInstanceKeyA = resultA.elementInstanceKey();
+    jobKeyA = resultA.jobKey();
+
+    // Create history item immediately while jobKeyA is still active, before waiting for
+    // agent B to be indexed (which can take long enough for the job to expire).
+    adminClient
+        .newCreateAgentHistoryItemCommand(agentInstanceKeyA)
+        .elementInstanceKey(elementInstanceKeyA)
+        .jobKey(jobKeyA)
+        .role(AgentInstanceHistoryRole.USER)
+        .content(List.of(AgentInstanceHistoryContent.text("Hello from " + TENANT_A)))
+        .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
+        .execute();
+
     final var resultB = createAgentInstanceWithResult(adminClient, TENANT_B);
     agentInstanceKeyB = resultB.agentInstanceKey();
     elementInstanceKeyB = resultB.elementInstanceKey();
     jobKeyB = resultB.jobKey();
 
+    // Create history item immediately while jobKeyB is still active.
+    adminClient
+        .newCreateAgentHistoryItemCommand(agentInstanceKeyB)
+        .elementInstanceKey(elementInstanceKeyB)
+        .jobKey(jobKeyB)
+        .role(AgentInstanceHistoryRole.USER)
+        .content(List.of(AgentInstanceHistoryContent.text("Hello from " + TENANT_B)))
+        .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
+        .execute();
+
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyA);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyB);
+    // Agent history search is not supported on RDBMS; searchHistory tests are already
+    // individually disabled via @DisabledIfSystemProperty for rdbms.* backends.
+    if (!System.getProperty("test.integration.camunda.database.type", "")
+        .toLowerCase()
+        .startsWith("rdbms")) {
+      waitForHistoryItemsToBeIndexed(adminClient, agentInstanceKeyA, 1);
+      waitForHistoryItemsToBeIndexed(adminClient, agentInstanceKeyB, 1);
+    }
   }
 
   // ── search ────────────────────────────────────────────────────────────────
@@ -218,6 +253,48 @@ public class AgentInstanceTenancyIT {
     assertThat(exception.details().getStatus()).isEqualTo(404);
   }
 
+  // ── searchHistory ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+  void searchHistoryShouldReturnOnlyTenantAHistoryForUser1(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // user1 belongs to TENANT_A only
+    final var resultA =
+        camundaClient.newAgentInstanceHistorySearchRequest(agentInstanceKeyA).execute();
+    final var resultB =
+        camundaClient.newAgentInstanceHistorySearchRequest(agentInstanceKeyB).execute();
+
+    assertThat(resultA.items()).isNotEmpty();
+    assertThat(resultB.items()).isEmpty();
+  }
+
+  @Test
+  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+  void searchHistoryShouldReturnAllHistoryForAdmin(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    final var resultA =
+        camundaClient.newAgentInstanceHistorySearchRequest(agentInstanceKeyA).execute();
+    final var resultB =
+        camundaClient.newAgentInstanceHistorySearchRequest(agentInstanceKeyB).execute();
+
+    assertThat(resultA.items()).isNotEmpty();
+    assertThat(resultB.items()).isNotEmpty();
+  }
+
+  @Test
+  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+  void searchHistoryShouldReturnEmptyForUserWithNoTenant(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    final var resultA =
+        camundaClient.newAgentInstanceHistorySearchRequest(agentInstanceKeyA).execute();
+    final var resultB =
+        camundaClient.newAgentInstanceHistorySearchRequest(agentInstanceKeyB).execute();
+
+    assertThat(resultA.items()).isEmpty();
+    assertThat(resultB.items()).isEmpty();
+  }
+
   // ── createHistoryItem ─────────────────────────────────────────────────────
 
   @Test
@@ -232,8 +309,8 @@ public class AgentInstanceTenancyIT {
                         .newCreateAgentHistoryItemCommand(agentInstanceKeyB)
                         .elementInstanceKey(elementInstanceKeyB)
                         .jobKey(jobKeyB)
-                        .role(AgentHistoryRole.USER)
-                        .content(List.of(AgentHistoryContent.text("hello")))
+                        .role(AgentInstanceHistoryRole.USER)
+                        .content(List.of(AgentInstanceHistoryContent.text("hello")))
                         .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
                         .execute())
             .actual();
@@ -246,6 +323,19 @@ public class AgentInstanceTenancyIT {
   }
 
   // ── helpers ───────────────────────────────────────────────────────────────
+
+  private static void waitForHistoryItemsToBeIndexed(
+      final CamundaClient client, final long agentInstanceKey, final int expectedCount) {
+    Awaitility.await("agent history indexed for key " + agentInstanceKey)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var response =
+                  client.newAgentInstanceHistorySearchRequest(agentInstanceKey).execute();
+              assertThat(response.items()).hasSizeGreaterThanOrEqualTo(expectedCount);
+            });
+  }
 
   private static void createTenant(final CamundaClient client, final String tenantId) {
     client.newCreateTenantCommand().tenantId(tenantId).name(tenantId).send().join();
@@ -260,10 +350,6 @@ public class AgentInstanceTenancyIT {
       final CamundaClient client, final BpmnModelInstance model, final String tenantId) {
     final String filename = PROCESS_ID + "-" + tenantId + ".bpmn";
     deployProcessForTenantAndWaitForIt(client, model, filename, tenantId);
-  }
-
-  private static long createAgentInstance(final CamundaClient client, final String tenantId) {
-    return createAgentInstanceWithResult(client, tenantId).agentInstanceKey();
   }
 
   private static AgentInstanceCreationResult createAgentInstanceWithResult(
@@ -300,15 +386,20 @@ public class AgentInstanceTenancyIT {
             .execute()
             .getAgentInstanceKey();
 
-    final long jobKey =
-        waitForJobs(client, List.of(processInstanceKey)).stream()
-            .filter(j -> JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX.equals(j.getType()))
-            .findFirst()
-            .map(Job::getJobKey)
-            .orElseThrow(
-                () ->
-                    new AssertionError(
-                        "No agent job found for process instance " + processInstanceKey));
+    final var activatedJobs =
+        client
+            .newActivateJobsCommand()
+            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .maxJobsToActivate(1)
+            .tenantIds(tenantId)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs();
+    assertThat(activatedJobs)
+        .as("expected to activate one agent job for process instance %d", processInstanceKey)
+        .isNotEmpty();
+    final long jobKey = activatedJobs.get(0).getKey();
 
     return new AgentInstanceCreationResult(agentInstanceKey, elementInstanceKey, jobKey);
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentHistoryItemTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentHistoryItemTest.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.it.engine.client.command;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -54,8 +54,8 @@ public final class CreateAgentHistoryItemTest {
             .newCreateAgentHistoryItemCommand(agentInstanceKey)
             .elementInstanceKey(Protocol.encodePartitionId(999, 2))
             .jobKey(Protocol.encodePartitionId(999, 3))
-            .role(AgentHistoryRole.USER)
-            .content(List.of(AgentHistoryContent.text("hello")))
+            .role(AgentInstanceHistoryRole.USER)
+            .content(List.of(AgentInstanceHistoryContent.text("hello")))
             .producedAt(OffsetDateTime.now())
             .send();
 
@@ -79,8 +79,8 @@ public final class CreateAgentHistoryItemTest {
             .newCreateAgentHistoryItemCommand(nonExistingKey)
             .elementInstanceKey(Protocol.encodePartitionId(partition, 3))
             .jobKey(Protocol.encodePartitionId(partition, 4))
-            .role(AgentHistoryRole.USER)
-            .content(List.of(AgentHistoryContent.text("hello")))
+            .role(AgentInstanceHistoryRole.USER)
+            .content(List.of(AgentInstanceHistoryContent.text("hello")))
             .producedAt(OffsetDateTime.now())
             .send();
 


### PR DESCRIPTION
## Summary

Adds `CamundaClient.newAgentInstanceHistorySearchRequest(long agentInstanceKey)` — typed search builder for `POST /v2/agent-instances/{agentInstanceKey}/history/search`.

Closes #55272. Part 4/4 of #51511.

## Changes

### Command API refactor (prerequisite)

Extracted shared model types out of the command API inner classes so both write and read paths use the same types:

- `AgentInstanceHistoryContent` — factory interface with concrete inner classes `TextContent`, `ObjectContent`, `DocumentContent`; replaces `CreateAgentHistoryItemCommandStep1.AgentHistoryContent`
- `AgentInstanceHistoryMetrics` — mutable builder class; replaces `CreateAgentHistoryItemCommandStep1.AgentHistoryMetrics`
- `AgentInstanceHistoryToolCall` — mutable builder class; replaces `CreateAgentHistoryItemCommandStep1.AgentHistoryToolCall`
- `AgentInstanceHistoryRole` (enum, `api/search/enums/`) — replaces `CreateAgentHistoryItemCommandStep1.AgentHistoryRole`; includes `UNKNOWN_ENUM_VALUE` for safe deserialization; command API rejects it with `IllegalArgumentException`

`CreateAgentHistoryItemCommandStep1` and `CreateAgentHistoryItemCommandImpl` updated to use these shared types. All `AgentHistory*` inner type references removed.

### Search API (new)

**API types**
- `AgentInstanceHistoryCommitStatus` enum
- `AgentInstanceHistoryRoleProperty` / `AgentInstanceHistoryCommitStatusProperty` filter property builder interfaces (`PropertyBase`, no `LikeProperty` — OpenAPI filter has no `$like` for these fields)
- `AgentInstanceHistoryFilter` interface: `historyItemKey`, `role`, `elementInstanceKey`, `jobKey`, `iteration`, `commitStatus`, `producedAt`
- `AgentInstanceHistorySort` interface: `producedAt`, `historyItemKey`, `iteration`
- `AgentInstanceHistorySearchRequest` interface
- `AgentInstanceHistory` response interface — uses shared command API types for `getContent()`, `getToolCalls()`, `getMetrics()`

**Implementations**
- `AgentInstanceHistoryFilterImpl` — converts long key fields via `toAgentHistoryItemKeyFilterProperty` / `toElementInstanceKeyFilterProperty` / `toJobKeyFilterProperty`, matching pattern from `AgentInstanceFilterImpl`
- `AgentInstanceHistorySortImpl`, `AgentInstanceHistorySearchRequestImpl`, `AgentInstanceHistoryImpl`
- Enum filter property impls for role and commitStatus

**Client wiring**
- `CamundaClient` + `CamundaClientImpl`: add `newAgentInstanceHistorySearchRequest(long)`
- `SearchRequestBuilders`: add `agentInstanceHistoryFilter` / `agentInstanceHistorySort` factory methods
- `SearchResponseMapper`: add `toAgentInstanceHistorySearchResponse`
- `SearchRequestSortMapper`: add sort field mapping for `producedAt`, `historyItemKey`, `iteration`

### Tests
- `SearchAgentInstanceHistoryTest`: 8 WireMock unit tests (filter, sort, pagination, full response field mapping)
- `AgentInstanceAuthorizationIT`: new `searchHistory` section — authorized user sees filtered results, unauthorized gets empty (not 403); RDBMS-disabled at method level
- `AgentInstanceTenancyIT`: new `searchHistory` section — tenant isolation for history search; RDBMS-disabled at method level
- `AgentInstanceHistorySearchIT`: 5 multi-DB search tests (filter by role, sort, pagination); RDBMS-disabled

RDBMS tests disabled via `@DisabledIfSystemProperty` — history search not yet supported on RDBMS.