### PR TITLE
docs: clarify why PhysicalTenantSecurityProperties wraps the per-tenant map

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/security/PhysicalTenantSecurityProperties.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/PhysicalTenantSecurityProperties.java
@@ -14,10 +14,11 @@ import java.util.Map;
  * Holds the {@link CamundaSecurityLibraryProperties} for every physical tenant, keyed by physical
  * tenant id.
  *
- * <p>A typed wrapper is required because injecting a bare {@code Map<String,
- * CamundaSecurityLibraryProperties>} would trigger Spring's collection-injection semantics: Spring
- * would look for beans of type {@code CamundaSecurityLibraryProperties} and key them by bean name
- * rather than by physical tenant id.
+ * <p>This wrapper record is not strictly required — a dedicated bean of type {@code Map<String,
+ * CamundaSecurityLibraryProperties>} would work just as well. It is used to keep the injection
+ * point explicit and unambiguous: it avoids any confusion with Spring's bean-collection autowiring,
+ * which for a bare {@code Map<String, CamundaSecurityLibraryProperties>} injection point keys the
+ * map by bean name rather than by physical tenant id.
  */
 public record PhysicalTenantSecurityProperties(
     Map<String, CamundaSecurityLibraryProperties> propertiesByPhysicalTenant) {}


### PR DESCRIPTION
## What

Rewords the `PhysicalTenantSecurityProperties` class Javadoc. The previous text overstated the rationale ("a typed wrapper is **required** because injecting a bare `Map<…>` would **trigger** Spring's collection-injection semantics"). The accurate statement: the wrapper keeps the map keyed by physical tenant id; a bare `Map<String, CamundaSecurityLibraryProperties>` would need a qualifier, otherwise Spring resolves it via bean-collection autowiring keyed by bean name.

## Why

Part of #55252 (PT authorization routing). The sibling per-tenant wrappers (`PhysicalTenantResourceAccessControllers`, `PhysicalTenantSearchClientReaders`) already use this precise wording after review feedback; this brings the last copy in line. Javadoc-only, no behaviour change.