### PR TITLE
deps: bump aws-advanced-jdbc-wrapper to 4.0.1 to resolve CVE-2026-11400

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -159,7 +159,7 @@
     <version.reactive-streams>1.0.4</version.reactive-streams>
     <version.postgresql>42.7.11</version.postgresql>
     <version.h2>2.4.240</version.h2>
-    <version.aws-advanced-jdbc-wrapper>3.2.0</version.aws-advanced-jdbc-wrapper>
+    <version.aws-advanced-jdbc-wrapper>4.0.1</version.aws-advanced-jdbc-wrapper>
     <version.aws-signing>4.0.1</version.aws-signing>
     <version.tc-keycloak>4.1.1</version.tc-keycloak>
     <version.jakarta-activation>2.1.4</version.jakarta-activation>


### PR DESCRIPTION
## Description

Bump `aws-advanced-jdbc-wrapper` from 3.2.0 to 4.0.1 to resolve CVE-2026-11400 (privilege escalation via GlobalDatabasePlugin, CVSS 8.0 High).

| File | Change |
|---|---|
| `parent/pom.xml` | `version.aws-advanced-jdbc-wrapper` 3.2.0 → 4.0.1 |

## Related issues

closes #55700