### PR TITLE
[Backport stable/8.8] feat: retry Reindex-by-ID with smaller batch sizes

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -209,7 +209,7 @@ public class ExporterConfiguration {
     private String usageMetricsRolloverInterval = "1M";
     private Integer rolloverBatchSize;
     private int reindexBatchSize = 2500;
-    private int archiveByIdMaxRetryAttempts = 3;
+    private int archiveByIdMaxRetryAttempts = 2;
     private int archiveByIdRetryDelayMs = 1000;
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -209,7 +209,7 @@ public class ExporterConfiguration {
     private String usageMetricsRolloverInterval = "1M";
     private Integer rolloverBatchSize;
     private int reindexBatchSize = 2500;
-    private int archiveByIdMaxRetryAttempts = 2;
+    private int archiveByIdMaxRetryAttempts = 3;
     private int archiveByIdRetryDelayMs = 1000;
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -27,8 +27,8 @@ import org.slf4j.Logger;
 
 public class ArchiveByIdTaskSupplier<SortFieldType> {
 
-  public static final int MINIMUM_BATCH_SIZE = 50;
-  public static final double BATCH_SIZE_REDUCTION_FACTOR = 0.5;
+  private static final int MINIMUM_BATCH_SIZE = 50;
+  private static final double BATCH_SIZE_REDUCTION_FACTOR = 0.5;
 
   private final HistoryConfiguration config;
   private final String sourceIdx;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -107,7 +107,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
                       ex -> {
                         if (isRetryableError(ex)
                             && retryCount.incrementAndGet()
-                                < config.getArchiveByIdMaxRetryAttempts()) {
+                                <= config.getArchiveByIdMaxRetryAttempts()) {
                           metrics.recordArchiverBatchRetry();
                           logger.trace(
                               "Encountered retryable error when archiving docs from '{}' to '{}', "

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.slf4j.Logger;
 
@@ -31,7 +30,8 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
   private final HistoryConfiguration config;
   private final String sourceIdx;
   private final String destinationIdx;
-  private final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
+  private final BiFunction<
+          List<SortFieldType>, Integer, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
       idsSupplier;
   private final TriFunction<String, String, List<IdWithRouting>, CompletableFuture<Long>> reindexer;
   private final BiFunction<String, List<IdWithRouting>, CompletableFuture<Long>> deleter;
@@ -51,7 +51,8 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
       final HistoryConfiguration config,
       final String sourceIdx,
       final String destinationIdx,
-      final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
+      final BiFunction<
+              List<SortFieldType>, Integer, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
           idsSupplier,
       final TriFunction<String, String, List<IdWithRouting>, CompletableFuture<Long>> reindexer,
       final BiFunction<String, List<IdWithRouting>, CompletableFuture<Long>> deleter,
@@ -84,7 +85,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
   public CompletableFuture<Long> moveNextBatch() {
     final Stopwatch stopwatch = Stopwatch.createStarted();
     return idsSupplier
-        .apply(getLastSearchPosition())
+        .apply(getLastSearchPosition(), getBatchSize())
         .thenComposeAsync(
             response -> {
               if (response.isEmpty()) {
@@ -111,11 +112,12 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
                           metrics.recordArchiverBatchRetry();
                           logger.trace(
                               "Encountered retryable error when archiving docs from '{}' to '{}', "
-                                  + "retrying the batch (attempt {}/{}). Error: {}",
+                                  + "retrying the batch (next attempt {}/{} will use batch size {}). Error: {}",
                               sourceIdx,
                               destinationIdx,
                               retryCount.get(),
                               config.getArchiveByIdMaxRetryAttempts(),
+                              getBatchSize(),
                               ex.getMessage());
 
                           // Whilst this is crude, we exploit the fact the ES/OS visibility is
@@ -148,6 +150,11 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
   private List<SortFieldType> getLastSearchPosition() {
     final ArchiveDocIdsBatch<SortFieldType> lstResponse = lastSearchResponse.get();
     return lstResponse == null ? List.of() : lstResponse.searchAfter();
+  }
+
+  private int getBatchSize() {
+    // reduce the batch size on every retry to increase the chance of success
+    return Math.max(1, config.getReindexBatchSize() / (retryCount.get() + 1));
   }
 
   private CompletableFuture<Long> reindex(final ArchiveDocIdsBatch<SortFieldType> response) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 public class ArchiveByIdTaskSupplier<SortFieldType> {
 
   public static final int MINIMUM_BATCH_SIZE = 50;
-  public static final double BATCH_SIZE_REDUCTION_RATIO = 0.5;
+  public static final double BATCH_SIZE_REDUCTION_FACTOR = 0.5;
 
   private final HistoryConfiguration config;
   private final String sourceIdx;
@@ -115,9 +115,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
                             && retryCount.incrementAndGet()
                                 <= config.getArchiveByIdMaxRetryAttempts()) {
                           metrics.recordArchiverBatchRetry();
-                          if (shouldReduceBatchSize(ex)) {
-                            reduceBatchSize();
-                          }
+                          adjustBatchSize(ex);
 
                           logger.trace(
                               "Encountered retryable error when archiving docs from '{}' to '{}', "
@@ -161,10 +159,15 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
     return lstResponse == null ? List.of() : lstResponse.searchAfter();
   }
 
-  private void reduceBatchSize() {
-    batchSize.updateAndGet(
-        currentSize ->
-            (int) Math.max(MINIMUM_BATCH_SIZE, currentSize * BATCH_SIZE_REDUCTION_RATIO));
+  private void adjustBatchSize(final Throwable ex) {
+    if (batchSize.get() <= MINIMUM_BATCH_SIZE) {
+      return;
+    }
+
+    if (shouldReduceBatchSize(ex)) {
+      batchSize.set(
+          (int) Math.max(MINIMUM_BATCH_SIZE, batchSize.get() * BATCH_SIZE_REDUCTION_FACTOR));
+    }
   }
 
   private CompletableFuture<Long> reindex(final ArchiveDocIdsBatch<SortFieldType> response) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -27,6 +27,9 @@ import org.slf4j.Logger;
 
 public class ArchiveByIdTaskSupplier<SortFieldType> {
 
+  public static final int MINIMUM_BATCH_SIZE = 50;
+  public static final double BATCH_SIZE_REDUCTION_RATIO = 0.5;
+
   private final HistoryConfiguration config;
   private final String sourceIdx;
   private final String destinationIdx;
@@ -43,6 +46,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
       new AtomicReference<>(null);
   private final AtomicBoolean finished = new AtomicBoolean(false);
   private final AtomicInteger retryCount = new AtomicInteger(0);
+  private final AtomicInteger batchSize = new AtomicInteger(0);
 
   private final AtomicLong totalArchived = new AtomicLong(0);
   private final AtomicLong totalTimeTakenMs = new AtomicLong(0);
@@ -68,6 +72,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
     this.executor = executor;
     this.metrics = metrics;
     this.logger = logger;
+    batchSize.set(config.getReindexBatchSize());
   }
 
   public boolean isComplete() {
@@ -85,7 +90,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
   public CompletableFuture<Long> moveNextBatch() {
     final Stopwatch stopwatch = Stopwatch.createStarted();
     return idsSupplier
-        .apply(getLastSearchPosition(), getBatchSize())
+        .apply(getLastSearchPosition(), batchSize.get())
         .thenComposeAsync(
             response -> {
               if (response.isEmpty()) {
@@ -110,14 +115,18 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
                             && retryCount.incrementAndGet()
                                 <= config.getArchiveByIdMaxRetryAttempts()) {
                           metrics.recordArchiverBatchRetry();
+                          if (shouldReduceBatchSize(ex)) {
+                            reduceBatchSize();
+                          }
+
                           logger.trace(
                               "Encountered retryable error when archiving docs from '{}' to '{}', "
-                                  + "retrying the batch (next attempt {}/{} will use batch size {}). Error: {}",
+                                  + "retrying the batch (attempt {}/{}). Next batch size {}. Error: {}",
                               sourceIdx,
                               destinationIdx,
                               retryCount.get(),
                               config.getArchiveByIdMaxRetryAttempts(),
-                              getBatchSize(),
+                              batchSize.get(),
                               ex.getMessage());
 
                           // Whilst this is crude, we exploit the fact the ES/OS visibility is
@@ -152,9 +161,10 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
     return lstResponse == null ? List.of() : lstResponse.searchAfter();
   }
 
-  private int getBatchSize() {
-    // reduce the batch size on every retry to increase the chance of success
-    return Math.max(1, config.getReindexBatchSize() / (retryCount.get() + 1));
+  private void reduceBatchSize() {
+    batchSize.updateAndGet(
+        currentSize ->
+            (int) Math.max(MINIMUM_BATCH_SIZE, currentSize * BATCH_SIZE_REDUCTION_RATIO));
   }
 
   private CompletableFuture<Long> reindex(final ArchiveDocIdsBatch<SortFieldType> response) {
@@ -184,6 +194,12 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
               operation, sourceIdx, processedCount, expectedCount));
     }
     return processedCount;
+  }
+
+  private boolean shouldReduceBatchSize(final Throwable thr) {
+    return thr != null
+        && thr.getCause() != null
+        && thr.getCause() instanceof SocketTimeoutException;
   }
 
   private boolean isRetryableError(final Throwable thr) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -29,6 +29,12 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
 
   private static final int MINIMUM_BATCH_SIZE = 50;
   private static final double BATCH_SIZE_REDUCTION_FACTOR = 0.5;
+  private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS =
+      List.of(
+          SocketTimeoutException.class,
+          ElasticsearchException.class,
+          OpenSearchException.class,
+          BatchCountMismatchException.class);
 
   private final HistoryConfiguration config;
   private final String sourceIdx;
@@ -46,7 +52,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
       new AtomicReference<>(null);
   private final AtomicBoolean finished = new AtomicBoolean(false);
   private final AtomicInteger retryCount = new AtomicInteger(0);
-  private final AtomicInteger batchSize = new AtomicInteger(0);
+  private final AtomicInteger batchSize;
 
   private final AtomicLong totalArchived = new AtomicLong(0);
   private final AtomicLong totalTimeTakenMs = new AtomicLong(0);
@@ -72,7 +78,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
     this.executor = executor;
     this.metrics = metrics;
     this.logger = logger;
-    batchSize.set(config.getReindexBatchSize());
+    batchSize = new AtomicInteger(config.getReindexBatchSize());
   }
 
   public boolean isComplete() {
@@ -200,19 +206,17 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
   }
 
   private boolean shouldReduceBatchSize(final Throwable thr) {
-    return thr != null
-        && thr.getCause() != null
-        && thr.getCause() instanceof SocketTimeoutException;
+    return matchesThrowableOrCause(thr, SocketTimeoutException.class);
   }
 
   private boolean isRetryableError(final Throwable thr) {
-    if (thr != null && thr.getCause() != null) {
-      return thr.getCause() instanceof SocketTimeoutException
-          || thr.getCause() instanceof ElasticsearchException
-          || thr.getCause() instanceof OpenSearchException
-          || thr.getCause() instanceof BatchCountMismatchException;
-    }
-    return false;
+    return RETRYABLE_EXCEPTIONS.stream().anyMatch(clazz -> matchesThrowableOrCause(thr, clazz));
+  }
+
+  private boolean matchesThrowableOrCause(
+      final Throwable thr, final Class<? extends Throwable> throwableClass) {
+    return thr != null
+        && (throwableClass.isInstance(thr) || throwableClass.isInstance(thr.getCause()));
   }
 
   public record ArchiveDocIdsBatch<T>(List<IdWithRouting> documents, List<T> searchAfter) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -433,7 +433,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final Map<String, String> inclusionFilters,
       final Map<String, String> exclusionFilters,
       final List<FieldValue> searchAfter,
-      final Integer size) {
+      final int size) {
     final Query query = buildFilterQuery(idFieldName, ids, inclusionFilters, exclusionFilters);
     final SearchRequest.Builder requestBuilder =
         new SearchRequest.Builder()

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -350,14 +350,15 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             config,
             sourceIndexName,
             destinationIndexName,
-            searchAfter ->
+            (searchAfter, size) ->
                 getArchiveDocIdsBatch(
                     sourceIndexName,
                     idFieldName,
                     ids,
                     inclusionFilters,
                     exclusionFilters,
-                    searchAfter),
+                    searchAfter,
+                    size),
             this::reindexDocumentsById,
             this::deleteDocumentsById,
             executor,
@@ -431,7 +432,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final List<String> ids,
       final Map<String, String> inclusionFilters,
       final Map<String, String> exclusionFilters,
-      final List<FieldValue> searchAfter) {
+      final List<FieldValue> searchAfter,
+      final Integer size) {
     final Query query = buildFilterQuery(idFieldName, ids, inclusionFilters, exclusionFilters);
     final SearchRequest.Builder requestBuilder =
         new SearchRequest.Builder()
@@ -440,7 +442,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             .allowNoIndices(true)
             .ignoreUnavailable(true)
             .query(query)
-            .size(config.getReindexBatchSize())
+            .size(size)
             .source(s -> s.fetch(false))
             .sort(SortOptions.of(s -> s.field(f -> f.field("id").order(SortOrder.Asc))));
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -352,14 +352,15 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             config,
             sourceIndexName,
             destinationIndexName,
-            searchAfter ->
+            (searchAfter, size) ->
                 getArchiveDocIdsBatch(
                     sourceIndexName,
                     idFieldName,
                     ids,
                     inclusionFilters,
                     exclusionFilters,
-                    searchAfter),
+                    searchAfter,
+                    size),
             this::reindexDocumentsById,
             this::deleteDocumentsById,
             executor,
@@ -437,7 +438,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final List<String> ids,
       final Map<String, String> inclusionFilters,
       final Map<String, String> exclusionFilters,
-      final List<FieldValue> searchAfter) {
+      final List<FieldValue> searchAfter,
+      final Integer size) {
     final Query query = buildFilterQuery(idFieldName, ids, inclusionFilters, exclusionFilters);
     final SearchRequest.Builder requestBuilder =
         new SearchRequest.Builder()
@@ -446,7 +448,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             .allowNoIndices(true)
             .ignoreUnavailable(true)
             .query(query)
-            .size(config.getReindexBatchSize())
+            .size(size)
             .source(s -> s.fetch(false))
             .sort(sort -> sort.field(field -> field.field("id").order(SortOrder.Asc)));
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -439,7 +439,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final Map<String, String> inclusionFilters,
       final Map<String, String> exclusionFilters,
       final List<FieldValue> searchAfter,
-      final Integer size) {
+      final int size) {
     final Query query = buildFilterQuery(idFieldName, ids, inclusionFilters, exclusionFilters);
     final SearchRequest.Builder requestBuilder =
         new SearchRequest.Builder()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -228,8 +228,8 @@ class ArchiveByIdTaskSupplierTest {
 
   @Test
   void shouldReduceReindexBatchSizeAfterEachRetry() {
-    // given - maxRetryAttempts=3: retries while retryCount < 3, so 2 retries before the 3rd
-    // failure throws. Reindex fails on calls 1 and 2, succeeds from call 3 onward.
+    // given - maxRetryAttempts=3: allows up to 3 retries (throws on the 4th consecutive failure).
+    // Reindex fails on calls 1 and 2, succeeds from call 3 onward.
     final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
     final var reindexCallCount = new AtomicInteger(0);
     final var batchSize = new AtomicInteger(0);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -19,6 +19,7 @@ import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsB
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import java.net.SocketTimeoutException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -229,7 +230,7 @@ class ArchiveByIdTaskSupplierTest {
   @Test
   void shouldReduceReindexBatchSizeAfterEachRetry() {
     // given - maxRetryAttempts=3: allows up to 3 retries (throws on the 4th consecutive failure).
-    // Reindex fails on calls 1 and 2, succeeds from call 3 onward.
+    // Reindex fails on calls 1, 2, and 5, succeeds on other calls.
     final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
     final var reindexCallCount = new AtomicInteger(0);
     final var batchSize = new AtomicInteger(0);
@@ -245,7 +246,7 @@ class ArchiveByIdTaskSupplierTest {
                   ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1")));
             },
             (source, dest, ids) -> {
-              if (reindexCallCount.incrementAndGet() <= 2) {
+              if (Set.of(1, 2, 5).contains(reindexCallCount.incrementAndGet())) {
                 return CompletableFuture.failedFuture(retryableError);
               }
               return CompletableFuture.completedFuture((long) ids.size());
@@ -255,21 +256,29 @@ class ArchiveByIdTaskSupplierTest {
             metrics,
             LOGGER);
 
-    // when - attempt 1 fails (retryCount: 0→1), full batch size used
+    // when - attempt 1 fails, full batch size used
     assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
     assertThat(batchSize.get()).isEqualTo(1200);
 
-    // when - attempt 2 fails (retryCount: 1→2), batch size halved
+    // when - attempt 2 fails, batch size was halved
     assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
     assertThat(batchSize.get()).isEqualTo(600);
 
-    // when - attempt 3 succeeds (retryCount=2 at fetch → size/3), then resets to 0
+    // when - attempt 3 succeeds, batch size was halved again
     assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
-    assertThat(batchSize.get()).isEqualTo(400);
+    assertThat(batchSize.get()).isEqualTo(300);
 
-    // when - next batch after success starts at full size again (retryCount reset to 0)
+    // when - attempt 4 successful, batch size is kept
     assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
-    assertThat(batchSize.get()).isEqualTo(1200);
+    assertThat(batchSize.get()).isEqualTo(300);
+
+    // when - attempt 5 fails, current batch size used
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(batchSize.get()).isEqualTo(300);
+
+    // when - attempt 6 succeeds, batch size was halved
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(batchSize.get()).isEqualTo(150);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -17,6 +17,7 @@ import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.BatchCountMismatchException;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import java.net.SocketTimeoutException;
 import java.util.List;
@@ -30,8 +31,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.opensearch.client.opensearch._types.ErrorCause;
-import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,24 +44,20 @@ class ArchiveByIdTaskSupplierTest {
 
   static Stream<Throwable> retryableErrors() {
     return Stream.of(
-        new SocketTimeoutException("timeout"),
-        new ElasticsearchException(
-            "endpoint1",
-            co.elastic.clients.elasticsearch._types.ErrorResponse.of(
-                e -> e.error(ec -> ec.type("test_exception").reason("test reason")).status(500))),
-        new OpenSearchException(
-            ErrorResponse.of(
-                e ->
-                    e.error(ErrorCause.of(ec -> ec.type("test_exception").reason("test reason")))
-                        .status(500))),
-        new ArchiveByIdTaskSupplier.BatchCountMismatchException("reindex", "count mismatch"));
+        new CompletionException(mock(SocketTimeoutException.class)),
+        new CompletionException(mock(ElasticsearchException.class)),
+        new CompletionException(mock(OpenSearchException.class)),
+        new CompletionException(mock(BatchCountMismatchException.class)),
+        mock(SocketTimeoutException.class),
+        mock(ElasticsearchException.class),
+        mock(OpenSearchException.class),
+        mock(BatchCountMismatchException.class));
   }
 
   @ParameterizedTest
   @MethodSource("retryableErrors")
-  void shouldRetryOnRetryableErrorAndRecordMetric(final Throwable cause) {
+  void shouldRetryOnRetryableErrorAndRecordMetric(final Throwable retryableError) {
     // given
-    final var retryableError = new CompletionException(cause);
     final var reindexCallCount = new AtomicInteger(0);
 
     final var taskSupplier =
@@ -360,8 +355,7 @@ class ArchiveByIdTaskSupplierTest {
   void shouldNotReduceBatchSizeForNonSocketTimeoutRetryableError() {
     // given - retryable error that is NOT a SocketTimeoutException
     final var batchMismatchError =
-        new CompletionException(
-            new ArchiveByIdTaskSupplier.BatchCountMismatchException("reindex", "count mismatch"));
+        new CompletionException(new BatchCountMismatchException("reindex", "count mismatch"));
     final var reindexCallCount = new AtomicInteger(0);
     final var batchSize = new AtomicInteger(0);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
@@ -25,7 +26,13 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch._types.ErrorResponse;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,10 +43,26 @@ class ArchiveByIdTaskSupplierTest {
 
   private final CamundaExporterMetrics metrics = mock(CamundaExporterMetrics.class);
 
-  @Test
-  void shouldRetryOnRetryableErrorAndRecordMetric() {
+  static Stream<Throwable> retryableErrors() {
+    return Stream.of(
+        new SocketTimeoutException("timeout"),
+        new ElasticsearchException(
+            "endpoint1",
+            co.elastic.clients.elasticsearch._types.ErrorResponse.of(
+                e -> e.error(ec -> ec.type("test_exception").reason("test reason")).status(500))),
+        new OpenSearchException(
+            ErrorResponse.of(
+                e ->
+                    e.error(ErrorCause.of(ec -> ec.type("test_exception").reason("test reason")))
+                        .status(500))),
+        new ArchiveByIdTaskSupplier.BatchCountMismatchException("reindex", "count mismatch"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("retryableErrors")
+  void shouldRetryOnRetryableErrorAndRecordMetric(final Throwable cause) {
     // given
-    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+    final var retryableError = new CompletionException(cause);
     final var reindexCallCount = new AtomicInteger(0);
 
     final var taskSupplier =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -87,12 +87,12 @@ class ArchiveByIdTaskSupplierTest {
 
   @Test
   void shouldThrowWhenMaxRetriesExceeded() {
-    // given - maxRetryCount of 2, so only 1 retry is allowed
+    // given - maxRetryCount of 1, so only 1 retry is allowed
     final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
 
     final var taskSupplier =
         new ArchiveByIdTaskSupplier<>(
-            historyConfigWithMaxRetry(2),
+            historyConfigWithMaxRetry(1),
             "source-idx",
             "destination-idx",
             searchAfter ->
@@ -104,12 +104,12 @@ class ArchiveByIdTaskSupplierTest {
             metrics,
             LOGGER);
 
-    // when - first call retries (retryCount becomes 1, which is < maxRetryCount 2)
+    // when - first call retries (retryCount becomes 1, which is <= maxRetryCount 1)
     final var firstResult = taskSupplier.moveNextBatch().join();
     assertThat(firstResult).isEqualTo(0L);
     verify(metrics, times(1)).recordArchiverBatchRetry();
 
-    // when - second call exceeds max retries (retryCount becomes 2, which is NOT < 2)
+    // when - second call exceeds max retries (retryCount becomes 2, which is NOT <= 1)
     final var future = taskSupplier.moveNextBatch();
 
     // then - should throw
@@ -170,14 +170,14 @@ class ArchiveByIdTaskSupplierTest {
 
   @Test
   void shouldResetRetryCountAfterSuccessfulBatch() {
-    // given - maxRetryAttempts=3 means 2 retries allowed before throwing on the 3rd failure.
+    // given - maxRetryAttempts=2 means 2 retries allowed before throwing on the 3rd failure.
     // reindex calls 1, 3, 4, 5, 6 fail; calls 2, 7 succeed.
     final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
     final var reindexCallCount = new AtomicInteger(0);
 
     final var taskSupplier =
         new ArchiveByIdTaskSupplier<>(
-            historyConfigWithMaxRetry(3),
+            historyConfigWithMaxRetry(2),
             "source-idx",
             "destination-idx",
             searchAfter ->
@@ -212,7 +212,7 @@ class ArchiveByIdTaskSupplierTest {
     assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
     verify(metrics, times(3)).recordArchiverBatchRetry();
 
-    // call 5 fails (retryCount=3, NOT < maxRetryAttempts 3) — throws and resets retryCount
+    // call 5 fails (retryCount=3, NOT <= maxRetryAttempts 2) — throws and resets retryCount
     assertThatThrownBy(() -> taskSupplier.moveNextBatch().join())
         .isInstanceOf(CompletionException.class)
         .hasCauseInstanceOf(SocketTimeoutException.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -282,6 +282,99 @@ class ArchiveByIdTaskSupplierTest {
   }
 
   @Test
+  void shouldNotReduceBatchSizeBelowMinimum() {
+    // given - starting batch size of 100 so it hits the floor at 50 after one halving
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+    final var reindexCallCount = new AtomicInteger(0);
+    final var batchSize = new AtomicInteger(0);
+
+    final var config = new HistoryConfiguration();
+    config.setArchiveByIdMaxRetryAttempts(10);
+    config.setArchiveByIdRetryDelayMs(0);
+    config.setReindexBatchSize(100);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            config,
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) -> {
+              batchSize.set(size);
+              return CompletableFuture.completedFuture(
+                  ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1")));
+            },
+            (source, dest, ids) -> {
+              if (reindexCallCount.incrementAndGet() <= 3) {
+                return CompletableFuture.failedFuture(retryableError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            LOGGER);
+
+    // when - attempt 1 fails: 100 used, reduction gives 50
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(batchSize.get()).isEqualTo(100);
+
+    // when - attempt 2 fails: 50 used, reduction stays at 50 (floor)
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(batchSize.get()).isEqualTo(50);
+
+    // when - attempt 3 fails: still 50 (floor enforced)
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(batchSize.get()).isEqualTo(50);
+
+    // when - attempt 4 succeeds: still 50
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(batchSize.get()).isEqualTo(50);
+  }
+
+  @Test
+  void shouldNotReduceBatchSizeForNonSocketTimeoutRetryableError() {
+    // given - retryable error that is NOT a SocketTimeoutException
+    final var batchMismatchError =
+        new CompletionException(
+            new ArchiveByIdTaskSupplier.BatchCountMismatchException("reindex", "count mismatch"));
+    final var reindexCallCount = new AtomicInteger(0);
+    final var batchSize = new AtomicInteger(0);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(3),
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) -> {
+              batchSize.set(size);
+              return CompletableFuture.completedFuture(
+                  ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1")));
+            },
+            (source, dest, ids) -> {
+              if (reindexCallCount.incrementAndGet() <= 2) {
+                return CompletableFuture.failedFuture(batchMismatchError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            LOGGER);
+
+    // when - attempt 1 fails with non-SocketTimeout error
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(batchSize.get()).isEqualTo(1200);
+
+    // when - attempt 2 fails: batch size unchanged
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(batchSize.get()).isEqualTo(1200);
+
+    // when - attempt 3 succeeds: batch size still unchanged
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(batchSize.get()).isEqualTo(1200);
+  }
+
+  @Test
   void shouldDelayBeforeRetryingRetryableError() {
     // given
     final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -46,7 +46,7 @@ class ArchiveByIdTaskSupplierTest {
             historyConfigWithMaxRetry(3),
             "source-idx",
             "destination-idx",
-            searchAfter ->
+            (searchAfter, size) ->
                 CompletableFuture.completedFuture(
                     ArchiveDocIdsBatch.from(
                         List.of(IdWithRouting.of("doc1"), IdWithRouting.of("doc2")),
@@ -95,7 +95,7 @@ class ArchiveByIdTaskSupplierTest {
             historyConfigWithMaxRetry(1),
             "source-idx",
             "destination-idx",
-            searchAfter ->
+            (searchAfter, size) ->
                 CompletableFuture.completedFuture(
                     ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> CompletableFuture.failedFuture(retryableError),
@@ -128,7 +128,7 @@ class ArchiveByIdTaskSupplierTest {
             historyConfigWithMaxRetry(3),
             "source-idx",
             "destination-idx",
-            searchAfter ->
+            (searchAfter, size) ->
                 CompletableFuture.completedFuture(
                     ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> CompletableFuture.failedFuture(nonRetryableError),
@@ -153,7 +153,7 @@ class ArchiveByIdTaskSupplierTest {
             historyConfigWithMaxRetry(3),
             "source-idx",
             "destination-idx",
-            searchAfter -> CompletableFuture.completedFuture(ArchiveDocIdsBatch.empty()),
+            (searchAfter, size) -> CompletableFuture.completedFuture(ArchiveDocIdsBatch.empty()),
             (source, dest, ids) -> CompletableFuture.completedFuture((long) ids.size()),
             (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
             DIRECT_EXECUTOR,
@@ -180,7 +180,7 @@ class ArchiveByIdTaskSupplierTest {
             historyConfigWithMaxRetry(2),
             "source-idx",
             "destination-idx",
-            searchAfter ->
+            (searchAfter, size) ->
                 CompletableFuture.completedFuture(
                     ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> {
@@ -227,6 +227,52 @@ class ArchiveByIdTaskSupplierTest {
   }
 
   @Test
+  void shouldReduceReindexBatchSizeAfterEachRetry() {
+    // given - maxRetryAttempts=3: retries while retryCount < 3, so 2 retries before the 3rd
+    // failure throws. Reindex fails on calls 1 and 2, succeeds from call 3 onward.
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+    final var reindexCallCount = new AtomicInteger(0);
+    final var batchSize = new AtomicInteger(0);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(3),
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) -> {
+              batchSize.set(size);
+              return CompletableFuture.completedFuture(
+                  ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1")));
+            },
+            (source, dest, ids) -> {
+              if (reindexCallCount.incrementAndGet() <= 2) {
+                return CompletableFuture.failedFuture(retryableError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            LOGGER);
+
+    // when - attempt 1 fails (retryCount: 0→1), full batch size used
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(batchSize.get()).isEqualTo(1200);
+
+    // when - attempt 2 fails (retryCount: 1→2), batch size halved
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(batchSize.get()).isEqualTo(600);
+
+    // when - attempt 3 succeeds (retryCount=2 at fetch → size/3), then resets to 0
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(batchSize.get()).isEqualTo(400);
+
+    // when - next batch after success starts at full size again (retryCount reset to 0)
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(batchSize.get()).isEqualTo(1200);
+  }
+
+  @Test
   void shouldDelayBeforeRetryingRetryableError() {
     // given
     final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
@@ -239,7 +285,7 @@ class ArchiveByIdTaskSupplierTest {
             config,
             "source-idx",
             "destination-idx",
-            searchAfter ->
+            (searchAfter, size) ->
                 CompletableFuture.completedFuture(
                     ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> {
@@ -268,6 +314,7 @@ class ArchiveByIdTaskSupplierTest {
     final var config = new HistoryConfiguration();
     config.setArchiveByIdMaxRetryAttempts(maxRetryCount);
     config.setArchiveByIdRetryDelayMs(0);
+    config.setReindexBatchSize(1200);
     return config;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -243,7 +243,8 @@ class ArchiveByIdTaskSupplierTest {
             (searchAfter, size) -> {
               batchSize.set(size);
               return CompletableFuture.completedFuture(
-                  ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1")));
+                  ArchiveDocIdsBatch.from(
+                      List.of(IdWithRouting.of("doc1")), List.of(IdWithRouting.of("after1"))));
             },
             (source, dest, ids) -> {
               if (Set.of(1, 2, 5).contains(reindexCallCount.incrementAndGet())) {
@@ -301,7 +302,8 @@ class ArchiveByIdTaskSupplierTest {
             (searchAfter, size) -> {
               batchSize.set(size);
               return CompletableFuture.completedFuture(
-                  ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1")));
+                  ArchiveDocIdsBatch.from(
+                      List.of(IdWithRouting.of("doc1")), List.of(IdWithRouting.of("after1"))));
             },
             (source, dest, ids) -> {
               if (reindexCallCount.incrementAndGet() <= 3) {
@@ -348,7 +350,8 @@ class ArchiveByIdTaskSupplierTest {
             (searchAfter, size) -> {
               batchSize.set(size);
               return CompletableFuture.completedFuture(
-                  ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1")));
+                  ArchiveDocIdsBatch.from(
+                      List.of(IdWithRouting.of("doc1")), List.of(IdWithRouting.of("after1"))));
             },
             (source, dest, ids) -> {
               if (reindexCallCount.incrementAndGet() <= 2) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -95,8 +95,8 @@ final class ElasticsearchArchiverRepositoryIT {
 
   @AutoClose private final RestClientTransport transport = createRestClient();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final HistoryConfiguration config = new HistoryConfiguration();
   private final RetentionConfiguration retention = new RetentionConfiguration();
+  private HistoryConfiguration config;
   private String indexPrefix;
   private final String zeebeIndexPrefix = "zeebe-record";
   private String processInstanceIndex;
@@ -117,6 +117,7 @@ final class ElasticsearchArchiverRepositoryIT {
 
   @BeforeEach
   void beforeEach() {
+    config = new HistoryConfiguration();
     config.setRetention(retention);
     indexPrefix = RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
     resourceProvider = new TestExporterResourceProvider(indexPrefix, true);
@@ -1009,7 +1010,8 @@ final class ElasticsearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of(),
                 Map.of(),
-                null)
+                null,
+                config.getReindexBatchSize())
             .join();
 
     assertThat(batch.documents())
@@ -1029,7 +1031,8 @@ final class ElasticsearchArchiverRepositoryIT {
                 List.of("999"),
                 Map.of(),
                 Map.of(),
-                null)
+                null,
+                config.getReindexBatchSize())
             .join();
 
     assertThat(emptyBatch.isEmpty()).isTrue();
@@ -1038,7 +1041,6 @@ final class ElasticsearchArchiverRepositoryIT {
 
     // when searching for process instance key 111 with reindex batch size of 2
     // then - we expect documents with IDs 1 and 2 to be returned
-    config.setReindexBatchSize(2);
     final var batchPg1 =
         repository
             .getArchiveDocIdsBatch(
@@ -1047,7 +1049,8 @@ final class ElasticsearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of(),
                 Map.of(),
-                null)
+                null,
+                2)
             .join();
 
     assertThat(batchPg1.documents())
@@ -1057,7 +1060,6 @@ final class ElasticsearchArchiverRepositoryIT {
 
     // when searching for process instance key 111 with searchAfter from page 1
     // then - we expect document with ID 4 to be returned
-    config.setReindexBatchSize(2);
     final var batchPg2 =
         repository
             .getArchiveDocIdsBatch(
@@ -1066,7 +1068,8 @@ final class ElasticsearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of(),
                 Map.of(),
-                batchPg1.searchAfter())
+                batchPg1.searchAfter(),
+                2)
             .join();
 
     assertThat(batchPg2.documents()).extracting(IdWithRouting::id).containsExactlyInAnyOrder("4");
@@ -1074,7 +1077,6 @@ final class ElasticsearchArchiverRepositoryIT {
 
     // when searching for process instance key 111 with searchAfter from page 2
     // then - we expect no documents to be returned
-    config.setReindexBatchSize(2);
     final var batchPg3 =
         repository
             .getArchiveDocIdsBatch(
@@ -1083,7 +1085,8 @@ final class ElasticsearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of(),
                 Map.of(),
-                batchPg2.searchAfter())
+                batchPg2.searchAfter(),
+                2)
             .join();
 
     assertThat(batchPg3.isEmpty()).isTrue();
@@ -1092,7 +1095,6 @@ final class ElasticsearchArchiverRepositoryIT {
 
     // when searching for process instance key 111 with exclusion filter for joinRelation=activity
     // then - we expect only documents with joinRelation != activity (IDs 1 and 4)
-    config.setReindexBatchSize(100);
     final var batchExcluded =
         repository
             .getArchiveDocIdsBatch(
@@ -1101,7 +1103,8 @@ final class ElasticsearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of(),
                 Map.of("joinRelation", "activity"),
-                null)
+                null,
+                100)
             .join();
 
     assertThat(batchExcluded.documents())
@@ -1119,7 +1122,8 @@ final class ElasticsearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of("joinRelation", "variable"),
                 Map.of("joinRelation", "activity"),
-                null)
+                null,
+                100)
             .join();
 
     assertThat(batchBothFilters.documents())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -100,10 +100,10 @@ final class OpenSearchArchiverRepositoryIT {
   private static final ObjectMapper MAPPER = TestObjectMapper.objectMapper();
   @AutoClose private final RestClientTransport transport = createRestClient();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private final HistoryConfiguration config = new HistoryConfiguration();
   private final ConnectConfiguration connectConfiguration = new ConnectConfiguration();
   private final RetentionConfiguration retention = new RetentionConfiguration();
   private String archiverBlockedIndex;
+  private HistoryConfiguration config;
   private String processInstanceIndex;
   private String batchOperationIndex;
   private final OpenSearchClient testClient = createOpenSearchClient();
@@ -126,6 +126,7 @@ final class OpenSearchArchiverRepositoryIT {
 
   @BeforeEach
   void beforeEach() {
+    config = new HistoryConfiguration();
     config.setRetention(retention);
     indexPrefix = RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
     resourceProvider = new TestExporterResourceProvider(indexPrefix, false);
@@ -144,7 +145,7 @@ final class OpenSearchArchiverRepositoryIT {
   @Test
   void shouldDeleteDocuments() throws IOException {
     // given
-    final var indexName = ARCHIVER_IDX_PREFIX + UUID.randomUUID().toString();
+    final var indexName = ARCHIVER_IDX_PREFIX + UUID.randomUUID();
     final var repository = createRepository();
     final var documents =
         List.of(new TestDocument("1"), new TestDocument("2"), new TestDocument("3"));
@@ -1107,7 +1108,8 @@ final class OpenSearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of(),
                 Map.of(),
-                null)
+                null,
+                config.getReindexBatchSize())
             .join();
 
     assertThat(batch.documents())
@@ -1127,7 +1129,8 @@ final class OpenSearchArchiverRepositoryIT {
                 List.of("999"),
                 Map.of(),
                 Map.of(),
-                null)
+                null,
+                config.getReindexBatchSize())
             .join();
 
     assertThat(emptyBatch.isEmpty()).isTrue();
@@ -1136,7 +1139,6 @@ final class OpenSearchArchiverRepositoryIT {
 
     // when searching for process instance key 111 with reindex batch size of 2
     // then - we expect documents with IDs 1 and 2 to be returned
-    config.setReindexBatchSize(2);
     final var batchPg1 =
         repository
             .getArchiveDocIdsBatch(
@@ -1145,7 +1147,8 @@ final class OpenSearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of(),
                 Map.of(),
-                null)
+                null,
+                2)
             .join();
 
     assertThat(batchPg1.documents())
@@ -1155,7 +1158,6 @@ final class OpenSearchArchiverRepositoryIT {
 
     // when searching for process instance key 111 with searchAfter from page 1
     // then - we expect document with ID 4 to be returned
-    config.setReindexBatchSize(2);
     final var batchPg2 =
         repository
             .getArchiveDocIdsBatch(
@@ -1164,7 +1166,8 @@ final class OpenSearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of(),
                 Map.of(),
-                batchPg1.searchAfter())
+                batchPg1.searchAfter(),
+                2)
             .join();
 
     assertThat(batchPg2.documents()).extracting(IdWithRouting::id).containsExactlyInAnyOrder("4");
@@ -1172,7 +1175,6 @@ final class OpenSearchArchiverRepositoryIT {
 
     // when searching for process instance key 111 with searchAfter from page 2
     // then - we expect no documents to be returned
-    config.setReindexBatchSize(2);
     final var batchPg3 =
         repository
             .getArchiveDocIdsBatch(
@@ -1181,7 +1183,8 @@ final class OpenSearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of(),
                 Map.of(),
-                batchPg2.searchAfter())
+                batchPg2.searchAfter(),
+                2)
             .join();
 
     assertThat(batchPg3.isEmpty()).isTrue();
@@ -1190,7 +1193,6 @@ final class OpenSearchArchiverRepositoryIT {
 
     // when searching for process instance key 111 with exclusion filter for joinRelation=activity
     // then - we expect only documents with joinRelation != activity (IDs 1 and 4)
-    config.setReindexBatchSize(100);
     final var batchExcluded =
         repository
             .getArchiveDocIdsBatch(
@@ -1199,7 +1201,8 @@ final class OpenSearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of(),
                 Map.of("joinRelation", "activity"),
-                null)
+                null,
+                100)
             .join();
 
     assertThat(batchExcluded.documents())
@@ -1217,7 +1220,8 @@ final class OpenSearchArchiverRepositoryIT {
                 List.of("111"),
                 Map.of("joinRelation", "variable"),
                 Map.of("joinRelation", "activity"),
-                null)
+                null,
+                100)
             .join();
 
     assertThat(batchBothFilters.documents())


### PR DESCRIPTION
## Description

Backport of #55059 to `stable/8.8`.

When an archiving batch fails with a retryable error, we retry with the same batch of IDs. To increase the chance of success on `SocketTimeoutException` (typically caused by ES/OS overload), the batch size is halved on each retry, down to a minimum of 50. The reduced batch size persists for the lifetime of the `ArchiveByIdTaskSupplier` — it is not reset between batches.

Also fixes an off-by-one bug where the archiver was retrying one fewer time than `archiveByIdMaxRetryAttempts` configured (the retry condition used `<` instead of `<=`).

## Conflicts resolved

`ElasticsearchArchiverRepository` and `OpenSearchArchiverRepository` diverged between `main` and `stable/8.8`: `main` refactored `getArchiveDocIdsBatch` to accept `keysByField` while `stable/8.8` still uses `idFieldName + List<String> ids`. Conflicts resolved by keeping the `stable/8.8` API while incorporating the `size` parameter and `int` type change from the original PR.

## Related issues

Closes #54477 (backport)