### PR TITLE
feat: export agent instance records in Optimize mode exporter filter

### DIFF
--- a/optimize/AGENTS.md
+++ b/optimize/AGENTS.md
@@ -38,6 +38,17 @@ C7 usage. Do **not** rename it to `processDefinitionId` or add
 For the complete field-by-field mapping between Optimize names and C8 Zeebe names, you can use the
 Zeebe import service code as reference.
 
+### Exporter Filter ↔ Optimize Importer Coupling
+
+The Zeebe Elasticsearch/OpenSearch **exporter filter** has an Optimize mode
+(`OptimizeModeFilter` in `zeebe/exporter-filter`) that exports only the records and intents
+Optimize needs. This list must stay in sync with the Optimize importer:
+
+- **When the Optimize importer starts consuming a new record type or intent**, verify and update
+  `OptimizeModeFilter` so those records are not silently dropped before reaching the indices.
+- **Any change to the Optimize importer regarding records or intents** must be evaluated from the
+  exporter filter perspective (and vice versa) to keep both sides consistent.
+
 ### Build
 
 Optimize is skipped by `-Dquickly` at the monorepo level. To build only Optimize:

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/OptimizeModeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/OptimizeModeFilter.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.filter;
 
 import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
  *   <li>INCIDENT: {@link IncidentIntent#CREATED}, {@link IncidentIntent#RESOLVED}
  *   <li>USER_TASK: ASSIGNED, CANCELED, COMPLETED, CREATING
  *   <li>VARIABLE: CREATED, UPDATED
+ *   <li>AGENT_INSTANCE: CREATED, UPDATED, COMPLETED
  * </ul>
  *
  * <p>The filter is applied only if the broker version is at least 8.9.0.
@@ -67,6 +69,10 @@ public final class OptimizeModeFilter implements ExporterRecordFilter, RecordVer
   private static final EnumSet<VariableIntent> ALLOWED_VARIABLE_INTENTS =
       EnumSet.of(VariableIntent.CREATED, VariableIntent.UPDATED);
 
+  private static final EnumSet<AgentInstanceIntent> ALLOWED_AGENT_INSTANCE_INTENTS =
+      EnumSet.of(
+          AgentInstanceIntent.CREATED, AgentInstanceIntent.UPDATED, AgentInstanceIntent.COMPLETED);
+
   @Override
   public boolean accept(final Record<?> record) {
     final boolean accepted =
@@ -76,6 +82,7 @@ public final class OptimizeModeFilter implements ExporterRecordFilter, RecordVer
           case INCIDENT -> isAcceptedIncident(record);
           case USER_TASK -> isAcceptedUserTask(record);
           case VARIABLE -> isAcceptedVariable(record);
+          case AGENT_INSTANCE -> isAcceptedAgentInstance(record);
           default -> false;
         };
     if (!accepted && LOG.isDebugEnabled()) {
@@ -120,6 +127,11 @@ public final class OptimizeModeFilter implements ExporterRecordFilter, RecordVer
   private boolean isAcceptedVariable(final Record<?> record) {
     final var intent = (VariableIntent) record.getIntent();
     return ALLOWED_VARIABLE_INTENTS.contains(intent);
+  }
+
+  private boolean isAcceptedAgentInstance(final Record<?> record) {
+    final var intent = (AgentInstanceIntent) record.getIntent();
+    return ALLOWED_AGENT_INSTANCE_INTENTS.contains(intent);
   }
 
   @Override

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/OptimizeModeFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/OptimizeModeFilterTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -150,6 +151,25 @@ final class OptimizeModeFilterTest {
     assertThat(filter.accept(created)).as("VARIABLE.CREATED should be accepted").isTrue();
     assertThat(filter.accept(updated)).as("VARIABLE.UPDATED should be accepted").isTrue();
     assertThat(filter.accept(migrated)).as("VARIABLE.MIGRATED should be rejected").isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // AGENT_INSTANCE
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptOnlyCreatedUpdatedAndCompletedAgentInstances() {
+    final var created = record(ValueType.AGENT_INSTANCE, AgentInstanceIntent.CREATED);
+    final var updated = record(ValueType.AGENT_INSTANCE, AgentInstanceIntent.UPDATED);
+    final var completed = record(ValueType.AGENT_INSTANCE, AgentInstanceIntent.COMPLETED);
+    final var createCommand = record(ValueType.AGENT_INSTANCE, AgentInstanceIntent.CREATE);
+
+    assertThat(filter.accept(created)).as("AGENT_INSTANCE.CREATED should be accepted").isTrue();
+    assertThat(filter.accept(updated)).as("AGENT_INSTANCE.UPDATED should be accepted").isTrue();
+    assertThat(filter.accept(completed)).as("AGENT_INSTANCE.COMPLETED should be accepted").isTrue();
+    assertThat(filter.accept(createCommand))
+        .as("AGENT_INSTANCE.CREATE is not in the allowed set and should be rejected")
+        .isFalse();
   }
 
   // ---------------------------------------------------------------------------

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ExporterFilterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ExporterFilterIT.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -283,17 +284,22 @@ final class ExporterFilterIT {
         processInstanceRecord(
             "any-process", ProcessInstanceIntent.ELEMENT_COMPLETED, BpmnElementType.SEQUENCE_FLOW);
 
+    // AgentInstanceIntent.CREATED is in the Optimize-allowed set
+    final var agentInstanceCreated = agentInstanceRecord(AgentInstanceIntent.CREATED);
+
     // when
     exportFiltered(variableCreated);
     exportFiltered(variableMigrated);
     exportFiltered(piCompleted);
     exportFiltered(piSequenceFlow);
+    exportFiltered(agentInstanceCreated);
 
     // then
     assertIndexed(variableCreated);
     assertNotIndexed(variableMigrated);
     assertIndexed(piCompleted);
     assertNotIndexed(piSequenceFlow);
+    assertIndexed(agentInstanceCreated);
 
     // and: disabling optimize mode again restores full export for the same records
     config.index.setOptimizeModeEnabled(false);
@@ -681,6 +687,15 @@ final class ExporterFilterIT {
                 .withRecordType(RecordType.EVENT)
                 .withIntent(VariableIntent.CREATED)
                 .withValue(value));
+  }
+
+  private Record<?> agentInstanceRecord(final AgentInstanceIntent intent) {
+    return factory.generateRecord(
+        ValueType.AGENT_INSTANCE,
+        r ->
+            r.withBrokerVersion(BROKER_VERSION)
+                .withRecordType(RecordType.EVENT)
+                .withIntent(intent));
   }
 
   private Record<ProcessInstanceRecordValue> processInstanceRecord(


### PR DESCRIPTION
Agent instance records are relevant for Optimize, so OptimizeModeFilter now accepts AGENT_INSTANCE records with CREATED, UPDATED, and COMPLETED intents instead of dropping them by default. Updates the filter Javadoc and adds unit and integration coverage for the new behavior.

## Related issues

closes https://github.com/camunda/camunda/issues/55584
