### PR TITLE
fix: pin stable load-test orchestration images to latest patch release

### DIFF
--- a/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
@@ -276,7 +276,7 @@ zeebe:
   image:
     registry: docker.io
     repository: camunda/zeebe
-    tag: 8.7-SNAPSHOT
+    tag: "8.7.33"
   # ClusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
   # PartitionCount defines how many zeebe partitions are set up in the cluster
@@ -395,7 +395,7 @@ zeebeGateway:
     # Image.registry defines which image registry to use
     registry: docker.io
     # Image.tag defines the tag / version which should be used in the chart
-    tag: 8.7-SNAPSHOT
+    tag: "8.7.33"
   # LogLevel defines the log level which is used by the gateway
   logLevel: debug
 

--- a/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
@@ -236,7 +236,7 @@ orchestration:
   image:
     registry: docker.io
     repository: camunda/camunda
-    tag: "8.8-SNAPSHOT"
+    tag: "8.8.28"
   ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
   ## @param core.partitionCount defines how many partitions are set up in the cluster

--- a/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
@@ -203,7 +203,7 @@ orchestration:
   image:
     registry: docker.io
     repository: camunda/camunda
-    tag: "SNAPSHOT"
+    tag: "8.9.9"
   ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
   ## @param core.partitionCount defines how many partitions are set up in the cluster


### PR DESCRIPTION
## Problem

Stable load-test setups (`stable-87`, `stable-88`, `stable-89`) used SNAPSHOT image tags for the orchestration engine. SNAPSHOT is mutable — a pod rescheduled mid-test (e.g. spot-VM preemption) re-pulls the tag and can land on a newer build, silently drifting the engine version under test. Even worse, the load test setups are not compatible with the latest snapshot, so this wouldn't work anyway.

## Change

Pin each stable configuration to the last known patch release:
- `stable-87`: `camunda/zeebe:8.7.33` (both `zeebe` and `zeebeGateway` components)
- `stable-88`: `camunda/camunda:8.8.28`
- `stable-89`: `camunda/camunda:8.9.9`

This is simpler than digest-pinning via a script: tags are explicit in the YAML, the change is visible in diffs, and there is no tooling dependency at scaffold time. Update these manually after new patch releases.

The internal-registry images (`registry.camunda.cloud/team-zeebe`) are unchanged — those cover load-test starter/worker images that have no versioned releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)