### PR TITLE
ci: fall back to maven central in case all other maven repos fail

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -234,6 +234,17 @@
       <name>Camunda BPM Snapshot Repository</name>
       <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
     </repository>
+
+    <!-- Fallback in case some dependency isn't visible in the central mirror yet -->
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>maven-central-fallback</id>
+      <name>Maven Central Fallback</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+    </repository>
   </repositories>
 
   <build>


### PR DESCRIPTION
This should resolve the issue where community PRs are frequently failing to build after camunda-security-library-api is bumped - the GCS maven mirror seems to take some hours to make the new artifacts resolvable, and community (i.e. forked) PRs aren't authenticated against our internal Artifactory so can't fall back there.

For first-party PRs, this would only fall back to Maven Central in the case that the artifact isn't resolvable from the GCS mirror _or_ our own Artifactory - this should be quite rare.

Closes: #55621