### PR TITLE
test: unskip 1 E2E test(s) referencing closed bugs (main)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -79,8 +79,7 @@ test.describe('Process Instances Filters', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // skipped due to bug 45156: https://github.com/camunda/camunda/issues/45156
-  test.skip('Interaction between diagram and filters', async ({
+  test('Interaction between diagram and filters', async ({
     operateProcessesPage,
     operateFiltersPanelPage,
     page,


### PR DESCRIPTION
## Auto-Unskip: Tests with Closed Bug References

> Opened automatically by the [auto-unskip workflow](https://github.com/camunda/qa-metrics-exporter/actions/runs/27823336416).

**1** test(s) in `main` were unskipped because their referenced bugs are now closed.

### Closed Bugs

- [camunda/camunda#45156](https://github.com/camunda/camunda/issues/45156) Operate – Incorrect process instances count when selecting flow node without active token — closed 2026-05-29

### Files Changed (1)

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts`: 1 skip(s) removed (camunda/camunda#45156)

### On-demand E2E

🔬 On-demand E2E run: https://github.com/camunda/camunda/actions/runs/27823532897

### Checklist

- [ ] On-demand test run passes on this branch
- [ ] No regressions in adjacent tests

