### PR TITLE
test: unskip 9 API test(s) referencing closed bugs (stable/8.8)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts
@@ -62,8 +62,7 @@ test.describe('Get Batch Operation Tests', () => {
         expect(json['operationsFailedCount']).toBeGreaterThanOrEqual(0);
         expect(json['operationsCompletedCount']).toBeGreaterThanOrEqual(0);
         expect(json['errors']).toBeDefined();
-        //Skipped due to bug 42165: https://github.com/camunda/camunda/issues/42165
-        // expect(json['startDate']).toBeDefined();
+        expect(json['startDate']).toBeDefined();
       }).toPass({
         intervals: [5_000, 10_000, 15_000, 25_000],
         timeout: 60_000,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
@@ -159,8 +159,7 @@ test.describe.parallel('Search Batch Operation Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Batch Operations Invalid Pagination', async ({request}) => {
+  test('Search Batch Operations Invalid Pagination', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl('/batch-operations/search'), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -132,8 +132,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  // Skipped due to bug 43097: https://github.com/camunda/camunda/issues/43097
-  test.skip('Suspend active batch operation returns 204 and status becomes SUSPENDED without resume', async ({
+  test('Suspend active batch operation returns 204 and status becomes SUSPENDED without resume', async ({
     request,
   }) => {
     const key = await test.step('Create cancel batch operation', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
@@ -291,8 +291,7 @@ test.describe('Element Instance Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Element Instances - with invalid pagination parameters', async ({
+  test('Search Element Instances - with invalid pagination parameters', async ({
     request,
   }) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
@@ -162,8 +162,7 @@ test.describe.parallel('Process Definition Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Process Definitions - with invalid pagination parameters', async ({
+  test('Search Process Definitions - with invalid pagination parameters', async ({
     request,
   }) => {
     const res = await request.post(buildUrl('/process-definitions/search'), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-resolve-incidents-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-resolve-incidents-api.spec.ts
@@ -48,8 +48,7 @@ test.describe
     await assertUnauthorizedRequest(res);
   });
 
-  // Skipped due to bug 41209:  https://github.com/camunda/camunda/issues/41209
-  test.skip('Create a Batch Operation to Resolve Incidents - Success', async ({
+  test('Create a Batch Operation to Resolve Incidents - Success', async ({
     request,
   }) => {
     const localState: Record<string, string> = {
@@ -151,8 +150,7 @@ test.describe
     );
   });
 
-  // Skipped due to bug 41209: https://github.com/camunda/camunda/issues/41209
-  test.skip('Create a Batch Operation to Resolve Incidents - With Multiple Filters', async ({
+  test('Create a Batch Operation to Resolve Incidents - With Multiple Filters', async ({
     request,
   }) => {
     const localState: Record<string, string> = {
@@ -245,8 +243,7 @@ test.describe
     await cancelProcessInstance(localState.processInstanceKey2);
   });
 
-  // Skipped due to bug 41209: https://github.com/camunda/camunda/issues/41209
-  test.skip('Create a Batch Operation to Resolve Incidents - With Or Filters', async ({
+  test('Create a Batch Operation to Resolve Incidents - With Or Filters', async ({
     request,
   }) => {
     const localState: Record<string, string> = {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts
@@ -237,8 +237,7 @@ test.describe.parallel('Search Variables API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test.skip('Search Variables with invalid pagination parameters', async ({
+  test('Search Variables with invalid pagination parameters', async ({
     request,
   }) => {
     await expect(async () => {


### PR DESCRIPTION
## Auto-Unskip: Tests with Closed Bug References

> Opened automatically by the [auto-unskip workflow](https://github.com/camunda/qa-metrics-exporter/actions/runs/27822503435).

**9** test(s) in `stable/8.8` were unskipped because their referenced bugs are now closed.

### Closed Bugs

- [camunda/camunda#42165](https://github.com/camunda/camunda/issues/42165) V2 Batch Operation Search: `startDate` missing in API response despite being documented — closed 2026-01-30
- [camunda/camunda#39372](https://github.com/camunda/camunda/issues/39372) No validation of page limit attribute in Search Request — closed 2026-03-09
- [camunda/camunda#43097](https://github.com/camunda/camunda/issues/43097) Suspend Batch Operation unexpectedly blocks further Batch Operation progress — closed 2026-03-09
- [camunda/camunda#41209](https://github.com/camunda/camunda/issues/41209) Process instance is still shown with incident after successfully resolving the incident — closed 2026-04-15

### Files Changed (7)

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts`: 1 skip(s) removed (camunda/camunda#42165)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts`: 1 skip(s) removed (camunda/camunda#43097)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-resolve-incidents-api.spec.ts`: 3 skip(s) removed (camunda/camunda#41209)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-search-api.spec.ts`: 1 skip(s) removed (camunda/camunda#39372)

### 🔎 Auto-uncommented — please double-check (1)

These commented-out code blocks (1 code line(s)) were *re-enabled* and their bug marker removed. Verify they compile and assert what you expect:

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-get-api.spec.ts` ~L65 (camunda/camunda#42165, 1 line(s) uncommented)

### ⚠️ Needs manual review — left untouched (2)

The referenced bug is **closed**, but the skip could not be removed automatically and was **left exactly as-is**. Each item below still needs a human to un-skip it:

- [ ] **[`clock-pin-api.spec.ts`:23](https://github.com/camunda/camunda/blob/8ac2fb6424540dca93893a723f83947729df5ff0/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts#L23)** — closed bug [camunda/camunda#48562](https://github.com/camunda/camunda/issues/48562)
  - Why it was skipped: Skip is inside a conditional/ternary (e.g. `isX ? test.describe.skip : test.describe`). Pick the correct branch and remove the skip by hand.
  - Path: `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts`
- [ ] **[`clock-reset-api.spec.ts`:22](https://github.com/camunda/camunda/blob/8ac2fb6424540dca93893a723f83947729df5ff0/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts#L22)** — closed bug [camunda/camunda#48562](https://github.com/camunda/camunda/issues/48562)
  - Why it was skipped: Skip is inside a conditional/ternary (e.g. `isX ? test.describe.skip : test.describe`). Pick the correct branch and remove the skip by hand.
  - Path: `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts`

### On-demand E2E

🔬 On-demand E2E run: https://github.com/camunda/camunda/actions/runs/27822613919

### Checklist

- [ ] On-demand test run passes on this branch
- [ ] No regressions in adjacent tests

