### PR TITLE
test: enforce RDBMS DbModel IT and SortIT coverage with ArchUnit

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogSortIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.auditlog;
+
+import static io.camunda.it.rdbms.db.fixtures.AuditLogFixtures.createAndSaveRandomAuditLogs;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.AuditLogDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.filter.AuditLogFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AuditLogQuery;
+import io.camunda.search.sort.AuditLogSort;
+import io.camunda.search.sort.AuditLogSort.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AuditLogSortIT {
+
+  public static final long PARTITION_ID = 0L;
+
+  @TestTemplate
+  public void shouldSortByAuditLogKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.auditLogKey().asc(),
+        Comparator.comparing(AuditLogEntity::auditLogKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByAuditLogKeyDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.auditLogKey().desc(),
+        Comparator.comparing(AuditLogEntity::auditLogKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByTimestampAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.timestamp().asc(),
+        Comparator.comparing(AuditLogEntity::timestamp));
+  }
+
+  @TestTemplate
+  public void shouldSortByTimestampDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.timestamp().desc(),
+        Comparator.comparing(AuditLogEntity::timestamp).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByActorIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.actorId().asc(),
+        Comparator.comparing(AuditLogEntity::actorId));
+  }
+
+  @TestTemplate
+  public void shouldSortByActorIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.actorId().desc(),
+        Comparator.comparing(AuditLogEntity::actorId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.tenantId().asc(),
+        Comparator.comparing(AuditLogEntity::tenantId));
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.tenantId().desc(),
+        Comparator.comparing(AuditLogEntity::tenantId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByEntityTypeAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.entityType().asc(),
+        Comparator.comparing(e -> e.entityType().name()));
+  }
+
+  @TestTemplate
+  public void shouldSortByEntityTypeDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.entityType().desc(),
+        Comparator.<AuditLogEntity, String>comparing(e -> e.entityType().name()).reversed());
+  }
+
+  private void testSorting(
+      final RdbmsService rdbmsService,
+      final Function<Builder, ObjectBuilder<AuditLogSort>> sortBuilder,
+      final Comparator<AuditLogEntity> comparator) {
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final AuditLogDbReader reader = rdbmsService.getAuditLogReader("default");
+
+    final var actorId = nextStringId();
+    createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.actorId(actorId));
+
+    final var searchResult =
+        reader
+            .search(
+                new AuditLogQuery(
+                    new AuditLogFilter.Builder().actorIds(actorId).build(),
+                    AuditLogSort.of(sortBuilder),
+                    SearchQueryPage.of(b -> b)))
+            .items();
+
+    assertThat(searchResult).hasSize(20);
+    assertThat(searchResult).isSortedAccordingTo(comparator);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/WaitStateFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/WaitStateFixtures.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.function.Function;
+
+public final class WaitStateFixtures extends CommonFixtures {
+
+  public static final int PARTITION_ID = 0;
+
+  private WaitStateFixtures() {}
+
+  public static WaitStateDbModel createRandomized(
+      final Function<WaitStateDbModel.Builder, WaitStateDbModel.Builder> builderFunction) {
+    final long key = nextKey();
+    final var builder =
+        new WaitStateDbModel.Builder()
+            .waitStateKey(key)
+            .rootProcessInstanceKey(nextKey())
+            .processInstanceKey(nextKey())
+            .elementInstanceKey(nextKey())
+            .elementId("element-" + key)
+            .elementType(BpmnElementType.SERVICE_TASK.name())
+            .waitStateType("JOB")
+            .processDefinitionId("process-" + generateRandomString(10))
+            .details("{\"jobKey\":" + key + ",\"jobType\":\"payment\",\"retries\":3}")
+            .tenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .partitionId(PARTITION_ID);
+
+    return builderFunction.apply(builder).build();
+  }
+
+  public static void createAndSaveRandomWaitStates(final RdbmsWriters rdbmsWriters) {
+    createAndSaveRandomWaitStates(rdbmsWriters, b -> b);
+  }
+
+  public static void createAndSaveRandomWaitStates(
+      final RdbmsWriters rdbmsWriters,
+      final Function<WaitStateDbModel.Builder, WaitStateDbModel.Builder> builderFunction) {
+    createAndSaveRandomWaitStates(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomWaitStates(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<WaitStateDbModel.Builder, WaitStateDbModel.Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
+      rdbmsWriters.getWaitStateWriter().create(createRandomized(builderFunction));
+    }
+    rdbmsWriters.flush();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobSortIT.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.job;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.it.rdbms.db.fixtures.JobFixtures.createAndSaveRandomJobs;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.JobDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.JobEntity;
+import io.camunda.search.filter.JobFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.JobQuery;
+import io.camunda.search.sort.JobSort;
+import io.camunda.search.sort.JobSort.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class JobSortIT {
+
+  public static final long PARTITION_ID = 0L;
+
+  @TestTemplate
+  public void shouldSortByJobKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.jobKey().asc(),
+        Comparator.comparing(JobEntity::jobKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByJobKeyDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.jobKey().desc(),
+        Comparator.comparing(JobEntity::jobKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByTypeAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.type().asc(),
+        Comparator.comparing(JobEntity::type));
+  }
+
+  @TestTemplate
+  public void shouldSortByTypeDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.type().desc(),
+        Comparator.comparing(JobEntity::type).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByWorkerAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.worker().asc(),
+        Comparator.comparing(JobEntity::worker));
+  }
+
+  @TestTemplate
+  public void shouldSortByWorkerDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.worker().desc(),
+        Comparator.comparing(JobEntity::worker).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.tenantId().asc(),
+        Comparator.comparing(JobEntity::tenantId));
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.tenantId().desc(),
+        Comparator.comparing(JobEntity::tenantId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.processInstanceKey().asc(),
+        Comparator.comparing(JobEntity::processInstanceKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessInstanceKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.processInstanceKey().desc(),
+        Comparator.comparing(JobEntity::processInstanceKey).reversed());
+  }
+
+  private void testSorting(
+      final RdbmsService rdbmsService,
+      final Function<Builder, ObjectBuilder<JobSort>> sortBuilder,
+      final Comparator<JobEntity> comparator) {
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final JobDbReader reader = rdbmsService.getJobReader("default");
+
+    final var processDefinitionId = nextStringId();
+    createAndSaveRandomJobs(rdbmsWriters, b -> b.processDefinitionId(processDefinitionId));
+
+    final var searchResult =
+        reader
+            .search(
+                new JobQuery(
+                    new JobFilter.Builder().processDefinitionIds(processDefinitionId).build(),
+                    JobSort.of(sortBuilder),
+                    SearchQueryPage.of(b -> b)))
+            .items();
+
+    assertThat(searchResult).hasSize(20);
+    assertThat(searchResult).isSortedAccordingTo(comparator);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetric/UsageMetricIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetric/UsageMetricIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.usagemetrics;
+package io.camunda.it.rdbms.db.usagemetric;
 
 import static io.camunda.db.rdbms.write.domain.UsageMetricDbModel.EventTypeDbModel.EDI;
 import static io.camunda.db.rdbms.write.domain.UsageMetricDbModel.EventTypeDbModel.RPI;
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
-public class UsageMetricsIT {
+public class UsageMetricIT {
 
   private static final long ASSIGNEE_HASH_1 = getStringHashValue("assignee1");
   private static final long ASSIGNEE_HASH_2 = getStringHashValue("assignee2");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateSortIT.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.waitstate;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.WaitStateFixtures.createAndSaveRandomWaitStates;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.WaitStateDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.filter.ElementInstanceWaitStateFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
+import io.camunda.search.sort.WaitStateSort;
+import io.camunda.search.sort.WaitStateSort.Builder;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.util.ObjectBuilder;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class WaitStateSortIT {
+
+  public static final long PARTITION_ID = 0L;
+
+  @TestTemplate
+  public void shouldSortByElementInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.elementInstanceKey().asc(),
+        Comparator.comparing(WaitStateEntity::elementInstanceKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByElementInstanceKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.elementInstanceKey().desc(),
+        Comparator.comparing(WaitStateEntity::elementInstanceKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.processInstanceKey().asc(),
+        Comparator.comparing(WaitStateEntity::processInstanceKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessInstanceKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.processInstanceKey().desc(),
+        Comparator.comparing(WaitStateEntity::processInstanceKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByRootProcessInstanceKeyAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.rootProcessInstanceKey().asc(),
+        Comparator.comparing(WaitStateEntity::rootProcessInstanceKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByRootProcessInstanceKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.rootProcessInstanceKey().desc(),
+        Comparator.comparing(WaitStateEntity::rootProcessInstanceKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByElementIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.elementId().asc(),
+        Comparator.comparing(WaitStateEntity::elementId));
+  }
+
+  @TestTemplate
+  public void shouldSortByElementIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.elementId().desc(),
+        Comparator.comparing(WaitStateEntity::elementId).reversed());
+  }
+
+  private void testSorting(
+      final RdbmsService rdbmsService,
+      final Function<Builder, ObjectBuilder<WaitStateSort>> sortBuilder,
+      final Comparator<WaitStateEntity> comparator) {
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final WaitStateDbReader reader = rdbmsService.getWaitStateReader("default");
+
+    final var processInstanceKey = nextKey();
+    createAndSaveRandomWaitStates(
+        rdbmsWriters,
+        b -> b.processInstanceKey(processInstanceKey).rootProcessInstanceKey(nextKey()));
+
+    final var searchResult =
+        reader
+            .search(
+                new ElementInstanceWaitStateQuery(
+                    new ElementInstanceWaitStateFilter.Builder()
+                        .processInstanceKeys(processInstanceKey)
+                        .build(),
+                    WaitStateSort.of(sortBuilder),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled())
+            .items();
+
+    assertThat(searchResult).hasSize(20);
+    assertThat(searchResult).isSortedAccordingTo(comparator);
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.satisfied;
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
+import io.camunda.archunit.IncludeTestClassesAndTestJars;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Enforces that every RDBMS entity model ({@code XXXDbModel}) is covered by at least one
+ * integration test ({@code XXXXIT}) in {@code io.camunda.it.rdbms.db}.
+ *
+ * <p>{@link AnalyzeClasses} scans only the production package (DbModel classes). IT class names are
+ * pre-computed at class-load time via a second {@link ClassFileImporter} restricted to test-jars,
+ * matching the dual-scan pattern used before this class was converted to the native ArchUnit
+ * {@code @ArchTest} format required by CI.
+ */
+@AnalyzeClasses(
+    packages = "io.camunda.db.rdbms.write.domain",
+    importOptions = DoNotIncludeTestsOrTestJars.class)
+class RdbmsDbModelCoverageArchTest {
+
+  // Sub-entities and variant models that are not independently tested by their own IT.
+  // They are covered by a parent entity's IT (see comment per entry).
+  static final Set<String> NON_INDEPENDENT_DB_MODELS =
+      Set.of(
+          "UsageMetricTUDbModel", // TU variant of UsageMetricDbModel; covered by UsageMetricIT
+          "UserTaskMigrationDbModel", // migration helper model; covered by UserTaskIT
+          "BatchOperationItemDbModel", // sub-entity of BatchOperation; covered by BatchOperationIT
+          "BatchOperationErrorDbModel", // error sub-entity of BatchOperation; covered by
+          // BatchOperationIT
+          "HistoryDeletionTypeDbModel", // type sub-model for HistoryDeletion; covered by
+          // HistoryDeletionIT
+          "EventTypeDbModel", // audit-event type enum model; no standalone IT
+          "UsageMetricStatisticsDbModel", // statistics sub-model; covered by UsageMetricIT
+          "UsageMetricTUStatisticsDbModel", // TU statistics variant; covered by UsageMetricIT
+          "UsageMetricTenantStatisticsDbModel", // tenant statistics variant; covered by
+          // UsageMetricIT
+          "UsageMetricTUTenantStatisticsDbModel" // TU tenant statistics variant; covered by
+          // UsageMetricIT
+          );
+
+  // IT class simple names scanned from test-jars once at class-load time.
+  static final Set<String> IT_SIMPLE_NAMES =
+      StreamSupport.stream(
+              new ClassFileImporter()
+                  .withImportOption(new IncludeTestClassesAndTestJars())
+                  .importPackages("io.camunda.it.rdbms.db")
+                  .spliterator(),
+              false)
+          .filter(c -> c.getSimpleName().endsWith("IT"))
+          .map(JavaClass::getSimpleName)
+          .collect(Collectors.toUnmodifiableSet());
+
+  @ArchTest
+  static final ArchRule EACH_DB_MODEL_HAS_RDBMS_IT =
+      ArchRuleDefinition.classes()
+          .that()
+          .haveSimpleNameEndingWith("DbModel")
+          .should(haveCorrespondingItTest())
+          .because(
+              "each RDBMS entity model must be covered by an IT in io.camunda.it.rdbms.db.*"
+                  + " to ensure it is tested against all databases");
+
+  private static ArchCondition<JavaClass> haveCorrespondingItTest() {
+    return new ArchCondition<>("have a corresponding IT in io.camunda.it.rdbms.db.*") {
+      @Override
+      public void check(final JavaClass javaClass, final ConditionEvents events) {
+        if (javaClass.getModifiers().contains(JavaModifier.ABSTRACT)
+            || javaClass.isInterface()
+            || NON_INDEPENDENT_DB_MODELS.contains(javaClass.getSimpleName())) {
+          events.add(satisfied(javaClass, "skipped — not an independently tested entity"));
+          return;
+        }
+        final String entityName = javaClass.getSimpleName().replace("DbModel", "");
+        final String expectedIt = entityName + "IT";
+        if (IT_SIMPLE_NAMES.contains(expectedIt)) {
+          events.add(satisfied(javaClass, "found " + expectedIt));
+        } else {
+          events.add(
+              violated(
+                  javaClass,
+                  javaClass.getSimpleName()
+                      + " has no '"
+                      + expectedIt
+                      + "' in io.camunda.it.rdbms.db.*; add the missing IT or add the DbModel"
+                      + " to NON_INDEPENDENT_DB_MODELS if it is not an independent entity"));
+        }
+      }
+    };
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.satisfied;
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
+import io.camunda.archunit.IncludeTestClassesAndTestJars;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Enforces that every RDBMS entity model ({@code XXXDbModel}) is accompanied by a sort test ({@code
+ * XXXSortIT}) in {@code io.camunda.it.rdbms.db}.
+ *
+ * <p>Sort-field coverage is the most commonly forgotten test concern when adding a new entity.
+ * DbModels that are sub-entities, variant models, or represent entities without user-facing sort
+ * fields are listed in {@link #NO_SORT_IT_REQUIRED} and exempted from the check.
+ *
+ * <p>See {@link RdbmsDbModelCoverageArchTest} for an explanation of the dual-scan pattern.
+ */
+@AnalyzeClasses(
+    packages = "io.camunda.db.rdbms.write.domain",
+    importOptions = DoNotIncludeTestsOrTestJars.class)
+class RdbmsDbModelSortITCoverageArchTest {
+
+  // DbModels that do not require a corresponding SortIT. Two categories:
+  //
+  // 1. Sub-entities / variant models with no independent IT (same rationale as
+  //    RdbmsDbModelCoverageArchTest.NON_INDEPENDENT_DB_MODELS).
+  // 2. Domain entities that have an IT but whose write-path has no user-facing sort fields.
+  static final Set<String> NO_SORT_IT_REQUIRED =
+      Set.of(
+          // Sub-entities / variant models — no standalone IT, so no SortIT either
+          "UsageMetricTUDbModel", // TU variant; covered by UsageMetricIT
+          "UserTaskMigrationDbModel", // migration helper; covered by UserTaskIT
+          "BatchOperationItemDbModel", // sub-entity; covered by BatchOperationIT
+          "GroupMemberDbModel", // member sub-entity; no GroupMemberSortIT
+          "TenantMemberDbModel", // member sub-entity; no TenantMemberSortIT
+          "RoleMemberDbModel", // member sub-entity; no RoleMemberSortIT
+          "ProcessDefinitionVariableNameLookupDbModel", // variable-name cache; has an IT but no
+          // sort fields
+          "BatchOperationErrorDbModel", // error sub-entity of BatchOperation; no sort fields
+          "HistoryDeletionTypeDbModel", // type sub-model for HistoryDeletion; no sort fields
+          "EventTypeDbModel", // audit-event type enum model; no sort fields
+          "UsageMetricStatisticsDbModel", // statistics sub-model; no sort fields
+          "UsageMetricTUStatisticsDbModel", // TU statistics variant; no sort fields
+          "UsageMetricTenantStatisticsDbModel", // tenant statistics variant; no sort fields
+          "UsageMetricTUTenantStatisticsDbModel", // TU tenant statistics variant; no sort fields
+          "JobMetricsBatchDbModel", // batch metrics; no sort fields
+          // Domain entities without user-facing sort fields
+          "CorrelatedMessageSubscriptionDbModel", // composite-key lookup, not a browseable list
+          "HistoryDeletionDbModel", // transient internal records
+          "SequenceFlowDbModel", // graph element, no ordering needed
+          "UsageMetricDbModel" // statistical aggregation
+          );
+
+  // SortIT class simple names scanned from test-jars once at class-load time.
+  static final Set<String> SORT_IT_SIMPLE_NAMES =
+      StreamSupport.stream(
+              new ClassFileImporter()
+                  .withImportOption(new IncludeTestClassesAndTestJars())
+                  .importPackages("io.camunda.it.rdbms.db")
+                  .spliterator(),
+              false)
+          .filter(c -> c.getSimpleName().endsWith("SortIT"))
+          .map(JavaClass::getSimpleName)
+          .collect(Collectors.toUnmodifiableSet());
+
+  @ArchTest
+  static final ArchRule EACH_DB_MODEL_HAS_SORT_IT =
+      ArchRuleDefinition.classes()
+          .that()
+          .haveSimpleNameEndingWith("DbModel")
+          .should(haveCorrespondingSortItTest())
+          .because(
+              "each RDBMS entity model must be accompanied by a SortIT in io.camunda.it.rdbms.db.*"
+                  + " to ensure sort-field coverage is tested against all databases");
+
+  private static ArchCondition<JavaClass> haveCorrespondingSortItTest() {
+    return new ArchCondition<>("have a corresponding SortIT in io.camunda.it.rdbms.db.*") {
+      @Override
+      public void check(final JavaClass javaClass, final ConditionEvents events) {
+        if (javaClass.getModifiers().contains(JavaModifier.ABSTRACT)
+            || javaClass.isInterface()
+            || NO_SORT_IT_REQUIRED.contains(javaClass.getSimpleName())) {
+          events.add(satisfied(javaClass, "skipped — not a sortable independent entity"));
+          return;
+        }
+        final String entityName = javaClass.getSimpleName().replace("DbModel", "");
+        final String expectedSortIt = entityName + "SortIT";
+        if (SORT_IT_SIMPLE_NAMES.contains(expectedSortIt)) {
+          events.add(satisfied(javaClass, "found " + expectedSortIt));
+        } else {
+          events.add(
+              violated(
+                  javaClass,
+                  javaClass.getSimpleName()
+                      + " has no '"
+                      + expectedSortIt
+                      + "' in io.camunda.it.rdbms.db.*; add the missing SortIT or add the DbModel"
+                      + " to NO_SORT_IT_REQUIRED if sorting is not applicable for this entity"));
+        }
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Adds two ArchUnit rules in `qa/archunit-tests` that fail whenever a concrete `XXXDbModel` is introduced without the corresponding `XXXXIT` or `XXXSortIT`:
  - `RdbmsDbModelCoverageTest` — each `DbModel` implementation must have an integration test in `io.camunda.it.rdbms.db.*`
  - `RdbmsDbModelSortItCoverageTest` — each `DbModel` implementation (excluding entities without user-facing sort fields) must have a sort integration test
- Adds `JobSortIT`, `AuditLogSortIT`, and `WaitStateSortIT` to bring `JobDbModel`, `AuditLogDbModel`, and `WaitStateDbModel` into compliance with the new SortIT rule; introduces `WaitStateFixtures` to support `WaitStateSortIT`
- Renames `UsageMetricsIT` → `UsageMetricIT` (and its package from `usagemetrics` → `usagemetric`) so the name matches `UsageMetricDbModel` exactly, satisfying the DbModel-coverage rule without a special-case exclusion

## Motivation

Historically, sort-field coverage and basic IT coverage have been the most commonly omitted tests when adding a new RDBMS entity. These rules make missing tests a build-time failure rather than a review-time observation.

## Implementation notes

Both rules use a dual-`ClassFileImporter` pattern: one scan over production JARs (`DoNotIncludeTestsOrTestJars`) for `DbModel` classes, and a second over test-jars (`IncludeTestClassesAndTestJars`) for IT/SortIT classes. This keeps infrastructure and metadata ITs (which have no `DbModel`) out of the exclusion sets automatically.

`WaitStateDbReader` has no convenience `search(query)` overload, so `WaitStateSortIT` calls `search(query, ResourceAccessChecks.disabled())` explicitly. `WaitStateFixtures` always sets `processDefinitionId` because `WaitStateEntityMapper` requires it non-null.

## Test plan

- [ ] `./mvnw verify -pl qa/archunit-tests -DskipTests=false -DskipITs -Dquickly` — all 52 ArchUnit tests pass
- [ ] New SortIT tests pass against an RDBMS backend (covered by the nightly RDBMS acceptance-test run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)