### PR TITLE
fix: reject deeply-nested variable documents to prevent exporter failures

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -22,6 +22,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private JobMetricsCfg jobMetrics = new JobMetricsCfg();
   private DistributionCfg distribution = new DistributionCfg();
   private int maxProcessDepth = EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
+  private int maxVariableNestingDepth = EngineConfiguration.DEFAULT_MAX_VARIABLE_NESTING_DEPTH;
   private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
   private ExpressionCfg expression = new ExpressionCfg();
   private ProcessInstanceCreationCfg processInstanceCreation = new ProcessInstanceCreationCfg();
@@ -107,6 +108,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.maxProcessDepth = maxProcessDepth;
   }
 
+  public int getMaxVariableNestingDepth() {
+    return maxVariableNestingDepth;
+  }
+
+  public void setMaxVariableNestingDepth(final int maxVariableNestingDepth) {
+    this.maxVariableNestingDepth = maxVariableNestingDepth;
+  }
+
   public GlobalListenersCfg getGlobalListeners() {
     return globalListeners;
   }
@@ -170,6 +179,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + distribution
         + ", maxProcessDepth="
         + maxProcessDepth
+        + ", maxVariableNestingDepth="
+        + maxVariableNestingDepth
         + ", expression="
         + expression
         + ", processInstanceCreation="
@@ -216,6 +227,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setCommandRedistributionInterval(distribution.getRedistributionInterval())
         .setCommandRedistributionMaxBackoff(distribution.getMaxBackoffDuration())
         .setMaxProcessDepth(getMaxProcessDepth())
+        .setMaxVariableNestingDepth(getMaxVariableNestingDepth())
         .setGlobalListeners(globalListeners.createGlobalListenersConfiguration())
         .setExpressionEvaluationTimeout(expression.getTimeout())
         .setBusinessIdUniquenessEnabled(processInstanceCreation.isBusinessIdUniquenessEnabled())

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -43,6 +43,8 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE);
     assertThat(configuration.getMaxProcessDepth())
         .isEqualTo(EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH);
+    assertThat(configuration.getMaxVariableNestingDepth())
+        .isEqualTo(EngineConfiguration.DEFAULT_MAX_VARIABLE_NESTING_DEPTH);
     assertThat(configuration.getCommandRedistributionInterval())
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL);
     assertThat(configuration.getCommandRedistributionMaxBackoff())
@@ -92,6 +94,7 @@ final class EngineCfgTest {
     assertThat(configuration.getJobsTimeoutCheckerBatchLimit()).isEqualTo(1000);
     assertThat(configuration.getValidatorsResultsOutputMaxSize()).isEqualTo(2000);
     assertThat(configuration.getMaxProcessDepth()).isEqualTo(2000);
+    assertThat(configuration.getMaxVariableNestingDepth()).isEqualTo(500);
     assertThat(configuration.getCommandRedistributionInterval()).isEqualTo(Duration.ofSeconds(60));
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(Duration.ofMinutes(20));

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -29,6 +29,7 @@ zeebe:
           redistributionInterval: 60s
           maxBackoffDuration: 20m
         maxProcessDepth: 2000
+        maxVariableNestingDepth: 500
         globalListeners:
           userTask:
             - type: test1

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -34,6 +34,7 @@ public final class EngineConfiguration {
   public static final boolean DEFAULT_ENABLE_AUTHORIZATION_CHECKS = false;
 
   public static final int DEFAULT_MAX_PROCESS_DEPTH = 1000;
+  public static final int DEFAULT_MAX_VARIABLE_NESTING_DEPTH = 1000;
   public static final Duration DEFAULT_USAGE_METRICS_EXPORT_INTERVAL = Duration.ofMinutes(5);
   public static final Duration DEFAULT_JOB_METRICS_EXPORT_INTERVAL = Duration.ofMinutes(5);
   public static final int DEFAULT_JOB_METRICS_MAX_WORKER_NAME_LENGTH = 100;
@@ -145,6 +146,7 @@ public final class EngineConfiguration {
   private int validatorsResultsOutputMaxSize = DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
   private boolean enableAuthorization = DEFAULT_ENABLE_AUTHORIZATION_CHECKS;
   private int maxProcessDepth = DEFAULT_MAX_PROCESS_DEPTH;
+  private int maxVariableNestingDepth = DEFAULT_MAX_VARIABLE_NESTING_DEPTH;
   private Duration batchOperationSchedulerInterval = DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL;
   private int batchOperationChunkSize = DEFAULT_BATCH_OPERATION_CHUNK_SIZE;
   private int batchOperationQueryPageSize = DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE;
@@ -330,6 +332,15 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setMaxProcessDepth(final int maxProcessDepth) {
     this.maxProcessDepth = maxProcessDepth;
+    return this;
+  }
+
+  public int getMaxVariableNestingDepth() {
+    return maxVariableNestingDepth;
+  }
+
+  public EngineConfiguration setMaxVariableNestingDepth(final int maxVariableNestingDepth) {
+    this.maxVariableNestingDepth = maxVariableNestingDepth;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -113,8 +113,7 @@ public final class BpmnProcessors {
         writers,
         processingState.getUserTaskState(),
         asyncRequestBehavior,
-        authCheckBehavior,
-        config);
+        authCheckBehavior);
     addProcessInstanceCreationStreamProcessors(
         typedRecordProcessors,
         processingState,
@@ -245,8 +244,7 @@ public final class BpmnProcessors {
       final Writers writers,
       final MutableUserTaskState userTaskState,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior,
-      final EngineConfiguration config) {
+      final AuthorizationCheckBehavior authCheckBehavior) {
     typedRecordProcessors.onCommand(
         ValueType.VARIABLE_DOCUMENT,
         VariableDocumentIntent.UPDATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -257,8 +257,7 @@ public final class BpmnProcessors {
             writers,
             userTaskState,
             asyncRequestBehavior,
-            authCheckBehavior,
-            config.getMaxVariableNestingDepth()));
+            authCheckBehavior));
   }
 
   private static void addProcessInstanceCreationStreamProcessors(
@@ -280,8 +279,7 @@ public final class BpmnProcessors {
             processingState.getBannedInstanceState(),
             authCheckBehavior,
             bpmnBehaviors,
-            config.isBusinessIdUniquenessEnabled(),
-            config.getMaxVariableNestingDepth());
+            config.isBusinessIdUniquenessEnabled());
     final ProcessInstanceCreationCreateProcessor createProcessor =
         new ProcessInstanceCreationCreateProcessor(
             keyGenerator, writers, metrics, processInstanceCreationHelper);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -113,7 +113,8 @@ public final class BpmnProcessors {
         writers,
         processingState.getUserTaskState(),
         asyncRequestBehavior,
-        authCheckBehavior);
+        authCheckBehavior,
+        config);
     addProcessInstanceCreationStreamProcessors(
         typedRecordProcessors,
         processingState,
@@ -244,7 +245,8 @@ public final class BpmnProcessors {
       final Writers writers,
       final MutableUserTaskState userTaskState,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final EngineConfiguration config) {
     typedRecordProcessors.onCommand(
         ValueType.VARIABLE_DOCUMENT,
         VariableDocumentIntent.UPDATE,
@@ -255,7 +257,8 @@ public final class BpmnProcessors {
             writers,
             userTaskState,
             asyncRequestBehavior,
-            authCheckBehavior));
+            authCheckBehavior,
+            config.getMaxVariableNestingDepth()));
   }
 
   private static void addProcessInstanceCreationStreamProcessors(
@@ -277,7 +280,8 @@ public final class BpmnProcessors {
             processingState.getBannedInstanceState(),
             authCheckBehavior,
             bpmnBehaviors,
-            config.isBusinessIdUniquenessEnabled());
+            config.isBusinessIdUniquenessEnabled(),
+            config.getMaxVariableNestingDepth());
     final ProcessInstanceCreationCreateProcessor createProcessor =
         new ProcessInstanceCreationCreateProcessor(
             keyGenerator, writers, metrics, processInstanceCreationHelper);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -708,7 +708,8 @@ public final class EngineProcessors {
             bpmnBehaviors.stateBehavior(),
             bpmnBehaviors.eventTriggerBehavior(),
             commandDistributionBehavior,
-            authCheckBehavior);
+            authCheckBehavior,
+            bpmnBehaviors.variableBehavior());
     typedRecordProcessors.onCommand(
         ValueType.SIGNAL, SignalIntent.BROADCAST, signalBroadcastProcessor);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -49,6 +50,7 @@ public class AdHocSubProcessInstructionActivateProcessor
   private final ProcessState processState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final BpmnAdHocSubProcessBehavior bpmnAdHocSubProcessBehavior;
+  private final VariableBehavior variableBehavior;
 
   public AdHocSubProcessInstructionActivateProcessor(
       final Writers writers,
@@ -62,6 +64,7 @@ public class AdHocSubProcessInstructionActivateProcessor
     elementInstanceState = processingState.getElementInstanceState();
     this.authCheckBehavior = authCheckBehavior;
     bpmnAdHocSubProcessBehavior = bpmnBehaviors.adHocSubProcessBehavior();
+    variableBehavior = bpmnBehaviors.variableBehavior();
   }
 
   @Override
