### PR TITLE
feat: route admin-user-presence check to the in-context physical tenant

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -14,7 +14,6 @@ import io.camunda.authentication.config.spi.IdentityToAdminComponentAliasAdapter
 import io.camunda.authentication.config.spi.SecurityPathAdapter;
 import io.camunda.authentication.config.spi.WebAppProviderAdapter;
 import io.camunda.authentication.pt.PhysicalTenantSecurityConfiguration;
-import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.model.CamundaAuthentication;
@@ -94,11 +93,7 @@ public class WebSecurityConfig {
       matchIfMissing = true)
   public AdminUserPresencePort adminUserPresencePort(
       final ServiceRegistry serviceRegistry, final CamundaSecurityLibraryProperties properties) {
-    return new AdminUserPresenceAdapter(
-        serviceRegistry.roleServices(
-            PhysicalTenantIds
-                .DEFAULT_PHYSICAL_TENANT_ID), // TODO apply this to all physical tenants
-        properties.getInitialization());
+    return new AdminUserPresenceAdapter(serviceRegistry, properties.getInitialization());
   }
 
   /**

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/AdminUserPresenceAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/AdminUserPresenceAdapter.java
@@ -12,7 +12,8 @@ import io.camunda.security.api.model.authz.DefaultRole;
 import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
 import io.camunda.security.core.port.out.AdminUserPresencePort;
-import io.camunda.service.RoleServices;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -34,13 +35,13 @@ public class AdminUserPresenceAdapter implements AdminUserPresencePort {
   private static final String ADMIN_ROLE_ID = DefaultRole.ADMIN.getId();
   private static final String USER_MEMBERS = "users";
 
-  private final RoleServices roleServices;
+  private final ServiceRegistry serviceRegistry;
   private final InitializationConfiguration initializationConfiguration;
 
   public AdminUserPresenceAdapter(
-      final RoleServices roleServices,
+      final ServiceRegistry serviceRegistry,
       final InitializationConfiguration initializationConfiguration) {
-    this.roleServices = roleServices;
+    this.serviceRegistry = serviceRegistry;
     this.initializationConfiguration = initializationConfiguration;
   }
 
@@ -57,8 +58,9 @@ public class AdminUserPresenceAdapter implements AdminUserPresencePort {
     }
 
     try {
-      return roleServices.hasMembersOfType(
-          ADMIN_ROLE_ID, EntityType.USER, CamundaAuthentication.anonymous());
+      return serviceRegistry
+          .roleServices(PhysicalTenantContext.current())
+          .hasMembersOfType(ADMIN_ROLE_ID, EntityType.USER, CamundaAuthentication.anonymous());
     } catch (final RuntimeException ex) {
       LOG.error(
           "Error while searching for admin role members. This might indicate that secondary storage is down.",

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/AdminUserPresenceAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/AdminUserPresenceAdapterTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -19,10 +20,17 @@ import io.camunda.security.api.model.authz.DefaultRole;
 import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
 import io.camunda.service.RoleServices;
+import io.camunda.service.registry.DefaultServiceRegistry;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 class AdminUserPresenceAdapterTest {
 
@@ -33,7 +41,21 @@ class AdminUserPresenceAdapterTest {
   private final InitializationConfiguration initializationConfiguration =
       new InitializationConfiguration();
   private final AdminUserPresenceAdapter port =
-      new AdminUserPresenceAdapter(roleServices, initializationConfiguration);
+      new AdminUserPresenceAdapter(
+          DefaultServiceRegistry.of(b -> b.roleServices("default", roleServices)),
+          initializationConfiguration);
+
+  @BeforeEach
+  void setUp() {
+    // Bind a plain request with no PT attribute — resolves to the "default" tenant.
+    RequestContextHolder.setRequestAttributes(
+        new ServletRequestAttributes(new MockHttpServletRequest()));
+  }
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+  }
 
   @Test
   void shouldReturnTrueWhenInitializationConfiguresAdminUser() {
@@ -79,5 +101,34 @@ class AdminUserPresenceAdapterTest {
 
     // when / then
     assertThat(port.adminUserExists()).isTrue();
+  }
+
+  @Test
+  void shouldRouteAdminCheckToRequestPhysicalTenant() {
+    // given — two tenants, request scoped to "tenanta"
+    final var defaultRoleServices = mock(RoleServices.class);
+    final var tenantARoleServices = mock(RoleServices.class);
+    final var adapter =
+        new AdminUserPresenceAdapter(
+            DefaultServiceRegistry.of(
+                b ->
+                    b.roleServices("default", defaultRoleServices)
+                        .roleServices("tenanta", tenantARoleServices)),
+            initializationConfiguration);
+    final var request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    when(tenantARoleServices.hasMembersOfType(
+            eq(ADMIN_ROLE_ID), eq(EntityType.USER), any(CamundaAuthentication.class)))
+        .thenReturn(true);
+
+    // when
+    final var exists = adapter.adminUserExists();
+
+    // then — admin presence resolved from the tenanta role services, not the default ones
+    assertThat(exists).isTrue();
+    verify(tenantARoleServices)
+        .hasMembersOfType(eq(ADMIN_ROLE_ID), eq(EntityType.USER), any(CamundaAuthentication.class));
+    verifyNoInteractions(defaultRoleServices);
   }
 }


### PR DESCRIPTION
## Context

Part of #55252 (PT authorization routing). ADR-0005 §4.3 / §8. Depends only on S1 (`PhysicalTenantContext.current()`) and the existing per-PT `ServiceRegistry` — both on `main` — so this is independent of the other slices (no file overlap).

## Problem

`AdminUserPresenceAdapter.adminUserExists()` checked for an admin user against the default physical tenant's role services (pinned at bean-creation time, with a `// TODO apply this to all physical tenants`). In a multi-PT deployment the admin-presence gate would consult the wrong tenant.

## What this PR does

- `AdminUserPresenceAdapter` now holds the `ServiceRegistry` (instead of a pre-resolved default `RoleServices`) and resolves `serviceRegistry.roleServices(PhysicalTenantContext.current())` inside `adminUserExists()`.
- `adminUserExists()` is invoked only on the request thread (CSL's `AdminUserCheckFilter`), so the per-PT lookup is moved out of the startup-time bean wiring and into the method, where the request scope — and thus `current()` — is valid. The request is already scoped to a PT, so each PT's chain checks its own admin presence (no enumeration needed; the ADR-0005 §8 "startup enumeration" branch does not apply because there is no non-request caller).
- The init-config short-circuit and the transient-error handling are unchanged.

## Acceptance criteria (#55441)

- ✅ `adminUserExists()` checks admin presence for the in-context PT (resolved via `current()`).
- ✅ Execution context confirmed request-scoped; no startup/bootstrap caller, so no PT enumeration is required.
- ✅ Single-PT behaviour unchanged — `current()` → `default` → the one configured tenant's role services.
- ✅ Unit test: a non-default PT routes the admin check to that PT's role services.

## Tests

- `AdminUserPresenceAdapterTest` (5/5): the original 4 cases preserved (init-config short-circuit, present, absent, transient error) under a request scope; new `shouldRouteAdminCheckToRequestPhysicalTenant` binds `default` + `tenanta` role services, stamps the request to `tenanta`, and asserts the tenant-A services are queried while the default ones are not.
- Full `authentication` module: 283 unit + 11 IT, 0 failures. Full-repo compile green.

Closes #55441