### PR TITLE
test: use parallel-test for CI RDBMS IT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -970,7 +970,7 @@ jobs:
     needs: [ detect-changes ]
     name: "General / Integration / RDBMS ITs"
     timeout-minutes: 30
-    runs-on: gcp-perf-core-8-default
+    runs-on: gcp-perf-core-16-default
     strategy:
       # In case of stress testing, we want the status from all jobs.
       fail-fast: false
@@ -1001,11 +1001,10 @@ jobs:
         shell: bash
         run: >
           ./mvnw -B -T1C --no-snapshot-updates
-          -D forkCount=1
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:stress-test') && '0' || env.FLAKY_TEST_RERUN_COUNT }} -D flaky.test.reportDir=failsafe-reports
-          -P rdbms,extract-flaky-tests
+          -P rdbms,extract-flaky-tests,parallel-tests
           -pl qa/acceptance-tests
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
