### PR TITLE
test: unskip 4 E2E test(s) referencing closed bugs (stable/8.8)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -272,7 +272,7 @@ test.describe('Operations', () => {
         },
         maxRetries: 10,
       });
-      
+
       await Promise.all(
         instances.map((instance) =>
           expect(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -97,9 +97,8 @@ test.describe('Operations', () => {
     });
   });
 
-  // Skipped due to bug 42375: https://github.com/camunda/camunda/issues/42375
   // !Note: assert the code after the bug is fixed as it was dicoverd during the test implementation
-  test.skip('Retry and cancel single instance', async ({
+  test('Retry and cancel single instance', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -154,13 +154,12 @@ test.describe('Process Instance Modifications', () => {
         operateProcessInstancePage.getVariableTestId('foo'),
       ).toBeVisible();
 
-      // Skipped due to bug 42546: https://github.com/camunda/camunda/issues/42546
-      // await expect(
-      //   operateProcessInstancePage.getEditVariableFieldSelector('test'),
-      // ).toHaveValue('123');
-      // await expect(
-      //   operateProcessInstancePage.getEditVariableFieldSelector('foo'),
-      // ).toHaveValue('1');
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('test'),
+      ).toHaveValue('123');
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('1');
     });
 
     await test.step('Undo again and verify all modifications removed', async () => {
@@ -202,10 +201,8 @@ test.describe('Process Instance Modifications', () => {
     });
   });
 
-  // Skipped due to bug 42546: https://github.com/camunda/camunda/issues/42546
   // !Note: assert the code after the bug is fixed as it was discoverd during the test implementation
-  // eslint-disable-next-line playwright/no-skipped-test
-  test.skip('Should apply/remove add variable modifications', async ({
+  test('Should apply/remove add variable modifications', async ({
     page,
     operateProcessInstancePage,
     operateProcessModificationModePage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -74,8 +74,7 @@ test.describe('Process Instances Table', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // Skipped due to bug 38103: https://github.com/camunda/camunda/issues/38103
-  test.skip('Sorting of process instances', async ({
+  test('Sorting of process instances', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,


### PR DESCRIPTION
## Auto-Unskip: Tests with Closed Bug References

> Opened automatically by the [auto-unskip workflow](https://github.com/camunda/qa-metrics-exporter/actions/runs/27823336416).

**4** test(s) in `stable/8.8` were unskipped because their referenced bugs are now closed.

### Closed Bugs

- [camunda/camunda#42375](https://github.com/camunda/camunda/issues/42375) Cancel operation is not added to operations panel when triggered for single instance — closed 2026-03-24
- [camunda/camunda#42546](https://github.com/camunda/camunda/issues/42546) Undo operation in modification mode removes incorrect modification when performed from different flow node scope — closed 2026-03-03
- [camunda/camunda#38103](https://github.com/camunda/camunda/issues/38103) Sort by Version fails after applying Process Instance filter — closed 2026-03-25

### Files Changed (3)

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts`: 1 skip(s) removed (camunda/camunda#42375)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts`: 2 skip(s) removed (camunda/camunda#42546)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts`: 1 skip(s) removed (camunda/camunda#38103)

### 🔎 Auto-uncommented — please double-check (1)

These commented-out code blocks (6 code line(s)) were *re-enabled* and their bug marker removed. Verify they compile and assert what you expect:

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts` ~L157 (camunda/camunda#42546, 6 line(s) uncommented)

### On-demand E2E

🔬 On-demand E2E run: https://github.com/camunda/camunda/actions/runs/27823550820

### Checklist

- [ ] On-demand test run passes on this branch
- [ ] No regressions in adjacent tests

