### PR TITLE
fix: ignore distributed exporter state for unconfigured exporters

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -489,10 +489,26 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       final String exporterId,
       final ExporterStateDistributeMessage.ExporterStateEntry exporterState) {
 
+    if (!isExporterConfigured(exporterId)) {
+      // The exporter is not configured (anymore) on this node, e.g. it was disabled or deleted.
+      // Accepting its state would re-introduce a removed exporter into the runtime state, where its
+      // stale position is never advanced and only removed again on the next restart via
+      // clearExporterState(). Since getLowestPosition() is the minimum across all exporter states,
+      // such a stale entry pins the snapshot/compaction position and prevents log compaction.
+      LOG.trace(
+          "Ignoring distributed state for exporter '{}' which is not configured anymore.",
+          exporterId);
+      return;
+    }
+
     if (state.getPosition(exporterId) < exporterState.position()) {
       state.setExporterState(exporterId, exporterState.position(), exporterState.metadata());
       metrics.setLastUpdatedExportedPosition(exporterId, exporterState.position());
     }
+  }
+
+  private boolean isExporterConfigured(final String exporterId) {
+    return containers.stream().anyMatch(container -> container.getId().equals(exporterId));
   }
 
   private void initContainers() throws Exception {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
@@ -222,6 +222,43 @@ public final class ExporterDirectorDistributionTest {
     };
   }
 
+  @Test
+  public void shouldNotConsumeStateForUnconfiguredExporter() {
+    // given - the active (leader) has both exporters configured, but the passive (follower) only
+    // has exporter-1, e.g. because exporter-2 was disabled/deleted on this node.
+    activeExporters.startExporterDirector(exporterDescriptors);
+    passiveExporters.startExporterDirector(List.of(exporterDescriptors.get(0)));
+
+    Awaitility.await("Active exporter has recovered and started exporting.")
+        .untilAsserted(
+            () ->
+                assertThat(activeExporters.getDirector().getPhase().join())
+                    .isEqualTo(ExporterPhase.EXPORTING));
+
+    // the still-configured exporter is ahead, the unconfigured one lags behind with a stale
+    // position, as a disabled exporter would.
+    final long configuredPosition = 20L;
+    final long stalePosition = 10L;
+    activeExporters.getExportersState().setPosition(EXPORTER_ID_1, configuredPosition);
+    activeExporters.getExportersState().setPosition(EXPORTER_ID_2, stalePosition);
+
+    // when - the active director distributes the state of both exporters
+    activeExporters.getClock().addTime(DISTRIBUTION_INTERVAL);
+
+    final var passiveExporterState = passiveExporters.getExportersState();
+    Awaitility.await("Active Director has distributed positions and passive has received it")
+        .conditionEvaluationListener(new ClockShifter(activeExporters.getClock()))
+        .untilAsserted(
+            () ->
+                assertThat(passiveExporterState.getPosition(EXPORTER_ID_1))
+                    .isEqualTo(configuredPosition));
+
+    // then - the unconfigured exporter is not re-introduced into the passive state, so its stale
+    // position cannot pin the lowest position (and therefore log compaction).
+    assertThat(passiveExporterState.getPosition(EXPORTER_ID_2)).isEqualTo(-1);
+    assertThat(passiveExporterState.getLowestPosition()).isEqualTo(configuredPosition);
+  }
+
   /**
    * Shifts the actor clock by the {@link this#DISTRIBUTION_INTERVAL} after an awaitility condition
    * was evaluated.


### PR DESCRIPTION
Guards the follower's exporter-state consume path so that distributed state for an exporter that is no longer configured on this node is ignored instead of being written back into the runtime state.

When an exporter is disabled or deleted it is removed from the runtime state, but `consumeExporterStateFromLeader` applied every entry the leader broadcast without checking whether the exporter is still configured. An in-flight `ExporterStateDistributeMessage` (or a leader that still held the entry) could therefore re-create the removed exporter's entry on a follower. Because `getLowestPosition()` is the minimum across all entries in the `EXPORTER` column family, and that value bounds the snapshot's exported position and therefore the compactable index, a stale low position from a removed exporter pins log compaction: the journal then grows without bound until a restart re-runs `clearExporterState()`. This was observed in production where a disabled exporter left tens of millions of uncompactable records on a partition and disk usage climbed until the broker was restarted.

The fix adds an `isExporterConfigured` check in `consumeExporterStateFromLeader` so distributed state for exporters not present in `containers` is dropped. This is consistent with the existing startup cleanup in `clearExporterState()` and fully closes the race, since all exporter-state mutations run on the `ExporterDirector` actor. Pre-existing stale entries still self-heal on the next restart via `clearExporterState()`, and the guard prevents them from being re-added afterwards.

Verified with a new regression test `shouldNotConsumeStateForUnconfiguredExporter` in `ExporterDirectorDistributionTest`, which configures fewer exporters on the follower than the leader distributes and asserts the unconfigured exporter is never added and cannot drag down `getLowestPosition()`. The test fails without the guard and passes with it. 

closes #55585