### PR TITLE
feat: single job priority update - REST API

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -308,7 +308,8 @@ public class RequestMapper {
                 updateRequest.getOperationReference(),
                 new UpdateJobChangeset(
                     updateRequest.getChangeset().getRetries(),
-                    updateRequest.getChangeset().getTimeout())));
+                    updateRequest.getChangeset().getTimeout(),
+                    updateRequest.getChangeset().getPriority())));
   }
 
   public static Either<ProblemDetail, DocumentCreateRequest> toDocumentCreateRequest(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/JobRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/JobRequestValidator.java
@@ -63,9 +63,12 @@ public final class JobRequestValidator {
         violations -> {
           final JobChangeset changeset = updateRequest.getChangeset();
           if (changeset == null
-              || (changeset.getRetries() == null && changeset.getTimeout() == null)) {
+              || (changeset.getRetries() == null
+                  && changeset.getTimeout() == null
+                  && changeset.getPriority() == null)) {
             violations.add(
-                ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted(List.of("retries", "timeout")));
+                ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted(
+                    List.of("retries", "timeout", "priority")));
           }
         });
   }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
@@ -622,7 +622,7 @@ class RequestMapperTest {
     @SuppressWarnings("NullAway")
     void shouldRejectWhenChangesetIsNull() {
       // given
-      final var request = JobUpdateRequest.Builder.create().changeset((JobChangeset) null).build();
+      final var request = JobUpdateRequest.Builder.create().changeset(null).build();
 
       // when
       final var result = RequestMapper.toJobUpdateRequest(request, 1L);

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
@@ -13,6 +13,8 @@ import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.protocol.model.AdvancedStringFilter;
 import io.camunda.gateway.protocol.model.DeleteResourceRequest;
 import io.camunda.gateway.protocol.model.JobActivationRequest;
+import io.camunda.gateway.protocol.model.JobChangeset;
+import io.camunda.gateway.protocol.model.JobUpdateRequest;
 import io.camunda.gateway.protocol.model.MigrateProcessInstanceMappingInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceFilter;
 import io.camunda.gateway.protocol.model.ProcessInstanceMigrationBatchOperationPlan;
@@ -20,6 +22,7 @@ import io.camunda.gateway.protocol.model.ProcessInstanceMigrationBatchOperationR
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationBatchOperationRequest;
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationMoveBatchOperationInstruction;
 import io.camunda.gateway.protocol.model.TenantFilterEnum;
+import io.camunda.service.JobServices.UpdateJobChangeset;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
@@ -581,6 +584,38 @@ class RequestMapperTest {
       assertThat(problemDetail.getDetail())
           .contains("ASSIGNED tenant filter")
           .contains("multi-tenancy is disabled");
+    }
+  }
+
+  @Nested
+  class JobUpdateRequestMappingTest {
+
+    @Test
+    void shouldMapPriorityToChangeset() {
+      // given
+      final var changeset = new JobChangeset().priority(80);
+      final var request = new JobUpdateRequest().changeset(changeset);
+
+      // when
+      final var result = RequestMapper.toJobUpdateRequest(request, 1L);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.get().changeset()).isEqualTo(new UpdateJobChangeset(null, null, 80));
+    }
+
+    @Test
+    void shouldMapNullPriorityWhenNotProvided() {
+      // given
+      final var changeset = new JobChangeset().retries(3);
+      final var request = new JobUpdateRequest().changeset(changeset);
+
+      // when
+      final var result = RequestMapper.toJobUpdateRequest(request, 1L);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.get().changeset()).isEqualTo(new UpdateJobChangeset(3, null, null));
     }
   }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
