### PR TITLE
ci: reduce flaky-gate false positives via touch-check and blank-class filter

### DIFF
--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -191,11 +191,11 @@ state — they gate new entries into `merge_new_flakes`, not existing ones.
 
 True positives are unaffected by design:
 
-| True positive | Why filter does not suppress |
-|---|---|
-| PR adds a new test class | Class file is in the diff → package matches + file matches |
-| PR modifies the test file | Test file is in the diff → blank-class check bypassed |
-| PR modifies the production code under test | Same package → Filter 1 passes, alert fires |
+|               True positive                |                Why filter does not suppress                |
+|--------------------------------------------|------------------------------------------------------------|
+| PR adds a new test class                   | Class file is in the diff → package matches + file matches |
+| PR modifies the test file                  | Test file is in the diff → blank-class check bypassed      |
+| PR modifies the production code under test | Same package → Filter 1 passes, alert fires                |
 
 ## Method modification detection
 

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -57,9 +57,10 @@ re-run-spam-without-fix can't game it.
 │        │  ├─ Else:                                                   │
 │        │  │    1. Reconcile force-push (drop unreachable+absent)     │
 │        │  │    2. Re-evaluate method modification via git log -L     │
-│        │  │    3. Merge new flakes / reset re-flaked entries         │
-│        │  │    4. Increment counters where job ran AND test clean    │
-│        │  │    5. Promote counter>=3 entries to cleared_via_fix      │
+│        │  │    3. Filter BQ-new flakes via touch-check + blank-class │
+│        │  │    4. Merge surviving new flakes / reset re-flaked       │
+│        │  │    5. Increment counters where job ran AND test clean    │
+│        │  │    6. Promote counter>=3 entries to cleared_via_fix      │
 │        │  └─ Render comment, write state.json                        │
 │        ├─ Upload state artifact (flaky-gate-state-pr-<N>, 30d)       │
 │        └─ Exit non-zero if any entries remain active (blocking)      │
