### PR TITLE
refactor: introduce deletion behavior classes

### DIFF
--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
@@ -24,6 +24,8 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
+import io.camunda.zeebe.engine.processing.resource.ResourceDeletionAuthorizationBehavior;
+import io.camunda.zeebe.engine.processing.resource.TenantAwareDeletionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
@@ -31,6 +33,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.function.Function;
 
 @AnalyzeClasses(
     packages = "io.camunda.zeebe.engine.processing..",
@@ -134,6 +137,17 @@ public class AuthorizationArchTest {
                     "isAuthorized",
                     TypedRecord.class,
                     DeployedProcess.class))
+            .or(
+                ArchConditions.callMethod(
+                    TenantAwareDeletionBehavior.class,
+                    "forEachAuthorizedTenantUntilDeleted",
+                    TypedRecord.class,
+                    Function.class))
+            .or(
+                ArchConditions.callMethod(
+                    ResourceDeletionAuthorizationBehavior.class,
+                    "checkAuthorizationForHistoryDeletion",
+                    TypedRecord.class))
             .check(item, events);
       }
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/DecisionRequirementsDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/DecisionRequirementsDeletionBehavior.java
@@ -29,6 +29,8 @@ import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -39,16 +41,37 @@ final class DecisionRequirementsDeletionBehavior {
   private final TypedCommandWriter commandWriter;
   private final KeyGenerator keyGenerator;
   private final DecisionState decisionState;
+  private final ResourceDeletionAuthorizationBehavior authorizationBehavior;
 
   DecisionRequirementsDeletionBehavior(
       final StateWriter stateWriter,
       final TypedCommandWriter commandWriter,
       final KeyGenerator keyGenerator,
-      final DecisionState decisionState) {
+      final DecisionState decisionState,
+      final ResourceDeletionAuthorizationBehavior authorizationBehavior) {
     this.stateWriter = stateWriter;
     this.commandWriter = commandWriter;
     this.keyGenerator = keyGenerator;
     this.decisionState = decisionState;
+    this.authorizationBehavior = authorizationBehavior;
+  }
+
+  boolean tryDelete(
+      final TypedRecord<ResourceDeletionRecord> command,
+      final long eventKey,
+      final DeployedDrg drg) {
+    command
+        .getValue()
+        .setResourceType(ResourceType.DECISION_REQUIREMENTS)
+        .setResourceId(drg.getDecisionRequirementsId())
+        .setTenantId(drg.getTenantId());
+    return authorizationBehavior.authorizeAndDelete(
+        command,
+        eventKey,
+        PermissionType.DELETE_DRD,
+        bufferAsString(drg.getDecisionRequirementsId()),
+        drg.getTenantId(),
+        () -> deleteDecisionRequirements(drg, command, eventKey));
   }
 
   void deleteDecisionRequirements(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/DecisionRequirementsDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/DecisionRequirementsDeletionBehavior.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -59,19 +60,21 @@ final class DecisionRequirementsDeletionBehavior {
   boolean tryDelete(
       final TypedRecord<ResourceDeletionRecord> command,
       final long eventKey,
+      final Intent intent,
       final DeployedDrg drg) {
     command
         .getValue()
         .setResourceType(ResourceType.DECISION_REQUIREMENTS)
         .setResourceId(drg.getDecisionRequirementsId())
         .setTenantId(drg.getTenantId());
-    return authorizationBehavior.authorizeAndDelete(
+    authorizationBehavior.authorize(
         command,
-        eventKey,
         PermissionType.DELETE_DRD,
         bufferAsString(drg.getDecisionRequirementsId()),
-        drg.getTenantId(),
-        () -> deleteDecisionRequirements(drg, command, eventKey));
+        drg.getTenantId());
+    stateWriter.appendFollowUpEvent(eventKey, intent, command.getValue());
+    deleteDecisionRequirements(drg, command, eventKey);
+    return true;
   }
 
   void deleteDecisionRequirements(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/DecisionRequirementsDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/DecisionRequirementsDeletionBehavior.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.search.filter.DecisionInstanceFilter;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
+import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
+import io.camunda.zeebe.engine.state.immutable.DecisionState;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.agrona.concurrent.UnsafeBuffer;
+
+final class DecisionRequirementsDeletionBehavior {
+
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+  private final KeyGenerator keyGenerator;
+  private final DecisionState decisionState;
+
+  DecisionRequirementsDeletionBehavior(
+      final StateWriter stateWriter,
+      final TypedCommandWriter commandWriter,
+      final KeyGenerator keyGenerator,
+      final DecisionState decisionState) {
+    this.stateWriter = stateWriter;
+    this.commandWriter = commandWriter;
+    this.keyGenerator = keyGenerator;
+    this.decisionState = decisionState;
+  }
+
+  void deleteDecisionRequirements(
+      final DeployedDrg drg,
+      final TypedRecord<ResourceDeletionRecord> command,
+      final long eventKey) {
+    decisionState
+        .findDecisionsByTenantAndDecisionRequirementsKey(
+            drg.getTenantId(), drg.getDecisionRequirementsKey())
+        .forEach(this::deleteDecision);
+
+    if (!command.isCommandDistributed() && command.getValue().isDeleteHistory()) {
+      deleteDecisionInstanceHistory(drg.getDecisionRequirementsKey(), eventKey, command.getValue());
+    }
+
+    final var drgRecord =
+        new DecisionRequirementsRecord()
+            .setDecisionRequirementsId(bufferAsString(drg.getDecisionRequirementsId()))
+            .setDecisionRequirementsName(bufferAsString(drg.getDecisionRequirementsName()))
+            .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
+            .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
+            .setResourceName(bufferAsString(drg.getResourceName()))
+            .setChecksum(drg.getChecksum())
+            .setResource(drg.getResource())
+            .setTenantId(drg.getTenantId())
+            .setDeploymentKey(drg.getDeploymentKey());
+
+    stateWriter.appendFollowUpEvent(
+        keyGenerator.nextKey(), DecisionRequirementsIntent.DELETED, drgRecord);
+  }
+
+  void deleteDecisionInstanceHistory(
+      final long decisionRequirementsKey,
+      final long eventKey,
+      final ResourceDeletionRecord resourceDeletionRecord) {
+    final var filter =
+        new DecisionInstanceFilter.Builder()
+            .decisionRequirementsKeys(decisionRequirementsKey)
+            .build();
+    final long batchOperationKey = keyGenerator.nextKey();
+    final var batchOperationRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE)
+            .setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)))
+            .setAuthentication(
+                new UnsafeBuffer(
+                    MsgPackConverter.convertToMsgPack(CamundaAuthentication.anonymous())))
+            .setFollowUpCommand(
+                ValueType.HISTORY_DELETION,
+                HistoryDeletionIntent.DELETE,
+                new HistoryDeletionRecord()
+                    .setResourceKey(decisionRequirementsKey)
+                    .setResourceType(HistoryDeletionType.DECISION_REQUIREMENTS));
+    commandWriter.appendFollowUpCommand(
+        eventKey, BatchOperationIntent.CREATE, batchOperationRecord);
+
+    resourceDeletionRecord.setBatchOperationKey(batchOperationKey);
+    resourceDeletionRecord.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
+  }
+
+  private void deleteDecision(final PersistedDecision persistedDecision) {
+    final var decisionRecord =
+        new DecisionRecord()
+            .setDecisionId(bufferAsString(persistedDecision.getDecisionId()))
+            .setDecisionName(bufferAsString(persistedDecision.getDecisionName()))
+            .setVersion(persistedDecision.getVersion())
+            .setVersionTag(persistedDecision.getVersionTag())
+            .setDecisionKey(persistedDecision.getDecisionKey())
+            .setDecisionRequirementsId(
+                bufferAsString(persistedDecision.getDecisionRequirementsId()))
+            .setDecisionRequirementsKey(persistedDecision.getDecisionRequirementsKey())
+            .setTenantId(persistedDecision.getTenantId())
+            .setDeploymentKey(persistedDecision.getDeploymentKey());
+
+    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), DecisionIntent.DELETED, decisionRecord);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/FormDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/FormDeletionBehavior.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.deployment.PersistedForm;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+final class FormDeletionBehavior {
+
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+
+  FormDeletionBehavior(final StateWriter stateWriter, final KeyGenerator keyGenerator) {
+    this.stateWriter = stateWriter;
+    this.keyGenerator = keyGenerator;
+  }
+
+  void deleteForm(final PersistedForm persistedForm) {
+    final var form =
+        new FormRecord()
+            .setFormId(persistedForm.getFormId())
+            .setFormKey(persistedForm.getFormKey())
+            .setTenantId(persistedForm.getTenantId())
+            .setResourceName(persistedForm.getResourceName())
+            .setResource(persistedForm.getResource())
+            .setChecksum(persistedForm.getChecksum())
+            .setVersion(persistedForm.getVersion())
+            .setVersionTag(persistedForm.getVersionTag())
+            .setDeploymentKey(persistedForm.getDeploymentKey());
+
+    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), FormIntent.DELETED, form);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/FormDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/FormDeletionBehavior.java
@@ -7,23 +7,52 @@
  */
 package io.camunda.zeebe.engine.processing.resource;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 final class FormDeletionBehavior {
 
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
+  private final ResourceDeletionAuthorizationBehavior authorizationBehavior;
 
-  FormDeletionBehavior(final StateWriter stateWriter, final KeyGenerator keyGenerator) {
+  FormDeletionBehavior(
+      final StateWriter stateWriter,
+      final KeyGenerator keyGenerator,
+      final ResourceDeletionAuthorizationBehavior authorizationBehavior) {
     this.stateWriter = stateWriter;
     this.keyGenerator = keyGenerator;
+    this.authorizationBehavior = authorizationBehavior;
   }
 
-  void deleteForm(final PersistedForm persistedForm) {
+  boolean tryDelete(
+      final TypedRecord<ResourceDeletionRecord> command,
+      final long eventKey,
+      final PersistedForm form) {
+    command
+        .getValue()
+        .setResourceType(ResourceType.FORM)
+        .setResourceId(form.getFormId())
+        .setTenantId(form.getTenantId());
+    return authorizationBehavior.authorizeAndDelete(
+        command,
+        eventKey,
+        PermissionType.DELETE_FORM,
+        bufferAsString(form.getFormId()),
+        form.getTenantId(),
+        () -> deleteForm(form));
+  }
+
+  private void deleteForm(final PersistedForm persistedForm) {
     final var form =
         new FormRecord()
             .setFormId(persistedForm.getFormId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/FormDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/FormDeletionBehavior.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -37,19 +38,18 @@ final class FormDeletionBehavior {
   boolean tryDelete(
       final TypedRecord<ResourceDeletionRecord> command,
       final long eventKey,
+      final Intent intent,
       final PersistedForm form) {
     command
         .getValue()
         .setResourceType(ResourceType.FORM)
         .setResourceId(form.getFormId())
         .setTenantId(form.getTenantId());
-    return authorizationBehavior.authorizeAndDelete(
-        command,
-        eventKey,
-        PermissionType.DELETE_FORM,
-        bufferAsString(form.getFormId()),
-        form.getTenantId(),
-        () -> deleteForm(form));
+    authorizationBehavior.authorize(
+        command, PermissionType.DELETE_FORM, bufferAsString(form.getFormId()), form.getTenantId());
+    stateWriter.appendFollowUpEvent(eventKey, intent, command.getValue());
+    deleteForm(form);
+    return true;
   }
 
   private void deleteForm(final PersistedForm persistedForm) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ProcessDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ProcessDeletionBehavior.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionReco
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
@@ -89,19 +90,21 @@ final class ProcessDeletionBehavior {
   boolean tryDelete(
       final TypedRecord<ResourceDeletionRecord> command,
       final long eventKey,
+      final Intent intent,
       final DeployedProcess process) {
     command
         .getValue()
         .setResourceType(ResourceType.PROCESS_DEFINITION)
         .setResourceId(process.getBpmnProcessId())
         .setTenantId(process.getTenantId());
-    return authorizationBehavior.authorizeAndDelete(
+    authorizationBehavior.authorize(
         command,
-        eventKey,
         PermissionType.DELETE_PROCESS,
         bufferAsString(process.getBpmnProcessId()),
-        process.getTenantId(),
-        () -> deleteProcess(process, command, eventKey));
+        process.getTenantId());
+    stateWriter.appendFollowUpEvent(eventKey, intent, command.getValue());
+    deleteProcess(process, command, eventKey);
+    return true;
   }
 
   void deleteProcess(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ProcessDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ProcessDeletionBehavior.java
@@ -36,6 +36,8 @@ import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import org.agrona.DirectBuffer;
@@ -58,6 +60,7 @@ final class ProcessDeletionBehavior {
   private final StartEventSubscriptionManager startEventSubscriptionManager;
   private final StartEventSubscriptions startEventSubscriptions;
   private final ProcessDefinitionMetrics processDefinitionMetrics;
+  private final ResourceDeletionAuthorizationBehavior authorizationBehavior;
 
   ProcessDeletionBehavior(
       final StateWriter stateWriter,
@@ -67,7 +70,8 @@ final class ProcessDeletionBehavior {
       final CatchEventBehavior catchEventBehavior,
       final StartEventSubscriptionManager startEventSubscriptionManager,
       final StartEventSubscriptions startEventSubscriptions,
-      final ProcessDefinitionMetrics processDefinitionMetrics) {
+      final ProcessDefinitionMetrics processDefinitionMetrics,
+      final ResourceDeletionAuthorizationBehavior authorizationBehavior) {
     this.stateWriter = stateWriter;
     this.commandWriter = commandWriter;
     this.keyGenerator = keyGenerator;
@@ -79,6 +83,25 @@ final class ProcessDeletionBehavior {
     this.startEventSubscriptionManager = startEventSubscriptionManager;
     this.startEventSubscriptions = startEventSubscriptions;
     this.processDefinitionMetrics = processDefinitionMetrics;
+    this.authorizationBehavior = authorizationBehavior;
+  }
+
+  boolean tryDelete(
+      final TypedRecord<ResourceDeletionRecord> command,
+      final long eventKey,
+      final DeployedProcess process) {
+    command
+        .getValue()
+        .setResourceType(ResourceType.PROCESS_DEFINITION)
+        .setResourceId(process.getBpmnProcessId())
+        .setTenantId(process.getTenantId());
+    return authorizationBehavior.authorizeAndDelete(
+        command,
+        eventKey,
+        PermissionType.DELETE_PROCESS,
+        bufferAsString(process.getBpmnProcessId()),
+        process.getTenantId(),
+        () -> deleteProcess(process, command, eventKey));
   }
 
   void deleteProcess(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ProcessDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ProcessDeletionBehavior.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_INSTANCE;
+import static io.camunda.zeebe.protocol.ZbColumnFamilies.PROCESS_CACHE_BY_ID_AND_VERSION;
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
+import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
+import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
+import io.camunda.zeebe.engine.processing.resource.ResourceDeletionExceptions.ActiveProcessInstancesException;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class ProcessDeletionBehavior {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessDeletionBehavior.class);
+
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+  private final KeyGenerator keyGenerator;
+  private final ProcessState processState;
+  private final ElementInstanceState elementInstanceState;
+  private final BannedInstanceState bannedInstanceState;
+  private final TimerInstanceState timerInstanceState;
+  private final CatchEventBehavior catchEventBehavior;
+  private final StartEventSubscriptionManager startEventSubscriptionManager;
+  private final StartEventSubscriptions startEventSubscriptions;
+  private final ProcessDefinitionMetrics processDefinitionMetrics;
+
+  ProcessDeletionBehavior(
+      final StateWriter stateWriter,
+      final TypedCommandWriter commandWriter,
+      final KeyGenerator keyGenerator,
+      final ProcessingState processingState,
+      final CatchEventBehavior catchEventBehavior,
+      final StartEventSubscriptionManager startEventSubscriptionManager,
+      final StartEventSubscriptions startEventSubscriptions,
+      final ProcessDefinitionMetrics processDefinitionMetrics) {
+    this.stateWriter = stateWriter;
+    this.commandWriter = commandWriter;
+    this.keyGenerator = keyGenerator;
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
+    bannedInstanceState = processingState.getBannedInstanceState();
+    timerInstanceState = processingState.getTimerState();
+    this.catchEventBehavior = catchEventBehavior;
+    this.startEventSubscriptionManager = startEventSubscriptionManager;
+    this.startEventSubscriptions = startEventSubscriptions;
+    this.processDefinitionMetrics = processDefinitionMetrics;
+  }
+
+  void deleteProcess(
+      final DeployedProcess process,
+      final TypedRecord<ResourceDeletionRecord> command,
+      final long eventKey) {
+    // We don't add the checksum or resource in this event. The checksum is not easily available
+    // and the resources are left out to prevent exceeding the maximum batch size.
+    final var processIdBuffer = process.getBpmnProcessId();
+    final var tenantId = process.getTenantId();
+    final var processRecord =
+        new ProcessRecord()
+            .setBpmnProcessId(processIdBuffer)
+            .setVersion(process.getVersion())
+            .setVersionTag(process.getVersionTag())
+            .setKey(process.getKey())
+            .setResourceName(process.getResourceName())
+            .setTenantId(tenantId)
+            .setDeploymentKey(process.getDeploymentKey());
+    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETING, processRecord);
+
+    final String processId = processRecord.getBpmnProcessId();
+    final var latestVersion = processState.getLatestProcessVersion(processId, tenantId);
+
+    // If we are deleting the latest version we must unsubscribe the start events
+    if (latestVersion == process.getVersion()) {
+      unsubscribeStartEvents(process);
+
+      final var previousVersion =
+          processState.findProcessVersionBefore(processId, latestVersion, tenantId);
+      // If there is a previous version we must resubscribe to the previous version's start events.
+      if (previousVersion.isPresent()) {
+        final var previousProcess =
+            processState.getProcessByProcessIdAndVersion(
+                processIdBuffer, previousVersion.get(), tenantId);
+        if (previousProcess == null) {
+          warnPreviousProcessNotFound(
+              processIdBuffer, previousVersion.get(), tenantId, processId, latestVersion);
+        } else {
+          startEventSubscriptions.resubscribeToStartEvents(previousProcess);
+        }
+      }
+    }
+
+    final var bannedInstances = bannedInstanceState.getBannedProcessInstanceKeys();
+    final var hasRunningInstances =
+        elementInstanceState.hasActiveProcessInstances(process.getKey(), bannedInstances);
+
+    if (!hasRunningInstances) {
+      if (!command.isCommandDistributed() && command.getValue().isDeleteHistory()) {
+        deleteProcessInstanceHistory(process.getKey(), eventKey, command.getValue());
+      }
+      stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETED, processRecord);
+      processDefinitionMetrics.processDefinitionDeleted(process.getKey());
+    } else {
+      throw new ActiveProcessInstancesException(process.getKey());
+    }
+  }
+
+  void deleteProcessInstanceHistory(
+      final long processDefinitionKey,
+      final long eventKey,
+      final ResourceDeletionRecord resourceDeletionRecord) {
+    final var filter =
+        new ProcessInstanceFilter.Builder().processDefinitionKeys(processDefinitionKey).build();
+    final long batchOperationKey = keyGenerator.nextKey();
+    final var batchOperationRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE)
+            .setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)))
+            .setAuthentication(
+                new UnsafeBuffer(
+                    MsgPackConverter.convertToMsgPack(CamundaAuthentication.anonymous())))
+            .setFollowUpCommand(
+                ValueType.HISTORY_DELETION,
+                HistoryDeletionIntent.DELETE,
+                new HistoryDeletionRecord()
+                    .setResourceKey(processDefinitionKey)
+                    .setResourceType(HistoryDeletionType.PROCESS_DEFINITION));
+    commandWriter.appendFollowUpCommand(
+        eventKey, BatchOperationIntent.CREATE, batchOperationRecord);
+
+    resourceDeletionRecord.setBatchOperationKey(batchOperationKey);
+    resourceDeletionRecord.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
+  }
+
+  private void unsubscribeStartEvents(final DeployedProcess deployedProcess) {
+    final var process = deployedProcess.getProcess();
+    if (process.hasTimerStartEvent()) {
+      timerInstanceState.forEachTimerForElementInstance(
+          NO_ELEMENT_INSTANCE,
+          timer -> {
+            if (timer.getProcessDefinitionKey() == deployedProcess.getKey()) {
+              catchEventBehavior.unsubscribeFromTimerEvent(timer);
+            }
+          });
+    }
+
+    startEventSubscriptionManager.closeStartEventSubscriptions(deployedProcess);
+  }
+
+  private void warnPreviousProcessNotFound(
+      final DirectBuffer processIdBuffer,
+      final int previousVersion,
+      final String tenantId,
+      final String processId,
+      final int latestVersion) {
+    LOG.warn(
+        "Expected to find previous process: {} with version: {} and tenant: '{}' to "
+            + "resubscribe start events, but no row exists in {}. "
+            + "knownVersions: {}, current latest version: {}.",
+        bufferAsString(processIdBuffer),
+        previousVersion,
+        tenantId,
+        PROCESS_CACHE_BY_ID_AND_VERSION.name(),
+        processState.getKnownProcessVersions(processId, tenantId),
+        latestVersion);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationBehavior.java
@@ -11,10 +11,8 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.resource.ResourceDeletionExceptions.NoSuchResourceException;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.ResourceType;
@@ -23,27 +21,27 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 final class ResourceDeletionAuthorizationBehavior {
 
   private final AuthorizationCheckBehavior authCheckBehavior;
-  private final StateWriter stateWriter;
 
-  ResourceDeletionAuthorizationBehavior(
-      final AuthorizationCheckBehavior authCheckBehavior, final StateWriter stateWriter) {
+  ResourceDeletionAuthorizationBehavior(final AuthorizationCheckBehavior authCheckBehavior) {
     this.authCheckBehavior = authCheckBehavior;
-    this.stateWriter = stateWriter;
   }
 
-  boolean authorizeAndDelete(
+  void authorize(
       final TypedRecord<ResourceDeletionRecord> command,
-      final long eventKey,
       final PermissionType permissionType,
       final String resourceId,
-      final String tenantId,
-      final Runnable deletionAction) {
-    checkAuthorization(
-        command, AuthorizationResourceType.RESOURCE, permissionType, resourceId, tenantId);
-    stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETING, command.getValue());
-    command.getValue().setTenantId(tenantId);
-    deletionAction.run();
-    return true;
+      final String tenantId) {
+    final var authRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.RESOURCE)
+            .permissionType(permissionType)
+            .tenantId(tenantId)
+            .addResourceId(resourceId)
+            .build();
+    if (authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).isLeft()) {
+      throw new ForbiddenException(authRequest);
+    }
   }
 
   /**
@@ -71,25 +69,6 @@ final class ResourceDeletionAuthorizationBehavior {
       } else {
         throw new ForbiddenException(authRequest);
       }
-    }
-  }
-
-  private void checkAuthorization(
-      final TypedRecord<ResourceDeletionRecord> command,
-      final AuthorizationResourceType resourceType,
-      final PermissionType permissionType,
-      final String resourceId,
-      final String tenantId) {
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(resourceType)
-            .permissionType(permissionType)
-            .tenantId(tenantId)
-            .addResourceId(resourceId)
-            .build();
-    if (authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).isLeft()) {
-      throw new ForbiddenException(authRequest);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationBehavior.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.resource;
 
-import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
-import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
@@ -31,14 +29,6 @@ final class ResourceDeletionAuthorizationBehavior {
       final AuthorizationCheckBehavior authCheckBehavior, final StateWriter stateWriter) {
     this.authCheckBehavior = authCheckBehavior;
     this.stateWriter = stateWriter;
-  }
-
-  AuthorizedTenants getAuthorizedTenants(final TypedRecord<ResourceDeletionRecord> command) {
-    final String tenantId = command.getValue().getTenantId();
-    if (tenantId.isEmpty()) {
-      return authCheckBehavior.getAuthorizedTenantIds(command);
-    }
-    return new AuthenticatedAuthorizedTenants(tenantId);
   }
 
   boolean authorizeAndDelete(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationBehavior.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
+import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.resource.ResourceDeletionExceptions.NoSuchResourceException;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+final class ResourceDeletionAuthorizationBehavior {
+
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final StateWriter stateWriter;
+
+  ResourceDeletionAuthorizationBehavior(
+      final AuthorizationCheckBehavior authCheckBehavior, final StateWriter stateWriter) {
+    this.authCheckBehavior = authCheckBehavior;
+    this.stateWriter = stateWriter;
+  }
+
+  AuthorizedTenants getAuthorizedTenants(final TypedRecord<ResourceDeletionRecord> command) {
+    final String tenantId = command.getValue().getTenantId();
+    if (tenantId.isEmpty()) {
+      return authCheckBehavior.getAuthorizedTenantIds(command);
+    }
+    return new AuthenticatedAuthorizedTenants(tenantId);
+  }
+
+  boolean authorizeAndDelete(
+      final TypedRecord<ResourceDeletionRecord> command,
+      final long eventKey,
+      final PermissionType permissionType,
+      final String resourceId,
+      final String tenantId,
+      final Runnable deletionAction) {
+    checkAuthorization(
+        command, AuthorizationResourceType.RESOURCE, permissionType, resourceId, tenantId);
+    stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETING, command.getValue());
+    command.getValue().setTenantId(tenantId);
+    deletionAction.run();
+    return true;
+  }
+
+  /**
+   * Checks authorization for history-only deletion (no resource found, only history remains).
+   * Distinguishes NOT_FOUND from FORBIDDEN so the caller can throw the appropriate exception.
+   */
+  void checkAuthorizationForHistoryDeletion(final TypedRecord<ResourceDeletionRecord> command) {
+    final var commandValue = command.getValue();
+    final var resourceType = commandValue.getResourceType();
+    final var authRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.RESOURCE)
+            .permissionType(
+                resourceType == ResourceType.PROCESS_DEFINITION
+                    ? PermissionType.DELETE_PROCESS
+                    : PermissionType.DELETE_DRD)
+            .addResourceId(commandValue.getResourceId())
+            .tenantId(commandValue.getTenantId())
+            .build();
+    final var authResponse = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
+    if (authResponse.isLeft()) {
+      if (authResponse.getLeft().type() == RejectionType.NOT_FOUND) {
+        throw new NoSuchResourceException(commandValue.getResourceKey());
+      } else {
+        throw new ForbiddenException(authRequest);
+      }
+    }
+  }
+
+  private void checkAuthorization(
+      final TypedRecord<ResourceDeletionRecord> command,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final String resourceId,
+      final String tenantId) {
+    final var authRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(resourceType)
+            .permissionType(permissionType)
+            .tenantId(tenantId)
+            .addResourceId(resourceId)
+            .build();
+    if (authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).isLeft()) {
+      throw new ForbiddenException(authRequest);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationBehavior.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
-final class ResourceDeletionAuthorizationBehavior {
+public final class ResourceDeletionAuthorizationBehavior {
 
   private final AuthorizationCheckBehavior authCheckBehavior;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionBehavior.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.deployment.PersistedResource;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+final class ResourceDeletionBehavior {
+
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+
+  ResourceDeletionBehavior(final StateWriter stateWriter, final KeyGenerator keyGenerator) {
+    this.stateWriter = stateWriter;
+    this.keyGenerator = keyGenerator;
+  }
+
+  void deleteResource(final PersistedResource persistedResource) {
+    final var resource =
+        new ResourceRecord()
+            .setResourceId(persistedResource.getResourceId())
+            .setResourceKey(persistedResource.getResourceKey())
+            .setTenantId(persistedResource.getTenantId())
+            .setResourceName(persistedResource.getResourceName())
+            .setResource(persistedResource.getResourceBuffer())
+            .setChecksum(persistedResource.getChecksum())
+            .setVersion(persistedResource.getVersion())
+            .setVersionTag(persistedResource.getVersionTag())
+            .setDeploymentKey(persistedResource.getDeploymentKey());
+    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ResourceIntent.DELETED, resource);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionBehavior.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.PersistedResource;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.ResourceType;
@@ -37,19 +38,21 @@ final class ResourceDeletionBehavior {
   boolean tryDelete(
       final TypedRecord<ResourceDeletionRecord> command,
       final long eventKey,
+      final Intent intent,
       final PersistedResource resource) {
     command
         .getValue()
         .setResourceType(ResourceType.UNKNOWN)
         .setResourceId(resource.getResourceId())
         .setTenantId(resource.getTenantId());
-    return authorizationBehavior.authorizeAndDelete(
+    authorizationBehavior.authorize(
         command,
-        eventKey,
         PermissionType.DELETE_RESOURCE,
         bufferAsString(resource.getResourceId()),
-        resource.getTenantId(),
-        () -> deleteResource(resource));
+        resource.getTenantId());
+    stateWriter.appendFollowUpEvent(eventKey, intent, command.getValue());
+    deleteResource(resource);
+    return true;
   }
 
   private void deleteResource(final PersistedResource persistedResource) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionBehavior.java
@@ -7,23 +7,52 @@
  */
 package io.camunda.zeebe.engine.processing.resource;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.PersistedResource;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 final class ResourceDeletionBehavior {
 
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
+  private final ResourceDeletionAuthorizationBehavior authorizationBehavior;
 
-  ResourceDeletionBehavior(final StateWriter stateWriter, final KeyGenerator keyGenerator) {
+  ResourceDeletionBehavior(
+      final StateWriter stateWriter,
+      final KeyGenerator keyGenerator,
+      final ResourceDeletionAuthorizationBehavior authorizationBehavior) {
     this.stateWriter = stateWriter;
     this.keyGenerator = keyGenerator;
+    this.authorizationBehavior = authorizationBehavior;
   }
 
-  void deleteResource(final PersistedResource persistedResource) {
+  boolean tryDelete(
+      final TypedRecord<ResourceDeletionRecord> command,
+      final long eventKey,
+      final PersistedResource resource) {
+    command
+        .getValue()
+        .setResourceType(ResourceType.UNKNOWN)
+        .setResourceId(resource.getResourceId())
+        .setTenantId(resource.getTenantId());
+    return authorizationBehavior.authorizeAndDelete(
+        command,
+        eventKey,
+        PermissionType.DELETE_RESOURCE,
+        bufferAsString(resource.getResourceId()),
+        resource.getTenantId(),
+        () -> deleteResource(resource));
+  }
+
+  private void deleteResource(final PersistedResource persistedResource) {
     final var resource =
         new ResourceRecord()
             .setResourceId(persistedResource.getResourceId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.resource.ResourceDeletionExceptions.ActiveProcessInstancesException;
@@ -29,19 +28,14 @@ import io.camunda.zeebe.engine.state.immutable.FormState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ResourceState;
-import io.camunda.zeebe.engine.state.immutable.TenantState;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.ResourceType;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 public class ResourceDeletionDeleteProcessor
     implements DistributedTypedRecordProcessor<ResourceDeletionRecord> {
@@ -58,12 +52,12 @@ public class ResourceDeletionDeleteProcessor
   private final ProcessState processState;
   private final FormState formState;
   private final ResourceState resourceState;
-  private final TenantState tenantState;
   private final ProcessDeletionBehavior processDeletionBehavior;
   private final FormDeletionBehavior formDeletionBehavior;
   private final DecisionRequirementsDeletionBehavior decisionRequirementsDeletionBehavior;
   private final ResourceDeletionBehavior resourceDeletionBehavior;
   private final ResourceDeletionAuthorizationBehavior authorizationBehavior;
+  private final TenantAwareDeletionBehavior tenantAwareDeletionBehavior;
 
   public ResourceDeletionDeleteProcessor(
       final Writers writers,
@@ -82,7 +76,6 @@ public class ResourceDeletionDeleteProcessor
     processState = processingState.getProcessState();
     formState = processingState.getFormState();
     resourceState = processingState.getResourceState();
-    tenantState = processingState.getTenantState();
 
     final var startEventSubscriptionManager =
         new StartEventSubscriptionManager(processingState, keyGenerator, stateWriter);
@@ -113,6 +106,9 @@ public class ResourceDeletionDeleteProcessor
 
     authorizationBehavior =
         new ResourceDeletionAuthorizationBehavior(authCheckBehavior, stateWriter);
+
+    tenantAwareDeletionBehavior =
+        new TenantAwareDeletionBehavior(authCheckBehavior, processingState.getTenantState());
   }
 
   @Override
@@ -176,7 +172,8 @@ public class ResourceDeletionDeleteProcessor
     final var value = command.getValue();
 
     final var resourceDeleted =
-        untilResourceDeleted(command, tenantId -> tryDeleteResource(command, tenantId, eventKey));
+        tenantAwareDeletionBehavior.untilResourceDeleted(
+            command, tenantId -> tryDeleteResource(command, tenantId, eventKey));
 
     if (!resourceDeleted) {
       if (value.isDeleteHistory()
@@ -290,40 +287,5 @@ public class ResourceDeletionDeleteProcessor
         // This should not be reached as SUPPORTED_HISTORY_DELETION_TYPES filters these out
       }
     }
-  }
-
-  private boolean untilResourceDeleted(
-      final TypedRecord<ResourceDeletionRecord> command,
-      final Function<String, Boolean> resourceDeletionCallback) {
-    final var authorizedTenants = authorizationBehavior.getAuthorizedTenants(command);
-
-    if (AuthorizedTenants.ANONYMOUS.equals(authorizedTenants)) {
-      return Optional.of(tryToDeleteResourceAssignedToDefaultTenant(resourceDeletionCallback))
-          .filter(Boolean::booleanValue)
-          .orElseGet(() -> forEachTenantUntilResourceDeleted(resourceDeletionCallback));
-    } else {
-      for (final var tenant : authorizedTenants.getAuthorizedTenantIds()) {
-        if (resourceDeletionCallback.apply(tenant)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private boolean tryToDeleteResourceAssignedToDefaultTenant(
-      final Function<String, Boolean> resourceDeletionCallback) {
-    return resourceDeletionCallback.apply(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  }
-
-  private boolean forEachTenantUntilResourceDeleted(
-      final Function<String, Boolean> resourceDeletionCallback) {
-    final var resourceDeleted = new AtomicBoolean(false);
-    tenantState.forEachTenant(
-        tenant -> {
-          resourceDeleted.set(resourceDeletionCallback.apply(tenant));
-          return !resourceDeleted.get();
-        });
-    return resourceDeleted.get();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -13,11 +13,9 @@ import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.resource.ResourceDeletionExceptions.ActiveProcessInstancesException;
 import io.camunda.zeebe.engine.processing.resource.ResourceDeletionExceptions.NoSuchResourceException;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
@@ -35,7 +33,6 @@ import io.camunda.zeebe.engine.state.immutable.TenantState;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -59,7 +56,6 @@ public class ResourceDeletionDeleteProcessor
   private final DecisionState decisionState;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final ProcessState processState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
   private final FormState formState;
   private final ResourceState resourceState;
   private final TenantState tenantState;
@@ -67,6 +63,7 @@ public class ResourceDeletionDeleteProcessor
   private final FormDeletionBehavior formDeletionBehavior;
   private final DecisionRequirementsDeletionBehavior decisionRequirementsDeletionBehavior;
   private final ResourceDeletionBehavior resourceDeletionBehavior;
+  private final ResourceDeletionAuthorizationBehavior authorizationBehavior;
 
   public ResourceDeletionDeleteProcessor(
       final Writers writers,
@@ -83,7 +80,6 @@ public class ResourceDeletionDeleteProcessor
     decisionState = processingState.getDecisionState();
     this.commandDistributionBehavior = commandDistributionBehavior;
     processState = processingState.getProcessState();
-    this.authCheckBehavior = authCheckBehavior;
     formState = processingState.getFormState();
     resourceState = processingState.getResourceState();
     tenantState = processingState.getTenantState();
@@ -114,6 +110,9 @@ public class ResourceDeletionDeleteProcessor
             stateWriter, writers.command(), keyGenerator, processingState.getDecisionState());
 
     resourceDeletionBehavior = new ResourceDeletionBehavior(stateWriter, keyGenerator);
+
+    authorizationBehavior =
+        new ResourceDeletionAuthorizationBehavior(authCheckBehavior, stateWriter);
   }
 
   @Override
@@ -202,7 +201,7 @@ public class ResourceDeletionDeleteProcessor
           .setResourceType(ResourceType.PROCESS_DEFINITION)
           .setResourceId(process.getBpmnProcessId())
           .setTenantId(process.getTenantId());
-      return authorizeAndDelete(
+      return authorizationBehavior.authorizeAndDelete(
           command,
           eventKey,
           PermissionType.DELETE_PROCESS,
@@ -220,7 +219,7 @@ public class ResourceDeletionDeleteProcessor
           .setResourceType(ResourceType.DECISION_REQUIREMENTS)
           .setResourceId(drg.getDecisionRequirementsId())
           .setTenantId(drg.getTenantId());
-      return authorizeAndDelete(
+      return authorizationBehavior.authorizeAndDelete(
           command,
           eventKey,
           PermissionType.DELETE_DRD,
@@ -239,7 +238,7 @@ public class ResourceDeletionDeleteProcessor
           .setResourceType(ResourceType.FORM)
           .setResourceId(form.getFormId())
           .setTenantId(form.getTenantId());
-      return authorizeAndDelete(
+      return authorizationBehavior.authorizeAndDelete(
           command,
           eventKey,
           PermissionType.DELETE_FORM,
@@ -256,7 +255,7 @@ public class ResourceDeletionDeleteProcessor
           .setResourceType(ResourceType.UNKNOWN)
           .setResourceId(resource.getResourceId())
           .setTenantId(resource.getTenantId());
-      return authorizeAndDelete(
+      return authorizationBehavior.authorizeAndDelete(
           command,
           eventKey,
           PermissionType.DELETE_RESOURCE,
@@ -268,21 +267,6 @@ public class ResourceDeletionDeleteProcessor
     return false;
   }
 
-  private boolean authorizeAndDelete(
-      final TypedRecord<ResourceDeletionRecord> command,
-      final long eventKey,
-      final PermissionType permissionType,
-      final String resourceId,
-      final String tenantId,
-      final Runnable deletionAction) {
-    checkAuthorization(
-        command, AuthorizationResourceType.RESOURCE, permissionType, resourceId, tenantId);
-    stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETING, command.getValue());
-    setTenantId(command, tenantId);
-    deletionAction.run();
-    return true;
-  }
-
   private void deleteHistory(
       final long eventKey, final TypedRecord<ResourceDeletionRecord> command) {
     if (command.isCommandDistributed()) {
@@ -290,32 +274,11 @@ public class ResourceDeletionDeleteProcessor
       // batch operation creator itself.
       return;
     }
+
+    authorizationBehavior.checkAuthorizationForHistoryDeletion(command);
+
     final var commandValue = command.getValue();
-    final var resourceType = commandValue.getResourceType();
-
-    // We cannot rely on the existing checkAuthorization method as it would swallow the not found in
-    // case the caller has no access to the tenant.
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.RESOURCE)
-            .permissionType(
-                resourceType == ResourceType.PROCESS_DEFINITION
-                    ? PermissionType.DELETE_PROCESS
-                    : PermissionType.DELETE_DRD)
-            .addResourceId(commandValue.getResourceId())
-            .tenantId(commandValue.getTenantId())
-            .build();
-    final var authResponse = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
-    if (authResponse.isLeft()) {
-      if (authResponse.getLeft().type() == RejectionType.NOT_FOUND) {
-        throw new NoSuchResourceException(commandValue.getResourceKey());
-      } else {
-        throw new ForbiddenException(authRequest);
-      }
-    }
-
-    switch (resourceType) {
+    switch (commandValue.getResourceType()) {
       case PROCESS_DEFINITION ->
           processDeletionBehavior.deleteProcessInstanceHistory(
               commandValue.getResourceKey(), eventKey, commandValue);
@@ -329,19 +292,10 @@ public class ResourceDeletionDeleteProcessor
     }
   }
 
-  private AuthorizedTenants getAuthorizedTenants(
-      final TypedRecord<ResourceDeletionRecord> command) {
-    final String tenantId = command.getValue().getTenantId();
-    if (tenantId.isEmpty()) {
-      return authCheckBehavior.getAuthorizedTenantIds(command);
-    }
-    return new AuthenticatedAuthorizedTenants(tenantId);
-  }
-
   private boolean untilResourceDeleted(
       final TypedRecord<ResourceDeletionRecord> command,
       final Function<String, Boolean> resourceDeletionCallback) {
-    final var authorizedTenants = getAuthorizedTenants(command);
+    final var authorizedTenants = authorizationBehavior.getAuthorizedTenants(command);
 
     if (AuthorizedTenants.ANONYMOUS.equals(authorizedTenants)) {
       return Optional.of(tryToDeleteResourceAssignedToDefaultTenant(resourceDeletionCallback))
@@ -371,29 +325,5 @@ public class ResourceDeletionDeleteProcessor
           return !resourceDeleted.get();
         });
     return resourceDeleted.get();
-  }
-
-  private void setTenantId(
-      final TypedRecord<ResourceDeletionRecord> command, final String tenantId) {
-    command.getValue().setTenantId(tenantId);
-  }
-
-  private void checkAuthorization(
-      final TypedRecord<ResourceDeletionRecord> command,
-      final AuthorizationResourceType resourceType,
-      final PermissionType permissionType,
-      final String resourceId,
-      final String tenantId) {
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(resourceType)
-            .permissionType(permissionType)
-            .tenantId(tenantId)
-            .addResourceId(resourceId)
-            .build();
-    if (authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).isLeft()) {
-      throw new ForbiddenException(authRequest);
-    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -83,8 +83,7 @@ public class ResourceDeletionDeleteProcessor
             bpmnBehaviors.catchEventBehavior(),
             startEventSubscriptionManager);
 
-    authorizationBehavior =
-        new ResourceDeletionAuthorizationBehavior(authCheckBehavior, stateWriter);
+    authorizationBehavior = new ResourceDeletionAuthorizationBehavior(authCheckBehavior);
 
     tenantAwareDeletionBehavior =
         new TenantAwareDeletionBehavior(authCheckBehavior, processingState.getTenantState());
@@ -196,26 +195,34 @@ public class ResourceDeletionDeleteProcessor
       final long eventKey) {
     final var resourceKey = command.getValue().getResourceKey();
     return Optional.ofNullable(processState.getProcessByKeyAndTenant(resourceKey, tenantId))
-        .map(process -> processDeletionBehavior.tryDelete(command, eventKey, process))
+        .map(
+            process ->
+                processDeletionBehavior.tryDelete(
+                    command, eventKey, ResourceDeletionIntent.DELETING, process))
         .or(
             () ->
                 decisionState
                     .findDecisionRequirementsByTenantAndKey(tenantId, resourceKey)
                     .map(
                         drg ->
-                            decisionRequirementsDeletionBehavior.tryDelete(command, eventKey, drg)))
+                            decisionRequirementsDeletionBehavior.tryDelete(
+                                command, eventKey, ResourceDeletionIntent.DELETING, drg)))
         .or(
             () ->
                 formState
                     .findFormByKey(resourceKey, tenantId)
-                    .map(form -> formDeletionBehavior.tryDelete(command, eventKey, form)))
+                    .map(
+                        form ->
+                            formDeletionBehavior.tryDelete(
+                                command, eventKey, ResourceDeletionIntent.DELETING, form)))
         .or(
             () ->
                 resourceState
                     .findResourceByKey(resourceKey, tenantId)
                     .map(
                         resource ->
-                            resourceDeletionBehavior.tryDelete(command, eventKey, resource)))
+                            resourceDeletionBehavior.tryDelete(
+                                command, eventKey, ResourceDeletionIntent.DELETING, resource)))
         .orElse(false);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -7,16 +7,10 @@
  */
 package io.camunda.zeebe.engine.processing.resource;
 
-import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_INSTANCE;
-import static io.camunda.zeebe.protocol.ZbColumnFamilies.PROCESS_CACHE_BY_ID_AND_VERSION;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
-import io.camunda.search.filter.DecisionInstanceFilter;
-import io.camunda.search.filter.ProcessInstanceFilter;
-import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
-import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
@@ -24,49 +18,24 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.resource.ResourceDeletionExceptions.ActiveProcessInstancesException;
+import io.camunda.zeebe.engine.processing.resource.ResourceDeletionExceptions.NoSuchResourceException;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
-import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
-import io.camunda.zeebe.engine.state.deployment.PersistedForm;
-import io.camunda.zeebe.engine.state.deployment.PersistedResource;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
-import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
-import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.FormState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ResourceState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
-import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
-import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
-import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
-import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
-import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
-import io.camunda.zeebe.protocol.record.intent.FormIntent;
-import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
-import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
-import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.BatchOperationType;
-import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -76,37 +45,28 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ResourceDeletionDeleteProcessor
     implements DistributedTypedRecordProcessor<ResourceDeletionRecord> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ResourceDeletionDeleteProcessor.class);
   private static final List<ResourceType> SUPPORTED_HISTORY_DELETION_TYPES =
       List.of(ResourceType.PROCESS_DEFINITION, ResourceType.DECISION_REQUIREMENTS);
 
   private final StateWriter stateWriter;
-  private final TypedCommandWriter commandWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final KeyGenerator keyGenerator;
   private final DecisionState decisionState;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final ProcessState processState;
-  private final ElementInstanceState elementInstanceState;
-  private final TimerInstanceState timerInstanceState;
-  private final BannedInstanceState bannedInstanceState;
-  private final CatchEventBehavior catchEventBehavior;
-  private final StartEventSubscriptions startEventSubscriptions;
   private final AuthorizationCheckBehavior authCheckBehavior;
-  private final StartEventSubscriptionManager startEventSubscriptionManager;
   private final FormState formState;
   private final ResourceState resourceState;
   private final TenantState tenantState;
-  private final ProcessDefinitionMetrics processDefinitionMetrics;
+  private final ProcessDeletionBehavior processDeletionBehavior;
+  private final FormDeletionBehavior formDeletionBehavior;
+  private final DecisionRequirementsDeletionBehavior decisionRequirementsDeletionBehavior;
+  private final ResourceDeletionBehavior resourceDeletionBehavior;
 
   public ResourceDeletionDeleteProcessor(
       final Writers writers,
@@ -117,27 +77,43 @@ public class ResourceDeletionDeleteProcessor
       final AuthorizationCheckBehavior authCheckBehavior,
       final ProcessDefinitionMetrics processDefinitionMetrics) {
     stateWriter = writers.state();
-    commandWriter = writers.command();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.keyGenerator = keyGenerator;
     decisionState = processingState.getDecisionState();
     this.commandDistributionBehavior = commandDistributionBehavior;
     processState = processingState.getProcessState();
-    elementInstanceState = processingState.getElementInstanceState();
-    timerInstanceState = processingState.getTimerState();
-    bannedInstanceState = processingState.getBannedInstanceState();
-    catchEventBehavior = bpmnBehaviors.catchEventBehavior();
     this.authCheckBehavior = authCheckBehavior;
-    startEventSubscriptionManager =
-        new StartEventSubscriptionManager(processingState, keyGenerator, stateWriter);
-    startEventSubscriptions =
-        new StartEventSubscriptions(
-            bpmnBehaviors.expressionProcessor(), catchEventBehavior, startEventSubscriptionManager);
     formState = processingState.getFormState();
     resourceState = processingState.getResourceState();
     tenantState = processingState.getTenantState();
-    this.processDefinitionMetrics = processDefinitionMetrics;
+
+    final var startEventSubscriptionManager =
+        new StartEventSubscriptionManager(processingState, keyGenerator, stateWriter);
+    final var startEventSubscriptions =
+        new StartEventSubscriptions(
+            bpmnBehaviors.expressionProcessor(),
+            bpmnBehaviors.catchEventBehavior(),
+            startEventSubscriptionManager);
+
+    processDeletionBehavior =
+        new ProcessDeletionBehavior(
+            stateWriter,
+            writers.command(),
+            keyGenerator,
+            processingState,
+            bpmnBehaviors.catchEventBehavior(),
+            startEventSubscriptionManager,
+            startEventSubscriptions,
+            processDefinitionMetrics);
+
+    formDeletionBehavior = new FormDeletionBehavior(stateWriter, keyGenerator);
+
+    decisionRequirementsDeletionBehavior =
+        new DecisionRequirementsDeletionBehavior(
+            stateWriter, writers.command(), keyGenerator, processingState.getDecisionState());
+
+    resourceDeletionBehavior = new ResourceDeletionBehavior(stateWriter, keyGenerator);
   }
 
   @Override
@@ -232,7 +208,7 @@ public class ResourceDeletionDeleteProcessor
           PermissionType.DELETE_PROCESS,
           bufferAsString(process.getBpmnProcessId()),
           process.getTenantId(),
-          () -> deleteProcess(process, command, eventKey));
+          () -> processDeletionBehavior.deleteProcess(process, command, eventKey));
     }
 
     final var drgOptional =
@@ -250,7 +226,9 @@ public class ResourceDeletionDeleteProcessor
           PermissionType.DELETE_DRD,
           bufferAsString(drg.getDecisionRequirementsId()),
           drg.getTenantId(),
-          () -> deleteDecisionRequirements(drg, command, eventKey));
+          () ->
+              decisionRequirementsDeletionBehavior.deleteDecisionRequirements(
+                  drg, command, eventKey));
     }
 
     final var formOptional = formState.findFormByKey(value.getResourceKey(), tenantId);
@@ -267,7 +245,7 @@ public class ResourceDeletionDeleteProcessor
           PermissionType.DELETE_FORM,
           bufferAsString(form.getFormId()),
           form.getTenantId(),
-          () -> deleteForm(form));
+          () -> formDeletionBehavior.deleteForm(form));
     }
 
     final var resourceOptional = resourceState.findResourceByKey(value.getResourceKey(), tenantId);
@@ -284,7 +262,7 @@ public class ResourceDeletionDeleteProcessor
           PermissionType.DELETE_RESOURCE,
           bufferAsString(resource.getResourceId()),
           resource.getTenantId(),
-          () -> deleteResource(resource));
+          () -> resourceDeletionBehavior.deleteResource(resource));
     }
 
     return false;
@@ -303,109 +281,6 @@ public class ResourceDeletionDeleteProcessor
     setTenantId(command, tenantId);
     deletionAction.run();
     return true;
-  }
-
-  private void deleteDecisionRequirements(
-      final DeployedDrg drg,
-      final TypedRecord<ResourceDeletionRecord> command,
-      final long eventKey) {
-    decisionState
-        .findDecisionsByTenantAndDecisionRequirementsKey(
-            drg.getTenantId(), drg.getDecisionRequirementsKey())
-        .forEach(this::deleteDecision);
-
-    if (!command.isCommandDistributed() && command.getValue().isDeleteHistory()) {
-      deleteDecisionInstanceHistory(drg.getDecisionRequirementsKey(), eventKey, command.getValue());
-    }
-
-    final var drgRecord =
-        new DecisionRequirementsRecord()
-            .setDecisionRequirementsId(bufferAsString(drg.getDecisionRequirementsId()))
-            .setDecisionRequirementsName(bufferAsString(drg.getDecisionRequirementsName()))
-            .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
-            .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
-            .setResourceName(bufferAsString(drg.getResourceName()))
-            .setChecksum(drg.getChecksum())
-            .setResource(drg.getResource())
-            .setTenantId(drg.getTenantId())
-            .setDeploymentKey(drg.getDeploymentKey());
-
-    stateWriter.appendFollowUpEvent(
-        keyGenerator.nextKey(), DecisionRequirementsIntent.DELETED, drgRecord);
-  }
-
-  private void deleteDecision(final PersistedDecision persistedDecision) {
-    final var decisionRecord =
-        new DecisionRecord()
-            .setDecisionId(bufferAsString(persistedDecision.getDecisionId()))
-            .setDecisionName(bufferAsString(persistedDecision.getDecisionName()))
-            .setVersion(persistedDecision.getVersion())
-            .setVersionTag(persistedDecision.getVersionTag())
-            .setDecisionKey(persistedDecision.getDecisionKey())
-            .setDecisionRequirementsId(
-                bufferAsString(persistedDecision.getDecisionRequirementsId()))
-            .setDecisionRequirementsKey(persistedDecision.getDecisionRequirementsKey())
-            .setTenantId(persistedDecision.getTenantId())
-            .setDeploymentKey(persistedDecision.getDeploymentKey());
-
-    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), DecisionIntent.DELETED, decisionRecord);
-  }
-
-  private void deleteProcess(
-      final DeployedProcess process,
-      final TypedRecord<ResourceDeletionRecord> command,
-      final long eventKey) {
-    // We don't add the checksum or resource in this event. The checksum is not easily available
-    // and the resources are left out to prevent exceeding the maximum batch size.
-    final var processIdBuffer = process.getBpmnProcessId();
-    final var tenantId = process.getTenantId();
-    final var processRecord =
-        new ProcessRecord()
-            .setBpmnProcessId(processIdBuffer)
-            .setVersion(process.getVersion())
-            .setVersionTag(process.getVersionTag())
-            .setKey(process.getKey())
-            .setResourceName(process.getResourceName())
-            .setTenantId(tenantId)
-            .setDeploymentKey(process.getDeploymentKey());
-    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETING, processRecord);
-
-    final String processId = processRecord.getBpmnProcessId();
-    final var latestVersion = processState.getLatestProcessVersion(processId, tenantId);
-
-    // If we are deleting the latest version we must unsubscribe the start events
-    if (latestVersion == process.getVersion()) {
-      unsubscribeStartEvents(process);
-
-      final var previousVersion =
-          processState.findProcessVersionBefore(processId, latestVersion, tenantId);
-      // If there is a previous version we must resubscribe to the previous version's start events.
-      if (previousVersion.isPresent()) {
-        final var previousProcess =
-            processState.getProcessByProcessIdAndVersion(
-                processIdBuffer, previousVersion.get(), tenantId);
-        if (previousProcess == null) {
-          warnPreviousProcessNotFound(
-              processIdBuffer, previousVersion.get(), tenantId, processId, latestVersion);
-        } else {
-          startEventSubscriptions.resubscribeToStartEvents(previousProcess);
-        }
-      }
-    }
-
-    final var bannedInstances = bannedInstanceState.getBannedProcessInstanceKeys();
-    final var hasRunningInstances =
-        elementInstanceState.hasActiveProcessInstances(process.getKey(), bannedInstances);
-
-    if (!hasRunningInstances) {
-      if (!command.isCommandDistributed() && command.getValue().isDeleteHistory()) {
-        deleteProcessInstanceHistory(process.getKey(), eventKey, command.getValue());
-      }
-      stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETED, processRecord);
-      processDefinitionMetrics.processDefinitionDeleted(process.getKey());
-    } else {
-      throw new ActiveProcessInstancesException(process.getKey());
-    }
   }
 
   private void deleteHistory(
@@ -442,136 +317,16 @@ public class ResourceDeletionDeleteProcessor
 
     switch (resourceType) {
       case PROCESS_DEFINITION ->
-          deleteProcessInstanceHistory(commandValue.getResourceKey(), eventKey, commandValue);
+          processDeletionBehavior.deleteProcessInstanceHistory(
+              commandValue.getResourceKey(), eventKey, commandValue);
       case DECISION_REQUIREMENTS ->
-          deleteDecisionInstanceHistory(commandValue.getResourceKey(), eventKey, commandValue);
+          decisionRequirementsDeletionBehavior.deleteDecisionInstanceHistory(
+              commandValue.getResourceKey(), eventKey, commandValue);
       default -> {
         // No history to delete for forms and unknown resources
         // This should not be reached as SUPPORTED_HISTORY_DELETION_TYPES filters these out
       }
     }
-  }
-
-  private void deleteProcessInstanceHistory(
-      final long processDefinitionKey,
-      final long eventKey,
-      final ResourceDeletionRecord resourceDeletionRecord) {
-    final var filter =
-        new ProcessInstanceFilter.Builder().processDefinitionKeys(processDefinitionKey).build();
-    final long batchOperationKey = keyGenerator.nextKey();
-    final var batchOperationRecord =
-        new BatchOperationCreationRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE)
-            .setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)))
-            .setAuthentication(
-                new UnsafeBuffer(
-                    MsgPackConverter.convertToMsgPack(CamundaAuthentication.anonymous())))
-            .setFollowUpCommand(
-                ValueType.HISTORY_DELETION,
-                HistoryDeletionIntent.DELETE,
-                new HistoryDeletionRecord()
-                    .setResourceKey(processDefinitionKey)
-                    .setResourceType(HistoryDeletionType.PROCESS_DEFINITION));
-    commandWriter.appendFollowUpCommand(
-        eventKey, BatchOperationIntent.CREATE, batchOperationRecord);
-
-    resourceDeletionRecord.setBatchOperationKey(batchOperationKey);
-    resourceDeletionRecord.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
-  }
-
-  private void deleteDecisionInstanceHistory(
-      final long decisionRequirementsKey,
-      final long eventKey,
-      final ResourceDeletionRecord resourceDeletionRecord) {
-    final var filter =
-        new DecisionInstanceFilter.Builder()
-            .decisionRequirementsKeys(decisionRequirementsKey)
-            .build();
-    final long batchOperationKey = keyGenerator.nextKey();
-    final var batchOperationRecord =
-        new BatchOperationCreationRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE)
-            .setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)))
-            .setAuthentication(
-                new UnsafeBuffer(
-                    MsgPackConverter.convertToMsgPack(CamundaAuthentication.anonymous())))
-            .setFollowUpCommand(
-                ValueType.HISTORY_DELETION,
-                HistoryDeletionIntent.DELETE,
-                new HistoryDeletionRecord()
-                    .setResourceKey(decisionRequirementsKey)
-                    .setResourceType(HistoryDeletionType.DECISION_REQUIREMENTS));
-    commandWriter.appendFollowUpCommand(
-        eventKey, BatchOperationIntent.CREATE, batchOperationRecord);
-
-    resourceDeletionRecord.setBatchOperationKey(batchOperationKey);
-    resourceDeletionRecord.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
-  }
-
-  private void warnPreviousProcessNotFound(
-      final DirectBuffer processIdBuffer,
-      final int previousVersion,
-      final String tenantId,
-      final String processId,
-      final int latestVersion) {
-    LOG.warn(
-        "Expected to find previous process: {} with version: {} and tenant: '{}' to "
-            + "resubscribe start events, but no row exists in {}. "
-            + "knownVersions: {}, current latest version: {}.",
-        bufferAsString(processIdBuffer),
-        previousVersion,
-        tenantId,
-        PROCESS_CACHE_BY_ID_AND_VERSION.name(),
-        processState.getKnownProcessVersions(processId, tenantId),
-        latestVersion);
-  }
-
-  private void unsubscribeStartEvents(final DeployedProcess deployedProcess) {
-    final var process = deployedProcess.getProcess();
-    if (process.hasTimerStartEvent()) {
-      timerInstanceState.forEachTimerForElementInstance(
-          NO_ELEMENT_INSTANCE,
-          timer -> {
-            if (timer.getProcessDefinitionKey() == deployedProcess.getKey()) {
-              catchEventBehavior.unsubscribeFromTimerEvent(timer);
-            }
-          });
-    }
-
-    startEventSubscriptionManager.closeStartEventSubscriptions(deployedProcess);
-  }
-
-  private void deleteForm(final PersistedForm persistedForm) {
-    final var form =
-        new FormRecord()
-            .setFormId(persistedForm.getFormId())
-            .setFormKey(persistedForm.getFormKey())
-            .setTenantId(persistedForm.getTenantId())
-            .setResourceName(persistedForm.getResourceName())
-            .setResource(persistedForm.getResource())
-            .setChecksum(persistedForm.getChecksum())
-            .setVersion(persistedForm.getVersion())
-            .setVersionTag(persistedForm.getVersionTag())
-            .setDeploymentKey(persistedForm.getDeploymentKey());
-
-    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), FormIntent.DELETED, form);
-  }
-
-  private void deleteResource(final PersistedResource persistedResource) {
-    final var resource =
-        new ResourceRecord()
-            .setResourceId(persistedResource.getResourceId())
-            .setResourceKey(persistedResource.getResourceKey())
-            .setTenantId(persistedResource.getTenantId())
-            .setResourceName(persistedResource.getResourceName())
-            .setResource(persistedResource.getResourceBuffer())
-            .setChecksum(persistedResource.getChecksum())
-            .setVersion(persistedResource.getVersion())
-            .setVersionTag(persistedResource.getVersionTag())
-            .setDeploymentKey(persistedResource.getDeploymentKey());
-    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ResourceIntent.DELETED, resource);
   }
 
   private AuthorizedTenants getAuthorizedTenants(
@@ -602,19 +357,11 @@ public class ResourceDeletionDeleteProcessor
     return false;
   }
 
