### PR TITLE
fix: add priority to jobChangesetSchema and use .int() on retries

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -18,7 +18,7 @@
 		"lint:knip": "knip --tsConfig tsconfig.browser.json"
 	},
 	"dependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.73",
+		"@camunda/camunda-api-zod-schemas": "0.0.74",
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
 		"bpmn-js": "18.16.1",
 		"diagram-js-minimap": "5.3.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -28,7 +28,7 @@
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
-				"@camunda/camunda-api-zod-schemas": "0.0.73",
+				"@camunda/camunda-api-zod-schemas": "0.0.74",
 				"@camunda/camunda-composite-components": "0.24.0",
 				"@carbon/react": "1.109.0",
 				"@carbon/type": "11.61.0",
@@ -357,7 +357,7 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
 			"integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@bpmn-io/diagram-js-ui": {
@@ -650,6 +650,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
 			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -661,6 +662,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
 			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -671,6 +673,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
 			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1035,7 +1038,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
 			"integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1045,7 +1048,7 @@
 			"version": "6.0.12",
 			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
 			"integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/core": "^11.1.9",
@@ -1067,7 +1070,7 @@
 			"version": "11.1.9",
 			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
 			"integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/ansi": "^2.0.5",
@@ -1094,7 +1097,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
 			"integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1104,7 +1107,7 @@
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
 			"integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1252,7 +1255,7 @@
 			"version": "0.41.6",
 			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.6.tgz",
 			"integrity": "sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@open-draft/deferred-promise": "^2.2.0",
@@ -1270,6 +1273,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
 			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1288,14 +1292,14 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
 			"integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@open-draft/logger": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
 			"integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-node-process": "^1.2.0",
@@ -1306,7 +1310,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
 			"integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -1436,9 +1440,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1456,9 +1457,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1476,9 +1474,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1496,9 +1491,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1516,9 +1508,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1536,9 +1525,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1556,9 +1542,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1576,9 +1559,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1789,9 +1769,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1806,9 +1783,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1823,9 +1797,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1840,9 +1811,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1857,9 +1825,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1874,9 +1839,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1891,9 +1853,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1908,9 +1867,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2301,7 +2257,7 @@
 			"version": "1.0.0-next.29",
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
 			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
@@ -2311,11 +2267,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2327,11 +2285,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2343,11 +2303,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2359,11 +2321,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2375,11 +2339,13 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2391,14 +2357,13 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2410,14 +2375,13 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2429,14 +2393,13 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2448,14 +2411,13 @@
 			"cpu": [
 				"s390x"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2467,14 +2429,13 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2486,14 +2447,13 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2505,11 +2465,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openharmony"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2521,8 +2483,10 @@
 			"cpu": [
 				"wasm32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@emnapi/core": "1.10.0",
 				"@emnapi/runtime": "1.10.0",
@@ -2539,11 +2503,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2555,11 +2521,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -2678,7 +2646,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -3524,6 +3492,7 @@
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
 			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -3534,7 +3503,7 @@
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
 			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/deep-eql": "*",
@@ -3560,7 +3529,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
 			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/esrecurse": {
@@ -3624,7 +3593,7 @@
 			"version": "25.9.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
 			"integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": ">=7.24.0 <7.24.7"
@@ -3663,7 +3632,7 @@
 			"version": "2.4.10",
 			"resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
 			"integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
@@ -3673,7 +3642,7 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
 			"integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/unist": {
@@ -3927,6 +3896,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3940,6 +3910,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3953,6 +3924,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3966,6 +3938,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3979,6 +3952,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3992,6 +3966,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4005,6 +3980,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4018,9 +3994,7 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4034,9 +4008,7 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4050,9 +4022,7 @@
 			"cpu": [
 				"loong64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4066,9 +4036,7 @@
 			"cpu": [
 				"loong64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4082,9 +4050,7 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4098,9 +4064,7 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4114,9 +4078,7 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4130,9 +4092,7 @@
 			"cpu": [
 				"s390x"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4146,9 +4106,7 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4162,9 +4120,7 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4178,6 +4134,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4191,6 +4148,7 @@
 			"cpu": [
 				"wasm32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -4209,6 +4167,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4222,6 +4181,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4235,6 +4195,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4271,7 +4232,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.9.tgz",
 			"integrity": "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@blazediff/core": "1.9.1",
@@ -4294,7 +4255,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.9.tgz",
 			"integrity": "sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/browser": "4.1.9",
@@ -4349,7 +4310,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
 			"integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
@@ -4367,7 +4328,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
 			"integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/spy": "4.1.9",
@@ -4394,7 +4355,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
@@ -4404,7 +4365,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
 			"integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tinyrainbow": "^3.1.0"
@@ -4417,7 +4378,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
 			"integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/utils": "4.1.9",
@@ -4431,7 +4392,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
 			"integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/pretty-format": "4.1.9",
@@ -4447,7 +4408,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
 			"integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -4457,7 +4418,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.9.tgz",
 			"integrity": "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/utils": "4.1.9",
@@ -4479,7 +4440,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
 			"integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/pretty-format": "4.1.9",
@@ -4550,7 +4511,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -4560,7 +4521,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -4585,7 +4546,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
 			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -4854,7 +4815,7 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
 			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -4978,7 +4939,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
 			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">= 12"
@@ -4988,7 +4949,7 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -5126,7 +5087,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
 			"integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -5698,7 +5659,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/entities": {
@@ -5735,7 +5696,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
 			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/es-toolkit": {
@@ -6072,7 +6033,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
 			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.0.0"
@@ -6113,14 +6074,14 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
 			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-string-width": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
 			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-string-truncated-width": "^3.0.2"
@@ -6130,7 +6091,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
 			"integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-string-width": "^3.0.2"
@@ -6167,7 +6128,7 @@
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
 			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/file-entry-cache": {
@@ -6266,12 +6227,14 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -6289,7 +6252,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
@@ -6397,7 +6360,7 @@
 			"version": "16.13.2",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
 			"integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -6457,7 +6420,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
 			"integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/set-cookie-parser": "^2.4.10",
@@ -6715,7 +6678,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6766,7 +6729,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
 			"integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-plain-obj": {
@@ -7090,9 +7053,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7110,9 +7070,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7130,9 +7087,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7150,9 +7104,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7170,9 +7121,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7190,9 +7138,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7210,9 +7155,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7230,9 +7172,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7448,11 +7387,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -7468,11 +7409,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -7488,11 +7431,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -7508,11 +7453,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -7528,11 +7475,13 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -7548,11 +7497,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -7568,11 +7519,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -7588,11 +7541,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -7608,11 +7563,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -7628,11 +7585,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -7648,11 +7607,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -8534,7 +8495,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
 			"integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -8550,7 +8511,7 @@
 			"version": "2.14.6",
 			"resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
 			"integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
-			"devOptional": true,
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8595,14 +8556,14 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
 			"integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mute-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
 			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -8752,7 +8713,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
 			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
@@ -8831,7 +8792,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
 			"integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/oxc-parser": {
@@ -9045,7 +9006,7 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
 			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/path-type": {
@@ -9105,7 +9066,7 @@
 			"version": "1.61.0",
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
 			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"playwright-core": "1.61.0"
@@ -9124,7 +9085,7 @@
 			"version": "1.61.0",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
 			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
@@ -9137,12 +9098,14 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -9151,7 +9114,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
 			"integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.19.0"
@@ -9463,7 +9426,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -9503,7 +9466,7 @@
 			"version": "0.11.11",
 			"resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
 			"integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/rolldown": {
@@ -9706,7 +9669,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
 			"integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/shebang-command": {
@@ -9747,14 +9710,14 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
 			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/signal-exit": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -9776,7 +9739,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
 			"integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@polka/url": "^1.0.0-next.24",
@@ -9903,14 +9866,14 @@
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
 			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/statuses": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
 			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -9927,14 +9890,14 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
 			"integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -9963,7 +9926,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -10098,7 +10061,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
 			"integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -10117,14 +10080,14 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
 			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
 			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -10150,7 +10113,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
 			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
@@ -10160,7 +10123,7 @@
 			"version": "7.0.28",
 			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
 			"integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tldts-core": "^7.0.28"
@@ -10173,7 +10136,7 @@
 			"version": "7.0.28",
 			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
 			"integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/toggle-selection": {
@@ -10186,7 +10149,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
 			"integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -10196,7 +10159,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
 			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tldts": "^7.0.5"
@@ -10259,7 +10222,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
 			"integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"dependencies": {
 				"tagged-tag": "^1.0.0"
@@ -10329,7 +10292,7 @@
 			"version": "7.24.6",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
 			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unified": {
@@ -10545,7 +10508,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
 			"integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/kettanaito"
@@ -10768,7 +10731,7 @@
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
 			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/expect": "4.1.9",
@@ -10883,7 +10846,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
 			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/void-elements": {
@@ -10937,7 +10900,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
 			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"siginfo": "^2.0.0",
@@ -10963,7 +10926,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -10988,7 +10951,7 @@
 			"version": "8.21.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
 			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -11026,7 +10989,7 @@
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
@@ -11042,7 +11005,7 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
 			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
@@ -11058,7 +11021,7 @@
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -11077,7 +11040,7 @@
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -11132,13 +11095,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.73",
+				"@camunda/camunda-api-zod-schemas": "0.0.74",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.73",
+			"version": "0.0.74",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.9.3",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.73",
+		"@camunda/camunda-api-zod-schemas": "0.0.74",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.0.74
+
+### 🚀 Enhancements
+
+- Add `priority` field to `jobChangesetSchema` for job update requests
+- Use `.int()` constraint on `retries` in `jobChangesetSchema` to match the OpenAPI `int32` schema
+
+### ❤️ Contributors
+
+- Eddie Tsedeke ([@etcd](https://github.com/etcd))
+
 ## v0.0.73
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/job.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/job.ts
@@ -240,8 +240,9 @@ const completeJob: Endpoint<Pick<Job, 'jobKey'>> = {
 };
 
 const jobChangesetSchema = z.object({
-	retries: z.number().optional(),
-	timeout: z.number().optional(),
+	retries: z.number().int().optional(),
+	timeout: z.number().int().optional(),
+	priority: z.number().int().optional(),
 });
 type JobChangeset = z.infer<typeof jobChangesetSchema>;
 

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.73",
+	"version": "0.0.74",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add `priority` field to `jobChangesetSchema` for job update requests and use `int` for retries.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