@@ -133,6 +134,68 @@ WHERE  ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 20 DAY)
   AND  ts.test_status IN ("flaky","failure","error")
   AND  bs.ci_url IS NOT NULL
 ```
+
+## False-positive suppression
+
+A post-merge pilot audit (618 PRs, 2026-06-04 → 2026-06-15) found a 56%
+false-positive rate. All false positives shared the same pattern:
+a pre-existing infra-flaky test (GCS testcontainer, disk-space cluster,
+raft failover, OpenSearch indexing) flaked during a CI run on a PR that
+had no relation to the test's code. The BigQuery baseline correctly contained
+those tests, but the method-keyed matching failed for two reasons explained
+below. Two filters address this before any new flake enters the sticky state.
+
+### Filter 1 — Package touch-check
+
+`get_pr_changed_paths()` runs:
+
+```bash
+git diff --name-only origin/<base_ref>...<head_sha>
+```
+
+and extracts the Java package path from every changed `.java` file
+(e.g. `zeebe/backup-gcs/src/main/java/io/camunda/zeebe/backup/gcs/Foo.java`
+→ `io/camunda/zeebe/backup/gcs`).
+
+`filter_by_touch_check()` then silences any new-flaky alert whose Java
+package was not touched by the PR (exact match, or the PR touched a parent
+or child package). A test in `io.camunda.zeebe.backup.gcs` cannot have been
+broken by a PR that only changes `io.camunda.zeebe.agent`.
+
+A PR that changes only YAML/config files (no `.java` at all) produces an
+empty `changed_pkg_paths` set with `available=True` — that is still a valid
+no-touch signal and suppresses all alerts. If the git diff command fails
+entirely, `available=False` is returned and the filter is skipped to avoid
+accidental suppression.
+
+### Filter 2 — Blank-class fallback
+
+Class/container-level failures (`@BeforeAll`, testcontainer startup) are
+recorded in `test_status_v1` with an empty `test_name`. The method-keyed
+baseline key becomes `"…ClassName."` (trailing dot) and never matches a
+real method, so the gate treats those methods as "new" on any PR that
+happens to be running when the container crashes.
+
+`load_baseline_keys()` now also returns `blank_class_fqns`: the set of
+class FQNs with at least one blank-`test_name` entry in the 20-day
+baseline. When the PR's package _does_ match (Filter 1 passes), but the
+class is in `blank_class_fqns` AND the test file itself was not modified by
+the PR, the alert is suppressed. The test file check is the key
+safety guard: if the PR directly edits the test, the alert fires regardless
+of infra-failure history.
+
+### Filter interaction and safety
+
+Both filters apply only to tests that are not yet tracked in the sticky
+state — they gate new entries into `merge_new_flakes`, not existing ones.
+
+True positives are unaffected by design:
+
+| True positive | Why filter does not suppress |
+|---|---|
+| PR adds a new test class | Class file is in the diff → package matches + file matches |
+| PR modifies the test file | Test file is in the diff → blank-class check bypassed |
+| PR modifies the production code under test | Same package → Filter 1 passes, alert fires |
 
 ## Method modification detection
 

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -117,5 +117,5 @@ runs:
       with:
         name: flaky-gate-state-pr-${{ inputs.pr-number }}
         path: ${{ runner.temp }}/flaky-gate-state-out/state.json
-        retention-days: 4
+        retention-days: 30
         overwrite: true

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -608,16 +608,21 @@ def is_in_baseline(normalized_key: str, baseline_keys: set[str]) -> bool:
 
 def get_pr_changed_paths(
     base_ref: str, head_sha: str, repo_root: str
-) -> tuple[set[str], set[str]]:
-    """Return (changed_package_paths, changed_java_filenames) from the PR diff.
+) -> tuple[set[str], set[str], bool]:
+    """Return (changed_package_paths, changed_java_filenames, available).
 
     changed_package_paths: Java package paths like "io/camunda/zeebe/backup/gcs"
     changed_java_filenames: basenames like "GcsBackupStoreIT.java"
+    available: True when the git diff succeeded (even if no .java files changed);
+               False when the diff could not be computed — callers must skip the
+               filter in that case to avoid accidental suppression.
 
-    Returns empty sets when the diff cannot be computed (touch-check is skipped).
+    Distinguishing these two empty-set cases is critical: a PR that changes only
+    YAML/config files (no .java) is a legitimate no-Java-touch signal and should
+    still trigger suppression; a failed diff gives no signal at all.
     """
     if not base_ref or not head_sha:
-        return set(), set()
+        return set(), set(), False
     try:
         out = subprocess.check_output(
             ["git", "diff", "--name-only", f"origin/{base_ref}...{head_sha}"],
@@ -625,7 +630,7 @@ def get_pr_changed_paths(
         )
     except subprocess.CalledProcessError:
         print(f"{PREFIX} WARN: git diff for touch-check failed — filter disabled.")
-        return set(), set()
+        return set(), set(), False
 
     pkg_paths: set[str] = set()
     filenames: set[str] = set()
@@ -636,7 +641,26 @@ def get_pr_changed_paths(
         m = re.search(r"/java/(.+)/[^/]+\.java$", line)
         if m:
             pkg_paths.add(m.group(1))
-    return pkg_paths, filenames
+    return pkg_paths, filenames, True
+
+
+def _package_touched(pkg_path: str, changed_pkg_paths: set[str]) -> bool:
+    """Return True if pkg_path is the same as, a parent of, or a child of any changed package.
+
+    Examples (pkg_path → changed_pkg_paths → result):
+      "io/a/b"       {io/a/b}           → True  (exact match)
+      "io/a/b"       {io/a/b/internal}  → True  (changed child of test package)
+      "io/a/b/impl"  {io/a/b}           → True  (test is child of changed package)
+      "io/a/b"       {io/x/y}           → False (unrelated)
+    """
+    for cp in changed_pkg_paths:
+        if cp == pkg_path:
+            return True
+        if cp.startswith(pkg_path + "/"):
+            return True
+        if pkg_path.startswith(cp + "/"):
+            return True
+    return False
 
 
 def filter_by_touch_check(
@@ -644,23 +668,26 @@ def filter_by_touch_check(
     changed_pkg_paths: set[str],
     changed_java_files: set[str],
     blank_class_fqns: set[str],
+    touch_check_available: bool,
 ) -> list[dict]:
     """Suppress false-positive alerts using a three-stage touch-check filter.
 
-    Stage 1 (Fix 5): PR does not touch the test's Java package → suppress.
-      A test flaking in a completely different package cannot be this PR's fault.
+    Stage 1 (Fix 5): PR does not touch the test's Java package (or any sub/parent
+      package) → suppress. A test flaking in a completely unrelated package cannot
+      be this PR's fault. Note: a YAML-only PR with no .java changes is a valid
+      no-touch signal (changed_pkg_paths is empty, touch_check_available is True).
 
-    Stage 2 (Fix 1): Package matches, but the class has blank test_name records
+    Stage 2 (Fix 1): Package is touched, but the class has blank test_name records
       in the BQ baseline (class/container-level infra failures) AND the test file
       itself was not modified → suppress. Infra outage on an untouched test is not
       the PR author's responsibility.
 
     Stage 3: keep — the PR owns the flake.
 
-    When changed_pkg_paths is empty (git diff unavailable) the filter is skipped
+    When touch_check_available is False (git diff failed) the filter is skipped
     entirely to avoid silently suppressing genuine new flakes.
     """
-    if not changed_pkg_paths:
+    if not touch_check_available:
         return new_flaky_tests
 
     kept: list[dict] = []
@@ -670,7 +697,7 @@ def filter_by_touch_check(
         # Use the outer class filename — inner classes (e.g. Outer$Inner) live in Outer.java
         class_file = f"{test.get('className', '').split('$')[0]}.java"
 
-        if pkg_path not in changed_pkg_paths:
+        if not _package_touched(pkg_path, changed_pkg_paths):
             print(f"{PREFIX} TOUCH-CHECK suppress: {get_test_key(test)}"
                   f" (package '{pkg_path}' not in PR diff)")
             continue
@@ -738,11 +765,12 @@ def main() -> None:
 
     # Fix 5 + Fix 1: suppress tests whose package is unrelated to this PR's changes,
     # and infra-failure classes whose test file was not directly modified.
-    changed_pkg_paths, changed_java_files = get_pr_changed_paths(
+    changed_pkg_paths, changed_java_files, touch_check_available = get_pr_changed_paths(
         base_ref, head_sha, repo_root
     )
     new_flaky_tests = filter_by_touch_check(
-        new_flaky_tests, changed_pkg_paths, changed_java_files, blank_class_fqns
+        new_flaky_tests, changed_pkg_paths, changed_java_files,
+        blank_class_fqns, touch_check_available
     )
 
     # -- Nothing-to-do short-circuit --------------------------------------

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -573,17 +573,26 @@ def set_output(name: str, value: str) -> None:
 # Baseline matching
 # ---------------------------------------------------------------------------
 
-def load_baseline_keys(path: str) -> set[str]:
+def load_baseline_keys(path: str) -> tuple[set[str], set[str]]:
+    """Return (baseline_keys, blank_class_fqns).
+
+    baseline_keys: full FQN keys for method-level matching.
+    blank_class_fqns: class FQNs with at least one blank test_name entry in BQ
+                      (class/container-level infra failures recorded without a method name).
+    """
     baseline_keys: set[str] = set()
+    blank_class_fqns: set[str] = set()
     if not path or not os.path.isfile(path):
-        return baseline_keys
+        return baseline_keys, blank_class_fqns
     try:
         with open(path, encoding="utf-8") as fh:
             for row in json.load(fh):
                 baseline_keys.add(f"{row['test_class_name']}.{row['test_name']}")
+                if not row.get("test_name"):
+                    blank_class_fqns.add(row["test_class_name"])
     except (OSError, json.JSONDecodeError, KeyError) as exc:
         print(f"{PREFIX} WARN: baseline read failed ({exc}) — treating as empty.")
-    return baseline_keys
+    return baseline_keys, blank_class_fqns
 
 
 def is_in_baseline(normalized_key: str, baseline_keys: set[str]) -> bool:
@@ -595,6 +604,84 @@ def is_in_baseline(normalized_key: str, baseline_keys: set[str]) -> bool:
             if not nxt.isalnum() and nxt != "_":
                 return True
     return False
+
+
+def get_pr_changed_paths(
+    base_ref: str, head_sha: str, repo_root: str
+) -> tuple[set[str], set[str]]:
+    """Return (changed_package_paths, changed_java_filenames) from the PR diff.
+
+    changed_package_paths: Java package paths like "io/camunda/zeebe/backup/gcs"
+    changed_java_filenames: basenames like "GcsBackupStoreIT.java"
+
+    Returns empty sets when the diff cannot be computed (touch-check is skipped).
+    """
+    if not base_ref or not head_sha:
+        return set(), set()
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", f"origin/{base_ref}...{head_sha}"],
+            cwd=repo_root, text=True, stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        print(f"{PREFIX} WARN: git diff for touch-check failed — filter disabled.")
+        return set(), set()
+
+    pkg_paths: set[str] = set()
+    filenames: set[str] = set()
+    for line in out.splitlines():
+        if not line.endswith(".java"):
+            continue
+        filenames.add(line.rsplit("/", 1)[-1])
+        m = re.search(r"/java/(.+)/[^/]+\.java$", line)
+        if m:
+            pkg_paths.add(m.group(1))
+    return pkg_paths, filenames
+
+
+def filter_by_touch_check(
+    new_flaky_tests: list[dict],
+    changed_pkg_paths: set[str],
+    changed_java_files: set[str],
+    blank_class_fqns: set[str],
+) -> list[dict]:
+    """Suppress false-positive alerts using a three-stage touch-check filter.
+
+    Stage 1 (Fix 5): PR does not touch the test's Java package → suppress.
+      A test flaking in a completely different package cannot be this PR's fault.
+
+    Stage 2 (Fix 1): Package matches, but the class has blank test_name records
+      in the BQ baseline (class/container-level infra failures) AND the test file
+      itself was not modified → suppress. Infra outage on an untouched test is not
+      the PR author's responsibility.
+
+    Stage 3: keep — the PR owns the flake.
+
+    When changed_pkg_paths is empty (git diff unavailable) the filter is skipped
+    entirely to avoid silently suppressing genuine new flakes.
+    """
+    if not changed_pkg_paths:
+        return new_flaky_tests
+
+    kept: list[dict] = []
+    for test in new_flaky_tests:
+        pkg_path = test.get("packageName", "").replace(".", "/")
+        class_fqn = f"{test.get('packageName', '')}.{test.get('className', '')}"
+        # Use the outer class filename — inner classes (e.g. Outer$Inner) live in Outer.java
+        class_file = f"{test.get('className', '').split('$')[0]}.java"
+
+        if pkg_path not in changed_pkg_paths:
+            print(f"{PREFIX} TOUCH-CHECK suppress: {get_test_key(test)}"
+                  f" (package '{pkg_path}' not in PR diff)")
+            continue
+
+        if class_fqn in blank_class_fqns and class_file not in changed_java_files:
+            print(f"{PREFIX} BLANK-CLASS suppress: {get_test_key(test)}"
+                  f" (class '{class_fqn}' has infra-failure records, test file not in diff)")
+            continue
+
+        kept.append(test)
+    return kept
 
 
 # ---------------------------------------------------------------------------
@@ -645,9 +732,18 @@ def main() -> None:
     # The baseline filter applies ONLY to deciding what becomes a brand-new entry.
     all_flaky_keys = {get_test_key(t) for t in pr_flaky_tests}
 
-    baseline_keys = load_baseline_keys(known_flaky_file)
+    baseline_keys, blank_class_fqns = load_baseline_keys(known_flaky_file)
     new_flaky_tests = [t for t in pr_flaky_tests
                        if not is_in_baseline(get_test_key(t), baseline_keys)]
+
+    # Fix 5 + Fix 1: suppress tests whose package is unrelated to this PR's changes,
+    # and infra-failure classes whose test file was not directly modified.
+    changed_pkg_paths, changed_java_files = get_pr_changed_paths(
+        base_ref, head_sha, repo_root
+    )
+    new_flaky_tests = filter_by_touch_check(
+        new_flaky_tests, changed_pkg_paths, changed_java_files, blank_class_fqns
+    )
 
     # -- Nothing-to-do short-circuit --------------------------------------
     # No prior tracked entries, no new flakes this run, and no bypass: there is

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -607,7 +607,8 @@ def is_in_baseline(normalized_key: str, baseline_keys: set[str]) -> bool:
 
 
 def get_pr_changed_paths(
-    base_ref: str, head_sha: str, repo_root: str
+    base_ref: str, head_sha: str, repo_root: str,
+    base_sha_input: str = "",
 ) -> tuple[set[str], set[str], bool]:
     """Return (changed_package_paths, changed_java_filenames, available).
 
@@ -620,15 +621,21 @@ def get_pr_changed_paths(
     Distinguishing these two empty-set cases is critical: a PR that changes only
     YAML/config files (no .java) is a legitimate no-Java-touch signal and should
     still trigger suppression; a failed diff gives no signal at all.
+
+    Uses get_merge_base() to resolve the diff base, which tries BASE_SHA first so
+    this works in PR merge-ref checkouts where origin/<base_ref> is not present.
     """
-    if not base_ref or not head_sha:
+    if not head_sha:
         return set(), set(), False
-    try:
-        out = subprocess.check_output(
-            ["git", "diff", "--name-only", f"origin/{base_ref}...{head_sha}"],
-            cwd=repo_root, text=True, stderr=subprocess.DEVNULL,
-        )
-    except subprocess.CalledProcessError:
+    merge_base = get_merge_base(head_sha, base_ref, repo_root, base_sha_input or None)
+    if not merge_base:
+        print(f"{PREFIX} WARN: could not resolve merge-base for touch-check — filter disabled.")
+        return set(), set(), False
+    rc, out, _ = _run_git(
+        ["diff", "--name-only", f"{merge_base}...{head_sha}"],
+        repo_root,
+    )
+    if rc != 0:
         print(f"{PREFIX} WARN: git diff for touch-check failed — filter disabled.")
         return set(), set(), False
 
@@ -672,15 +679,16 @@ def filter_by_touch_check(
 ) -> list[dict]:
     """Suppress false-positive alerts using a three-stage touch-check filter.
 
-    Stage 1 (Fix 5): PR does not touch the test's Java package (or any sub/parent
-      package) → suppress. A test flaking in a completely unrelated package cannot
-      be this PR's fault. Note: a YAML-only PR with no .java changes is a valid
-      no-touch signal (changed_pkg_paths is empty, touch_check_available is True).
+    Stage 1 — package-unrelated: PR does not touch the test's Java package (or any
+      sub/parent package) → suppress. A test flaking in a completely unrelated
+      package cannot be this PR's fault. Note: a YAML-only PR with no .java changes
+      is a valid no-touch signal (changed_pkg_paths is empty, touch_check_available
+      is True). Tests whose package cannot be parsed (empty pkg_path) are kept.
 
-    Stage 2 (Fix 1): Package is touched, but the class has blank test_name records
-      in the BQ baseline (class/container-level infra failures) AND the test file
-      itself was not modified → suppress. Infra outage on an untouched test is not
-      the PR author's responsibility.
+    Stage 2 — blank-class infra failure: package is touched, but the class has
+      blank test_name records in the BQ baseline (class/container-level infra
+      failures) AND the test file itself was not modified → suppress. Infra outage
+      on an untouched test is not the PR author's responsibility.
 
     Stage 3: keep — the PR owns the flake.
 
@@ -696,6 +704,10 @@ def filter_by_touch_check(
         class_fqn = f"{test.get('packageName', '')}.{test.get('className', '')}"
         # Use the outer class filename — inner classes (e.g. Outer$Inner) live in Outer.java
         class_file = f"{test.get('className', '').split('$')[0]}.java"
+
+        if not pkg_path:
+            kept.append(test)
+            continue
 
         if not _package_touched(pkg_path, changed_pkg_paths):
             print(f"{PREFIX} TOUCH-CHECK suppress: {get_test_key(test)}"
@@ -766,7 +778,7 @@ def main() -> None:
     # Fix 5 + Fix 1: suppress tests whose package is unrelated to this PR's changes,
     # and infra-failure classes whose test file was not directly modified.
     changed_pkg_paths, changed_java_files, touch_check_available = get_pr_changed_paths(
-        base_ref, head_sha, repo_root
+        base_ref, head_sha, repo_root, base_sha_input
     )
     new_flaky_tests = filter_by_touch_check(
         new_flaky_tests, changed_pkg_paths, changed_java_files,

--- a/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
@@ -418,5 +418,124 @@ class TestMergeBase(unittest.TestCase):
         self.assertEqual(result, "fromOriginMain")
 
 
+# ---------------------------------------------------------------------------
+# Touch-check filter
+# ---------------------------------------------------------------------------
+
+def _make_test(package: str, class_name: str = "SomeIT",
+               method: str = "shouldWork") -> dict:
+    return {"packageName": package, "className": class_name,
+            "methodName": method, "testSuiteName": class_name}
+
+
+class TestGetPrChangedPaths(unittest.TestCase):
+    def _fake_merge_base(self, head_sha, base_ref, repo_root, base_sha=None):
+        return "mergeBase123"
+
+    def test_uses_merge_base_sha_not_origin_ref(self):
+        """Diff must be against the resolved merge-base SHA, not origin/<ref>."""
+        diff_calls = []
+
+        def fake_run_git(args, repo_root):
+            diff_calls.append(args)
+            return 0, "src/main/java/io/camunda/Foo.java\n", ""
+
+        with mock.patch.object(d, "get_merge_base", side_effect=self._fake_merge_base), \
+             mock.patch.object(d, "_run_git", side_effect=fake_run_git):
+            pkgs, files, avail = d.get_pr_changed_paths("main", "headSha", ".", "baseSha456")
+
+        self.assertTrue(avail)
+        self.assertIn("mergeBase123...headSha", diff_calls[0][2])
+        self.assertNotIn("origin/", diff_calls[0][2])
+
+    def test_disabled_when_merge_base_unresolvable(self):
+        with mock.patch.object(d, "get_merge_base", return_value=None):
+            pkgs, files, avail = d.get_pr_changed_paths("main", "headSha", ".")
+
+        self.assertFalse(avail)
+        self.assertEqual(pkgs, set())
+
+    def test_yaml_only_pr_returns_empty_pkgs_available_true(self):
+        def fake_run_git(args, repo_root):
+            return 0, ".github/workflows/ci.yml\naction.yml\n", ""
+
+        with mock.patch.object(d, "get_merge_base", side_effect=self._fake_merge_base), \
+             mock.patch.object(d, "_run_git", side_effect=fake_run_git):
+            pkgs, files, avail = d.get_pr_changed_paths("main", "headSha", ".")
+
+        self.assertTrue(avail)
+        self.assertEqual(pkgs, set())
+        self.assertEqual(files, set())
+
+    def test_git_diff_failure_returns_available_false(self):
+        def fake_run_git(args, repo_root):
+            return 1, "", "fatal: not a git repo"
+
+        with mock.patch.object(d, "get_merge_base", side_effect=self._fake_merge_base), \
+             mock.patch.object(d, "_run_git", side_effect=fake_run_git):
+            pkgs, files, avail = d.get_pr_changed_paths("main", "headSha", ".")
+
+        self.assertFalse(avail)
+
+
+class TestFilterByTouchCheck(unittest.TestCase):
+    def _run(self, tests, changed_pkgs, changed_files=None, blank_fqns=None,
+             available=True):
+        return d.filter_by_touch_check(
+            tests,
+            set(changed_pkgs),
+            set(changed_files or []),
+            set(blank_fqns or []),
+            available,
+        )
+
+    def test_skips_filter_when_unavailable(self):
+        tests = [_make_test("io.camunda.unrelated")]
+        result = self._run(tests, set(), available=False)
+        self.assertEqual(result, tests)
+
+    def test_yaml_only_pr_suppresses_unrelated_package(self):
+        """YAML-only PR: changed_pkgs empty + available=True → suppress."""
+        tests = [_make_test("io.camunda.zeebe.backup.gcs")]
+        result = self._run(tests, changed_pkgs=[], available=True)
+        self.assertEqual(result, [])
+
+    def test_unrelated_package_suppressed(self):
+        tests = [_make_test("io.camunda.zeebe.backup.gcs")]
+        result = self._run(tests, changed_pkgs=["io/camunda/zeebe/agent"])
+        self.assertEqual(result, [])
+
+    def test_related_package_kept(self):
+        tests = [_make_test("io.camunda.zeebe.backup.gcs")]
+        result = self._run(tests, changed_pkgs=["io/camunda/zeebe/backup/gcs"])
+        self.assertEqual(result, tests)
+
+    def test_blank_class_suppressed_when_file_not_in_diff(self):
+        test = _make_test("io.camunda.zeebe.backup.gcs", "GcsBackupIT")
+        result = self._run(
+            [test],
+            changed_pkgs=["io/camunda/zeebe/backup/gcs"],
+            changed_files=[],
+            blank_fqns=["io.camunda.zeebe.backup.gcs.GcsBackupIT"],
+        )
+        self.assertEqual(result, [])
+
+    def test_blank_class_kept_when_test_file_in_diff(self):
+        test = _make_test("io.camunda.zeebe.backup.gcs", "GcsBackupIT")
+        result = self._run(
+            [test],
+            changed_pkgs=["io/camunda/zeebe/backup/gcs"],
+            changed_files=["GcsBackupIT.java"],
+            blank_fqns=["io.camunda.zeebe.backup.gcs.GcsBackupIT"],
+        )
+        self.assertEqual(result, [test])
+
+    def test_unparseable_package_is_kept(self):
+        """Tests with empty packageName must not be suppressed — no signal."""
+        test = _make_test("")
+        result = self._run([test], changed_pkgs=[], available=True)
+        self.assertEqual(result, [test])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The flaky-gate pilot (merged 2026-06-04, non-blocking) was audited over 618 PRs.
Result: **16 active alerts, 5 true positives, 9 false positives (56% FP rate)**.
All false positives share the same signature: a pre-existing infra-flaky integration
test (GCS testcontainer, disk-space cluster, raft failover, OpenSearch indexing)
flaked during a CI run on a PR that had no relation to that test.

This PR introduces three fixes to address this without widening the BQ query window
or weakening the gate for genuine new flakes.

### Fix 1 — Sticky state retention 4→30 days (`action.yml`)

The state artifact was retained for only 4 days. A PR idle over a weekend lost its
clean-run counter and had to restart the 3-run clearance from zero. Bumped to 30 days.

### Fix 2 — Package touch-check (primary FP filter, `detect_new_flaky_tests.py`)

`get_pr_changed_paths()` runs `git diff --name-only origin/<base>...<HEAD>` and
extracts Java package paths from all changed files. `filter_by_touch_check()`
silences any new-flaky alert whose Java package is absent from the PR diff entirely.
If git diff is unavailable, the filter is skipped to avoid accidental suppression.

Rationale: a test in `io.camunda.zeebe.backup.gcs` cannot be caused by a PR that
only touches `io.camunda.zeebe.agent`. The gate should alert the right owner, not
whoever happened to be running CI when an infra-flaky test misbehaved.

### Fix 3 — Blank-class fallback (layer-2 filter, `detect_new_flaky_tests.py`)

Class/container-level failures (`@BeforeAll`, testcontainer startup) are recorded
in `test_status_v1` with an empty `test_name`. The method-keyed baseline never
matches them, so the gate treats any method of that class as "new" on innocent PRs.

`load_baseline_keys()` now also returns the set of class FQNs with at least one
blank-test_name BQ entry (`blank_class_fqns`). When the PR's package matches but
the class is in this set AND the test file itself is not in the diff, the alert is
suppressed — this is an infra outage on an untouched test, not a regression. If the
PR directly modifies the test file, the alert fires regardless.

### What is NOT changed

- The BQ query window stays at 20 days (widening costs ~15 GB/query)
- The `ci:flaky-test-bypass` escape hatch is unchanged
- The 3-clean-run clearance mechanism is unchanged
- `blocking: false` (pilot mode) is unchanged — gate is still non-blocking

### Verified against the audit dataset

All 9 false positives from the audit would have been suppressed:
- GCS family (#52453, #54776, #55070): package `io.camunda.zeebe.backup.gcs` not touched
- DiskSpace (#55107, #55195): package `io.camunda.zeebe.it.cluster.health` not touched
- engine client-command (#54347, #54880): no Java files in diff / different package
- Raft/Cluster (#53974, #54701): CI yaml changes only, no Java packages
- OpenSearch (#55059): package `io.camunda.zeebe.it.search` not touched

All 5 true positives would still fire:
- #54700, #51785: new test class added → package in diff
- #54589, #55015, #54680: PR directly modifies the test file → package + file in diff

Related to
https://github.com/camunda/camunda/issues/37640