### PR TITLE
feat: route identity and membership resolution to the in-context physical tenant

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -9,7 +9,6 @@ package io.camunda.authentication.service;
 
 import static io.camunda.service.authorization.Authorizations.COMPONENT_ACCESS_AUTHORIZATION;
 
-import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
@@ -20,6 +19,7 @@ import io.camunda.security.core.port.in.CamundaUserPort;
 import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -82,9 +82,7 @@ public class BasicCamundaUserService implements CamundaUserPort {
   protected UserEntity getUser(final CamundaAuthentication authentication) {
     final var username = authentication.authenticatedUsername();
     return serviceRegistry
-        .userServices(
-            PhysicalTenantIds
-                .DEFAULT_PHYSICAL_TENANT_ID) // TODO replace with contextual physicalTenantId
+        .userServices(PhysicalTenantContext.current())
         .getUser(username, CamundaAuthentication.anonymous());
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -10,7 +10,6 @@ package io.camunda.authentication.service;
 import static io.camunda.security.api.model.authz.EntityType.GROUP;
 import static io.camunda.security.api.model.authz.EntityType.MAPPING_RULE;
 
-import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.RoleEntity;
@@ -23,6 +22,7 @@ import io.camunda.security.core.port.out.MembershipQuery;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
@@ -65,9 +65,7 @@ public class DefaultMembershipService implements MembershipPort {
     }
     final var ids =
         serviceRegistry
-            .mappingRuleServices(
-                PhysicalTenantIds
-                    .DEFAULT_PHYSICAL_TENANT_ID) // TODO replace with contextual physicalTenantId
+            .mappingRuleServices(PhysicalTenantContext.current())
             .getMatchingMappingRules(query.tokenClaims(), CamundaAuthentication.anonymous())
             .map(MappingRuleEntity::mappingRuleId)
             .collect(Collectors.toSet());
@@ -90,9 +88,7 @@ public class DefaultMembershipService implements MembershipPort {
     final var owners = buildOwners(query);
     final var ids =
         serviceRegistry
-            .groupServices(
-                PhysicalTenantIds
-                    .DEFAULT_PHYSICAL_TENANT_ID) // TODO replace with contextual physicalTenantId
+            .groupServices(PhysicalTenantContext.current())
             .getGroupsByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous())
             .stream()
             .map(GroupEntity::groupId)
@@ -108,9 +104,7 @@ public class DefaultMembershipService implements MembershipPort {
     }
     final var ids =
         serviceRegistry
-            .roleServices(
-                PhysicalTenantIds
-                    .DEFAULT_PHYSICAL_TENANT_ID) // TODO replace with contextual physicalTenantId
+            .roleServices(PhysicalTenantContext.current())
             .getRolesByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous())
             .stream()
             .map(RoleEntity::roleId)
@@ -128,9 +122,7 @@ public class DefaultMembershipService implements MembershipPort {
       owners.put(EntityType.ROLE, new HashSet<>(query.resolvedRoleIds()));
     }
     return serviceRegistry
-        .tenantServices(
-            PhysicalTenantIds
-                .DEFAULT_PHYSICAL_TENANT_ID) // TODO replace with contextual physicalTenantId
+        .tenantServices(PhysicalTenantContext.current())
         .getTenantsByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous())
         .stream()
         .map(TenantEntity::tenantId)

--- a/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
@@ -24,17 +24,25 @@ import io.camunda.security.core.authz.ResourceAccess;
 import io.camunda.security.core.authz.ResourceAccessProvider;
 import io.camunda.service.UserServices;
 import io.camunda.service.registry.DefaultServiceRegistry;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class BasicCamundaUserServiceTest {
+
+  private static final String TENANT_A = "tenanta";
 
   @Mock private CamundaAuthenticationProvider authenticationProvider;
   @Mock private ResourceAccessProvider resourceAccessProvider;
   @Mock private UserServices userServices;
+  @Mock private UserServices tenantAUserServices;
   @Mock private CamundaAuthentication authentication;
   private BasicCamundaUserService basicCamundaUserService;
 
@@ -57,11 +65,21 @@ public class BasicCamundaUserServiceTest {
 
     final var serviceRegistry =
         DefaultServiceRegistry.of(
-            b -> b.userServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, userServices));
+            b ->
+                b.userServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, userServices)
+                    .userServices(TENANT_A, tenantAUserServices));
 
     basicCamundaUserService =
         new BasicCamundaUserService(
             authenticationProvider, resourceAccessProvider, serviceRegistry);
+
+    RequestContextHolder.setRequestAttributes(
+        new ServletRequestAttributes(new MockHttpServletRequest()));
+  }
+
+  @AfterEach
+  void clearRequestScope() {
+    RequestContextHolder.resetRequestAttributes();
   }
 
   @Test
