### PR TITLE
feat: add incident-resolution load test scenario and metrics

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -37,6 +37,7 @@ on:
           - typical
           - max
           - archiver
+          - incidents
         default: max
       secondary-storage-type:
         description: 'Secondary database backend for Camunda Platform'
@@ -141,7 +142,7 @@ on:
         default: ""
         required: false
       scenario:
-        description: 'Workload scenario to run. Options: latency, realistic, typical, max, archiver.'
+        description: 'Workload scenario to run. Options: latency, realistic, typical, max, archiver, incidents.'
         type: string
         required: false
         default: ""

--- a/load-tests/docs/assets/incident-resolution-dashboard.json
+++ b/load-tests/docs/assets/incident-resolution-dashboard.json
@@ -1,0 +1,456 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Benchmark Prometheus (monitor.benchmark.camunda.cloud)",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.0.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Incident-resolution load test: reproduces incidents stuck in PENDING before promotion to ACTIVE and measures incident-resolution latency (creationTime -> first observed ACTIVE). Mirrors the process-instance visibility-latency panels in load-tests/docs/metrics.md.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "Incident-resolution latency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Incident-resolution latency = incident creationTime (engine wall-clock) -> first observed ACTIVE in the load tester. The headline number; direct analogue of process-instance data-availability latency. Aggregated across all partitions.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["last", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(starter_incident_pending_to_active_latency_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(starter_incident_pending_to_active_latency_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Incident-resolution latency — p50 / p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "p99 incident-resolution latency broken out per partition. A single partition diverging upward is the head-of-line-blocking signature. Partitions that go fully stuck emit NO samples here — use the backlog and last-promotion-age panels below to catch those.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["last", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, partition) (rate(starter_incident_pending_to_active_latency_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "partition {{partition}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Incident-resolution latency — p99 per partition",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 10 },
+      "id": 101,
+      "panels": [],
+      "title": "Stuck detection (backlog present + promotions absent)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Pending-incident backlog per partition (watch-map size in the IncidentResolutionMeter). The smoking gun: a backlog that grows without bound on a partition is the 'stuck' symptom. A stable backlog is fine; a climbing one is not.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "pending incidents",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 11 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["last", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "max by (partition) (starter_incident_pending_backlog{namespace=~\"$namespace\"})",
+          "legendFormat": "partition {{partition}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pending backlog per partition",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Seconds since the last recorded promotion on each partition (primary stuck detector). Normal cadence is 2-5s; this climbs precisely when a partition stops promoting. STUCK condition: backlog > 0 AND this > ~60s. The red 60s threshold marks the alert boundary.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 60 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 11 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["last", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "max by (partition) (starter_incident_partition_last_promotion_age{namespace=~\"$namespace\"})",
+          "legendFormat": "partition {{partition}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Last promotion age per partition (60s stuck threshold)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+      "id": 102,
+      "panels": [],
+      "title": "Server-side corroboration & survivorship",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Exporter-side confirmation of head-of-line blocking (no new code — existing zeebe.camunda.exporter.incident.updates counter). retry climbing while processed stays flat == the per-partition cursor is repeatedly skipping a batch on missing list-view data. NOTE: this counter carries only an 'action' tag (no partition label), so it is broken out per POD, not per partition — a broker pod aggregates every partition it leads.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "events/s",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*retry.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": ".*processed.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 21 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["last", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(zeebe_camunda_exporter_incident_updates_total{namespace=~\"$namespace\", action=\"retry\"}[$__rate_interval]))",
+          "legendFormat": "retry — {{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(zeebe_camunda_exporter_incident_updates_total{namespace=~\"$namespace\", action=\"processed\"}[$__rate_interval]))",
+          "legendFormat": "processed — {{pod}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Exporter incident updates — retry vs processed (per pod)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Rate of incidents that hit the watch cap (default 20m) without being observed ACTIVE and were recorded as a capped/timeout sample. Survivorship-safe handling: a non-zero rate here means the latency percentiles above include capped values and are NOT optimistic. NOTE: this counter has no partition tag, so it is a single cluster-wide rate (not per partition).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "timeouts/s",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.001 }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 21 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["last", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum (rate(starter_incident_resolution_timeout_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "watch-cap timeouts",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Incident-resolution timeouts (watch-cap hits)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["load-test", "incidents", "camunda-exporter"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(starter_incident_pending_to_active_latency_seconds_bucket, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(starter_incident_pending_to_active_latency_seconds_bucket, namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Load Test — Incident Resolution",
+  "uid": "load-test-incident-resolution",
+  "version": 1,
+  "weekStart": ""
+}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/StarterProperties.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/StarterProperties.java
@@ -26,6 +26,10 @@ public class StarterProperties {
   private int durationLimit = 0;
   private boolean startViaMessage = false;
   private String msgName = "msg";
+  private boolean monitorIncidentResolution = false;
+  private Duration incidentResolutionInterval = Duration.ofSeconds(2);
+  private Duration incidentResolutionWatchCap = Duration.ofMinutes(20);
+  private double incidentResolutionCancelRate = 20;
 
   public String getProcessId() {
     return processId;
@@ -150,5 +154,52 @@ public class StarterProperties {
 
   public void setMsgName(final String msgName) {
     this.msgName = msgName;
+  }
+
+  /**
+   * Whether the starter runs the {@code IncidentResolutionMeter}, which measures
+   * incident-resolution latency (creation → first observed {@code ACTIVE}) and surfaces the pending
+   * backlog per partition. Disabled by default.
+   */
+  public boolean isMonitorIncidentResolution() {
+    return monitorIncidentResolution;
+  }
+
+  public void setMonitorIncidentResolution(final boolean monitorIncidentResolution) {
+    this.monitorIncidentResolution = monitorIncidentResolution;
+  }
+
+  /** How often the incident-resolution meter discovers and confirms incidents. */
+  public Duration getIncidentResolutionInterval() {
+    return incidentResolutionInterval;
+  }
+
+  public void setIncidentResolutionInterval(final Duration incidentResolutionInterval) {
+    this.incidentResolutionInterval = incidentResolutionInterval;
+  }
+
+  /**
+   * The watch cap for a pending incident: once an incident has been pending longer than this, the
+   * meter records the capped elapsed time, increments the timeout counter, and drops it from the
+   * watch-map (survivorship-safe stuck handling).
+   */
+  public Duration getIncidentResolutionWatchCap() {
+    return incidentResolutionWatchCap;
+  }
+
+  public void setIncidentResolutionWatchCap(final Duration incidentResolutionWatchCap) {
+    this.incidentResolutionWatchCap = incidentResolutionWatchCap;
+  }
+
+  /**
+   * The maximum number of stuck process instances cancelled per second by the cancel-after-
+   * measurement drain. Bounds the cleanup load on the cluster.
+   */
+  public double getIncidentResolutionCancelRate() {
+    return incidentResolutionCancelRate;
+  }
+
+  public void setIncidentResolutionCancelRate(final double incidentResolutionCancelRate) {
+    this.incidentResolutionCancelRate = incidentResolutionCancelRate;
   }
 }

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/WorkerProperties.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/WorkerProperties.java
@@ -21,6 +21,7 @@ public class WorkerProperties {
   private boolean sendMessage = false;
   private String messageName = "messageName";
   private String correlationKeyVariableName = "correlationKey-var";
+  private double incidentRatio = 0;
 
   public Duration getCompletionDelay() {
     return completionDelay;
@@ -60,5 +61,19 @@ public class WorkerProperties {
 
   public void setCorrelationKeyVariableName(final String correlationKeyVariableName) {
     this.correlationKeyVariableName = correlationKeyVariableName;
+  }
+
+  /**
+   * The fraction of jobs the worker deliberately fails with zero retries in order to mint incidents
+   * (the {@code incident generation ratio}). {@code 0} (the default) disables incident generation;
+   * {@code 0.01} mirrors the reported customer shape (~1%); higher values force a backlog faster
+   * during bring-up. The failing fraction is selected deterministically per job key.
+   */
+  public double getIncidentRatio() {
+    return incidentRatio;
+  }
+
+  public void setIncidentRatio(final double incidentRatio) {
+    this.incidentRatio = incidentRatio;
   }
 }

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/IncidentResolutionMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/IncidentResolutionMeter.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.metrics;
+
+import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.zeebe.metrics.StarterMetricsDoc.StarterMetricKeyNames;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Measures the incident-resolution latency — the interval from an incident's {@code creationTime}
+ * (engine wall-clock, carried on the incident document) to the moment it is first observed in
+ * {@code ACTIVE} state — and surfaces the pending backlog per partition so that a fully stuck
+ * partition can be detected.
+ *
+ * <p>Modeled on {@link ProcessInstanceStartMeter}, with one deliberate divergence: because the
+ * start timestamp is an absolute engine wall-clock that rides on the incident document, the latency
+ * end timestamp is taken from a wall clock ({@link Instant}), not from {@link System#nanoTime()}.
+ *
+ * <p>Each tick the meter:
+ *
+ * <ul>
+ *   <li><b>discovers</b> incidents created at or after a {@code creationTime} cursor, over states
+ *       {@code {PENDING, ACTIVE}}: an {@code ACTIVE} and unmeasured incident is recorded
+ *       immediately (capturing the healthy baseline of incidents born and promoted within one
+ *       tick); a {@code PENDING} incident is put in the watch-map;
+ *   <li><b>confirms</b> the watch-map by looking incidents up by key in batches; any that flipped
+ *       to {@code ACTIVE} is recorded, its process instance enqueued for cancellation, and it is
+ *       removed from the watch-map;
+ *   <li><b>expires</b> watch-map entries past the watch cap (records the capped elapsed and
+ *       increments the timeout counter — survivorship-safe — then drops them);
+ *   <li><b>cancels</b> a rate-limited batch of measured process instances (cancel-after-
+ *       measurement);
+ *   <li><b>refreshes</b> the per-partition backlog gauges.
+ * </ul>
+ */
+public class IncidentResolutionMeter implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IncidentResolutionMeter.class);
+  private static final long NANOS_PER_SECOND = Duration.ofSeconds(1).toNanos();
+  private static final int DISCOVERY_PAGE_SIZE = 100;
+  private static final int MAX_DISCOVERY_PAGES = 50;
+  private static final int LOOKUP_BATCH_SIZE = 100;
+
+  private final Clock clock;
+  private final Supplier<Instant> wallClock;
+  private final MeterRegistry registry;
+  private final ScheduledExecutorService executor;
+  private final Duration checkInterval;
+  private final Duration watchCap;
+  private final int maxCancellationsPerTick;
+  private final IncidentSource incidentSource;
+
+  private final ConcurrentHashMap<Integer, Timer> partitionToLatencyTimer =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Integer, AtomicInteger> backlogByPartition =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Integer, AtomicLong> lastPromotionNanosByPartition =
+      new ConcurrentHashMap<>();
+  private final Map<Long, WatchedIncident> watchMap = new ConcurrentHashMap<>();
+  private final Set<Long> measured = ConcurrentHashMap.newKeySet();
+  private final Queue<Long> cancellationQueue = new ConcurrentLinkedQueue<>();
+  private final AtomicReference<OffsetDateTime> cursor = new AtomicReference<>();
+
+  private Counter timeoutCounter;
+
+  public IncidentResolutionMeter(
+      final Clock clock,
+      final Supplier<Instant> wallClock,
+      final MeterRegistry registry,
+      final ScheduledExecutorService executor,
+      final Duration checkInterval,
+      final Duration watchCap,
+      final double cancelRatePerSecond,
+      final IncidentSource incidentSource) {
+    this.clock = clock;
+    this.wallClock = wallClock;
+    this.registry = registry;
+    this.executor = executor;
+    this.checkInterval = checkInterval;
+    this.watchCap = watchCap;
+    this.incidentSource = incidentSource;
+    maxCancellationsPerTick =
+        Math.max(1, (int) Math.round(cancelRatePerSecond * checkInterval.toMillis() / 1000.0));
+  }
+
+  /** Starts the periodic discovery and confirmation of incidents. */
+  public void start() {
+    timeoutCounter =
+        Counter.builder(IncidentResolutionMetricsDoc.RESOLUTION_TIMEOUT.getName())
+            .description(IncidentResolutionMetricsDoc.RESOLUTION_TIMEOUT.getDescription())
+            .register(registry);
+    cursor.set(OffsetDateTime.ofInstant(wallClock.get(), ZoneOffset.UTC));
+    scheduleCheck(checkInterval.toMillis());
+  }
+
+  /** Stops the periodic checking. */
+  public void stop() {
+    close();
+  }
+
+  @Override
+  public void close() {
+    executor.shutdownNow();
+  }
+
+  private void scheduleCheck(final long delayMillis) {
+    executor.schedule(this::check, delayMillis, TimeUnit.MILLISECONDS);
+  }
+
+  private void check() {
+    final long startNanos = clock.getNanos();
+    try {
+      discover();
+      confirm();
+      expireStaleWatches();
+      drainCancellations();
+      refreshBacklogGauges();
+    } catch (final Exception e) {
+      LOG.error("Failed to check incidents. Will retry...", e);
+    } finally {
+      rescheduleCheck(clock.getNanos() - startNanos);
+    }
+  }
+
+  private void rescheduleCheck(final long elapsedNanos) {
+    final long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+    final long nextDelay = Math.max(0, checkInterval.toMillis() - elapsedMillis);
+    scheduleCheck(nextDelay);
+  }
+
+  /**
+   * Pulls incidents created at or after the cursor, over states {@code {PENDING, ACTIVE}}, sorted
+   * by creation time ascending. {@code ACTIVE} & unmeasured are recorded immediately; {@code
+   * PENDING} go to the watch-map. The cursor advances to the latest creation time observed;
+   * re-scanning the boundary is harmless because the {@code measured} set and the watch-map key
+   * deduplicate.
+   */
+  private void discover() {
+    final OffsetDateTime from = cursor.get();
+    OffsetDateTime maxCreationTime = from;
+    int page = 0;
+    boolean more = true;
+    while (more && page < MAX_DISCOVERY_PAGES) {
+      final List<IncidentSnapshot> incidents =
+          join(incidentSource.discover(from, page * DISCOVERY_PAGE_SIZE, DISCOVERY_PAGE_SIZE));
+      for (final IncidentSnapshot incident : incidents) {
+        ensurePartitionRegistered(incident.partitionId());
+        if (incident.creationTime().isAfter(maxCreationTime)) {
+          maxCreationTime = incident.creationTime();
+        }
+        if (incident.state() == IncidentState.ACTIVE) {
+          recordPromotion(incident);
+        } else if (incident.state() == IncidentState.PENDING
+            && !measured.contains(incident.incidentKey())) {
+          watchMap.put(incident.incidentKey(), WatchedIncident.from(incident));
+        }
+      }
+      more = incidents.size() == DISCOVERY_PAGE_SIZE;
+      page++;
+    }
+    if (more) {
+      LOG.warn(
+          "Discovery hit the page cap of {} pages ({} incidents) in a single tick; "
+              + "remaining incidents will be picked up on the next tick.",
+          MAX_DISCOVERY_PAGES,
+          MAX_DISCOVERY_PAGES * DISCOVERY_PAGE_SIZE);
+    }
+    cursor.set(maxCreationTime);
+  }
+
+  /**
+   * Re-queries the watched incidents by key in batches and records any that flipped to {@code
+   * ACTIVE}.
+   */
+  private void confirm() {
+    if (watchMap.isEmpty()) {
+      return;
+    }
+    final List<Long> keys = new ArrayList<>(watchMap.keySet());
+    for (int start = 0; start < keys.size(); start += LOOKUP_BATCH_SIZE) {
+      final List<Long> batch =
+          keys.subList(start, Math.min(start + LOOKUP_BATCH_SIZE, keys.size()));
+      final List<IncidentSnapshot> snapshots = join(incidentSource.lookup(batch));
+      for (final IncidentSnapshot snapshot : snapshots) {
+        if (snapshot.state() == IncidentState.ACTIVE
+            && watchMap.containsKey(snapshot.incidentKey())) {
+          recordPromotion(snapshot);
+        }
+      }
+    }
+  }
+
+  /**
+   * Records the capped elapsed time for incidents that have been pending past the watch cap and
+   * increments the timeout counter, then drops them from the watch-map. A timeout is <em>not</em> a
+   * promotion, so the partition's last-promotion timestamp is deliberately left untouched.
+   */
+  private void expireStaleWatches() {
+    final Instant now = wallClock.get();
+    final List<WatchedIncident> expired = new ArrayList<>();
+    for (final WatchedIncident watched : watchMap.values()) {
+      if (Duration.between(watched.creationTime().toInstant(), now).compareTo(watchCap) > 0) {
+        expired.add(watched);
+      }
+    }
+    for (final WatchedIncident watched : expired) {
+      if (watchMap.remove(watched.incidentKey()) == null) {
+        continue;
+      }
+      measured.add(watched.incidentKey());
+      latencyTimer(watched.partitionId()).record(watchCap.toMillis(), TimeUnit.MILLISECONDS);
+      timeoutCounter.increment();
+      LOG.debug(
+          "Incident {} on partition {} exceeded the watch cap of {}; recorded as a timeout.",
+          watched.incidentKey(),
+          watched.partitionId(),
+          watchCap);
+    }
+  }
+
+  private void drainCancellations() {
+    for (int i = 0; i < maxCancellationsPerTick; i++) {
+      final Long processInstanceKey = cancellationQueue.poll();
+      if (processInstanceKey == null) {
+        return;
+      }
+      incidentSource
+          .cancel(processInstanceKey)
+          .whenComplete(
+              (ignored, error) -> {
+                if (error != null) {
+                  LOG.debug("Failed to cancel process instance {}", processInstanceKey, error);
+                }
+              });
+    }
+  }
+
+  private void refreshBacklogGauges() {
+    final Map<Integer, Integer> counts = new HashMap<>();
+    for (final WatchedIncident watched : watchMap.values()) {
+      counts.merge(watched.partitionId(), 1, Integer::sum);
+    }
+    backlogByPartition.forEach(
+        (partitionId, backlog) -> backlog.set(counts.getOrDefault(partitionId, 0)));
+  }
+
+  /**
+   * Records an observed promotion: the incident-resolution latency (wall-clock now − creation time,
+   * clamped to {@code >= 0}) into the per-partition timer, marks the partition's last promotion,
+   * deduplicates via the {@code measured} set, enqueues the process instance for cancellation, and
+   * removes the incident from the watch-map.
+   */
+  private void recordPromotion(final IncidentSnapshot incident) {
+    if (!measured.add(incident.incidentKey())) {
+      watchMap.remove(incident.incidentKey());
+      return;
+    }
+    final long latencyMillis =
+        Math.max(
+            0, Duration.between(incident.creationTime().toInstant(), wallClock.get()).toMillis());
+    latencyTimer(incident.partitionId()).record(latencyMillis, TimeUnit.MILLISECONDS);
+    lastPromotionNanos(incident.partitionId()).set(clock.getNanos());
+    watchMap.remove(incident.incidentKey());
+    cancellationQueue.add(incident.processInstanceKey());
+    LOG.debug(
+        "Incident {} on partition {} resolved in {} ms",
+        incident.incidentKey(),
+        incident.partitionId(),
+        latencyMillis);
+  }
+
+  private Timer latencyTimer(final int partitionId) {
+    return partitionToLatencyTimer.computeIfAbsent(
+        partitionId,
+        key ->
+            MicrometerUtil.buildTimer(IncidentResolutionMetricsDoc.PENDING_TO_ACTIVE_LATENCY)
+                .tag(StarterMetricKeyNames.PARTITION.asString(), Integer.toString(key))
+                .register(registry));
+  }
+
+  private AtomicLong lastPromotionNanos(final int partitionId) {
+    ensurePartitionRegistered(partitionId);
+    return lastPromotionNanosByPartition.get(partitionId);
+  }
+
+  /**
+   * Lazily registers the per-partition gauges the first time a partition is observed, seeding the
+   * last-promotion timestamp to "now" so the promotion-age gauge starts at zero rather than a large
+   * value.
+   */
+  private void ensurePartitionRegistered(final int partitionId) {
+    lastPromotionNanosByPartition.computeIfAbsent(
+        partitionId,
+        key -> {
+          final AtomicLong lastPromotion = new AtomicLong(clock.getNanos());
+          Gauge.builder(
+                  IncidentResolutionMetricsDoc.PARTITION_LAST_PROMOTION_AGE.getName(),
+                  lastPromotion,
+                  value -> (clock.getNanos() - value.get()) / (double) NANOS_PER_SECOND)
+              .description(
+                  IncidentResolutionMetricsDoc.PARTITION_LAST_PROMOTION_AGE.getDescription())
+              .tag(StarterMetricKeyNames.PARTITION.asString(), Integer.toString(key))
+              .register(registry);
+          return lastPromotion;
+        });
+    backlogByPartition.computeIfAbsent(
+        partitionId,
+        key -> {
+          final AtomicInteger backlog = new AtomicInteger(0);
+          Gauge.builder(
+                  IncidentResolutionMetricsDoc.PENDING_BACKLOG.getName(),
+                  backlog,
+                  AtomicInteger::doubleValue)
+              .description(IncidentResolutionMetricsDoc.PENDING_BACKLOG.getDescription())
+              .tag(StarterMetricKeyNames.PARTITION.asString(), Integer.toString(key))
+              .register(registry);
+          return backlog;
+        });
+  }
+
+  private static <T> T join(final java.util.concurrent.CompletionStage<T> stage) {
+    return stage.toCompletableFuture().join();
+  }
+
+  /** A pending incident the meter is watching until it flips to {@code ACTIVE} or times out. */
+  private record WatchedIncident(
+      long incidentKey, long processInstanceKey, OffsetDateTime creationTime, int partitionId) {
+    static WatchedIncident from(final IncidentSnapshot incident) {
+      return new WatchedIncident(
+          incident.incidentKey(),
+          incident.processInstanceKey(),
+          incident.creationTime(),
+          incident.partitionId());
+    }
+  }
+
+  /** A minimal view of an incident as seen by the meter. */
+  public record IncidentSnapshot(
+      long incidentKey, long processInstanceKey, OffsetDateTime creationTime, IncidentState state) {
+
+    public int partitionId() {
+      return Protocol.decodePartitionId(incidentKey);
+    }
+  }
+
+  /**
+   * Decouples the meter from the search/command client. Implementations issue the actual incident
+   * search and cancel commands against the cluster.
+   */
+  public interface IncidentSource {
+
+    /**
+     * Discovers incidents created at or after the given time, over states {@code {PENDING,
+     * ACTIVE}}, sorted by creation time ascending, returning the page starting at {@code from} with
+     * at most {@code limit} items.
+     */
+    java.util.concurrent.CompletionStage<List<IncidentSnapshot>> discover(
+        OffsetDateTime createdAtOrAfter, int from, int limit);
+
+    /** Looks up the current state of the given incident keys. */
+    java.util.concurrent.CompletionStage<List<IncidentSnapshot>> lookup(List<Long> incidentKeys);
+
+    /** Cancels the given process instance (cancel-after-measurement cleanup). */
+    java.util.concurrent.CompletionStage<Void> cancel(long processInstanceKey);
+  }
+}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/IncidentResolutionMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/IncidentResolutionMetricsDoc.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.metrics;
+
+import io.camunda.zeebe.metrics.StarterMetricsDoc.StarterMetricKeyNames;
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+/**
+ * Metrics emitted by the {@link IncidentResolutionMeter}. They measure the incident-resolution
+ * latency — the interval from an incident's creation (engine wall-clock, carried on the incident
+ * document) to the moment the load tester first observes it in {@code ACTIVE} state — and surface
+ * the pending backlog so that a fully stuck partition can be detected from backlog presence plus
+ * promotion absence.
+ */
+public enum IncidentResolutionMetricsDoc implements ExtendedMeterDocumentation {
+
+  /**
+   * The incident-resolution latency, tagged by partition (decoded from the incident key). Measures
+   * the time from an incident's {@code creationTime} to the moment it is first observed {@code
+   * ACTIVE}. The end timestamp is wall-clock ({@code Instant.now()}), not {@code nanoTime} — a
+   * deliberate divergence from {@link ProcessInstanceStartMeter}, because the start is an absolute
+   * engine wall-clock carried on the incident document.
+   */
+  PENDING_TO_ACTIVE_LATENCY {
+    private static final KeyName[] KEY_NAMES = new KeyName[] {StarterMetricKeyNames.PARTITION};
+
+    private static final Duration[] BUCKETS = {
+      Duration.ofSeconds(1),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30),
+      Duration.ofMinutes(1),
+      Duration.ofMinutes(2),
+      Duration.ofMinutes(5),
+      Duration.ofMinutes(10),
+      Duration.ofMinutes(15),
+    };
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The incident-resolution latency: the time from an incident's creation time to the moment it is first observed in ACTIVE state.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.incident.pending.to.active.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /**
+   * Number of incidents that exceeded the watch cap before being observed {@code ACTIVE}. Their
+   * capped elapsed time is still recorded into {@link #PENDING_TO_ACTIVE_LATENCY} so a stuck run
+   * does not show optimistically low percentiles, and this counter reflects how many samples were
+   * capped.
+   */
+  RESOLUTION_TIMEOUT {
+    @Override
+    public String getDescription() {
+      return "Number of incidents that exceeded the watch cap before being observed ACTIVE.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.incident.resolution.timeout";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+  },
+
+  /**
+   * The number of pending incidents currently being watched on a partition (the per-partition
+   * watch-map size). Together with {@link #PARTITION_LAST_PROMOTION_AGE} it detects a fully stuck
+   * partition, which — emitting no latency samples — is invisible in the latency percentiles.
+   */
+  PENDING_BACKLOG {
+    private static final KeyName[] KEY_NAMES = new KeyName[] {StarterMetricKeyNames.PARTITION};
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The number of pending incidents currently being watched on a partition.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.incident.pending.backlog";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
+
+  /**
+   * Seconds since the last incident promotion (PENDING → ACTIVE) recorded on a partition. This is
+   * the primary stuck detector: it climbs precisely when a partition stops promoting. Stuck
+   * condition: {@code backlog{p} > 0 AND last_promotion_age{p} > ~60s} (normal cadence is 2–5s).
+   */
+  PARTITION_LAST_PROMOTION_AGE {
+    private static final KeyName[] KEY_NAMES = new KeyName[] {StarterMetricKeyNames.PARTITION};
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Seconds since the last incident promotion recorded on a partition.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.incident.partition.last.promotion.age";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  }
+}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -15,12 +15,17 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.zeebe.config.LoadTesterProperties;
 import io.camunda.zeebe.config.StarterProperties;
 import io.camunda.zeebe.metrics.ConnectionMonitor;
+import io.camunda.zeebe.metrics.IncidentResolutionMeter;
+import io.camunda.zeebe.metrics.IncidentResolutionMeter.IncidentSnapshot;
+import io.camunda.zeebe.metrics.IncidentResolutionMeter.IncidentSource;
 import io.camunda.zeebe.metrics.ProcessInstanceStartMeter;
 import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc;
 import io.camunda.zeebe.metrics.StarterMetricsDoc;
@@ -42,9 +47,11 @@ import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
@@ -95,6 +102,7 @@ public class Starter implements CommandLineRunner {
   private Counter processInstancesStartedCounter;
   private ScheduledExecutorService executorService;
   private ProcessInstanceStartMeter processInstanceStartMeter;
+  private IncidentResolutionMeter incidentResolutionMeter;
   private DataReadMeter dataReadMeter;
   private OptimizeReportEvaluator optimizeReportEvaluator;
 
@@ -147,6 +155,10 @@ public class Starter implements CommandLineRunner {
       setupDataAvailabilityMeter();
     }
 
+    if (starterCfg.isMonitorIncidentResolution()) {
+      setupIncidentResolutionMeter();
+    }
+
     if (properties.isPerformReadBenchmarks()) {
       setupDataReadMeter();
     }
@@ -197,6 +209,9 @@ public class Starter implements CommandLineRunner {
     if (processInstanceStartMeter != null) {
       processInstanceStartMeter.close();
     }
+    if (incidentResolutionMeter != null) {
+      incidentResolutionMeter.close();
+    }
     if (dataReadMeter != null) {
       dataReadMeter.close();
     }
@@ -229,6 +244,64 @@ public class Starter implements CommandLineRunner {
                           .toList());
             });
     processInstanceStartMeter.start();
+  }
+
+  private void setupIncidentResolutionMeter() {
+    LOG.info("Monitor incident-resolution latency of generated incidents");
+    incidentResolutionMeter =
+        new IncidentResolutionMeter(
+            System::nanoTime,
+            Instant::now,
+            registry,
+            Executors.newScheduledThreadPool(1),
+            starterCfg.getIncidentResolutionInterval(),
+            starterCfg.getIncidentResolutionWatchCap(),
+            starterCfg.getIncidentResolutionCancelRate(),
+            new IncidentSource() {
+              @Override
+              public CompletionStage<List<IncidentSnapshot>> discover(
+                  final OffsetDateTime createdAtOrAfter, final int from, final int limit) {
+                return client
+                    .newIncidentSearchRequest()
+                    .filter(
+                        f ->
+                            f.creationTime(d -> d.gte(createdAtOrAfter))
+                                .state(s -> s.in(IncidentState.PENDING, IncidentState.ACTIVE)))
+                    .sort(s -> s.creationTime().asc())
+                    .page(p -> p.from(from).limit(limit))
+                    .send()
+                    .thenApply(
+                        response -> response.items().stream().map(this::toSnapshot).toList());
+              }
+
+              @Override
+              public CompletionStage<List<IncidentSnapshot>> lookup(final List<Long> incidentKeys) {
+                return client
+                    .newIncidentSearchRequest()
+                    .filter(f -> f.incidentKey(k -> k.in(incidentKeys)))
+                    .page(p -> p.limit(incidentKeys.size()))
+                    .send()
+                    .thenApply(
+                        response -> response.items().stream().map(this::toSnapshot).toList());
+              }
+
+              @Override
+              public CompletionStage<Void> cancel(final long processInstanceKey) {
+                return client
+                    .newCancelInstanceCommand(processInstanceKey)
+                    .send()
+                    .thenApply(ignored -> null);
+              }
+
+              private IncidentSnapshot toSnapshot(final Incident incident) {
+                return new IncidentSnapshot(
+                    incident.getIncidentKey(),
+                    incident.getProcessInstanceKey(),
+                    incident.getCreationTime(),
+                    incident.getState());
+              }
+            });
+    incidentResolutionMeter.start();
   }
 
   private void setupOptimizeReportEvaluator() {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/Worker.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/Worker.java
@@ -35,6 +35,9 @@ public class Worker {
   private static final Logger LOGGER = LoggerFactory.getLogger(Worker.class);
   private static final Logger THROTTLED_LOGGER = new ThrottledLogger(LOGGER, Duration.ofSeconds(5));
   private static final int REQUEST_FUTURES_CAPACITY = 10_000;
+  // Bucket count used to select the deterministic failing fraction per job key. A ratio of 0.01
+  // fails keys landing in buckets [0, 100); 0.5 fails [0, 5000).
+  private static final long INCIDENT_RATIO_BUCKETS = 10_000;
 
   private final CamundaClient client;
   private final WorkerProperties workerCfg;
@@ -87,6 +90,21 @@ public class Worker {
   public void handleJob(final JobClient jobClient, final ActivatedJob job) {
     final long startHandlingTime = System.currentTimeMillis();
 
+    if (shouldGenerateIncident(job.getKey())) {
+      // Deliberately fail the job with zero retries so the engine raises an incident on a real
+      // service-task failure (the incident generation ratio). These incidents are never resolved;
+      // they accumulate so the load test can measure incident-resolution latency. The same
+      // completion delay as the success path is applied so failing jobs do not re-poll faster.
+      final var failCommand =
+          jobClient
+              .newFailCommand(job.getKey())
+              .retries(0)
+              .errorMessage("load-test: deliberate incident generation");
+      addDelayToCompletion(workerCfg.getCompletionDelay().toMillis(), startHandlingTime);
+      trackRequest(failCommand.send());
+      return;
+    }
+
     if (workerCfg.isSendMessage()) {
       final var correlationKey =
           job.getVariable(workerCfg.getCorrelationKeyVariableName()).toString();
@@ -117,15 +135,32 @@ public class Worker {
 
     final var command = jobClient.newCompleteCommand(job.getKey()).variables(variables);
     addDelayToCompletion(workerCfg.getCompletionDelay().toMillis(), startHandlingTime);
-    if (!requestFutures.offer(command.send())) {
+    trackRequest(command.send());
+  }
+
+  private void trackRequest(final Future<?> future) {
+    if (!requestFutures.offer(future)) {
       // Non-blocking: if the response-check queue is saturated, drop tracking for this
-      // completion rather than stalling the job handler thread (which would cascade into
+      // request rather than stalling the job handler thread (which would cascade into
       // broker timeouts). We lose visibility into its eventual result — log throttled so
       // the operator can notice sustained backpressure without flooding the log.
       THROTTLED_LOGGER.warn(
           "Completion-response queue full (capacity: {}); dropping future tracking",
           REQUEST_FUTURES_CAPACITY);
     }
+  }
+
+  private boolean shouldGenerateIncident(final long jobKey) {
+    final double ratio = workerCfg.getIncidentRatio();
+    if (ratio <= 0) {
+      return false;
+    }
+    if (ratio >= 1) {
+      return true;
+    }
+    // Deterministic per-job selection: job keys carry a per-partition sequence in their low bits,
+    // so floorMod spreads them evenly across the bucket range; fail the first `ratio` fraction.
+    return Math.floorMod(jobKey, INCIDENT_RATIO_BUCKETS) < ratio * INCIDENT_RATIO_BUCKETS;
   }
 
   private boolean publishMessage(final String correlationKey) {

--- a/load-tests/load-tester/src/main/resources/application.yaml
+++ b/load-tests/load-tester/src/main/resources/application.yaml
@@ -94,6 +94,12 @@ load-tester:
     duration-limit: ${LOAD_TESTER_STARTER_DURATION_LIMIT:0}
     msg-name: msg
     start-via-message: false
+    # Incident-resolution meter: measures incident-resolution latency (creation -> first observed
+    # ACTIVE) and surfaces the pending backlog per partition. Disabled by default.
+    monitor-incident-resolution: ${LOAD_TESTER_STARTER_MONITOR_INCIDENT_RESOLUTION:false}
+    incident-resolution-interval: ${LOAD_TESTER_STARTER_INCIDENT_RESOLUTION_INTERVAL:2s}
+    incident-resolution-watch-cap: ${LOAD_TESTER_STARTER_INCIDENT_RESOLUTION_WATCH_CAP:20m}
+    incident-resolution-cancel-rate: ${LOAD_TESTER_STARTER_INCIDENT_RESOLUTION_CANCEL_RATE:20}
   # Worker-specific properties consumed by Worker.java.
   # These control what the job handler does (completion delay, message publishing, payload).
   # Connection properties (type, name, threads, capacity, polling, streaming, timeout)
@@ -104,6 +110,9 @@ load-tester:
     send-message: ${LOAD_TESTER_WORKER_SEND_MESSAGE:false}
     message-name: ${LOAD_TESTER_WORKER_MESSAGE_NAME:messageName}
     correlation-key-variable-name: ${LOAD_TESTER_WORKER_CORRELATION_KEY_VARIABLE_NAME:correlationKey-var}
+    # Fraction of jobs deliberately failed with zero retries to mint incidents (incident
+    # generation ratio). 0 disables it; ~0.01 mirrors the customer shape; 0.5 forces a backlog fast.
+    incident-ratio: ${LOAD_TESTER_WORKER_INCIDENT_RATIO:0}
 
   # Optional Optimize report-evaluation meter (starter-only); requires api.jwtAuthForApiEnabled=true.
   optimize:

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/metrics/IncidentResolutionMeterTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/metrics/IncidentResolutionMeterTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.zeebe.metrics.IncidentResolutionMeter.IncidentSnapshot;
+import io.camunda.zeebe.metrics.IncidentResolutionMeter.IncidentSource;
+import io.camunda.zeebe.metrics.StarterMetricsDoc.StarterMetricKeyNames;
+import io.camunda.zeebe.protocol.Protocol;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IncidentResolutionMeterTest {
+
+  private static final int PARTITION = 3;
+  private static final long PROCESS_INSTANCE_KEY = 1234L;
+  // The meter seeds its discovery cursor from the wall clock at start(); tests therefore start the
+  // meter at T0, advance the clock to an observation time, then make incidents discoverable with a
+  // creation time in (T0, observation] — mirroring "incident created after the meter started".
+  private static final Instant T0 = Instant.parse("2026-06-22T10:00:00Z");
+
+  private SimpleMeterRegistry registry;
+  private StubIncidentSource source;
+  private AtomicReference<Instant> now;
+  private IncidentResolutionMeter meter;
+
+  @BeforeEach
+  void setUp() {
+    registry = new SimpleMeterRegistry();
+    source = new StubIncidentSource();
+    now = new AtomicReference<>(T0);
+    meter = newMeter(Duration.ofMinutes(20));
+  }
+
+  @AfterEach
+  void tearDown() {
+    meter.stop();
+    registry.close();
+  }
+
+  private IncidentResolutionMeter newMeter(final Duration watchCap) {
+    return new IncidentResolutionMeter(
+        System::nanoTime,
+        now::get,
+        registry,
+        Executors.newScheduledThreadPool(1),
+        Duration.ofMillis(1),
+        watchCap,
+        1000,
+        source);
+  }
+
+  @Test
+  void shouldRecordLatencyWhenIncidentDiscoveredActive() {
+    // given - the meter is running and the wall clock has advanced 3s past the incident's creation
+    final long incidentKey = Protocol.encodePartitionId(PARTITION, 1);
+    meter.start();
+    now.set(T0.plusSeconds(3));
+
+    // when - an incident born and promoted within one tick is discovered already ACTIVE
+    source.discoverable(active(incidentKey, T0));
+
+    // then - the latency is recorded against the decoded partition tag
+    awaitLatencyCount(1);
+    assertThat(latencyTimer().totalTime(TimeUnit.MILLISECONDS)).isBetween(2999.0, 3001.0);
+  }
+
+  @Test
+  void shouldRecordLatencyWhenWatchedPendingIncidentPromotes() {
+    // given - a pending incident is discovered and watched
+    final long incidentKey = Protocol.encodePartitionId(PARTITION, 2);
+    meter.start();
+    now.set(T0.plusSeconds(10));
+    source.discoverable(pending(incidentKey, T0));
+    awaitBacklog(1);
+
+    // when - the incident is promoted (now visible as ACTIVE via lookup)
+    source.lookupState(active(incidentKey, T0));
+
+    // then - the latency is recorded and the backlog drains
+    awaitLatencyCount(1);
+    awaitBacklog(0);
+    assertThat(latencyTimer().totalTime(TimeUnit.MILLISECONDS)).isBetween(9999.0, 10001.0);
+  }
+
+  @Test
+  void shouldMeasureLatencyWithWallClockNotNanoTime() {
+    // given - the wall clock has advanced 7s past the incident's creation time
+    final long incidentKey = Protocol.encodePartitionId(PARTITION, 3);
+    meter.start();
+    now.set(T0.plusSeconds(7));
+
+    // when
+    source.discoverable(active(incidentKey, T0));
+
+    // then - the recorded latency equals the wall-clock interval (creation -> observed), proving
+    // the
+    // end timestamp comes from the wall clock and not from System.nanoTime()
+    awaitLatencyCount(1);
+    assertThat(latencyTimer().totalTime(TimeUnit.MILLISECONDS)).isBetween(6999.0, 7001.0);
+  }
+
+  @Test
+  void shouldClampNegativeLatencyToZero() {
+    // given - a creation time in the future relative to the wall clock (clock skew)
+    final long incidentKey = Protocol.encodePartitionId(PARTITION, 4);
+    meter.start();
+    now.set(T0.plusSeconds(5));
+
+    // when - the incident's creation time is after the current wall clock
+    source.discoverable(active(incidentKey, T0.plusSeconds(20)));
+
+    // then - the latency is clamped to zero rather than recorded as negative
+    awaitLatencyCount(1);
+    assertThat(latencyTimer().totalTime(TimeUnit.MILLISECONDS)).isZero();
+  }
+
+  @Test
+  void shouldRecordTimeoutWhenWatchCapExceeded() {
+    // given - a meter with a 5s watch cap and a pending incident already older than the cap
+    meter = newMeter(Duration.ofSeconds(5));
+    final long incidentKey = Protocol.encodePartitionId(PARTITION, 5);
+    meter.start();
+    now.set(T0.plusSeconds(8));
+    source.discoverable(pending(incidentKey, T0));
+
+    // when - the incident never promotes (lookup keeps returning PENDING)
+
+    // then - the capped elapsed is recorded into the timer and the timeout counter is incremented
+    awaitLatencyCount(1);
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        registry
+                            .get(IncidentResolutionMetricsDoc.RESOLUTION_TIMEOUT.getName())
+                            .counter()
+                            .count())
+                    .isEqualTo(1.0));
+    assertThat(latencyTimer().totalTime(TimeUnit.MILLISECONDS))
+        .describedAs("the capped watch-cap value is recorded, not the true (larger) elapsed")
+        .isBetween(4999.0, 5001.0);
+    awaitBacklog(0);
+  }
+
+  @Test
+  void shouldNotRecordSameIncidentTwice() {
+    // given - an ACTIVE incident that keeps being re-discovered (its creation time stays >= cursor)
+    final long incidentKey = Protocol.encodePartitionId(PARTITION, 6);
+    meter.start();
+    now.set(T0.plusSeconds(2));
+    source.discoverable(active(incidentKey, T0));
+
+    // when - the meter runs many ticks
+    awaitLatencyCount(1);
+
+    // then - the measured set prevents the rediscovered incident from being counted again
+    await()
+        .during(Duration.ofMillis(200))
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(() -> assertThat(latencyTimer().count()).isEqualTo(1L));
+  }
+
+  @Test
+  void shouldAdvanceDiscoveryCursorPastObservedIncidents() {
+    // given - an incident created 30s after the initial (start-time) cursor
+    final long incidentKey = Protocol.encodePartitionId(PARTITION, 7);
+    final OffsetDateTime creationTime = offset(T0.plusSeconds(30));
+    meter.start();
+    now.set(T0.plusSeconds(60));
+    source.discoverable(active(incidentKey, T0.plusSeconds(30)));
+
+    // when
+    awaitLatencyCount(1);
+
+    // then - subsequent discovery queries start from the latest observed creation time
+    await().untilAsserted(() -> assertThat(source.lastDiscoverFrom()).isEqualTo(creationTime));
+  }
+
+  @Test
+  void shouldCancelProcessInstanceAfterMeasurement() {
+    // given - an incident observed ACTIVE
+    final long incidentKey = Protocol.encodePartitionId(PARTITION, 8);
+    meter.start();
+    now.set(T0.plusSeconds(1));
+    source.discoverable(active(incidentKey, T0));
+
+    // when
+    awaitLatencyCount(1);
+
+    // then - the stuck instance is cancelled only after its latency has been recorded
+    await().untilAsserted(() -> assertThat(source.cancelled()).contains(PROCESS_INSTANCE_KEY));
+  }
+
+  @Test
+  void shouldTrackPendingBacklogPerPartition() {
+    // given - two pending incidents on the same partition
+    meter.start();
+    now.set(T0.plusSeconds(5));
+    source.discoverable(
+        pending(Protocol.encodePartitionId(PARTITION, 9), T0),
+        pending(Protocol.encodePartitionId(PARTITION, 10), T0));
+
+    // when / then - the backlog gauge reflects the watch-map size for that partition
+    awaitBacklog(2);
+  }
+
+  private static IncidentSnapshot active(final long incidentKey, final Instant creationTime) {
+    return new IncidentSnapshot(
+        incidentKey, PROCESS_INSTANCE_KEY, offset(creationTime), IncidentState.ACTIVE);
+  }
+
+  private static IncidentSnapshot pending(final long incidentKey, final Instant creationTime) {
+    return new IncidentSnapshot(
+        incidentKey, PROCESS_INSTANCE_KEY, offset(creationTime), IncidentState.PENDING);
+  }
+
+  private static OffsetDateTime offset(final Instant instant) {
+    return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+  }
+
+  private Timer latencyTimer() {
+    return registry
+        .get(IncidentResolutionMetricsDoc.PENDING_TO_ACTIVE_LATENCY.getName())
+        .tag(StarterMetricKeyNames.PARTITION.asString(), Integer.toString(PARTITION))
+        .timer();
+  }
+
+  private void awaitLatencyCount(final long expected) {
+    await().untilAsserted(() -> assertThat(latencyTimer().count()).isEqualTo(expected));
+  }
+
+  private void awaitBacklog(final double expected) {
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        registry
+                            .get(IncidentResolutionMetricsDoc.PENDING_BACKLOG.getName())
+                            .tag(
+                                StarterMetricKeyNames.PARTITION.asString(),
+                                Integer.toString(PARTITION))
+                            .gauge()
+                            .value())
+                    .isEqualTo(expected));
+  }
+
+  /** A configurable in-memory {@link IncidentSource} for driving the meter deterministically. */
+  private static final class StubIncidentSource implements IncidentSource {
+
+    private final List<IncidentSnapshot> discoverable = new CopyOnWriteArrayList<>();
+    private final List<IncidentSnapshot> lookupStates = new CopyOnWriteArrayList<>();
+    private final List<Long> cancelled = new CopyOnWriteArrayList<>();
+    private final AtomicReference<OffsetDateTime> lastDiscoverFrom = new AtomicReference<>();
+
+    void discoverable(final IncidentSnapshot... snapshots) {
+      discoverable.clear();
+      discoverable.addAll(List.of(snapshots));
+    }
+
+    void lookupState(final IncidentSnapshot snapshot) {
+      lookupStates.removeIf(s -> s.incidentKey() == snapshot.incidentKey());
+      lookupStates.add(snapshot);
+    }
+
+    List<Long> cancelled() {
+      return cancelled;
+    }
+
+    OffsetDateTime lastDiscoverFrom() {
+      return lastDiscoverFrom.get();
+    }
+
+    @Override
+    public CompletionStage<List<IncidentSnapshot>> discover(
+        final OffsetDateTime createdAtOrAfter, final int from, final int limit) {
+      lastDiscoverFrom.set(createdAtOrAfter);
+      if (from > 0) {
+        // single page only: signal no further pages
+        return CompletableFuture.completedFuture(List.of());
+      }
+      final List<IncidentSnapshot> page = new ArrayList<>();
+      for (final IncidentSnapshot snapshot : discoverable) {
+        if (!snapshot.creationTime().isBefore(createdAtOrAfter)) {
+          page.add(snapshot);
+        }
+      }
+      return CompletableFuture.completedFuture(page);
+    }
+
+    @Override
+    public CompletionStage<List<IncidentSnapshot>> lookup(final List<Long> incidentKeys) {
+      final List<IncidentSnapshot> result =
+          lookupStates.stream().filter(s -> incidentKeys.contains(s.incidentKey())).toList();
+      return CompletableFuture.completedFuture(result);
+    }
+
+    @Override
+    public CompletionStage<Void> cancel(final long processInstanceKey) {
+      cancelled.add(processInstanceKey);
+      return CompletableFuture.completedFuture(null);
+    }
+  }
+}

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/worker/WorkerTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/worker/WorkerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.worker;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -18,10 +19,13 @@ import static org.mockito.Mockito.when;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
+import io.camunda.client.api.command.FailJobCommandStep1;
+import io.camunda.client.api.command.FailJobCommandStep1.FailJobCommandStep2;
 import io.camunda.client.api.command.PublishMessageCommandStep1;
 import io.camunda.client.api.command.PublishMessageCommandStep1.PublishMessageCommandStep2;
 import io.camunda.client.api.command.PublishMessageCommandStep1.PublishMessageCommandStep3;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.FailJobResponse;
 import io.camunda.client.api.response.PublishMessageResponse;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.zeebe.config.LoadTesterProperties;
@@ -61,6 +65,42 @@ class WorkerTest {
     verify(jobClient, never()).newCompleteCommand(job);
     verify(jobClient, never()).newFailCommand(anyLong());
     verify(jobClient, never()).newFailCommand(job);
+  }
+
+  @Test
+  void shouldFailJobWithZeroRetriesWhenIncidentRatioForcesGeneration() {
+    // given — a worker configured to generate an incident for every job (ratio = 1)
+    final var jobClient = mock(JobClient.class);
+    final var job = mockJob();
+    final var client = mock(CamundaClient.class);
+    final var failStep1 = mockFailJob(jobClient);
+    final var worker = newWorker(client, incidentProperties(1.0));
+
+    // when
+    worker.handleJob(jobClient, job);
+
+    // then — the job is failed with zero retries to mint an incident and never completed
+    verify(jobClient).newFailCommand(job.getKey());
+    verify(failStep1).retries(0);
+    verify(jobClient, never()).newCompleteCommand(anyLong());
+  }
+
+  @Test
+  void shouldCompleteJobWhenIncidentRatioIsZero() {
+    // given — incident generation disabled (the default ratio of 0)
+    final var jobClient = mock(JobClient.class);
+    final var job = mockJob();
+    final var client = mock(CamundaClient.class);
+    final var completeStep = mockCompleteJob(jobClient);
+    final var worker = newWorker(client, incidentProperties(0));
+
+    // when
+    worker.handleJob(jobClient, job);
+
+    // then — the job is completed and never failed
+    verify(jobClient).newCompleteCommand(job.getKey());
+    verify(completeStep).send();
+    verify(jobClient, never()).newFailCommand(anyLong());
   }
 
   @Test
@@ -107,6 +147,13 @@ class WorkerTest {
     return props;
   }
 
+  private static WorkerProperties incidentProperties(final double incidentRatio) {
+    final var props = new WorkerProperties();
+    props.setCompletionDelay(Duration.ZERO);
+    props.setIncidentRatio(incidentRatio);
+    return props;
+  }
+
   private static Worker newWorker(final CamundaClient client, final WorkerProperties workerProps) {
     final var properties = new LoadTesterProperties();
     properties.setWorker(workerProps);
@@ -142,6 +189,18 @@ class WorkerTest {
     when(step3.send()).thenReturn(future);
     when(future.get(anyLong(), org.mockito.ArgumentMatchers.any(TimeUnit.class)))
         .thenReturn(mock(PublishMessageResponse.class));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static FailJobCommandStep1 mockFailJob(final JobClient jobClient) {
+    final var failStep1 = mock(FailJobCommandStep1.class);
+    final var failStep2 = mock(FailJobCommandStep2.class);
+    final CamundaFuture<FailJobResponse> future = mock(CamundaFuture.class);
+    when(jobClient.newFailCommand(anyLong())).thenReturn(failStep1);
+    when(failStep1.retries(anyInt())).thenReturn(failStep2);
+    when(failStep2.errorMessage(anyString())).thenReturn(failStep2);
+    when(failStep2.send()).thenReturn((CamundaFuture) future);
+    return failStep1;
   }
 
   @SuppressWarnings("unchecked")

--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -19,7 +19,7 @@ helm_chart_platform := camunda-platform-helm/charts/$(helm_chart)
 helm_chart_load_tests := camunda-load-tests/camunda-load-tests
 
 # Scenario: controls the workload profile for the load test.
-# Options: latency, realistic, typical, max, archiver
+# Options: latency, realistic, typical, max, archiver, incidents
 # Use named targets (make max) or pass directly: make install scenario=max
 scenario ?=
 
@@ -37,6 +37,15 @@ _scenario_load_test_flags := --set starter.rate=300
 _scenario_platform_flags  := --set-file 'orchestration.extraConfiguration[1].content=./camunda-platform-override-values.yaml'
 else ifeq ($(scenario),archiver)
 _scenario_load_test_flags := --set starter.rate=1 --set starter.rateDuration=10m --set starter.processId=multiInstanceElements --set starter.bpmnXmlPath=bpmn/multiInstanceElements.bpmn --set starter.payloadPath=bpmn/multiInstanceElementsPayload.json --set workers.worker.replicas=0
+_scenario_platform_flags  :=
+else ifeq ($(scenario),incidents)
+# Reproduce incidents stuck in PENDING: a typical-derived workload at ~80 PI/s with large sustained
+# volume, where the worker fails a fraction of jobs (incident generation ratio) to mint incidents and
+# the starter runs the incident-resolution meter. Start the ratio at 0.5 to confirm reproduction, then
+# dial toward 0.01 for customer fidelity (~1%).
+# NOTE: reproduction depends on the cluster keeping the production default ignoreMissingData=false, so
+# head-of-line blocking can manifest — no platform override is applied here.
+_scenario_load_test_flags := --set starter.rate=80 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn --set workers.worker.replicas=6 --set global.extraConfig.load-tester.worker.incident-ratio=0.5 --set global.extraConfig.load-tester.starter.monitor-incident-resolution=true
 _scenario_platform_flags  :=
 else
 _scenario_load_test_flags :=
@@ -288,7 +297,7 @@ print-scenario:
 
 # Workload scenario shortcuts — each runs 'make install' with the corresponding scenario profile.
 # For stable VMs, use: make install-stable scenario=<name>
-.PHONY: latency realistic typical max archiver
+.PHONY: latency realistic typical max archiver incidents
 latency:
 	$(MAKE) install scenario=latency
 realistic:
@@ -299,6 +308,8 @@ max:
 	$(MAKE) install scenario=max
 archiver:
 	$(MAKE) install scenario=archiver
+incidents:
+	$(MAKE) install scenario=incidents
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Reproduce incidents stuck in PENDING before promotion to ACTIVE under load and measure incident-resolution latency (incident creation -> first observed ACTIVE), the direct analogue of the process-instance visibility metric. This gives us a way to reproduce and quantify the reported customer symptom rather than reasoning about it only from the exporter's post-processing code.

- Worker mints incidents by failing a configurable fraction of jobs with zero retries (incident generation ratio), selected deterministically per job key so the rate is stable and reproducible.
- Starter runs an IncidentResolutionMeter behind a flag: discovers incidents by a creationTime cursor over {PENDING, ACTIVE}, records latency per partition on first ACTIVE (wall-clock end timestamp), and cancels each instance only after measuring (cancel-after-measurement).
- Per-partition pending-backlog and last-promotion-age gauges plus a survivorship-safe timeout counter detect a fully stuck partition, which emits no latency samples and is otherwise invisible in percentiles.
- Add an `incidents` scenario to the load-test Makefile and the camunda-load-test workflow, and a Grafana dashboard consuming the metrics.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
