### PR TITLE
Handle groups with names different from IDs in Tasklist V1 API search

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskRestrictionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskRestrictionsIT.java
@@ -64,6 +64,7 @@ public class UserTaskRestrictionsIT {
   private static final String GROUP1 = "group1";
   private static final String GROUP2 = "group2";
   private static final String GROUP3_ID = "group3";
+  private static final String GROUP3_NAME = "Group 3";
 
   private static final String PROCESS_ID_1 = "processWithCandidateUsers";
   private static final BpmnModelInstance PROCESS_1 =
@@ -96,7 +97,7 @@ public class UserTaskRestrictionsIT {
           .moveToNode("startParallel")
           .userTask("group3Task")
           .zeebeUserTask()
-          .zeebeCandidateGroups(GROUP3_ID)
+          .zeebeCandidateGroups(GROUP3_NAME)
           .done();
 
   @UserDefinition
@@ -152,7 +153,7 @@ public class UserTaskRestrictionsIT {
   private static final TestGroup GROUP3_GROUP =
       new TestGroup(
           GROUP3_ID,
-          GROUP3_ID,
+          GROUP3_NAME,
           List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))),
           List.of(new Membership(USER5, EntityType.USER)));
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskRestrictionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskRestrictionsIT.java
@@ -100,6 +100,16 @@ public class UserTaskRestrictionsIT {
           .zeebeCandidateGroups(GROUP3_NAME)
           .done();
 
+  private static final String PROCESS_ID_3 = "processWithCandidateGroupById";
+  private static final BpmnModelInstance PROCESS_3 =
+      Bpmn.createExecutableProcess(PROCESS_ID_3)
+          .startEvent()
+          .userTask("group3TaskByGroupId")
+          .zeebeUserTask()
+          .zeebeCandidateGroups(GROUP3_ID)
+          .endEvent()
+          .done();
+
   @UserDefinition
   private static final TestUser ADMIN_USER =
       new TestUser(
@@ -159,18 +169,23 @@ public class UserTaskRestrictionsIT {
 
   private static long processInstanceKeyCandidateUsers;
   private static long processInstanceKeyCandidateGroups;
+  private static long processInstanceKeyCandidateGroupById;
 
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
     deployResource(adminClient, PROCESS_1, PROCESS_ID_1 + ".bpmn");
     deployResource(adminClient, PROCESS_2, PROCESS_ID_2 + ".bpmn");
+    deployResource(adminClient, PROCESS_3, PROCESS_ID_3 + ".bpmn");
     final var startEvent1 = startProcessInstance(adminClient, PROCESS_ID_1);
     final var startEvent2 = startProcessInstance(adminClient, PROCESS_ID_2);
+    final var startEvent3 = startProcessInstance(adminClient, PROCESS_ID_3);
     processInstanceKeyCandidateUsers = startEvent1.getProcessInstanceKey();
     processInstanceKeyCandidateGroups = startEvent2.getProcessInstanceKey();
+    processInstanceKeyCandidateGroupById = startEvent3.getProcessInstanceKey();
 
     awaitUserTaskBeingAvailable(adminClient, processInstanceKeyCandidateUsers, 2);
     awaitUserTaskBeingAvailable(adminClient, processInstanceKeyCandidateGroups, 3);
+    awaitUserTaskBeingAvailable(adminClient, processInstanceKeyCandidateGroupById, 1);
   }
 
   @Test
@@ -229,7 +244,8 @@ public class UserTaskRestrictionsIT {
       // searching for tasks available to user1 and user2 (no process instance key provided)
       final HttpResponse<String> user3Response = tasklistUser3RestClient.searchTasks(null);
       final HttpResponse<String> user4Response = tasklistUser4RestClient.searchTasks(null);
-      final HttpResponse<String> user5Response = tasklistUser5RestClient.searchTasks(null);
+      final HttpResponse<String> user5Response =
+          tasklistUser5RestClient.searchTasks(processInstanceKeyCandidateGroups);
 
       // then
       assertThat(user3Response).isNotNull();
@@ -254,6 +270,32 @@ public class UserTaskRestrictionsIT {
               user5Response.body(), TaskSearchResponse[].class);
       assertThat(tasksUser5).hasSize(1);
       // The engine resolves the group name to its ID at task creation time
+      assertThat(tasksUser5[0].getCandidateGroups()).containsExactly(GROUP3_ID);
+    }
+  }
+
+  @Test
+  public void searchShouldReturnCandidateGroupTasksWhenCandidateGroupIsId()
+      throws JsonProcessingException {
+    // given
+    try (final var tasklistUser5RestClient =
+        STANDALONE_CAMUNDA
+            .newTasklistClient()
+            .withAuthentication(USER5_USER.username(), USER5_USER.password())) {
+
+      // when
+      // user5 is a member of group3 (ID: "group3", name: "Group 3")
+      // the task defines the candidate group by ID; the Tasklist V1 API must resolve both sides
+      // to names before comparing so the task is visible even when group name != group ID
+      final HttpResponse<String> user5Response =
+          tasklistUser5RestClient.searchTasks(processInstanceKeyCandidateGroupById);
+
+      // then
+      assertThat(user5Response.statusCode()).isEqualTo(200);
+      final TaskSearchResponse[] tasksUser5 =
+          TestRestTasklistClient.OBJECT_MAPPER.readValue(
+              user5Response.body(), TaskSearchResponse[].class);
+      assertThat(tasksUser5).hasSize(1);
       assertThat(tasksUser5[0].getCandidateGroups()).containsExactly(GROUP3_ID);
     }
   }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -47,8 +47,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -138,8 +140,8 @@ public class TaskController extends ApiErrorController {
           new TaskByCandidateUserOrGroup();
       taskByCandidateUserOrGroup.setUserName(userName);
 
-      final var setOfUserGroupNames = resolveGroupNames(userGroupService.getUserGroups());
-      taskByCandidateUserOrGroup.setUserGroups(setOfUserGroupNames.toArray(String[]::new));
+      final var userGroupIdentifiers = resolveGroupIdentifiers(userGroupService.getUserGroups());
+      taskByCandidateUserOrGroup.setUserGroups(userGroupIdentifiers.toArray(String[]::new));
 
       query.setTaskByCandidateUserOrGroup(taskByCandidateUserOrGroup);
     }
@@ -261,13 +263,18 @@ public class TaskController extends ApiErrorController {
       // this is backwards compatible with previous versions, but in the future this will change
       return true;
     }
-    final Set<String> setOfUserGroups = resolveGroupNames(userGroupService.getUserGroups());
     final var task = taskSupplier.get();
     final boolean allUsersTask =
         task.getCandidateUsers() == null && task.getCandidateGroups() == null;
-    final boolean candidateGroupTasks =
-        task.getCandidateGroups() != null
-            && !Collections.disjoint(Arrays.asList(task.getCandidateGroups()), setOfUserGroups);
+    final boolean candidateGroupTasks;
+    if (task.getCandidateGroups() != null) {
+      final Set<String> userGroupIdentifiers =
+          resolveGroupIdentifiers(userGroupService.getUserGroups());
+      candidateGroupTasks =
+          !Collections.disjoint(Arrays.asList(task.getCandidateGroups()), userGroupIdentifiers);
+    } else {
+      candidateGroupTasks = false;
+    }
     final boolean candidateUserTasks =
         task.getCandidateUsers() != null
             && Arrays.asList(task.getCandidateUsers()).contains(userName);
@@ -531,19 +538,19 @@ public class TaskController extends ApiErrorController {
     return ResponseEntity.ok(variables);
   }
 
-  private Set<String> resolveGroupNames(final List<String> userGroupIds) {
-    // candidate groups use group names instead of group ids
-    // so we need to resolve the group names from the group ids
-    if (userGroupIds.isEmpty()) {
-      return Collections.EMPTY_SET;
+  private Set<String> resolveGroupIdentifiers(final Collection<String> groupIds) {
+    // Groups can be stored as IDs or names; return the union so comparisons work either way.
+    if (groupIds.isEmpty()) {
+      return Collections.emptySet();
     }
-    final Set<String> setOfUserGroupIds = userGroupIds.stream().collect(Collectors.toSet());
+    final Set<String> ids = groupIds.stream().collect(Collectors.toSet());
     final var groups =
         groupServices.search(
-            GroupQuery.of(
-                groupQuery -> groupQuery.filter(filter -> filter.groupIds(setOfUserGroupIds))),
+            GroupQuery.of(groupQuery -> groupQuery.filter(filter -> filter.groupIds(ids))),
             CamundaAuthentication.anonymous());
-    return groups.items().stream().map(g -> g.name()).collect(Collectors.toSet());
+    final Set<String> identifiers = new HashSet<>(ids);
+    groups.items().forEach(g -> identifiers.add(g.name()));
+    return identifiers;
   }
 
   private LazySupplier<TaskDTO> getTaskSupplier(final String taskId) {


### PR DESCRIPTION
## Description

Closes #55576

**Root cause:** Two PRs introduced conflicting resolution logic:

- **PR #38710** (fix #38515): Tasklist V1 backend resolves the authenticated user's group IDs → names before comparing against task `candidateGroups`.
- **PR #51918** (fix #51608): Zeebe engine resolves `candidateGroup` names → IDs at user task creation time, so tasks always store candidate groups as IDs.

After PR #51918, when a group has a name different from its ID:
- Task `candidateGroups`: stored as IDs (resolved by engine)
- User groups in Tasklist V1: resolved to names (by backend)
- Comparison: always a mismatch → tasks invisible to group members

**Fix:** Include both group IDs and names in the Elasticsearch search filter query so the task appears in search results regardless of whether the BPMN used the name or ID.

## Changes

- `TaskController.java`: resolve user groups to names and use both the resolved names and the IDs when comparing with candidate groups (access check + search filter)
- `UserTaskRestrictionsIT.java`:
  - restore old test covering the case where the BPMN model specifies the name as `candidateGroups` for a group whose name differs from its ID
  - add test covering the case where the BPMN model specifies the group ID as `candidateGroups` for a group whose name differs from its ID

## Related

- Fixes: #55576
- Regression introduced by: #51918 (fix for #51608 / SUPPORT-32424)
- Conflicts with: #38710 (fix for #38515)
- Support case: [SUPPORT-33391](https://jira.camunda.com/browse/SUPPORT-33391)

## Workaround (for affected customers)

Until this fix is released, set the following flag on the cluster to prevent the engine from resolving group names to IDs:
```
ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false
```
Note: this only helps for **newly created** tasks; already-existing tasks retain the IDs and remain broken.