-  /**
-   * Tries to delete the resource, iff it is assigned to the default tenant. If the resource was
-   * deleted, it returns true, otherwise false.
-   */
   private boolean tryToDeleteResourceAssignedToDefaultTenant(
       final Function<String, Boolean> resourceDeletionCallback) {
     return resourceDeletionCallback.apply(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 
-  /**
-   * Loops over the existing tenants to find the resource to delete. If found and deleted, it
-   * returns true, otherwise false.
-   */
   private boolean forEachTenantUntilResourceDeleted(
       final Function<String, Boolean> resourceDeletionCallback) {
     final var resourceDeleted = new AtomicBoolean(false);
@@ -647,24 +394,6 @@ public class ResourceDeletionDeleteProcessor
             .build();
     if (authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).isLeft()) {
       throw new ForbiddenException(authRequest);
-    }
-  }
-
-  private static final class NoSuchResourceException extends IllegalStateException {
-    private static final String ERROR_MESSAGE_RESOURCE_NOT_FOUND =
-        "Expected to delete resource but no resource found with key `%d`";
-
-    private NoSuchResourceException(final long resourceKey) {
-      super(String.format(ERROR_MESSAGE_RESOURCE_NOT_FOUND, resourceKey));
-    }
-  }
-
-  private static final class ActiveProcessInstancesException extends IllegalStateException {
-    private static final String ERROR_MESSAGE_RUNNING_INSTANCES =
-        "Expected to delete resource with key `%d` but there are still running instances";
-
-    private ActiveProcessInstancesException(final long processDefinitionKey) {
-      super(String.format(ERROR_MESSAGE_RUNNING_INSTANCES, processDefinitionKey));
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -176,7 +176,7 @@ public class ResourceDeletionDeleteProcessor
     final var value = command.getValue();
 
     final var resourceDeleted =
-        tenantAwareDeletionBehavior.untilResourceDeleted(
+        tenantAwareDeletionBehavior.forEachAuthorizedTenantUntilDeleted(
             command, tenantId -> tryDeleteResource(command, tenantId, eventKey));
 
     if (!resourceDeleted) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.resource;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
-
 import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
@@ -31,11 +29,11 @@ import io.camunda.zeebe.engine.state.immutable.ResourceState;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
-import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.List;
+import java.util.Optional;
 
 public class ResourceDeletionDeleteProcessor
     implements DistributedTypedRecordProcessor<ResourceDeletionRecord> {
@@ -48,10 +46,10 @@ public class ResourceDeletionDeleteProcessor
   private final TypedRejectionWriter rejectionWriter;
   private final KeyGenerator keyGenerator;
   private final DecisionState decisionState;
-  private final CommandDistributionBehavior commandDistributionBehavior;
   private final ProcessState processState;
   private final FormState formState;
   private final ResourceState resourceState;
+  private final CommandDistributionBehavior commandDistributionBehavior;
   private final ProcessDeletionBehavior processDeletionBehavior;
   private final FormDeletionBehavior formDeletionBehavior;
   private final DecisionRequirementsDeletionBehavior decisionRequirementsDeletionBehavior;
@@ -85,6 +83,12 @@ public class ResourceDeletionDeleteProcessor
             bpmnBehaviors.catchEventBehavior(),
             startEventSubscriptionManager);
 
+    authorizationBehavior =
+        new ResourceDeletionAuthorizationBehavior(authCheckBehavior, stateWriter);
+
+    tenantAwareDeletionBehavior =
+        new TenantAwareDeletionBehavior(authCheckBehavior, processingState.getTenantState());
+
     processDeletionBehavior =
         new ProcessDeletionBehavior(
             stateWriter,
@@ -94,21 +98,22 @@ public class ResourceDeletionDeleteProcessor
             bpmnBehaviors.catchEventBehavior(),
             startEventSubscriptionManager,
             startEventSubscriptions,
-            processDefinitionMetrics);
+            processDefinitionMetrics,
+            authorizationBehavior);
 
-    formDeletionBehavior = new FormDeletionBehavior(stateWriter, keyGenerator);
+    formDeletionBehavior =
+        new FormDeletionBehavior(stateWriter, keyGenerator, authorizationBehavior);
 
     decisionRequirementsDeletionBehavior =
         new DecisionRequirementsDeletionBehavior(
-            stateWriter, writers.command(), keyGenerator, processingState.getDecisionState());
+            stateWriter,
+            writers.command(),
+            keyGenerator,
+            processingState.getDecisionState(),
+            authorizationBehavior);
 
-    resourceDeletionBehavior = new ResourceDeletionBehavior(stateWriter, keyGenerator);
-
-    authorizationBehavior =
-        new ResourceDeletionAuthorizationBehavior(authCheckBehavior, stateWriter);
-
-    tenantAwareDeletionBehavior =
-        new TenantAwareDeletionBehavior(authCheckBehavior, processingState.getTenantState());
+    resourceDeletionBehavior =
+        new ResourceDeletionBehavior(stateWriter, keyGenerator, authorizationBehavior);
   }
 
   @Override
@@ -189,79 +194,29 @@ public class ResourceDeletionDeleteProcessor
       final TypedRecord<ResourceDeletionRecord> command,
       final String tenantId,
       final long eventKey) {
-    final var value = command.getValue();
-
-    final var process = processState.getProcessByKeyAndTenant(value.getResourceKey(), tenantId);
-    if (process != null) {
-      command
-          .getValue()
-          .setResourceType(ResourceType.PROCESS_DEFINITION)
-          .setResourceId(process.getBpmnProcessId())
-          .setTenantId(process.getTenantId());
-      return authorizationBehavior.authorizeAndDelete(
-          command,
-          eventKey,
-          PermissionType.DELETE_PROCESS,
-          bufferAsString(process.getBpmnProcessId()),
-          process.getTenantId(),
-          () -> processDeletionBehavior.deleteProcess(process, command, eventKey));
-    }
-
-    final var drgOptional =
-        decisionState.findDecisionRequirementsByTenantAndKey(tenantId, value.getResourceKey());
-    if (drgOptional.isPresent()) {
-      final var drg = drgOptional.get();
-      command
-          .getValue()
-          .setResourceType(ResourceType.DECISION_REQUIREMENTS)
-          .setResourceId(drg.getDecisionRequirementsId())
-          .setTenantId(drg.getTenantId());
-      return authorizationBehavior.authorizeAndDelete(
-          command,
-          eventKey,
-          PermissionType.DELETE_DRD,
-          bufferAsString(drg.getDecisionRequirementsId()),
-          drg.getTenantId(),
-          () ->
-              decisionRequirementsDeletionBehavior.deleteDecisionRequirements(
-                  drg, command, eventKey));
-    }
-
-    final var formOptional = formState.findFormByKey(value.getResourceKey(), tenantId);
-    if (formOptional.isPresent()) {
-      final var form = formOptional.get();
-      command
-          .getValue()
-          .setResourceType(ResourceType.FORM)
-          .setResourceId(form.getFormId())
-          .setTenantId(form.getTenantId());
-      return authorizationBehavior.authorizeAndDelete(
-          command,
-          eventKey,
-          PermissionType.DELETE_FORM,
-          bufferAsString(form.getFormId()),
-          form.getTenantId(),
-          () -> formDeletionBehavior.deleteForm(form));
-    }
-
-    final var resourceOptional = resourceState.findResourceByKey(value.getResourceKey(), tenantId);
-    if (resourceOptional.isPresent()) {
-      final var resource = resourceOptional.get();
-      command
-          .getValue()
-          .setResourceType(ResourceType.UNKNOWN)
-          .setResourceId(resource.getResourceId())
-          .setTenantId(resource.getTenantId());
-      return authorizationBehavior.authorizeAndDelete(
-          command,
-          eventKey,
-          PermissionType.DELETE_RESOURCE,
-          bufferAsString(resource.getResourceId()),
-          resource.getTenantId(),
-          () -> resourceDeletionBehavior.deleteResource(resource));
-    }
-
-    return false;
+    final var resourceKey = command.getValue().getResourceKey();
+    return Optional.ofNullable(processState.getProcessByKeyAndTenant(resourceKey, tenantId))
+        .map(process -> processDeletionBehavior.tryDelete(command, eventKey, process))
+        .or(
+            () ->
+                decisionState
+                    .findDecisionRequirementsByTenantAndKey(tenantId, resourceKey)
+                    .map(
+                        drg ->
+                            decisionRequirementsDeletionBehavior.tryDelete(command, eventKey, drg)))
+        .or(
+            () ->
+                formState
+                    .findFormByKey(resourceKey, tenantId)
+                    .map(form -> formDeletionBehavior.tryDelete(command, eventKey, form)))
+        .or(
+            () ->
+                resourceState
+                    .findResourceByKey(resourceKey, tenantId)
+                    .map(
+                        resource ->
+                            resourceDeletionBehavior.tryDelete(command, eventKey, resource)))
+        .orElse(false);
   }
 
   private void deleteHistory(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionExceptions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionExceptions.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+final class ResourceDeletionExceptions {
+
+  private ResourceDeletionExceptions() {}
+
+  static final class NoSuchResourceException extends IllegalStateException {
+    private static final String ERROR_MESSAGE =
+        "Expected to delete resource but no resource found with key `%d`";
+
+    NoSuchResourceException(final long resourceKey) {
+      super(String.format(ERROR_MESSAGE, resourceKey));
+    }
+  }
+
+  static final class ActiveProcessInstancesException extends IllegalStateException {
+    private static final String ERROR_MESSAGE =
+        "Expected to delete resource with key `%d` but there are still running instances";
+
+    ActiveProcessInstancesException(final long processDefinitionKey) {
+      super(String.format(ERROR_MESSAGE, processDefinitionKey));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/TenantAwareDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/TenantAwareDeletionBehavior.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
+import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.state.immutable.TenantState;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+final class TenantAwareDeletionBehavior {
+
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final TenantState tenantState;
+
+  TenantAwareDeletionBehavior(
+      final AuthorizationCheckBehavior authCheckBehavior, final TenantState tenantState) {
+    this.authCheckBehavior = authCheckBehavior;
+    this.tenantState = tenantState;
+  }
+
+  boolean untilResourceDeleted(
+      final TypedRecord<ResourceDeletionRecord> command, final Function<String, Boolean> callback) {
+    final var authorizedTenants = getAuthorizedTenants(command);
+
+    if (AuthorizedTenants.ANONYMOUS.equals(authorizedTenants)) {
+      return Optional.of(callback.apply(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+          .filter(Boolean::booleanValue)
+          .orElseGet(() -> forEachTenantUntilResourceDeleted(callback));
+    }
+
+    for (final var tenant : authorizedTenants.getAuthorizedTenantIds()) {
+      if (callback.apply(tenant)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private AuthorizedTenants getAuthorizedTenants(
+      final TypedRecord<ResourceDeletionRecord> command) {
+    final String tenantId = command.getValue().getTenantId();
+    if (tenantId.isEmpty()) {
+      return authCheckBehavior.getAuthorizedTenantIds(command);
+    }
+    return new AuthenticatedAuthorizedTenants(tenantId);
+  }
+
+  private boolean forEachTenantUntilResourceDeleted(final Function<String, Boolean> callback) {
+    final var deleted = new AtomicBoolean(false);
+    tenantState.forEachTenant(
+        tenant -> {
+          deleted.set(callback.apply(tenant));
+          return !deleted.get();
+        });
+    return deleted.get();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/TenantAwareDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/TenantAwareDeletionBehavior.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
-final class TenantAwareDeletionBehavior {
+public final class TenantAwareDeletionBehavior {
 
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final TenantState tenantState;
@@ -29,7 +29,7 @@ final class TenantAwareDeletionBehavior {
     this.tenantState = tenantState;
   }
 
-  boolean untilResourceDeleted(
+  boolean forEachAuthorizedTenantUntilDeleted(
       final TypedRecord<ResourceDeletionRecord> command, final Function<String, Boolean> callback) {
     final var authorizedTenants = getAuthorizedTenants(command);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/TenantAwareDeletionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/TenantAwareDeletionBehavior.java
@@ -33,7 +33,7 @@ public final class TenantAwareDeletionBehavior {
       final TypedRecord<ResourceDeletionRecord> command, final Function<String, Boolean> callback) {
     final var authorizedTenants = getAuthorizedTenants(command);
 
-    if (AuthorizedTenants.ANONYMOUS.equals(authorizedTenants)) {
+    if (authorizedTenants.isAnonymous()) {
       return Optional.of(callback.apply(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
           .filter(Boolean::booleanValue)
           .orElseGet(() -> forEachTenantUntilResourceDeleted(callback));


### PR DESCRIPTION
## Description

Goal is to make `ResourceDeletionDeleteProcessor` more readable.
We decided ([ref](https://camunda.slack.com/archives/C08G19SQ1BM/p1783089132337459)) to introduce Behavior classes to simplify `ResourceDeletionDeleteProcessor`.

### Behavior classes

#### Per resource type behavior

- `ProcessDeletionBehavior`
- `DecisionRequirementsDeletionBehavior`
- `FormDeletionBehavior`
- `ResourceDeletionBehavior`

#### Resource deletion authorization behavior

- `ResourceDeletionAuthorizationBehavior`

#### Tenant aware deletion

- `TenantAwareDeletionBehavior`

### Note

This is setting up follow up issues.
Creating dedicated processors, intent, records per resource type and reuse these Behavior classes.
Future possibility of introducing API endpoints to delete a specific resource type.

## Related issues

closes #55158
