### PR TITLE
feat: integrate C3 navigation V2 into Optimize behind IS_NAV_V2_ENABLED

### DIFF
--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -53,7 +53,19 @@
     "termsOfUse": "Nutzungsbedingungen",
     "imprint": "Impressum",
     "academy": "Camunda Academy",
-    "feedback": "Feedback und Support"
+    "feedback": "Feedback und Support",
+    "info": "Info",
+    "settings": "Einstellungen",
+    "notifications": "Benachrichtigungen",
+    "notificationsDismissAll": "Alle verwerfen",
+    "notificationsEmptyTitle": "Keine Benachrichtigungen",
+    "notificationsEmptyDescription": "Neue Updates zu Ihren Prozessen, Clustern und mehr erscheinen hier.",
+    "sidebarCollapse": "Einklappen",
+    "sidebarExpand": "Ausklappen",
+    "sidebarCollapseAria": "Seitenleiste einklappen",
+    "sidebarExpandAria": "Seitenleiste ausklappen",
+    "sidebarGroupCollapseAria": "{label} einklappen",
+    "sidebarGroupExpandAria": "{label} ausklappen"
   },
   "login": {
     "label": "Einloggen",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -53,7 +53,19 @@
     "termsOfUse": "Terms of use",
     "imprint": "Imprint",
     "academy": "Camunda Academy",
-    "feedback": "Feedback and Support"
+    "feedback": "Feedback and Support",
+    "info": "Info",
+    "settings": "Settings",
+    "notifications": "Notifications",
+    "notificationsDismissAll": "Dismiss all",
+    "notificationsEmptyTitle": "No notifications",
+    "notificationsEmptyDescription": "New updates regarding your processes, clusters and more will appear here.",
+    "sidebarCollapse": "Collapse",
+    "sidebarExpand": "Expand",
+    "sidebarCollapseAria": "Collapse sidebar",
+    "sidebarExpandAria": "Expand sidebar",
+    "sidebarGroupCollapseAria": "Collapse {label}",
+    "sidebarGroupExpandAria": "Expand {label}"
   },
   "login": {
     "label": "Log in",

--- a/optimize/client/package.json
+++ b/optimize/client/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "dependencies": {
     "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-    "@camunda/camunda-composite-components": "^0.23.0",
+    "@camunda/camunda-composite-components": "^0.25.0",
     "@carbon/icons-react": "^11.41.0",
     "@carbon/react": "^1.77.0",
     "@lexical/react": "^0.41.0",

--- a/optimize/client/src/components/Analysis/Analysis.js
+++ b/optimize/client/src/components/Analysis/Analysis.js
@@ -20,7 +20,6 @@ import './Analysis.scss';
 export default function Analysis() {
   const {pathname} = useLocation();
 
-  // V2 surfaces Task/Branch in the sidebar group, so drop the in-page tabs.
   if (IS_NAV_V2_ENABLED) {
     return (
       <div className="Analysis">

--- a/optimize/client/src/components/Analysis/Analysis.js
+++ b/optimize/client/src/components/Analysis/Analysis.js
@@ -10,6 +10,7 @@ import {Link, Route, Switch, useLocation} from 'react-router-dom';
 
 import {ErrorPage, Tabs} from 'components';
 import {t} from 'translation';
+import {IS_NAV_V2_ENABLED} from 'feature-flags';
 
 import {BranchAnalysis} from './BranchAnalysis';
 import {TaskAnalysis} from './TaskAnalysis';
@@ -18,6 +19,20 @@ import './Analysis.scss';
 
 export default function Analysis() {
   const {pathname} = useLocation();
+
+  // V2 surfaces Task/Branch in the sidebar group, so drop the in-page tabs.
+  if (IS_NAV_V2_ENABLED) {
+    return (
+      <div className="Analysis">
+        <Switch>
+          <Route path="/analysis/branchAnalysis" component={BranchAnalysis} />
+          <Route path="/analysis/taskAnalysis" component={TaskAnalysis} />
+          <Route path="/analysis/" exact component={TaskAnalysis} />
+          <Route path="*" component={() => <ErrorPage noLink />} />
+        </Switch>
+      </div>
+    );
+  }
 
   const tabValue = getTabValue(pathname);
 

--- a/optimize/client/src/components/Analysis/Analysis.test.js
+++ b/optimize/client/src/components/Analysis/Analysis.test.js
@@ -10,15 +10,36 @@ import {shallow} from 'enzyme';
 
 import Analysis from './Analysis';
 
-jest.mock('feature-flags', () => ({IS_NAV_V2_ENABLED: false}));
+let mockNavV2Enabled = false;
+jest.mock('feature-flags', () => ({
+  get IS_NAV_V2_ENABLED() {
+    return mockNavV2Enabled;
+  },
+}));
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: jest.fn().mockReturnValue({pathname: '/analysis/branchAnalysis'}),
 }));
 
+beforeEach(() => {
+  mockNavV2Enabled = false;
+});
+
 it('should select the correct table', () => {
   const node = shallow(<Analysis />);
 
   expect(node.find('Tabs').prop('value')).toBe(1);
+});
+
+it('should drop the in-page tabs and render the analysis routes when nav V2 is enabled', () => {
+  mockNavV2Enabled = true;
+
+  const node = shallow(<Analysis />);
+
+  expect(node.find('Tabs')).toHaveLength(0);
+  const routePaths = node.find('Route').map((route) => route.prop('path'));
+  expect(routePaths).toEqual(
+    expect.arrayContaining(['/analysis/taskAnalysis', '/analysis/branchAnalysis'])
+  );
 });

--- a/optimize/client/src/components/Analysis/Analysis.test.js
+++ b/optimize/client/src/components/Analysis/Analysis.test.js
@@ -10,6 +10,8 @@ import {shallow} from 'enzyme';
 
 import Analysis from './Analysis';
 
+jest.mock('feature-flags', () => ({IS_NAV_V2_ENABLED: false}));
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: jest.fn().mockReturnValue({pathname: '/analysis/branchAnalysis'}),

--- a/optimize/client/src/components/Header/Header.scss
+++ b/optimize/client/src/components/Header/Header.scss
@@ -45,7 +45,6 @@
   }
 }
 
-// V2 renders the user panel's custom section outside `.cds--header`.
 .HeaderV2-timezone {
   padding: var(--cds-spacing-05);
   color: var(--cds-text-secondary);

--- a/optimize/client/src/components/Header/Header.scss
+++ b/optimize/client/src/components/Header/Header.scss
@@ -44,3 +44,13 @@
     letter-spacing: var(--cds-label-01-letter-spacing);
   }
 }