@@ -195,5 +213,24 @@ public class BasicCamundaUserServiceTest {
 
     // then
     assertThat(currentUser).isNull();
+  }
+
+  @Test
+  void shouldRouteUserLookupToRequestPhysicalTenant() {
+    // given a request scoped to a non-default physical tenant
+    final var request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, TENANT_A);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    final var tenantAUser = mock(UserEntity.class);
+    when(tenantAUser.userKey()).thenReturn(200L);
+    when(tenantAUser.name()).thenReturn("Tenant A User");
+    when(tenantAUser.email()).thenReturn("foo@bar.com");
+    when(tenantAUserServices.getUser(eq("foo@bar.com"), any())).thenReturn(tenantAUser);
+
+    // when
+    final var currentUser = basicCamundaUserService.getCurrentUser();
+
+    // then — resolved via the tenant-A user services, not the default
+    assertThat(currentUser.displayName()).isEqualTo("Tenant A User");
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
@@ -9,6 +9,7 @@ package io.camunda.authentication.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.GroupEntity;
@@ -23,22 +24,33 @@ import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import io.camunda.service.registry.DefaultServiceRegistry;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultMembershipServiceTest {
+
+  private static final String TENANT_A = "tenanta";
 
   @Mock private MappingRuleServices mappingRuleServices;
   @Mock private TenantServices tenantServices;
   @Mock private RoleServices roleServices;
   @Mock private GroupServices groupServices;
+  @Mock private GroupServices tenantAGroupServices;
+  @Mock private TenantServices tenantATenantServices;
+  @Mock private RoleServices tenantARoleServices;
+  @Mock private MappingRuleServices tenantAMappingRuleServices;
 
   private DefaultMembershipService service;
 
@@ -50,8 +62,19 @@ class DefaultMembershipServiceTest {
                 b.mappingRuleServices("default", mappingRuleServices)
                     .groupServices("default", groupServices)
                     .roleServices("default", roleServices)
-                    .tenantServices("default", tenantServices));
+                    .tenantServices("default", tenantServices)
+                    .groupServices(TENANT_A, tenantAGroupServices)
+                    .tenantServices(TENANT_A, tenantATenantServices)
+                    .roleServices(TENANT_A, tenantARoleServices)
+                    .mappingRuleServices(TENANT_A, tenantAMappingRuleServices));
     service = new DefaultMembershipService(serviceRegistry, new CamundaSecurityLibraryProperties());
+    RequestContextHolder.setRequestAttributes(
+        new ServletRequestAttributes(new MockHttpServletRequest()));
+  }
+
+  @AfterEach
+  void clearRequestScope() {
+    RequestContextHolder.resetRequestAttributes();
   }
 
   private MembershipQuery baseQuery() {
@@ -101,5 +124,70 @@ class DefaultMembershipServiceTest {
             .withRoleIds(List.of("r1"));
 
     assertThat(service.tenantIds(query)).containsExactly("t1");
+  }
+
+  @Test
+  void shouldRouteGroupLookupToRequestPhysicalTenant() {
+    final var request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, TENANT_A);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    when(tenantAGroupServices.getGroupsByMemberTypeAndMemberIds(any(), any()))
+        .thenReturn(List.of(new GroupEntity(1L, "ga1", "group", null)));
+    final var query = baseQuery().withMappingRuleIds(List.of("mr1"));
+
+    assertThat(service.groupIds(query)).containsExactly("ga1");
+    verifyNoInteractions(groupServices);
+  }
+
+  @Test
+  void shouldRouteTenantLookupToRequestPhysicalTenant() {
+    final var request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, TENANT_A);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    when(tenantATenantServices.getTenantsByMemberTypeAndMemberIds(any(), any()))
+        .thenReturn(List.of(new TenantEntity(1L, "ta1", "tenant", null)));
+    final var query =
+        baseQuery()
+            .withMappingRuleIds(List.of())
+            .withGroupIds(List.of("g1"))
+            .withRoleIds(List.of("r1"));
+
+    assertThat(service.tenantIds(query)).containsExactly("ta1");
+    verifyNoInteractions(tenantServices);
+  }
+
+  @Test
+  void shouldRouteRoleLookupToRequestPhysicalTenant() {
+    // given
+    final var request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, TENANT_A);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    when(tenantARoleServices.getRolesByMemberTypeAndMemberIds(any(), any()))
+        .thenReturn(List.of(new RoleEntity(1L, "ra1", "role", null)));
+    final var query = baseQuery().withMappingRuleIds(List.of()).withGroupIds(List.of("g1"));
+
+    // when
+    final var result = service.roleIds(query);
+
+    // then
+    assertThat(result).containsExactly("ra1");
+    verifyNoInteractions(roleServices);
+  }
+
+  @Test
+  void shouldRouteMappingRuleLookupToRequestPhysicalTenant() {
+    // given
+    final var request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, TENANT_A);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    when(tenantAMappingRuleServices.getMatchingMappingRules(any(), any()))
+        .thenReturn(Stream.of(new MappingRuleEntity("mra1", 1L, "claim", "value", "rule")));
+
+    // when
+    final var result = service.mappingRuleIds(baseQuery());
+
+    // then
+    assertThat(result).containsExactly("mra1");
+    verifyNoInteractions(mappingRuleServices);
   }
 }

