### PR TITLE
55503 optimize export filter hint

### DIFF
--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -966,6 +966,12 @@
     "instanceIds": "Instanz IDs",
     "processInstanceIds": "Prozessinstanz IDs",
     "seeDocs": "Siehe Dokumentation",
+    "exportFilterHint": {
+      "iconLabel": "Informationen zur Export-Filterung",
+      "variableText": "Die hier verfügbaren Variablen und Ergebnisse hängen von der Exporter-Konfiguration Ihres Clusters ab. Die Filterung des Variablen-Exports kann beeinflussen, welche Variablen und Prozessdaten angezeigt werden.",
+      "reportSetupLabel": "Ein Prozess oder eine Variable wird nicht angezeigt?",
+      "reportSetupText": "Die hier verfügbaren Prozesse und Variablen hängen von der Exporter-Konfiguration Ihres Clusters ab. Die Filterung des Prozess- oder Variablen-Exports kann beeinflussen, welche Prozesse und Variablen angezeigt werden."
+    },
     "undefined": "nicht definiert",
     "null": "null",
     "nullOrUndefined": "Null oder nicht definiert",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -966,6 +966,12 @@
     "instanceIds": "Instance IDs",
     "processInstanceIds": "Process instance IDs",
     "seeDocs": "See documentation",
+    "exportFilterHint": {
+      "iconLabel": "Information about export filtering",
+      "variableText": "The variables and results available here depend on your cluster's exporter configuration. Variable export filtering can affect which variables and process data appear.",
+      "reportSetupLabel": "Not seeing a process or variable?",
+      "reportSetupText": "The processes and variables available here depend on your cluster's exporter configuration. Process or variable export filtering can affect which processes and variables appear."
+    },
     "undefined": "undefined",
     "null": "null",
     "nullOrUndefined": "Null or undefined",

--- a/optimize/client/src/components/Reports/controlPanels/ReportControlPanel.js
+++ b/optimize/client/src/components/Reports/controlPanels/ReportControlPanel.js
@@ -14,8 +14,7 @@ import {Db2Database, Factor, Filter as FilterIcon} from '@carbon/icons-react';
 
 import {Filter} from 'filter';
 import {useDocs, useErrorHandling} from 'hooks';