@@ -593,8 +593,8 @@ class RequestMapperTest {
     @Test
     void shouldMapPriorityToChangeset() {
       // given
-      final var changeset = new JobChangeset().priority(80);
-      final var request = new JobUpdateRequest().changeset(changeset);
+      final var changeset = JobChangeset.Builder.create().priority(80).build();
+      final var request = JobUpdateRequest.Builder.create().changeset(changeset).build();
 
       // when
       final var result = RequestMapper.toJobUpdateRequest(request, 1L);
@@ -607,8 +607,8 @@ class RequestMapperTest {
     @Test
     void shouldMapNullPriorityWhenNotProvided() {
       // given
-      final var changeset = new JobChangeset().retries(3);
-      final var request = new JobUpdateRequest().changeset(changeset);
+      final var changeset = JobChangeset.Builder.create().retries(3).build();
+      final var request = JobUpdateRequest.Builder.create().changeset(changeset).build();
 
       // when
       final var result = RequestMapper.toJobUpdateRequest(request, 1L);
@@ -616,6 +616,35 @@ class RequestMapperTest {
       // then
       assertThat(result.isRight()).isTrue();
       assertThat(result.get().changeset()).isEqualTo(new UpdateJobChangeset(3, null, null));
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void shouldRejectWhenChangesetIsNull() {
+      // given
+      final var request = JobUpdateRequest.Builder.create().changeset((JobChangeset) null).build();
+
+      // when
+      final var result = RequestMapper.toJobUpdateRequest(request, 1L);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      assertThat(result.getLeft().getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void shouldRejectWhenAllChangesetFieldsAreNull() {
+      // given
+      final var changeset = JobChangeset.Builder.create().build();
+      final var request = JobUpdateRequest.Builder.create().changeset(changeset).build();
+
+      // when
+      final var result = RequestMapper.toJobUpdateRequest(request, 1L);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      assertThat(result.getLeft().getStatus()).isEqualTo(400);
+      assertThat(result.getLeft().getDetail()).contains("retries", "timeout", "priority");
     }
   }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/JobRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/JobRequestValidatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.gateway.protocol.model.JobChangeset;
+import io.camunda.gateway.protocol.model.JobUpdateRequest;
+import org.junit.jupiter.api.Test;
+
+class JobRequestValidatorTest {
+
+  @Test
+  void shouldAcceptChangesetWithOnlyPriority() {
+    // given
+    final var changeset = JobChangeset.Builder.create().priority(50).build();
+    final var request = JobUpdateRequest.Builder.create().changeset(changeset).build();
+
+    // when
+    final var result = JobRequestValidator.validateJobUpdateRequest(request);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldRejectNullChangeset() {
+    // given
+    final var request = JobUpdateRequest.Builder.create().changeset((JobChangeset) null).build();
+
+    // when
+    final var result = JobRequestValidator.validateJobUpdateRequest(request);
+
+    // then
+    assertThat(result).isPresent();
+    assertThat(result.get().getDetail()).contains("retries", "timeout", "priority");
+  }
+
+  @Test
+  void shouldRejectChangesetWithAllNullFields() {
+    // given
+    final var changeset = JobChangeset.Builder.create().build();
+    final var request = JobUpdateRequest.Builder.create().changeset(changeset).build();
+
+    // when
+    final var result = JobRequestValidator.validateJobUpdateRequest(request);
+
+    // then
+    assertThat(result).isPresent();
+    assertThat(result.get().getDetail()).contains("retries", "timeout", "priority");
+  }
+}

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/JobRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/JobRequestValidatorTest.java
@@ -31,7 +31,7 @@ class JobRequestValidatorTest {
   @Test
   void shouldRejectNullChangeset() {
     // given
-    final var request = JobUpdateRequest.Builder.create().changeset((JobChangeset) null).build();
+    final var request = JobUpdateRequest.Builder.create().changeset(null).build();
 
     // when
     final var result = JobRequestValidator.validateJobUpdateRequest(request);

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -144,7 +144,7 @@ public class IncidentTools {
           CallToolResultMapper.executeServiceMethod(
               serviceRegistry
                   .<JobActivationResult>jobServices(physicalTenantId)
-                  .updateJob(jobKey, null, new UpdateJobChangeset(1, null), authentication));
+                  .updateJob(jobKey, null, new UpdateJobChangeset(1, null, null), authentication));
       if (updateResult.isLeft()) {
         return CallToolResultMapper.mapErrorToResult(updateResult.getLeft());
       }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -461,7 +461,7 @@ class IncidentToolsTest extends OperationalToolsTest {
 
       verify(incidentServices, times(2)).resolveIncident(eq(5L), isNull(), any());
       verify(incidentServices).getByKey(eq(5L), any());
-      verify(jobServices).updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null)), any());
+      verify(jobServices).updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null, null)), any());
     }
 
     @Test
@@ -500,7 +500,7 @@ class IncidentToolsTest extends OperationalToolsTest {
 
       verify(incidentServices).resolveIncident(eq(5L), isNull(), any());
       verify(incidentServices).getByKey(eq(5L), any());
-      verify(jobServices).updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null)), any());
+      verify(jobServices).updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null, null)), any());
 
       assertTextContentFallback(result);
     }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -461,7 +461,8 @@ class IncidentToolsTest extends OperationalToolsTest {
 
       verify(incidentServices, times(2)).resolveIncident(eq(5L), isNull(), any());
       verify(incidentServices).getByKey(eq(5L), any());
-      verify(jobServices).updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null, null)), any());
+      verify(jobServices)
+          .updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null, null)), any());
     }
 
     @Test