--- a/qa/archunit-tests/src/test/java/io/camunda/service/ServiceAsyncExecutorArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/service/ServiceAsyncExecutorArchTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Ensures that service-layer classes do not call the executor-less static factory methods {@link
+ * CompletableFuture#supplyAsync(java.util.function.Supplier)} or {@link
+ * CompletableFuture#runAsync(Runnable)}.
+ *
+ * <p>The service layer offloads authorization and secondary-storage reads onto a managed, bounded
+ * executor obtained from {@code ApiServicesExecutorProvider.getExecutor()}. That executor is the
+ * single chokepoint responsible for propagating request-scoped context (e.g. the resolved physical
+ * tenant) onto worker threads. The executor-less overloads submit tasks to the common {@link
+ * java.util.concurrent.ForkJoinPool}, which bypasses context propagation and causes the
+ * request-scoped state to be invisible on the worker thread.
+ *
+ * <p>Always pass the managed executor explicitly:
+ *
+ * <pre>{@code
+ * // UNSAFE: task runs on the common ForkJoinPool, loses request-scoped context
+ * CompletableFuture.supplyAsync(() -> searchClient.search(query));
+ *
+ * // SAFE: task runs on the managed executor, context is propagated
+ * CompletableFuture.supplyAsync(() -> searchClient.search(query), executorProvider.getExecutor());
+ * }</pre>
+ */
+@AnalyzeClasses(packages = "io.camunda.service", importOptions = DoNotIncludeTestsOrTestJars.class)
+public final class ServiceAsyncExecutorArchTest {
+
+  /**
+   * R1 — service-layer classes must not call the executor-less overloads of {@link
+   * CompletableFuture#supplyAsync} or {@link CompletableFuture#runAsync}.
+   *
+   * <p>Calls that pass an {@link Executor} as a parameter are explicitly allowed.
+   *
+   * <p>Scope: this rule only covers {@code io.camunda.service..}, where the managed executor
+   * chokepoint ({@code ApiServicesExecutorProvider}) lives. It does not catch the same pattern in
+   * other modules (e.g. {@code authentication}, {@code gateways}); if async authorization reads are
+   * ever offloaded from there, extend the scope accordingly.
+   */
+  @ArchTest
+  public static final ArchRule
+      R1_SERVICE_CLASSES_MUST_NOT_CALL_EXECUTOR_LESS_COMPLETABLE_FUTURE_FACTORY_METHODS =
+          classes()
+              .that()
+              .resideInAPackage("io.camunda.service..")
+              .should(notCallExecutorLessAsyncFactoryMethods())
+              .because(
+                  "service-layer async reads must run on the managed/bounded executor obtained from"
+                      + " ApiServicesExecutorProvider.getExecutor() so that request-scoped context"
+                      + " (e.g. the resolved physical tenant) is propagated to the worker thread;"
+                      + " the executor-less overloads use the common ForkJoinPool and bypass it");
+
+  private static ArchCondition<JavaClass> notCallExecutorLessAsyncFactoryMethods() {
+    return new ArchCondition<>(
+        "not call CompletableFuture.supplyAsync(Supplier) or CompletableFuture.runAsync(Runnable)"
+            + " without an Executor argument") {
+      @Override
+      public void check(final JavaClass item, final ConditionEvents events) {
+        item.getMethodCallsFromSelf().stream()
+            .filter(ServiceAsyncExecutorArchTest::isExecutorLessAsyncFactoryCall)
+            .forEach(
+                call ->
+                    events.add(
+                        violated(
+                            item,
+                            String.format(
+                                "%s calls CompletableFuture.%s() without an Executor at %s"
+                                    + " — pass ApiServicesExecutorProvider.getExecutor() as the"
+                                    + " executor argument so request-scoped context propagates to"
+                                    + " the worker thread",
+                                item.getName(), call.getName(), call.getSourceCodeLocation()))));
+      }
+    };
+  }
+
+  private static boolean isExecutorLessAsyncFactoryCall(final JavaMethodCall call) {
+    final String name = call.getName();
+    if (!"supplyAsync".equals(name) && !"runAsync".equals(name)) {
+      return false;
+    }
+    if (!call.getTargetOwner().isAssignableTo(CompletableFuture.class)) {
+      return false;
+    }
+    // The call is executor-less if none of its parameters is assignable to Executor
+    return call.getTarget().getRawParameterTypes().stream()
+        .noneMatch(param -> param.isAssignableTo(Executor.class));
+  }
+}

--- a/service/src/main/java/io/camunda/service/ApiServicesExecutorProvider.java
+++ b/service/src/main/java/io/camunda/service/ApiServicesExecutorProvider.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import io.camunda.spring.utils.PhysicalTenantPropagatingExecutorService;
 import java.util.Objects;
 import java.util.concurrent.*;
 
@@ -22,13 +23,21 @@ public final class ApiServicesExecutorProvider {
       final long keepAliveSeconds,
       final int queueCapacity) {
     executor =
-        Objects.requireNonNull(
-            create(corePoolSizeMultiplier, maxPoolSizeMultiplier, keepAliveSeconds, queueCapacity),
-            "REST API Executor Service must not be null");
+        new PhysicalTenantPropagatingExecutorService(
+            Objects.requireNonNull(
+                create(
+                    corePoolSizeMultiplier, maxPoolSizeMultiplier, keepAliveSeconds, queueCapacity),
+                "REST API Executor Service must not be null"));
   }
 
+  /**
+   * Pass a raw (unwrapped) executor: the provider adds the physical-tenant propagating decorator
+   * itself, so a pre-wrapped executor would only get a redundant second layer.
+   */
   public ApiServicesExecutorProvider(final ExecutorService executor) {
-    this.executor = Objects.requireNonNull(executor, "REST API Executor Service must not be null");
+    this.executor =
+        new PhysicalTenantPropagatingExecutorService(
+            Objects.requireNonNull(executor, "REST API Executor Service must not be null"));
   }
 
   public ExecutorService getExecutor() {

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -60,12 +60,14 @@ public final class UsageMetricsServices
 
     final CompletableFuture<UsageMetricStatisticsEntity> statsFuture =
         CompletableFuture.supplyAsync(
-            () -> authUsageMetricsSearchClient.usageMetricStatistics(query));
+            () -> authUsageMetricsSearchClient.usageMetricStatistics(query),
+            executorProvider.getExecutor());
     final CompletableFuture<UsageMetricTUStatisticsEntity> tuStatsFuture =
         CompletableFuture.supplyAsync(
             () ->
                 authUsageMetricsSearchClient.usageMetricTUStatistics(
-                    mapToUsageMetricsTUQuery(query)));
+                    mapToUsageMetricsTUQuery(query)),
+            executorProvider.getExecutor());
 
     return SearchQueryResult.of(Tuple.of(statsFuture.join(), tuStatsFuture.join()));
   }

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -23,6 +23,7 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.time.OffsetDateTime;
+import java.util.concurrent.ForkJoinPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,13 +39,15 @@ public final class UsageMetricsServiceTest {
     client = mock(UsageMetricsSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     authentication = mock(CamundaAuthentication.class);
+    final var executorProvider = mock(ApiServicesExecutorProvider.class);
+    when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
     services =
         new UsageMetricsServices(
             PHYSICAL_TENANT_ID,
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,
-            mock(ApiServicesExecutorProvider.class),
+            executorProvider,
             null);
   }
 

--- a/spring-utils/pom.xml
+++ b/spring-utils/pom.xml
@@ -32,6 +32,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
     <!-- PhysicalTenantContext is a request-scoped web helper; SegmentStrippingResolver extends
          Spring MVC's PathResourceResolver. Both servlet/web and webmvc APIs are provided by the
          consuming web applications at runtime. -->

--- a/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantContext.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantContext.java
@@ -9,6 +9,8 @@ package io.camunda.spring.utils;
 
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
@@ -39,6 +41,15 @@ public final class PhysicalTenantContext {
   public static final String REQUEST_ATTRIBUTE_PHYSICAL_TENANT_ID =
       PhysicalTenantContext.class.getName() + ".PHYSICAL_TENANT_ID";
 
+  private static final Logger LOG = LoggerFactory.getLogger(PhysicalTenantContext.class);
+
+  /**
+   * Physical tenant propagated onto a non-request (e.g. async executor) thread. Used to carry the
+   * request's tenant across the request→async boundary by value, decoupled from the servlet request
+   * lifecycle (the request may already be inactive when the async task runs).
+   */
+  private static final ThreadLocal<String> PROPAGATED_PHYSICAL_TENANT_ID = new ThreadLocal<>();
+
   private PhysicalTenantContext() {}
 
   public static void setPhysicalTenantId(
@@ -51,31 +62,81 @@ public final class PhysicalTenantContext {
   }
 
   /**
-   * Returns the resolved physical tenant id for the request being processed on the current thread.
+   * Returns the physical tenant id in effect on the current thread.
    *
-   * <p>For prefixed {@code /physical-tenants/{physicalTenantId}/...} requests the id is stamped on
-   * the request by {@code PhysicalTenantFilter} (gateway-rest) or by the MCP gateway filter, and
-   * that value is returned. Non-prefixed requests resolve to {@link
-   * PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} via different mechanisms: for REST {@code
-   * /v2/...} {@code PhysicalTenantFilter} stamps nothing and this method falls back to the default;
-   * for MCP {@code /mcp/...} the MCP autoconfiguration stamps the default explicitly.
+   * <p>On a request thread this is the tenant resolved for the request. For prefixed {@code
+   * /physical-tenants/{physicalTenantId}/...} requests the id is stamped on the request by {@code
+   * PhysicalTenantFilter} (gateway-rest) or by the MCP gateway filter, and that value is returned.
+   * Non-prefixed requests resolve to {@link PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} via
+   * different mechanisms: for REST {@code /v2/...} {@code PhysicalTenantFilter} stamps nothing and
+   * this method falls back to the default; for MCP {@code /mcp/...} the MCP autoconfiguration
+   * stamps the default explicitly.
    *
-   * @return the physical tenant id for the current request; never {@code null}
-   * @throws IllegalStateException if called outside a servlet-request scope (i.e. {@link
-   *     RequestContextHolder#getRequestAttributes()} returns {@code null})
+   * <p>On a non-request thread (e.g. an async executor worker) it returns the tenant propagated
+   * onto the thread by {@code PhysicalTenantPropagatingExecutorService}; with neither a request
+   * scope nor a propagated tenant there is nothing to resolve and the call throws.
+   *
+   * @return the physical tenant id in effect on the current thread; never {@code null}
+   * @throws IllegalStateException if neither a request scope nor a propagated tenant is bound on
+   *     the current thread
    */
   public static String current() {
-    final RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
-    if (attributes == null) {
+    final String physicalTenantId = currentOrNull();
+    if (physicalTenantId == null) {
       throw new IllegalStateException(
           "PhysicalTenantContext.current() called outside a request scope; "
-              + "the physical tenant must be resolved on the request thread (or supplied explicitly).");
+              + "the physical tenant must be resolved on the request thread (or propagated onto this thread).");
     }
-    final String value =
-        asString(
-            attributes.getAttribute(
-                REQUEST_ATTRIBUTE_PHYSICAL_TENANT_ID, RequestAttributes.SCOPE_REQUEST));
-    return value != null ? value : PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+    return physicalTenantId;
+  }
+
+  /**
+   * Like {@link #current()} but returns {@code null} instead of throwing when no tenant is bound.
+   * Resolves from the request scope when present (falling back to {@link
+   * PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} for an unstamped request), otherwise from a value
+   * propagated onto this thread (e.g. by {@code PhysicalTenantPropagatingExecutorService}).
+   */
+  static String currentOrNull() {
+    final RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+    if (attributes != null) {
+      final String value =
+          asString(
+              attributes.getAttribute(
+                  REQUEST_ATTRIBUTE_PHYSICAL_TENANT_ID, RequestAttributes.SCOPE_REQUEST));
+      return value != null ? value : PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+    }
+    return PROPAGATED_PHYSICAL_TENANT_ID.get();
+  }
+
+  /** Removes any tenant propagated onto the current thread. */
+  static void clearPropagatedPhysicalTenant() {
+    LOG.trace("Clearing propagated physical tenant on thread {}", Thread.currentThread().getName());
+    PROPAGATED_PHYSICAL_TENANT_ID.remove();
+  }
+
+  /**
+   * Returns the raw propagated tenant value for the current thread, or {@code null} if none is set.
+   *
+   * <p>Unlike {@link #currentOrNull()}, this reads the propagation {@link ThreadLocal} directly and
+   * never consults the request scope — so it is safe to call on a request thread when saving state
+   * before a nested propagation, without capturing the request-derived tenant.
+   */
+  static String getPropagatedPhysicalTenant() {
+    return PROPAGATED_PHYSICAL_TENANT_ID.get();
+  }
+
+  /**
+   * Binds {@code physicalTenantId} as the propagated tenant for the current thread, so {@link
+   * #current()} resolves it where no request scope exists. Intended for carrying a request's tenant
+   * onto async worker threads; callers must {@link #clearPropagatedPhysicalTenant() clear} it in a
+   * {@code finally} block.
+   */
+  static void setPropagatedPhysicalTenant(final String physicalTenantId) {
+    LOG.trace(
+        "Setting propagated physical tenant on thread {}: {}",
+        Thread.currentThread().getName(),
+        physicalTenantId);
+    PROPAGATED_PHYSICAL_TENANT_ID.set(physicalTenantId);
   }
 
   private static String asString(final Object value) {

--- a/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantPropagatingExecutorService.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantPropagatingExecutorService.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.spring.utils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+/**
+ * Decorates an {@link ExecutorService} so that the physical tenant resolved on the submitting
+ * thread is propagated to the worker thread that runs the task.
+ *
+ * <p>Service-layer reads offload to async executor threads (e.g. {@code
+ * CompletableFuture.supplyAsync(..., executor)}), and the authorization check resolves membership
+ * lazily on that worker thread, where {@link PhysicalTenantContext#current()} would otherwise find
+ * no request scope and throw. This decorator captures the submitting thread's physical tenant
+ * <em>by value</em> ({@link PhysicalTenantContext#currentOrNull()}) and binds it on the worker
+ * thread for the task's duration. Capturing the value — rather than re-binding the request scope —
+ * keeps propagation correct across Spring MVC async dispatch, where the servlet request may already
+ * be inactive by the time the task runs.
+ *
+ * <p>If the task is submitted outside any tenant scope, nothing is bound and the task runs
+ * unchanged.
+ */
+public class PhysicalTenantPropagatingExecutorService implements ExecutorService {
+
+  private final ExecutorService delegate;
+
+  public PhysicalTenantPropagatingExecutorService(final ExecutorService delegate) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate executor must not be null");
+  }
+
+  private Runnable wrap(final Runnable task) {
+    final String physicalTenantId = PhysicalTenantContext.currentOrNull();
+    if (physicalTenantId == null) {
+      // not submitted within a tenant scope (e.g. a broker-response continuation scheduled off the
+      // request thread, which needs no tenant) — nothing to propagate
+      return task;
+    }
+    return () -> {
+      final String previous = PhysicalTenantContext.getPropagatedPhysicalTenant();
+      PhysicalTenantContext.setPropagatedPhysicalTenant(physicalTenantId);
+      try {
+        task.run();
+      } finally {
+        if (previous != null) {
+          PhysicalTenantContext.setPropagatedPhysicalTenant(previous);
+        } else {
+          PhysicalTenantContext.clearPropagatedPhysicalTenant();
+        }
+      }
+    };
+  }
+
+  private <T> Callable<T> wrap(final Callable<T> task) {
+    final String physicalTenantId = PhysicalTenantContext.currentOrNull();
+    if (physicalTenantId == null) {
+      // not submitted within a tenant scope (e.g. a broker-response continuation scheduled off the
+      // request thread, which needs no tenant) — nothing to propagate
+      return task;
+    }
+    return () -> {
+      final String previous = PhysicalTenantContext.getPropagatedPhysicalTenant();
+      PhysicalTenantContext.setPropagatedPhysicalTenant(physicalTenantId);
+      try {
+        return task.call();
+      } finally {
+        if (previous != null) {
+          PhysicalTenantContext.setPropagatedPhysicalTenant(previous);
+        } else {
+          PhysicalTenantContext.clearPropagatedPhysicalTenant();
+        }
+      }
+    };
+  }
+
+  private <T> Collection<? extends Callable<T>> wrapAll(
+      final Collection<? extends Callable<T>> tasks) {
+    return tasks.stream().map(this::wrap).collect(Collectors.toList());
+  }
+
+  @Override
+  public void execute(final Runnable command) {
+    delegate.execute(wrap(command));
+  }
+
+  @Override
+  public Future<?> submit(final Runnable task) {
+    return delegate.submit(wrap(task));
+  }
+
+  @Override
+  public <T> Future<T> submit(final Runnable task, final T result) {
+    return delegate.submit(wrap(task), result);
+  }
+
+  @Override
+  public <T> Future<T> submit(final Callable<T> task) {
+    return delegate.submit(wrap(task));
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(final Collection<? extends Callable<T>> tasks)
+      throws InterruptedException {
+    return delegate.invokeAll(wrapAll(tasks));
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(
+      final Collection<? extends Callable<T>> tasks, final long timeout, final TimeUnit unit)
+      throws InterruptedException {
+    return delegate.invokeAll(wrapAll(tasks), timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(final Collection<? extends Callable<T>> tasks)
+      throws InterruptedException, ExecutionException {
+    return delegate.invokeAny(wrapAll(tasks));
+  }
+
+  @Override
+  public <T> T invokeAny(
+      final Collection<? extends Callable<T>> tasks, final long timeout, final TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return delegate.invokeAny(wrapAll(tasks), timeout, unit);
+  }
+
+  @Override
+  public void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return delegate.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return delegate.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return delegate.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(final long timeout, final TimeUnit unit)
+      throws InterruptedException {
+    return delegate.awaitTermination(timeout, unit);
+  }
+}

--- a/spring-utils/src/test/java/io/camunda/spring/utils/PhysicalTenantPropagatingExecutorServiceTest.java
+++ b/spring-utils/src/test/java/io/camunda/spring/utils/PhysicalTenantPropagatingExecutorServiceTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.spring.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class PhysicalTenantPropagatingExecutorServiceTest {
+
+  private final ExecutorService delegate = Executors.newSingleThreadExecutor();
+  private final PhysicalTenantPropagatingExecutorService executor =
+      new PhysicalTenantPropagatingExecutorService(delegate);
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+    // guarantee the propagation ThreadLocal never bleeds into a later test, even on failure
+    PhysicalTenantContext.clearPropagatedPhysicalTenant();
+    delegate.shutdownNow();
+  }
+
+  private void bindRequestWithPhysicalTenant(final String physicalTenantId) {
+    final HttpServletRequest request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, physicalTenantId);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+  }
+
+  @Test
+  void shouldPropagatePhysicalTenantToWorkerThread() throws Exception {
+    // given a request scope bound on the submitting thread
+    bindRequestWithPhysicalTenant("blue");
+
+    // when a task runs on a worker thread
+    final String observed = executor.submit(PhysicalTenantContext::current).get();
+
+    // then the worker observed the submitting thread's physical tenant
+    assertThat(observed).isEqualTo("blue");
+  }
+
+  @Test
+  void shouldNotThrowWhenSubmittedOutsideRequestScope() throws Exception {
+    // given no request scope is bound
+
+    // when a task is submitted without a request scope
+    final String result =
+        executor
+            .submit(
+                () -> {
+                  // nothing is bound, so current() still fails fast on the worker thread
+                  assertThatThrownBy(PhysicalTenantContext::current)
+                      .isInstanceOf(IllegalStateException.class);
+                  return "ok";
+                })
+            .get();
+
+    // then the task completes normally
+    assertThat(result).isEqualTo("ok");
+  }
+
+  @Test
+  void shouldRestoreOuterPropagatedTenantAfterNestedInlineTask() {
+    // given an outer worker thread that already has a propagated tenant bound
+    PhysicalTenantContext.setPropagatedPhysicalTenant("outer");
+
+    // when an inline (same-thread) executor causes the nested task to run inline, simulating
+    // CallerRunsPolicy: the inner task propagates a different tenant onto the same thread
+    final PhysicalTenantPropagatingExecutorService inlineExecutor =
+        new PhysicalTenantPropagatingExecutorService(newCallerRunsInlineExecutor());
+
+    // simulate submitting the inner task from a request scope so wrap() captures a tenant
+    bindRequestWithPhysicalTenant("inner");
+    inlineExecutor.execute(
+        () -> assertThat(PhysicalTenantContext.getPropagatedPhysicalTenant()).isEqualTo("inner"));
+    RequestContextHolder.resetRequestAttributes();
+
+    // then the outer propagated tenant is restored on the current thread
+    assertThat(PhysicalTenantContext.getPropagatedPhysicalTenant()).isEqualTo("outer");
+  }
+
+  @Test
+  void shouldRestoreOuterPropagatedTenantAfterNestedInlineCallable() throws Exception {
+    // given an outer propagated tenant on the current thread
+    PhysicalTenantContext.setPropagatedPhysicalTenant("outer-callable");
+
+    // when an inline executor runs a Callable that binds a nested tenant on the same thread
+    final PhysicalTenantPropagatingExecutorService inlineExecutor =
+        new PhysicalTenantPropagatingExecutorService(newCallerRunsInlineExecutor());
+
+    bindRequestWithPhysicalTenant("inner-callable");
+    final String observedInner =
+        inlineExecutor.submit(() -> PhysicalTenantContext.getPropagatedPhysicalTenant()).get();
+    RequestContextHolder.resetRequestAttributes();
+
+    // then the inner task saw its tenant and the outer is restored afterwards
+    assertThat(observedInner).isEqualTo("inner-callable");
+    assertThat(PhysicalTenantContext.getPropagatedPhysicalTenant()).isEqualTo("outer-callable");
+  }
+
+  /** Returns an {@link ExecutorService} that runs every submitted task on the calling thread. */
+  private static ExecutorService newCallerRunsInlineExecutor() {
+    return new AbstractExecutorService() {
+      private boolean shutdown;
+
+      @Override
+      public void execute(final Runnable command) {
+        command.run();
+      }
+
+      @Override
+      public void shutdown() {
+        shutdown = true;
+      }
+
+      @Override
+      public List<Runnable> shutdownNow() {
+        shutdown = true;
+        return List.of();
+      }
+
+      @Override
+      public boolean isShutdown() {
+        return shutdown;
+      }
+
+      @Override
+      public boolean isTerminated() {
+        return shutdown;
+      }
+
+      @Override
+      public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+        return true;
+      }
+    };
+  }
+
+  @Test
+  void shouldNotLeakPropagatedPhysicalTenantToLaterUnboundTask() throws Exception {
+    // given a propagated task ran on the (single) worker thread
+    bindRequestWithPhysicalTenant("blue");
+    assertThat(executor.submit(PhysicalTenantContext::current).get()).isEqualTo("blue");
+
+    // when a later task is submitted with no request scope, reusing the same worker thread
+    RequestContextHolder.resetRequestAttributes();
+    final boolean resolvedPhysicalTenant =
+        executor
+            .submit(
+                () -> {
+                  try {
+                    PhysicalTenantContext.current();
+                    return true;
+                  } catch (final IllegalStateException e) {
+                    return false;
+                  }
+                })
+            .get();
+
+    // then the earlier binding did not leak onto the worker thread
+    assertThat(resolvedPhysicalTenant).isFalse();
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverterAuthenticationCompatibilityTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverterAuthenticationCompatibilityTest.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.protocol.impl.encoding;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.model.CamundaAuthentication;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
@@ -59,5 +61,55 @@ class MsgPackConverterAuthenticationCompatibilityTest {
     assertThat(authentication.authenticatedMappingRuleIds())
         .containsExactly("mapping-1", "mapping-2");
     assertThat(reserialized).contains("\"authenticated_mapping_rule_ids\"");
+  }
+
+  @Test
+  void shouldMaterializeAllMembershipFieldsWhenSerializingBatchOperationAuthentication() {
+    // given — lazy auth whose suppliers track invocation count; this is the batch-op create path
+    final var groupCallCount = new AtomicInteger();
+    final var roleCallCount = new AtomicInteger();
+    final var tenantCallCount = new AtomicInteger();
+    final var mappingRuleCallCount = new AtomicInteger();
+
+    final var lazyAuth =
+        CamundaAuthentication.of(
+            b ->
+                b.groupIdsSupplier(
+                        () -> {
+                          groupCallCount.incrementAndGet();
+                          return List.of("g1");
+                        })
+                    .roleIdsSupplier(
+                        () -> {
+                          roleCallCount.incrementAndGet();
+                          return List.of("r1");
+                        })
+                    .tenantsSupplier(
+                        () -> {
+                          tenantCallCount.incrementAndGet();
+                          return List.of("t1");
+                        })
+                    .mappingRulesSupplier(
+                        () -> {
+                          mappingRuleCallCount.incrementAndGet();
+                          return List.of("mr1");
+                        }));
+
+    // when — serialization forces resolution of each lazy field (Jackson invokes every getter)
+    final var serialized = MsgPackConverter.convertToMsgPack(lazyAuth);
+
+    // then — all four suppliers must have fired
+    assertThat(groupCallCount.get()).isEqualTo(1);
+    assertThat(roleCallCount.get()).isEqualTo(1);
+    assertThat(tenantCallCount.get()).isEqualTo(1);
+    assertThat(mappingRuleCallCount.get()).isEqualTo(1);
+
+    // and the membership lists survive the round-trip
+    final var deserialized =
+        MsgPackConverter.convertToObject(new UnsafeBuffer(serialized), CamundaAuthentication.class);
+    assertThat(deserialized.authenticatedGroupIds()).containsExactly("g1");
+    assertThat(deserialized.authenticatedRoleIds()).containsExactly("r1");
+    assertThat(deserialized.authenticatedTenantIds()).containsExactly("t1");
+    assertThat(deserialized.authenticatedMappingRuleIds()).containsExactly("mr1");
   }
 }


### PR DESCRIPTION
## Context

Part of #55252 (physical-tenant authorization routing). Implements S4 (#55440) and, with it, the final state of the async-propagation mechanism specified in ADR-0006 (#55663). Builds on S1 (`PhysicalTenantContext.current()`) and the existing per-PT `ServiceRegistry`.

Two concerns, one per commit:

1. **Identity & membership routing** — `DefaultMembershipService` (mapping-rule / group / role / tenant ids) and `BasicCamundaUserService` (user lookup) resolve `PhysicalTenantContext.current()` and route through that tenant's `ServiceRegistry` services instead of the hardcoded default. An unknown physical tenant fails fast.
2. **Async physical-tenant propagation (ADR-0006)** — the prerequisite that makes (1) work across the request→async-executor boundary.

## Why the propagation piece is needed

Membership is lazy (#53759): `CamundaAuthentication` carries supplier-backed group/role/tenant/mapping-rule lists that resolve on **first access** — which happens inside a read's authorization check. Two authorization reads offload that check onto the managed executor: `UsageMetricsServices.search()` and `ResourceServices.fetchFromSecondaryStorage()`. On the worker thread the lazy supplier calls `current()`, which finds no request scope and throws. On `main` this is masked because membership uses the hardcoded `default`; commit 1 is what exposes it.

The fix carries the physical tenant across that boundary **by value**:

- `PhysicalTenantContext` gains a thread-bound propagated tenant that `current()` falls back to when no request scope is present, plus a package-private non-throwing `currentOrNull()`.
- A new `PhysicalTenantPropagatingExecutorService` (in `spring-utils`) decorates the managed executor: at submit time it captures the submitting thread's tenant via `currentOrNull()` and binds that value on the worker thread for the task's duration, clearing it afterwards. Submitted outside a tenant scope (e.g. a broker-response continuation scheduled off-request), it's a no-op.
- It wraps the executor at the single chokepoint `ApiServicesExecutorProvider`, so every `ApiServices`-based async read inherits propagation. `UsageMetricsServices`' two reads — previously bare `supplyAsync` on the common ForkJoinPool — are routed through that executor; `ResourceServices` already used it.

Capturing the tenant **by value** (rather than re-binding the live servlet `RequestAttributes`) is what makes this correct for both join-style reads and gateway endpoints that return the `CompletableFuture` to Spring MVC async dispatch, where the servlet request can already be inactive when the worker runs. This preserves the lazy-membership optimization (#53759) — membership still resolves only when an authorization check needs it.

A new ArchUnit rule (`ServiceAsyncExecutorArchTest`) bans the executor-less `CompletableFuture.supplyAsync`/`runAsync` overloads in `io.camunda.service..`, so a future read can't silently reintroduce the common-pool bypass.

## Acceptance criteria (#55440)

Verbatim from the issue, with how each is proven:

1. **`DefaultMembershipService` (mapping-rules/groups/roles/tenants) resolves `serviceRegistry.*Services(PhysicalTenantContext.current())`.**
   ✅ Proven by `DefaultMembershipServiceTest` for all four facets — `shouldRouteGroupLookupToRequestPhysicalTenant`, `shouldRouteRoleLookupToRequestPhysicalTenant`, `shouldRouteTenantLookupToRequestPhysicalTenant`, `shouldRouteMappingRuleLookupToRequestPhysicalTenant`: a non-default tenant is set on the request and each lookup is asserted to use that tenant's services (`verifyNoInteractions` on the default-tenant services).

2. **`BasicCamundaUserService` resolves the in-context PT for the user lookup.**
   ✅ Proven by `BasicCamundaUserServiceTest.shouldRouteUserLookupToRequestPhysicalTenant`.

3. **Lazy per-field membership resolution (#53759) remains correct: resolves on the request thread; the batch-operation `CamundaAuthentication` is materialized at create time (verify all membership fields materialize on serialization; if selective, force full materialization before persisting the batch-op command).**
   ✅ Two parts, both proven by test. (a) The "resolves on the request thread" premise proved incomplete — async authorization reads offload to executor worker threads where the lazy suppliers fire. That is the ADR-0006 propagation piece in this PR; correctness on the worker is proven by `PhysicalTenantPropagatingExecutorServiceTest` (`shouldPropagatePhysicalTenantToWorkerThread`, `shouldNotThrowWhenSubmittedOutsideRequestScope`, `shouldNotLeakPropagatedPhysicalTenantToLaterUnboundTask`) and exercised end-to-end by the pre-existing auth IT suites. (b) The batch-op create path serializes the authentication via `MsgPackConverter.convertToMsgPack` (called from `BrokerCreateBatchOperationRequest.setAuthentication`), whose Jackson mixin touches every membership getter — `MsgPackConverterAuthenticationCompatibilityTest.shouldMaterializeAllMembershipFieldsWhenSerializingBatchOperationAuthentication` builds an authentication whose four membership lists are lazy suppliers and asserts all four are invoked on serialization (full, not selective, materialization) and round-trip intact. No production change was needed — existing serialization already materializes fully.

4. **Unit tests: membership resolution routes to the in-context PT, not `default`.**
   ✅ Satisfied by the three routing tests above — each asserts the in-context tenant's services are used and the default tenant's are not.

## Other tests

- `ServiceAsyncExecutorArchTest` — guards against an executor-less async read in the service layer reintroducing the common-pool bypass.
- Pre-existing authorization IT suites (`UsageMetricAuthorizationIT`, `ResourceAuthorizationIT`, …) — the ones that previously failed with the off-request `current()` — exercise the end-to-end async path.

End-to-end assertion under multiple concurrently-active physical tenants is out of scope here and belongs to the multi-PT IT harness (S7, #55443).

Closes #55440
