### PR TITLE
test: use spring properties for CSL configuration

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/AuthenticationProperties.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/AuthenticationProperties.java
@@ -7,58 +7,9 @@
  */
 package io.camunda.authentication.config;
 
-import io.camunda.security.api.model.config.AuthenticationMethod;
-import io.camunda.security.spring.CamundaSecurityLibraryProperties;
-
 public final class AuthenticationProperties {
   public static final String METHOD = "camunda.security.authentication.method";
   public static final String API_UNPROTECTED = "camunda.security.authentication.unprotected-api";
-  public static final String OIDC_CLIENT_ID = "camunda.security.authentication.oidc.client-id";
-  public static final String OIDC_CLIENT_SECRET =
-      "camunda.security.authentication.oidc.client-secret";
-  public static final String OIDC_ISSUER_URI = "camunda.security.authentication.oidc.issuer-uri";
-  public static final String OIDC_REDIRECT_URI =
-      "camunda.security.authentication.oidc.redirect-uri";
-  public static final String OIDC_AUTHORIZATION_URI =
-      "camunda.security.authentication.oidc.authorization-uri";
-  public static final String OIDC_TOKEN_URI = "camunda.security.authentication.oidc.token-uri";
-  public static final String OIDC_JWK_SET_URI = "camunda.security.authentication.oidc.jwk-set-uri";
 
   private AuthenticationProperties() {}
-
-  public static String getUnprotectedApiEnvVar() {
-    return API_UNPROTECTED.replace(".", "_").replace("-", "").toUpperCase();
-  }
-
-  /**
-   * Mirrors a {@code camunda.security.*} property change into an existing {@link
-   * CamundaSecurityLibraryProperties} bean when {@code @ConfigurationProperties} binding is not
-   * active for that instance. Does nothing if {@code cslProperties} or {@code value} is {@code
-   * null}.
-   */
-  public static void applyToSecurityConfig(
-      final CamundaSecurityLibraryProperties cslProperties, final String key, final Object value) {
-    if (cslProperties == null || value == null) {
-      return;
-    }
-    final var oidc = cslProperties.getAuthentication().getOidc();
-    switch (key) {
-      case METHOD ->
-          cslProperties
-              .getAuthentication()
-              .setMethod(AuthenticationMethod.parse(String.valueOf(value)));
-      case API_UNPROTECTED ->
-          cslProperties
-              .getAuthentication()
-              .setUnprotectedApi(Boolean.parseBoolean(String.valueOf(value)));
-      case OIDC_CLIENT_ID -> oidc.setClientId(String.valueOf(value));
-      case OIDC_CLIENT_SECRET -> oidc.setClientSecret(String.valueOf(value));
-      case OIDC_ISSUER_URI -> oidc.setIssuerUri(String.valueOf(value));
-      case OIDC_REDIRECT_URI -> oidc.setRedirectUri(String.valueOf(value));
-      case OIDC_AUTHORIZATION_URI -> oidc.setAuthorizationUri(String.valueOf(value));
-      case OIDC_TOKEN_URI -> oidc.setTokenUri(String.valueOf(value));
-      case OIDC_JWK_SET_URI -> oidc.setJwkSetUri(String.valueOf(value));
-      default -> {}
-    }
-  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/OidcNoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/OidcNoSecondaryStorageTest.java
@@ -67,17 +67,13 @@ public class OidcNoSecondaryStorageTest {
       new TestStandaloneBroker()
           .withAuthenticatedAccess()
           .withAuthenticationMethod(AuthenticationMethod.OIDC)
-          .withProperty("camunda.security.authentication.method", "oidc")
-          // OIDC client config goes through withProperty so CSL's CamundaSecurityLibraryProperties
-          // — bound from Spring's property sources — sees the values. See OidcAuthOverRestIT.
-          .withProperty(
-              "camunda.security.authentication.oidc.issuer-uri",
-              KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM)
-          // Required for OIDC configuration even if not used in this test
-          .withProperty("camunda.security.authentication.oidc.client-id", "example")
-          .withProperty("camunda.security.authentication.oidc.redirect-uri", "example.com")
           .withSecurityConfig(
               c -> {
+                c.getAuthentication()
+                    .getOidc()
+                    .setIssuerUri(KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM);
+                c.getAuthentication().getOidc().setClientId("example");
+                c.getAuthentication().getOidc().setRedirectUri("example.com");
                 c.getAuthorizations().setEnabled(true);
                 c.getInitialization()
                     .setMappingRules(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -8,15 +8,12 @@
 package io.camunda.it.rdbms.db.util;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.util.Map;
-import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,12 +28,8 @@ public final class CamundaRdbmsTestApplication
 
   private GenericContainer<?> databaseContainer;
 
-  private final Camunda unifiedConfig;
-
   public CamundaRdbmsTestApplication(final Class<?>... springConfigurations) {
     super(springConfigurations);
-
-    unifiedConfig = new Camunda();
   }
 
   public CamundaRdbmsTestApplication withDatabaseContainer(
@@ -104,10 +97,6 @@ public final class CamundaRdbmsTestApplication
     // we need to hook in at the last minute and set the property as it won't resolve from the
     // config bean
     withProperty("zeebe.broker.gateway.enable", true);
-    // Flatten the in-memory unified config into camunda.* properties at the latest possible point,
-    // so the rdbms URL set in start() (after the container is up) is captured. Refreshable so that
-    // fields cleared between stop/start don't remain.
-    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return super.createSpringBuilder();
   }
 
@@ -139,18 +128,6 @@ public final class CamundaRdbmsTestApplication
   @Override
   public boolean isGateway() {
     return false;
-  }
-
-  /**
-   * Modifies the unified configuration (camunda.* properties).
-   *
-   * @param modifier a configuration function that accepts the Camunda configuration object
-   * @return itself for chaining
-   */
-  @Override
-  public CamundaRdbmsTestApplication withUnifiedConfig(final Consumer<Camunda> modifier) {
-    modifier.accept(unifiedConfig);
-    return this;
   }
 
   public RdbmsService getRdbmsService() {

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -244,10 +244,5 @@
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-testcontainer</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -16,11 +16,8 @@ import io.camunda.application.Profile;
 import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.application.initializers.McpGatewayInitializer;
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
-import io.camunda.authentication.config.AuthenticationProperties;
-import io.camunda.configuration.Camunda;
 import io.camunda.configuration.EngineJob;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.security.api.model.config.AuthenticationMethod;
@@ -61,8 +58,6 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         TestStandaloneApplication<TestCamundaApplication> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestCamundaApplication.class);
-  private final Camunda unifiedConfig;
-  private final CamundaSecurityLibraryProperties cslProperties;
   private final boolean isGatewayEnabled = true;
 
   public TestCamundaApplication() {
@@ -74,8 +69,6 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         WebappsModuleConfiguration.class,
         BrokerModuleConfiguration.class,
         IndexTemplateDescriptorsConfigurator.class);
-
-    unifiedConfig = new Camunda();
 
     unifiedConfig
         .getCluster()
@@ -111,10 +104,10 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     unifiedConfig.getProcessing().setEnableForeignKeyChecks(true);
     unifiedConfig.getProcessing().setEnablePreconditionsCheck(true);
 
-    cslProperties = new CamundaSecurityLibraryProperties();
-    cslProperties.getAuthorizations().setEnabled(false);
-    cslProperties.getAuthentication().setUnprotectedApi(true);
-    cslProperties
+    unifiedConfig.getSecurity().getAuthorizations().setEnabled(false);
+    unifiedConfig.getSecurity().getAuthentication().setUnprotectedApi(true);
+    unifiedConfig
+        .getSecurity()
         .getInitialization()
         .setUsers(
             List.of(
@@ -123,7 +116,8 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
                     InitializationConfiguration.DEFAULT_USER_PASSWORD,
                     InitializationConfiguration.DEFAULT_USER_NAME,
                     InitializationConfiguration.DEFAULT_USER_EMAIL)));
-    cslProperties
+    unifiedConfig
+        .getSecurity()
         .getInitialization()
         .setMappingRules(
             List.of(
@@ -131,7 +125,8 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
                     DEFAULT_MAPPING_RULE_ID,
                     DEFAULT_MAPPING_RULE_CLAIM_NAME,
                     DEFAULT_MAPPING_RULE_CLAIM_VALUE)));
-    cslProperties
+    unifiedConfig
+        .getSecurity()
         .getInitialization()
         .setDefaultRoles(
             Map.of(
@@ -142,15 +137,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
                     "mappingRules",
                     List.of(DEFAULT_MAPPING_RULE_ID))));
 
-    //noinspection resource
-    withBean("security-config", cslProperties, CamundaSecurityLibraryProperties.class)
-        .withProperty(
-            AuthenticationProperties.API_UNPROTECTED,
-            cslProperties.getAuthentication().isUnprotectedApi())
-        .withProperty(
-            "camunda.security.authorizations.enabled",
-            cslProperties.getAuthorizations().isEnabled())
-        .withAdditionalProfile(Profile.BROKER)
+    withAdditionalProfile(Profile.BROKER)
         .withAdditionalProfile(Profile.OPERATE)
         .withAdditionalProfile(Profile.TASKLIST)
         .withAdditionalProfile(Profile.ADMIN)
@@ -176,14 +163,6 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
   }
 
   @Override
-  public TestCamundaApplication withProperty(final String key, final Object value) {
-    // Since the security config is not constructed from the properties, we need to manually update
-    // it when we override a property.
-    AuthenticationProperties.applyToSecurityConfig(cslProperties, key, value);
-    return super.withProperty(key, value);
-  }
-
-  @Override
   protected SpringApplicationBuilder createSpringBuilder() {
     // because @ConditionalOnRestGatewayEnabled relies on the zeebe.broker.gateway.enable property,
     // we need to hook in at the last minute and set the property as it won't resolve from the
@@ -192,16 +171,12 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     withProperty(
         "zeebe.broker.gateway.enable",
         property("zeebe.broker.gateway.enable", Boolean.class, isGatewayEnabled));
-    // Flatten the in-memory unified config into camunda.* properties at the latest possible point.
-    // Refreshable so that fields cleared between stop/start don't remain.
-    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return super.createSpringBuilder();
   }
 
   public TestCamundaApplication withAuthorizationsEnabled() {
     // when using authorizations, api authentication needs to be enforced too
     withAuthenticatedAccess();
-    withProperty("camunda.security.authorizations.enabled", true);
     return withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
   }
 
@@ -212,13 +187,11 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
 
   public TestCamundaApplication withMultiTenancyEnabled() {
     withAuthenticatedAccess();
-    withProperty("camunda.security.multiTenancy.checksEnabled", true);
     return withSecurityConfig(cfg -> cfg.getMultiTenancy().setChecksEnabled(true));
   }
 
   public TestCamundaApplication withMultiTenancyDisabled() {
     withAuthenticatedAccess();
-    withProperty("camunda.security.multiTenancy.checksEnabled", false);
     return withSecurityConfig(cfg -> cfg.getMultiTenancy().setChecksEnabled(false));
   }
 
@@ -251,12 +224,6 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
   }
 
   @Override
-  public TestCamundaApplication withUnifiedConfig(final Consumer<Camunda> modifier) {
-    modifier.accept(unifiedConfig);
-    return this;
-  }
-
-  @Override
   public URI grpcAddress() {
     if (!isGateway()) {
       throw new IllegalStateException(
@@ -269,17 +236,6 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
   @Override
   public GatewayHealthActuator gatewayHealth() {
     throw new UnsupportedOperationException("Brokers do not support the gateway health indicators");
-  }
-
-  /**
-   * Returns the unified configuration object. This provides access to the camunda.* configuration
-   * structure and is the primary way to read/configure the test broker.
-   *
-   * @return the Camunda unified configuration object
-   */
-  @Override
-  public Camunda unifiedConfig() {
-    return unifiedConfig;
   }
 
   /**
@@ -324,7 +280,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
   @Override
   public TestCamundaApplication withSecurityConfig(
       final Consumer<CamundaSecurityLibraryProperties> modifier) {
-    modifier.accept(cslProperties);
+    modifier.accept(unifiedConfig.getSecurity());
     return this;
   }
 

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
@@ -14,13 +14,10 @@ import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
 import io.camunda.application.commons.search.NativeSearchClientsConfiguration;
 import io.camunda.application.commons.search.PhysicalTenantSearchClientReadersConfiguration;
 import io.camunda.application.commons.search.SearchClientReaderConfiguration;
-import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
-import java.util.function.Consumer;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
@@ -29,7 +26,6 @@ public class TestStandaloneBackupManager
 
   private Long backupId;
   private boolean skipSchemaCheck;
-  private final Camunda unifiedConfig;
 
   public TestStandaloneBackupManager() {
     super(
@@ -39,8 +35,6 @@ public class TestStandaloneBackupManager
         NativeSearchClientsConfiguration.class,
         PhysicalTenantSearchClientReadersConfiguration.class,
         SearchClientReaderConfiguration.class);
-
-    unifiedConfig = new Camunda();
   }
 
   @Override
@@ -63,18 +57,6 @@ public class TestStandaloneBackupManager
     return false;
   }
 
-  /**
-   * Modifies the unified configuration (camunda.* properties).
-   *
-   * @param modifier a configuration function that accepts the Camunda configuration object
-   * @return itself for chaining
-   */
-  @Override
-  public TestStandaloneBackupManager withUnifiedConfig(final Consumer<Camunda> modifier) {
-    modifier.accept(unifiedConfig);
-    return this;
-  }
-
   @Override
   protected String[] commandLineArgs() {
     if (backupId == null) {
@@ -88,9 +70,6 @@ public class TestStandaloneBackupManager
 
   @Override
   protected SpringApplicationBuilder createSpringBuilder() {
-    // Flatten the in-memory unified config into camunda.* properties at the latest possible point.
-    // Refreshable so that fields cleared between stop/start don't remain.
-    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return super.createSpringBuilder().web(WebApplicationType.NONE);
   }
 

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneSchemaManager.java
@@ -10,25 +10,18 @@ package io.camunda.qa.util.cluster;
 import io.atomix.cluster.MemberId;
 import io.camunda.application.StandaloneSchemaManager;
 import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
-import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
-import java.util.function.Consumer;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
 public class TestStandaloneSchemaManager
     extends TestSpringApplication<TestStandaloneSchemaManager> {
 
-  private final Camunda unifiedConfig;
-
   public TestStandaloneSchemaManager() {
     super(UnifiedConfigurationModule.class, StandaloneSchemaManager.class);
-
-    unifiedConfig = new Camunda();
   }
 
   @Override
@@ -52,18 +45,6 @@ public class TestStandaloneSchemaManager
   }
 
   /**
-   * Modifies the unified configuration (camunda.* properties).
-   *
-   * @param modifier a configuration function that accepts the Camunda configuration object
-   * @return itself for chaining
-   */
-  @Override
-  public TestStandaloneSchemaManager withUnifiedConfig(final Consumer<Camunda> modifier) {
-    modifier.accept(unifiedConfig);
-    return this;
-  }
-
-  /**
    * Convenience method for setting the secondary storage type in the unified configuration.
    *
    * @param type the secondary storage type
@@ -76,9 +57,6 @@ public class TestStandaloneSchemaManager
 
   @Override
   protected SpringApplicationBuilder createSpringBuilder() {
-    // Flatten the in-memory unified config into camunda.* properties at the latest possible point.
-    // Refreshable so that fields cleared between stop/start don't remain.
-    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return super.createSpringBuilder().web(WebApplicationType.NONE);
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -426,20 +426,18 @@ public class CamundaMultiDBExtension
             .orElse(false);
     if (shouldSetupKeycloak) {
       setupKeycloak();
-      // Push via withProperty (rather than mutating SecurityConfiguration in withSecurityConfig)
-      // so the values land in Spring's property sources. Both OC's SecurityConfiguration and
-      // CSL's CamundaSecurityLibraryProperties bind under camunda.security.* and need to see
-      // the OIDC client config — CSL's clientRegistrationRepository reads its own typed bean,
-      // not OC's, so a post-binding mutation would leave CSL with an empty OIDC config.
       final var issuerUri =
           keycloakContainer.getAuthServerUrl()
               + "/realms/"
               + CamundaMultiDBExtension.KEYCLOAK_REALM;
       applicationUnderTest
           .application()
-          .withProperty("camunda.security.authentication.oidc.client-id", "example")
-          .withProperty("camunda.security.authentication.oidc.redirect-uri", "example.com")
-          .withProperty("camunda.security.authentication.oidc.issuer-uri", issuerUri);
+          .withSecurityConfig(
+              c -> {
+                c.getAuthentication().getOidc().setClientId("example");
+                c.getAuthentication().getOidc().setRedirectUri("example.com");
+                c.getAuthentication().getOidc().setIssuerUri(issuerUri);
+              });
     }
 
     if (shouldSetupKeycloak) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/Ipv6IntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/Ipv6IntegrationTest.java
@@ -114,8 +114,8 @@ final class Ipv6IntegrationTest {
               cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
               cfg.getCluster().getNetwork().setAdvertisedHost(hostName);
               cfg.getCluster().getNetwork().setHost(INADDR6_ANY);
+              cfg.getSecurity().getAuthentication().setUnprotectedApi(true);
             })
-        .withProperty("camunda.security.authentication.unprotected-api", true)
         .withCreateContainerCmdModifier(cmd -> configureHostForIPv6(cmd, BROKER_IP));
   }
 
@@ -141,8 +141,8 @@ final class Ipv6IntegrationTest {
               cfg.getCluster().getNetwork().setAdvertisedHost(hostName);
               cfg.getCluster().getNetwork().setHost(INADDR6_ANY);
               cfg.getApi().getGrpc().setAddress(INADDR6_ANY);
+              cfg.getSecurity().getAuthentication().setUnprotectedApi(true);
             })
-        .withProperty("camunda.security.authentication.unprotected-api", true)
         .withEnv(UNPROTECTED_API_ENV_VAR, "true")
         .withCreateContainerCmdModifier(cmd -> configureHostForIPv6(cmd, GATEWAY_IP));
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverGrpcIT.java
@@ -76,19 +76,13 @@ public class OidcAuthOverGrpcIT {
           .withProperty(
               "camunda.data.secondary-storage.elasticsearch.url",
               "http://" + CONTAINER.getHttpHostAddress())
-          // OIDC client config goes through withProperty (not withSecurityConfig) so CSL's
-          // CamundaSecurityLibraryProperties — bound from Spring's property sources — sees the
-          // values. Mutating SecurityConfiguration post-binding would only update OC's typed
-          // config and leave CSL's clientRegistrationRepository looking at an empty OIDC block.
-          .withProperty(
-              "camunda.security.authentication.oidc.issuer-uri",
-              KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM)
-          // The following two properties are only needed for the webapp login flow which we don't
-          // test here, but CSL requires client-id to build a ClientRegistrationRepository.
-          .withProperty("camunda.security.authentication.oidc.client-id", "example")
-          .withProperty("camunda.security.authentication.oidc.redirect-uri", "example.com")
           .withSecurityConfig(
               c -> {
+                c.getAuthentication()
+                    .getOidc()
+                    .setIssuerUri(KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM);
+                c.getAuthentication().getOidc().setClientId("example");
+                c.getAuthentication().getOidc().setRedirectUri("example.com");
                 c.getAuthorizations().setEnabled(true);
                 c.getInitialization()
                     .setMappingRules(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestIT.java
@@ -76,19 +76,13 @@ public class OidcAuthOverRestIT {
           .withProperty(
               "camunda.data.secondary-storage.elasticsearch.url",
               "http://" + CONTAINER.getHttpHostAddress())
-          // OIDC client config goes through withProperty (not withSecurityConfig) so CSL's
-          // CamundaSecurityLibraryProperties — bound from Spring's property sources — sees the
-          // values. Mutating SecurityConfiguration post-binding would only update OC's typed
-          // config and leave CSL's clientRegistrationRepository looking at an empty OIDC block.
-          .withProperty(
-              "camunda.security.authentication.oidc.issuer-uri",
-              KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM)
-          // The following two properties are only needed for the webapp login flow which we don't
-          // test here, but CSL requires client-id to build a ClientRegistrationRepository.
-          .withProperty("camunda.security.authentication.oidc.client-id", "example")
-          .withProperty("camunda.security.authentication.oidc.redirect-uri", "example.com")
           .withSecurityConfig(
               c -> {
+                c.getAuthentication()
+                    .getOidc()
+                    .setIssuerUri(KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM);
+                c.getAuthentication().getOidc().setClientId("example");
+                c.getAuthentication().getOidc().setRedirectUri("example.com");
                 c.getAuthorizations().setEnabled(true);
                 c.getInitialization()
                     .setMappingRules(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestInitializerIT.java
@@ -50,17 +50,13 @@ public class OidcAuthOverRestInitializerIT {
           .withAuthenticatedAccess()
           .withAuthenticationMethod(AuthenticationMethod.OIDC)
           .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
-          // OIDC client config goes through withProperty so CSL's CamundaSecurityLibraryProperties
-          // — bound from Spring's property sources — sees the values. See OidcAuthOverRestIT.
-          .withProperty(
-              "camunda.security.authentication.oidc.issuer-uri",
-              KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM)
-          // The following two properties are only needed for the webapp login flow which we don't
-          // test here, but CSL requires client-id to build a ClientRegistrationRepository.
-          .withProperty("camunda.security.authentication.oidc.client-id", "example")
-          .withProperty("camunda.security.authentication.oidc.redirect-uri", "example.com")
           .withSecurityConfig(
               c -> {
+                c.getAuthentication()
+                    .getOidc()
+                    .setIssuerUri(KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM);
+                c.getAuthentication().getOidc().setClientId("example");
+                c.getAuthentication().getOidc().setRedirectUri("example.com");
                 c.getAuthorizations().setEnabled(true);
                 // add a preconfigured user. This should not be allowed with OIDC
                 c.getInitialization()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestStartupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestStartupIT.java
@@ -41,13 +41,11 @@ public class OidcAuthOverRestStartupIT {
           .withAuthenticatedAccess()
           .withAuthenticationMethod(AuthenticationMethod.OIDC)
           .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
-          // OIDC client config goes through withProperty so CSL's CamundaSecurityLibraryProperties
-          // — bound from Spring's property sources — sees the values. See OidcAuthOverRestIT.
-          .withProperty("camunda.security.authentication.oidc.issuer-uri", UNREACHABLE_ISSUER_URI)
-          .withProperty("camunda.security.authentication.oidc.client-id", "example")
-          .withProperty("camunda.security.authentication.oidc.redirect-uri", "example.com")
           .withSecurityConfig(
               c -> {
+                c.getAuthentication().getOidc().setIssuerUri(UNREACHABLE_ISSUER_URI);
+                c.getAuthentication().getOidc().setClientId("example");
+                c.getAuthentication().getOidc().setRedirectUri("example.com");
                 c.getAuthorizations().setEnabled(true);
                 final var defaultRoles = new HashMap<>(c.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER_ID)));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
@@ -167,20 +167,15 @@ final class IdentitySetupInitializerIT {
     assertThat(passwordEncoder.matches(user2.getPassword(), secondUser.getPassword())).isTrue();
   }
 
-  @Test
-  void shouldInitializeWithMappingRulesAndRoleMemberships() {
+  // Each key form is exercised in its own broker: config is flattened to camunda.* properties and
+  // re-bound by Spring, which collapses case-variant map keys into a single canonical key. Putting
+  // several variants in one default-roles map would therefore drop all but one, so we verify the
+  // forms independently — matching how a real user supplies a single form via YAML/env.
+  @ParameterizedTest
+  @ValueSource(strings = {"mappingRules", "mappingrules", "mapping-rules"})
+  void shouldInitializeWithMappingRulesAndRoleMemberships(final String mappingRulesKey) {
     // given a broker with authorization enabled
-    final var mappingRules1 =
-        new ConfiguredMappingRule(
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString());
-    final var mappingRules2 =
-        new ConfiguredMappingRule(
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString());
-    final var mappingRules3 =
+    final var mappingRule =
         new ConfiguredMappingRule(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
@@ -189,18 +184,10 @@ final class IdentitySetupInitializerIT {
         true,
         1,
         cfg -> {
-          cfg.getInitialization()
-              .setMappingRules(List.of(mappingRules1, mappingRules2, mappingRules3));
+          cfg.getInitialization().setMappingRules(List.of(mappingRule));
           final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
           defaultRoles.put(
-              "admin",
-              Map.of(
-                  "mappingRules",
-                  List.of(mappingRules1.getMappingRuleId()),
-                  "mappingrules",
-                  List.of(mappingRules2.getMappingRuleId()),
-                  "mapping-rules",
-                  List.of(mappingRules3.getMappingRuleId())));
+              "admin", Map.of(mappingRulesKey, List.of(mappingRule.getMappingRuleId())));
           cfg.getInitialization().setDefaultRoles(defaultRoles);
         });
 
@@ -213,30 +200,12 @@ final class IdentitySetupInitializerIT {
     final var firstMappingRule = record.getMappingRules().getFirst();
     Assertions.assertThat(firstMappingRule)
         .isNotNull()
-        .hasMappingRuleId(mappingRules1.getMappingRuleId())
-        .hasClaimName(mappingRules1.getClaimName())
-        .hasClaimValue(mappingRules1.getClaimValue());
-
-    final var secondMappingRule = record.getMappingRules().get(1);
-    Assertions.assertThat(secondMappingRule)
-        .isNotNull()
-        .hasMappingRuleId(mappingRules2.getMappingRuleId())
-        .hasClaimName(mappingRules2.getClaimName())
-        .hasClaimValue(mappingRules2.getClaimValue());
-
-    final var thirdMappingRule = record.getMappingRules().get(2);
-    Assertions.assertThat(thirdMappingRule)
-        .isNotNull()
-        .hasMappingRuleId(mappingRules3.getMappingRuleId())
-        .hasClaimName(mappingRules3.getClaimName())
-        .hasClaimValue(mappingRules3.getClaimValue());
+        .hasMappingRuleId(mappingRule.getMappingRuleId())
+        .hasClaimName(mappingRule.getClaimName())
+        .hasClaimValue(mappingRule.getClaimValue());
 
     final var members = record.getRoleMembers().stream().map(RoleRecordValue::getEntityId).toList();
-    assertThat(members)
-        .containsExactlyInAnyOrder(
-            mappingRules1.getMappingRuleId(),
-            mappingRules2.getMappingRuleId(),
-            mappingRules3.getMappingRuleId());
+    assertThat(members).containsExactly(mappingRule.getMappingRuleId());
   }
 
   private void createBroker(
@@ -246,8 +215,8 @@ final class IdentitySetupInitializerIT {
       final Consumer<CamundaSecurityLibraryProperties> securityCfg) {
     broker =
         new TestStandaloneBroker()
-            .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(authorizationsEnabled))
-            .withSecurityConfig(securityCfg)
+            .withSecurityConfig(
+                securityCfg.andThen(sc -> sc.getAuthorizations().setEnabled(authorizationsEnabled)))
             .withClusterConfig(cluster -> cluster.setPartitionCount(partitionCount))
             .withRecordingExporter(true);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersOidcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersOidcIT.java
@@ -104,13 +104,11 @@ public class SecurityHeadersOidcIT extends SecurityHeadersBaseIT {
                       .getSecondaryStorage()
                       .getElasticsearch()
                       .setUrl("http://" + CONTAINER.getHttpHostAddress()))
-          // OIDC client config goes through withProperty so CSL's CamundaSecurityLibraryProperties
-          // — bound from Spring's property sources — sees the values. See OidcAuthOverRestIT.
-          .withProperty("camunda.security.authentication.oidc.issuer-uri", buildKeycloakIssuerUri())
-          .withProperty("camunda.security.authentication.oidc.client-id", EXAMPLE_CLIENT_ID)
-          .withProperty("camunda.security.authentication.oidc.redirect-uri", EXAMPLE_REDIRECT_URI)
           .withSecurityConfig(
               c -> {
+                c.getAuthentication().getOidc().setIssuerUri(buildKeycloakIssuerUri());
+                c.getAuthentication().getOidc().setClientId(EXAMPLE_CLIENT_ID);
+                c.getAuthentication().getOidc().setRedirectUri(EXAMPLE_REDIRECT_URI);
                 c.getAuthorizations().setEnabled(true);
                 c.getInitialization()
                     .setMappingRules(

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
@@ -10,21 +10,18 @@ package io.camunda.zeebe.qa.util.cluster;
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
 import io.camunda.configuration.Camunda;
-import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.restore.RestoreApp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
 /** Represents an instance of the {@link RestoreApp} Spring application. */
 public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> {
-  private final Camunda config;
   private long[] backupId;
   private Instant from;
   private Instant to;
@@ -34,8 +31,7 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
   }
 
   public TestRestoreApp(final Camunda config) {
-    super(RestoreApp.class);
-    this.config = config;
+    super(config, RestoreApp.class);
     withAdditionalProfile(Profile.RESTORE);
   }
 
@@ -46,7 +42,7 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
 
   @Override
   public MemberId nodeId() {
-    return MemberId.from(String.valueOf(config.getCluster().getNodeId()));
+    return MemberId.from(String.valueOf(unifiedConfig.getCluster().getNodeId()));
   }
 
   @Override
@@ -57,12 +53,6 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
   @Override
   public boolean isGateway() {
     return false;
-  }
-
-  @Override
-  public TestRestoreApp withUnifiedConfig(final Consumer<Camunda> modifier) {
-    modifier.accept(config);
-    return this;
   }
 
   @Override
@@ -81,9 +71,6 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
 
   @Override
   protected SpringApplicationBuilder createSpringBuilder() {
-    // Flatten the in-memory unified config into camunda.* properties at the latest possible point.
-    // Refreshable so that fields cleared between stop/start don't linger.
-    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(config));
     return super.createSpringBuilder().web(WebApplicationType.NONE);
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -14,7 +14,8 @@ import io.camunda.application.MainSupport;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.application.initializers.HealthConfigurationInitializer;
-import io.camunda.authentication.config.AuthenticationProperties;
+import io.camunda.configuration.Camunda;
+import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.zeebe.qa.util.cluster.util.ContextOverrideInitializer;
 import io.camunda.zeebe.qa.util.cluster.util.ContextOverrideInitializer.Bean;
@@ -28,6 +29,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.Banner.Mode;
@@ -42,6 +44,7 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   private static final Logger LOGGER = LoggerFactory.getLogger(TestSpringApplication.class);
 
   protected ConfigurableApplicationContext springContext;
+  protected final Camunda unifiedConfig;
 
   private final Class<?>[] springApplications;
   private final Map<String, Bean<?>> beans;
@@ -52,14 +55,21 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   private final Set<String> refreshableKeys = new HashSet<>();
 
   public TestSpringApplication(final Class<?>... springApplications) {
-    this(new HashMap<>(), new HashMap<>(), new ArrayList<>(), springApplications);
+    this(new Camunda(), springApplications);
+  }
+
+  protected TestSpringApplication(
+      final Camunda unifiedConfig, final Class<?>... springApplications) {
+    this(unifiedConfig, new HashMap<>(), new HashMap<>(), new ArrayList<>(), springApplications);
   }
 
   private TestSpringApplication(
+      final Camunda unifiedConfig,
       final Map<String, Bean<?>> beans,
       final Map<String, Object> propertyOverrides,
       final Collection<String> additionalProfiles,
       final Class<?>... springApplications) {
+    this.unifiedConfig = unifiedConfig;
     this.springApplications = springApplications;
     this.beans = beans;
     this.propertyOverrides = propertyOverrides;
@@ -173,6 +183,32 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   /**
+   * Modifies the unified configuration (camunda.* properties). The in-memory config is flattened
+   * into camunda.* properties at {@link #createSpringBuilder()} time, so all mutations made up to
+   * start are captured. This is the single source of truth for camunda.* properties and is
+   * preferred over {@link #withProperty} for any key that has a unified-config representation, to
+   * avoid conflicts between directly-set properties and the flattened config.
+   *
+   * @param modifier a configuration function that accepts the Camunda configuration object
+   * @return itself for chaining
+   */
+  @Override
+  public T withUnifiedConfig(final Consumer<Camunda> modifier) {
+    modifier.accept(unifiedConfig);
+    return self();
+  }
+
+  /**
+   * Returns the unified configuration object. This provides access to the camunda.* configuration
+   * structure and is the primary way to read/configure the test application.
+   *
+   * @return the Camunda unified configuration object
+   */
+  public Camunda unifiedConfig() {
+    return unifiedConfig;
+  }
+
+  /**
    * Replaces a set of properties that should be re-derived from in-memory builder state on every
    * {@link #start()}. Keys set in a previous call are removed before the new {@code properties} are
    * applied, so fields that disappear between restarts (e.g. an exporter cleared from the unified
@@ -189,7 +225,7 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   public T withBasicAuth() {
-    withProperty(AuthenticationProperties.METHOD, AuthenticationMethod.BASIC.name());
+    unifiedConfig.getSecurity().getAuthentication().setMethod(AuthenticationMethod.BASIC);
     withAdditionalProfile(Profile.CONSOLIDATED_AUTH);
     return self();
   }
@@ -200,12 +236,13 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   public T withAuthenticationMethod(final AuthenticationMethod authenticationMethod) {
-    return withAdditionalProfile(Profile.CONSOLIDATED_AUTH)
-        .withProperty(AuthenticationProperties.METHOD, authenticationMethod.name());
+    unifiedConfig.getSecurity().getAuthentication().setMethod(authenticationMethod);
+    return withAdditionalProfile(Profile.CONSOLIDATED_AUTH);
   }
 
   protected T withUnauthenticatedAccess(final boolean unprotectedApi) {
-    return withProperty(AuthenticationProperties.API_UNPROTECTED, unprotectedApi);
+    unifiedConfig.getSecurity().getAuthentication().setUnprotectedApi(unprotectedApi);
+    return self();
   }
 
   public final T withUnauthenticatedAccess() {
@@ -240,15 +277,12 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   public final Optional<AuthenticationMethod> apiAuthenticationMethod() {
-    if (property(AuthenticationProperties.API_UNPROTECTED, Boolean.class, true)) {
+    final var authentication = unifiedConfig.getSecurity().getAuthentication();
+    if (authentication.isUnprotectedApi()) {
       return Optional.empty();
     } else {
-      return Optional.of(
-          AuthenticationMethod.parse(
-              property(
-                  AuthenticationProperties.METHOD,
-                  String.class,
-                  AuthenticationMethod.BASIC.name())));
+      final var method = authentication.getMethod();
+      return Optional.of(method != null ? method : AuthenticationMethod.BASIC);
     }
   }
 
@@ -262,6 +296,10 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
    * can override this to customize the behavior of the test application.
    */
   protected SpringApplicationBuilder createSpringBuilder() {
+    // Flatten the in-memory unified config into camunda.* properties at the latest possible point,
+    // so every with*Config / withUnifiedConfig call made up to now is captured. Refreshable so that
+    // fields cleared between stop/start (e.g. an exporter removed) don't remain.
+    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return MainSupport.createDefaultApplicationBuilder()
         .bannerMode(Mode.OFF)
         .registerShutdownHook(false)

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -11,8 +11,6 @@ import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
 import io.camunda.application.StandaloneCamunda;
 import io.camunda.application.commons.CommonsModuleConfiguration;
-import io.camunda.authentication.config.AuthenticationProperties;
-import io.camunda.configuration.Camunda;
 import io.camunda.configuration.EngineJob;
 import io.camunda.configuration.NodeIdProvider.Type;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
@@ -20,7 +18,6 @@ import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
 import io.camunda.configuration.beans.SearchEngineRetentionProperties;
-import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.initialization.ConfiguredMappingRule;
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
@@ -54,8 +51,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   public static final String DEFAULT_MAPPING_RULE_CLAIM_NAME = "client_id";
   public static final String DEFAULT_MAPPING_RULE_CLAIM_VALUE = "default";
   public static final String RECORDING_EXPORTER_ID = "recordingExporter";
-  private final Camunda unifiedConfig;
-  private final CamundaSecurityLibraryProperties cslProperties;
   private boolean isGatewayEnabled = true;
   private final Map<String, Consumer<Map<String, Object>>> exporterMutators = new HashMap<>();
 
@@ -64,8 +59,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         BrokerModuleConfiguration.class,
         CommonsModuleConfiguration.class,
         NodeIdProviderConfiguration.class);
-
-    unifiedConfig = new Camunda();
 
     // Initialize unified config with test-friendly defaults
     initializeUnifiedConfigDefaults();
@@ -80,10 +73,10 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
 
     withAdditionalProfile(Profile.BROKER);
 
-    cslProperties = new CamundaSecurityLibraryProperties();
-    cslProperties.getAuthorizations().setEnabled(false);
-    cslProperties.getAuthentication().setUnprotectedApi(true);
-    cslProperties
+    unifiedConfig.getSecurity().getAuthorizations().setEnabled(false);
+    unifiedConfig.getSecurity().getAuthentication().setUnprotectedApi(true);
+    unifiedConfig
+        .getSecurity()
         .getInitialization()
         .setUsers(
             List.of(
@@ -92,7 +85,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
                     InitializationConfiguration.DEFAULT_USER_PASSWORD,
                     InitializationConfiguration.DEFAULT_USER_NAME,
                     InitializationConfiguration.DEFAULT_USER_EMAIL)));
-    cslProperties
+    unifiedConfig
+        .getSecurity()
         .getInitialization()
         .setMappingRules(
             List.of(
@@ -100,7 +94,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
                     DEFAULT_MAPPING_RULE_ID,
                     DEFAULT_MAPPING_RULE_CLAIM_NAME,
                     DEFAULT_MAPPING_RULE_CLAIM_VALUE)));
-    cslProperties
+    unifiedConfig
+        .getSecurity()
         .getInitialization()
         .setDefaultRoles(
             Map.of(
@@ -110,13 +105,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
                     List.of(InitializationConfiguration.DEFAULT_USER_USERNAME),
                     "mappingRules",
                     List.of(DEFAULT_MAPPING_RULE_ID))));
-
-    withBean("cslProperties", cslProperties, CamundaSecurityLibraryProperties.class);
-    withProperty(
-        AuthenticationProperties.API_UNPROTECTED,
-        cslProperties.getAuthentication().isUnprotectedApi());
-    withProperty(
-        "camunda.security.authorizations.enabled", cslProperties.getAuthorizations().isEnabled());
     // by default, we don't want to create the schema as ES/OS containers may not be used in the
     // current test
     withCreateSchema(false);
@@ -133,21 +121,13 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   }
 
   @Override
-  public TestStandaloneBroker withProperty(final String key, final Object value) {
-    // Since the security config is not constructed from the properties, we need to manually update
-    // it when we override a property.
-    AuthenticationProperties.applyToSecurityConfig(cslProperties, key, value);
-    return super.withProperty(key, value);
-  }
-
-  @Override
   public TestStandaloneBroker withAuthenticationMethod(
       final AuthenticationMethod authenticationMethod) {
     // as mode is OIDC, and we have a user created by default in `TestStandaloneBroker`
     // we need to reset the list of users to empty list as having pre-configured user in
     // OIDC is not allowed
     if (authenticationMethod == AuthenticationMethod.OIDC) {
-      cslProperties.getInitialization().setUsers(new ArrayList<>());
+      unifiedConfig.getSecurity().getInitialization().setUsers(new ArrayList<>());
     }
     return super.withAuthenticationMethod(authenticationMethod);
   }
@@ -160,17 +140,12 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     withProperty(
         "zeebe.broker.gateway.enable",
         property("zeebe.broker.gateway.enable", Boolean.class, isGatewayEnabled));
-    // Flatten the in-memory unified config into camunda.* properties at the latest possible point,
-    // so every withClusterConfig/withDataConfig/... call made up to now is captured. Refreshable
-    // so that fields cleared between stop/start (e.g. an exporter removed) don't remain.
-    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return super.createSpringBuilder();
   }
 
   public TestStandaloneBroker withAuthorizationsEnabled() {
     // when using authorizations, api authentication needs to be enforced too
     withAuthenticatedAccess();
-    withProperty("camunda.security.authorizations.enabled", true);
     return withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
   }
 
@@ -217,22 +192,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     return isGatewayEnabled;
   }
 
-  /**
-   * Modifies the unified configuration (camunda.* properties). This is the recommended way to
-   * configure test brokers going forward.
-   *
-   * <p>The unified configuration will be merged into BrokerBasedProperties at Spring application
-   * startup via BrokerBasedPropertiesOverride, with unified config taking precedence.
-   *
-   * @param modifier a configuration function that accepts the Camunda configuration object
-   * @return itself for chaining
-   */
-  @Override
-  public TestStandaloneBroker withUnifiedConfig(final Consumer<Camunda> modifier) {
-    modifier.accept(unifiedConfig);
-    return this;
-  }
-
   public TestStandaloneBroker withGatewayEnabled(final boolean enabled) {
     // Gateway enable flag is set via property (not fully in unified config yet)
     isGatewayEnabled = enabled;
@@ -255,20 +214,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     throw new UnsupportedOperationException("Brokers do not support the gateway health indicators");
   }
 
-  /**
-   * Returns the unified configuration object. This provides access to the camunda.* configuration
-   * structure and is the primary way to read/configure the test broker.
-   *
-   * @return the Camunda unified configuration object
-   */
-  @Override
-  public Camunda unifiedConfig() {
-    return unifiedConfig;
-  }
-
   /** Enables multi-tenancy in the security configuration. */
   public TestStandaloneBroker withMultiTenancyEnabled() {
-    withProperty("camunda.security.multiTenancy.checksEnabled", "true");
     return withSecurityConfig(cfg -> cfg.getMultiTenancy().setChecksEnabled(true));
   }
 
@@ -421,7 +368,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   @Override
   public TestStandaloneBroker withSecurityConfig(
       final Consumer<CamundaSecurityLibraryProperties> modifier) {
-    modifier.accept(cslProperties);
+    modifier.accept(unifiedConfig.getSecurity());
     return this;
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -10,26 +10,18 @@ package io.camunda.zeebe.qa.util.cluster;
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.CommonsModuleConfiguration;
-import io.camunda.configuration.Camunda;
-import io.camunda.container.ExtendedConfigurationBuilder;
-import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.util.function.Consumer;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 
 /** Encapsulates an instance of the {@link GatewayModuleConfiguration} Spring application. */
 public final class TestStandaloneGateway extends TestSpringApplication<TestStandaloneGateway>
     implements TestGateway<TestStandaloneGateway> {
-  private final Camunda unifiedConfig;
-  private final CamundaSecurityLibraryProperties cslProperties;
 
   public TestStandaloneGateway() {
     super(GatewayModuleConfiguration.class, CommonsModuleConfiguration.class);
     // this is needed to ensure no default spring boot 4.0 security setup kicks in
     withAdditionalProfile(Profile.CONSOLIDATED_AUTH);
-
-    unifiedConfig = new Camunda();
 
     unifiedConfig.getApi().getGrpc().setAddress("0.0.0.0");
     unifiedConfig.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort());
@@ -40,11 +32,8 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
         .setPort(SocketUtil.getNextAddress().getPort());
     withAdditionalProfile(Profile.GATEWAY);
 
-    cslProperties = new CamundaSecurityLibraryProperties();
-    cslProperties.getAuthentication().setUnprotectedApi(true);
-    cslProperties.getAuthorizations().setEnabled(false);
-    //noinspection resource
-    withBean("cslProperties", cslProperties, CamundaSecurityLibraryProperties.class);
+    unifiedConfig.getSecurity().getAuthentication().setUnprotectedApi(true);
+    unifiedConfig.getSecurity().getAuthorizations().setEnabled(false);
 
     // by default, we don't want to create the schema as ES/OS containers may not be used in the
     // current test
@@ -72,18 +61,6 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
     return true;
   }
 
-  /**
-   * Modifies the unified configuration (camunda.* properties).
-   *
-   * @param modifier a configuration function that accepts the Camunda configuration object
-   * @return itself for chaining
-   */
-  @Override
-  public TestStandaloneGateway withUnifiedConfig(final Consumer<Camunda> modifier) {
-    modifier.accept(unifiedConfig);
-    return this;
-  }
-
   @Override
   public int mappedPort(final TestZeebePort port) {
     return switch (port) {
@@ -91,26 +68,6 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
       case CLUSTER -> unifiedConfig.getCluster().getNetwork().getInternalApi().getPort();
       default -> super.mappedPort(port);
     };
-  }
-
-  @Override
-  protected SpringApplicationBuilder createSpringBuilder() {
-    // Flatten the in-memory unified config into camunda.* properties at the latest possible point,
-    // so every withClusterConfig/withUnifiedConfig/... call made up to now is captured. Refreshable
-    // so that fields cleared between stop/start don't remain.
-    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
-    return super.createSpringBuilder();
-  }
-
-  /**
-   * Returns the unified configuration object. This provides access to the camunda.* configuration
-   * structure.
-   *
-   * @return the Camunda unified configuration object
-   */
-  @Override
-  public Camunda unifiedConfig() {
-    return unifiedConfig;
   }
 
   /**


### PR DESCRIPTION
## Description

Test applications now configure the Camunda Security Library (CSL, `CamundaSecurityLibraryProperties`) through the unified `Camunda` configuration object. That object is flattened to `camunda.*` Spring properties at application startup (`ExtendedConfigurationBuilder.flatPropertiesFor`) and bound the normal way, so the flattened unified config is the single source of truth and standard Spring binding wires CSL — including the OIDC `ClientRegistrationRepository`.

Previously, OIDC/auth settings had to be set via raw `withProperty("camunda.security.authentication.*", …)` calls: mutating the in-memory `SecurityConfiguration` after binding only updated the typed config and left CSL looking at an empty OIDC block. That required mirroring helpers in `AuthenticationProperties` and made it easy to introduce conflicts between directly-set properties and the flattened unified config.

### Key changes

- **`TestSpringApplication`** now owns the unified-config plumbing shared by all test apps:
  - the `unifiedConfig` (`Camunda`) field plus `withUnifiedConfig(...)` / `unifiedConfig()`;
  - the config flattening in `createSpringBuilder()`, done once in the base instead of in each subclass;
  - the auth helpers (`withUnauthenticatedAccess` / `withAuthenticatedAccess`, `withAuthenticationMethod`, `withBasicAuth`, `apiAuthenticationMethod`) mutate the unified config instead of setting `camunda.security.*` properties directly, removing a class of property-vs-unified-config conflicts.
- Subclasses (`TestStandaloneBroker`, `TestStandaloneGateway`, `TestCamundaApplication`, `TestRestoreApp`, `TestStandaloneBackupManager`, `TestStandaloneSchemaManager`, `CamundaRdbmsTestApplication`) drop their per-class `unifiedConfig` field, overrides, and flatten call.
- OIDC tests (`OidcAuthOverGrpcIT`, `OidcAuthOverRestIT`, `OidcAuthOverRestInitializerIT`, `OidcAuthOverRestStartupIT`, `SecurityHeadersOidcIT`, `OidcNoSecondaryStorageTest`) and `Ipv6IntegrationTest` configure OIDC/auth through `withSecurityConfig(...)` / the unified config instead of raw `camunda.security.*` properties.
- `AuthenticationProperties`: removed the now-unused test-only mirroring helpers (`applyToSecurityConfig`, `getUnprotectedApiEnvVar`) and `OIDC_*` constants.
- `IdentitySetupInitializerIT`: `shouldInitializeWithMappingRulesAndRoleMemberships` is now parameterized over the supported default-role key forms (`mappingRules` / `mappingrules` / `mapping-rules`), each in its own broker — because config now round-trips through Spring property binding, the case-variant keys can no longer coexist in a single map.
- `qa/util/pom.xml`: drop the now-unused `camunda-testcontainer` dependency.

No production behavior change beyond removing dead, test-only code from `AuthenticationProperties`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
