### PR TITLE
fix(c8run): pass JDK 25 runtime options to bundled Connectors

### DIFF
--- a/c8run/internal/start/startuphandler.go
+++ b/c8run/internal/start/startuphandler.go
@@ -23,6 +23,61 @@ import (
 
 var evalSymlinks = filepath.EvalSymlinks
 
+const (
+	java25RuntimeVersion      = 25
+	jdkJavaOptionsEnvironment = "JDK_JAVA_OPTIONS"
+)
+
+// java25RuntimeOptions are the JVM options required to run Camunda and the
+// bundled Connectors runtime on JDK 25+. Without them the Connectors runtime
+// can hang on JDK 25 because sun.misc.Unsafe memory access is denied by
+// default. They are applied via JDK_JAVA_OPTIONS so they reach every child
+// JVM (Camunda and Connectors alike), not only the main process.
+var java25RuntimeOptions = []string{
+	"--enable-native-access=ALL-UNNAMED",
+	"--sun-misc-unsafe-memory-access=allow",
+}
+
+// configureJavaCompatibilityOptions injects the JDK 25+ runtime options into
+// JDK_JAVA_OPTIONS when running on JDK 25 or newer. It is a no-op on older
+// JDKs and never duplicates options that are already present.
+func configureJavaCompatibilityOptions(javaMajorVersion int) error {
+	if javaMajorVersion < java25RuntimeVersion {
+		return nil
+	}
+
+	currentOptions := os.Getenv(jdkJavaOptionsEnvironment)
+	updatedOptions := appendMissingOptions(currentOptions, java25RuntimeOptions)
+	if updatedOptions == currentOptions {
+		return nil
+	}
+	if err := os.Setenv(jdkJavaOptionsEnvironment, updatedOptions); err != nil {
+		return fmt.Errorf("failed to set %s: %w", jdkJavaOptionsEnvironment, err)
+	}
+	return nil
+}
+
+// appendMissingOptions appends each required option to currentOptions unless it
+// is already present, preserving any options the user already set.
+func appendMissingOptions(currentOptions string, requiredOptions []string) string {
+	updatedOptions := strings.TrimSpace(currentOptions)
+	existingOptions := make(map[string]struct{})
+	for _, option := range strings.Fields(currentOptions) {
+		existingOptions[option] = struct{}{}
+	}
+	for _, option := range requiredOptions {
+		if _, exists := existingOptions[option]; exists {
+			continue
+		}
+		if updatedOptions == "" {
+			updatedOptions = option
+		} else {
+			updatedOptions = updatedOptions + " " + option
+		}
+	}
+	return updatedOptions
+}
+
 func printSystemInformation(javaVersion, javaHome, javaOpts string) {
 	fmt.Println("")
 	fmt.Println("")
@@ -265,6 +320,10 @@ func (s *StartupHandler) StartCommand(wg *sync.WaitGroup, ctx context.Context, s
 	javaMajorVersionInt, _ := strconv.Atoi(javaMajorVersion)
 	if javaMajorVersionInt < expectedJavaVersion {
 		fmt.Print("You must use at least JDK " + strconv.Itoa(expectedJavaVersion) + " to start Camunda Platform Run.\n")
+		os.Exit(1)
+	}
+	if err := configureJavaCompatibilityOptions(javaMajorVersionInt); err != nil {
+		fmt.Println(err.Error())
 		os.Exit(1)
 	}
 

--- a/c8run/internal/start/startuphandler_test.go
+++ b/c8run/internal/start/startuphandler_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -71,5 +72,57 @@ func TestResolveJavaHomeAndBinaryKeepsCustomPathWhenSymlinkResolutionFails(t *te
 
 	if resolvedBinary != expectedJavaBinary {
 		t.Fatalf("expected java binary %s, got %s", expectedJavaBinary, resolvedBinary)
+	}
+}
+
+func TestConfigureJavaCompatibilityOptionsAddsJava25Options(t *testing.T) {
+	// given
+	t.Setenv(jdkJavaOptionsEnvironment, "-Dexisting=true")
+
+	// when
+	err := configureJavaCompatibilityOptions(25)
+
+	// then
+	if err != nil {
+		t.Fatalf("configureJavaCompatibilityOptions returned error: %v", err)
+	}
+	actualOptions := os.Getenv(jdkJavaOptionsEnvironment)
+	for _, expectedOption := range []string{"-Dexisting=true", "--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow"} {
+		if !strings.Contains(actualOptions, expectedOption) {
+			t.Fatalf("expected %s in %s", expectedOption, actualOptions)
+		}
+	}
+}
+
+func TestConfigureJavaCompatibilityOptionsSkipsOlderJavaVersions(t *testing.T) {
+	// given
+	t.Setenv(jdkJavaOptionsEnvironment, "-Dexisting=true")
+
+	// when
+	err := configureJavaCompatibilityOptions(21)
+
+	// then
+	if err != nil {
+		t.Fatalf("configureJavaCompatibilityOptions returned error: %v", err)
+	}
+	if os.Getenv(jdkJavaOptionsEnvironment) != "-Dexisting=true" {
+		t.Fatalf("expected existing options to be unchanged, got %s", os.Getenv(jdkJavaOptionsEnvironment))
+	}
+}
+
+func TestConfigureJavaCompatibilityOptionsDoesNotDuplicateJava25Options(t *testing.T) {
+	// given
+	options := "--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
+	t.Setenv(jdkJavaOptionsEnvironment, options)
+
+	// when
+	err := configureJavaCompatibilityOptions(25)
+
+	// then
+	if err != nil {
+		t.Fatalf("configureJavaCompatibilityOptions returned error: %v", err)
+	}
+	if os.Getenv(jdkJavaOptionsEnvironment) != options {
+		t.Fatalf("expected options to be unchanged, got %s", os.Getenv(jdkJavaOptionsEnvironment))
 	}
 }


### PR DESCRIPTION
## Description

On `stable/8.9`, c8run launches its JVMs (Camunda and the **bundled Connectors runtime**) without any JDK 25 compatibility options. Under **JDK 25 — a supported runtime for 8.9** (OpenJDK 21–25 per [supported-environments](https://docs.camunda.io/docs/8.9/reference/supported-environments/), Connectors included) — the Connectors runtime intermittently **hangs a few minutes after startup**: it starts, processes jobs, then its `/actuator/health` stops responding (connection times out, not refused → hung JVM).

This change backports the JDK 25 runtime-option handling that already exists on `main`/8.10: when the runtime JDK is 25+, append `--enable-native-access=ALL-UNNAMED` and `--sun-misc-unsafe-memory-access=allow` to `JDK_JAVA_OPTIONS` so the options reach **every child JVM** (Camunda *and* Connectors), not just the main process. It's a focused port — no jlink/packaging changes from the originating commit.

## Evidence (c8-cross-component-e2e-tests C8Run Nightly Linux)

| Config | Java | Result |
|---|---|---|
| c8Run-8.9 v2 RDBMS | **25** | **7 failed** (all connector specs; `waitForConnectorsReady` times out) |
| c8Run-8.9 v2 RDBMS | 21 | 24 passed ✅ |
| c8Run-8.10 v2 RDBMS | 25 | 20 passed ✅ |

- Reproduced on 3 of the last ~8 nightlies (06-16, 06-19, 06-22), always the same `8.9 + Java 25` job.
- Connectors log: starts fine, processes jobs until it freezes; early log shows `module java.base does not "opens java.util.concurrent"` (JDK strict-module symptom). Zeebe core stays up the whole time.
- 8.10 runs the same connector specs on Java 25 green — the only material difference is that 8.10's c8run sets these JDK 25 options and 8.9's does not.

## Origin

The behaviour was introduced on `main` in `e64e41b3` ("feat: minimal JRE via jlink"), which bundled the Java 25 runtime *and* added `configureJavaCompatibilityOptions`. That commit is large and mixes in jlink/packaging changes not appropriate for a maintenance branch, so this PR ports only the runtime-options logic.

## Testing

- `go build ./...`, `go vet ./internal/start/`, `gofmt` — all clean.
- `go test ./internal/start/` — full package passes, including 3 new focused tests (adds options on 25, no-op on 21, no duplication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
