### PR TITLE
test: extend message businessId correlation ITs with boundary events, event subprocesses, CorrelateMessage command, and cross-tenant uniqueness

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationBusinessIdTest.java
@@ -60,6 +60,36 @@ public final class MessageCorrelationBusinessIdTest {
           .endEvent()
           .done();
 
+  // Interrupting boundary message event on a service task: correlation cancels the task and the
+  // boundary path runs to the end event, so the process completes — a deterministic positive
+  // terminal.
+  private static final BpmnModelInstance INTERRUPTING_BOUNDARY_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .boundaryEvent("boundary")
+          .cancelActivity(true)
+          .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+          .endEvent()
+          .moveToActivity("task")
+          .endEvent()
+          .done();
+
+  // Non-interrupting boundary message event: correlation spawns a token on the boundary path while
+  // the service task keeps running, so the process does not complete; the CORRELATED record is the
+  // positive terminal instead.
+  private static final BpmnModelInstance NON_INTERRUPTING_BOUNDARY_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .boundaryEvent("boundary")
+          .cancelActivity(false)
+          .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+          .endEvent()
+          .moveToActivity("task")
+          .endEvent()
+          .done();
+
   @Rule public final EngineRule engine = EngineRule.singlePartition();
 
   // --- Asymmetric rule, publish-then-subscribe is not relevant; these test
@@ -458,6 +488,139 @@ public final class MessageCorrelationBusinessIdTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
   }
 