@@ -500,7 +501,8 @@ class IncidentToolsTest extends OperationalToolsTest {
 
       verify(incidentServices).resolveIncident(eq(5L), isNull(), any());
       verify(incidentServices).getByKey(eq(5L), any());
-      verify(jobServices).updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null, null)), any());
+      verify(jobServices)
+          .updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null, null)), any());
 
       assertTextContentFallback(result);
     }

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -155,7 +155,8 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final UpdateJobChangeset changeset,
       final CamundaAuthentication authentication) {
     final var brokerRequest =
-        new BrokerUpdateJobRequest(jobKey, changeset.retries(), changeset.timeout());
+        new BrokerUpdateJobRequest(
+            jobKey, changeset.retries(), changeset.timeout(), changeset.priority());
     if (operationReference != null) {
       brokerRequest.setOperationReference(operationReference);
     }
@@ -239,5 +240,5 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       List<String> fetchVariable,
       long requestTimeout) {}
 
-  public record UpdateJobChangeset(Integer retries, Long timeout) {}
+  public record UpdateJobChangeset(Integer retries, Long timeout, Integer priority) {}
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -1078,6 +1078,11 @@ components:
           format: int64
           description: The new timeout for the job in milliseconds.
           nullable: true
+        priority:
+          type: integer
+          format: int32
+          description: The new priority for the job. Higher values indicate higher priority.
+          nullable: true
 
     ## Enums
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -1083,6 +1083,9 @@ components:
           format: int32
           description: The new priority for the job. Higher values indicate higher priority.
           nullable: true
+      x-properties-added-in-version:
+        - propertyName: priority
+          addedInVersion: "8.10"
 
     ## Enums
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -681,7 +681,7 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, 1000L)), any());
+        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, 1000L, null)), any());
   }
 
   @Test
@@ -710,7 +710,7 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, null)), any());
+        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, null, null)), any());
   }
 
   @Test
@@ -738,7 +738,7 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(null, 1000L)), any());
+        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(null, 1000L, null)), any());
   }
 
   @Test
