### PR TITLE
deps: bump Spring version to resolve CVE-2026-41846

### DIFF
--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -24,7 +24,7 @@
     <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
     <!-- Override Spring Boot version for 4.x compatibility -->
-    <version.spring-boot>4.0.6</version.spring-boot>
+    <version.spring-boot>4.0.7</version.spring-boot>
     <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
     <version.spring>7.0.8</version.spring>
     <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -26,7 +26,7 @@
     <!-- Override Spring Boot version for 4.x compatibility -->
     <version.spring-boot>4.0.6</version.spring-boot>
     <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
-    <version.spring>7.0.7</version.spring>
+    <version.spring>7.0.8</version.spring>
     <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->
     <version.junit>6.0.3</version.junit>
     <spring-boot-starter-camunda-sdk.sourcedir>${project.basedir}/../spring-boot-starter-camunda-sdk/src</spring-boot-starter-camunda-sdk.sourcedir>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -102,7 +102,7 @@
     <version.spring-security>6.5.11</version.spring-security>
     <!--  Adding spring-security.version to ensure Spring Boot's BOM honors the override regardless of import order.  -->
     <spring-security.version>${version.spring-security}</spring-security.version>
-    <version.spring-boot>3.5.14</version.spring-boot>
+    <version.spring-boot>3.5.15</version.spring-boot>
     <version.tomcat>10.1.55</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,7 +98,7 @@
     <version.feel-scala>1.18.5</version.feel-scala>
     <version.dmn-scala>1.10.1</version.dmn-scala>
     <version.rest-assured>5.5.7</version.rest-assured>
-    <version.spring>6.2.18</version.spring>
+    <version.spring>6.2.19</version.spring>
     <version.spring-security>6.5.11</version.spring-security>
     <!--  Adding spring-security.version to ensure Spring Boot's BOM honors the override regardless of import order.  -->
     <spring-security.version>${version.spring-security}</spring-security.version>

--- a/testing/camunda-process-test-spring-4/pom.xml
+++ b/testing/camunda-process-test-spring-4/pom.xml
@@ -33,7 +33,7 @@
     <!-- Override Spring Boot version for 4.x compatibility -->
     <version.spring-boot>4.0.3</version.spring-boot>
     <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
-    <version.spring>7.0.5</version.spring>
+    <version.spring>7.0.8</version.spring>
     <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->
     <version.junit>6.0.3</version.junit>
   </properties>

--- a/testing/camunda-process-test-spring-4/pom.xml
+++ b/testing/camunda-process-test-spring-4/pom.xml
@@ -31,7 +31,7 @@
     <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
     <!-- Override Spring Boot version for 4.x compatibility -->
-    <version.spring-boot>4.0.3</version.spring-boot>
+    <version.spring-boot>4.0.6</version.spring-boot>
     <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
     <version.spring>7.0.8</version.spring>
     <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->

--- a/testing/camunda-process-test-spring-4/pom.xml
+++ b/testing/camunda-process-test-spring-4/pom.xml
@@ -31,7 +31,7 @@
     <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
     <!-- Override Spring Boot version for 4.x compatibility -->
-    <version.spring-boot>4.0.6</version.spring-boot>
+    <version.spring-boot>4.0.7</version.spring-boot>
     <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
     <version.spring>7.0.8</version.spring>
     <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->


### PR DESCRIPTION
## Description

Bump Spring versions to resolve CVE-2026-41846 and CVE-2026-41711.

- **CVE-2026-41846** — XSS via unescaped CSS attributes in JSP form tags (CVSS 6.1 Medium)
- **CVE-2026-41711** — DoS via StackOverflowException when parsing Sort parameters (CVSS 5.9 Medium)

| File | Change |
|---|---|
| `parent/pom.xml` | `version.spring` 6.2.18 → 6.2.19, `version.spring-boot` 3.5.14 → 3.5.15 |
| `clients/camunda-spring-boot-4-starter/pom.xml` | `version.spring` 7.0.7 → 7.0.8, `version.spring-boot` 4.0.6 → 4.0.7 |
| `testing/camunda-process-test-spring-4/pom.xml` | `version.spring` 7.0.5 → 7.0.8, `version.spring-boot` 4.0.3 → 4.0.7 |

## Related issues

closes #55659