### PR TITLE
deps: bump @camunda/camunda-composite-components to 0.25.0 in tasklist

### DIFF
--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -12,7 +12,7 @@
         "@bpmn-io/form-js-carbon-styles": "1.21.3",
         "@bpmn-io/form-js-viewer": "1.21.3",
         "@camunda/camunda-api-zod-schemas": "0.0.72",
-        "@camunda/camunda-composite-components": "0.24.0",
+        "@camunda/camunda-composite-components": "0.25.0",
         "@carbon/react": "1.108.0",
         "@monaco-editor/react": "4.7.0",
         "@tanstack/eslint-plugin-query": "5.101.0",
@@ -587,15 +587,15 @@
       }
     },
     "node_modules/@camunda/camunda-composite-components": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-composite-components/-/camunda-composite-components-0.24.0.tgz",
-      "integrity": "sha512-Uxq/RRLgfLV8N8Od/mA/WUnyTH9aQ5x4A+tMGGbUpv0FuccQPT8h2qLimc2YxOzZwljdXhAaTsNL2kb80mvfkg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-composite-components/-/camunda-composite-components-0.25.0.tgz",
+      "integrity": "sha512-ssf47QUuNxgXEROUX+0Ti8bwIN8ekj+4r/vz9nSu2QnSZjMaFpgwRWP2x+fm3EvAt41UX5l6Q+WrYn8WLttPuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "4.0.0",
-        "react-error-boundary": "6.1.1",
+        "react-error-boundary": "6.1.2",
         "react-markdown": "10.1.0",
-        "semver": "7.8.0"
+        "semver": "7.8.4"
       },
       "peerDependencies": {
         "@carbon/react": "1.x",
@@ -603,15 +603,6 @@
         "react": "18.x || 19.x",
         "react-dom": "18.x || 19.x",
         "styled-components": "5.x || 6.x"
-      }
-    },
-    "node_modules/@camunda/camunda-composite-components/node_modules/react-error-boundary": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.1.tgz",
-      "integrity": "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@camunda/lint-config": {
@@ -3580,9 +3571,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3597,9 +3585,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3614,9 +3599,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3631,9 +3613,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3648,9 +3627,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3665,9 +3641,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3682,9 +3655,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3699,9 +3669,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3716,9 +3683,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3733,9 +3697,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9602,9 +9563,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -8,7 +8,7 @@
     "@bpmn-io/form-js-carbon-styles": "1.21.3",
     "@bpmn-io/form-js-viewer": "1.21.3",
     "@camunda/camunda-api-zod-schemas": "0.0.72",
-    "@camunda/camunda-composite-components": "0.24.0",
+    "@camunda/camunda-composite-components": "0.25.0",
     "@carbon/react": "1.108.0",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/eslint-plugin-query": "5.101.0",


### PR DESCRIPTION
## Summary

Bumps Tasklist's `@camunda/camunda-composite-components` from `0.24.0` to `0.25.0` (latest release), keeping the C3 nav components current.

## Verification

- [x] `npm install` resolves cleanly against the new lockfile
- [x] `tsc --noEmit` clean — no API changes required
- [x] Header test suite green: **38 tests / 10 files** in `src/pages/Layout/Header`

No source changes were needed; the V2 nav preview API is unchanged between 0.24.0 and 0.25.0 for Tasklist's usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)