### PR TITLE
deps: bump Spring version to resolve CVE-2026-41846

### DIFF
--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -24,7 +24,7 @@
     <version.java>17</version.java>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
     <!-- Override Spring Boot version for 3.x compatibility -->
-    <version.spring-boot>3.5.14</version.spring-boot>
+    <version.spring-boot>3.5.15</version.spring-boot>
     <!-- Spring Framework 6.x is required for Spring Boot 3.x -->
     <version.spring>6.2.19</version.spring>
     <version.roaster>2.31.0.Final</version.roaster>

--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -26,7 +26,7 @@
     <!-- Override Spring Boot version for 3.x compatibility -->
     <version.spring-boot>3.5.14</version.spring-boot>
     <!-- Spring Framework 6.x is required for Spring Boot 3.x -->
-    <version.spring>6.2.18</version.spring>
+    <version.spring>6.2.19</version.spring>
     <version.roaster>2.31.0.Final</version.roaster>
     <version.aspectjweaver>1.9.25.1</version.aspectjweaver>
     <generated.test.sources.path>${project.build.directory}/generated-test-sources/java</generated.test.sources.path>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -112,7 +112,7 @@
     <version.feel-scala>1.21.0</version.feel-scala>
     <version.dmn-scala>1.12.0</version.dmn-scala>
     <version.rest-assured>6.0.0</version.rest-assured>
-    <version.spring>7.0.7</version.spring>
+    <version.spring>7.0.8</version.spring>
     <version.spring-security>7.0.6</version.spring-security>
     <version.spring-boot>4.0.6</version.spring-boot>
     <version.spring-ai>2.0.0-M7</version.spring-ai>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -114,7 +114,7 @@
     <version.rest-assured>6.0.0</version.rest-assured>
     <version.spring>7.0.8</version.spring>
     <version.spring-security>7.0.6</version.spring-security>
-    <version.spring-boot>4.0.6</version.spring-boot>
+    <version.spring-boot>4.0.7</version.spring-boot>
     <version.spring-ai>2.0.0-M7</version.spring-ai>
     <version.mcp-sdk>2.0.0-M3</version.mcp-sdk>
     <version.jsonschema-generator>5.0.0</version.jsonschema-generator>

--- a/testing/camunda-process-test-spring-boot-3/pom.xml
+++ b/testing/camunda-process-test-spring-boot-3/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <version.java>17</version.java>
     <!-- Override Spring Boot version for 3.x compatibility -->
-    <version.spring-boot>3.5.14</version.spring-boot>
+    <version.spring-boot>3.5.15</version.spring-boot>
     <!-- Spring Framework 6.x is required for Spring Boot 3.x -->
     <version.spring>6.2.19</version.spring>
   </properties>

--- a/testing/camunda-process-test-spring-boot-3/pom.xml
+++ b/testing/camunda-process-test-spring-boot-3/pom.xml
@@ -18,7 +18,7 @@
     <!-- Override Spring Boot version for 3.x compatibility -->
     <version.spring-boot>3.5.14</version.spring-boot>
     <!-- Spring Framework 6.x is required for Spring Boot 3.x -->
-    <version.spring>6.2.18</version.spring>
+    <version.spring>6.2.19</version.spring>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Description

Bump Spring versions to resolve CVE-2026-41846 and CVE-2026-41711.

- **CVE-2026-41846** — XSS via unescaped CSS attributes in JSP form tags (CVSS 6.1 Medium)
- **CVE-2026-41711** — DoS via StackOverflowException when parsing Sort parameters (CVSS 5.9 Medium)

| File | Change |
|---|---|
| `parent/pom.xml` | `version.spring` 7.0.7 → 7.0.8, `version.spring-boot` 4.0.6 → 4.0.7 |
| `clients/camunda-spring-boot-3-starter/pom.xml` | `version.spring` 6.2.18 → 6.2.19, `version.spring-boot` 3.5.14 → 3.5.15 |
| `testing/camunda-process-test-spring-boot-3/pom.xml` | `version.spring` 6.2.18 → 6.2.19, `version.spring-boot` 3.5.14 → 3.5.15 |

## Related issues

closes #55659