### PR TITLE
feat: skip required physical-tenant init validation when authorization is disabled

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
@@ -101,9 +101,9 @@ final class PhysicalTenantRequiredOverrideValidation {
             .toList();
     if (!missing.isEmpty()) {
       throw new UnifiedConfigurationException(
-          "Each explicitly-configured physical tenant must declare its own initialization block, "
-              + "if authorizations are enabled, under "
-              + "'camunda.physical-tenants.<id>.security.initialization.*'; it may not be "
+          "Each explicitly-configured physical tenant must declare its own initialization block under "
+              + "'camunda.physical-tenants.<id>.security.initialization.*' when authorization is enabled "
+              + "for that tenant; it may not be "
               + "inherited from the root (the '"
               + PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID
               + "' tenant keeps the top-level 'camunda.security.initialization'). Physical tenants "

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
@@ -99,8 +99,9 @@ final class PhysicalTenantRequiredOverrideValidation {
             .toList();
     if (!missing.isEmpty()) {
       throw new UnifiedConfigurationException(
-          "Each explicitly-configured physical tenant must declare its own initialization block "
-              + "under 'camunda.physical-tenants.<id>.security.initialization.*'; it may not be "
+          "Each explicitly-configured physical tenant must declare its own initialization block, "
+              + "if authorizations are enabled, under "
+              + "'camunda.physical-tenants.<id>.security.initialization.*'; it may not be "
               + "inherited from the root (the '"
               + PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID
               + "' tenant keeps the top-level 'camunda.security.initialization'). Physical tenants "

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
@@ -26,7 +26,8 @@ import org.springframework.core.env.Environment;
 /**
  * Required-override policy for physical-tenant configuration: every explicitly-configured physical
  * tenant must declare its own {@code initialization} block under {@code
- * camunda.physical-tenants.<id>.security.initialization.*}.
+ * camunda.physical-tenants.<id>.security.initialization.*}, unless authorization is disabled for
+ * that tenant.
  *
  * <p>The {@code initialization} block seeds tenant-scoped identity (users, roles, authorizations,
  * tenants, …). Unlike the cluster-wide settings guarded by {@link
@@ -39,10 +40,11 @@ import org.springframework.core.env.Environment;
  * root configuration and keeps the top-level {@code camunda.security.initialization}, whether it is
  * synthesized from the root or declared explicitly.
  *
- * <p>Enforcement is pure <em>key inspection</em> over the declared {@code physical-tenants.<id>.*}
- * keys — the same walk {@link PhysicalTenantResolver#discover(Environment)} does — with no value
- * comparison and no binding. A tenant that declares no key at or under {@code
- * security.initialization} fails resolution.
+ * <p>Enforcement is <em>key inspection</em> over the declared {@code physical-tenants.<id>.*} keys
+ * — the same walk {@link PhysicalTenantResolver#discover(Environment)} does. The one value it binds
+ * is the tenant's effective {@code security.authorization.enabled} (per-tenant override, else root,
+ * else the default), which determines whether the tenant is exempt. A tenant with authorization
+ * enabled that declares no key at or under {@code security.initialization} fails resolution.
  */
 @NullMarked
 final class PhysicalTenantRequiredOverrideValidation {
@@ -93,8 +95,8 @@ final class PhysicalTenantRequiredOverrideValidation {
         declaredTenants.stream()
             .filter(id -> !PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(id))
             .filter(id -> !tenantsWithInitialization.contains(id))
-            // an initialization block seeds authorizations; a tenant running with
-            // authorization disabled has no use for it, so it is not required.
+            // the initialization block only takes effect when authorization is enabled, so a
+            // tenant running with authorization disabled is not required to declare one.
             .filter(id -> authorizationEnabledFor(binder, id))
             .toList();
     if (!missing.isEmpty()) {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidation.java
@@ -14,6 +14,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.jspecify.annotations.NullMarked;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName.Form;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
@@ -86,10 +88,14 @@ final class PhysicalTenantRequiredOverrideValidation {
       }
     }
 
+    final Binder binder = Binder.get(environment);
     final List<String> missing =
         declaredTenants.stream()
             .filter(id -> !PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(id))
             .filter(id -> !tenantsWithInitialization.contains(id))
+            // an initialization block seeds authorizations; a tenant running with
+            // authorization disabled has no use for it, so it is not required.
+            .filter(id -> authorizationEnabledFor(binder, id))
             .toList();
     if (!missing.isEmpty()) {
       throw new UnifiedConfigurationException(
@@ -106,5 +112,23 @@ final class PhysicalTenantRequiredOverrideValidation {
   private static boolean declaresInitialization(final ConfigurationPropertyName relative) {
     return REQUIRED_INITIALIZATION.equals(relative)
         || REQUIRED_INITIALIZATION.isAncestorOf(relative);
+  }
+
+  /**
+   * Resolves the effective {@code authorization.enabled} for a tenant: the per-tenant override if
+   * declared, otherwise the root value, otherwise the default ({@code true}). This is the only
+   * value read by this validation; the rest is pure key inspection.
+   */
+  private static boolean authorizationEnabledFor(final Binder binder, final String tenantId) {
+    final var perTenant =
+        binder.bind(
+            Camunda.PREFIX + ".physical-tenants." + tenantId + ".security.authorization.enabled",
+            Bindable.of(Boolean.class));
+    if (perTenant.isBound()) {
+      return perTenant.get();
+    }
+    return binder
+        .bind(Camunda.PREFIX + ".security.authorization.enabled", Bindable.of(Boolean.class))
+        .orElse(true);
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidationTest.java
@@ -185,4 +185,21 @@ class PhysicalTenantRequiredOverrideValidationTest {
         .withMessageContaining("tenantb")
         .withMessageNotContaining("tenanta");
   }
+
+  @Test
+  void shouldRequireInitializationWhenAuthorizationValueIsBlank() {
+    // given a non-default tenant whose authorization.enabled is present but blank (YAML
+    // 'enabled:'), with no initialization block and no root override
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of("camunda.physical-tenants.tenanta.security.authorization.enabled", ""));
+
+    // when / then Spring binds a blank value to "unbound", so authorization resolves to the
+    // default (enabled) and initialization is still required — a clear configuration error,
+    // not a NullPointerException (which would not match UnifiedConfigurationException)
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .withMessageContaining("camunda.physical-tenants.<id>.security.initialization")
+        .withMessageContaining("tenanta");
+  }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantRequiredOverrideValidationTest.java
@@ -127,4 +127,62 @@ class PhysicalTenantRequiredOverrideValidationTest {
     assertThatCode(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
         .doesNotThrowAnyException();
   }
+
+  @Test
+  void shouldNotRequireInitializationWhenTenantAuthorizationDisabled() {
+    // given a non-default tenant with authorization disabled and no initialization block
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of("camunda.physical-tenants.tenanta.security.authorization.enabled", false));
+
+    // when / then the initialization block is not required for an authz-disabled tenant
+    assertThatCode(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldNotRequireInitializationWhenRootAuthorizationDisabled() {
+    // given root authorization disabled and a tenant that does not override it or declare init
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.security.authorization.enabled",
+                false,
+                "camunda.physical-tenants.tenanta.cluster.partition-count",
+                3));
+
+    // when / then the tenant inherits the disabled root authorization and is exempt
+    assertThatCode(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRequireInitializationWhenTenantAuthorizationEnabledExplicitly() {
+    // given a tenant that explicitly enables authorization but declares no initialization block
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of("camunda.physical-tenants.tenanta.security.authorization.enabled", true));
+
+    // when / then initialization is still required, and the offending tenant is named
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .withMessageContaining("camunda.physical-tenants.<id>.security.initialization")
+        .withMessageContaining("tenanta");
+  }
+
+  @Test
+  void shouldOnlyExemptTenantsWithAuthorizationDisabled() {
+    // given one authz-disabled tenant and one authz-enabled tenant, neither with init
+    final MockEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.physical-tenants.tenanta.security.authorization.enabled", false,
+                "camunda.physical-tenants.tenantb.security.authorization.enabled", true));
+
+    // when / then only the authz-enabled tenant is reported as missing initialization
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> PhysicalTenantRequiredOverrideValidation.validate(environment))
+        .withMessageContaining("tenantb")
+        .withMessageNotContaining("tenanta");
+  }
 }


### PR DESCRIPTION
## Description

`PhysicalTenantRequiredOverrideValidation` requires every explicitly-configured non-`default` physical tenant to declare its own initialization block under `camunda.physical-tenants.<id>.security.initialization.*`. That block exists to seed tenant-scoped authorizations (default roles / admin grants) — so it only matters when authorization is enabled.

This change exempts a non-`default` physical tenant from the requirement when authorization is **effectively disabled** for that tenant. Authorization-enabled tenants keep the existing requirement unchanged.

"Effectively disabled" follows the same inherit-from-root model as the rest of per-tenant config:
1. the per-tenant override `camunda.physical-tenants.<id>.security.authorization.enabled` if declared,
2. else the root `camunda.security.authorization.enabled`,
3. else the default (`true`).

This is the first value the validation binds; the rest stays pure config-key inspection.

## Acceptance criteria coverage

All tests live in `PhysicalTenantRequiredOverrideValidationTest`.

**AC1 — authz-disabled non-default PT is not required to declare a `security.initialization` block**
- `shouldNotRequireInitializationWhenTenantAuthorizationDisabled`
- `shouldNotRequireInitializationWhenRootAuthorizationDisabled`
- `shouldOnlyExemptTenantsWithAuthorizationDisabled`

**AC2 — authz-enabled PT keeps the existing required-initialization validation**
- `shouldRequireInitializationWhenTenantAuthorizationEnabledExplicitly`
- `shouldOnlyExemptTenantsWithAuthorizationDisabled`
- `shouldRejectTenantWithoutInitializationBlock`, `shouldReportEveryTenantMissingInitialization`, `shouldOnlyRejectTenantsThatAreMissingInitialization` (pre-existing, default authz-on path)

**AC3 — both cases covered**: union of the AC1 and AC2 tests above.

Closes #55598

🤖 Generated with [Claude Code](https://claude.com/claude-code)