### PR TITLE
feat: job priority update — runtime mutation via JobUpdate command

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTest.java
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 package io.camunda.zeebe.engine.processing.job;
+
 // seed-data-demo: test PR for /seed-data sibling walkthrough — safe to delete
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTest.java
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 package io.camunda.zeebe.engine.processing.job;
+// seed-data-demo: test PR for /seed-data sibling walkthrough — safe to delete
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;


### PR DESCRIPTION
## Description

Extend the Zeebe engine to support runtime priority mutation for jobs via the `JobUpdate` command. When a job is in ACTIVATABLE state, its priority can be changed, triggering a new `JOB:PRIORITY_UPDATED` event and automatically re-indexing the job in the `JOB_ACTIVATABLE_BY_PRIORITY` column-family so it activates at the new priority level.

> **Note:** This is a test/demo PR for the `/seed-data` sibling walkthrough. Safe to close.

## Checklist

- [ ] Enable backports when necessary

## Related issues

closes #53839