### PR TITLE
feat: make served webapps physical-tenant-prefix-aware

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1097,7 +1097,6 @@
             <dependency>io.camunda:identity-webjar</dependency>
 
             <dependency>io.camunda:operate-data-generator</dependency>
-            <dependency>io.camunda:operate-webapp</dependency>
 
             <dependency>io.camunda:tasklist-data-generator</dependency>
 

--- a/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdvice.java
+++ b/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdvice.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.pt;
 
 import io.camunda.spring.utils.PhysicalTenantContext;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NullMarked;
@@ -26,12 +27,13 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
  * client-config.js} for physical-tenant-prefixed webapp requests so the runtime SPA config reports
  * PT-prefixed paths.
  *
- * <p>Operate and Tasklist publish their bootstrap config from {@code
- * ClientConfigRestService#getClientConfig}, a {@code String} returning {@code window.clientConfig =
- * {...};} document with {@code "contextPath":""} and {@code "baseName":"/<app>"}. The SPA feeds
- * {@code baseName} to react-router as its basename; without this rewrite the router rejects any URL
- * outside the unprefixed {@code /operate} (or {@code /tasklist}) space — including the PT-prefixed
- * entry path.
+ * <p>Operate and Tasklist publish their bootstrap config from {@code getClientConfig} on {@link
+ * io.camunda.operate.webapp.rest.ClientConfigRestService} and {@link
+ * io.camunda.tasklist.webapp.rest.ClientConfigRestService} respectively, returning a {@code
+ * window.clientConfig = {...};} document with {@code "contextPath":""} and {@code
+ * "baseName":"/<app>"}. The SPA feeds {@code baseName} to react-router as its basename; without
+ * this rewrite the router rejects any URL outside the unprefixed {@code /operate} (or {@code
+ * /tasklist}) space — including the PT-prefixed entry path.
  *
  * <p>Approach: a string-level rewrite of the two known JSON fields on the body Spring just
  * serialised. The field names and value types are fixed by {@code ClientConfig}, so capturing the
