### PR TITLE
fix: fix Operate data generator

### DIFF
--- a/operate/data-generator/pom.xml
+++ b/operate/data-generator/pom.xml
@@ -21,6 +21,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>configuration-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>webapps-schema</artifactId>
     </dependency>
 

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -12,8 +12,9 @@ import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.worker.JobWorker;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.operate.data.usertest.UserTestDataGenerator;
-import io.camunda.search.clients.ProcessDefinitionSearchClient;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.security.core.auth.SecurityContext;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
@@ -45,7 +46,7 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   private boolean shutdown = false;
 
   @Autowired(required = false)
-  private ProcessDefinitionSearchClient processDefinitionSearchClient;
+  private SearchClientsProxy searchClientsProxy;
 
   @PostConstruct
   private void startDataGenerator() {
@@ -108,15 +109,16 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   }
 
   public boolean shouldCreateData(final boolean manuallyCalled) {
-    if (processDefinitionSearchClient == null) {
+    if (searchClientsProxy == null) {
       LOGGER.warn(
-          "ProcessDefinitionSearchClient is null. Assuming no data exists and it should be created...");
+          "SearchClientsProxy is null. Assuming no data exists and it should be created...");
       return true;
     }
     if (!manuallyCalled) { // when called manually, always create the data
       final boolean exists;
       exists =
-          processDefinitionSearchClient
+          searchClientsProxy
+                  .withPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                   .withSecurityContext(
                       SecurityContext.of(b -> b.withAuthentication(a -> a.anonymous(true))))
                   .searchProcessDefinitions(ProcessDefinitionQuery.of(q -> q))


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

When running `make env-up` inside `operate/` I was getting the error below. This PR tries to fix that:

```
12:14:09.168 [] [pool-3-thread-1] [] ERROR io.camunda.operate.data.AbstractDataGenerator - Error occurred when creating demo data: CamundaSearchClients must be scoped to a physical tenant via withPhysicalTenant() before performing reads. Retrying...
java.lang.IllegalStateException: CamundaSearchClients must be scoped to a physical tenant via withPhysicalTenant() before performing reads
	at io.camunda.search.clients.CamundaSearchClients.requireScoped(CamundaSearchClients.java:772)
	at io.camunda.search.clients.CamundaSearchClients.requireScopedReaders(CamundaSearchClients.java:778)
	at io.camunda.search.clients.CamundaSearchClients.searchProcessDefinitions(CamundaSearchClients.java:396)
	at io.camunda.operate.data.AbstractDataGenerator.shouldCreateData(AbstractDataGenerator.java:122)
	at io.camunda.operate.data.AbstractDataGenerator.createZeebeData(AbstractDataGenerator.java:103)
	at io.camunda.operate.data.usertest.UserTestDataGenerator.createZeebeData(UserTestDataGenerator.java:53)
	at io.camunda.operate.data.AbstractDataGenerator.lambda$createZeebeDataAsync$0(AbstractDataGenerator.java:88)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
12:14:11.174 [] [pool-3-thread-1] [] ERROR io.camunda.operate.data.AbstractDataGenerator - Error occurred when creating demo data: CamundaSearchClients must be scoped to a physical tenant via withPhysicalTenant() before performing reads. Retrying...
```