### PR TITLE
test: stabilize Operate cancel and migration nightly e2e assertions

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -148,6 +148,9 @@ test.describe('Operations', () => {
       const operationEntry =
         operateOperationPanelPage.getCancelOperationEntry(1);
 
+      // The cancel operation's success count is only rendered once Operate's
+      // importer marks the cancellation complete, which can lag under load.
+      // Reload and retry generously so this importer delay does not flake.
       await waitForAssertion({
         assertion: async () => {
           await expect(operationEntry).toBeVisible();
@@ -156,7 +159,7 @@ test.describe('Operations', () => {
         onFailure: async () => {
           await page.reload();
         },
-        maxRetries: 10,
+        maxRetries: 15,
       });
 
       const operationId = await operationEntry.getByRole('link').innerText();
@@ -187,7 +190,7 @@ test.describe('Operations', () => {
         onFailure: async () => {
           await page.reload();
         },
-        maxRetries: 3,
+        maxRetries: 8,
       });
 
       await operateOperationPanelPage.collapseOperationIdField();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -601,9 +601,21 @@ test.describe.serial('Process Instance Migration', () => {
 
       await validateURL(page, /operationId=/);
 
-      await expect(
-        operateProcessesPage.getVersionCells(targetVersion),
-      ).toHaveCount(3, {timeout: 60000});
+      // The migrate operation reports success once Zeebe applies it, but the
+      // operationId-filtered list does not refetch on its own, so it can stay
+      // stale showing only the instances re-indexed so far. Reload between
+      // attempts to force a fresh fetch until all 3 reflect the target version.
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.getVersionCells(targetVersion),
+          ).toHaveCount(3, {timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 5,
+      });
 
       await expect(
         operateProcessesPage.getVersionCells(sourceVersion),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -320,10 +320,24 @@ test.describe.serial('Process Instance Migration', () => {
           await validateURL(page, /operationId=/);
         },
       });
-      await expect(
-        operateProcessesPage.getVersionCells(targetVersion),
-      ).toHaveCount(6, {
-        timeout: 30000,
+
+      // The "6 results" header updates as soon as the operationId filter
+      // resolves, but the operationId-filtered list does not refetch on its
+      // own, so the target-version row cells can stay stale (0 elements) until
+      // the importer finishes re-indexing the migrated instances. Reload
+      // between attempts to force a fresh fetch until all 6 reflect the target
+      // version — same reload-retry pattern used by the manual mapping test.
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.getVersionCells(targetVersion),
+          ).toHaveCount(6, {timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+          await validateURL(page, /operationId=/);
+        },
+        maxRetries: 5,
       });
     });
   });


### PR DESCRIPTION
## What

Fixes two failing tests in the stable/8.7 C8 orchestration-cluster nightly E2E run (Tasklist v1 mode):

- `operate/operations.spec.ts` — **Retry and cancel single instance**
- `operate/processInstanceMigration.spec.ts` — **Manual mapping migration**

## Why

Both failures are asynchronous importer-propagation flakes in v1 (importer) mode, not product regressions:

- **Cancel single instance** — the Cancel operation's `1 success` count and the instance `CANCELED` icon are only rendered once Operate's importer marks the cancellation complete. Attempt 0 failed at the `CANCELED-icon` step (`maxRetries: 3`); attempt 1 failed at the `1 success` step (`maxRetries: 10`) — a step that *passed* in attempt 0. The non-determinism confirms a timing boundary. Retry budgets raised (10→15, 3→8) so the existing reload-retry loop spans the importer delay.
- **Manual mapping migration** — the migrate operation reported `3 success` (all 3 instances migrated in Zeebe), but the `operationId`-filtered instance list did not refetch and stayed stale at 1 re-indexed instance for the full 60s (`123 × locator resolved to 1 element`). The count assertion is now wrapped in `waitForAssertion` with `page.reload()` so a fresh fetch picks up the remaining instances — consistent with the reload-retry pattern used throughout this file.

No test logic or coverage was weakened; only the wait budgets/refetch behavior changed. No `skip`/`fixme` introduced.

## Nightly run

https://github.com/camunda/camunda/actions/runs/27924072924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/28019014257
