### PR TITLE
deps: update spring version to clear CVE-2026-41850/41852 (optimize 8.7)

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -51,8 +51,8 @@
     <apache.http5-client.version>5.5</apache.http5-client.version>
     <apache.http5-core.version>5.3.6</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
-    <spring.boot.version>3.5.14</spring.boot.version>
-    <spring.version>6.2.17</spring.version>
+    <spring.boot.version>3.5.15</spring.boot.version>
+    <spring.version>6.2.19</spring.version>
     <spring.security.version>6.5.10</spring.security.version>
     <version.tomcat>10.1.55</version.tomcat>
     <httpclient.version>4.5.14</httpclient.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,11 +98,11 @@
     <version.feel-scala>1.18.0</version.feel-scala>
     <version.dmn-scala>1.10.0</version.dmn-scala>
     <version.rest-assured>5.5.0</version.rest-assured>
-    <version.spring>6.2.17</version.spring>
+    <version.spring>6.2.19</version.spring>
     <version.spring-security>6.5.10</version.spring-security>
     <!--  Adding spring-security.version to ensure Spring Boot's BOM honors the override regardless of import order.  -->
     <spring-security.version>${version.spring-security}</spring-security.version>
-    <version.spring-boot>3.5.14</version.spring-boot>
+    <version.spring-boot>3.5.15</version.spring-boot>
     <version.logback>1.5.25</version.logback>
     <version.tomcat>10.1.55</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>


### PR DESCRIPTION
## Description

Dependency is present, but not used in a way that makes the CVE reachable


## Related issues

relates #55623
