### PR TITLE
feat: spike for document store PT config overlay

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -8,7 +8,9 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -53,6 +55,14 @@ public class Document {
 
   /** In-memory document stores keyed by store id. */
   @NestedConfigurationProperty private Map<String, InMemoryStore> inMemory = new LinkedHashMap<>();
+
+  /**
+   * Optional per-tenant restriction: a flat list of store ids that narrows the inherited catalog to
+   * a subset for this physical tenant (least privilege). Meaningful only on a tenant overlay
+   * ({@code camunda.physical-tenants.<id>.document.assigned}); ignored at the root. An empty list
+   * means "no restriction" — the tenant keeps the full union of inherited and private stores.
+   */
+  private List<String> assigned = new ArrayList<>();
 
   public String getDefaultStoreId() {
     final String value =
@@ -120,6 +130,14 @@ public class Document {
 
   public void setInMemory(final Map<String, InMemoryStore> inMemory) {
     this.inMemory = inMemory;
+  }
+
+  public List<String> getAssigned() {
+    return assigned;
+  }
+
+  public void setAssigned(final List<String> assigned) {
+    this.assigned = assigned;
   }
 
   public static class AwsStore {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidation.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Document;
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Cross-tenant rule (#54366): no two physical tenants may resolve a document store to the same
+ * physical location ({@link DocumentStoreLocation}).
+ *
+ * <p>Two tenants sharing a store location would silently write into the same bucket/path — the
+ * document analogue of the secondary-storage double-write footgun (see {@link
+ * SecondaryStorageIsolationValidation}). Comparing <em>fully resolved</em> locations means a
+ * non-default tenant that inherits a store unchanged collides with {@code default} too, which is
+ * the intended cost of the inherit-and-override model: a tenant must either override the path or
+ * drop the store via {@code assigned}. Hard-fail, no opt-out. The synthesized {@code default}
+ * tenant participates like any other; single-tenant deployments are a no-op.
+ *
+ * <p>The collision check runs <em>after</em> per-tenant resolution (so {@code assigned}-restricted
+ * stores are already removed and cannot trigger a false collision). Locations are grouped across
+ * all tenants and any location used by more than one tenant is reported as a single error naming
+ * the colliding tenants.
+ */
+@NullMarked
+class DocumentStoreIsolationValidation implements CrossTenantValidation {
+
+  @Override
+  public void validate(final Map<String, Camunda> resolvedByTenant) {
+    if (resolvedByTenant.size() <= 1) {
+      // a single tenant (the common single-tenant deployment) cannot collide with anything
+      return;
+    }
+
+    final Map<DocumentStoreLocation, Set<String>> tenantsByLocation = new LinkedHashMap<>();
+    resolvedByTenant.forEach(
+        (tenantId, camunda) ->
+            locationsOf(camunda.getDocument())
+                .forEach(
+                    location ->
+                        tenantsByLocation
+                            .computeIfAbsent(location, k -> new LinkedHashSet<>())
+                            .add(tenantId)));
+
+    final List<String> collisions = new ArrayList<>();
+    tenantsByLocation.forEach(
+        (location, tenantIds) -> {
+          if (tenantIds.size() > 1) {
+            collisions.add(
+                String.format(
+                    "tenants %s share the same document-store location [%s]",
+                    tenantIds, location.describe()));
+          }
+        });
+
+    if (!collisions.isEmpty()) {
+      throw new UnifiedConfigurationException(
+          "Physical tenants must not share a document-store location, or they would write into the "
+              + "same bucket/path. Use a distinct bucket/container, a distinct path/prefix per "
+              + "tenant, or drop the store via 'document.assigned'. Conflicts: "
+              + String.join("; ", collisions));
+    }
+  }
+
+  /**
+   * The location of every store with a defined location identity. In-memory stores are skipped:
+   * they are ephemeral per-instance objects that can never collide.
+   */
+  private static List<DocumentStoreLocation> locationsOf(final Document doc) {
+    final List<DocumentStoreLocation> locations = new ArrayList<>();
+    doc.getAws().values().forEach(store -> locations.add(DocumentStoreLocation.aws(store)));
+    doc.getGcp().values().forEach(store -> locations.add(DocumentStoreLocation.gcp(store)));
+    doc.getAzure().values().forEach(store -> locations.add(DocumentStoreLocation.azure(store)));
+    doc.getLocal().values().forEach(store -> locations.add(DocumentStoreLocation.local(store)));
+    return locations;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Document.AwsStore;
+import io.camunda.configuration.Document.AzureStore;
+import io.camunda.configuration.Document.GcpStore;
+import io.camunda.configuration.Document.LocalStore;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The minimal, location-determining tuple that decides whether two physical tenants would write
+ * into the <em>same</em> physical document-store location: {@code (provider, coordinates)}. Two
+ * stores resolving to equal {@code DocumentStoreLocation} values collide.
+ *
+ * <p>Mirrors {@link StorageIdentity}'s philosophy: identity is location-only and minimal — adding a
+ * non-location field (e.g. AWS {@code region}, since S3 bucket names are global) could let an
+ * incidental difference mask a real collision. Detection is therefore best-effort and static.
+ *
+ * <p><b>SPIKE note:</b> the production target is a {@code sealed interface} implemented by the
+ * store POJOs, so adding a provider is a compile-time obligation (exhaustive {@code switch}). This
+ * POC uses per-provider factory methods instead, to avoid touching the shared {@code Document}
+ * POJOs; the per-provider {@code coordinates} are identical to what the sealed version would yield.
+ *
+ * <table>
+ *   <caption>Per-provider location coordinates</caption>
+ *   <tr><th>Provider</th><th>Coordinates</th><th>Notes</th></tr>
+ *   <tr><td>{@code aws}</td><td>bucketName + bucketPath</td>
+ *       <td>region excluded (S3 names global); bucketTtl is not location</td></tr>
+ *   <tr><td>{@code gcp}</td><td>bucketName + prefix</td><td></td></tr>
+ *   <tr><td>{@code azure}</td><td>containerName + containerPath + endpoint</td>
+ *       <td>account/credential discrimination deferred (#54366)</td></tr>
+ *   <tr><td>{@code local}</td><td>path</td><td>test-only</td></tr>
+ *   <tr><td>{@code in-memory}</td><td>none → never collides</td>
+ *       <td>test-only; ephemeral per-instance</td></tr>
+ * </table>
+ *
+ * @param provider the provider discriminator ({@code aws}/{@code gcp}/{@code azure}/{@code local})
+ * @param coordinates the normalized location coordinates for that provider
+ */
+@NullMarked
+record DocumentStoreLocation(String provider, List<String> coordinates) {
+
+  static DocumentStoreLocation aws(final AwsStore store) {
+    // region excluded: S3 bucket names are globally unique, so it is redundant and could mask a
+    // collision. bucketTtl is a retention policy, not a location.
+    return new DocumentStoreLocation(
+        "aws", List.of(norm(store.getBucketName()), norm(store.getBucketPath())));
+  }
+
+  static DocumentStoreLocation gcp(final GcpStore store) {
+    return new DocumentStoreLocation(
+        "gcp", List.of(norm(store.getBucketName()), norm(store.getPrefix())));
+  }
+
+  static DocumentStoreLocation azure(final AzureStore store) {
+    // connectionString (credential) excluded; account discrimination deferred (#54366).
+    return new DocumentStoreLocation(
+        "azure",
+        List.of(
+            norm(store.getContainerName()),
+            norm(store.getContainerPath()),
+            norm(store.getEndpoint())));
+  }
+
+  static DocumentStoreLocation local(final LocalStore store) {
+    return new DocumentStoreLocation("local", List.of(norm(store.getPath())));
+  }
+
+  // in-memory has no location() — an ephemeral per-instance object that can never collide. There is
+  // intentionally no factory: callers skip the in-memory map entirely.
+
+  /**
+   * Light, best-effort normalization mirroring {@link StorageIdentity}: trim, strip a trailing
+   * slash, lowercase; {@code null} maps to empty so omitted ≡ "" and both collide.
+   */
+  private static String norm(final @Nullable String value) {
+    if (value == null) {
+      return "";
+    }
+    String normalized = value.trim();
+    if (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    return normalized.toLowerCase();
+  }
+
+  /** A human-readable rendering of this location for error messages. */
+  String describe() {
+    return String.format("provider=%s, coordinates=%s", provider, coordinates);
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAssignedProvidersValidation.java
@@ -26,8 +26,8 @@ import org.springframework.core.env.Environment;
 
 /**
  * Fail-fast startup validation for the per-physical-tenant OIDC provider selection {@code
- * providers.assigned} (issue #54730, see ADR-0004). This is the configuration-layer counterpart of
- * the auth-merge narrowing in {@code PhysicalTenantAuthConfigurations.narrowToAssigned} (the {@code
+ * providers.assigned} (issue #54730). This is the configuration-layer counterpart of the auth-merge
+ * narrowing in {@code PhysicalTenantAuthConfigurations.narrowToAssigned} (the {@code
  * authentication} module): validation rejects an invalid selection here so the merge only ever
  * <em>applies</em> an already-valid one — a non-default tenant can therefore never silently end up
  * with no providers and hence no usable API chain.

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Document;
+import io.camunda.configuration.Document.AwsStore;
+import io.camunda.configuration.Document.AzureStore;
+import io.camunda.configuration.Document.GcpStore;
+import io.camunda.configuration.Document.InMemoryStore;
+import io.camunda.configuration.Document.LocalStore;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
+
+/**
+ * SPIKE (POC) — derives a merged {@link Document} configuration for a specific physical tenant
+ * (catalog-with-inheritance). Mirrors the OIDC provider overlay ({@code
+ * PhysicalTenantAuthConfigurations} in the {@code authentication} module) — same steps, same names
+ * — to keep one mental model across OIDC, documents, and (future) exporters. The two cannot share
+ * code: OIDC lives in {@code authentication/} because CSL is an external library, whereas the
+ * resolved per-tenant {@link Document} is exactly what consumers read here in {@code
+ * configuration/}.
+ *
+ * <p>Resolution per tenant:
+ *
+ * <ol>
+ *   <li><b>Union</b> — root-declared stores ∪ the tenant's own stores. The Spring {@link Binder}
+ *       binds the root {@code camunda.document.*} into a fresh {@link Document}, then binds the
+ *       tenant overlay {@code camunda.physical-tenants.<id>.document.*} into the <em>same</em>
+ *       instance, key-merging the per-provider maps.
+ *   <li><b>Field-override of shared ids</b> — the overlay bind <em>replaces</em> the value POJO of
+ *       any store id present on both sides (the {@code Map}-value footgun characterized for
+ *       exporters), dropping root's sibling fields. {@link #mergeSharedStores} repairs that by
+ *       re-binding the overlay onto each <em>pristine</em> root store POJO (tenant value wins per
+ *       field; omitted fields inherit root). Clean here with no deep-merge because document stores
+ *       are pure typed POJOs with no free-form map field.
+ *   <li><b>Optional restriction</b> — {@link #narrowToAssigned} drops every store id absent from a
+ *       tenant's {@code document.assigned} list (least privilege). Optional, unlike OIDC's
+ *       mandatory {@code assigned}: an inherited store yields the tenant its own isolated location,
+ *       not access to another tenant's data, and the cross-tenant collision check is the real
+ *       guardrail.
+ *   <li><b>Tenant-private stores</b> survive the union automatically (root-only and tenant-only
+ *       stores need no repair).
+ * </ol>
+ *
+ * <p>Cross-tenant location isolation is enforced separately, after all tenants resolve, by {@code
+ * DocumentStoreIsolationValidation}.
+ */
+@NullMarked
+public final class PhysicalTenantDocumentConfigurations {
+
+  private static final String ROOT_PREFIX = "camunda.document";
+  private static final String PT_PREFIX_TEMPLATE = "camunda.physical-tenants.%s.document";
+
+  private PhysicalTenantDocumentConfigurations() {}
+
+  /**
+   * Produces the merged {@link Document} for the given physical tenant id: the union of root and
+   * tenant stores, shared ids field-merged, narrowed to the tenant's optional {@code assigned}
+   * selection.
+   *
+   * @param tenantId the physical tenant id (e.g. {@code "tenanta"})
+   * @param environment the Spring {@link Environment} for binding root and overlay config
+   * @return the resolved per-tenant {@link Document}
+   */
+  public static Document forPhysicalTenant(final String tenantId, final Environment environment) {
+    final Binder binder = Binder.get(environment);
+    final String ptPrefix = PT_PREFIX_TEMPLATE.formatted(tenantId);
+
+    // Bind the root catalog into a fresh, per-call instance (safe to mutate below).
+    final Document doc =
+        binder.bind(ROOT_PREFIX, Bindable.of(Document.class)).orElseGet(Document::new);
+
+    // `assigned` is meaningful only on a tenant overlay; discard anything declared at the root so
+    // the overlay bind is the sole source of the restriction.
+    doc.setAssigned(new ArrayList<>());
+
+    // Snapshot the pristine root store POJOs before the overlay bind can replace shared ids.
+    final Map<String, AwsStore> rootAws = new LinkedHashMap<>(doc.getAws());
+    final Map<String, GcpStore> rootGcp = new LinkedHashMap<>(doc.getGcp());
+    final Map<String, AzureStore> rootAzure = new LinkedHashMap<>(doc.getAzure());
+    final Map<String, LocalStore> rootLocal = new LinkedHashMap<>(doc.getLocal());
+    final Map<String, InMemoryStore> rootInMemory = new LinkedHashMap<>(doc.getInMemory());
+
+    // Bind the overlay into the SAME instance: scalars override, provider maps key-merge (but
+    // replace the value POJO of any shared store id — repaired next).
+    binder.bind(ptPrefix, Bindable.ofInstance(doc));
+
+    // Repair shared store ids: re-bind the overlay onto each pristine root POJO so fields the
+    // overlay omitted survive (override + inherit, all by Binder). Root-only and tenant-only stores
+    // need no repair.
+    mergeSharedStores(binder, ptPrefix, "aws", rootAws, doc.getAws());
+    mergeSharedStores(binder, ptPrefix, "gcp", rootGcp, doc.getGcp());
+    mergeSharedStores(binder, ptPrefix, "azure", rootAzure, doc.getAzure());
+    mergeSharedStores(binder, ptPrefix, "local", rootLocal, doc.getLocal());
+    mergeSharedStores(binder, ptPrefix, "in-memory", rootInMemory, doc.getInMemory());
+
+    narrowToAssigned(doc);
+    return doc;
+  }
+
+  /**
+   * Repairs store ids present on both root and overlay. The overlay bind replaced each such value
+   * with a fresh POJO carrying only the overlay's keys; here we re-bind the overlay onto the
+   * <em>pristine</em> root POJO so the fields the overlay omitted survive. Root-only and
+   * tenant-only stores need no repair. Generic over the provider's store POJO type.
+   */
+  private static <T> void mergeSharedStores(
+      final Binder binder,
+      final String ptPrefix,
+      final String providerKey,
+      final Map<String, T> rootSnapshot,
+      final Map<String, T> merged) {
+    rootSnapshot.forEach(
+        (id, rootStore) -> {
+          if (merged.containsKey(id)) {
+            binder.bind(ptPrefix + "." + providerKey + "." + id, Bindable.ofInstance(rootStore));
+            merged.put(id, rootStore);
+          }
+        });
+  }
+
+  /**
+   * Narrows the merged union to the store ids a tenant has explicitly selected via {@code
+   * document.assigned} (least privilege). A tenant with no {@code assigned} list keeps the full
+   * union — selection is optional. Store ids live in a single flat id space across providers, so
+   * the selection is applied to every provider map. Simpler than OIDC: documents have no unnamed
+   * default slot, so OIDC's reserved-id handling does not carry over.
+   */
+  private static void narrowToAssigned(final Document doc) {
+    final List<String> assigned = doc.getAssigned();
+    if (assigned == null || assigned.isEmpty()) {
+      return; // no restriction — keep the full union
+    }
+    // Defensive: tolerate null/blank list elements (some yaml list shapes bind them).
+    final Set<String> assignedIds = new LinkedHashSet<>();
+    for (final String id : assigned) {
+      if (id != null && !id.isBlank()) {
+        assignedIds.add(id);
+      }
+    }
+    doc.getAws().keySet().removeIf(id -> !assignedIds.contains(id));
+    doc.getGcp().keySet().removeIf(id -> !assignedIds.contains(id));
+    doc.getAzure().keySet().removeIf(id -> !assignedIds.contains(id));
+    doc.getLocal().keySet().removeIf(id -> !assignedIds.contains(id));
+    doc.getInMemory().keySet().removeIf(id -> !assignedIds.contains(id));
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -71,7 +71,8 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
   private static final List<CrossTenantValidation> CROSS_TENANT_VALIDATIONS =
       List.of(
           new SecondaryStorageIsolationValidation(),
-          new SecondaryStorageTypeHomogeneityValidation());
+          new SecondaryStorageTypeHomogeneityValidation(),
+          new DocumentStoreIsolationValidation());
 
   private final Map<String, Camunda> resolved;
 
@@ -96,6 +97,13 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
       binder.bind(Camunda.PREFIX, Bindable.ofInstance(physicalTenant));
       binder.bind(
           PHYSICAL_TENANTS_PREFIX + "." + physicalTenantId, Bindable.ofInstance(physicalTenant));
+      // Recompute only camunda.document.* via the catalog-with-inheritance overlay.
+      // The generic two-bind above replaces the value POJO of any shared store id,
+      // dropping root's sibling fields (the Map-value footgun). forPhysicalTenant repairs shared
+      // stores (field-override) and applies the optional `assigned` restriction. Every other
+      // property keeps the generic two-bind.
+      physicalTenant.setDocument(
+          PhysicalTenantDocumentConfigurations.forPhysicalTenant(physicalTenantId, environment));
       resolvedPhysicalTenants.put(physicalTenantId, physicalTenant);
     }
     if (!resolvedPhysicalTenants.containsKey(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)) {

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Document.AwsStore;
+import io.camunda.configuration.Document.InMemoryStore;
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SPIKE (POC) — proves the cross-tenant document-store location collision check. Mirrors {@code
+ * SecondaryStorageIsolationValidationTest}: hard-fail when two tenants resolve a store to the same
+ * physical location, pass when locations differ.
+ */
+class DocumentStoreIsolationValidationTest {
+
+  private final DocumentStoreIsolationValidation validation =
+      new DocumentStoreIsolationValidation();
+
+  private static Camunda withAws(
+      final String bucketName, final String bucketPath, final String region) {
+    final Camunda camunda = new Camunda();
+    final AwsStore store = new AwsStore();
+    store.setBucketName(bucketName);
+    store.setBucketPath(bucketPath);
+    store.setRegion(region);
+    camunda.getDocument().getAws().put("s3", store);
+    return camunda;
+  }
+
+  @Test
+  void shouldFailWhenTwoTenantsShareBucketAndPath() {
+    // given two tenants whose stores resolve to the same bucket + path
+    final Map<String, Camunda> resolved = new LinkedHashMap<>();
+    resolved.put("tenanta", withAws("docs", "shared/", "eu-west-1"));
+    resolved.put("tenantb", withAws("docs", "shared/", "eu-west-1"));
+
+    // when / then the check hard-fails naming both tenants
+    assertThatThrownBy(() -> validation.validate(resolved))
+        .isInstanceOf(UnifiedConfigurationException.class)
+        .hasMessageContaining("tenanta")
+        .hasMessageContaining("tenantb")
+        .hasMessageContaining("document-store location");
+  }
+
+  @Test
+  void shouldPassWhenPathsDiffer() {
+    // given two tenants sharing a bucket but with distinct paths (the blessed pattern)
+    final Map<String, Camunda> resolved = new LinkedHashMap<>();
+    resolved.put("tenanta", withAws("docs", "tenant-a/", "eu-west-1"));
+    resolved.put("tenantb", withAws("docs", "tenant-b/", "eu-west-1"));
+
+    // when / then no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailIgnoringRegionDifference() {
+    // given same bucket + path but DIFFERENT region — region is not part of the location identity
+    final Map<String, Camunda> resolved = new LinkedHashMap<>();
+    resolved.put("tenanta", withAws("docs", "shared/", "eu-west-1"));
+    resolved.put("tenantb", withAws("docs", "shared/", "us-east-1"));
+
+    // when / then it still collides: region must not mask a real collision
+    assertThatThrownBy(() -> validation.validate(resolved))
+        .isInstanceOf(UnifiedConfigurationException.class);
+  }
+
+  @Test
+  void shouldTreatOmittedAndTrailingSlashPathAsEqual() {
+    // given one tenant with bucket-path "shared" and another with "shared/" (normalization)
+    final Map<String, Camunda> resolved = new LinkedHashMap<>();
+    resolved.put("tenanta", withAws("docs", "shared", "eu-west-1"));
+    resolved.put("tenantb", withAws("docs", "shared/", "eu-west-1"));
+
+    // when / then a trailing slash does not create a spurious distinct location
+    assertThatThrownBy(() -> validation.validate(resolved))
+        .isInstanceOf(UnifiedConfigurationException.class);
+  }
+
+  @Test
+  void shouldNeverCollideOnInMemoryStores() {
+    // given two tenants each with an in-memory store of the same id
+    final Camunda a = new Camunda();
+    a.getDocument().getInMemory().put("mem", new InMemoryStore());
+    final Camunda b = new Camunda();
+    b.getDocument().getInMemory().put("mem", new InMemoryStore());
+    final Map<String, Camunda> resolved = new LinkedHashMap<>();
+    resolved.put("tenanta", a);
+    resolved.put("tenantb", b);
+
+    // when / then in-memory stores are ephemeral per-instance and never collide
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldBeNoOpForSingleTenant() {
+    final Map<String, Camunda> resolved = new LinkedHashMap<>();
+    resolved.put("tenanta", withAws("docs", "shared/", "eu-west-1"));
+
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldDistinguishProvidersWithSameCoordinates() {
+    // given an aws store and (hypothetically) a gcp store with identical coordinate strings
+    final Camunda a = withAws("docs", "shared/", "eu-west-1");
+    final Camunda b = new Camunda();
+    final var gcp = new io.camunda.configuration.Document.GcpStore();
+    gcp.setBucketName("docs");
+    gcp.setPrefix("shared/");
+    b.getDocument().getGcp().put("g", gcp);
+    final Map<String, Camunda> resolved = new LinkedHashMap<>();
+    resolved.put("tenanta", a);
+    resolved.put("tenantb", b);
+
+    // when / then the provider discriminator keeps them distinct
+    assertThat(resolved).hasSize(2);
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Document;
+import io.camunda.configuration.Document.AwsStore;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * SPIKE (POC) — proves the per-tenant document-store overlayimplemented by {@link
+ * PhysicalTenantDocumentConfigurations}. Counterpart to {@code
+ * ExporterArgsOverlayCharacterizationTest}, which pins the native (broken) behavior: here we prove
+ * the overlay repairs it.
+ *
+ * <p>Each test seeds a root catalog plus a {@code tenanta} overlay and resolves only the document
+ * config (the overlay in isolation — no per-PT required-override validation, which is exercised
+ * end-to-end in {@link PhysicalTenantResolverDocumentTest}).
+ */
+class PhysicalTenantDocumentOverlayTest {
+
+  private MockEnvironment environment;
+
+  @BeforeEach
+  void setUp() {
+    environment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(environment);
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  private void withProperties(final Map<String, Object> properties) {
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+  }
+
+  @Test
+  void shouldFieldOverrideSharedStoreInsteadOfReplacing() {
+    // given a root store with three fields and a tenant overriding ONLY the bucket-path
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("camunda.document.aws.shared-s3.bucket-name", "global-docs");
+    properties.put("camunda.document.aws.shared-s3.region", "eu-west-1");
+    properties.put("camunda.document.aws.shared-s3.bucket-path", "root/");
+    properties.put(
+        "camunda.physical-tenants.tenanta.document.aws.shared-s3.bucket-path", "tenant-a/");
+    withProperties(properties);
+
+    // when the tenant's document config is resolved
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then the overridden field wins and the omitted fields are INHERITED (not nulled — the footgun
+    // the native overlay would hit, see ExporterArgsOverlayCharacterizationTest)
+    final AwsStore store = doc.getAws().get("shared-s3");
+    assertThat(store).as("the shared store survives the overlay").isNotNull();
+    assertThat(store.getBucketPath())
+        .as("overridden field takes the tenant value")
+        .isEqualTo("tenant-a/");
+    assertThat(store.getBucketName()).as("omitted field inherits root").isEqualTo("global-docs");
+    assertThat(store.getRegion()).as("omitted field inherits root").isEqualTo("eu-west-1");
+  }
+
+  @Test
+  void shouldInheritStoreNotTouchedByTenant() {
+    // given a root catalog with two stores and a tenant touching only one
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("camunda.document.aws.shared-s3.bucket-name", "global-docs");
+    properties.put("camunda.document.gcp.analytics-gcs.bucket-name", "analytics");
+    properties.put("camunda.document.gcp.analytics-gcs.prefix", "root/");
+    properties.put(
+        "camunda.physical-tenants.tenanta.document.aws.shared-s3.bucket-path", "tenant-a/");
+    withProperties(properties);
+
+    // when resolved
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then the untouched store is inherited whole
+    assertThat(doc.getGcp()).containsKey("analytics-gcs");
+    assertThat(doc.getGcp().get("analytics-gcs").getBucketName()).isEqualTo("analytics");
+    assertThat(doc.getGcp().get("analytics-gcs").getPrefix()).isEqualTo("root/");
+  }
+
+  @Test
+  void shouldKeepTenantPrivateStore() {
+    // given a tenant declaring a store id that does not exist at the root
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("camunda.document.aws.shared-s3.bucket-name", "global-docs");
+    properties.put(
+        "camunda.physical-tenants.tenantb.document.azure.tenantb-blob.container-name", "tenantb");
+    properties.put(
+        "camunda.physical-tenants.tenantb.document.azure.tenantb-blob.container-path", "docs/");
+    withProperties(properties);
+
+    // when resolved
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenantb", environment);
+
+    // then the tenant-private store survives the union alongside the inherited one
+    assertThat(doc.getAws()).containsKey("shared-s3");
+    assertThat(doc.getAzure()).containsKey("tenantb-blob");
+    assertThat(doc.getAzure().get("tenantb-blob").getContainerName()).isEqualTo("tenantb");
+  }
+
+  @Test
+  void shouldNarrowToAssignedWhenDeclared() {
+    // given a root catalog of two stores and a tenant restricting to a subset
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("camunda.document.aws.shared-s3.bucket-name", "global-docs");
+    properties.put("camunda.document.gcp.analytics-gcs.bucket-name", "analytics");
+    properties.put("camunda.physical-tenants.tenantb.document.assigned[0]", "shared-s3");
+    withProperties(properties);
+
+    // when resolved
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenantb", environment);
+
+    // then only the assigned store remains; the unlisted one is dropped
+    assertThat(doc.getAws()).containsKey("shared-s3");
+    assertThat(doc.getGcp()).doesNotContainKey("analytics-gcs");
+  }
+
+  @Test
+  void shouldKeepFullUnionWhenNoAssigned() {
+    // given a root catalog and a tenant with NO assigned list
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("camunda.document.aws.shared-s3.bucket-name", "global-docs");
+    properties.put("camunda.document.gcp.analytics-gcs.bucket-name", "analytics");
+    properties.put(
+        "camunda.physical-tenants.tenanta.document.aws.shared-s3.bucket-path", "tenant-a/");
+    withProperties(properties);
+
+    // when resolved
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then the full union is kept (selection is optional, unlike OIDC)
+    assertThat(doc.getAws()).containsKey("shared-s3");
+    assertThat(doc.getGcp()).containsKey("analytics-gcs");
+  }
+
+  @Test
+  void shouldIgnoreAssignedDeclaredAtRoot() {
+    // given an `assigned` declared at the ROOT (meaningless) and a tenant that declares none
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("camunda.document.aws.shared-s3.bucket-name", "global-docs");
+    properties.put("camunda.document.gcp.analytics-gcs.bucket-name", "analytics");
+    properties.put("camunda.document.assigned[0]", "shared-s3"); // ignored at root
+    properties.put(
+        "camunda.physical-tenants.tenanta.document.aws.shared-s3.bucket-path", "tenant-a/");
+    withProperties(properties);
+
+    // when resolved
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then the root `assigned` does NOT narrow the tenant — the full union is kept
+    assertThat(doc.getAws()).containsKey("shared-s3");
+    assertThat(doc.getGcp()).containsKey("analytics-gcs");
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverDocumentTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverDocumentTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * SPIKE (POC) — proves the per-tenant document overlay is wired end-to-end into {@link
+ * PhysicalTenantResolver#of}: the recompute runs per tenant and {@code
+ * DocumentStoreIsolationValidation} fails boot on a location collision (#54366).
+ */
+class PhysicalTenantResolverDocumentTest {
+
+  private MockEnvironment environment;
+
+  @BeforeEach
+  void setUp() {
+    environment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(environment);
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  /** Per-PT prerequisites required by the resolver's other validations, unrelated to documents. */
+  private void addTenantPrerequisites(final Map<String, Object> properties, final String tenantId) {
+    // distinct secondary-storage location so SecondaryStorageIsolationValidation does not fire
+    // first
+    properties.put(
+        "camunda.physical-tenants."
+            + tenantId
+            + ".data.secondary-storage.elasticsearch.index-prefix",
+        tenantId);
+    // each PT must provide its own initialization block (required per-PT override)
+    properties.put(
+        "camunda.physical-tenants."
+            + tenantId
+            + ".security.initialization.default-roles.admin.users[0]",
+        tenantId + "-admin");
+  }
+
+  private Camunda resolveRoot() {
+    final Camunda camunda = new Camunda();
+    Binder.get(environment).bind(Camunda.PREFIX, Bindable.ofInstance(camunda));
+    return camunda;
+  }
+
+  @Test
+  void shouldFailBootWhenTwoTenantsInheritSameStoreUnchanged() {
+    // given a root store that both tenants inherit WITHOUT overriding its path
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("camunda.document.aws.shared-s3.bucket-name", "global-docs");
+    properties.put("camunda.document.aws.shared-s3.bucket-path", "root/");
+    addTenantPrerequisites(properties, "tenanta");
+    addTenantPrerequisites(properties, "tenantb");
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+
+    // when / then resolution fails fast: both tenants (and 'default') resolve to global-docs:root/
+    assertThatThrownBy(() -> PhysicalTenantResolver.of(environment, resolveRoot()))
+        .isInstanceOf(UnifiedConfigurationException.class)
+        .hasMessageContaining("document-store location");
+  }
+
+  @Test
+  void shouldResolveWhenEachTenantOverridesPathDistinctly() {
+    // given each tenant overriding ONLY the bucket-path to a distinct value
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("camunda.document.aws.shared-s3.bucket-name", "global-docs");
+    properties.put("camunda.document.aws.shared-s3.bucket-path", "root/");
+    properties.put(
+        "camunda.physical-tenants.tenanta.document.aws.shared-s3.bucket-path", "tenant-a/");
+    properties.put(
+        "camunda.physical-tenants.tenantb.document.aws.shared-s3.bucket-path", "tenant-b/");
+    addTenantPrerequisites(properties, "tenanta");
+    addTenantPrerequisites(properties, "tenantb");
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+
+    // when resolved
+    final PhysicalTenantResolver resolver = PhysicalTenantResolver.of(environment, resolveRoot());
+
+    // then it boots, and each tenant has the field-merged store (name inherited, path overridden)
+    final Camunda tenantA = resolver.forPhysicalTenant("tenanta");
+    assertThat(tenantA.getDocument().getAws().get("shared-s3").getBucketName())
+        .isEqualTo("global-docs");
+    assertThat(tenantA.getDocument().getAws().get("shared-s3").getBucketPath())
+        .isEqualTo("tenant-a/");
+  }
+
+  @Test
+  void shouldResolveWhenTenantDropsCollidingStoreViaAssigned() {
+    // given a root store both tenants would inherit, but tenantb drops it and brings its own
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("camunda.document.aws.shared-s3.bucket-name", "global-docs");
+    properties.put("camunda.document.aws.shared-s3.bucket-path", "root/");
+    // tenanta overrides the path; tenantb restricts to its own private store, dropping shared-s3
+    properties.put(
+        "camunda.physical-tenants.tenanta.document.aws.shared-s3.bucket-path", "tenant-a/");
+    properties.put("camunda.physical-tenants.tenantb.document.assigned[0]", "tenantb-blob");
+    properties.put(
+        "camunda.physical-tenants.tenantb.document.azure.tenantb-blob.container-name", "tenantb");
+    properties.put(
+        "camunda.physical-tenants.tenantb.document.azure.tenantb-blob.container-path", "docs/");
+    addTenantPrerequisites(properties, "tenanta");
+    addTenantPrerequisites(properties, "tenantb");
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+
+    // when resolved
+    final PhysicalTenantResolver resolver = PhysicalTenantResolver.of(environment, resolveRoot());
+
+    // then tenantb dropped the inherited store (no collision with 'default') and kept its private
+    // one
+    final Camunda tenantB = resolver.forPhysicalTenant("tenantb");
+    assertThat(tenantB.getDocument().getAws()).doesNotContainKey("shared-s3");
+    assertThat(tenantB.getDocument().getAzure()).containsKey("tenantb-blob");
+  }
+
+  @Test
+  void shouldResolveSingleTenantWithoutCollision() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("camunda.document.aws.shared-s3.bucket-name", "global-docs");
+    properties.put("camunda.document.aws.shared-s3.bucket-path", "root/");
+    addTenantPrerequisites(properties, "tenanta");
+    properties.put(
+        "camunda.physical-tenants.tenanta.document.aws.shared-s3.bucket-path", "tenant-a/");
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+
+    assertThatCode(() -> PhysicalTenantResolver.of(environment, resolveRoot()))
+        .doesNotThrowAnyException();
+  }
+}


### PR DESCRIPTION
## Description

Spike / POC exploring how each **physical tenant** gets its own document-store configuration, and how we keep tenants from silently writing into the same physical location.

Design context: [Per-tenant document store configuration (design doc)](https://docs.google.com/document/d/1hLdPXbKNZvijRxwFn-N1QUW8pAMXX4vZtrrnpAr9TGM/edit?tab=t.tl54tsmcckua).

### What it does

Extends the physical-tenant resolver so a tenant's `camunda.document.*` is resolved from a shared root catalog with per-tenant overrides, instead of relying on the native Spring overlay:

- **Inherit the catalog** — a tenant inherits every store declared at the root.
- **Field-level override** — a tenant can override individual fields of an inherited store (e.g. just the `bucket-path`) without losing the sibling fields. This fixes the native-overlay footgun where touching one field of a map-valued store resets the rest to `null`.
- **Optional restriction** — a tenant may narrow its inherited catalog to a subset via an optional `document.assigned` list (least privilege). Omitting it keeps the full union.
- **Tenant-private stores** — a tenant can declare stores that exist only for itself.
- **Hard-fail isolation** — at startup, if two tenants resolve a store to the same physical location (same bucket + path, container + path, etc.), the boot fails fast and names the offending tenants. No opt-out. This mirrors the existing secondary-storage isolation check.

The resolution steps and naming deliberately mirror the existing per-tenant OIDC provider overlay, so the two share one mental model.

### Changes

- `Document` — new optional `assigned` field (tenant-overlay only).
- `PhysicalTenantDocumentConfigurations` — the per-tenant document overlay (inherit → field-override → narrow-to-assigned).
- `DocumentStoreLocation` + `DocumentStoreIsolationValidation` — provider-dependent location identity and the cross-tenant collision check, registered in `PhysicalTenantResolver`.
- Tests covering the overlay, the isolation check, and the end-to-end resolver path.

### Spike caveats (follow-ups for a production change)

- Location identity uses a pattern-match helper rather than a compiler-enforced exhaustive form; adding a provider is not yet a compile-time obligation.
- No fail-fast validation of `document.assigned` ids (the overlay only *applies* a selection; it does not yet reject an invalid one).
- Azure account/credential discrimination is not yet part of the location identity.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Relates to #54366
