### PR TITLE
deps: upgrade renovate-pr-maintainer composite action

### DIFF
--- a/.github/workflows/renovate-pr-maintainer.yml
+++ b/.github/workflows/renovate-pr-maintainer.yml
@@ -42,7 +42,7 @@ jobs:
     # rebase stale PRs (by adding the Renovate `rebase` label) or re-run their
     # failed required jobs.
     - name: Maintain Renovate PRs
-      uses: camunda/infra-global-github-actions/renovate-pr-maintainer@0b9cc967700205dc4e42250aa9b53f35d46411a0
+      uses: camunda/infra-global-github-actions/renovate-pr-maintainer@be5b0496892a83e6b3c5cedb818b771e8ed68121
       with:
         dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/1053.

Upgrade the `camunda/infra-global-github-actions/renovate-pr-maintainer` composite action to the last version.

Renovate is currently experiencing issues: https://camunda.slack.com/archives/C071KP5BTHB/p1782124439953929

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