-// imported via its direct path rather than the 'components' barrel to avoid a barrel
-// initialization cycle that leaves the export undefined when pulled alongside other barrel imports
+// not via the 'components' barrel — see components/ExportFilterHint/index.tsx
 import {ExportFilterHint} from 'components/ExportFilterHint';
 import {
   getFlowNodeNames,

--- a/optimize/client/src/components/Reports/controlPanels/ReportControlPanel.js
+++ b/optimize/client/src/components/Reports/controlPanels/ReportControlPanel.js
@@ -14,6 +14,9 @@ import {Db2Database, Factor, Filter as FilterIcon} from '@carbon/icons-react';
 
 import {Filter} from 'filter';
 import {useDocs, useErrorHandling} from 'hooks';
+// imported via its direct path rather than the 'components' barrel to avoid a barrel
+// initialization cycle that leaves the export undefined when pulled alongside other barrel imports
+import {ExportFilterHint} from 'components/ExportFilterHint';
 import {
   getFlowNodeNames,
   loadProcessDefinitionXml,
@@ -381,6 +384,10 @@ export default function ReportControlPanel({report, updateReport, setLoading}) {
             open
           >
             <ul className="reportSetup">
+              <li className="exportFilterHint">
+                {t('common.exportFilterHint.reportSetupLabel')}{' '}
+                <ExportFilterHint variant="reportSetup" />
+              </li>
               <li className="select">
                 <span className="label">{t(`report.view.label`)}</span>
                 <View

--- a/optimize/client/src/components/Reports/controlPanels/ReportControlPanel.scss
+++ b/optimize/client/src/components/Reports/controlPanels/ReportControlPanel.scss
@@ -68,6 +68,12 @@
         margin-top: 10px;
       }
 
+      &.exportFilterHint {
+        gap: 4px;
+        font-size: 12px;
+        color: var(--cds-text-secondary, #525252);
+      }
+
       .Select {
         min-width: 0;
         flex-grow: 1;

--- a/optimize/client/src/components/Reports/controlPanels/ReportControlPanel.test.js
+++ b/optimize/client/src/components/Reports/controlPanels/ReportControlPanel.test.js
@@ -100,6 +100,12 @@ it('should call the provided updateReport property function when a setting chang
   expect(spy).toHaveBeenCalled();
 });
 
+it('should render the variable export filter hint in the report setup section', () => {
+  const node = shallow(<ReportControlPanel {...props} />);
+
+  expect(node.find('.exportFilterHint').find('ExportFilterHint')).toExist();
+});
+
 it('should load the variables of the process', () => {
   shallow(<ReportControlPanel {...props} />);
 

--- a/optimize/client/src/modules/components/ExportFilterHint/ExportFilterHint.test.tsx
+++ b/optimize/client/src/modules/components/ExportFilterHint/ExportFilterHint.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {shallow} from 'enzyme';
+
+import {DocsLink} from 'components/DocsLink';
+
+import ExportFilterHint from './ExportFilterHint';
+
+const EXPORTER_DOCS_PAGE =
+  'self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter/';
+
+it('should render an info toggletip with the localized hint text and icon label', () => {
+  const node = shallow(<ExportFilterHint variant="variable" />);
+
+  expect(node.find('Toggletip')).toExist();
+  expect(node.find('ToggletipButton').prop('label')).toContain('export filtering');
+  expect(node.find('span').text()).toContain('exporter configuration');
+});
+
+it('should link the variable variant to the variable-name filter documentation', () => {
+  const node = shallow(<ExportFilterHint variant="variable" />);
+
+  expect(node.find(DocsLink).prop('location')).toBe(EXPORTER_DOCS_PAGE + '#variable-name-filters');
+});
+
+it('should link the report-setup variant to the bpmn process filter documentation', () => {
+  const node = shallow(<ExportFilterHint variant="reportSetup" />);
+
+  expect(node.find(DocsLink).prop('location')).toBe(EXPORTER_DOCS_PAGE + '#bpmn-process-filters');
+  expect(node.find('span').text()).toContain('processes and variables');
+});

--- a/optimize/client/src/modules/components/ExportFilterHint/ExportFilterHint.test.tsx
+++ b/optimize/client/src/modules/components/ExportFilterHint/ExportFilterHint.test.tsx
@@ -8,12 +8,19 @@
 
 import {shallow} from 'enzyme';
 
-import {DocsLink} from 'components/DocsLink';
+import {useUiConfig} from 'hooks';
+
+import {DocsLink} from '../DocsLink';
 
 import ExportFilterHint from './ExportFilterHint';
 
-const EXPORTER_DOCS_PAGE =
+jest.mock('hooks', () => ({
+  useUiConfig: jest.fn(() => ({optimizeDatabase: 'elasticsearch'})),
+}));
+
+const esPage =
   'self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter/';
+const osPage = 'self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter/';
 
 it('should render an info toggletip with the localized hint text and icon label', () => {
   const node = shallow(<ExportFilterHint variant="variable" />);
@@ -26,12 +33,20 @@ it('should render an info toggletip with the localized hint text and icon label'
 it('should link the variable variant to the variable-name filter documentation', () => {
   const node = shallow(<ExportFilterHint variant="variable" />);
 
-  expect(node.find(DocsLink).prop('location')).toBe(EXPORTER_DOCS_PAGE + '#variable-name-filters');
+  expect(node.find(DocsLink).prop('location')).toBe(esPage + '#variable-name-filters');
 });
 
 it('should link the report-setup variant to the bpmn process filter documentation', () => {
   const node = shallow(<ExportFilterHint variant="reportSetup" />);
 
-  expect(node.find(DocsLink).prop('location')).toBe(EXPORTER_DOCS_PAGE + '#bpmn-process-filters');
+  expect(node.find(DocsLink).prop('location')).toBe(esPage + '#bpmn-process-filters');
   expect(node.find('span').text()).toContain('processes and variables');
+});
+
+it('should link to the opensearch exporter docs when optimize runs on opensearch', () => {
+  (useUiConfig as jest.Mock).mockReturnValueOnce({optimizeDatabase: 'opensearch'});
+
+  const node = shallow(<ExportFilterHint variant="variable" />);
+
+  expect(node.find(DocsLink).prop('location')).toBe(osPage + '#variable-name-filters');
 });

--- a/optimize/client/src/modules/components/ExportFilterHint/ExportFilterHint.tsx
+++ b/optimize/client/src/modules/components/ExportFilterHint/ExportFilterHint.tsx
@@ -9,15 +9,16 @@
 import {Information} from '@carbon/icons-react';
 import {Toggletip, ToggletipActions, ToggletipButton, ToggletipContent} from '@carbon/react';
 
-// imported via its direct path rather than the 'components' barrel to avoid a barrel
-// initialization cycle (this component itself lives in that barrel)
-import {DocsLink} from 'components/DocsLink';
+// DocsLink is imported relatively (not via the 'components' barrel) — see this folder's index.tsx.
+import {DocsLink} from '../DocsLink';
+import {useUiConfig} from 'hooks';
 import {t} from 'translation';
 
-// Path (relative to the docs base resolved by DocsLink) of the exporter docs page that explains
-// process- and variable-export filtering. Each variant links to the relevant anchor on that page.
-const EXPORTER_DOCS_PAGE =
-  'self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter/';
+// The exporter docs page depends on which store the cluster exports to. We use Optimize's own
+// database as the signal (the Zeebe exporter writes to the same store Optimize reads from). Both
+// the Elasticsearch and OpenSearch exporter pages expose the same filter anchors.
+const exporterDocsPage = (database: 'opensearch' | 'elasticsearch') =>
+  `self-managed/components/orchestration-cluster/zeebe/exporters/${database}-exporter/`;
 
 // The contexts the hint is shown in. Each maps to its own explanation and docs anchor:
 // - variable: variable filters (variable-name export filtering)
@@ -35,6 +36,7 @@ interface ExportFilterHintProps {
 }
 
 export default function ExportFilterHint({variant}: ExportFilterHintProps): JSX.Element {
+  const {optimizeDatabase} = useUiConfig();
   const {textKey, docsAnchor} = VARIANTS[variant];
 
   return (
@@ -45,7 +47,9 @@ export default function ExportFilterHint({variant}: ExportFilterHintProps): JSX.
       <ToggletipContent>
         <span>{t(textKey)}</span>
         <ToggletipActions>
-          <DocsLink location={EXPORTER_DOCS_PAGE + docsAnchor}>{t('common.seeDocs')}</DocsLink>
+          <DocsLink location={exporterDocsPage(optimizeDatabase) + docsAnchor}>
+            {t('common.seeDocs')}
+          </DocsLink>
         </ToggletipActions>
       </ToggletipContent>
     </Toggletip>

--- a/optimize/client/src/modules/components/ExportFilterHint/ExportFilterHint.tsx
+++ b/optimize/client/src/modules/components/ExportFilterHint/ExportFilterHint.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Information} from '@carbon/icons-react';
+import {Toggletip, ToggletipActions, ToggletipButton, ToggletipContent} from '@carbon/react';
+
+// imported via its direct path rather than the 'components' barrel to avoid a barrel
+// initialization cycle (this component itself lives in that barrel)
+import {DocsLink} from 'components/DocsLink';
+import {t} from 'translation';
+
+// Path (relative to the docs base resolved by DocsLink) of the exporter docs page that explains
+// process- and variable-export filtering. Each variant links to the relevant anchor on that page.
+const EXPORTER_DOCS_PAGE =
+  'self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter/';
+
+// The contexts the hint is shown in. Each maps to its own explanation and docs anchor:
+// - variable: variable filters (variable-name export filtering)
+// - reportSetup: report setup, where whole processes can also be excluded
+const VARIANTS = {
+  variable: {textKey: 'common.exportFilterHint.variableText', docsAnchor: '#variable-name-filters'},
+  reportSetup: {
+    textKey: 'common.exportFilterHint.reportSetupText',
+    docsAnchor: '#bpmn-process-filters',
+  },
+} as const;
+
+interface ExportFilterHintProps {
+  variant: keyof typeof VARIANTS;
+}
+
+export default function ExportFilterHint({variant}: ExportFilterHintProps): JSX.Element {
+  const {textKey, docsAnchor} = VARIANTS[variant];
+
+  return (
+    <Toggletip className="ExportFilterHint" align="bottom" autoAlign>
+      <ToggletipButton label={t('common.exportFilterHint.iconLabel').toString()}>
+        <Information />
+      </ToggletipButton>
+      <ToggletipContent>
+        <span>{t(textKey)}</span>
+        <ToggletipActions>
+          <DocsLink location={EXPORTER_DOCS_PAGE + docsAnchor}>{t('common.seeDocs')}</DocsLink>
+        </ToggletipActions>
+      </ToggletipContent>
+    </Toggletip>
+  );
+}

--- a/optimize/client/src/modules/components/ExportFilterHint/index.tsx
+++ b/optimize/client/src/modules/components/ExportFilterHint/index.tsx
@@ -1,0 +1,9 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export {default as ExportFilterHint} from './ExportFilterHint';

--- a/optimize/client/src/modules/components/ExportFilterHint/index.tsx
+++ b/optimize/client/src/modules/components/ExportFilterHint/index.tsx
@@ -6,4 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+// NOTE: ExportFilterHint is deliberately NOT re-exported from the 'components' barrel
+// (modules/components/index.tsx). That barrel is heavily self-referential — dozens of its members
+// import from 'components' — and adding this component there makes it resolve to `undefined` when
+// imported through the barrel (verified: every other member resolves; this one does not, regardless
+// of export order or re-export style). Consumers must import it directly from
+// 'components/ExportFilterHint' instead. See PR camunda/camunda#55692 for the investigation.
 export {default as ExportFilterHint} from './ExportFilterHint';

--- a/optimize/client/src/modules/components/index.tsx
+++ b/optimize/client/src/modules/components/index.tsx
@@ -47,6 +47,9 @@ export {BulkDeleter} from './BulkDeleter';
 export {MenuDropdown} from './MenuDropdown';
 export {MenuButton} from './MenuButton';
 export {MultiValueInput} from './MultiValueInput';
+// ExportFilterHint is intentionally NOT re-exported here: importing it through this barrel
+// alongside other barrel members triggers an initialization cycle that resolves it to undefined.
+// Import it directly from 'components/ExportFilterHint' instead.
 
 export type {User, Identity} from './UserTypeahead';
 export type {Canvas, ModdleElement, RegistryElement} from './BPMNDiagram';

--- a/optimize/client/src/modules/components/index.tsx
+++ b/optimize/client/src/modules/components/index.tsx
@@ -47,9 +47,6 @@ export {BulkDeleter} from './BulkDeleter';
 export {MenuDropdown} from './MenuDropdown';
 export {MenuButton} from './MenuButton';
 export {MultiValueInput} from './MultiValueInput';
-// ExportFilterHint is intentionally NOT re-exported here: importing it through this barrel
-// alongside other barrel members triggers an initialization cycle that resolves it to undefined.
-// Import it directly from 'components/ExportFilterHint' instead.
 
 export type {User, Identity} from './UserTypeahead';
 export type {Canvas, ModdleElement, RegistryElement} from './BPMNDiagram';

--- a/optimize/client/src/modules/filter/modals/variable/MultipleVariableFilter.js
+++ b/optimize/client/src/modules/filter/modals/variable/MultipleVariableFilter.js
@@ -11,6 +11,9 @@ import classnames from 'classnames';
 import {Button} from '@carbon/react';
 
 import {Modal} from 'components';
+// imported via its direct path rather than the 'components' barrel to avoid a barrel
+// initialization cycle that leaves the export undefined when pulled alongside other barrel imports
+import {ExportFilterHint} from 'components/ExportFilterHint';
 import {t} from 'translation';
 
 import FilterSingleDefinitionSelection from '../FilterSingleDefinitionSelection';
@@ -142,9 +145,14 @@ export default function MultipleVariableFilter({
       className={classnames('MultipleVariableFilterModal', className)}
     >
       <Modal.Header
-        title={t('common.filter.modalHeader', {
-          type: t(`common.filter.types.${filterType}`),
-        })}
+        title={
+          <>
+            {t('common.filter.modalHeader', {
+              type: t(`common.filter.types.${filterType}`),
+            })}{' '}
+            <ExportFilterHint variant="variable" />
+          </>
+        }
       />
       <Modal.Content>
         {definitions && (

--- a/optimize/client/src/modules/filter/modals/variable/MultipleVariableFilter.js
+++ b/optimize/client/src/modules/filter/modals/variable/MultipleVariableFilter.js
@@ -11,8 +11,7 @@ import classnames from 'classnames';
 import {Button} from '@carbon/react';
 
 import {Modal} from 'components';
-// imported via its direct path rather than the 'components' barrel to avoid a barrel
-// initialization cycle that leaves the export undefined when pulled alongside other barrel imports
+// not via the 'components' barrel — see components/ExportFilterHint/index.tsx
 import {ExportFilterHint} from 'components/ExportFilterHint';
 import {t} from 'translation';
 

--- a/optimize/client/src/modules/filter/modals/variable/MultipleVariableFilter.test.js
+++ b/optimize/client/src/modules/filter/modals/variable/MultipleVariableFilter.test.js
@@ -9,6 +9,8 @@
 import React, {runAllEffects} from 'react';
 import {shallow} from 'enzyme';
 
+import {Modal} from 'components';
+
 import MultipleVariableFilter from './MultipleVariableFilter';
 import {DateInput} from './date';
 
@@ -57,6 +59,13 @@ it('should contain a modal', () => {
   const node = shallow(<MultipleVariableFilter {...props} />);
 
   expect(node.find('Modal')).toExist();
+});
+
+it('should render the variable export filter hint in the modal header', () => {
+  const node = shallow(<MultipleVariableFilter {...props} />);
+
+  const header = shallow(<div>{node.find(Modal.Header).prop('title')}</div>);
+  expect(header.find('ExportFilterHint')).toExist();
 });
 
 it('should take filter given by properties', async () => {

--- a/optimize/client/src/modules/filter/modals/variable/VariableFilter.js
+++ b/optimize/client/src/modules/filter/modals/variable/VariableFilter.js
@@ -11,6 +11,9 @@ import classnames from 'classnames';
 import {Button, ComboBox, InlineNotification, Stack, TextInputSkeleton} from '@carbon/react';
 
 import {Modal} from 'components';
+// imported via its direct path rather than the 'components' barrel to avoid a barrel
+// initialization cycle that leaves the export undefined when pulled alongside other barrel imports
+import {ExportFilterHint} from 'components/ExportFilterHint';
 import {t} from 'translation';
 
 import FilterSingleDefinitionSelection from '../FilterSingleDefinitionSelection';
@@ -135,9 +138,19 @@ export default function VariableFilter({
       className={classnames('VariableFilter__modal', className)}
     >
       <Modal.Header
-        title={t('common.filter.modalHeader', {
-          type: t(`common.filter.types.${filterType}`),
-        })}
+        title={
+          <>
+            {t('common.filter.modalHeader', {
+              type: t(`common.filter.types.${filterType}`),
+            })}
+            {t(`common.filter.types.${filterType}`) === t(`common.filter.types.variable`) && (
+              <>
+                {' '}
+                <ExportFilterHint variant="variable" />
+              </>
+            )}
+          </>
+        }
       />
       <Modal.Content>
         <Stack gap={6}>

--- a/optimize/client/src/modules/filter/modals/variable/VariableFilter.js
+++ b/optimize/client/src/modules/filter/modals/variable/VariableFilter.js
@@ -11,8 +11,7 @@ import classnames from 'classnames';
 import {Button, ComboBox, InlineNotification, Stack, TextInputSkeleton} from '@carbon/react';
 
 import {Modal} from 'components';
-// imported via its direct path rather than the 'components' barrel to avoid a barrel
-// initialization cycle that leaves the export undefined when pulled alongside other barrel imports
+// not via the 'components' barrel — see components/ExportFilterHint/index.tsx
 import {ExportFilterHint} from 'components/ExportFilterHint';
 import {t} from 'translation';
 
@@ -143,7 +142,7 @@ export default function VariableFilter({
             {t('common.filter.modalHeader', {
               type: t(`common.filter.types.${filterType}`),
             })}
-            {t(`common.filter.types.${filterType}`) === t(`common.filter.types.variable`) && (
+            {filterType === 'variable' && (
               <>
                 {' '}
                 <ExportFilterHint variant="variable" />


### PR DESCRIPTION
## Description

This PR change includes adding a toggle tip on the report setup to let users know that some variables and processes might be filtered out with the new export filter values that can be set via config. This toggletip info will also contain links to the docs

## Screenshots
<img width="1493" height="657" alt="Screenshot 2026-06-22 at 4 40 00 PM" src="https://github.com/user-attachments/assets/b6d59252-39dd-4131-aae7-e6955a999f7b" />
<img width="447" height="255" alt="Screenshot 2026-06-22 at 4 39 25 PM" src="https://github.com/user-attachments/assets/3bbc9f35-f535-441a-847f-7c8a438ca3f7" />
<img width="921" height="477" alt="Screenshot 2026-06-22 at 4 39 15 PM" src="https://github.com/user-attachments/assets/d01cf2a3-b849-4207-823f-fdb7ba21021a" />


closes #55503