+
+// V2 renders the user panel's custom section outside `.cds--header`.
+.HeaderV2-timezone {
+  padding: var(--cds-spacing-05);
+  color: var(--cds-text-secondary);
+  font-size: var(--cds-label-01-font-size);
+  font-weight: var(--cds-label-01-font-weight);
+  line-height: var(--cds-label-01-line-height);
+  letter-spacing: var(--cds-label-01-letter-spacing);
+}

--- a/optimize/client/src/components/Header/HeaderV2/index.test.tsx
+++ b/optimize/client/src/components/Header/HeaderV2/index.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {runLastEffect} from '__mocks__/react';
+import {shallow} from 'enzyme';
+
+import {useUiConfig} from 'hooks';
+
+import HeaderV2 from '.';
+
+const defaultUiConfig = {
+  optimizeProfile: 'ccsm',
+  onboarding: {
+    orgId: 'orgId',
+    clusterId: 'clusterId',
+  },
+};
+
+jest.mock('hooks', () => ({
+  useErrorHandling: jest.fn(() => ({
+    mightFail: jest.fn(async (data, cb) => cb(await data)),
+  })),
+  useDocs: jest.fn(() => ({
+    getBaseDocsUrl: () => 'docsUrl',
+  })),
+  useUser: jest.fn(() => ({
+    user: undefined,
+  })),
+  useUiConfig: jest.fn(() => defaultUiConfig),
+}));
+
+jest.mock('../service', () => ({
+  getUserToken: jest.fn().mockReturnValue('userToken'),
+}));
+
+beforeEach(() => {
+  (useUiConfig as jest.Mock).mockReturnValue(defaultUiConfig);
+});
+
+it('should not provide cluster configuration context outside of cloud', async () => {
+  const node = shallow(<HeaderV2 />);
+
+  await runLastEffect();
+  await node.update();
+
+  expect(node.find('NavbarWrapper').prop('isCloud')).toBe(false);
+});
+
+it('should provide cluster configuration context in cloud mode', async () => {
+  (useUiConfig as jest.Mock).mockReturnValue({...defaultUiConfig, optimizeProfile: 'cloud'});
+
+  const node = shallow(<HeaderV2 />);
+
+  await runLastEffect();
+  await node.update();
+
+  expect(node.find('NavbarWrapper').props()).toMatchObject({
+    isCloud: true,
+    organizationId: 'orgId',
+    clusterId: 'clusterId',
+    userToken: 'userToken',
+    getNewUserToken: expect.any(Function),
+  });
+});

