### PR TITLE
deps: bump camunda-security-library to 0.1.0-alpha34

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha33</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha34</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Bump camunda-security-library to 0.1.0-alpha34

Bumps `version.camunda-security-library` from `0.1.0-alpha33` to `0.1.0-alpha34` in `parent/pom.xml`.

alpha34 ships the metadata-aware per-scope id_token **audience** resolution from [camunda-security-library#441](https://github.com/camunda/camunda-security-library/pull/441): `ScopedClientRegistrationFactory` stashes each scope's configured audiences in the registration's `providerConfigurationMetadata`, and `TokenValidatorFactory` reads them back so a per-scope chain validates id_tokens against *its own* audiences instead of the cluster's. No monorepo code change is needed — the host already wires `tokenValidatorFactory::createTokenValidator` into the id_token decoder factory.

This is the audience half of physical-tenant login; it pairs with the id_token JWS algorithm fix (#55632, resolves the algorithm per `registrationId`). Together they make scoped id_token verification (signature + audience) correct under `/physical-tenants/<id>/...`.

Part of the per-physical-tenant identity slice (#54897).