+  // --- Boundary message events: the asymmetric rule holds identically for interrupting and
+  // --- non-interrupting boundary events. The subscription opens the same way (when the attached
+  // --- activity activates) and carries the PI's businessId captured at OPEN time. The positive
+  // --- terminal differs per variant — see each test.
+
+  @Test
+  public void
+      shouldFireInterruptingBoundaryForMessageWithoutBusinessIdAgainstSubscriptionWithOne() {
+    // given a PI with businessId "biz-42" waiting on an interrupting boundary message event
+    engine.deployment().withXmlResource(INTERRUPTING_BOUNDARY_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-bnd-1")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when a message without a businessId is published (asymmetric rule: it still correlates)
+    engine.message().withName("message").withCorrelationKey("order-bnd-1").publish();
+
+    // then the boundary event interrupts the task and the process completes, and the CORRELATED
+    // event carries the subscribing PI's businessId
+    assertProcessCompleted(processInstanceKey);
+    assertThat(correlatedSubscriptionBusinessId(processInstanceKey)).isEqualTo("biz-42");
+  }
+
+  @Test
+  public void shouldFireInterruptingBoundaryForMessageWithMatchingBusinessId() {
+    // given
+    engine.deployment().withXmlResource(INTERRUPTING_BOUNDARY_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-bnd-2")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when an exactly-matching businessId is published
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-bnd-2")
+        .withBusinessId("biz-42")
+        .publish();
+
+    // then the boundary event fires and the process completes
+    assertProcessCompleted(processInstanceKey);
+  }
+
+  @Test
+  public void shouldNotFireInterruptingBoundaryForMessageWithDifferentBusinessId() {
+    // given
+    engine.deployment().withXmlResource(INTERRUPTING_BOUNDARY_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-bnd-3")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when a message with a different businessId is published with TTL=0 for a deterministic
+    // EXPIRED terminal
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-bnd-3")
+        .withBusinessId("other-biz")
+        .withTimeToLive(0L)
+        .publish();
+
+    // then the boundary event never fires
+    assertNoCorrelationUpToMessageExpiry(processInstanceKey, "message", "order-bnd-3");
+  }
+
+  @Test
+  public void shouldFireNonInterruptingBoundaryForMessageWithMatchingBusinessId() {
+    // given a PI with businessId "biz-42" waiting on a non-interrupting boundary message event
+    engine.deployment().withXmlResource(NON_INTERRUPTING_BOUNDARY_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-bnd-4")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when an exactly-matching businessId is published
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-bnd-4")
+        .withBusinessId("biz-42")
+        .publish();
+
+    // then the boundary event fires (the task stays active, so the CORRELATED record — carrying the
+    // PI's businessId — is the terminal, not process completion)
+    assertThat(correlatedSubscriptionBusinessId(processInstanceKey)).isEqualTo("biz-42");
+  }
+
+  @Test
+  public void shouldNotFireNonInterruptingBoundaryForMessageWithDifferentBusinessId() {
+    // given
+    engine.deployment().withXmlResource(NON_INTERRUPTING_BOUNDARY_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-bnd-5")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when a message with a different businessId is published with TTL=0 for a deterministic
+    // EXPIRED terminal
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-bnd-5")
+        .withBusinessId("other-biz")
+        .withTimeToLive(0L)
+        .publish();
+
+    // then the boundary event never fires
+    assertNoCorrelationUpToMessageExpiry(processInstanceKey, "message", "order-bnd-5");
+  }
+
   private static BpmnModelInstance processWithIntermediateCatch(final String processId) {
     return Bpmn.createExecutableProcess(processId)
         .startEvent()
@@ -472,6 +635,15 @@ public final class MessageCorrelationBusinessIdTest {
     return RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
         .getFirst();
+  }
+
+  private static String correlatedSubscriptionBusinessId(final long processInstanceKey) {
+    return RecordingExporter.processMessageSubscriptionRecords(
+            ProcessMessageSubscriptionIntent.CORRELATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst()
+        .getValue()
+        .getBusinessId();
   }
 
   private static void assertProcessCompleted(final long processInstanceKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationBusinessIdTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -43,7 +44,9 @@ import org.junit.Test;
  *
  * <p>Tests cover both correlation directions (publish-then-subscribe and subscribe-then-publish), a
  * multi-definition scenario where two processes share the same name/key but differ in business id
- * usage, and a pin that the value captured at OPEN time is what governs later correlation.
+ * usage, and a pin that the value captured at OPEN time is what governs later correlation. The
+ * asymmetric rule is also exercised through the explicit {@code CorrelateMessage} command, not only
+ * the {@code PublishMessage} path, since the two are distinct engine entry points.
  */
 public final class MessageCorrelationBusinessIdTest {
 
@@ -366,6 +369,93 @@ public final class MessageCorrelationBusinessIdTest {
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
     assertThat(correlated.getValue().getBusinessId()).isEmpty();
+  }
+
+  // --- Explicit CorrelateMessage command path: a distinct engine entry point
+  // --- (MessageCorrelationRecord) from the asynchronous PublishMessage path (MessageRecord).
+
+  @Test
+  public void shouldCorrelateViaCommandWhenBusinessIdMatches() {
+    // given a PI with businessId "biz-42" waiting on an intermediate catch event
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-cmd-1")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when an exactly-matching businessId is correlated through the explicit command
+    engine
+        .messageCorrelation()
+        .withName("message")
+        .withCorrelationKey("order-cmd-1")
+        .withBusinessId("biz-42")
+        .expectNothing()
+        .correlate();
+
+    // then the catch event fires and the process completes
+    assertProcessCompleted(processInstanceKey);
+  }
+
+  @Test
+  public void shouldCorrelateViaCommandWithoutBusinessIdToSubscriptionWithOne() {
+    // given a PI with businessId "biz-42" waiting on an intermediate catch event
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-cmd-2")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when a command without a businessId is correlated (asymmetric rule: it still correlates)
+    engine
+        .messageCorrelation()
+        .withName("message")
+        .withCorrelationKey("order-cmd-2")
+        .expectNothing()
+        .correlate();
+
+    // then the catch event fires and the process completes
+    assertProcessCompleted(processInstanceKey);
+  }
+
+  /**
+   * A CorrelateMessage whose businessId excludes the only subscription (via the asymmetric filter)
+   * leaves nothing to correlate, so the command is rejected NOT_FOUND — unlike PublishMessage,
+   * which would simply not correlate.
+   */
+  @Test
+  public void shouldNotCorrelateViaCommandWhenBusinessIdDiffers() {
+    // given a PI with businessId "biz-42" waiting on an intermediate catch event
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-cmd-3")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when a command with a different businessId is correlated, the only subscription is excluded
+    // by the asymmetric filter, leaving nothing to correlate
+    final var rejection =
+        engine
+            .messageCorrelation()
+            .withName("message")
+            .withCorrelationKey("order-cmd-3")
+            .withBusinessId("other-biz")
+            .expectRejection()
+            .correlate();
+
+    // then the command is rejected because no (matching) subscription was found
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
   }
 
   private static BpmnModelInstance processWithIntermediateCatch(final String processId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageEventSubprocessBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageEventSubprocessBusinessIdTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.function.Predicate;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Event-subprocess arm of the non-start {@code businessId} filter. A message-start event inside an
+ * event subprocess does <b>not</b> create a root process instance — it correlates into an already
+ * running instance via an instance-scoped {@link
+ * io.camunda.zeebe.protocol.record.ValueType#PROCESS_MESSAGE_SUBSCRIPTION} (the same record type as
+ * an intermediate catch or boundary event), never a definition-scoped {@code
+ * MessageStartEventSubscription}. Therefore the start-event {@code businessId} <em>uniqueness</em>
+ * constraint must not apply here: {@code businessId} is a plain catch-style filter only.
+ *
+ * <p>These tests run with {@code businessIdUniquenessEnabled} <b>on</b> so the no-uniqueness
+ * guarantee is actually tested and not trivially true: a second top-level {@code
+ * CreateProcessInstance} with the same {@code businessId} for the same definition would be rejected
+ * {@code ALREADY_EXISTS} (pinned in {@code CreateProcessInstanceBusinessIdUniquenessTest}); a
+ * message that resolves to an event-subprocess start carrying that very same in-use {@code
+ * businessId} is not.
+ */
+public final class MessageEventSubprocessBusinessIdTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String MESSAGE_NAME = "message";
+  private static final String EVENT_SUBPROCESS_START = "event-subprocess-start";
+
+  // A non-interrupting event subprocess started by a message event, on a process whose main flow
+  // parks on a service task so the instance stays active. The event-subprocess subscription is
+  // opened (carrying the instance's businessId captured at OPEN time) as soon as the instance
+  // activates, exactly like a catch/boundary subscription.
+  private static final BpmnModelInstance EVENT_SUBPROCESS_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .eventSubProcess(
+              "event-subprocess",
+              s ->
+                  s.startEvent(EVENT_SUBPROCESS_START)
+                      .interrupting(false)
+                      .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKeyExpression("key"))
+                      .serviceTask("sub-task", t -> t.zeebeJobType("sub"))
+                      .endEvent())
+          .startEvent()
+          .serviceTask("main-task", t -> t.zeebeJobType("main"))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+
+  @Test
+  public void shouldTriggerEventSubprocessStartForMessageWithInUseBusinessIdWithoutUniqueness() {
+    // given an active instance holding businessId "biz-42" with an event-subprocess message start.
+    // A second top-level create with this businessId for this definition would be rejected
+    // ALREADY_EXISTS (CreateProcessInstanceBusinessIdUniquenessTest); the event-subprocess
+    // correlation below must not be.
+    final long processInstanceKey = deployAndAwaitSubscription("biz-42", "order-1");
+
+    // when a message carrying that same in-use businessId is published
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("order-1")
+        .withBusinessId("biz-42")
+        .publish();
+
+    // then the event subprocess start fires on the already-running instance — the observable proof
+    // that the uniqueness machinery was not engaged: a message carrying an in-use businessId
+    // correlated into the existing instance instead of being treated as a guarded new root start.
+    // The CORRELATED subscription carries the instance's businessId.
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId(EVENT_SUBPROCESS_START)
+                .getFirst())
+        .isNotNull();
+    assertThat(correlatedRecord(processInstanceKey).getValue().getBusinessId()).isEqualTo("biz-42");
+  }
+
+  @Test
+  public void shouldNotTriggerEventSubprocessStartForMessageWithDifferentBusinessId() {
+    // given
+    final long processInstanceKey = deployAndAwaitSubscription("biz-42", "order-2");
+
+    // when a message with a different businessId is published with TTL=0 for a deterministic
+    // EXPIRED terminal
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("order-2")
+        .withBusinessId("other-biz")
+        .withTimeToLive(0L)
+        .publish();
+
+    // then the event subprocess start never fires
+    final Predicate<Record<?>> messageExpired =
+        r ->
+            r.getIntent() == MessageIntent.EXPIRED
+                && r.getValue() instanceof final MessageRecordValue v
+                && MESSAGE_NAME.equals(v.getName())
+                && "order-2".equals(v.getCorrelationKey());
+    final boolean triggered =
+        RecordingExporter.records()
+            .limit(messageExpired::test)
+            .processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(EVENT_SUBPROCESS_START)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .exists();
+    assertThat(triggered).isFalse();
+  }
+
+  private long deployAndAwaitSubscription(final String businessId, final String correlationKey) {
+    engine.deployment().withXmlResource(EVENT_SUBPROCESS_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId(businessId)
+            .withVariable("key", correlationKey)
+            .create();
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    return processInstanceKey;
+  }
+
+  private static Record<ProcessMessageSubscriptionRecordValue> correlatedRecord(
+      final long processInstanceKey) {
+    return RecordingExporter.processMessageSubscriptionRecords(
+            ProcessMessageSubscriptionIntent.CORRELATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
@@ -193,6 +193,41 @@ public final class MessageStartEventBusinessIdUniquenessTest {
   }
 
   @Test
+  public void shouldAllowSameBusinessIdForMessageStartsInDifferentTenants() {
+    // given the message-start process deployed to two tenants
+    engine.deployment().withTenantId("tenant-a").withXmlResource(MESSAGE_START_PROCESS).deploy();
+    engine.deployment().withTenantId("tenant-b").withXmlResource(MESSAGE_START_PROCESS).deploy();
+
+    // when a message carrying the same businessId is published to each tenant
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("") // empty key so the correlation-key lock is not the gate
+        .withBusinessId("biz-shared")
+        .withTenantId("tenant-a")
+        .withVariables(Map.of("seq", 1))
+        .publish();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-shared")
+        .withTenantId("tenant-b")
+        .withVariables(Map.of("seq", 2))
+        .publish();
+
+    // then both tenants start a PI with the shared businessId — uniqueness is tenant-scoped, so the
+    // same businessId in a different tenant does not collide
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withElementType(BpmnElementType.PROCESS)
+                .limit(2))
+        .allSatisfy(r -> assertThat(r.getValue().getBusinessId()).isEqualTo("biz-shared"))
+        .extracting(r -> r.getValue().getTenantId())
+        .containsExactlyInAnyOrder("tenant-a", "tenant-b");
+  }
+
+  @Test
   public void shouldAllowMessageWithoutBusinessIdEvenWhenBusinessIdIsHeld() {
     // given a PI already holds "biz-42"
     engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -12,8 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -351,6 +353,102 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
             .create();
 
     // then
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withBpmnProcessId(processId)
+                .withTags("secondInstance")
+                .getFirst()
+                .getValue())
+        .hasBusinessId(businessId)
+        .hasProcessInstanceKey(secondProcessInstanceKey);
+  }
+
+  @Test
+  public void shouldRejectCreateProcessInstanceWhenBusinessIdHeldByMessageStartedInstance() {
+    final String processId = helper.getBpmnProcessId();
+    final String messageName = processId + "_msg";
+    final String messageStartJobType = processId + "_msg_job";
+    final String businessId = "biz-123";
+
+    // given an instance started by a message-start event holds the business id for this definition.
+    // This is the converse of the cross-API direction pinned in
+    // MessageStartEventBusinessIdUniquenessTest (a CreateProcessInstance holder blocking a message
+    // start): a message-started instance must hold its business id in the same uniqueness index.
+    ENGINE
+        .deployment()
+        .withXmlResource(dualStartProcess(processId, messageName, messageStartJobType))
+        .deploy();
+    ENGINE
+        .message()
+        .withName(messageName)
+        .withCorrelationKey("start-key")
+        .withBusinessId(businessId)
+        .publish();
+    RecordingExporter.jobRecords(JobIntent.CREATED).withType(messageStartJobType).getFirst();
+
+    // when a CreateProcessInstance with the same business id for the same definition is attempted
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withBusinessId(businessId)
+        .withTags("rejectedInstance")
+        .expectRejection()
+        .create();
+
+    // then it is rejected because the message-started instance already holds the business id
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .onlyCommandRejections()
+                .withTags("rejectedInstance")
+                .withBpmnProcessId(processId)
+                .getFirst())
+        .hasRejectionType(RejectionType.ALREADY_EXISTS)
+        .hasRejectionReason(
+            """
+            Expected to create instance of process with business id '%s', \
+            but an instance with this business id already exists for process definition '%s'"""
+                .formatted(businessId, processId));
+  }
+
+  @Test
+  public void shouldCreateProcessInstanceWithBusinessIdNoLongerInUseDueToMessageStartedHolderEnd() {
+    final String processId = helper.getBpmnProcessId();
+    final String messageName = processId + "_msg";
+    final String messageStartJobType = processId + "_msg_job";
+    final String businessId = "biz-123";
+
+    // given a message-started instance holds the business id (a create with the same business id is
+    // rejected at this point — see the test above)
+    ENGINE
+        .deployment()
+        .withXmlResource(dualStartProcess(processId, messageName, messageStartJobType))
+        .deploy();
+    ENGINE
+        .message()
+        .withName(messageName)
+        .withCorrelationKey("start-key")
+        .withBusinessId(businessId)
+        .publish();
+    final var holderJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED).withType(messageStartJobType).getFirst();
+
+    // when the message-started holder completes, freeing the business id
+    ENGINE.job().withKey(holderJob.getKey()).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(holderJob.getValue().getProcessInstanceKey())
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then a CreateProcessInstance with the same business id now succeeds
+    final var secondProcessInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withBusinessId(businessId)
+            .withTags("secondInstance")
+            .create();
+
     assertThat(
             RecordingExporter.processInstanceCreationRecords()
                 .withIntent(ProcessInstanceCreationIntent.CREATED)
@@ -924,5 +1022,23 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
             Expected to create instance of process with business id '%s', \
             but an instance with this business id already exists for process definition '%s'"""
                 .formatted(businessId, processId));
+  }
+
+  // One definition reachable two ways: a none-start event (used by CreateProcessInstance) and a
+  // message-start event (used by a published message), so a PI started either way contends for the
+  // same business id slot. The message-start arm parks on a service task so the holder stays active
+  // and can be completed deterministically by its job key.
+  private static BpmnModelInstance dualStartProcess(
+      final String processId, final String messageName, final String messageStartJobType) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent("none-start")
+        .userTask("none-task", AbstractUserTaskBuilder::zeebeUserTask)
+        .endEvent()
+        .moveToProcess(processId)
+        .startEvent("message-start")
+        .message(messageName)
+        .serviceTask("message-task", t -> t.zeebeJobType(messageStartJobType))
+        .endEvent()
+        .done();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
@@ -93,6 +93,11 @@ public final class MessageCorrelationClient {
     return this;
   }
 
+  public MessageCorrelationClient withBusinessId(final String businessId) {
+    messageCorrelationRecord.setBusinessId(businessId);
+    return this;
+  }
+
   public MessageCorrelationClient onPartition(final int partitionId) {
     this.partitionId = partitionId;
     return this;


### PR DESCRIPTION
## Description

Extends the engine-level integration test suite for message `businessId` correlation by adding the missing scenarios identified in the issue:

### New coverage

**`MessageCorrelationBusinessIdTest`**
- **`CorrelateMessage` command path**: the asymmetric businessId filter must hold for the explicit `CorrelateMessage` command (a distinct engine entry point from `PublishMessage`/`MessageRecord`). Three scenarios added:
  - Matching businessId → process completes
  - No businessId on command → still correlates to a subscription that has one (asymmetric rule)
  - Mismatching businessId → `NOT_FOUND` rejection
- **Interrupting boundary message events**: matching, asymmetric (no-businessId message), and mismatching businessId scenarios
- **Non-interrupting boundary message events**: matching and mismatching businessId scenarios
- Helper `correlatedSubscriptionBusinessId()` to assert the businessId captured in the CORRELATED record

**`MessageEventSubprocessBusinessIdTest`** _(new file)_
- Verifies that a message-start event inside an **event subprocess** behaves as a catch-style filter — no start-event uniqueness applies. A message carrying an in-use businessId must trigger the event subprocess start without triggering an `ALREADY_EXISTS` rejection.
- Tests run with `businessIdUniquenessEnabled = true` to ensure the no-uniqueness guarantee is not trivially satisfied.

**`MessageStartEventBusinessIdUniquenessTest`**
- **Multi-tenant isolation**: the same businessId in two different tenants must not collide — each tenant starts its own process instance.

**`CreateProcessInstanceBusinessIdUniquenessTest`**
- **Cross-API uniqueness (message-start → CreateProcessInstance)**: a message-started instance holding a businessId must block a subsequent `CreateProcessInstance` call with the same businessId for the same definition.
- **Release after message-started holder ends**: once the message-started holder completes, the businessId slot is freed and a `CreateProcessInstance` with the same businessId now succeeds.

**`MessageCorrelationClient`**
- Exposes `withBusinessId(String)` so tests can drive the `CorrelateMessage` command with an explicit businessId.

## Related issues

closes #55502