### PR TITLE
test: unskip 4 E2E test(s) referencing closed bugs (stable/8.8)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -277,6 +277,12 @@ class OperateProcessesPage {
     });
   }
 
+  getInstanceOperationSpinner(processInstanceKey: string): Locator {
+    return this.page.getByTitle(
+      `Instance ${processInstanceKey} has scheduled Operations`,
+    );
+  }
+
   getCancelInstanceButton(processInstanceKey: string): Locator {
     return this.page.getByRole('button', {
       name: `Cancel Instance ${processInstanceKey}`,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -240,7 +240,7 @@ class TaskDetailsPage {
   }
 
   async checkChecklistBox(label: string): Promise<void> {
-    await this.page.getByLabel(label, {exact: true}).check();
+    await this.form.getByLabel(label, {exact: true}).check();
   }
 
   async enterTwoValuesInTagList(value1: string, value2: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -272,7 +272,7 @@ test.describe('Operations', () => {
         },
         maxRetries: 10,
       });
-      
+
       await Promise.all(
         instances.map((instance) =>
           expect(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -97,9 +97,8 @@ test.describe('Operations', () => {
     });
   });
 
-  // Skipped due to bug 42375: https://github.com/camunda/camunda/issues/42375
   // !Note: assert the code after the bug is fixed as it was dicoverd during the test implementation
-  test.skip('Retry and cancel single instance', async ({
+  test('Retry and cancel single instance', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -125,7 +125,9 @@ test.describe('Operations', () => {
       );
 
       await expect(operateProcessesPage.singleOperationSpinner).toBeVisible();
-      await expect(operateProcessesPage.singleOperationSpinner).toBeHidden();
+      await expect(operateProcessesPage.singleOperationSpinner).toBeHidden({
+        timeout: 90000,
+      });
     });
 
     await test.step('Cancel single instance using operation button', async () => {
@@ -153,6 +155,14 @@ test.describe('Operations', () => {
 
       await expect(retryEntry).toBeVisible();
       await expect(retryEntry.getByText(DATE_REGEX)).toBeVisible();
+
+      const operationId = await retryEntry.getByRole('link').innerText();
+
+      await operateOperationPanelPage.clickOperationLink(retryEntry);
+      await expect(operateFiltersPanelPage.operationIdFilter).toHaveValue(
+        operationId,
+      );
+      await expect(operateProcessesPage.resultsCount).toBeVisible();
     });
 
     await test.step('Verify cancel does not create an operations panel entry', async () => {
@@ -166,7 +176,7 @@ test.describe('Operations', () => {
 
       await expect(
         operateProcessesPage.getCanceledIcon(instance.processInstanceKey),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 60000});
 
       await expect(instanceRow.getByText(instance.bpmnProcessId)).toBeVisible();
       await expect(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -120,14 +120,20 @@ test.describe('Operations', () => {
     });
 
     await test.step('Retry single instance using operation button', async () => {
+      await expect(
+        operateProcessesPage.getRetryInstanceButton(
+          instance.processInstanceKey,
+        ),
+      ).toBeVisible({timeout: 120000});
       await operateProcessesPage.clickRetryInstanceButton(
         instance.processInstanceKey,
       );
 
-      await expect(operateProcessesPage.singleOperationSpinner).toBeVisible();
-      await expect(operateProcessesPage.singleOperationSpinner).toBeHidden({
-        timeout: 90000,
-      });
+      const instanceSpinner = operateProcessesPage.getInstanceOperationSpinner(
+        instance.processInstanceKey,
+      );
+      await expect(instanceSpinner).toBeVisible();
+      await expect(instanceSpinner).toBeHidden({timeout: 90000});
     });
 
     await test.step('Cancel single instance using operation button', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -97,10 +97,10 @@ test.describe('Operations', () => {
     });
   });
 
-  // Skipped due to bug 42375: https://github.com/camunda/camunda/issues/42375
-  // Bug closed as "not planned": a cancel operation on a single instance is not
-  // added to the operations panel by design, so this test's assertion cannot pass.
-  test.skip('Retry and cancel single instance', async ({
+  // Regression coverage for bug 42375 (closed as "not planned" / intended behavior):
+  // a retry on a single instance is added to the operations panel, but a cancel is not.
+  // https://github.com/camunda/camunda/issues/42375
+  test('Retry and cancel single instance', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,
@@ -140,25 +140,25 @@ test.describe('Operations', () => {
       ).toBeVisible();
     });
 
-    await test.step('Validate operation in operations list', async () => {
+    await test.step('Verify retry operation appears in operations list', async () => {
       await expect(operateOperationPanelPage.operationList).toBeHidden();
       await operateOperationPanelPage.expandOperationIdField();
 
       await expect(operateOperationPanelPage.operationList).toBeVisible();
 
-      const operationEntry =
-        operateOperationPanelPage.getCancelOperationEntry(1);
+      const retryEntry = operateOperationPanelPage
+        .getAllOperationEntries()
+        .filter({hasText: 'Retry'})
+        .first();
 
-      await expect(operationEntry).toBeVisible();
-      await expect(operationEntry.getByText(DATE_REGEX)).toBeVisible();
+      await expect(retryEntry).toBeVisible();
+      await expect(retryEntry.getByText(DATE_REGEX)).toBeVisible();
+    });
 
-      const operationId = await operationEntry.getByRole('link').innerText();
-
-      await operateOperationPanelPage.clickOperationLink(operationEntry);
-      await expect(operateFiltersPanelPage.operationIdFilter).toHaveValue(
-        operationId,
-      );
-      await expect(operateProcessesPage.resultsCount).toBeVisible();
+    await test.step('Verify cancel does not create an operations panel entry', async () => {
+      await expect(
+        operateOperationPanelPage.getCancelOperationEntry(1),
+      ).toBeHidden();
     });
 
     await test.step('Validate canceled instance details', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -97,8 +97,10 @@ test.describe('Operations', () => {
     });
   });
 
-  // !Note: assert the code after the bug is fixed as it was dicoverd during the test implementation
-  test('Retry and cancel single instance', async ({
+  // Skipped due to bug 42375: https://github.com/camunda/camunda/issues/42375
+  // Bug closed as "not planned": a cancel operation on a single instance is not
+  // added to the operations panel by design, so this test's assertion cannot pass.
+  test.skip('Retry and cancel single instance', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -162,7 +162,11 @@ test.describe('Operations', () => {
       await expect(operateFiltersPanelPage.operationIdFilter).toHaveValue(
         operationId,
       );
-      await expect(operateProcessesPage.resultsCount).toBeVisible();
+      await expect(
+        operateProcessesPage.processInstanceLinkByKey(
+          instance.processInstanceKey,
+        ),
+      ).toBeVisible();
     });
 
     await test.step('Verify cancel does not create an operations panel entry', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -154,13 +154,12 @@ test.describe('Process Instance Modifications', () => {
         operateProcessInstancePage.getVariableTestId('foo'),
       ).toBeVisible();
 
-      // Skipped due to bug 42546: https://github.com/camunda/camunda/issues/42546
-      // await expect(
-      //   operateProcessInstancePage.getEditVariableFieldSelector('test'),
-      // ).toHaveValue('123');
-      // await expect(
-      //   operateProcessInstancePage.getEditVariableFieldSelector('foo'),
-      // ).toHaveValue('1');
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('test'),
+      ).toHaveValue('123');
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('1');
     });
 
     await test.step('Undo again and verify all modifications removed', async () => {
@@ -202,10 +201,8 @@ test.describe('Process Instance Modifications', () => {
     });
   });
 
-  // Skipped due to bug 42546: https://github.com/camunda/camunda/issues/42546
   // !Note: assert the code after the bug is fixed as it was discoverd during the test implementation
-  // eslint-disable-next-line playwright/no-skipped-test
-  test.skip('Should apply/remove add variable modifications', async ({
+  test('Should apply/remove add variable modifications', async ({
     page,
     operateProcessInstancePage,
     operateProcessModificationModePage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -155,10 +155,10 @@ test.describe('Process Instance Modifications', () => {
       ).toBeVisible();
 
       await expect(
-        operateProcessInstancePage.getEditVariableFieldSelector('test'),
+        operateProcessModificationModePage.getEditVariableFieldSelector('test'),
       ).toHaveValue('123');
       await expect(
-        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+        operateProcessModificationModePage.getEditVariableFieldSelector('foo'),
       ).toHaveValue('1');
     });
 
@@ -201,7 +201,8 @@ test.describe('Process Instance Modifications', () => {
     });
   });
 
-  // !Note: assert the code after the bug is fixed as it was discoverd during the test implementation
+  // Regression coverage for bug 42546 (fixed):
+  // https://github.com/camunda/camunda/issues/42546
   test('Should apply/remove add variable modifications', async ({
     page,
     operateProcessInstancePage,


### PR DESCRIPTION
## Auto-Unskip: Tests with Closed Bug References

> Opened automatically by the [auto-unskip workflow](https://github.com/camunda/qa-metrics-exporter/actions/runs/27951198940) on 2026-06-22.

**4** test(s) in `stable/8.8` were unskipped because their referenced bugs are now closed.

### Closed Bugs

- [camunda/camunda#42375](https://github.com/camunda/camunda/issues/42375) Cancel operation is not added to operations panel when triggered for single instance — closed 2026-03-24
- [camunda/camunda#42546](https://github.com/camunda/camunda/issues/42546) Undo operation in modification mode removes incorrect modification when performed from different flow node scope — closed 2026-03-03
- [camunda/camunda#38103](https://github.com/camunda/camunda/issues/38103) Sort by Version fails after applying Process Instance filter — closed 2026-03-25

### Files Changed (3)

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts`: 1 skip(s) removed (camunda/camunda#42375)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts`: 2 skip(s) removed (camunda/camunda#42546)
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts`: 1 skip(s) removed (camunda/camunda#38103)

### 🔎 Auto-uncommented — please double-check (1)

These commented-out code blocks (6 code line(s)) were *re-enabled* and their bug marker removed. Verify they compile and assert what you expect:

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts` ~L157 (camunda/camunda#42546, 6 line(s) uncommented)

### On-demand E2E

🔬 On-demand E2E run: https://github.com/camunda/camunda/actions/runs/27951540301

### Checklist

- [ ] On-demand test run passes on this branch
- [ ] No regressions in adjacent tests

