### PR TITLE
deps: bump netty to 4.1.135.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,7 @@
     <version.mockito>5.18.0</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.12</version.msgpack>
-    <version.netty>4.1.134.Final</version.netty>
+    <version.netty>4.1.135.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <version.opensearch>2.17.1</version.opensearch>
     <version.opensearch-java>2.19.0</version.opensearch-java>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix Netty CVEs.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