--- a/optimize/client/src/components/Header/HeaderV2/index.tsx
+++ b/optimize/client/src/components/Header/HeaderV2/index.tsx
@@ -53,8 +53,6 @@ export default function HeaderV2({noActions}: {noActions?: boolean}) {
   );
 }
 
-// Rendered inside NavbarWrapper so the C3 tools and cluster-webapp breadcrumbs
-// resolve against the C3UserConfigurationProvider context (SaaS).
 function HeaderV2Body({noActions, isCloud}: {noActions?: boolean; isCloud: boolean}) {
   const history = useHistory();
   const {getBaseDocsUrl} = useDocs();

--- a/optimize/client/src/components/Header/HeaderV2/index.tsx
+++ b/optimize/client/src/components/Header/HeaderV2/index.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ComponentProps, useEffect, useMemo, useState} from 'react';
+import {Link, useHistory} from 'react-router-dom';
+import {
+  C3LicenseTag,
+  C3UserConfigurationProvider,
+  preview_C3NavigationV2 as C3NavigationV2,
+  preview_useC3NavigationV2 as useC3NavigationV2,
+  preview_useClusterWebappBreadcrumbs as useClusterWebappBreadcrumbs,
+} from '@camunda/camunda-composite-components';
+
+import {showError} from 'notifications';
+import {t} from 'translation';
+import {isLogoutHidden} from 'config';
+import {useDocs, useErrorHandling, useUiConfig, useUser} from 'hooks';
+
+import {getUserToken} from '../service';
+import useSidebarChildren from './useSidebarChildren';
+import useCamundaToolsConfig from './useCamundaToolsConfig';
+
+import '../Header.scss';
+
+const SKIP_TO_CONTENT_TARGET_ID = 'main-content';
+
+export default function HeaderV2({noActions}: {noActions?: boolean}) {
+  const [userToken, setUserToken] = useState<string | null>(null);
+  const {mightFail} = useErrorHandling();
+  const {optimizeProfile, onboarding} = useUiConfig();
+
+  useEffect(() => {
+    mightFail(getUserToken(), setUserToken, showError);
+  }, [mightFail]);
+
+  const isCloud = optimizeProfile === 'cloud';
+
+  return (
+    <NavbarWrapper
+      isCloud={isCloud}
+      userToken={userToken}
+      getNewUserToken={getUserToken}
+      organizationId={onboarding.orgId}
+      clusterId={onboarding.clusterId}
+    >
+      <HeaderV2Body noActions={noActions} isCloud={isCloud} />
+    </NavbarWrapper>
+  );
+}
+
+// Rendered inside NavbarWrapper so the C3 tools and cluster-webapp breadcrumbs
+// resolve against the C3UserConfigurationProvider context (SaaS).
+function HeaderV2Body({noActions, isCloud}: {noActions?: boolean; isCloud: boolean}) {
+  const history = useHistory();
+  const {getBaseDocsUrl} = useDocs();
+  const {user} = useUser();
+  const {mightFail} = useErrorHandling();
+  const {enterpriseMode, optimizeVersion, validLicense, licenseType, commercial, expiresAt} =
+    useUiConfig();
+  const [logoutHidden, setLogoutHidden] = useState(false);
+
+  useEffect(() => {
+    mightFail(isLogoutHidden(), setLogoutHidden, showError);
+  }, [mightFail, user]);
+
+  const timezone = t('footer.timezone') + ' ' + Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const breadcrumbs = useClusterWebappBreadcrumbs({currentApp: 'optimize'});
+  const sidebarChildren = useSidebarChildren(noActions);
+  const {tools, ToolsProvider} = useCamundaToolsConfig({
+    noActions,
+    isCloud,
+    enterpriseMode,
+    optimizeVersion,
+    userName: user?.name ?? '',
+    userEmail: user?.email ?? '',
+    docsUrl: getBaseDocsUrl(),
+    timezone,
+    logoutHidden,
+    onLogout: () => history.replace('/logout'),
+  });
+
+  const showLicenseTag = !noActions && licenseType !== 'saas';
+
+  const options = useMemo(
+    (): Parameters<typeof useC3NavigationV2>[0] => ({
+      app: {
+        ariaLabel: t('appFullName').toString(),
+        linkProps: {to: '/'},
+      },
+      skipToContentTargetId: SKIP_TO_CONTENT_TARGET_ID,
+      sidebarLabels: {
+        collapse: t('navigation.sidebarCollapse').toString(),
+        expand: t('navigation.sidebarExpand').toString(),
+        toggleAriaLabel: (expanded) =>
+          expanded
+            ? t('navigation.sidebarCollapseAria').toString()
+            : t('navigation.sidebarExpandAria').toString(),
+        groupToggleAriaLabel: ({label, isExpanded}) =>
+          isExpanded
+            ? t('navigation.sidebarGroupCollapseAria', {label}).toString()
+            : t('navigation.sidebarGroupExpandAria', {label}).toString(),
+      },
+      activeItemKey: '',
+      sidebarChildren,
+      breadcrumbs,
+      tools,
+      // @ts-expect-error - we need to fix it from the C3 side
+      linkComponent: Link,
+      headerTrailingContent: showLicenseTag ? (
+        <C3LicenseTag
+          isProductionLicense={validLicense}
+          isCommercial={commercial}
+          expiresAt={expiresAt ?? undefined}
+        />
+      ) : undefined,
+    }),
+    [sidebarChildren, breadcrumbs, tools, showLicenseTag, validLicense, commercial, expiresAt]
+  );
+
+  const {navProps} = useC3NavigationV2(options);
+
+  return (
+    <ToolsProvider>
+      <C3NavigationV2 {...navProps} />
+    </ToolsProvider>
+  );
+}
+
+function getStage(host: string): 'dev' | 'int' | 'prod' {
+  if (host.includes('dev.ultrawombat.com')) {
+    return 'dev';
+  }
+
+  if (host.includes('ultrawombat.com')) {
+    return 'int';
+  }
+
+  if (host.includes('camunda.io')) {
+    return 'prod';
+  }
+
+  return 'dev';
+}
+
+type NavbarWrapperProps = Omit<
+  ComponentProps<typeof C3UserConfigurationProvider>,
+  'userToken' | 'activeOrganizationId'
+> & {
+  isCloud: boolean;
+  organizationId?: string;
+  clusterId?: string;
+  userToken?: string | null;
+};
+
+function NavbarWrapper({
+  isCloud,
+  userToken,
+  organizationId,
+  children,
+  clusterId,
+}: NavbarWrapperProps) {
+  if (isCloud && userToken && organizationId && clusterId) {
+    return (
+      <C3UserConfigurationProvider
+        userToken={userToken}
+        getNewUserToken={getUserToken}
+        activeOrganizationId={organizationId}
+        currentClusterUuid={clusterId}
+        currentApp="optimize"
+        stage={getStage(typeof window === 'undefined' ? '' : window.location.host)}
+      >
+        {children}
+      </C3UserConfigurationProvider>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/optimize/client/src/components/Header/HeaderV2/useCamundaToolsConfig.tsx
+++ b/optimize/client/src/components/Header/HeaderV2/useCamundaToolsConfig.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMemo} from 'react';
+import {
+  preview_useCamundaTools as useCamundaTools,
+  type UseCamundaToolsOptions,
+} from '@camunda/camunda-composite-components';
+
+import {t} from 'translation';
+
+type ToolsConfigParams = {
+  noActions?: boolean;
+  isCloud: boolean;
+  enterpriseMode: boolean;
+  optimizeVersion: string;
+  userName: string;
+  userEmail: string;
+  docsUrl: string;
+  timezone: string;
+  logoutHidden: boolean;
+  onLogout: () => void;
+};
+
+export default function useCamundaToolsConfig(params: ToolsConfigParams) {
+  const {
+    noActions,
+    isCloud,
+    enterpriseMode,
+    optimizeVersion,
+    userName,
+    userEmail,
+    docsUrl,
+    timezone,
+    logoutHidden,
+    onLogout,
+  } = params;
+
+  const options = useMemo(
+    () =>
+      ({
+        notifications: isCloud
+          ? {
+              title: t('navigation.notifications').toString(),
+              labels: {
+                dismissAll: t('navigation.notificationsDismissAll').toString(),
+                emptyTitle: t('navigation.notificationsEmptyTitle').toString(),
+                emptyDescription: t('navigation.notificationsEmptyDescription').toString(),
+              },
+            }
+          : undefined,
+        info: noActions
+          ? undefined
+          : {
+              ariaLabel: t('navigation.info').toString(),
+              title: t('navigation.info').toString(),
+              elements: [
+                {
+                  key: 'documentation',
+                  label: t('navigation.documentation').toString(),
+                  onClick: () => window.open(docsUrl, '_blank'),
+                },
+                {
+                  key: 'academy',
+                  label: t('navigation.academy').toString(),
+                  onClick: () => window.open('https://academy.camunda.com/', '_blank'),
+                },
+                {
+                  key: 'feedbackAndSupport',
+                  label: t('navigation.feedback').toString(),
+                  onClick: () =>
+                    window.open(
+                      enterpriseMode
+                        ? 'https://jira.camunda.com/projects/SUPPORT/queues'
+                        : 'https://forum.camunda.io/',
+                      '_blank'
+                    ),
+                },
+                {
+                  key: 'slackCommunityChannel',
+                  label: 'Slack Community Channel',
+                  onClick: () => window.open('https://camunda.com/slack', '_blank'),
+                },
+              ],
+            },
+        user: noActions
+          ? undefined
+          : {
+              ariaLabel: t('navigation.settings').toString(),
+              title: t('navigation.settings').toString(),
+              version: optimizeVersion,
+              name: userName,
+              email: userEmail,
+              onLogout: logoutHidden ? undefined : onLogout,
+              labels: {logOut: t('navigation.logout').toString()},
+              customSection: <div className="HeaderV2-timezone">{timezone}</div>,
+              elements: [
+                {
+                  key: 'terms',
+                  label: t('navigation.termsOfUse').toString(),
+                  onClick: () =>
+                    window.open(
+                      'https://camunda.com/legal/terms/camunda-platform/camunda-platform-8-saas-trial/',
+                      '_blank'
+                    ),
+                },
+                {
+                  key: 'privacy',
+                  label: t('navigation.privacyPolicy').toString(),
+                  onClick: () => window.open('https://camunda.com/legal/privacy/', '_blank'),
+                },
+                {
+                  key: 'imprint',
+                  label: t('navigation.imprint').toString(),
+                  onClick: () => window.open('https://camunda.com/legal/imprint/', '_blank'),
+                },
+              ],
+            },
+      }) satisfies UseCamundaToolsOptions,
+    [
+      noActions,
+      isCloud,
+      enterpriseMode,
+      optimizeVersion,
+      userName,
+      userEmail,
+      docsUrl,
+      timezone,
+      logoutHidden,
+      onLogout,
+    ]
+  );
+
+  return useCamundaTools(options);
+}

--- a/optimize/client/src/components/Header/HeaderV2/useSidebarChildren.tsx
+++ b/optimize/client/src/components/Header/HeaderV2/useSidebarChildren.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {matchPath, useLocation} from 'react-router-dom';
+import {Bot, Branch, ChartLineSmooth, Dashboard, Folder, Task} from '@carbon/react/icons';
+import type {SidebarNodeDescriptor} from '@camunda/camunda-composite-components';
+
+import {t} from 'translation';
+
+function isCurrentPage(active: string[], pathname: string): boolean {
+  return active.some((path) => matchPath(pathname, {path, exact: true}) !== null);
+}
+
+export default function useSidebarChildren(noActions?: boolean): SidebarNodeDescriptor[] {
+  const {pathname} = useLocation();
+
+  if (noActions) {
+    return [];
+  }
+
+  const isAnalysis = isCurrentPage(['/analysis/', '/analysis/*'], pathname);
+
+  const children = [
+    {
+      type: 'item',
+      key: 'dashboards',
+      label: t('navigation.dashboards').toString(),
+      icon: Dashboard,
+      linkProps: {to: '/'},
+      isActive: isCurrentPage(
+        ['/', '/processes/', '/processes/*', '/dashboard/instant/*'],
+        pathname
+      ),
+    },
+    {
+      type: 'item',
+      key: 'collections',
+      label: t('navigation.collections').toString(),
+      icon: Folder,
+      linkProps: {to: '/collections'},
+      isActive:
+        isCurrentPage(['/collections/', '/report/*', '/dashboard/*', '/collection/*'], pathname) &&
+        !isCurrentPage(['/dashboard/instant/*'], pathname),
+    },
+    {
+      type: 'group-item',
+      key: 'analysis',
+      label: t('navigation.analysis').toString(),
+      icon: ChartLineSmooth,
+      linkProps: {to: '/analysis'},
+      isActive: isAnalysis,
+      defaultExpanded: isAnalysis,
+      children: [
+        {
+          type: 'item',
+          key: 'analysis-task',
+          label: t('analysis.task.label').toString(),
+          icon: Task,
+          linkProps: {to: '/analysis/taskAnalysis'},
+          isActive: isCurrentPage(['/analysis/', '/analysis/taskAnalysis'], pathname),
+        },
+        {
+          type: 'item',
+          key: 'analysis-branch',
+          label: t('analysis.branchAnalysis').toString(),
+          icon: Branch,
+          linkProps: {to: '/analysis/branchAnalysis'},
+          isActive: isCurrentPage(['/analysis/branchAnalysis'], pathname),
+        },
+      ],
+    },
+    {
+      type: 'item',
+      key: 'agentic-control-plane',
+      label: t('navigation.agenticControlPlane').toString(),
+      icon: Bot,
+      linkProps: {to: '/agentic-control-plane'},
+      isActive: isCurrentPage(['/agentic-control-plane', '/agentic-control-plane/*'], pathname),
+    },
+  ];
+
+  // @ts-expect-error - we need to fix it from the C3 side
+  return children;
+}

--- a/optimize/client/src/components/PrivateRoute/PrivateRoute.js
+++ b/optimize/client/src/components/PrivateRoute/PrivateRoute.js
@@ -39,7 +39,7 @@ export function PrivateRoute({component: Component, ...rest}) {
           <>
             <Header />
             <main>
-              <div className="PrivateRoute">
+              <div className="PrivateRoute" id="main-content" tabIndex={-1}>
                 {rest.render ? rest.render(props) : <Component {...props} />}
               </div>
             </main>

--- a/optimize/client/src/components/PrivateRoute/PrivateRoute.js
+++ b/optimize/client/src/components/PrivateRoute/PrivateRoute.js
@@ -9,6 +9,7 @@
 import React, {useEffect} from 'react';
 import {Route} from 'react-router-dom';
 import {addHandler, removeHandler} from 'request';
+import {IS_NAV_V2_ENABLED} from 'feature-flags';
 
 import {Header} from '..';
 
@@ -39,7 +40,11 @@ export function PrivateRoute({component: Component, ...rest}) {
           <>
             <Header />
             <main>
-              <div className="PrivateRoute" id="main-content" tabIndex={-1}>
+              <div
+                className={'PrivateRoute' + (IS_NAV_V2_ENABLED ? ' nav-v2' : '')}
+                id="main-content"
+                tabIndex={-1}
+              >
                 {rest.render ? rest.render(props) : <Component {...props} />}
               </div>
             </main>

--- a/optimize/client/src/components/PrivateRoute/PrivateRoute.scss
+++ b/optimize/client/src/components/PrivateRoute/PrivateRoute.scss
@@ -9,4 +9,12 @@
     height: 100%;
     width: 100%;
   }
+
+  &.nav-v2 {
+    .cds--popover,
+    .cds--popover-content,
+    .Popover .cds--popover {
+      z-index: 8500;
+    }
+  }
 }

--- a/optimize/client/src/components/PrivateRoute/PrivateRoute.scss
+++ b/optimize/client/src/components/PrivateRoute/PrivateRoute.scss
@@ -1,5 +1,8 @@
 .PrivateRoute {
-  padding-top: 48px;
+  padding-top: var(--c3-header-height, 48px);
+  padding-left: var(--c3-sidebar-width, 0);
+  box-sizing: border-box;
+  transition: padding-left 0.15s ease-out;
 
   &,
   & > div {

--- a/optimize/client/src/modules/feature-flags.ts
+++ b/optimize/client/src/modules/feature-flags.ts
@@ -6,9 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {IS_NAV_V2_ENABLED} from 'feature-flags';
+const IS_NAV_V2_ENABLED = false;
 
-import LegacyHeader from './Header';
-import HeaderV2 from './HeaderV2';
-
-export const Header = IS_NAV_V2_ENABLED ? HeaderV2 : LegacyHeader;
+export {IS_NAV_V2_ENABLED};

--- a/optimize/client/yarn.lock
+++ b/optimize/client/yarn.lock
@@ -1262,15 +1262,15 @@
     inherits "^2.0.4"
     tiny-svg "^3.0.0"
 
-"@camunda/camunda-composite-components@^0.23.0":
-  version "0.23.3"
-  resolved "https://registry.npmjs.org/@camunda/camunda-composite-components/-/camunda-composite-components-0.23.3.tgz"
-  integrity sha512-/q4NeHifKu+NgI4G2U34+X7vW+C0aQxxXs87eSFgM0NPptSSNRW9GmILJU2f1Me+gPgNB9MiIxjQ3ti9zYQWWQ==
+"@camunda/camunda-composite-components@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@camunda/camunda-composite-components/-/camunda-composite-components-0.25.0.tgz#86dd4bb896da42d6466f551c1676f6cd501cc089"
+  integrity sha512-ssf47QUuNxgXEROUX+0Ti8bwIN8ekj+4r/vz9nSu2QnSZjMaFpgwRWP2x+fm3EvAt41UX5l6Q+WrYn8WLttPuw==
   dependencies:
     jwt-decode "4.0.0"
-    react-error-boundary "6.1.1"
+    react-error-boundary "6.1.2"
     react-markdown "10.1.0"
-    semver "7.7.4"
+    semver "7.8.4"
 
 "@carbon/colors@^11.30.0":
   version "11.30.0"
@@ -13650,10 +13650,10 @@ react-draggable@^4.4.6:
     clsx "^2.1.1"
     prop-types "^15.8.1"
 
-react-error-boundary@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.1.tgz"
-  integrity sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==
+react-error-boundary@6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-6.1.2.tgz#d213780329ceb3678cec7813a76a00e2a7584f48"
+  integrity sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==
 
 react-error-boundary@^6.0.0:
   version "6.1.0"
@@ -14569,10 +14569,10 @@ semver@7.5.3:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.7.4:
-  version "7.7.4"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
-  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+semver@7.8.4:
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.4.tgz#c73eceebae0616934be8dff28a7fd70757c8e696"
+  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
 
 semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"


### PR DESCRIPTION
## Summary

Per-app follow-up to #55050 (Tasklist C3 V2 integration), extracted cleanly from the all-apps demo branch #55216. Adds the C3 navigation V2 surface (collapsible sidebar + cluster-webapp breadcrumbs + tool panels) to **Optimize**, side-by-side with the existing V1 header, selected at build time by a new `IS_NAV_V2_ENABLED` flag (**default `false`** — V1 is unchanged).

This follows the conventions Vinicius established in the merged Tasklist PR and deliberately avoids the divergences present in the #55216 draft (see below).

## What it does

- **`modules/feature-flags.ts`** — introduces `IS_NAV_V2_ENABLED`. Lives under `src/modules` so `wireModules` auto-aliases it to the bare `feature-flags` specifier for both Vite and Jest.
- **`Header/index` switch** — the former `Header.tsx` moves verbatim to `LegacyHeader.tsx` (untouched V1); `Header.tsx` becomes a thin compile-time switch.
- **`Header/HeaderV2/`** — split into focused files (`index` + `useSidebarChildren` + `useCamundaToolsConfig`) rather than a monolith. The V2 body renders inside the existing `NavbarWrapper` so `useCamundaTools` / `useClusterWebappBreadcrumbs` resolve against the `C3UserConfigurationProvider` context; the SaaS wiring (`getStage` / `getUserToken`) is reused unchanged.
- **Sidebar** mirrors the existing navbar: Dashboards, Collections, an Analysis group (Task / Branch Analysis), and Agentic Control Plane. With the group in the sidebar, `Analysis` drops its in-page tabs under V2 and renders only the routed content.
- **Layout offset** uses pure CSS custom properties in `PrivateRoute.scss` (`--c3-header-height` / `--c3-sidebar-width` with fallbacks); `PrivateRoute` exposes `id="main-content"` for the skip-link target.
- **i18n** — V2-only nav/sidebar/notification strings added to both `en.json` and `de.json`, including the group collapse/expand aria keys.
- **deps** — `@camunda/camunda-composite-components` → `^0.25.0` (the latest release; Tasklist is bumped to the same in #55564). Optimize pins via caret per its existing convention.

## Divergences from the #55216 Optimize draft that are intentionally dropped

- No `getC3SidebarWidth.ts` JS service or `Popover.tsx` change — the layout offset is pure CSS, matching Tasklist.
- No `as never` casts — the sidebar tree is properly typed; the single known C3-vs-Carbon icon type gap is suppressed once at the boundary, as in Tasklist.
- No invented `getSaasModelerUrl` / hardcoded modeler URLs passed to breadcrumbs — `useClusterWebappBreadcrumbs({currentApp: 'optimize'})` derives links from the cluster context.
- Adds the previously-missing `agentic-control-plane` sidebar entry and the missing `sidebarGroup{Collapse,Expand}Aria` i18n keys.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `yarn test` green for `Header` / `HeaderV2` / `LegacyHeader` / `Analysis` (switch + V1 + V2 surfaces)
- [x] eslint/prettier clean on changed files
- [ ] Flag flipped to `true` locally: C3NavigationV2 header + sidebar render; Analysis sub-pages reachable from the sidebar group; license tag in self-managed; notifications in cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)
