### PR TITLE
fix: resolve id_token JWS algorithm by registrationId for per-PT scoped chains

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -206,20 +206,24 @@ public class OidcOverrideBeansConfiguration {
   @Bean
   public JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory(
       final TokenValidatorFactory tokenValidatorFactory,
-      final OidcProviderConfigurationPort oidcAuthenticationConfigurationRepository,
-      final ClientRegistrationRepository clientRegistrationRepository) {
+      final OidcProviderConfigurationPort oidcAuthenticationConfigurationRepository) {
     final var decoderFactory = new OidcIdTokenDecoderFactory();
     decoderFactory.setJwtValidatorFactory(tokenValidatorFactory::createTokenValidator);
 
     final Map<String, OidcConfiguration> oidcAuthenticationConfigurations =
         oidcAuthenticationConfigurationRepository.getOidcAuthenticationConfigurations();
-    final Map<ClientRegistration, JwsAlgorithm> clientRegistrationToAlgorithmMap =
+    // Key the id_token JWS algorithm by registrationId rather than by ClientRegistration instance:
+    // per-physical-tenant scoped chains build their own ClientRegistration instances (same
+    // registrationId, different objects), so an instance-keyed lookup returns null for them and the
+    // scoped id_token signature verification fails. Resolving by registrationId works for both the
+    // cluster chain and the scoped chains.
+    final Map<String, JwsAlgorithm> algorithmByRegistrationId =
         oidcAuthenticationConfigurations.entrySet().stream()
             .collect(
-                toMap(
-                    e -> clientRegistrationRepository.findByRegistrationId(e.getKey()),
-                    e -> parseAlgorithm(e.getValue().getIdTokenAlgorithm())));
-    decoderFactory.setJwsAlgorithmResolver(clientRegistrationToAlgorithmMap::get);
+                toMap(Map.Entry::getKey, e -> parseAlgorithm(e.getValue().getIdTokenAlgorithm())));
+    decoderFactory.setJwsAlgorithmResolver(
+        clientRegistration ->
+            algorithmByRegistrationId.get(clientRegistration.getRegistrationId()));
     return decoderFactory;
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -212,11 +212,8 @@ public class OidcOverrideBeansConfiguration {
 
     final Map<String, OidcConfiguration> oidcAuthenticationConfigurations =
         oidcAuthenticationConfigurationRepository.getOidcAuthenticationConfigurations();
-    // Key the id_token JWS algorithm by registrationId rather than by ClientRegistration instance:
-    // per-physical-tenant scoped chains build their own ClientRegistration instances (same
-    // registrationId, different objects), so an instance-keyed lookup returns null for them and the
-    // scoped id_token signature verification fails. Resolving by registrationId works for both the
-    // cluster chain and the scoped chains.
+    // The decoder factory is a single bean applied to every oauth2Login chain, so it resolves each
+    // registration's configured id_token JWS algorithm by registrationId.
     final Map<String, JwsAlgorithm> algorithmByRegistrationId =
         oidcAuthenticationConfigurations.entrySet().stream()
             .collect(

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationIdTokenDecoderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationIdTokenDecoderTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import io.camunda.security.core.port.in.OidcProviderConfigurationPort;
+import io.camunda.security.spring.oidc.TokenValidatorFactory;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+
+/**
+ * Regression test for the bug where {@code idTokenDecoderFactory}'s JWS algorithm resolver was
+ * keyed by {@link ClientRegistration} instance rather than by {@code registrationId}. Per-PT scoped
+ * chains construct their own {@link ClientRegistration} objects (same {@code registrationId},
+ * different object identity), so the old instance-keyed map returned {@code null} and the scoped
+ * id_token signature verification failed with {@code missing_signature_verifier}.
+ *
+ * <p>The fix keys the resolver by {@code registrationId} string, which works for both the cluster
+ * chain and PT scoped chains regardless of object identity.
+ */
+@ExtendWith(MockitoExtension.class)
+class OidcOverrideBeansConfigurationIdTokenDecoderTest {
+
+  @Mock private OidcProviderConfigurationPort oidcProviderConfigurationPort;
+
+  @Test
+  void shouldResolveIdTokenAlgorithmByRegistrationIdNotInstance() {
+    // given
+    final var registrationId = "tenanta";
+
+    final var oidcConfig = new OidcConfiguration();
+    oidcConfig.setIdTokenAlgorithm(OidcConfiguration.DEFAULT_ID_TOKEN_ALGORITHM); // "RS256"
+
+    when(oidcProviderConfigurationPort.getOidcAuthenticationConfigurations())
+        .thenReturn(Map.of(registrationId, oidcConfig));
+
+    final var tokenValidatorFactory =
+        new TokenValidatorFactory(
+            Map.of(registrationId, oidcConfig), Duration.ofSeconds(60), List.of());
+
+    final var configuration = new OidcOverrideBeansConfiguration(null);
+    final JwtDecoderFactory<ClientRegistration> decoderFactory =
+        configuration.idTokenDecoderFactory(tokenValidatorFactory, oidcProviderConfigurationPort);
+
+    // Build a fresh ClientRegistration with the same registrationId but a different object
+    // identity — this is exactly what PT scoped chains do at runtime.
+    final var freshRegistration = buildRegistration(registrationId);
+
+    // when
+    final JwtDecoder decoder = decoderFactory.createDecoder(freshRegistration);
+
+    // then — must be non-null; before the fix, the instance lookup returned null and
+    // OidcIdTokenDecoderFactory threw "missing_signature_verifier".
+    assertThat(decoder).isNotNull();
+  }
+
+  @Test
+  void shouldResolveIdenticallyForDistinctInstancesWithSameRegistrationId() {
+    // given
+    final var registrationId = "tenanta";
+
+    final var oidcConfig = new OidcConfiguration();
+    oidcConfig.setIdTokenAlgorithm(OidcConfiguration.DEFAULT_ID_TOKEN_ALGORITHM);
+
+    when(oidcProviderConfigurationPort.getOidcAuthenticationConfigurations())
+        .thenReturn(Map.of(registrationId, oidcConfig));
+
+    final var tokenValidatorFactory =
+        new TokenValidatorFactory(
+            Map.of(registrationId, oidcConfig), Duration.ofSeconds(60), List.of());
+
+    final var configuration = new OidcOverrideBeansConfiguration(null);
+    final JwtDecoderFactory<ClientRegistration> decoderFactory =
+        configuration.idTokenDecoderFactory(tokenValidatorFactory, oidcProviderConfigurationPort);
+
+    // Two distinct instances — same registrationId, different objects
+    final var instanceOne = buildRegistration(registrationId);
+    final var instanceTwo = buildRegistration(registrationId);
+
+    // when
+    final JwtDecoder decoderOne = decoderFactory.createDecoder(instanceOne);
+    final JwtDecoder decoderTwo = decoderFactory.createDecoder(instanceTwo);
+
+    // then — both resolve successfully; the pre-fix code would have thrown for both because
+    // neither instance was the object stored in the algorithm map.
+    assertThat(decoderOne).isNotNull();
+    assertThat(decoderTwo).isNotNull();
+  }
+
+  private static ClientRegistration buildRegistration(final String registrationId) {
+    return ClientRegistration.withRegistrationId(registrationId)
+        .clientId("client-id")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+        .authorizationUri("https://example.com/oauth2/authorize")
+        .tokenUri("https://example.com/oauth2/token")
+        .jwkSetUri("https://example.com/oauth2/jwks")
+        .build();
+  }
+}


### PR DESCRIPTION
## Resolve id_token JWS algorithm by registrationId for per-physical-tenant scoped chains

The host `OidcOverrideBeansConfiguration#idTokenDecoderFactory` is a single `JwtDecoderFactory<ClientRegistration>` bean that Spring applies to every `oauth2Login` chain, including the per-physical-tenant scoped webapp chains. Its `jwsAlgorithmResolver` was a `Map<ClientRegistration, JwsAlgorithm>::get` keyed by the **cluster** `ClientRegistration` instances. Scoped chains build their own `ClientRegistration` instances (same `registrationId`, different object identity), so the lookup returned `null` → `missing_signature_verifier` / "JWS Algorithm: null" → 401 at the scoped login callback.

Key the resolver by `registrationId` instead, so the one shared bean resolves the algorithm for both the cluster and the scoped chains.

### Test
`OidcOverrideBeansConfigurationIdTokenDecoderTest`: the algorithm resolves by `registrationId` for fresh/distinct `ClientRegistration` instances (regression for the instance-key collision).

### Scope note
The companion id_token **audience** issue (scoped chains validating their own `pt-*-aud`) is handled in CSL, not here — see camunda/camunda-security-library#441 (metadata-carried per-scope audiences). This PR is only the algorithm resolver.

Verified end-to-end against a PT-configured cluster: per-PT scoped webapp login completes and renders the operate shell. Part of the per-physical-tenant identity slice (#54897).
