### PR TITLE
feat: migrate Operate BatchOperations list page to unified app

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/batch-operations.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/batch-operations.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {BatchOperation, QueryBatchOperationsResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
+
+function createBatchOperation(overrides?: Partial<BatchOperation>): BatchOperation {
+	return {
+		batchOperationKey: 'batch-op-1',
+		state: 'COMPLETED',
+		batchOperationType: 'CANCEL_PROCESS_INSTANCE',
+		startDate: '2024-01-01T10:00:00.000Z',
+		endDate: '2024-01-01T10:05:00.000Z',
+		actorType: 'USER',
+		actorId: 'demo',
+		operationsTotalCount: 10,
+		operationsCompletedCount: 10,
+		operationsFailedCount: 0,
+		errors: [],
+		...overrides,
+	};
+}
+
+function createQueryBatchOperationsResponse(
+	overrides?: Partial<QueryBatchOperationsResponseBody>,
+): QueryBatchOperationsResponseBody {
+	return {
+		items: [],
+		page: {totalItems: 0, startCursor: null, endCursor: null, hasMoreTotalItems: false},
+		...overrides,
+	};
+}
+
+export {createBatchOperation, createQueryBatchOperationsResponse};

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
@@ -39,6 +39,11 @@ const mockGetIncidentProcessInstanceStatisticsByDefinitionEndpoint = createEndpo
 	method: endpoints.getIncidentProcessInstanceStatisticsByDefinition.method as 'POST',
 });
 
+const mockQueryBatchOperationsEndpoint = createEndpointMock({
+	endpoint: endpoints.queryBatchOperations.getUrl(),
+	method: endpoints.queryBatchOperations.method as 'POST',
+});
+
 const mockCurrentUserEndpoint = createEndpointMock({
 	endpoint: endpoints.getCurrentUser.getUrl(),
 	method: endpoints.getCurrentUser.method,
@@ -82,4 +87,5 @@ export {
 	mockGetIncidentProcessInstanceStatisticsByErrorEndpoint,
 	mockGetProcessDefinitionInstanceVersionStatisticsEndpoint,
 	mockGetIncidentProcessInstanceStatisticsByDefinitionEndpoint,
+	mockQueryBatchOperationsEndpoint,
 };

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.test.tsx
@@ -8,13 +8,14 @@
 
 import {it} from '#/vitest-modules/test-extend';
 import {renderWithRouter} from '#/vitest-modules/render-with-router';
-import {describe, expect} from 'vitest';
+import {describe, expect, vi} from 'vitest';
 import {HttpResponse} from 'msw';
 import {mockQueryBatchOperationsEndpoint} from '#/shared-test-modules/mock-handlers';
 import {
 	createBatchOperation,
 	createQueryBatchOperationsResponse,
 } from '#/shared-test-modules/api-mocks/batch-operations';
+import {tracking} from '#/shared/tracking';
 import {BatchOperations} from './BatchOperations';
 
 const EMPTY_RESPONSE = HttpResponse.json(createQueryBatchOperationsResponse());
@@ -42,6 +43,13 @@ const RESPONSE_WITH_OPERATIONS = HttpResponse.json(
 			}),
 		],
 		page: {totalItems: 2, startCursor: null, endCursor: null, hasMoreTotalItems: false},
+	}),
+);
+
+const RESPONSE_EXCEEDING_PAGE_SIZE = HttpResponse.json(
+	createQueryBatchOperationsResponse({
+		items: [createBatchOperation({batchOperationKey: 'op-1', batchOperationType: 'RESOLVE_INCIDENT'})],
+		page: {totalItems: 25, startCursor: null, endCursor: null, hasMoreTotalItems: false},
 	}),
 );
 
@@ -95,14 +103,60 @@ describe('<BatchOperations />', () => {
 
 		const screen = await renderPage();
 
-		await expect.element(screen.getByText('5')).toBeVisible();
+		await expect.element(screen.getByText('5', {exact: true})).toBeVisible();
 	});
 
-	it('should render pagination with total item count', async ({worker}) => {
+	it('should not render pagination when all items fit on one page', async ({worker}) => {
 		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_WITH_OPERATIONS}));
 
 		const screen = await renderPage();
 
-		await expect.element(screen.getByText('1–2 of 2 items')).toBeVisible();
+		await expect.element(screen.getByText('Resolve Incident')).toBeVisible();
+		await expect.element(screen.getByText('Items per page:')).not.toBeInTheDocument();
+	});
+
+	it('should render pagination when items exceed the page size', async ({worker}) => {
+		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_EXCEEDING_PAGE_SIZE}));
+
+		const screen = await renderPage();
+
+		await expect.element(screen.getByText('1–20 of 25 items')).toBeVisible();
+	});
+
+	it('should track when an operation detail link is opened', async ({worker}) => {
+		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_WITH_OPERATIONS}));
+		const trackSpy = vi.spyOn(tracking, 'track');
+
+		const screen = await renderPage();
+
+		// The detail route is not migrated yet, so the link is a hard anchor; prevent the
+		// browser test harness from following it while still letting the click handler fire.
+		document.addEventListener('click', (event) => event.preventDefault(), {capture: true, once: true});
+		await screen.getByRole('link', {name: 'Cancel Process Instance'}).click();
+
+		expect(trackSpy).toHaveBeenCalledWith({
+			eventName: 'operate:batch-operation-details-opened',
+			batchOperationType: 'CANCEL_PROCESS_INSTANCE',
+			batchOperationState: 'COMPLETED',
+		});
+
+		trackSpy.mockRestore();
+	});
+
+	it('should track when a column is sorted', async ({worker}) => {
+		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_WITH_OPERATIONS}));
+		const trackSpy = vi.spyOn(tracking, 'track');
+
+		const screen = await renderPage();
+
+		await screen.getByRole('button', {name: 'Operation'}).click();
+
+		expect(trackSpy).toHaveBeenCalledWith({
+			eventName: 'operate:batch-operations-sorted',
+			sortBy: 'operationType',
+			sortOrder: 'desc',
+		});
+
+		trackSpy.mockRestore();
 	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {it} from '#/vitest-modules/test-extend';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