@@ -767,7 +767,35 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), eq(12345678L), eq(new UpdateJobChangeset(null, 1000L)), any());
+        .updateJob(eq(1L), eq(12345678L), eq(new UpdateJobChangeset(null, 1000L, null)), any());
+  }
+
+  @Test
+  void shouldUpdateJobWithPriority() {
+    // given
+    when(jobServices.updateJob(anyLong(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+    final var request =
+        """
+            {
+              "changeset": {
+                "priority": 80
+              }
+            }""";
+    // when/then
+    webClient
+        .patch()
+        .uri(JOBS_BASE_URL + "/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    Mockito.verify(jobServices)
+        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(null, null, 80)), any());
   }
 
   @Test
@@ -786,7 +814,7 @@ public class JobControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "At least one of [retries, timeout] is required.",
+              "detail": "At least one of [retries, timeout, priority] is required.",
               "instance": "%s"
             }"""
             .formatted(JOBS_BASE_URL + "/1");

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRequest.java
@@ -21,10 +21,7 @@ public class BrokerUpdateJobRequest extends BrokerExecuteCommand<JobRecord> {
   private final JobRecord requestDto = new JobRecord();
 
   public BrokerUpdateJobRequest(
-      final long jobKey,
-      final Integer retries,
-      final Long timeout,
-      final Integer priority) {
+      final long jobKey, final Integer retries, final Long timeout, final Integer priority) {
     super(ValueType.JOB, JobIntent.UPDATE);
     request.setKey(jobKey);
     final Set<String> changedAttributes = new HashSet<>();

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRequest.java
@@ -20,7 +20,11 @@ public class BrokerUpdateJobRequest extends BrokerExecuteCommand<JobRecord> {
 
   private final JobRecord requestDto = new JobRecord();
 
-  public BrokerUpdateJobRequest(final long jobKey, final Integer retries, final Long timeout) {
+  public BrokerUpdateJobRequest(
+      final long jobKey,
+      final Integer retries,
+      final Long timeout,
+      final Integer priority) {
     super(ValueType.JOB, JobIntent.UPDATE);
     request.setKey(jobKey);
     final Set<String> changedAttributes = new HashSet<>();
@@ -31,6 +35,10 @@ public class BrokerUpdateJobRequest extends BrokerExecuteCommand<JobRecord> {
     if (timeout != null) {
       requestDto.setTimeout(timeout);
       changedAttributes.add(JobRecord.TIMEOUT);
+    }
+    if (priority != null) {
+      requestDto.setPriority(priority);
+      changedAttributes.add(JobRecord.PRIORITY);
     }
     requestDto.setChangedAttributes(changedAttributes);
   }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRequestTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRequestTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import org.junit.jupiter.api.Test;
+
+final class BrokerUpdateJobRequestTest {
+
+  @Test
+  void shouldIncludePriorityInChangedAttributesWhenSet() {
+    // given/when
+    final var request = new BrokerUpdateJobRequest(1L, null, null, 80);
+
+    // then
+    assertThat(request.getRequestWriter()).isInstanceOf(JobRecord.class);
+    final var record = (JobRecord) request.getRequestWriter();
+    assertThat(record.getChangedAttributes()).contains(JobRecord.PRIORITY);
+    assertThat(record.getPriority()).isEqualTo(80);
+  }
+
+  @Test
+  void shouldExcludePriorityFromChangedAttributesWhenNull() {
+    // given/when
+    final var request = new BrokerUpdateJobRequest(1L, 3, null, null);
+
+    // then
+    final var record = (JobRecord) request.getRequestWriter();
+    assertThat(record.getChangedAttributes()).doesNotContain(JobRecord.PRIORITY);
+  }
+
+  @Test
+  void shouldIncludePriorityZeroInChangedAttributes() {
+    // given/when
+    final var request = new BrokerUpdateJobRequest(1L, null, null, 0);
+
+    // then
+    final var record = (JobRecord) request.getRequestWriter();
+    assertThat(record.getChangedAttributes()).contains(JobRecord.PRIORITY);
+    assertThat(record.getPriority()).isEqualTo(0);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateJobTest.java
@@ -318,7 +318,7 @@ public class UpdateJobTest {
   }
 
   @Test
-  public void shouldRejectIfBothFieldsAreNull(final TestInfo testInfo) {
+  public void shouldRejectIfAllFieldsAreNull(final TestInfo testInfo) {
     // given
     final String jobType = "job-" + testInfo.getDisplayName();
     createProcessInstance(jobType);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateJobTest.java
@@ -326,7 +326,7 @@ public class UpdateJobTest {
     final long jobKey = job.getKey();
 
     // then
-    final var expectedMessage = "At least one of [retries, timeout] is required";
+    final var expectedMessage = "At least one of [retries, timeout, priority] is required";
 
     assertThatThrownBy(() -> client.newUpdateJobCommand(jobKey).update(null, null).send().join())
         .hasMessageContaining(expectedMessage);
@@ -341,7 +341,7 @@ public class UpdateJobTest {
     final long jobKey = job.getKey();
 
     // then
-    final var expectedMessage = "At least one of [retries, timeout] is required";
+    final var expectedMessage = "At least one of [retries, timeout, priority] is required";
 
     assertThatThrownBy(() -> client.newUpdateJobCommand(jobKey).update(null).send().join())
         .hasMessageContaining(expectedMessage);


### PR DESCRIPTION
## Description

Add an optional `priority` field to `PATCH /v2/jobs/{jobKey}` so operators can update a job's runtime priority. The engine already handles `PRIORITY` in `changedAttributes` (M2-6, merged); this PR wires the REST path to emit it by extending the OpenAPI schema, Java models, mapper, and validator. A priority-only changeset is now accepted, and `PRIORITY` is added to `changedAttributes` only when priority is non-null, preserving backward compatibility.

## Checklist

<!--- Please delete options that are not relevant. -->

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53855