@@ -159,6 +162,18 @@ public class AdHocSubProcessInstructionActivateProcessor
 
     if (command.getValue().isCancelRemainingInstances()) {
       bpmnAdHocSubProcessBehavior.terminateChildInstances(bpmnElementContext);
+    }
+
+    // validate variable documents before activating any elements
+    for (final var elementValue : command.getValue().activateElements()) {
+      final var validation =
+          variableBehavior.validateDocument(
+              adHocSubProcessElementInstance.getKey(), elementValue.getVariablesBuffer());
+      if (validation.isLeft()) {
+        writeRejectionError(
+            command, RejectionType.INVALID_ARGUMENT, validation.getLeft().getMessage());
+        return;
+      }
     }
 
     // activate the elements

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -179,7 +179,11 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     variableMappingBehavior =
         new BpmnVariableMappingBehavior(
-            expressionProcessor, processingState, variableBehavior, eventTriggerBehavior);
+            expressionProcessor,
+            processingState,
+            variableBehavior,
+            eventTriggerBehavior,
+            config.getMaxVariableNestingDepth());
 
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -139,7 +139,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getVariableState(),
             writers.state(),
             conditionalBehavior,
-            processingState.getKeyGenerator());
+            processingState.getKeyGenerator(),
+            config.getMaxVariableNestingDepth());
 
     catchEventBehavior =
         new CatchEventBehavior(
@@ -163,7 +164,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             writers,
             processingState,
             stateBehavior,
-            conditionalBehavior);
+            conditionalBehavior,
+            config.getMaxVariableNestingDepth());
 
     bpmnDecisionBehavior =
         new BpmnDecisionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -164,8 +164,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             writers,
             processingState,
             stateBehavior,
