### PR TITLE
test: increase archiver IT assertion timeout to fix CI flakiness

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -51,7 +51,6 @@ import io.camunda.webapps.schema.entities.post.PostImporterQueueEntity;
 import io.camunda.webapps.schema.entities.usertask.SnapshotTaskVariableEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
-import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -82,7 +81,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
           // check that the process is no longer in the main index
           verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
@@ -118,7 +117,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(5);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(5);
 
           // check that the first batch of processes are no longer in the main index
           for (var i = 0; i < batchSize; i++) {
@@ -153,7 +152,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
           // check that the finished process is no longer in the main index
           verifyMoved(listViewTemplate, client, finishedInstance, "2020-01-01");
@@ -185,7 +184,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
           // check that the finished process is no longer in the main index
           verifyMoved(listViewTemplate, client, finishedInstance, "2020-01-01");
@@ -223,7 +222,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
           // check that the process is no longer in the main index
           verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
@@ -265,7 +264,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
           // check that the process is no longer in the main index
           verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
@@ -319,7 +318,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
           // check that the process is no longer in the main index
           verifyMoved(listViewTemplate, client, finishedInstance, "2020-01-01");
@@ -375,7 +374,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
           // check that the process is no longer in the main index
           verifyMoved(listViewTemplate, client, finishedInstance, "2020-01-01");
@@ -423,7 +422,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
           // check that the process is no longer in the main index
           verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -64,6 +64,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
   protected static final int PARTITION_ID = 1;
   protected static final AtomicLong ID_GENERATOR = new AtomicLong(1);
   protected static final Instant NOW = Instant.parse("2026-05-01T10:26:00Z");
+  protected static final Duration ARCHIVE_TIMEOUT = Duration.ofSeconds(30L);
 
   @RegisterExtension private static SearchDBExtension searchDB = SearchDBExtension.create();
 
@@ -117,7 +118,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(0);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(0);
         });
   }
 


### PR DESCRIPTION

## Description

With 3 shards (added in #55376 to catch routing bugs), reindex/delete operations using slices:auto spawn one task per shard. Under CI load this regularly pushes job.execute() past the previous 5s succeedsWithin limit, causing spurious failures on the OpenSearch parameterised variant.

Extracted a shared ARCHIVE_TIMEOUT constant (30s) in ArchiverJobIT and replaced all 10 hardcoded Duration.ofSeconds(5L) usages across ArchiverJobIT and AbstractProcessInstanceArchiverJobIT.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