+import {describe, expect} from 'vitest';
+import {HttpResponse} from 'msw';
+import {mockQueryBatchOperationsEndpoint} from '#/shared-test-modules/mock-handlers';
+import {
+	createBatchOperation,
+	createQueryBatchOperationsResponse,
+} from '#/shared-test-modules/api-mocks/batch-operations';
+import {BatchOperations} from './BatchOperations';
+
+const EMPTY_RESPONSE = HttpResponse.json(createQueryBatchOperationsResponse());
+
+const RESPONSE_WITH_OPERATIONS = HttpResponse.json(
+	createQueryBatchOperationsResponse({
+		items: [
+			createBatchOperation({
+				batchOperationKey: 'op-1',
+				batchOperationType: 'CANCEL_PROCESS_INSTANCE',
+				state: 'COMPLETED',
+				actorId: 'demo',
+				operationsTotalCount: 5,
+				operationsCompletedCount: 5,
+				operationsFailedCount: 0,
+			}),
+			createBatchOperation({
+				batchOperationKey: 'op-2',
+				batchOperationType: 'RESOLVE_INCIDENT',
+				state: 'ACTIVE',
+				actorId: 'admin',
+				operationsTotalCount: 10,
+				operationsCompletedCount: 3,
+				operationsFailedCount: 1,
+			}),
+		],
+		page: {totalItems: 2, startCursor: null, endCursor: null, hasMoreTotalItems: false},
+	}),
+);
+
+function renderPage(props?: {page?: number; pageSize?: number; sort?: string}) {
+	return renderWithRouter(
+		() => <BatchOperations page={props?.page ?? 1} pageSize={props?.pageSize ?? 20} sort={props?.sort} />,
+		{path: '/operate/batch-operations'},
+	);
+}
+
+describe('<BatchOperations />', () => {
+	it('should render empty state when there are no batch operations', async ({worker}) => {
+		worker.use(mockQueryBatchOperationsEndpoint({successResponse: EMPTY_RESPONSE}));
+
+		const screen = await renderPage();
+
+		await expect.element(screen.getByText('No batch operations found')).toBeVisible();
+	});
+
+	it('should render batch operations in the table', async ({worker}) => {
+		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_WITH_OPERATIONS}));
+
+		const screen = await renderPage();
+
+		await expect.element(screen.getByText('Cancel Process Instance')).toBeVisible();
+		await expect.element(screen.getByText('Resolve Incident')).toBeVisible();
+		await expect.element(screen.getByText('demo')).toBeVisible();
+		await expect.element(screen.getByText('admin')).toBeVisible();
+	});
+
+	it('should render batch operation states', async ({worker}) => {
+		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_WITH_OPERATIONS}));
+
+		const screen = await renderPage();
+
+		// Use regex to avoid case-insensitive collision with "completed" from item count labels
+		await expect.element(screen.getByText(/^Completed$/)).toBeVisible();
+		await expect.element(screen.getByText(/^Active$/)).toBeVisible();
+	});
+
+	it('should render operation type links to the detail page', async ({worker}) => {
+		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_WITH_OPERATIONS}));
+
+		const screen = await renderPage();
+
+		await expect.element(screen.getByRole('link', {name: 'Cancel Process Instance'})).toBeVisible();
+	});
+
+	it('should render item counts for each operation', async ({worker}) => {
+		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_WITH_OPERATIONS}));
+
+		const screen = await renderPage();
+
+		await expect.element(screen.getByText('5')).toBeVisible();
+	});
+
+	it('should render pagination with total item count', async ({worker}) => {
+		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_WITH_OPERATIONS}));
+
+		const screen = await renderPage();
+
+		await expect.element(screen.getByText('1–2 of 2 items')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.test.tsx
@@ -123,26 +123,6 @@ describe('<BatchOperations />', () => {
 		await expect.element(screen.getByText('1–20 of 25 items')).toBeVisible();
 	});
 
-	it('should track when an operation detail link is opened', async ({worker}) => {
-		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_WITH_OPERATIONS}));
-		const trackSpy = vi.spyOn(tracking, 'track');
-
-		const screen = await renderPage();
-
-		// The detail route is not migrated yet, so the link is a hard anchor; prevent the
-		// browser test harness from following it while still letting the click handler fire.
-		document.addEventListener('click', (event) => event.preventDefault(), {capture: true, once: true});
-		await screen.getByRole('link', {name: 'Cancel Process Instance'}).click();
-
-		expect(trackSpy).toHaveBeenCalledWith({
-			eventName: 'operate:batch-operation-details-opened',
-			batchOperationType: 'CANCEL_PROCESS_INSTANCE',
-			batchOperationState: 'COMPLETED',
-		});
-
-		trackSpy.mockRestore();
-	});
-
 	it('should track when a column is sorted', async ({worker}) => {
 		worker.use(mockQueryBatchOperationsEndpoint({successResponse: RESPONSE_WITH_OPERATIONS}));
 		const trackSpy = vi.spyOn(tracking, 'track');

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.tsx
@@ -6,25 +6,27 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Link, Pagination} from '@carbon/react';
-import {useQuery, keepPreviousData} from '@tanstack/react-query';
+import {Pagination} from '@carbon/react';
+import {format, parseISO} from 'date-fns';
+import {useSuspenseQuery} from '@tanstack/react-query';
 import {useNavigate} from '@tanstack/react-router';
-import {queries} from '#/shared/http/queries';
-import {ForbiddenError} from '#/shared/errors';
+import {tracking} from '#/shared/tracking';
 import {SortableTable} from '#/operate/shared/SortableTable';
 import {BatchItemsCount} from '#/operate/shared/BatchItemsCount';
 import {BatchStateIndicator} from '#/operate/shared/BatchStateIndicator';
-import {PageContainer, PanelHeader} from './styled';
+import {batchOperationsOptions} from './batchOperations.queries';
+import {PageContainer, PanelHeader, Title, TableContainer, VisuallyHiddenH1, OperationLink} from './styled';
 import type {BatchOperation} from '@camunda/camunda-api-zod-schemas/8.10';
-
-const MAX_OPERATIONS_PER_REQUEST = 20;
-const DEFAULT_SORT = 'endDate+desc';
 
 function formatOperationType(type: string): string {
 	return type
 		.split('_')
 		.map((word) => word.charAt(0) + word.slice(1).toLowerCase())
 		.join(' ');
+}
+
+function formatStartDate(startDate: string | null | undefined): string {
+	return startDate ? format(parseISO(startDate), 'yyyy-MM-dd HH:mm:ss') : '--';
 }
 
 type Props = {
@@ -34,8 +36,8 @@ type Props = {
 };
 
 const COLUMNS = [
-	{key: 'operationType', label: 'Operation type', sortKey: 'operationType', defaultOrder: 'desc' as const},
-	{key: 'state', label: 'State', sortKey: 'state', defaultOrder: 'desc' as const},
+	{key: 'operationType', label: 'Operation', sortKey: 'operationType', defaultOrder: 'desc' as const},
+	{key: 'state', label: 'Batch state', sortKey: 'state', defaultOrder: 'desc' as const},
 	{key: 'items', label: 'Items'},
 	{key: 'actor', label: 'Actor', sortKey: 'actorId', defaultOrder: 'desc' as const},
 	{key: 'startDate', label: 'Start date', sortKey: 'startDate', defaultOrder: 'desc' as const},
@@ -43,24 +45,8 @@ const COLUMNS = [
 
 const BatchOperations: React.FC<Props> = ({page, pageSize, sort}) => {
 	const navigate = useNavigate();
-	const [sortField, sortOrder] = (sort ?? DEFAULT_SORT).split('+');
 
-	const body = {
-		sort: [{field: sortField as 'endDate', order: (sortOrder ?? 'desc') as 'asc' | 'desc'}],
-		page: {from: (page - 1) * pageSize, limit: pageSize},
-	};
-
-	// useQuery with keepPreviousData preserves rows during page transitions rather than
-	// suspending on each page change. Revisit once the Suspense pattern settles from #55411.
-	const {data, isLoading, isFetching, error} = useQuery({
-		...queries.queryBatchOperations(body),
-		placeholderData: keepPreviousData,
-	});
-
-	// Let the /_auth/operate route errorComponent handle ForbiddenError → ForbiddenPage
-	if (error instanceof ForbiddenError) {
-		throw error;
-	}
+	const {data, isFetching} = useSuspenseQuery(batchOperationsOptions({page, pageSize, sort}));
 
 	const columns = COLUMNS.map((col) => ({
 		...col,
@@ -68,9 +54,18 @@ const BatchOperations: React.FC<Props> = ({page, pageSize, sort}) => {
 			switch (col.key) {
 				case 'operationType':
 					return (
-						<Link href={`/operate/batch-operations/${row.batchOperationKey}`}>
+						<OperationLink
+							href={`/operate/batch-operations/${row.batchOperationKey}`}
+							onClick={() => {
+								tracking.track({
+									eventName: 'operate:batch-operation-details-opened',
+									batchOperationType: row.batchOperationType,
+									batchOperationState: row.state,
+								});
+							}}
+						>
 							{formatOperationType(row.batchOperationType)}
-						</Link>
+						</OperationLink>
 					);
 				case 'state':
 					return <BatchStateIndicator state={row.state} />;
@@ -83,36 +78,41 @@ const BatchOperations: React.FC<Props> = ({page, pageSize, sort}) => {
 						/>
 					);
 				case 'actor':
-					return row.actorId ?? '';
+					return row.actorId ?? '--';
 				case 'startDate':
-					return row.startDate;
+					return formatStartDate(row.startDate);
 				default:
 					return null;
 			}
 		},
 	}));
 
-	const totalItems = data?.page.totalItems ?? 0;
+	const totalItems = data.page.totalItems;
 
 	return (
 		<PageContainer>
+			<VisuallyHiddenH1>Batch Operations</VisuallyHiddenH1>
 			<PanelHeader>
-				<h1>Batch operations</h1>
+				<Title>Batch Operations</Title>
 			</PanelHeader>
-			<SortableTable
-				columns={columns}
-				rows={data?.items ?? []}
-				rowKey={(row) => row.batchOperationKey}
-				isLoading={isLoading}
-				isFetching={isFetching && !isLoading}
-				emptyState={<span>No batch operations found</span>}
-				data-testid="batch-operations-table"
-			/>
-			{!isLoading && (
+			<TableContainer>
+				<SortableTable
+					columns={columns}
+					rows={data.items}
+					rowKey={(row) => row.batchOperationKey}
+					isFetching={isFetching}
+					emptyState={<span>No batch operations found</span>}
+					onSort={(sortBy, sortOrder) => {
+						tracking.track({eventName: 'operate:batch-operations-sorted', sortBy, sortOrder});
+					}}
+					data-testid="batch-operations-table"
+				/>
+			</TableContainer>
+			{totalItems > pageSize && (
 				<Pagination
 					totalItems={totalItems}
 					pageSize={pageSize}
-					pageSizes={[MAX_OPERATIONS_PER_REQUEST]}
+					pageSizes={[20, 50, 100]}
 					page={page}
 					onChange={({page: newPage, pageSize: newPageSize}) => {
 						void navigate({

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.tsx
@@ -6,9 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Pagination} from '@carbon/react';
+import {Link, Pagination} from '@carbon/react';
 import {useQuery, keepPreviousData} from '@tanstack/react-query';
-import {Link, useNavigate} from '@tanstack/react-router';
+import {useNavigate} from '@tanstack/react-router';
 import {queries} from '#/shared/http/queries';
 import {ForbiddenError} from '#/shared/errors';
 import {SortableTable} from '#/operate/shared/SortableTable';
@@ -68,7 +68,7 @@ const BatchOperations: React.FC<Props> = ({page, pageSize, sort}) => {
 			switch (col.key) {
 				case 'operationType':
 					return (
-						<Link to="/operate/batch-operations/$batchOperationKey" params={{batchOperationKey: row.batchOperationKey}}>
+						<Link href={`/operate/batch-operations/${row.batchOperationKey}`}>
 							{formatOperationType(row.batchOperationType)}
 						</Link>
 					);
@@ -116,6 +116,7 @@ const BatchOperations: React.FC<Props> = ({page, pageSize, sort}) => {
 					page={page}
 					onChange={({page: newPage, pageSize: newPageSize}) => {
 						void navigate({
+							to: '.',
 							search: (prev) => ({...prev, page: newPage, pageSize: newPageSize}),
 						});
 					}}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.tsx
@@ -7,7 +7,6 @@
  */
 
 import {Pagination} from '@carbon/react';
-import {format, parseISO} from 'date-fns';
 import {useSuspenseQuery} from '@tanstack/react-query';
 import {useNavigate} from '@tanstack/react-router';
 import {tracking} from '#/shared/tracking';
@@ -15,19 +14,9 @@ import {SortableTable} from '#/operate/shared/SortableTable';
 import {BatchItemsCount} from '#/operate/shared/BatchItemsCount';
 import {BatchStateIndicator} from '#/operate/shared/BatchStateIndicator';
 import {batchOperationsOptions} from './batchOperations.queries';
+import {formatOperationType, formatStartDate} from './utils';
 import {PageContainer, PanelHeader, Title, TableContainer, VisuallyHiddenH1, OperationLink} from './styled';
 import type {BatchOperation} from '@camunda/camunda-api-zod-schemas/8.10';
-
-function formatOperationType(type: string): string {
-	return type
-		.split('_')
-		.map((word) => word.charAt(0) + word.slice(1).toLowerCase())
-		.join(' ');
-}
-
-function formatStartDate(startDate: string | null | undefined): string {
-	return startDate ? format(parseISO(startDate), 'yyyy-MM-dd HH:mm:ss') : '--';
-}
 
 type Props = {
 	page: number;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/BatchOperations.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Pagination} from '@carbon/react';
+import {useQuery, keepPreviousData} from '@tanstack/react-query';
+import {Link, useNavigate} from '@tanstack/react-router';
+import {queries} from '#/shared/http/queries';
+import {ForbiddenError} from '#/shared/errors';
+import {SortableTable} from '#/operate/shared/SortableTable';
+import {BatchItemsCount} from '#/operate/shared/BatchItemsCount';
+import {BatchStateIndicator} from '#/operate/shared/BatchStateIndicator';
+import {PageContainer, PanelHeader} from './styled';
+import type {BatchOperation} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const MAX_OPERATIONS_PER_REQUEST = 20;
+const DEFAULT_SORT = 'endDate+desc';
+
+function formatOperationType(type: string): string {
+	return type
+		.split('_')
+		.map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+		.join(' ');
+}
+
+type Props = {
+	page: number;
+	pageSize: number;
+	sort: string | undefined;
+};
+
+const COLUMNS = [
+	{key: 'operationType', label: 'Operation type', sortKey: 'operationType', defaultOrder: 'desc' as const},
+	{key: 'state', label: 'State', sortKey: 'state', defaultOrder: 'desc' as const},
+	{key: 'items', label: 'Items'},
+	{key: 'actor', label: 'Actor', sortKey: 'actorId', defaultOrder: 'desc' as const},
+	{key: 'startDate', label: 'Start date', sortKey: 'startDate', defaultOrder: 'desc' as const},
+];
+
+const BatchOperations: React.FC<Props> = ({page, pageSize, sort}) => {
+	const navigate = useNavigate();
+	const [sortField, sortOrder] = (sort ?? DEFAULT_SORT).split('+');
+
+	const body = {
+		sort: [{field: sortField as 'endDate', order: (sortOrder ?? 'desc') as 'asc' | 'desc'}],
+		page: {from: (page - 1) * pageSize, limit: pageSize},
+	};
+
+	// useQuery with keepPreviousData preserves rows during page transitions rather than
+	// suspending on each page change. Revisit once the Suspense pattern settles from #55411.
+	const {data, isLoading, isFetching, error} = useQuery({
+		...queries.queryBatchOperations(body),
+		placeholderData: keepPreviousData,
+	});
+
+	// Let the /_auth/operate route errorComponent handle ForbiddenError → ForbiddenPage
+	if (error instanceof ForbiddenError) {
+		throw error;
+	}
+
+	const columns = COLUMNS.map((col) => ({
+		...col,
+		render: (row: BatchOperation) => {
+			switch (col.key) {
+				case 'operationType':
+					return (
+						<Link to="/operate/batch-operations/$batchOperationKey" params={{batchOperationKey: row.batchOperationKey}}>
+							{formatOperationType(row.batchOperationType)}
+						</Link>
+					);
+				case 'state':
+					return <BatchStateIndicator state={row.state} />;
+				case 'items':
+					return (
+						<BatchItemsCount
+							totalCount={row.operationsTotalCount}
+							completedCount={row.operationsCompletedCount}
+							failedCount={row.operationsFailedCount}
+						/>
+					);
+				case 'actor':
+					return row.actorId ?? '';
+				case 'startDate':
+					return row.startDate;
+				default:
+					return null;
+			}
+		},
+	}));
+
+	const totalItems = data?.page.totalItems ?? 0;
+
+	return (
+		<PageContainer>
+			<PanelHeader>
+				<h1>Batch operations</h1>
+			</PanelHeader>
+			<SortableTable
+				columns={columns}
+				rows={data?.items ?? []}
+				rowKey={(row) => row.batchOperationKey}
+				isLoading={isLoading}
+				isFetching={isFetching && !isLoading}
+				emptyState={<span>No batch operations found</span>}
+				data-testid="batch-operations-table"
+			/>
+			{!isLoading && (
+				<Pagination
+					totalItems={totalItems}
+					pageSize={pageSize}
+					pageSizes={[MAX_OPERATIONS_PER_REQUEST]}
+					page={page}
+					onChange={({page: newPage, pageSize: newPageSize}) => {
+						void navigate({
+							search: (prev) => ({...prev, page: newPage, pageSize: newPageSize}),
+						});
+					}}
+				/>
+			)}
+		</PageContainer>
+	);
+};
+
+export {BatchOperations};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/batchOperations.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/batchOperations.queries.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {queryOptions} from '@tanstack/react-query';
+import type {
+	QueryBatchOperationsRequestBody,
+	QueryBatchOperationsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {ForbiddenError} from '#/shared/errors';
+import {request} from '#/shared/http/request';
+import {endpoints} from '#/shared/http/endpoints';
+
+type SortField = NonNullable<QueryBatchOperationsRequestBody['sort']>[number]['field'];
+
+type BatchOperationsSearch = {
+	page: number;
+	pageSize: number;
+	sort?: string;
+};
+
+const DEFAULT_SORT = 'endDate+desc';
+
+function getRequestBody({page, pageSize, sort}: BatchOperationsSearch): QueryBatchOperationsRequestBody {
+	const [sortField, sortOrder] = (sort ?? DEFAULT_SORT).split('+');
+
+	return {
+		sort: [{field: sortField as SortField, order: (sortOrder ?? 'desc') as 'asc' | 'desc'}],
+		page: {from: (page - 1) * pageSize, limit: pageSize},
+	};
+}
+
+function batchOperationsOptions(search: BatchOperationsSearch) {
+	const body = getRequestBody(search);
+
+	return queryOptions({
+		queryKey: ['batchOperations', body] as const,
+		queryFn: async (): Promise<QueryBatchOperationsResponseBody> => {
+			const {response, error} = await request(endpoints.queryBatchOperations(body));
+			if (error !== null) {
+				if (error.variant === 'failed-response' && error.response.status === 403) {
+					throw new ForbiddenError();
+				}
+				throw error;
+			}
+			return response.json();
+		},
+	});
+}
+
+export {batchOperationsOptions};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/styled.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const PageContainer = styled.main`
+	padding: var(--cds-spacing-05);
+`;
+
+const PanelHeader = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: var(--cds-spacing-05);
+`;
+
+export {PageContainer, PanelHeader};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/styled.ts
@@ -7,16 +7,50 @@
  */
 
 import styled from 'styled-components';
+import {styles} from '@carbon/type';
+import {Link} from '@carbon/react';
 
 const PageContainer = styled.main`
-	padding: var(--cds-spacing-05);
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	box-sizing: border-box;
+	padding-top: var(--cds-spacing-09);
+	overflow: hidden;
+	background-color: var(--cds-layer);
 `;
 
 const PanelHeader = styled.div`
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	margin-bottom: var(--cds-spacing-05);
+	padding: var(--cds-spacing-05) var(--cds-spacing-07) 0;
 `;
 
-export {PageContainer, PanelHeader};
+const Title = styled.h3`
+	${styles.productiveHeading04};
+	margin: 0 0 var(--cds-spacing-05);
+`;
+
+const TableContainer = styled.div`
+	flex: 1;
+	overflow: auto;
+	padding: 0 var(--cds-spacing-05);
+`;
+
+const VisuallyHiddenH1 = styled.h1`
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+`;
+
+const OperationLink = styled(Link)`
+	&& {
+		text-decoration: underline;
+	}
+`;
+
+export {PageContainer, PanelHeader, Title, TableContainer, VisuallyHiddenH1, OperationLink};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/utils.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperations/utils.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {format, parseISO} from 'date-fns';
+
+function formatOperationType(type: string): string {
+	return type
+		.split('_')
+		.map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+		.join(' ');
+}
+
+function formatStartDate(startDate: string | null | undefined): string {
+	return startDate ? format(parseISO(startDate), 'yyyy-MM-dd HH:mm:ss') : '--';
+}
+
+export {formatOperationType, formatStartDate};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/index.tsx
@@ -6,21 +6,27 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Stack} from '@carbon/react';
+import {Tooltip} from '@carbon/react';
+import {Checkmark, CircleDash, ErrorOutline, Pending} from '@carbon/react/icons';
 import styled from 'styled-components';
 
 const ItemGroup = styled.div`
 	display: flex;
 	align-items: center;
-	gap: var(--cds-spacing-02);
+	gap: var(--cds-spacing-04);
 `;
 
 const Item = styled.span<{$color?: string}>`
+	display: flex;
+	align-items: center;
+	gap: var(--cds-spacing-02);
+	cursor: default;
+	min-width: 3rem;
 	color: ${({$color}) => $color ?? 'inherit'};
-	font-size: var(--cds-body-short-01-font-size);
 `;
 
-const fmt = new Intl.NumberFormat('en', {notation: 'compact'});
+const formatCount = (count: number): string =>
+	Intl.NumberFormat('en', {notation: 'compact', maximumFractionDigits: 1}).format(count);
 
 type Props = {
 	totalCount: number;
@@ -29,23 +35,42 @@ type Props = {
 };
 
 const BatchItemsCount: React.FC<Props> = ({totalCount, completedCount, failedCount}) => {
-	const pendingCount = Math.max(0, totalCount - completedCount - failedCount);
+	const pendingCount = totalCount - completedCount - failedCount;
+	const hasAnyProgress = completedCount > 0 || failedCount > 0;
+
+	if (!hasAnyProgress && pendingCount > 0) {
+		const description = 'not started';
+		return (
+			<Tooltip description={description} align="bottom">
+				<Item $color="var(--cds-status-gray)" aria-label={description}>
+					<CircleDash aria-hidden="true" focusable="false" /> 0
+				</Item>
+			</Tooltip>
+		);
+	}
+
+	const statusConfig = [
+		{key: 'successful', count: completedCount, label: 'successful', Icon: Checkmark, color: 'var(--cds-status-green)'},
+		{key: 'failed', count: failedCount, label: 'failed', Icon: ErrorOutline, color: 'var(--cds-status-red)'},
+		{key: 'pending', count: pendingCount, label: 'pending', Icon: Pending, color: 'var(--cds-status-gray)'},
+	];
 
 	return (
-		<Stack as="span" orientation="horizontal" gap={3}>
-			<ItemGroup title={`${completedCount} completed`}>
-				<Item $color="var(--cds-support-success)">{fmt.format(completedCount)}</Item>
-				<span>completed</span>
-			</ItemGroup>
-			<ItemGroup title={`${failedCount} failed`}>
-				<Item $color="var(--cds-support-error)">{fmt.format(failedCount)}</Item>
-				<span>failed</span>
-			</ItemGroup>
-			<ItemGroup title={`${pendingCount} pending`}>
-				<Item>{fmt.format(pendingCount)}</Item>
-				<span>pending</span>
-			</ItemGroup>
-		</Stack>
+		<ItemGroup>
+			{statusConfig
+				.filter(({count}) => count > 0)
+				.map(({key, count, label, Icon, color}) => {
+					const description = `${count.toLocaleString()} ${label}`;
+					return (
+						<Tooltip key={key} description={description} align="bottom">
+							<Item role="status" aria-label={description}>
+								<Icon color={color} aria-hidden="true" focusable="false" />
+								{formatCount(count)}
+							</Item>
+						</Tooltip>
+					);
+				})}
+		</ItemGroup>
 	);
 };
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/index.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Stack} from '@carbon/react';
+import styled from 'styled-components';
+
+const ItemGroup = styled.div`
+	display: flex;
+	align-items: center;
+	gap: var(--cds-spacing-02);
+`;
+
+const Item = styled.span<{$color?: string}>`
+	color: ${({$color}) => $color ?? 'inherit'};
+	font-size: var(--cds-body-short-01-font-size);
+`;
+
+const fmt = new Intl.NumberFormat('en', {notation: 'compact'});
+
+type Props = {
+	totalCount: number;
+	completedCount: number;
+	failedCount: number;
+};
+
+const BatchItemsCount: React.FC<Props> = ({totalCount, completedCount, failedCount}) => {
+	const pendingCount = Math.max(0, totalCount - completedCount - failedCount);
+
+	return (
+		<Stack as="span" orientation="horizontal" gap={3}>
+			<ItemGroup title={`${completedCount} completed`}>
+				<Item $color="var(--cds-support-success)">{fmt.format(completedCount)}</Item>
+				<span>completed</span>
+			</ItemGroup>
+			<ItemGroup title={`${failedCount} failed`}>
+				<Item $color="var(--cds-support-error)">{fmt.format(failedCount)}</Item>
+				<span>failed</span>
+			</ItemGroup>
+			<ItemGroup title={`${pendingCount} pending`}>
+				<Item>{fmt.format(pendingCount)}</Item>
+				<span>pending</span>
+			</ItemGroup>
+		</Stack>
+	);
+};
+
+export {BatchItemsCount};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/index.tsx
@@ -8,22 +8,7 @@
 
 import {Tooltip} from '@carbon/react';
 import {Checkmark, CircleDash, ErrorOutline, Pending} from '@carbon/react/icons';
-import styled from 'styled-components';
-
-const ItemGroup = styled.div`
-	display: flex;
-	align-items: center;
-	gap: var(--cds-spacing-04);
-`;
-
-const Item = styled.span<{$color?: string}>`
-	display: flex;
-	align-items: center;
-	gap: var(--cds-spacing-02);
-	cursor: default;
-	min-width: 3rem;
-	color: ${({$color}) => $color ?? 'inherit'};
-`;
+import {ItemGroup, Item} from './styled';
 
 const formatCount = (count: number): string =>
 	Intl.NumberFormat('en', {notation: 'compact', maximumFractionDigits: 1}).format(count);

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/styled.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const ItemGroup = styled.div`
+	display: flex;
+	align-items: center;
+	gap: var(--cds-spacing-04);
+`;
+
+const Item = styled.span<{$color?: string}>`
+	display: flex;
+	align-items: center;
+	gap: var(--cds-spacing-02);
+	cursor: default;
+	min-width: 3rem;
+	color: ${({$color}) => $color ?? 'inherit'};
+`;
+
+export {ItemGroup, Item};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
@@ -6,35 +6,42 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {CheckmarkFilled, CheckmarkOutline, CloseFilled, Pause, Pending, Renew, Warning} from '@carbon/react/icons';
+import {
+	CheckmarkFilled,
+	CircleDash,
+	ErrorFilled,
+	Incomplete,
+	InProgress,
+	MisuseOutline,
+	PauseOutlineFilled,
+	type CarbonIconType,
+} from '@carbon/react/icons';
 import styled from 'styled-components';
 import type {BatchOperationState} from '@camunda/camunda-api-zod-schemas/8.10';
 
-const Container = styled.span<{$color: string}>`
-	display: inline-flex;
-	align-items: center;
-	gap: var(--cds-spacing-02);
-	color: ${({$color}) => $color};
+const Container = styled.div`
+	display: flex;
+
+	svg {
+		align-self: center;
+		margin-inline-end: var(--cds-spacing-03);
+	}
 `;
 
 type Config = {
-	icon: React.ReactNode;
+	Icon: CarbonIconType;
 	color: string;
 	label: string;
 };
 
 const STATE_CONFIG: Record<BatchOperationState, Config> = {
-	COMPLETED: {icon: <CheckmarkFilled size={16} />, color: 'var(--cds-support-success)', label: 'Completed'},
-	PARTIALLY_COMPLETED: {
-		icon: <CheckmarkOutline size={16} />,
-		color: 'var(--cds-support-warning)',
-		label: 'Partially completed',
-	},
-	ACTIVE: {icon: <Renew size={16} />, color: 'var(--cds-link-primary)', label: 'Active'},
-	CREATED: {icon: <Pending size={16} />, color: 'var(--cds-link-primary)', label: 'Created'},
-	SUSPENDED: {icon: <Pause size={16} />, color: 'var(--cds-support-warning)', label: 'Suspended'},
-	FAILED: {icon: <Warning size={16} />, color: 'var(--cds-support-error)', label: 'Failed'},
-	CANCELED: {icon: <CloseFilled size={16} />, color: 'var(--cds-text-secondary)', label: 'Canceled'},
+	COMPLETED: {Icon: CheckmarkFilled, color: 'var(--cds-status-green)', label: 'Completed'},
+	ACTIVE: {Icon: InProgress, color: 'var(--cds-status-blue)', label: 'Active'},
+	SUSPENDED: {Icon: PauseOutlineFilled, color: 'var(--cds-status-gray)', label: 'Suspended'},
+	CANCELED: {Icon: MisuseOutline, color: 'var(--cds-status-red)', label: 'Canceled'},
+	FAILED: {Icon: ErrorFilled, color: 'var(--cds-status-red)', label: 'Failed'},
+	CREATED: {Icon: CircleDash, color: 'var(--cds-status-gray)', label: 'Created'},
+	PARTIALLY_COMPLETED: {Icon: Incomplete, color: 'var(--cds-status-blue)', label: 'Partially completed'},
 };
 
 type Props = {
@@ -42,11 +49,11 @@ type Props = {
 };
 
 const BatchStateIndicator: React.FC<Props> = ({state}) => {
-	const {icon, color, label} = STATE_CONFIG[state];
+	const {Icon, color, label} = STATE_CONFIG[state];
 	return (
-		<Container $color={color}>
-			{icon}
-			<span>{label}</span>
+		<Container role="status" aria-label={`Batch operation status: ${label}`}>
+			<Icon style={{color}} aria-hidden="true" focusable="false" />
+			{label}
 		</Container>
 	);
 };

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {CheckmarkFilled, CheckmarkOutline, CloseFilled, Pause, Pending, Renew, Warning} from '@carbon/icons-react';
+import styled from 'styled-components';
+import type {BatchOperationState} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const Container = styled.span<{$color: string}>`
+	display: inline-flex;
+	align-items: center;
+	gap: var(--cds-spacing-02);
+	color: ${({$color}) => $color};
+`;
+
+type Config = {
+	icon: React.ReactNode;
+	color: string;
+	label: string;
+};
+
+const STATE_CONFIG: Record<BatchOperationState, Config> = {
+	COMPLETED: {icon: <CheckmarkFilled size={16} />, color: 'var(--cds-support-success)', label: 'Completed'},
+	PARTIALLY_COMPLETED: {
+		icon: <CheckmarkOutline size={16} />,
+		color: 'var(--cds-support-warning)',
+		label: 'Partially completed',
+	},
+	ACTIVE: {icon: <Renew size={16} />, color: 'var(--cds-link-primary)', label: 'Active'},
+	CREATED: {icon: <Pending size={16} />, color: 'var(--cds-link-primary)', label: 'Created'},
+	SUSPENDED: {icon: <Pause size={16} />, color: 'var(--cds-support-warning)', label: 'Suspended'},
+	FAILED: {icon: <Warning size={16} />, color: 'var(--cds-support-error)', label: 'Failed'},
+	CANCELED: {icon: <CloseFilled size={16} />, color: 'var(--cds-text-secondary)', label: 'Canceled'},
+};
+
+type Props = {
+	state: BatchOperationState;
+};
+
+const BatchStateIndicator: React.FC<Props> = ({state}) => {
+	const {icon, color, label} = STATE_CONFIG[state];
+	return (
+		<Container $color={color}>
+			{icon}
+			<span>{label}</span>
+		</Container>
+	);
+};
+
+export {BatchStateIndicator};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {CheckmarkFilled, CheckmarkOutline, CloseFilled, Pause, Pending, Renew, Warning} from '@carbon/icons-react';
+import {CheckmarkFilled, CheckmarkOutline, CloseFilled, Pause, Pending, Renew, Warning} from '@carbon/react/icons';
 import styled from 'styled-components';
 import type {BatchOperationState} from '@camunda/camunda-api-zod-schemas/8.10';
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
@@ -16,17 +16,8 @@ import {
 	PauseOutlineFilled,
 	type CarbonIconType,
 } from '@carbon/react/icons';
-import styled from 'styled-components';
 import type {BatchOperationState} from '@camunda/camunda-api-zod-schemas/8.10';
-
-const Container = styled.div`
-	display: flex;
-
-	svg {
-		align-self: center;
-		margin-inline-end: var(--cds-spacing-03);
-	}
-`;
+import {Container} from './styled';
 
 type Config = {
 	Icon: CarbonIconType;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/styled.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const Container = styled.div`
+	display: flex;
+
+	svg {
+		align-self: center;
+		margin-inline-end: var(--cds-spacing-03);
+	}
+`;
+
+export {Container};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/ColumnHeader.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/ColumnHeader.tsx
@@ -30,7 +30,7 @@ const ColumnHeader: React.FC<Props> = ({sortKey, label, isDefault = false, defau
 	const handleSort = () => {
 		const newOrder: SortOrder =
 			isActive && activeOrder === 'asc' ? 'desc' : isActive && activeOrder === 'desc' ? 'asc' : defaultOrder;
-		void navigate({search: (prev) => ({...prev, sort: `${sortKey}+${newOrder}`})});
+		void navigate({to: '.', search: (prev) => ({...prev, sort: `${sortKey}+${newOrder}`})});
 	};
 
 	return (

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/ColumnHeader.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/ColumnHeader.tsx
@@ -16,9 +16,10 @@ type Props = {
 	label: string;
 	isDefault?: boolean;
 	defaultOrder?: SortOrder;
+	onSort?: (sortKey: string, order: SortOrder) => void;
 };
 
-const ColumnHeader: React.FC<Props> = ({sortKey, label, isDefault = false, defaultOrder = 'desc'}) => {
+const ColumnHeader: React.FC<Props> = ({sortKey, label, isDefault = false, defaultOrder = 'desc', onSort}) => {
 	const navigate = useNavigate();
 	const search = useSearch({strict: false}) as {sort?: string};
 
@@ -30,6 +31,7 @@ const ColumnHeader: React.FC<Props> = ({sortKey, label, isDefault = false, defau
 	const handleSort = () => {
 		const newOrder: SortOrder =
 			isActive && activeOrder === 'asc' ? 'desc' : isActive && activeOrder === 'desc' ? 'asc' : defaultOrder;
+		onSort?.(sortKey, newOrder);
 		void navigate({to: '.', search: (prev) => ({...prev, sort: `${sortKey}+${newOrder}`})});
 	};
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/ColumnHeader.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/ColumnHeader.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {TableHeader} from '@carbon/react';
+import {useNavigate, useSearch} from '@tanstack/react-router';
+
+type SortOrder = 'asc' | 'desc';
+
+type Props = {
+	sortKey: string;
+	label: string;
+	isDefault?: boolean;
+	defaultOrder?: SortOrder;
+};
+
+const ColumnHeader: React.FC<Props> = ({sortKey, label, isDefault = false, defaultOrder = 'desc'}) => {
+	const navigate = useNavigate();
+	const search = useSearch({strict: false}) as {sort?: string};
+
+	const [currentSortKey, currentSortOrder] = (search.sort ?? '').split('+') as [string, SortOrder | undefined];
+	const isActive = currentSortKey === sortKey || (currentSortKey === '' && isDefault);
+	const activeOrder: SortOrder =
+		currentSortKey === sortKey && currentSortOrder !== undefined ? currentSortOrder : defaultOrder;
+
+	const handleSort = () => {
+		const newOrder: SortOrder =
+			isActive && activeOrder === 'asc' ? 'desc' : isActive && activeOrder === 'desc' ? 'asc' : defaultOrder;
+		void navigate({search: (prev) => ({...prev, sort: `${sortKey}+${newOrder}`})});
+	};
+
+	return (
+		<TableHeader
+			isSortable
+			isSortHeader={isActive}
+			sortDirection={isActive ? (activeOrder === 'asc' ? 'ASC' : 'DESC') : 'NONE'}
+			onClick={handleSort}
+		>
+			{label}
+		</TableHeader>
+	);
+};
+
+export {ColumnHeader};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {DataTableSkeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@carbon/react';
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@carbon/react';
 import {TableContainer, LoadingOverlay, EmptyStateContainer} from './styled';
 import {ColumnHeader} from './ColumnHeader';
 
@@ -26,7 +26,6 @@ type Props<TRow> = {
 	rows: TRow[];
 	rowKey: (row: TRow) => string;
 	size?: TableSize;
-	isLoading?: boolean;
 	isFetching?: boolean;
 	emptyState?: React.ReactNode;
 	onSort?: (sortKey: string, order: 'asc' | 'desc') => void;
@@ -38,16 +37,11 @@ function SortableTable<TRow>({
 	rows,
 	rowKey,
 	size = 'md',
-	isLoading = false,
 	isFetching = false,
 	emptyState,
 	onSort,
 	'data-testid': dataTestId,
 }: Props<TRow>) {
-	if (isLoading) {
-		return <DataTableSkeleton columnCount={columns.length} rowCount={5} showHeader={false} showToolbar={false} />;
-	}
-
 	return (
 		<TableContainer data-testid={dataTestId}>
 			{isFetching && <LoadingOverlay aria-hidden />}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/index.tsx
@@ -6,9 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {DataTableSkeleton, Table, TableBody, TableCell, TableHead, TableRow} from '@carbon/react';
+import {DataTableSkeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@carbon/react';
 import {TableContainer, LoadingOverlay, EmptyStateContainer} from './styled';
 import {ColumnHeader} from './ColumnHeader';
+
+type TableSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 type Column<TRow> = {
 	key: string;
@@ -23,9 +25,11 @@ type Props<TRow> = {
 	columns: Column<TRow>[];
 	rows: TRow[];
 	rowKey: (row: TRow) => string;
-	isLoading: boolean;
-	isFetching: boolean;
+	size?: TableSize;
+	isLoading?: boolean;
+	isFetching?: boolean;
 	emptyState?: React.ReactNode;
+	onSort?: (sortKey: string, order: 'asc' | 'desc') => void;
 	'data-testid'?: string;
 };
 
@@ -33,9 +37,11 @@ function SortableTable<TRow>({
 	columns,
 	rows,
 	rowKey,
-	isLoading,
-	isFetching,
+	size = 'md',
+	isLoading = false,
+	isFetching = false,
 	emptyState,
+	onSort,
 	'data-testid': dataTestId,
 }: Props<TRow>) {
 	if (isLoading) {
@@ -45,7 +51,7 @@ function SortableTable<TRow>({
 	return (
 		<TableContainer data-testid={dataTestId}>
 			{isFetching && <LoadingOverlay aria-hidden />}
-			<Table>
+			<Table size={size} isSortable>
 				<TableHead>
 					<TableRow>
 						{columns.map((col) =>
@@ -56,11 +62,12 @@ function SortableTable<TRow>({
 									label={col.label}
 									isDefault={col.isDefault}
 									defaultOrder={col.defaultOrder}
+									onSort={onSort}
 								/>
 							) : (
-								<th key={col.key} scope="col">
+								<TableHeader key={col.key} isSortable={false}>
 									{col.label}
-								</th>
+								</TableHeader>
 							),
 						)}
 					</TableRow>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/index.tsx
@@ -74,11 +74,11 @@ function SortableTable<TRow>({
 				</TableHead>
 				<TableBody>
 					{rows.length === 0 && emptyState !== undefined ? (
-						<tr>
-							<td colSpan={columns.length}>
+						<TableRow>
+							<TableCell colSpan={columns.length}>
 								<EmptyStateContainer>{emptyState}</EmptyStateContainer>
-							</td>
-						</tr>
+							</TableCell>
+						</TableRow>
 					) : (
 						rows.map((row) => (
 							<TableRow key={rowKey(row)}>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/index.tsx
@@ -88,4 +88,3 @@ function SortableTable<TRow>({
 }
 
 export {SortableTable};
-export type {Column};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/index.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {DataTableSkeleton, Table, TableBody, TableCell, TableHead, TableRow} from '@carbon/react';
+import {TableContainer, LoadingOverlay, EmptyStateContainer} from './styled';
+import {ColumnHeader} from './ColumnHeader';
+
+type Column<TRow> = {
+	key: string;
+	label: string;
+	sortKey?: string;
+	isDefault?: boolean;
+	defaultOrder?: 'asc' | 'desc';
+	render: (row: TRow) => React.ReactNode;
+};
+
+type Props<TRow> = {
+	columns: Column<TRow>[];
+	rows: TRow[];
+	rowKey: (row: TRow) => string;
+	isLoading: boolean;
+	isFetching: boolean;
+	emptyState?: React.ReactNode;
+	'data-testid'?: string;
+};
+
+function SortableTable<TRow>({
+	columns,
+	rows,
+	rowKey,
+	isLoading,
+	isFetching,
+	emptyState,
+	'data-testid': dataTestId,
+}: Props<TRow>) {
+	if (isLoading) {
+		return <DataTableSkeleton columnCount={columns.length} rowCount={5} showHeader={false} showToolbar={false} />;
+	}
+
+	return (
+		<TableContainer data-testid={dataTestId}>
+			{isFetching && <LoadingOverlay aria-hidden />}
+			<Table>
+				<TableHead>
+					<TableRow>
+						{columns.map((col) =>
+							col.sortKey !== undefined ? (
+								<ColumnHeader
+									key={col.key}
+									sortKey={col.sortKey}
+									label={col.label}
+									isDefault={col.isDefault}
+									defaultOrder={col.defaultOrder}
+								/>
+							) : (
+								<th key={col.key} scope="col">
+									{col.label}
+								</th>
+							),
+						)}
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					{rows.length === 0 && emptyState !== undefined ? (
+						<tr>
+							<td colSpan={columns.length}>
+								<EmptyStateContainer>{emptyState}</EmptyStateContainer>
+							</td>
+						</tr>
+					) : (
+						rows.map((row) => (
+							<TableRow key={rowKey(row)}>
+								{columns.map((col) => (
+									<TableCell key={col.key}>{col.render(row)}</TableCell>
+								))}
+							</TableRow>
+						))
+					)}
+				</TableBody>
+			</Table>
+		</TableContainer>
+	);
+}
+
+export {SortableTable};
+export type {Column};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/styled.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {TableContainer as CarbonTableContainer} from '@carbon/react';
+
+const TableContainer = styled(CarbonTableContainer)`
+	position: relative;
+`;
+
+const LoadingOverlay = styled.div`
+	position: absolute;
+	inset: 0;
+	background: var(--cds-layer);
+	opacity: 0.5;
+	z-index: 1;
+	pointer-events: none;
+`;
+
+const EmptyStateContainer = styled.div`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding: var(--cds-spacing-09) 0;
+`;
+
+export {TableContainer, LoadingOverlay, EmptyStateContainer};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/SortableTable/styled.ts
@@ -11,6 +11,7 @@ import {TableContainer as CarbonTableContainer} from '@carbon/react';
 
 const TableContainer = styled(CarbonTableContainer)`
 	position: relative;
+	background-color: var(--cds-layer);
 `;
 
 const LoadingOverlay = styled.div`

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/operate/batch-operations.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/operate/batch-operations.tsx
@@ -22,9 +22,7 @@ export const Route = createFileRoute('/_auth/operate/batch-operations')({
 	validateSearch: batchOperationsSearchSchema,
 	loaderDeps: ({search}) => ({...search}),
 	loader: ({context: {queryClient}, deps}) => queryClient.ensureQueryData(batchOperationsOptions(deps)),
-	pendingComponent: () => (
-		<DataTableSkeleton columnCount={5} rowCount={5} showHeader={false} showToolbar={false} />
-	),
+	pendingComponent: () => <DataTableSkeleton columnCount={5} rowCount={5} showHeader={false} showToolbar={false} />,
 	component: function BatchOperationsRoute() {
 		const {page, pageSize, sort} = Route.useSearch();
 		return <BatchOperations page={page} pageSize={pageSize} sort={sort} />;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/operate/batch-operations.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/operate/batch-operations.tsx
@@ -7,7 +7,19 @@
  */
 
 import {createFileRoute} from '@tanstack/react-router';
+import {z} from 'zod';
+import {BatchOperations} from '#/operate/pages/BatchOperations/BatchOperations';
+
+const batchOperationsSearchSchema = z.object({
+	page: z.number().int().positive().default(1),
+	pageSize: z.number().int().positive().default(20),
+	sort: z.string().optional(),
+});
 
 export const Route = createFileRoute('/_auth/operate/batch-operations')({
-	component: () => null,
+	validateSearch: batchOperationsSearchSchema,
+	component: function BatchOperationsRoute() {
+		const {page, pageSize, sort} = Route.useSearch();
+		return <BatchOperations page={page} pageSize={pageSize} sort={sort} />;
+	},
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/operate/batch-operations.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/operate/batch-operations.tsx
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {DataTableSkeleton} from '@carbon/react';
 import {createFileRoute} from '@tanstack/react-router';
 import {z} from 'zod';
 import {BatchOperations} from '#/operate/pages/BatchOperations/BatchOperations';
@@ -21,6 +22,9 @@ export const Route = createFileRoute('/_auth/operate/batch-operations')({
 	validateSearch: batchOperationsSearchSchema,
 	loaderDeps: ({search}) => ({...search}),
 	loader: ({context: {queryClient}, deps}) => queryClient.ensureQueryData(batchOperationsOptions(deps)),
+	pendingComponent: () => (
+		<DataTableSkeleton columnCount={5} rowCount={5} showHeader={false} showToolbar={false} />
+	),
 	component: function BatchOperationsRoute() {
 		const {page, pageSize, sort} = Route.useSearch();
 		return <BatchOperations page={page} pageSize={pageSize} sort={sort} />;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/operate/batch-operations.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/operate/batch-operations.tsx
@@ -9,6 +9,7 @@
 import {createFileRoute} from '@tanstack/react-router';
 import {z} from 'zod';
 import {BatchOperations} from '#/operate/pages/BatchOperations/BatchOperations';
+import {batchOperationsOptions} from '#/operate/pages/BatchOperations/batchOperations.queries';
 
 const batchOperationsSearchSchema = z.object({
 	page: z.number().int().positive().default(1),
@@ -18,6 +19,8 @@ const batchOperationsSearchSchema = z.object({
 
 export const Route = createFileRoute('/_auth/operate/batch-operations')({
 	validateSearch: batchOperationsSearchSchema,
+	loaderDeps: ({search}) => ({...search}),
+	loader: ({context: {queryClient}, deps}) => queryClient.ensureQueryData(batchOperationsOptions(deps)),
 	component: function BatchOperationsRoute() {
 		const {page, pageSize, sort} = Route.useSearch();
 		return <BatchOperations page={page} pageSize={pageSize} sort={sort} />;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
@@ -14,6 +14,7 @@ import {
 	type GetProcessDefinitionInstanceVersionStatisticsRequestBody,
 	type GetIncidentProcessInstanceStatisticsByErrorRequestBody,
 	type GetIncidentProcessInstanceStatisticsByDefinitionRequestBody,
+	type QueryBatchOperationsRequestBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {getBootConfig} from '#/shared/config/getBootConfig';
 import {mergePathname} from './mergePathname';
@@ -119,6 +120,14 @@ const endpoints = {
 			headers: {'Content-Type': 'application/json'},
 		}),
 
+	queryBatchOperations: (body: QueryBatchOperationsRequestBody) =>
+		new Request(getFullURL(unifiedAPIEndpoints.queryBatchOperations.getUrl()), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.queryBatchOperations.method,
+			body: JSON.stringify(body),
+			headers: {'Content-Type': 'application/json'},
+		}),
+
 	getIncidentProcessInstanceStatisticsByDefinition: (
 		body: GetIncidentProcessInstanceStatisticsByDefinitionRequestBody,
 	) =>
@@ -126,6 +135,13 @@ const endpoints = {
 			...BASE_REQUEST_OPTIONS,
 			method: unifiedAPIEndpoints.getIncidentProcessInstanceStatisticsByDefinition.method,
 			body: JSON.stringify(body),
+			headers: {'Content-Type': 'application/json'},
+		}),
+
+	getBatchOperation: ({batchOperationKey}: {batchOperationKey: string}) =>
+		new Request(getFullURL(unifiedAPIEndpoints.getBatchOperation.getUrl({batchOperationKey})), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.getBatchOperation.method,
 			headers: {'Content-Type': 'application/json'},
 		}),
 };

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/queries.ts
@@ -19,7 +19,10 @@ import type {
 	GetIncidentProcessInstanceStatisticsByErrorRequestBody,
 	GetProcessDefinitionInstanceStatisticsResponseBody,
 	GetIncidentProcessInstanceStatisticsByErrorResponseBody,
+	QueryBatchOperationsRequestBody,
+	QueryBatchOperationsResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
+import {ForbiddenError} from '#/shared/errors';
 import {request} from './request';
 import {endpoints} from './endpoints';
 
@@ -157,6 +160,21 @@ const queries = {
 			queryFn: async (): Promise<GetIncidentProcessInstanceStatisticsByErrorResponseBody> => {
 				const {response, error} = await request(endpoints.getIncidentProcessInstanceStatisticsByError(body));
 				if (error !== null) {
+					throw error;
+				}
+				return response.json();
+			},
+		}),
+
+	queryBatchOperations: (body: QueryBatchOperationsRequestBody) =>
+		queryOptions({
+			queryKey: ['batchOperations', body],
+			queryFn: async (): Promise<QueryBatchOperationsResponseBody> => {
+				const {response, error} = await request(endpoints.queryBatchOperations(body));
+				if (error !== null) {
+					if (error.variant === 'failed-response' && error.response.status === 403) {
+						throw new ForbiddenError();
+					}
 					throw error;
 				}
 				return response.json();

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/queries.ts
@@ -19,10 +19,7 @@ import type {
 	GetIncidentProcessInstanceStatisticsByErrorRequestBody,
 	GetProcessDefinitionInstanceStatisticsResponseBody,
 	GetIncidentProcessInstanceStatisticsByErrorResponseBody,
-	QueryBatchOperationsRequestBody,
-	QueryBatchOperationsResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
-import {ForbiddenError} from '#/shared/errors';
 import {request} from './request';
 import {endpoints} from './endpoints';
 
@@ -160,21 +157,6 @@ const queries = {
 			queryFn: async (): Promise<GetIncidentProcessInstanceStatisticsByErrorResponseBody> => {
 				const {response, error} = await request(endpoints.getIncidentProcessInstanceStatisticsByError(body));
 				if (error !== null) {
-					throw error;
-				}
-				return response.json();
-			},
-		}),
-
-	queryBatchOperations: (body: QueryBatchOperationsRequestBody) =>
-		queryOptions({
-			queryKey: ['batchOperations', body],
-			queryFn: async (): Promise<QueryBatchOperationsResponseBody> => {
-				const {response, error} = await request(endpoints.queryBatchOperations(body));
-				if (error !== null) {
-					if (error.variant === 'failed-response' && error.response.status === 403) {
-						throw new ForbiddenError();
-					}
 					throw error;
 				}
 				return response.json();

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/tracking.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/tracking.tsx
@@ -124,6 +124,16 @@ type Events =
 	| {
 			eventName: 'operate:dashboard-link-clicked';
 			link: 'operate-docs' | 'modeler';
+	  }
+	| {
+			eventName: 'operate:batch-operation-details-opened';
+			batchOperationType: string;
+			batchOperationState: string;
+	  }
+	| {
+			eventName: 'operate:batch-operations-sorted';
+			sortBy: string;
+			sortOrder: 'asc' | 'desc';
 	  };
 
 const STAGE_ENV = getStage(window.location.host);


### PR DESCRIPTION
## Description

Migrates the Operate Batch Operations list page from the legacy app to the unified webapp (`webapp/`), rendered 1:1 with legacy Operate.

- **`operate/pages/BatchOperations/`**: page component, colocated `batchOperations.queries.ts`, `styled.ts`, `utils.ts`, and unit tests
- **`operate/shared/SortableTable/`**: shared sortable table; column headers drive sort via TanStack Router URL params (`sort=field+order`)
- **`operate/shared/BatchStateIndicator/`** and **`operate/shared/BatchItemsCount/`**: state icon with label, and completed/failed/pending counts, ported from legacy
- **`shared/http/endpoints.ts`**: adds `queryBatchOperations` and `getBatchOperation`
- **`shared/tracking.tsx`**: adds `operate:batch-operation-details-opened` and `operate:batch-operations-sorted`

Data loading uses the route loader plus `useSuspenseQuery` pattern (consistent with Tasklist and Dashboard), with the query defined as a colocated `queryOptions` function (per TkDodo "Creating Query Abstractions"). Tracking events match legacy.

Note: the diff is around 800 lines, above the 500 line guideline; the bulk is the new page plus three shared components and their tests.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Closes #55642

Part of epic #51305