-            conditionalBehavior,
-            config.getMaxVariableNestingDepth());
+            variableBehavior);
 
     bpmnDecisionBehavior =
         new BpmnDecisionBehavior(
@@ -181,11 +180,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     variableMappingBehavior =
         new BpmnVariableMappingBehavior(
-            expressionProcessor,
-            processingState,
-            variableBehavior,
-            eventTriggerBehavior,
-            config.getMaxVariableNestingDepth());
+            expressionProcessor, processingState, variableBehavior, eventTriggerBehavior);
 
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
+import io.camunda.zeebe.engine.processing.variable.VariableNestingDepthValidator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -32,20 +34,22 @@ public final class BpmnVariableMappingBehavior {
   private final ElementInstanceState elementInstanceState;
   private final VariableBehavior variableBehavior;
   private final EventScopeInstanceState eventScopeInstanceState;
-
   private final EventTriggerBehavior eventTriggerBehavior;
+  private final int maxVariableNestingDepth;
 
   public BpmnVariableMappingBehavior(
       final ExpressionProcessor expressionProcessor,
       final ProcessingState processingState,
       final VariableBehavior variableBehavior,
-      final EventTriggerBehavior eventTriggerBehavior) {
+      final EventTriggerBehavior eventTriggerBehavior,
+      final int maxVariableNestingDepth) {
     this.expressionProcessor = expressionProcessor;
     elementInstanceState = processingState.getElementInstanceState();
     variablesState = processingState.getVariableState();
     this.variableBehavior = variableBehavior;
     eventScopeInstanceState = processingState.getEventScopeInstanceState();
     this.eventTriggerBehavior = eventTriggerBehavior;
+    this.maxVariableNestingDepth = maxVariableNestingDepth;
   }
 
   /**
@@ -68,8 +72,15 @@ public final class BpmnVariableMappingBehavior {
     if (inputMappingExpression.isPresent()) {
       return expressionProcessor
           .evaluateVariableMappingExpression(inputMappingExpression.get(), scopeKey, tenantId)
-          .map(
+          .flatMap(
               result -> {
+                final var nestingResult =
+                    VariableNestingDepthValidator.validate(result, maxVariableNestingDepth);
+                if (nestingResult.isLeft()) {
+                  return Either.left(
+                      new Failure(
+                          nestingResult.getLeft().reason(), ErrorType.IO_MAPPING_ERROR, scopeKey));
+                }
                 variableBehavior.mergeLocalDocument(
                     scopeKey,
                     processDefinitionKey,
@@ -78,7 +89,7 @@ public final class BpmnVariableMappingBehavior {
                     bpmnProcessId,
                     context.getTenantId(),
                     result);
-                return null;
+                return Either.right(null);
               });
     }
     return Either.right(null);
@@ -123,6 +134,12 @@ public final class BpmnVariableMappingBehavior {
     if (outputMappingExpression.isPresent()) {
       // set as local variables
       if (hasVariables) {
+        final var nestingResult =
+            VariableNestingDepthValidator.validate(variables, maxVariableNestingDepth);
+        if (nestingResult.isLeft()) {
+          return Either.left(
+              new Failure(nestingResult.getLeft().reason(), ErrorType.IO_MAPPING_ERROR, scopeKey));
+        }
         variableBehavior.mergeLocalDocument(
             elementInstanceKey,
             processDefinitionKey,
@@ -137,8 +154,15 @@ public final class BpmnVariableMappingBehavior {
       return expressionProcessor
           .evaluateVariableMappingExpression(
               outputMappingExpression.get(), elementInstanceKey, tenantId)
-          .map(
+          .flatMap(
               result -> {
+                final var nestingResult =
+                    VariableNestingDepthValidator.validate(result, maxVariableNestingDepth);
+                if (nestingResult.isLeft()) {
+                  return Either.left(
+                      new Failure(
+                          nestingResult.getLeft().reason(), ErrorType.IO_MAPPING_ERROR, scopeKey));
+                }
                 variableBehavior.mergeDocument(
                     scopeKey,
                     processDefinitionKey,
@@ -147,11 +171,17 @@ public final class BpmnVariableMappingBehavior {
                     bpmnProcessId,
                     context.getTenantId(),
                     result);
-                return null;
+                return Either.right(null);
               });
 
     } else if (hasVariables) {
       // merge/propagate the event variables by default
+      final var nestingResult =
+          VariableNestingDepthValidator.validate(variables, maxVariableNestingDepth);
+      if (nestingResult.isLeft()) {
+        return Either.left(
+            new Failure(nestingResult.getLeft().reason(), ErrorType.IO_MAPPING_ERROR, scopeKey));
+      }
       variableBehavior.mergeDocument(
           elementInstanceKey,
           processDefinitionKey,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -68,6 +68,7 @@ public final class BpmnVariableMappingBehavior {
     if (inputMappingExpression.isPresent()) {
       return expressionProcessor
           .evaluateVariableMappingExpression(inputMappingExpression.get(), scopeKey, tenantId)
+          .flatMap(result -> variableBehavior.validateDocument(scopeKey, result))
           .map(
               result -> {
                 variableBehavior.mergeLocalDocument(
@@ -118,6 +119,13 @@ public final class BpmnVariableMappingBehavior {
           context.getTenantId(),
           elementInstanceKey,
           element.getId());
+    }
+
+    // validate variables
+    final Either<Failure, DirectBuffer> validation =
+        variableBehavior.validateDocument(scopeKey, variables);
+    if (validation.isLeft()) {
+      return Either.left(validation.getLeft());
     }
 
     if (outputMappingExpression.isPresent()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
-import io.camunda.zeebe.engine.processing.variable.VariableNestingDepthValidator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -23,7 +22,6 @@ import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -34,22 +32,20 @@ public final class BpmnVariableMappingBehavior {
   private final ElementInstanceState elementInstanceState;
   private final VariableBehavior variableBehavior;
   private final EventScopeInstanceState eventScopeInstanceState;
+
   private final EventTriggerBehavior eventTriggerBehavior;
-  private final int maxVariableNestingDepth;
 
   public BpmnVariableMappingBehavior(
       final ExpressionProcessor expressionProcessor,
       final ProcessingState processingState,
       final VariableBehavior variableBehavior,
-      final EventTriggerBehavior eventTriggerBehavior,
-      final int maxVariableNestingDepth) {
+      final EventTriggerBehavior eventTriggerBehavior) {
     this.expressionProcessor = expressionProcessor;
     elementInstanceState = processingState.getElementInstanceState();
     variablesState = processingState.getVariableState();
     this.variableBehavior = variableBehavior;
     eventScopeInstanceState = processingState.getEventScopeInstanceState();
     this.eventTriggerBehavior = eventTriggerBehavior;
-    this.maxVariableNestingDepth = maxVariableNestingDepth;
   }
 
   /**
@@ -72,15 +68,8 @@ public final class BpmnVariableMappingBehavior {
     if (inputMappingExpression.isPresent()) {
       return expressionProcessor
           .evaluateVariableMappingExpression(inputMappingExpression.get(), scopeKey, tenantId)
-          .flatMap(
+          .map(
               result -> {
-                final var nestingResult =
-                    VariableNestingDepthValidator.validate(result, maxVariableNestingDepth);
-                if (nestingResult.isLeft()) {
-                  return Either.left(
-                      new Failure(
-                          nestingResult.getLeft().reason(), ErrorType.IO_MAPPING_ERROR, scopeKey));
-                }
                 variableBehavior.mergeLocalDocument(
                     scopeKey,
                     processDefinitionKey,
@@ -89,7 +78,7 @@ public final class BpmnVariableMappingBehavior {
                     bpmnProcessId,
                     context.getTenantId(),
                     result);
-                return Either.right(null);
+                return null;
               });
     }
     return Either.right(null);
@@ -134,12 +123,6 @@ public final class BpmnVariableMappingBehavior {
     if (outputMappingExpression.isPresent()) {
       // set as local variables
       if (hasVariables) {
-        final var nestingResult =
-            VariableNestingDepthValidator.validate(variables, maxVariableNestingDepth);
-        if (nestingResult.isLeft()) {
-          return Either.left(
-              new Failure(nestingResult.getLeft().reason(), ErrorType.IO_MAPPING_ERROR, scopeKey));
-        }
         variableBehavior.mergeLocalDocument(
             elementInstanceKey,
             processDefinitionKey,
@@ -154,15 +137,8 @@ public final class BpmnVariableMappingBehavior {
       return expressionProcessor
           .evaluateVariableMappingExpression(
               outputMappingExpression.get(), elementInstanceKey, tenantId)
-          .flatMap(
+          .map(
               result -> {
-                final var nestingResult =
-                    VariableNestingDepthValidator.validate(result, maxVariableNestingDepth);
-                if (nestingResult.isLeft()) {
-                  return Either.left(
-                      new Failure(
-                          nestingResult.getLeft().reason(), ErrorType.IO_MAPPING_ERROR, scopeKey));
-                }
                 variableBehavior.mergeDocument(
                     scopeKey,
                     processDefinitionKey,
@@ -171,17 +147,11 @@ public final class BpmnVariableMappingBehavior {
                     bpmnProcessId,
                     context.getTenantId(),
                     result);
-                return Either.right(null);
+                return null;
               });
 
     } else if (hasVariables) {
       // merge/propagate the event variables by default
-      final var nestingResult =
-          VariableNestingDepthValidator.validate(variables, maxVariableNestingDepth);
-      if (nestingResult.isLeft()) {
-        return Either.left(
-            new Failure(nestingResult.getLeft().reason(), ErrorType.IO_MAPPING_ERROR, scopeKey));
-      }
       variableBehavior.mergeDocument(
           elementInstanceKey,
           processDefinitionKey,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.common;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceLifecycle;
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnConditionalBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
@@ -50,8 +49,7 @@ public class EventTriggerBehavior {
       final Writers writers,
       final ProcessingState processingState,
       final BpmnStateBehavior stateBehavior,
-      final BpmnConditionalBehavior conditionalBehavior,
-      final int maxVariableNestingDepth) {
+      final VariableBehavior variableBehavior) {
     this.keyGenerator = keyGenerator;
     this.catchEventBehavior = catchEventBehavior;
     commandWriter = writers.command();
@@ -60,13 +58,7 @@ public class EventTriggerBehavior {
     elementInstanceState = processingState.getElementInstanceState();
     eventScopeInstanceState = processingState.getEventScopeInstanceState();
 
-    variableBehavior =
-        new VariableBehavior(
-            processingState.getVariableState(),
-            writers.state(),
-            conditionalBehavior,
-            keyGenerator,
-            maxVariableNestingDepth);
+    this.variableBehavior = variableBehavior;
     this.stateBehavior = stateBehavior;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -50,7 +50,8 @@ public class EventTriggerBehavior {
       final Writers writers,
       final ProcessingState processingState,
       final BpmnStateBehavior stateBehavior,
-      final BpmnConditionalBehavior conditionalBehavior) {
+      final BpmnConditionalBehavior conditionalBehavior,
+      final int maxVariableNestingDepth) {
     this.keyGenerator = keyGenerator;
     this.catchEventBehavior = catchEventBehavior;
     commandWriter = writers.command();
@@ -61,7 +62,11 @@ public class EventTriggerBehavior {
 
     variableBehavior =
         new VariableBehavior(
-            processingState.getVariableState(), writers.state(), conditionalBehavior, keyGenerator);
+            processingState.getVariableState(),
+            writers.state(),
+            conditionalBehavior,
+            keyGenerator,
+            maxVariableNestingDepth);
     this.stateBehavior = stateBehavior;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
-import io.camunda.zeebe.engine.processing.variable.VariableNestingDepthValidator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
@@ -134,7 +133,6 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
   private final TypedRejectionWriter rejectionWriter;
 
   private final boolean includeVariablesInJobCompletedEvent;
-  private final int maxVariableNestingDepth;
 
   public JobCompleteProcessor(
       final ProcessingState state,
@@ -143,8 +141,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
       final EventHandle eventHandle,
       final AuthorizationCheckBehavior authCheckBehavior,
       final VariableBehavior variableBehavior,
-      final boolean includeVariablesInJobCompletedEvent,
-      final int maxVariableNestingDepth) {
+      final boolean includeVariablesInJobCompletedEvent) {
     processState = state;
     userTaskState = state.getUserTaskState();
     jobState = state.getJobState();
@@ -154,7 +151,6 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.includeVariablesInJobCompletedEvent = includeVariablesInJobCompletedEvent;
-    this.maxVariableNestingDepth = maxVariableNestingDepth;
     preconditionChecker =
         new JobCommandPreconditionValidator(
             state.getJobState(),
@@ -182,7 +178,6 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     preconditionChecker
         .check(record)
         .flatMap(job -> checkAuthorization(record, job))
-        .flatMap(job -> validateVariablesNestingDepth(record, job))
         .ifRightOrLeft(
             job -> completeJob(record, job, session),
             rejection -> {
@@ -535,13 +530,6 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
                 new IllegalStateException(
                     MISSING_OR_INVALID_USER_TASK_KEY_FROM_ELEMENT_INSTANCE_MESSAGE.formatted(
                         job.getElementInstanceKey(), job.getProcessInstanceKey())));
-  }
-
-  private Either<Rejection, JobRecord> validateVariablesNestingDepth(
-      final TypedRecord<JobRecord> command, final JobRecord job) {
-    return VariableNestingDepthValidator.validate(
-            command.getValue().getVariablesBuffer(), maxVariableNestingDepth)
-        .map(unused -> job);
   }
 
   private Either<Rejection, JobRecord> checkAuthorization(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -53,6 +53,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
 
 public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecord> {
 
@@ -178,8 +179,9 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     preconditionChecker
         .check(record)
         .flatMap(job -> checkAuthorization(record, job))
+        .flatMap(job -> validateJobVariables(record.getValue().getVariablesBuffer(), job))
         .ifRightOrLeft(
-            job -> completeJob(record, job, session),
+            (JobRecord job) -> completeJob(record, job, session),
             rejection -> {
               rejectionWriter.appendRejection(record, rejection.type(), rejection.reason());
               responseWriter.writeRejectionOnCommand(record, rejection.type(), rejection.reason());
@@ -335,6 +337,17 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
         targetAdHocSubProcessInstanceValue.getBpmnProcessIdBuffer(),
         targetAdHocSubProcessInstanceValue.getTenantId(),
         completingJobRecord.getVariablesBuffer());
+  }
+
+  private Either<Rejection, JobRecord> validateJobVariables(
+      final DirectBuffer variables, final JobRecord job) {
+    final var validation =
+        variableBehavior.validateDocument(job.getElementInstanceKey(), variables);
+    if (validation.isLeft()) {
+      return Either.left(
+          new Rejection(RejectionType.INVALID_ARGUMENT, validation.getLeft().getMessage()));
+    }
+    return Either.right(job);
   }
 
   private Either<Rejection, JobRecord>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
+import io.camunda.zeebe.engine.processing.variable.VariableNestingDepthValidator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
@@ -133,6 +134,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
   private final TypedRejectionWriter rejectionWriter;
 
   private final boolean includeVariablesInJobCompletedEvent;
+  private final int maxVariableNestingDepth;
 
   public JobCompleteProcessor(
       final ProcessingState state,
@@ -141,7 +143,8 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
       final EventHandle eventHandle,
       final AuthorizationCheckBehavior authCheckBehavior,
       final VariableBehavior variableBehavior,
-      final boolean includeVariablesInJobCompletedEvent) {
+      final boolean includeVariablesInJobCompletedEvent,
+      final int maxVariableNestingDepth) {
     processState = state;
     userTaskState = state.getUserTaskState();
     jobState = state.getJobState();
@@ -151,6 +154,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.includeVariablesInJobCompletedEvent = includeVariablesInJobCompletedEvent;
+    this.maxVariableNestingDepth = maxVariableNestingDepth;
     preconditionChecker =
         new JobCommandPreconditionValidator(
             state.getJobState(),
@@ -178,6 +182,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     preconditionChecker
         .check(record)
         .flatMap(job -> checkAuthorization(record, job))
+        .flatMap(job -> validateVariablesNestingDepth(record, job))
         .ifRightOrLeft(
             job -> completeJob(record, job, session),
             rejection -> {
@@ -530,6 +535,13 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
                 new IllegalStateException(
                     MISSING_OR_INVALID_USER_TASK_KEY_FROM_ELEMENT_INSTANCE_MESSAGE.formatted(
                         job.getElementInstanceKey(), job.getProcessInstanceKey())));
+  }
+
+  private Either<Rejection, JobRecord> validateVariablesNestingDepth(
+      final TypedRecord<JobRecord> command, final JobRecord job) {
+    return VariableNestingDepthValidator.validate(
+            command.getValue().getVariablesBuffer(), maxVariableNestingDepth)
+        .map(unused -> job);
   }
 
   private Either<Rejection, JobRecord> checkAuthorization(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -61,8 +61,7 @@ public final class JobEventProcessors {
                 eventHandle,
                 authCheckBehavior,
                 bpmnBehaviors.variableBehavior(),
-                config.isIncludeVariablesInJobCompletedEvent(),
-                config.getMaxVariableNestingDepth()))
+                config.isIncludeVariablesInJobCompletedEvent()))
         .onCommand(
             ValueType.JOB,
             JobIntent.FAIL,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -61,7 +61,8 @@ public final class JobEventProcessors {
                 eventHandle,
                 authCheckBehavior,
                 bpmnBehaviors.variableBehavior(),
-                config.isIncludeVariablesInJobCompletedEvent()))
+                config.isIncludeVariablesInJobCompletedEvent(),
+                config.getMaxVariableNestingDepth()))
         .onCommand(
             ValueType.JOB,
             JobIntent.FAIL,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -104,6 +105,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
     preconditionChecker
         .check(record)
         .flatMap(job -> checkAuthorization(record, job))
+        .flatMap(job -> validateVariables(record.getValue().getVariablesBuffer(), job))
         .ifRightOrLeft(
             failedJob -> failJob(record, failedJob),
             rejection -> {
@@ -205,6 +207,17 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
       case JobKind.TASK_LISTENER -> ErrorType.TASK_LISTENER_NO_RETRIES;
       case JobKind.AD_HOC_SUB_PROCESS -> ErrorType.AD_HOC_SUB_PROCESS_NO_RETRIES;
     };
+  }
+
+  private Either<Rejection, JobRecord> validateVariables(
+      final DirectBuffer variables, final JobRecord job) {
+    final var validation =
+        variableBehavior.validateDocument(job.getElementInstanceKey(), variables);
+    if (validation.isLeft()) {
+      return Either.left(
+          new Rejection(RejectionType.INVALID_ARGUMENT, validation.getLeft().getMessage()));
+    }
+    return Either.right(job);
   }
 
   private Either<Rejection, JobRecord> checkAuthorization(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -86,7 +86,8 @@ public final class MessageEventProcessors {
                 routingInfo,
                 elementInstanceState,
                 bannedInstanceState,
-                businessIdUniquenessEnabled))
+                businessIdUniquenessEnabled,
+                bpmnBehaviors.variableBehavior()))
         .onCommand(
             ValueType.MESSAGE_BATCH,
             MessageBatchIntent.EXPIRE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
@@ -54,6 +55,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
   private final TypedRejectionWriter rejectionWriter;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final RoutingInfo routingInfo;
+  private final VariableBehavior variableBehavior;
 
   public MessagePublishProcessor(
       final int partitionId,
@@ -71,7 +73,8 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
       final RoutingInfo routingInfo,
       final ElementInstanceState elementInstanceState,
       final BannedInstanceState bannedInstanceState,
-      final boolean businessIdUniquenessEnabled) {
+      final boolean businessIdUniquenessEnabled,
+      final VariableBehavior variableBehavior) {
     this.partitionId = partitionId;
     this.messageState = messageState;
     this.keyGenerator = keyGenerator;
@@ -80,6 +83,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
     rejectionWriter = writers.rejection();
     this.authCheckBehavior = authCheckBehavior;
     this.routingInfo = routingInfo;
+    this.variableBehavior = variableBehavior;
     final var eventHandle =
         new EventHandle(
             keyGenerator,
@@ -133,6 +137,17 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
       responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, reason);
       return;
     }
+    final var variablesValidation =
+        variableBehavior.validateDocument(-1L, messageRecord.getVariablesBuffer());
+    if (variablesValidation.isLeft()) {
+      final var failure = variablesValidation.getLeft();
+      rejectionWriter.appendRejection(
+          command, RejectionType.INVALID_ARGUMENT, failure.getMessage());
+      responseWriter.writeRejectionOnCommand(
+          command, RejectionType.INVALID_ARGUMENT, failure.getMessage());
+      return;
+    }
+
     if (messageRecord.hasMessageId()
         && messageState.exist(
             messageRecord.getNameBuffer(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -62,6 +62,8 @@ public final class ProcessInstanceCreationCreateProcessor
     persistedProcess
         .flatMap(process -> helper.isAuthorized(command, process))
         .flatMap(process -> helper.validateCommand(command.getValue(), process))
+        .flatMap(
+            process -> helper.validateVariables(command.getValue().getVariablesBuffer(), process))
         .ifRightOrLeft(
             process -> createProcessInstance(command, process),
             rejection -> reject(command, rejection.type(), rejection.reason()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
@@ -65,6 +65,8 @@ public final class ProcessInstanceCreationCreateWithAwaitingResultProcessor
     persistedProcess
         .flatMap(process -> helper.isAuthorized(command, process))
         .flatMap(process -> helper.validateCommand(command.getValue(), process))
+        .flatMap(
+            process -> helper.validateVariables(command.getValue().getVariablesBuffer(), process))
         .ifRightOrLeft(
             process -> createProcessInstance(command, process),
             rejection -> reject(command, rejection.type(), rejection.reason()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSeq
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
+import io.camunda.zeebe.engine.processing.variable.VariableNestingDepthValidator;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
@@ -71,6 +72,7 @@ public class ProcessInstanceCreationHelper {
   private final boolean businessIdUniquenessEnabled;
   private final ElementInstanceState elementInstanceState;
   private final BannedInstanceState bannedInstanceState;
+  private final int maxVariableNestingDepth;
 
   public ProcessInstanceCreationHelper(
       final ProcessState processState,
@@ -78,7 +80,8 @@ public class ProcessInstanceCreationHelper {
       final BannedInstanceState bannedInstanceState,
       final AuthorizationCheckBehavior authCheckBehavior,
       final BpmnBehaviors bpmnBehaviors,
-      final boolean businessIdUniquenessEnabled) {
+      final boolean businessIdUniquenessEnabled,
+      final int maxVariableNestingDepth) {
     this.processState = processState;
     this.elementInstanceState = elementInstanceState;
     this.bannedInstanceState = bannedInstanceState;
@@ -86,6 +89,7 @@ public class ProcessInstanceCreationHelper {
     variableBehavior = bpmnBehaviors.variableBehavior();
     elementActivationBehavior = bpmnBehaviors.elementActivationBehavior();
     this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
+    this.maxVariableNestingDepth = maxVariableNestingDepth;
   }
 
   public Either<Rejection, DeployedProcess> findRelevantProcess(
@@ -225,6 +229,10 @@ public class ProcessInstanceCreationHelper {
                     businessId,
                     bufferAsString(deployedProcess.getBpmnProcessId()),
                     command.getTenantId()))
+        .flatMap(
+            valid ->
+                VariableNestingDepthValidator.validate(
+                    command.getVariablesBuffer(), maxVariableNestingDepth))
         .map(valid -> deployedProcess);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSeq
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
-import io.camunda.zeebe.engine.processing.variable.VariableNestingDepthValidator;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
@@ -72,7 +71,6 @@ public class ProcessInstanceCreationHelper {
   private final boolean businessIdUniquenessEnabled;
   private final ElementInstanceState elementInstanceState;
   private final BannedInstanceState bannedInstanceState;
-  private final int maxVariableNestingDepth;
 
   public ProcessInstanceCreationHelper(
       final ProcessState processState,
@@ -80,8 +78,7 @@ public class ProcessInstanceCreationHelper {
       final BannedInstanceState bannedInstanceState,
       final AuthorizationCheckBehavior authCheckBehavior,
       final BpmnBehaviors bpmnBehaviors,
-      final boolean businessIdUniquenessEnabled,
-      final int maxVariableNestingDepth) {
+      final boolean businessIdUniquenessEnabled) {
     this.processState = processState;
     this.elementInstanceState = elementInstanceState;
     this.bannedInstanceState = bannedInstanceState;
@@ -89,7 +86,6 @@ public class ProcessInstanceCreationHelper {
     variableBehavior = bpmnBehaviors.variableBehavior();
     elementActivationBehavior = bpmnBehaviors.elementActivationBehavior();
     this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
-    this.maxVariableNestingDepth = maxVariableNestingDepth;
   }
 
   public Either<Rejection, DeployedProcess> findRelevantProcess(
@@ -229,10 +225,6 @@ public class ProcessInstanceCreationHelper {
                     businessId,
                     bufferAsString(deployedProcess.getBpmnProcessId()),
                     command.getTenantId()))
-        .flatMap(
-            valid ->
-                VariableNestingDepthValidator.validate(
-                    command.getVariablesBuffer(), maxVariableNestingDepth))
         .map(valid -> deployedProcess);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -240,7 +240,6 @@ public class ProcessInstanceCreationHelper {
 
   public void setVariablesFromDocument(
       final ProcessInstanceRecord processInstance, final DirectBuffer variablesBuffer) {
-
     variableBehavior.mergeLocalDocument(
         processInstance.getProcessInstanceKey(),
         processInstance.getProcessDefinitionKey(),
@@ -474,6 +473,16 @@ public class ProcessInstanceCreationHelper {
     }
 
     return VALID;
+  }
+
+  public Either<Rejection, DeployedProcess> validateVariables(
+      final DirectBuffer variablesBuffer, final DeployedProcess process) {
+    final var validation = variableBehavior.validateDocument(process.getKey(), variablesBuffer);
+    if (validation.isLeft()) {
+      return Either.left(
+          new Rejection(RejectionType.INVALID_ARGUMENT, validation.getLeft().getMessage()));
+    }
+    return Either.right(process);
   }
 
   private boolean doesElementBelongToAnEventBasedGateway(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -335,6 +335,16 @@ public final class ProcessInstanceModificationModifyProcessor
       return;
     }
 
+    final var variableValidationResult =
+        validateActivationVariables(activateInstructions, processInstance.getKey());
+    if (variableValidationResult.isLeft()) {
+      final var rejection = variableValidationResult.getLeft();
+      enrichRejectionCommand(command, processInstance.getValue());
+      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+      return;
+    }
+
     final var extendedRecord = new ProcessInstanceModificationRecord();
     extendedRecord
         .setProcessInstanceKey(value.getProcessInstanceKey())
@@ -1333,6 +1343,25 @@ public final class ProcessInstanceModificationModifyProcessor
             String.join(", ", conflictingActivations));
 
     return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
+  }
+
+  private Either<Rejection, Void> validateActivationVariables(
+      final List<? extends ProcessInstanceModificationActivateInstructionValue> instructions,
+      final long scopeKey) {
+    for (final var instruction : instructions) {
+      for (final var vi : instruction.getVariableInstructions()) {
+        if (vi
+            instanceof final ProcessInstanceModificationVariableInstruction variableInstruction) {
+          final var validation =
+              variableBehavior.validateDocument(scopeKey, variableInstruction.getVariablesBuffer());
+          if (validation.isLeft()) {
+            return Either.left(
+                new Rejection(RejectionType.INVALID_ARGUMENT, validation.getLeft().getMessage()));
+          }
+        }
+      }
+    }
+    return Either.right(null);
   }
 
   public void executeVariableInstruction(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -51,6 +52,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
   private final ProcessState processState;
   private final ElementInstanceState elementInstanceState;
   private final AuthorizationCheckBehavior authCheckBehavior;
+  private final VariableBehavior variableBehavior;
 
   public SignalBroadcastProcessor(
       final Writers writers,
@@ -59,7 +61,8 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
       final BpmnStateBehavior stateBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final VariableBehavior variableBehavior) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
@@ -69,6 +72,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     this.commandDistributionBehavior = commandDistributionBehavior;
     elementInstanceState = processingState.getElementInstanceState();
     this.authCheckBehavior = authCheckBehavior;
+    this.variableBehavior = variableBehavior;
     eventHandle =
         new EventHandle(
             keyGenerator,
@@ -96,6 +100,17 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
         responseWriter.writeRejectionOnCommand(command, RejectionType.FORBIDDEN, message);
         return;
       }
+    }
+
+    final var variablesValidation =
+        variableBehavior.validateDocument(-1L, signalRecord.getVariablesBuffer());
+    if (variablesValidation.isLeft()) {
+      final var failure = variablesValidation.getLeft();
+      rejectionWriter.appendRejection(
+          command, RejectionType.INVALID_ARGUMENT, failure.getMessage());
+      responseWriter.writeRejectionOnCommand(
+          command, RejectionType.INVALID_ARGUMENT, failure.getMessage());
+      return;
     }
 
     triggerSignal(command, eventKey, isAuthNeeded);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
@@ -37,6 +37,7 @@ public final class VariableBehavior {
   private final StateWriter stateWriter;
   private final BpmnConditionalBehavior conditionalBehavior;
   private final KeyGenerator keyGenerator;
+  private final int maxVariableNestingDepth;
 
   private final IndexedDocument indexedDocument = new IndexedDocument();
   private final VariableRecord variableRecord = new VariableRecord();
@@ -46,11 +47,13 @@ public final class VariableBehavior {
       final VariableState variableState,
       final StateWriter stateWriter,
       final BpmnConditionalBehavior conditionalBehavior,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final int maxVariableNestingDepth) {
     this.variableState = variableState;
     this.stateWriter = stateWriter;
     this.conditionalBehavior = conditionalBehavior;
     this.keyGenerator = keyGenerator;
+    this.maxVariableNestingDepth = maxVariableNestingDepth;
     variableSourceRecord = VariableSourceRecord.none();
   }
 
@@ -59,17 +62,24 @@ public final class VariableBehavior {
       final StateWriter stateWriter,
       final BpmnConditionalBehavior conditionalBehavior,
       final KeyGenerator keyGenerator,
+      final int maxVariableNestingDepth,
       final VariableSourceRecord variableSourceRecord) {
     this.variableState = variableState;
     this.stateWriter = stateWriter;
     this.conditionalBehavior = conditionalBehavior;
     this.keyGenerator = keyGenerator;
+    this.maxVariableNestingDepth = maxVariableNestingDepth;
     this.variableSourceRecord = variableSourceRecord;
   }
 
   public VariableBehavior withVariableSource(final VariableSourceRecord source) {
     return new VariableBehavior(
-        variableState, stateWriter, conditionalBehavior, keyGenerator, source);
+        variableState,
+        stateWriter,
+        conditionalBehavior,
+        keyGenerator,
+        maxVariableNestingDepth,
+        source);
   }
 
   /**
@@ -98,6 +108,7 @@ public final class VariableBehavior {
     if (indexedDocument.isEmpty()) {
       return;
     }
+    validateNestingDepth(document);
 
     variableRecord
         .setScopeKey(scopeKey)
@@ -151,6 +162,7 @@ public final class VariableBehavior {
     if (indexedDocument.isEmpty()) {
       return;
     }
+    validateNestingDepth(document);
 
     long currentScope = scopeKey;
     long parentScope;
@@ -271,5 +283,12 @@ public final class VariableBehavior {
     variableRecordCopy.copyFrom(variableRecord);
 
     return variableRecordCopy;
+  }
+
+  private void validateNestingDepth(final DirectBuffer document) {
+    final var result = VariableNestingDepthValidator.validate(document, maxVariableNestingDepth);
+    if (result.isLeft()) {
+      throw new IllegalArgumentException(result.getLeft().reason());
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.variable;
 
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnConditionalBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnConditionalBehavior.VariableEvent;
+import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.variable.DocumentEntry;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableSourceRecord;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -108,8 +110,6 @@ public final class VariableBehavior {
     if (indexedDocument.isEmpty()) {
       return;
     }
-    validateNestingDepth(document);
-
     variableRecord
         .setScopeKey(scopeKey)
         .setProcessDefinitionKey(processDefinitionKey)
@@ -162,8 +162,6 @@ public final class VariableBehavior {
     if (indexedDocument.isEmpty()) {
       return;
     }
-    validateNestingDepth(document);
-
     long currentScope = scopeKey;
     long parentScope;
     final List<VariableEvent> variableEvents = new ArrayList<>();
@@ -285,10 +283,15 @@ public final class VariableBehavior {
     return variableRecordCopy;
   }
 
-  private void validateNestingDepth(final DirectBuffer document) {
-    final var result = VariableNestingDepthValidator.validate(document, maxVariableNestingDepth);
-    if (result.isLeft()) {
-      throw new IllegalArgumentException(result.getLeft().reason());
-    }
+  /**
+   * Validates that the given document does not exceed the configured maximum nesting depth.
+   *
+   * @return {@link Either#right(Object)} with the given document if it is valid; otherwise, {@link
+   *     Either#left(Object)} with a {@link Failure} describing the error
+   */
+  public Either<Failure, DirectBuffer> validateDocument(
+      final long scopeKey, final DirectBuffer document) {
+    return VariableNestingDepthValidator.validate(scopeKey, document, maxVariableNestingDepth)
+        .map(unused -> document);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -62,6 +62,7 @@ public final class VariableDocumentUpdateProcessor
   private final AsyncRequestBehavior asyncRequestBehavior;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final BannedInstanceCommandCheck bannedInstanceCheck;
+  private final int maxVariableNestingDepth;
 
   public VariableDocumentUpdateProcessor(
       final ProcessingState processingState,
@@ -70,7 +71,8 @@ public final class VariableDocumentUpdateProcessor
       final Writers writers,
       final MutableUserTaskState userTaskState,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final int maxVariableNestingDepth) {
     elementInstanceState = processingState.getElementInstanceState();
     this.userTaskState = userTaskState;
     processState = processingState.getProcessState();
@@ -84,6 +86,7 @@ public final class VariableDocumentUpdateProcessor
     this.authCheckBehavior = authCheckBehavior;
     this.bannedInstanceCheck =
         new BannedInstanceCommandCheck(processingState.getBannedInstanceState());
+    this.maxVariableNestingDepth = maxVariableNestingDepth;
   }
 
   @Override
@@ -127,6 +130,15 @@ public final class VariableDocumentUpdateProcessor
               : rejection.reason();
       writers.rejection().appendRejection(record, rejection.type(), errorMessage);
       writers.response().writeRejectionOnCommand(record, rejection.type(), errorMessage);
+      return;
+    }
+
+    final var nestingValidation =
+        VariableNestingDepthValidator.validate(value.getVariablesBuffer(), maxVariableNestingDepth);
+    if (nestingValidation.isLeft()) {
+      final var rejection = nestingValidation.getLeft();
+      writers.rejection().appendRejection(record, rejection.type(), rejection.reason());
+      writers.response().writeRejectionOnCommand(record, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -82,8 +82,7 @@ public final class VariableDocumentUpdateProcessor
     this.writers = writers;
     this.asyncRequestBehavior = asyncRequestBehavior;
     this.authCheckBehavior = authCheckBehavior;
-    this.bannedInstanceCheck =
-        new BannedInstanceCommandCheck(processingState.getBannedInstanceState());
+    bannedInstanceCheck = new BannedInstanceCommandCheck(processingState.getBannedInstanceState());
   }
 
   @Override
@@ -131,6 +130,21 @@ public final class VariableDocumentUpdateProcessor
     }
 
     final String tenantId = scope.getValue().getTenantId();
+
+    if (hasVariables(value)) {
+      final var validation =
+          variableBehavior.validateDocument(scope.getKey(), value.getVariablesBuffer());
+      if (validation.isLeft()) {
+        final var failure = validation.getLeft();
+        writers
+            .rejection()
+            .appendRejection(record, RejectionType.INVALID_ARGUMENT, failure.getMessage());
+        writers
+            .response()
+            .writeRejectionOnCommand(record, RejectionType.INVALID_ARGUMENT, failure.getMessage());
+        return;
+      }
+    }
 
     if (isCamundaUserTask(scope)) {
       final long userTaskKey = scope.getUserTaskKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -62,7 +62,6 @@ public final class VariableDocumentUpdateProcessor
   private final AsyncRequestBehavior asyncRequestBehavior;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final BannedInstanceCommandCheck bannedInstanceCheck;
-  private final int maxVariableNestingDepth;
 
   public VariableDocumentUpdateProcessor(
       final ProcessingState processingState,
@@ -71,8 +70,7 @@ public final class VariableDocumentUpdateProcessor
       final Writers writers,
       final MutableUserTaskState userTaskState,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior,
-      final int maxVariableNestingDepth) {
+      final AuthorizationCheckBehavior authCheckBehavior) {
     elementInstanceState = processingState.getElementInstanceState();
     this.userTaskState = userTaskState;
     processState = processingState.getProcessState();
@@ -86,7 +84,6 @@ public final class VariableDocumentUpdateProcessor
     this.authCheckBehavior = authCheckBehavior;
     this.bannedInstanceCheck =
         new BannedInstanceCommandCheck(processingState.getBannedInstanceState());
-    this.maxVariableNestingDepth = maxVariableNestingDepth;
   }
 
   @Override
@@ -130,15 +127,6 @@ public final class VariableDocumentUpdateProcessor
               : rejection.reason();
       writers.rejection().appendRejection(record, rejection.type(), errorMessage);
       writers.response().writeRejectionOnCommand(record, rejection.type(), errorMessage);
-      return;
-    }
-
-    final var nestingValidation =
-        VariableNestingDepthValidator.validate(value.getVariablesBuffer(), maxVariableNestingDepth);
-    if (nestingValidation.isLeft()) {
-      final var rejection = nestingValidation.getLeft();
-      writers.rejection().appendRejection(record, rejection.type(), rejection.reason());
-      writers.response().writeRejectionOnCommand(record, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthValidator.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import org.agrona.DirectBuffer;
+
+/**
+ * Validates that a msgpack variable document does not exceed a configurable maximum nesting depth.
+ *
+ * <p>Deep nesting (beyond the Jackson {@code StreamWriteConstraints} default of 1000 levels) would
+ * break the Elasticsearch/OpenSearch exporter when it serializes the document to JSON, causing
+ * partition-level export failures with no recovery path.
+ *
+ * <p>The depth walk is <em>iterative</em> (uses an explicit stack via {@link ArrayDeque}) and
+ * therefore cannot itself overflow the call stack on deeply-nested input.
+ */
+public final class VariableNestingDepthValidator {
+
+  static final String NESTING_DEPTH_EXCEEDED_ERROR_MESSAGE =
+      "Expected variable document to be nested at most %d levels deep, but it exceeds that limit";
+  private static final String INVALID_VARIABLES_MSGPACK_ERROR_MESSAGE =
+      "Expected variables to be valid msgpack, but it could not be read: '%s'";
+
+  private VariableNestingDepthValidator() {}
+
+  /**
+   * Validates that the given msgpack document does not exceed {@code maxNestingDepth} levels of
+   * container nesting.
+   *
+   * @param variablesBuffer the msgpack document to validate
+   * @param maxNestingDepth the maximum allowed nesting depth (inclusive)
+   * @return {@link Either#right(Object)} when within the limit; {@link Either#left(Object)} with a
+   *     {@link RejectionType#INVALID_ARGUMENT} rejection when the limit is exceeded
+   */
+  public static Either<Rejection, Void> validate(
+      final DirectBuffer variablesBuffer, final int maxNestingDepth) {
+    if (isEmpty(variablesBuffer)) {
+      return Either.right(null);
+    }
+    try {
+      if (exceedsMaxDepth(variablesBuffer, maxNestingDepth)) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_ARGUMENT,
+                NESTING_DEPTH_EXCEEDED_ERROR_MESSAGE.formatted(maxNestingDepth)));
+      }
+    } catch (final RuntimeException exception) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              INVALID_VARIABLES_MSGPACK_ERROR_MESSAGE.formatted(exception.getMessage())));
+    }
+    return Either.right(null);
+  }
+
+  /**
+   * Returns {@code true} if the msgpack buffer's container nesting depth exceeds {@code
+   * maxNestingDepth}; {@code false} otherwise. Short-circuits as soon as the limit is exceeded.
+   *
+   * <p>Uses an iterative algorithm with an explicit stack to avoid {@link StackOverflowError} on
+   * deeply nested input.
+   */
+  static boolean exceedsMaxDepth(final DirectBuffer buffer, final int maxNestingDepth) {
+    final var reader = new MsgPackReader();
+    reader.wrap(buffer, 0, buffer.capacity());
+
+    // Each stack entry holds the number of tokens that still remain at the parent depth level once
+    // we finish the current container. We track this per-level so that ascending back to the parent
+    // restores the correct remaining count.
+    final Deque<Long> stack = new ArrayDeque<>();
+    long remaining = 1; // one root token to read
+    int depth = 0;
+
+    while (true) {
+      // Ascend past any fully-consumed levels.
+      while (remaining == 0) {
+        if (stack.isEmpty()) {
+          return false;
+        }
+        remaining = stack.pop();
+        depth--;
+      }
+
+      remaining--;
+      final var token = reader.readToken();
+
+      switch (token.getType()) {
+        case MAP -> {
+          depth++;
+          if (depth > maxNestingDepth) {
+            return true;
+          }
+          stack.push(remaining);
+          // A map with N entries contains N key tokens + N value tokens.
+          remaining = (long) token.getSize() * 2;
+        }
+        case ARRAY -> {
+          depth++;
+          if (depth > maxNestingDepth) {
+            return true;
+          }
+          stack.push(remaining);
+          remaining = token.getSize();
+        }
+        default -> {
+          // Scalar value: nothing to descend into.
+        }
+      }
+    }
+  }
+
+  private static boolean isEmpty(final DirectBuffer buffer) {
+    return buffer == null || buffer.capacity() == 0;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthValidator.java
@@ -7,9 +7,10 @@
  */
 package io.camunda.zeebe.engine.processing.variable;
 
-import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -38,28 +39,31 @@ public final class VariableNestingDepthValidator {
    * Validates that the given msgpack document does not exceed {@code maxNestingDepth} levels of
    * container nesting.
    *
+   * @param scopeKey the scope key to use in the failure if the validation fails
    * @param variablesBuffer the msgpack document to validate
    * @param maxNestingDepth the maximum allowed nesting depth (inclusive)
    * @return {@link Either#right(Object)} when within the limit; {@link Either#left(Object)} with a
    *     {@link RejectionType#INVALID_ARGUMENT} rejection when the limit is exceeded
    */
-  public static Either<Rejection, Void> validate(
-      final DirectBuffer variablesBuffer, final int maxNestingDepth) {
+  public static Either<Failure, Void> validate(
+      final long scopeKey, final DirectBuffer variablesBuffer, final int maxNestingDepth) {
     if (isEmpty(variablesBuffer)) {
       return Either.right(null);
     }
     try {
       if (exceedsMaxDepth(variablesBuffer, maxNestingDepth)) {
         return Either.left(
-            new Rejection(
-                RejectionType.INVALID_ARGUMENT,
-                NESTING_DEPTH_EXCEEDED_ERROR_MESSAGE.formatted(maxNestingDepth)));
+            new Failure(
+                NESTING_DEPTH_EXCEEDED_ERROR_MESSAGE.formatted(maxNestingDepth),
+                ErrorType.IO_MAPPING_ERROR,
+                scopeKey));
       }
     } catch (final RuntimeException exception) {
       return Either.left(
-          new Rejection(
-              RejectionType.INVALID_ARGUMENT,
-              INVALID_VARIABLES_MSGPACK_ERROR_MESSAGE.formatted(exception.getMessage())));
+          new Failure(
+              INVALID_VARIABLES_MSGPACK_ERROR_MESSAGE.formatted(exception.getMessage()),
+              ErrorType.IO_MAPPING_ERROR,
+              scopeKey));
     }
     return Either.right(null);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthValidator.java
@@ -75,21 +75,17 @@ public final class VariableNestingDepthValidator {
     final var reader = new MsgPackReader();
     reader.wrap(buffer, 0, buffer.capacity());
 
-    // Each stack entry holds the number of tokens that still remain at the parent depth level once
-    // we finish the current container. We track this per-level so that ascending back to the parent
-    // restores the correct remaining count.
+    // Stack entries save the parent's remaining token count so we can restore it when ascending.
     final Deque<Long> stack = new ArrayDeque<>();
     long remaining = 1; // one root token to read
     int depth = 0;
 
-    while (true) {
-      // Ascend past any fully-consumed levels.
-      while (remaining == 0) {
-        if (stack.isEmpty()) {
-          return false;
-        }
+    while (remaining > 0 || !stack.isEmpty()) {
+      if (remaining == 0) {
+        // Ascend one level; outer condition re-checks until a non-empty level is found.
         remaining = stack.pop();
         depth--;
+        continue;
       }
 
       remaining--;
@@ -118,6 +114,7 @@ public final class VariableNestingDepthValidator {
         }
       }
     }
+    return false;
   }
 
   private static boolean isEmpty(final DirectBuffer buffer) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/InputMappingNestingDepthIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/InputMappingNestingDepthIncidentTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class InputMappingNestingDepthIncidentTest {
+
+  private static final int MAX_DEPTH = 3;
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition().withEngineConfig(c -> c.setMaxVariableNestingDepth(MAX_DEPTH));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  private long processDefinitionKey;
+  private String processId;
+
+  @Before
+  public void init() {
+    processId = helper.getBpmnProcessId();
+    processDefinitionKey =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(
+                        "task",
+                        t ->
+                            t.zeebeJobType(helper.getJobType())
+                                .zeebeInputExpression("{a: {b: {c: \"leaf\"}}}", "nested"))
+                    .endEvent()
+                    .done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0)
+            .getProcessDefinitionKey();
+  }
+
+  @Test
+  public void shouldCreateIncidentWhenInputMappingExceedsNestingDepth() {
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    final var incident =
+        RecordingExporter.incidentRecords()
+            .onlyEvents()
+            .withIntent(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(incident.getValue())
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
+        .hasBpmnProcessId(processId)
+        .hasProcessDefinitionKey(processDefinitionKey)
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasElementId("task")
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    assertThat(incident.getValue().getErrorMessage())
+        .contains(
+            "Expected variable document to be nested at most %d levels deep, but it exceeds that limit"
+                .formatted(MAX_DEPTH));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.AtomicKeyGenerator;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
@@ -101,9 +103,14 @@ public final class MessageStreamProcessorTest {
           final var mockAuthCheckBehavior = mock(AuthorizationCheckBehavior.class);
           when(mockAuthCheckBehavior.isAuthorizedOrInternalCommand(any(AuthorizationRequest.class)))
               .thenReturn(Either.right(null));
+          final var mockBpmnBehaviors = mock(BpmnBehaviors.class);
+          final var mockVariableBehavior = mock(VariableBehavior.class);
+          when(mockVariableBehavior.validateDocument(anyLong(), any(DirectBuffer.class)))
+              .thenReturn(Either.right(null));
+          when(mockBpmnBehaviors.variableBehavior()).thenReturn(mockVariableBehavior);
           MessageEventProcessors.addMessageProcessors(
               PARTITION_ID,
-              mock(BpmnBehaviors.class),
+              mockBpmnBehaviors,
               typedRecordProcessors,
               processingState,
               scheduledTaskState,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
@@ -77,7 +77,11 @@ final class VariableBehaviorTest {
     state = processingState.getVariableState();
     behavior =
         new VariableBehavior(
-            state, stateWriter, conditionalBehavior, processingState.getKeyGenerator());
+            state,
+            stateWriter,
+            conditionalBehavior,
+            processingState.getKeyGenerator(),
+            EngineConfiguration.DEFAULT_MAX_VARIABLE_NESTING_DEPTH);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthRejectionTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class VariableNestingDepthRejectionTest {
+
+  private static final int MAX_DEPTH = 3;
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition().withEngineConfig(c -> c.setMaxVariableNestingDepth(MAX_DEPTH));
+
+  private static final Map<String, Object> DEEPLY_NESTED =
+      Map.of("a", Map.of("b", Map.of("c", Map.of("d", 1))));
+  private static final String EXPECTED_REJECTION_REASON =
+      "Expected variable document to be nested at most %d levels deep, but it exceeds that limit"
+          .formatted(MAX_DEPTH);
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  private String processId;
+  private String jobType;
+
+  @Before
+  public void setUp() {
+    processId = helper.getBpmnProcessId();
+    jobType = helper.getJobType();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done())
+        .deploy();
+  }
+
+  @Test
+  public void shouldRejectProcessInstanceCreationWithDeeplyNestedVariables() {
+    // when
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVariables(DEEPLY_NESTED)
+        .expectRejection()
+        .create();
+
+    // then
+    final var rejection =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(EXPECTED_REJECTION_REASON);
+  }
+
+  @Test
+  public void shouldRejectProcessInstanceCreationWithAwaitingResultWithDeeplyNestedVariables() {
+    // when
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withVariables(DEEPLY_NESTED)
+        .withResult()
+        .createExpectingRejection();
+
+    // then
+    final var rejection =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(EXPECTED_REJECTION_REASON);
+  }
+
+  @Test
+  public void shouldRejectVariableDocumentUpdateWithDeeplyNestedVariables() {
+    // given
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // when
+    ENGINE
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(DEEPLY_NESTED)
+        .expectRejection()
+        .update();
+
+    // then
+    final var rejection =
+        RecordingExporter.variableDocumentRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(EXPECTED_REJECTION_REASON);
+  }
+
+  @Test
+  public void shouldRejectJobCompleteWithDeeplyNestedVariables() {
+    // given
+    ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    final var jobs = ENGINE.jobs().withType(jobType).activate();
+    final long jobKey = jobs.getValue().getJobKeys().get(0);
+
+    // when
+    ENGINE.job().withKey(jobKey).withVariables(DEEPLY_NESTED).expectRejection().complete();
+
+    // then
+    final var rejection = RecordingExporter.jobRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(EXPECTED_REJECTION_REASON);
+  }
+
+  @Test
+  public void shouldRejectJobFailWithDeeplyNestedVariables() {
+    // given
+    ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    final var jobs = ENGINE.jobs().withType(jobType).activate();
+    final long jobKey = jobs.getValue().getJobKeys().get(0);
+
+    // when
+    ENGINE
+        .job()
+        .withKey(jobKey)
+        .withVariables(DEEPLY_NESTED)
+        .withRetries(3)
+        .expectRejection()
+        .fail();
+
+    // then
+    final var rejection = RecordingExporter.jobRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(EXPECTED_REJECTION_REASON);
+  }
+
+  @Test
+  public void shouldRejectMessagePublishWithDeeplyNestedVariables() {
+    // when
+    ENGINE
+        .message()
+        .withName("msg")
+        .withCorrelationKey("key")
+        .withVariables(DEEPLY_NESTED)
+        .expectRejection()
+        .publish();
+
+    // then
+    final var rejection =
+        RecordingExporter.messageRecords(MessageIntent.PUBLISH).onlyCommandRejections().getFirst();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(EXPECTED_REJECTION_REASON);
+  }
+
+  @Test
+  public void shouldRejectSignalBroadcastWithDeeplyNestedVariables() {
+    // when
+    ENGINE
+        .signal()
+        .withSignalName("signal")
+        .withVariables(DEEPLY_NESTED)
+        .expectRejection()
+        .broadcast();
+
+    // then
+    final var rejection =
+        RecordingExporter.signalRecords(SignalIntent.BROADCAST).onlyCommandRejections().getFirst();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(EXPECTED_REJECTION_REASON);
+  }
+
+  @Test
+  public void shouldRejectProcessInstanceModificationWithDeeplyNestedVariables() {
+    // given
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("task")
+        .withVariables("task", DEEPLY_NESTED)
+        .expectRejection()
+        .modify();
+
+    // then
+    final var rejection =
+        RecordingExporter.processInstanceModificationRecords(
+                ProcessInstanceModificationIntent.MODIFY)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(EXPECTED_REJECTION_REASON);
+  }
+
+  @Test
+  public void shouldRejectAdHocSubProcessActivationWithDeeplyNestedElementVariables() {
+    // given
+    final String adHocProcessId = helper.getBpmnProcessId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(adHocProcessId)
+                .startEvent()
+                .adHocSubProcess("ad-hoc", b -> b.task("A"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(adHocProcessId).create();
+
+    final long adHocSubProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+            .map(r -> r.getKey())
+            .limit(1)
+            .findFirst()
+            .orElseThrow();
+
+    // when
+    ENGINE
+        .adHocSubProcessActivity()
+        .withAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey)
+        .withElementIdAndVariables("A", DEEPLY_NESTED)
+        .expectRejection()
+        .activate();
+
+    // then
+    final var rejection =
+        RecordingExporter.adHocSubProcessInstructionRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(EXPECTED_REJECTION_REASON);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthValidatorTest.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.variable;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
-import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +58,7 @@ public final class VariableNestingDepthValidatorTest {
   @Test
   void shouldReturnRightForNullBuffer() {
     // when
-    final var result = VariableNestingDepthValidator.validate(null, 1000);
+    final var result = VariableNestingDepthValidator.validate(-1, null, 1000);
 
     // then
     assertThat(result.isRight()).isTrue();
@@ -70,7 +70,7 @@ public final class VariableNestingDepthValidatorTest {
     final var buffer = new UnsafeBuffer(new byte[0]);
 
     // when
-    final var result = VariableNestingDepthValidator.validate(buffer, 1000);
+    final var result = VariableNestingDepthValidator.validate(-1, buffer, 1000);
 
     // then
     assertThat(result.isRight()).isTrue();
@@ -82,7 +82,7 @@ public final class VariableNestingDepthValidatorTest {
     final var buffer = msgPackOf(buildNestedJson(1000));
 
     // when
-    final var result = VariableNestingDepthValidator.validate(buffer, 1000);
+    final var result = VariableNestingDepthValidator.validate(-1, buffer, 1000);
 
     // then
     assertThat(result.isRight()).isTrue();
@@ -94,12 +94,12 @@ public final class VariableNestingDepthValidatorTest {
     final var buffer = msgPackOf(buildNestedJson(1001));
 
     // when
-    final var result = VariableNestingDepthValidator.validate(buffer, 1000);
+    final var result = VariableNestingDepthValidator.validate(-1, buffer, 1000);
 
     // then
     assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft().type()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(result.getLeft().reason())
+    assertThat(result.getLeft().getErrorType()).isEqualTo(ErrorType.IO_MAPPING_ERROR);
+    assertThat(result.getLeft().getMessage())
         .isEqualTo(
             VariableNestingDepthValidator.NESTING_DEPTH_EXCEEDED_ERROR_MESSAGE.formatted(1000));
   }
@@ -110,10 +110,11 @@ public final class VariableNestingDepthValidatorTest {
     final var buffer = msgPackOf(buildNestedJson(50_000));
 
     // when / then — must not throw
-    final var result = VariableNestingDepthValidator.validate(buffer, 1000);
+    final var result = VariableNestingDepthValidator.validate(-1, buffer, 1000);
 
     assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft().type()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(result.getLeft().getErrorType()).isEqualTo(ErrorType.IO_MAPPING_ERROR);
   }
 
   /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthValidatorTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+public final class VariableNestingDepthValidatorTest {
+
+  @Test
+  public void shouldNotExceedDepthForFlatDocument() {
+    // given
+    final var buffer = msgPackOf("{\"a\": 1, \"b\": 2}");
+
+    // when / then
+    assertThat(VariableNestingDepthValidator.exceedsMaxDepth(buffer, 1)).isFalse();
+  }
+
+  @Test
+  public void shouldHandleArrayNesting() {
+    // given — {"a": [[[1]]]} is 4 levels deep (root map + 3 arrays)
+    final var buffer = msgPackOf("{\"a\": [[[1]]]}");
+
+    // when / then
+    assertThat(VariableNestingDepthValidator.exceedsMaxDepth(buffer, 4)).isFalse();
+    assertThat(VariableNestingDepthValidator.exceedsMaxDepth(buffer, 3)).isTrue();
+  }
+
+  @Test
+  public void shouldHandleMixedNesting() {
+    // given — {"a": [{"b": 1}]} is 3 levels deep (root map + array + inner map)
+    final var buffer = msgPackOf("{\"a\": [{\"b\": 1}]}");
+
+    // when / then
+    assertThat(VariableNestingDepthValidator.exceedsMaxDepth(buffer, 3)).isFalse();
+    assertThat(VariableNestingDepthValidator.exceedsMaxDepth(buffer, 2)).isTrue();
+  }
+
+  @Test
+  void shouldHandleEmptyNestedContainers() {
+    // given — {"a": {}, "b": []} — both inner containers are depth 2
+    final var buffer = msgPackOf("{\"a\": {}, \"b\": []}");
+
+    // when / then
+    assertThat(VariableNestingDepthValidator.exceedsMaxDepth(buffer, 2)).isFalse();
+    assertThat(VariableNestingDepthValidator.exceedsMaxDepth(buffer, 1)).isTrue();
+  }
+
+  @Test
+  void shouldReturnRightForNullBuffer() {
+    // when
+    final var result = VariableNestingDepthValidator.validate(null, 1000);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldReturnRightForEmptyBuffer() {
+    // given
+    final var buffer = new UnsafeBuffer(new byte[0]);
+
+    // when
+    final var result = VariableNestingDepthValidator.validate(buffer, 1000);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldReturnRightWhenDocumentIsWithinLimit() {
+    // given
+    final var buffer = msgPackOf(buildNestedJson(1000));
+
+    // when
+    final var result = VariableNestingDepthValidator.validate(buffer, 1000);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldReturnLeftWhenDocumentExceedsLimit() {
+    // given
+    final var buffer = msgPackOf(buildNestedJson(1001));
+
+    // when
+    final var result = VariableNestingDepthValidator.validate(buffer, 1000);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().type()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(result.getLeft().reason())
+        .isEqualTo(
+            VariableNestingDepthValidator.NESTING_DEPTH_EXCEEDED_ERROR_MESSAGE.formatted(1000));
+  }
+
+  @Test
+  void shouldNotThrowStackOverflowOnPathologicalInput() {
+    // given — 50 000 levels deep: validates that the iterative algorithm handles extreme input
+    final var buffer = msgPackOf(buildNestedJson(50_000));
+
+    // when / then — must not throw
+    final var result = VariableNestingDepthValidator.validate(buffer, 1000);
+
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().type()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+  }
+
+  /**
+   * Builds a JSON document with {@code depth} levels of map nesting, e.g. {@code depth=3} produces
+   * {@code {"k":{"k":{"k":1}}}}.
+   */
+  private static String buildNestedJson(final int depth) {
+    final var sb = new StringBuilder();
+    sb.repeat("{\"k\":", Math.max(0, depth));
+    sb.append("1");
+    sb.repeat("}", Math.max(0, depth));
+    return sb.toString();
+  }
+
+  private static UnsafeBuffer msgPackOf(final String json) {
+    final byte[] bytes = MsgPackConverter.convertToMsgPack(json);
+    return new UnsafeBuffer(bytes);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
@@ -12,8 +12,10 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 public class AdHocSubProcessActivityClient {
@@ -69,6 +71,16 @@ public class AdHocSubProcessActivityClient {
     for (final String elementId : elementIds) {
       adHocSubProcessInstructionRecord.activateElements().add().setElementId(elementId);
     }
+    return this;
+  }
+
+  public AdHocSubProcessActivityClient withElementIdAndVariables(
+      final String elementId, final Map<String, Object> variables) {
+    adHocSubProcessInstructionRecord
+        .activateElements()
+        .add()
+        .setElementId(elementId)
+        .setVariables(MsgPackUtil.asMsgPack(variables));
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -275,6 +275,21 @@ public final class ProcessInstanceClient {
           record,
           username);
     }
+
+    public Record<ProcessInstanceCreationRecordValue> createExpectingRejection() {
+      final long position =
+          writer.writeCommand(
+              requestStreamId,
+              requestId,
+              ProcessInstanceCreationIntent.CREATE_WITH_AWAITING_RESULT,
+              record);
+
+      return RecordingExporter.processInstanceCreationRecords()
+          .onlyCommandRejections()
+          .withIntent(ProcessInstanceCreationIntent.CREATE_WITH_AWAITING_RESULT)
+          .withSourceRecordPosition(position)
+          .getFirst();
+    }
   }
 
   public static class ExistingInstanceClient {


### PR DESCRIPTION
## Description

A variable whose JSON nests deeper than 1000 levels would break the Elasticsearch/OpenSearch exporter: Jackson's default StreamWriteConstraints limits JSON generator depth to 1000, causing StreamConstraintsException that blocks partition-level exporting with no recovery path (issue #54335).

Guards ingestion vectors:
- Added a variable validation method to check for nesting depth for variables.
- Client commands (`SetVariables`, `CreateProcessInstance`, `JobComplete`) are now guarded with the variable validation method and now return `INVALID_ARGUMENT` when the variable document exceeds the limit.
- Internal expression/output-mapping results (e.g. FEEL script tasks) raise an `IO_MAPPING_ERROR` incident instead of crashing the exporter.

Default limit is 1000 (matching the Jackson write-constraint default) and is configurable via `EngineConfiguration.setMaxVariableNestingDepth()` / `zeebe.broker.experimental.engine.maxVariableNestingDepth`.

Guarding is required for variables that pass through externally. The usage of variableBehavior is listed below:

Internal — documents sourced from already-stored variables (no new nesting possible):
- `BpmnStateBehavior` — reads from variablesState.getVariablesAsDocument(...), copies existing variables
- `AdHocSubProcessInstructionActivateProcessor` – handles `AdHocSubProcessInstructionIntent.ACTIVATE` commands, which are sent by external clients via REST/gRPC, does not have any variable changes aside from already processed internal variables.

External — user-controlled documents that bypass current validation:
- `ProcessInstanceCreationHelper` (`ProcessInstanceCreationCreateProcessor` and `ProcessInstanceCreationCreateWithAwaitingResultProcessor`) — initial variables at process start (REST/gRPC)
- `JobCompleteProcessor` — job output variables from a worker completing a task ← **this is the "script task" path that resulted in the exporter failure**
- `JobFailProcessor` — variables on job failure 
- `VariableDocumentUpdateProcessor` — variable update via REST/gRPC API
- `ProcessInstanceModificationModifyProcessor` — activation variables via modification API
- `MessagePublishProcessor` (line 182: `messageCorrelationRecord.getVariablesBuffer()`) — message payload variables from REST/gRPC
- `SignalBroadcastProcessor` (line 216/219: `signalRecord.getVariablesBuffer()`) — signal payload variables from REST/gRPC


Slack thread context: https://camunda.slack.com/archives/C08F5RD5X8B/p1782205695677419

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54335
