### PR TITLE
deps: update spring version to clear CVE-2026-41850/41852

### DIFF
--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -26,7 +26,7 @@
     <!-- Override Spring Boot version for 3.x compatibility -->
     <version.spring-boot>3.5.14</version.spring-boot>
     <!-- Spring Framework 6.x is required for Spring Boot 3.x -->
-    <version.spring>6.2.18</version.spring>
+    <version.spring>6.2.19</version.spring>
     <version.roaster>2.31.0.Final</version.roaster>
     <version.aspectjweaver>1.9.25.1</version.aspectjweaver>
     <generated.test.sources.path>${project.build.directory}/generated-test-sources/java</generated.test.sources.path>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -112,7 +112,7 @@
     <version.feel-scala>1.21.0</version.feel-scala>
     <version.dmn-scala>1.12.0</version.dmn-scala>
     <version.rest-assured>6.0.0</version.rest-assured>
-    <version.spring>7.0.7</version.spring>
+    <version.spring>7.0.8</version.spring>
     <version.spring-security>7.0.5</version.spring-security>
     <version.spring-boot>4.0.6</version.spring-boot>
     <version.spring-ai>2.0.0-M7</version.spring-ai>

--- a/testing/camunda-process-test-spring-boot-3/pom.xml
+++ b/testing/camunda-process-test-spring-boot-3/pom.xml
@@ -18,7 +18,7 @@
     <!-- Override Spring Boot version for 3.x compatibility -->
     <version.spring-boot>3.5.14</version.spring-boot>
     <!-- Spring Framework 6.x is required for Spring Boot 3.x -->
-    <version.spring>6.2.18</version.spring>
+    <version.spring>6.2.19</version.spring>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Description

Dependency is present, but not used in a way that makes the CVE reachable

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #55623