@@ -50,7 +52,10 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 @ControllerAdvice
 public class PhysicalTenantWebappClientConfigRewriteAdvice implements ResponseBodyAdvice<String> {
 
-  private static final String CLIENT_CONFIG_SERVICE = "ClientConfigRestService";
+  private static final Set<Class<?>> CLIENT_CONFIG_SERVICES =
+      Set.of(
+          io.camunda.operate.webapp.rest.ClientConfigRestService.class,
+          io.camunda.tasklist.webapp.rest.ClientConfigRestService.class);
   private static final String GET_CLIENT_CONFIG = "getClientConfig";
 
   private static final Pattern CONTEXT_PATH = Pattern.compile("(\"contextPath\":\")([^\"]*)(\")");
@@ -62,7 +67,7 @@ public class PhysicalTenantWebappClientConfigRewriteAdvice implements ResponseBo
       final Class<? extends HttpMessageConverter<?>> converterType) {
     final var method = returnType.getMethod();
     return method != null
-        && CLIENT_CONFIG_SERVICE.equals(returnType.getDeclaringClass().getSimpleName())
+        && CLIENT_CONFIG_SERVICES.contains(returnType.getDeclaringClass())
         && GET_CLIENT_CONFIG.equals(method.getName());
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdvice.java
+++ b/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdvice.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.pt;
+
+import io.camunda.spring.utils.PhysicalTenantContext;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * Prefixes the {@code contextPath} and {@code baseName} fields of the served {@code
+ * client-config.js} for physical-tenant-prefixed webapp requests so the runtime SPA config reports
+ * PT-prefixed paths.
+ *
+ * <p>Operate and Tasklist publish their bootstrap config from {@code
+ * ClientConfigRestService#getClientConfig}, a {@code String} returning {@code window.clientConfig =
+ * {...};} document with {@code "contextPath":""} and {@code "baseName":"/<app>"}. The SPA feeds
+ * {@code baseName} to react-router as its basename; without this rewrite the router rejects any URL
+ * outside the unprefixed {@code /operate} (or {@code /tasklist}) space — including the PT-prefixed
+ * entry path.
+ *
+ * <p>Approach: a string-level rewrite of the two known JSON fields on the body Spring just
+ * serialised. The field names and value types are fixed by {@code ClientConfig}, so capturing the
+ * current value and re-emitting it with the prefix is safe; it deliberately avoids re-parsing the
+ * body as JSON.
+ *
+ * <p>Active only for PT-prefixed requests ({@link
+ * PhysicalTenantContext#getPhysicalTenantId(jakarta.servlet.http.HttpServletRequest)} non-null);
+ * cluster requests are passed through unchanged.
+ *
+ * <p>Admin's client config ({@code AdminClientConfigController#getClientConfig}, {@code
+ * /admin/config.js}) emits neither {@code contextPath} nor {@code baseName} and is therefore out of
+ * scope here.
+ */
+@NullMarked
+@ControllerAdvice
+public class PhysicalTenantWebappClientConfigRewriteAdvice implements ResponseBodyAdvice<String> {
+
+  private static final String CLIENT_CONFIG_SERVICE = "ClientConfigRestService";
+  private static final String GET_CLIENT_CONFIG = "getClientConfig";
+
+  private static final Pattern CONTEXT_PATH = Pattern.compile("(\"contextPath\":\")([^\"]*)(\")");
+  private static final Pattern BASE_NAME = Pattern.compile("(\"baseName\":\")([^\"]*)(\")");
+
+  @Override
+  public boolean supports(
+      final MethodParameter returnType,
+      final Class<? extends HttpMessageConverter<?>> converterType) {
+    final var method = returnType.getMethod();
+    return method != null
+        && CLIENT_CONFIG_SERVICE.equals(returnType.getDeclaringClass().getSimpleName())
+        && GET_CLIENT_CONFIG.equals(method.getName());
+  }
+
+  @Override
+  public @Nullable String beforeBodyWrite(
+      final @Nullable String body,
+      final MethodParameter returnType,
+      final MediaType selectedContentType,
+      final Class<? extends HttpMessageConverter<?>> selectedConverterType,
+      final ServerHttpRequest request,
+      final ServerHttpResponse response) {
+    if (body == null || !(request instanceof final ServletServerHttpRequest servletRequest)) {
+      return body;
+    }
+    final String physicalTenantId =
+        PhysicalTenantContext.getPhysicalTenantId(servletRequest.getServletRequest());
+    if (physicalTenantId == null) {
+      return body;
+    }
+    final String prefix = PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + physicalTenantId;
+    return prefixField(prefixField(body, CONTEXT_PATH, prefix), BASE_NAME, prefix);
+  }
+
+  private static String prefixField(final String body, final Pattern field, final String prefix) {
+    final Matcher matcher = field.matcher(body);
+    if (!matcher.find()) {
+      return body;
+    }
+    // Re-emit the matched field with the captured value verbatim, prefix-prepended.
+    return matcher.replaceFirst(
+        Matcher.quoteReplacement(matcher.group(1) + prefix + matcher.group(2) + matcher.group(3)));
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdviceTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdviceTest.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.pt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.operate.webapp.rest.ClientConfigRestService;
 import io.camunda.spring.utils.PhysicalTenantContext;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
@@ -32,12 +33,35 @@ class PhysicalTenantWebappClientConfigRewriteAdviceTest {
       new PhysicalTenantWebappClientConfigRewriteAdvice();
 
   @Test
-  void shouldSupportClientConfigRestServiceGetClientConfig() throws NoSuchMethodException {
+  void shouldSupportOperateClientConfigRestServiceGetClientConfig() throws NoSuchMethodException {
     // given
-    final MethodParameter returnType = clientConfigReturnType();
+    final Method method = ClientConfigRestService.class.getDeclaredMethod("getClientConfig");
+    final MethodParameter returnType = new MethodParameter(method, -1);
 
     // when / then
     assertThat(advice.supports(returnType, stringConverter())).isTrue();
+  }
+
+  @Test
+  void shouldSupportTasklistClientConfigRestServiceGetClientConfig() throws NoSuchMethodException {
+    // given
+    final Method method =
+        io.camunda.tasklist.webapp.rest.ClientConfigRestService.class.getDeclaredMethod(
+            "getClientConfig");
+    final MethodParameter returnType = new MethodParameter(method, -1);
+
+    // when / then
+    assertThat(advice.supports(returnType, stringConverter())).isTrue();
+  }
+
+  @Test
+  void shouldNotSupportUnknownClassWithGetClientConfig() throws NoSuchMethodException {
+    // given — a class with a getClientConfig method that is NOT in the registered set
+    final Method method = UnknownClientConfigService.class.getDeclaredMethod("getClientConfig");
+    final MethodParameter returnType = new MethodParameter(method, -1);
+
+    // when / then
+    assertThat(advice.supports(returnType, stringConverter())).isFalse();
   }
 
   @Test
@@ -114,8 +138,8 @@ class PhysicalTenantWebappClientConfigRewriteAdviceTest {
     return (Class<? extends HttpMessageConverter<?>>) (Class<?>) StringHttpMessageConverter.class;
   }
 
-  /** Stand-in matching the operate/tasklist {@code ClientConfigRestService#getClientConfig}. */
-  private static final class ClientConfigRestService {
+  /** A class with {@code getClientConfig} that is NOT registered in the advice's set. */
+  private static final class UnknownClientConfigService {
     @SuppressWarnings("unused")
     String getClientConfig() {
       return "";

--- a/dist/src/test/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdviceTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdviceTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.pt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.spring.utils.PhysicalTenantContext;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class PhysicalTenantWebappClientConfigRewriteAdviceTest {
+
+  private static final String OPERATE_BODY =
+      "window.clientConfig = {\"isEnterprise\":true,\"contextPath\":\"\",\"baseName\":\"/operate\"};";
+  private static final String TASKLIST_BODY =
+      "window.clientConfig = {\"contextPath\":\"\",\"baseName\":\"/tasklist\",\"clientMode\":\"v2\"};";
+
+  private final PhysicalTenantWebappClientConfigRewriteAdvice advice =
+      new PhysicalTenantWebappClientConfigRewriteAdvice();
+
+  @Test
+  void shouldSupportClientConfigRestServiceGetClientConfig() throws NoSuchMethodException {
+    // given
+    final MethodParameter returnType = clientConfigReturnType();
+
+    // when / then
+    assertThat(advice.supports(returnType, stringConverter())).isTrue();
+  }
+
+  @Test
+  void shouldNotSupportOtherEndpoints() throws NoSuchMethodException {
+    // given
+    final Method method = OtherRestService.class.getDeclaredMethod("somethingElse");
+    final MethodParameter returnType = new MethodParameter(method, -1);
+
+    // when / then
+    assertThat(advice.supports(returnType, stringConverter())).isFalse();
+  }
+
+  @Test
+  void shouldPrefixContextPathAndBaseNameForPhysicalTenantRequest() throws NoSuchMethodException {
+    // given
+    final MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(httpRequest, "tenanta");
+
+    // when
+    final String result = rewrite(OPERATE_BODY, httpRequest);
+
+    // then
+    assertThat(result)
+        .contains("\"contextPath\":\"/physical-tenants/tenanta\"")
+        .contains("\"baseName\":\"/physical-tenants/tenanta/operate\"");
+  }
+
+  @Test
+  void shouldPrefixTasklistBaseNameForPhysicalTenantRequest() throws NoSuchMethodException {
+    // given
+    final MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(httpRequest, "default");
+
+    // when
+    final String result = rewrite(TASKLIST_BODY, httpRequest);
+
+    // then
+    assertThat(result)
+        .contains("\"contextPath\":\"/physical-tenants/default\"")
+        .contains("\"baseName\":\"/physical-tenants/default/tasklist\"")
+        .contains("\"clientMode\":\"v2\"");
+  }
+
+  @Test
+  void shouldNotChangeBodyForClusterRequest() throws NoSuchMethodException {
+    // given — no physical tenant id stamped on the request
+    final MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+
+    // when
+    final String result = rewrite(OPERATE_BODY, httpRequest);
+
+    // then
+    assertThat(result).isEqualTo(OPERATE_BODY);
+  }
+
+  private String rewrite(final String body, final MockHttpServletRequest httpRequest)
+      throws NoSuchMethodException {
+    return advice.beforeBodyWrite(
+        body,
+        clientConfigReturnType(),
+        MediaType.valueOf("text/javascript"),
+        StringHttpMessageConverter.class,
+        new ServletServerHttpRequest(httpRequest),
+        new ServletServerHttpResponse(new MockHttpServletResponse()));
+  }
+
+  private static MethodParameter clientConfigReturnType() throws NoSuchMethodException {
+    final Method method = ClientConfigRestService.class.getDeclaredMethod("getClientConfig");
+    return new MethodParameter(method, -1);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Class<? extends HttpMessageConverter<?>> stringConverter() {
+    return (Class<? extends HttpMessageConverter<?>>) (Class<?>) StringHttpMessageConverter.class;
+  }
+
+  /** Stand-in matching the operate/tasklist {@code ClientConfigRestService#getClientConfig}. */
+  private static final class ClientConfigRestService {
+    @SuppressWarnings("unused")
+    String getClientConfig() {
+      return "";
+    }
+  }
+
+  private static final class OtherRestService {
+    @SuppressWarnings("unused")
+    String somethingElse() {
+      return "";
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebMvcConfig.java
@@ -17,6 +17,7 @@ import org.springframework.boot.webmvc.autoconfigure.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -30,10 +31,11 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  * /admin}, {@code /webapp}) automatically gets a {@code /physical-tenants/{physicalTenantId}/...}
  * sibling registration.
  *
- * <p>This config is responsible for <em>routing</em> only. The physical tenant id is extracted from
- * the request by {@code PhysicalTenantFilter} (which runs before the security chain so the id is
- * available to in-chain components), and unknown tenants are rejected by CSL's catch-all security
- * chain — so no MVC interceptor is registered here. See ADR-0003.
+ * <p>The physical tenant id is extracted from the request by {@code PhysicalTenantFilter} (which
+ * runs before the security chain so the id is available to in-chain components), and unknown
+ * tenants are rejected by CSL's catch-all security chain (see ADR-0003). Alongside routing and
+ * static assets, {@link PhysicalTenantWebappContextPathInterceptor} is registered so a PT-prefixed
+ * request renders an SPA shell whose {@code <base href>} carries the tenant prefix.
  */
 @Configuration
 public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
@@ -54,6 +56,13 @@ public class PhysicalTenantWebMvcConfig implements WebMvcConfigurer {
   public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
     // Enables `@PhysicalTenantId String physicalTenantId` injection on controller methods.
     resolvers.add(new PhysicalTenantIdArgumentResolver());
+  }
+
+  @Override
+  public void addInterceptors(final InterceptorRegistry registry) {
+    // Always wired; no-op for cluster (unprefixed) requests — PT addressing is decided per request
+    // from PhysicalTenantContext, not by a boot-time condition.
+    registry.addInterceptor(new PhysicalTenantWebappContextPathInterceptor());
   }
 
   @Override

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebappContextPathInterceptor.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebappContextPathInterceptor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.config;
+
+import io.camunda.spring.utils.PhysicalTenantContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * Prefixes the {@code contextPath} model attribute set by the webapp index controllers (operate,
+ * tasklist, admin) so a physical-tenant-prefixed request renders an SPA whose {@code <base href>}
+ * carries the PT prefix.
+ *
+ * <p>The index controllers set {@code contextPath = servletContextPath + "/<app>/"} unconditionally
+ * (e.g. {@code /operate/}). Without this interceptor the rendered shell's base href would always be
+ * {@code /operate/}, so even when entered through {@code /physical-tenants/<id>/operate} the
+ * browser would resolve assets and API calls back to the unprefixed URL space, where the PT session
+ * cookie does not apply and the SPA breaks.
+ *
+ * <p>The physical tenant id is resolved from the request via {@link
+ * PhysicalTenantContext#getPhysicalTenantId(HttpServletRequest)}, which {@code
+ * PhysicalTenantFilter} stamps for {@code /physical-tenants/<id>/...} requests and leaves {@code
+ * null} for cluster (unprefixed) requests. The attribute survives the internal forward the index
+ * controllers perform for SPA sub-paths, so reading it is more robust than parsing the
+ * (post-forward) request URI.
+ *
+ * <p>No-op when the request is not PT-prefixed or carries no model.
+ */
+public class PhysicalTenantWebappContextPathInterceptor implements HandlerInterceptor {
+
+  private static final String CONTEXT_PATH_ATTRIBUTE = "contextPath";
+
+  @Override
+  public void postHandle(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final Object handler,
+      final ModelAndView modelAndView) {
+    if (modelAndView == null) {
+      return;
+    }
+    final String physicalTenantId = PhysicalTenantContext.getPhysicalTenantId(request);
+    if (physicalTenantId == null) {
+      return;
+    }
+    final Object existing = modelAndView.getModel().get(CONTEXT_PATH_ATTRIBUTE);
+    if (existing instanceof final String existingPath) {
+      // PT routes are servlet-context-relative, so the external path is
+      // <contextPath>/physical-tenants/<id>/<webapp>/. The index controllers set the model's
+      // contextPath to <contextPath>/<webapp>/, so the PT segment must be inserted after the
+      // servlet context path (which is empty in the common case) — not before it.
+      final String contextPath = request.getContextPath();
+      final String afterContextPath =
+          existingPath.startsWith(contextPath)
+              ? existingPath.substring(contextPath.length())
+              : existingPath;
+      modelAndView.addObject(
+          CONTEXT_PATH_ATTRIBUTE,
+          contextPath
+              + PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT
+              + physicalTenantId
+              + afterContextPath);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebappContextPathInterceptorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebappContextPathInterceptorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.spring.utils.PhysicalTenantContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.ModelAndView;
+
+class PhysicalTenantWebappContextPathInterceptorTest {
+
+  private final PhysicalTenantWebappContextPathInterceptor interceptor =
+      new PhysicalTenantWebappContextPathInterceptor();
+
+  @Test
+  void shouldPrefixContextPathForPhysicalTenantRequest() {
+    // given
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final ModelAndView modelAndView = new ModelAndView("operate/index");
+    modelAndView.addObject("contextPath", "/operate/");
+
+    // when
+    interceptor.postHandle(request, new MockHttpServletResponse(), new Object(), modelAndView);
+
+    // then
+    assertThat(modelAndView.getModel().get("contextPath"))
+        .isEqualTo("/physical-tenants/tenanta/operate/");
+  }
+
+  @Test
+  void shouldPrefixContextPathForDefaultPhysicalTenant() {
+    // given
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, "default");
+    final ModelAndView modelAndView = new ModelAndView("tasklist/index");
+    modelAndView.addObject("contextPath", "/tasklist/");
+
+    // when
+    interceptor.postHandle(request, new MockHttpServletResponse(), new Object(), modelAndView);
+
+    // then
+    assertThat(modelAndView.getModel().get("contextPath"))
+        .isEqualTo("/physical-tenants/default/tasklist/");
+  }
+
+  @Test
+  void shouldInsertPrefixAfterServletContextPath() {
+    // given — a non-empty servlet context path; the index controller's contextPath includes it
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContextPath("/camunda");
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final ModelAndView modelAndView = new ModelAndView("operate/index");
+    modelAndView.addObject("contextPath", "/camunda/operate/");
+
+    // when
+    interceptor.postHandle(request, new MockHttpServletResponse(), new Object(), modelAndView);
+
+    // then — the PT segment is inserted after the context path, not before it
+    assertThat(modelAndView.getModel().get("contextPath"))
+        .isEqualTo("/camunda/physical-tenants/tenanta/operate/");
+  }
+
+  @Test
+  void shouldNotChangeContextPathForClusterRequest() {
+    // given — no physical tenant id stamped on the request
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    final ModelAndView modelAndView = new ModelAndView("operate/index");
+    modelAndView.addObject("contextPath", "/operate/");
+
+    // when
+    interceptor.postHandle(request, new MockHttpServletResponse(), new Object(), modelAndView);
+
+    // then
+    assertThat(modelAndView.getModel().get("contextPath")).isEqualTo("/operate/");
+  }
+
+  @Test
+  void shouldNoOpWhenNoModelAndView() {
+    // given
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+
+    // when / then — no model to mutate, must not throw
+    interceptor.postHandle(request, new MockHttpServletResponse(), new Object(), null);
+  }
+
+  @Test
+  void shouldNoOpWhenModelHasNoContextPath() {
+    // given
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final ModelAndView modelAndView = new ModelAndView("operate/index");
+
+    // when
+    interceptor.postHandle(request, new MockHttpServletResponse(), new Object(), modelAndView);
+
+    // then
+    assertThat(modelAndView.getModel()).doesNotContainKey("contextPath");
+  }
+}


### PR DESCRIPTION
## Make the served webapps physical-tenant-prefix-aware

Closes #55314. Builds on the PT webapp routing (#55313/#55481): the routes are reachable, but under `/physical-tenants/<id>/operate` the served SPA still emitted the unprefixed context path and `client-config.js`, so its assets and API calls resolved off-prefix. This makes the served shell + runtime config carry the prefix.

### Changes
- **`PhysicalTenantWebappContextPathInterceptor`** (`zeebe/gateway-rest/.../config`) — a `HandlerInterceptor` that, for a PT-prefixed request, prepends `/physical-tenants/<id>` to the index shell's `contextPath` model attribute (which drives the SPA's `<base href>`). It's registered by the **existing `PhysicalTenantWebMvcConfig`**, alongside the PT request-mapping and static-asset wiring — no separate config class.
- **`PhysicalTenantWebappClientConfigRewriteAdvice`** (`dist/.../commons/pt`) — a component-scanned `@ControllerAdvice ResponseBodyAdvice<String>` that rewrites the served `client-config.js` so `contextPath` and `baseName` carry the prefix (operate + tasklist), prefixing the SPA's router basename and API base.

Both key off `PhysicalTenantContext.getPhysicalTenantId(request)` (null for cluster requests → no-op) and the `/physical-tenants/<id>` prefix.

### Notes
- The interceptor lives in `gateway-rest` (not `dist`) so it can be registered by the existing `PhysicalTenantWebMvcConfig`; the advice is a `@ControllerAdvice` and stays component-scanned in `dist`.
- Admin's client-config (`/admin/config.js`) emits neither `contextPath` nor `baseName`, so it is out of scope.

### Tests
Unit tests for both components: interceptor prefixes for a PT request (incl. default PT), no-ops for cluster / no-model / no-contextPath; advice supports the operate/tasklist `getClientConfig`, prefixes `contextPath`+`baseName`, and leaves cluster requests untouched.

Part of the per-physical-tenant identity slice (#54897).
