### PR TITLE
fix: make RdbmsExporter#export idempotent on flush failure

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/BatchInsertMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/BatchInsertMerger.java
@@ -7,35 +7,71 @@
  */
 package io.camunda.db.rdbms.write.queue;
 
+import java.util.Objects;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 class BatchInsertMerger<M> implements QueueItemMerger {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BatchInsertMerger.class);
 
   private final ContextType contextType;
   private final M model;
   private final int maxBatchSize;
+  private final Function<M, Object> keyExtractor;
 
   protected BatchInsertMerger(
-      final ContextType contextType, final M model, final int maxBatchSize) {
+      final ContextType contextType,
+      final M model,
+      final int maxBatchSize,
+      final Function<M, Object> keyExtractor) {
     this.contextType = contextType;
     this.model = model;
     this.maxBatchSize = maxBatchSize;
+    this.keyExtractor = keyExtractor;
   }
 
   @Override
   public boolean canBeMerged(final QueueItem queueItem) {
+    if (queueItem.contextType() != contextType
+        || queueItem.statementType() != WriteStatementType.INSERT
+        || !(queueItem.parameter() instanceof BatchInsertDto)) {
+      return false;
+    }
+
+    final var batch = (BatchInsertDto<M>) queueItem.parameter();
+    // If the model is already present in this batch, claim the item regardless of the batch size
+    // limit so that merge() can drop it as a no-op. Otherwise the writer would fall back to
+    // executeInQueue and create a second batch item holding the duplicate, which still violates the
+    // primary key when flushed.
+    if (containsModelKey(batch)) {
+      return true;
+    }
+
     if (maxBatchSize == 1) {
       return false;
     }
-    return queueItem.contextType() == contextType
-        && queueItem.statementType() == WriteStatementType.INSERT
-        && queueItem.parameter() instanceof BatchInsertDto
-        && ((BatchInsertDto<M>) queueItem.parameter()).dbModels().size() < maxBatchSize;
+    return batch.dbModels().size() < maxBatchSize;
   }
 
   @Override
   public QueueItem merge(final QueueItem originalItem) {
-    return originalItem.copy(
-        b ->
-            b.parameter(
-                BatchInsertDto.class.cast(originalItem.parameter()).withAdditionalDbModel(model)));
+    final var batch = (BatchInsertDto<M>) originalItem.parameter();
+    if (containsModelKey(batch)) {
+      // The exporter may re-process and re-enqueue the same record after a failed flush. Dropping
+      // the duplicate here keeps the same primary key from appearing twice in one batch INSERT.
+      LOG.warn(
+          "Dropping duplicate {} insert for key {} that is already queued in the current batch",
+          contextType,
+          keyExtractor.apply(model));
+      return originalItem;
+    }
+    return originalItem.copy(b -> b.parameter(batch.withAdditionalDbModel(model)));
+  }
+
+  private boolean containsModelKey(final BatchInsertDto<M> batch) {
+    final Object key = keyExtractor.apply(model);
+    return batch.dbModels().stream().anyMatch(m -> Objects.equals(keyExtractor.apply(m), key));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics.FlushTrigger;
 import io.camunda.db.rdbms.write.util.PerMessageThrottledLogger;
 import io.camunda.zeebe.util.ObjectSizeEstimator;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,6 +25,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.ibatis.executor.BatchResult;
 import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.TransactionIsolationLevel;
 import org.slf4j.Logger;
@@ -241,6 +243,8 @@ public class DefaultExecutionQueue implements ExecutionQueue {
     final var optimizedItems = optimizeQueueOrder(queue);
 
     try {
+      assertManualCommitMode(session);
+
       if (!inTransactionHooks.isEmpty()) {
         LOG.trace("[RDBMS ExecutionQueue, Partition {}] Call in-transaction hooks", partitionId);
         for (final InTransactionHook hook : inTransactionHooks) {
@@ -269,6 +273,7 @@ public class DefaultExecutionQueue implements ExecutionQueue {
       }
 
       session.commit();
+
       queue.clear();
       if (!postFlushListeners.isEmpty()) {
         LOG.trace("[RDBMS ExecutionQueue, Partition {}] Call post flush listeners", partitionId);
@@ -282,9 +287,19 @@ public class DefaultExecutionQueue implements ExecutionQueue {
 
       return flushedElements;
     } catch (final Exception e) {
-      LOG.error("[RDBMS ExecutionQueue, Partition {}] Error while executing queue", partitionId, e);
-      session.rollback();
-
+      LOG.error(
+          "[RDBMS ExecutionQueue, Partition {}] Error while executing queue ({} items)",
+          partitionId,
+          optimizedItems.size(),
+          e);
+      try {
+        session.rollback();
+      } catch (final Exception rollbackError) {
+        LOG.error(
+            "[RDBMS ExecutionQueue, Partition {}] Rollback failed after flush error",
+            partitionId,
+            rollbackError);
+      }
       throw e;
     } finally {
       session.close();
@@ -326,6 +341,28 @@ public class DefaultExecutionQueue implements ExecutionQueue {
     }
 
     return resultList;
+  }
+
+  /**
+   * Verifies that the session's connection manages commits manually ({@code autoCommit = false}).
+   *
+   * <p>The flush relies on every statement of a batch committing or rolling back atomically via
+   * {@link org.apache.ibatis.session.SqlSession#commit()} / {@link
+   * org.apache.ibatis.session.SqlSession#rollback()}. Failing fast here turns that silent
+   * corruption into an immediate, diagnosable error and guards against a misconfigured data source.
+   */
+  private static void assertManualCommitMode(final SqlSession session) {
+    try {
+      if (session.getConnection().getAutoCommit()) {
+        throw new IllegalStateException(
+            "RDBMS connection is in autoCommit=true mode, but the execution queue requires "
+                + "autoCommit=false so that all statements of a flush commit or roll back atomically. "
+                + "Aborting flush to prevent partially-committed batches and duplicate-key errors on retry.");
+      }
+    } catch (final SQLException e) {
+      throw new IllegalStateException(
+          "Failed to verify autoCommit mode of the RDBMS connection before flushing", e);
+    }
   }
 
   LinkedList<QueueItem> getQueue() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertAuditLogMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertAuditLogMerger.java
@@ -12,6 +12,6 @@ import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 public class InsertAuditLogMerger extends BatchInsertMerger<AuditLogDbModel> {
 
   public InsertAuditLogMerger(final AuditLogDbModel auditLog, final int maxBatchSize) {
-    super(ContextType.AUDIT_LOG, auditLog, maxBatchSize);
+    super(ContextType.AUDIT_LOG, auditLog, maxBatchSize, AuditLogDbModel::auditLogKey);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertFlowNodeInstanceMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertFlowNodeInstanceMerger.java
@@ -13,6 +13,10 @@ public class InsertFlowNodeInstanceMerger extends BatchInsertMerger<FlowNodeInst
 
   public InsertFlowNodeInstanceMerger(
       final FlowNodeInstanceDbModel flowNodeInstance, final int maxBatchSize) {
-    super(ContextType.FLOW_NODE, flowNodeInstance, maxBatchSize);
+    super(
+        ContextType.FLOW_NODE,
+        flowNodeInstance,
+        maxBatchSize,
+        FlowNodeInstanceDbModel::flowNodeInstanceKey);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertJobMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertJobMerger.java
@@ -12,6 +12,6 @@ import io.camunda.db.rdbms.write.domain.JobDbModel;
 public class InsertJobMerger extends BatchInsertMerger<JobDbModel> {
 
   public InsertJobMerger(final JobDbModel job, final int maxBatchSize) {
-    super(ContextType.JOB, job, maxBatchSize);
+    super(ContextType.JOB, job, maxBatchSize, JobDbModel::jobKey);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertVariableMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertVariableMerger.java
@@ -12,6 +12,6 @@ import io.camunda.db.rdbms.write.domain.VariableDbModel;
 public class InsertVariableMerger extends BatchInsertMerger<VariableDbModel> {
 
   public InsertVariableMerger(final VariableDbModel variable, final int maxBatchSize) {
-    super(ContextType.VARIABLE, variable, maxBatchSize);
+    super(ContextType.VARIABLE, variable, maxBatchSize, VariableDbModel::variableKey);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/BatchInsertMergerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/BatchInsertMergerTest.java
@@ -201,28 +201,11 @@ class BatchInsertMergerTest {
 
   @Test
   void shouldNotMergeWhenBatchSizeLimitReached() {
-    final var variable =
-        new VariableDbModel(
-            1L,
-            "var",
-            ValueTypeEnum.STRING,
-            null,
-            null,
-            "value",
-            null,
-            false,
-            100L,
-            200L,
-            200L,
-            "process1",
-            "tenant1",
-            1,
-            -1L,
-            null);
+    // distinct keys so the batch-size limit (not duplicate-key absorption) is what blocks the merge
+    final var merger = new InsertVariableMerger(newVariable(3L), 2); // Max batch size of 2
 
-    final var merger = new InsertVariableMerger(variable, 2); // Max batch size of 2
-
-    final var parameter = new BatchInsertDto<>(List.of(variable, variable)); // Already at max size
+    final var parameter =
+        new BatchInsertDto<>(List.of(newVariable(1L), newVariable(2L))); // Already at max size
 
     final var queueItem =
         new QueueItem(ContextType.VARIABLE, WriteStatementType.INSERT, 1L, "statement", parameter);
@@ -232,33 +215,78 @@ class BatchInsertMergerTest {
 
   @Test
   void shouldNotMergeWhenMaxBatchSizeIsOne() {
-    final var variable =
-        new VariableDbModel(
-            1L,
-            "var",
-            ValueTypeEnum.STRING,
-            null,
-            null,
-            "value",
-            null,
-            false,
-            100L,
-            200L,
-            200L,
-            "process1",
-            "tenant1",
-            1,
-            -1L,
-            null);
+    // distinct key so the maxBatchSize==1 short-cut (not duplicate-key absorption) blocks the merge
+    final var merger = new InsertVariableMerger(newVariable(2L), 1); // Max batch size of 1
 
-    final var merger = new InsertVariableMerger(variable, 1); // Max batch size of 1
-
-    final var parameter = new BatchInsertDto<>(List.of(variable));
+    final var parameter = new BatchInsertDto<>(List.of(newVariable(1L)));
 
     final var queueItem =
         new QueueItem(ContextType.VARIABLE, WriteStatementType.INSERT, 1L, "statement", parameter);
 
     // Should return false immediately due to maxBatchSize == 1 short-cut
     assertThat(merger.canBeMerged(queueItem)).isFalse();
+  }
+
+  @Test
+  void shouldDropDuplicateWhenKeyAlreadyPresentInBatch() {
+    final var original = newVariable(1L);
+    // a different model instance carrying the SAME key, mirroring a re-enqueued record on retry
+    final var duplicate = newVariable(1L);
+
+    final var merger = new InsertVariableMerger(duplicate, 50);
+    final var parameter = new BatchInsertDto<>(List.of(original));
+    final var queueItem =
+        new QueueItem(ContextType.VARIABLE, WriteStatementType.INSERT, 1L, "statement", parameter);
+
+    // the merger claims the item so the writer does NOT enqueue a second batch item ...
+    assertThat(merger.canBeMerged(queueItem)).isTrue();
+
+    // ... and merge() is a no-op: the key stays in the batch exactly once
+    final var mergedItem = merger.merge(queueItem);
+    assertThat(mergedItem.parameter())
+        .asInstanceOf(InstanceOfAssertFactories.type(BatchInsertDto.class))
+        .satisfies(
+            p -> {
+              assertThat(p.dbModels()).hasSize(1);
+              assertThat(p.dbModels().get(0)).isEqualTo(original);
+            });
+  }
+
+  @Test
+  void shouldClaimAndDropDuplicateEvenWhenBatchIsFull() {
+    final var duplicateOfFirst = newVariable(1L);
+    final var merger = new InsertVariableMerger(duplicateOfFirst, 2); // batch is at max size
+
+    final var parameter = new BatchInsertDto<>(List.of(newVariable(1L), newVariable(2L)));
+    final var queueItem =
+        new QueueItem(ContextType.VARIABLE, WriteStatementType.INSERT, 1L, "statement", parameter);
+
+    // even though the batch is full, a present key is claimed so it is not spilled into a new batch
+    assertThat(merger.canBeMerged(queueItem)).isTrue();
+
+    final var mergedItem = merger.merge(queueItem);
+    assertThat(mergedItem.parameter())
+        .asInstanceOf(InstanceOfAssertFactories.type(BatchInsertDto.class))
+        .satisfies(p -> assertThat(p.dbModels()).hasSize(2));
+  }
+
+  private static VariableDbModel newVariable(final long key) {
+    return new VariableDbModel(
+        key,
+        "var" + key,
+        ValueTypeEnum.STRING,
+        null,
+        null,
+        "value" + key,
+        null,
+        false,
+        100L,
+        200L,
+        200L,
+        "process1",
+        "tenant1",
+        1,
+        -1L,
+        null);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
+import java.sql.Connection;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -37,13 +38,16 @@ class DefaultExecutionQueueTest {
   private DefaultExecutionQueue executionQueue;
 
   @BeforeEach
-  public void beforeEach() {
+  public void beforeEach() throws Exception {
     session = mock(SqlSession.class);
     sqlSessionFactory = mock(SqlSessionFactory.class);
     metrics = mock(RdbmsWriterMetrics.class);
     when(sqlSessionFactory.openSession(
             ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED))
         .thenReturn(session);
+    final var connection = mock(Connection.class);
+    when(connection.getAutoCommit()).thenReturn(false);
+    when(session.getConnection()).thenReturn(connection);
 
     executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 10, 0, metrics);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
@@ -49,6 +49,7 @@ public class RdbmsFlushRollbackIT {
   private static final int PARTITION_ID_POST_FLUSH = 10_003;
   private static final int PARTITION_ID_HOOK = 10_004;
   private static final int PARTITION_ID_FULL_SCENARIO = 10_005;
+  private static final int PARTITION_ID_DUPLICATE_INSERT = 10_006;
 
   @TestTemplate
   void shouldRollbackAllStatementsWhenSecondStatementFails(
@@ -372,6 +373,37 @@ public class RdbmsFlushRollbackIT {
             flowNodeInstanceReader.getByKey(
                 flowNodeInstance2.flowNodeInstanceKey(), resourceAccessChecksFromTenantIds()))
         .as("Items must be committed on the successful retry")
+        .isNotNull();
+  }
+
+  /**
+   * Verifies that creating the same entity twice within a single flush (as happens when the
+   * exporter re-processes and re-enqueues a record after a failed flush) does not produce a
+   * duplicate row in the batch INSERT. The {@code BatchInsertMerger} must absorb the second insert
+   * so the flush succeeds with a single row instead of failing with a primary-key violation.
+   */
+  @TestTemplate
+  void shouldDropDuplicateInsertWithinSameFlush(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID_DUPLICATE_INSERT);
+    final FlowNodeInstanceDbReader flowNodeInstanceReader =
+        rdbmsService.getFlowNodeInstanceReader("default");
+
+    final var flowNodeInstance = FlowNodeInstanceFixtures.createRandomized(b -> b);
+
+    // the same flow node instance is queued twice into one flush (mirrors the re-enqueue on retry)
+    rdbmsWriters.getFlowNodeInstanceWriter().create(flowNodeInstance);
+    rdbmsWriters.getFlowNodeInstanceWriter().create(flowNodeInstance);
+
+    // when: the flush must succeed (the duplicate is absorbed), not throw a duplicate-key error
+    rdbmsWriters.flush();
+
+    // then: the row exists exactly once
+    assertThat(
+            flowNodeInstanceReader.getByKey(
+                flowNodeInstance.flowNodeInstanceKey(), resourceAccessChecksFromTenantIds()))
+        .as("The de-duplicated flow node must be committed exactly once")
         .isNotNull();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -342,14 +342,7 @@ class RdbmsExporterIT {
   public void shouldExportAll() {
     // given
     final var processInstanceRecord = FIXTURES.getProcessInstanceStartedRecord();
-
-    final Record<RecordValue> variableCreated =
-        ImmutableRecord.builder()
-            .from(RecordFixtures.FACTORY.generateRecord(ValueType.VARIABLE))
-            .withIntent(VariableIntent.CREATED)
-            .withPosition(2L)
-            .withTimestamp(System.currentTimeMillis())
-            .build();
+    final var variableCreated = FIXTURES.getVariableCreatedRecord();
     final List<Record<RecordValue>> recordList = List.of(processInstanceRecord, variableCreated);
 
     // when

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
@@ -442,6 +443,15 @@ public class RecordFixtures {
                 .withEncodedStrings(encodedStrings)
                 .withRecordSizeLimitExceeded(recordSizeLimitExceeded)
                 .build())
+        .build();
+  }
+
+  public ImmutableRecord<RecordValue> getVariableCreatedRecord() {
+    return ImmutableRecord.builder()
+        .from(RecordFixtures.FACTORY.generateRecord(ValueType.VARIABLE))
+        .withIntent(VariableIntent.CREATED)
+        .withPosition(nextPosition())
+        .withTimestamp(System.currentTimeMillis())
         .build();
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -240,9 +240,14 @@ public final class RdbmsExporter {
         record.getValueType(),
         record.getIntent());
 
+    // this may be a retry - do not re-process the record but still trigger a flush
+    // when it is not a retry but a re-delivery because of other reasons (exporter guarantees
+    // at-least-once), the queue will be empty and flush will be a no-op.
+    final boolean alreadyProcessed = record.getPosition() <= lastPosition;
+
     boolean exported = false;
     boolean shouldFlushAfterRecordProcessed = false;
-    if (registeredHandlers.containsKey(record.getValueType())) {
+    if (!alreadyProcessed && registeredHandlers.containsKey(record.getValueType())) {
       for (final var handler : registeredHandlers.get(record.getValueType())) {
         if (handler.canExport(record)) {
           LOG.trace(
@@ -263,7 +268,7 @@ public final class RdbmsExporter {
               record.getValueType());
         }
       }
-    } else {
+    } else if (!alreadyProcessed) {
       LOG.trace(
           "[RDBMS Exporter P{} T-{}] No registered handler found for {}",
           partitionId,
@@ -271,20 +276,25 @@ public final class RdbmsExporter {
           record.getValueType());
     }
 
-    // Always update lastPosition for every record, including ignored ones, so that the exporter
-    // position is advanced even when no handler processes the record.
-    lastPosition = record.getPosition();
+    if (!alreadyProcessed) {
+      lastPosition = record.getPosition();
+    }
 
-    if (exported) {
-      // Track the oldest record timestamp in the current batch
-      final long recordTimestamp = record.getTimestamp();
-      if (oldestRecordTimestampInBatch < 0 || recordTimestamp < oldestRecordTimestampInBatch) {
-        oldestRecordTimestampInBatch = recordTimestamp;
+    if (exported || alreadyProcessed) {
+      if (exported) {
+        // Track the oldest record timestamp in the current batch
+        final long recordTimestamp = record.getTimestamp();
+        if (oldestRecordTimestampInBatch < 0 || recordTimestamp < oldestRecordTimestampInBatch) {
+          oldestRecordTimestampInBatch = recordTimestamp;
+        }
       }
       // causes a flush check after each processed record. Depending on the queue size and
-      // configuration, the writers ExecutionQueue may or may not flush here.
+      // configuration, the writers ExecutionQueue may or may not flush here. When retrying an
+      // already-processed record we force the flush so the queue that failed to flush before is
+      // drained instead of lingering.
       try {
-        final boolean shouldFlush = flushAfterEachRecord() || shouldFlushAfterRecordProcessed;
+        final boolean shouldFlush =
+            alreadyProcessed || flushAfterEachRecord() || shouldFlushAfterRecordProcessed;
         final boolean flushed = rdbmsWriters.flush(shouldFlush);
         if (flushed) {
           resetIntervalFlush();

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -574,6 +574,42 @@ class RdbmsExporterTest {
     exceptionAssert.isInstanceOf(ExporterException.class);
   }
 
+  @Test
+  void shouldNotReexportAlreadyProcessedRecordOnRetry() {
+    // given
+    final var jobHandler = mockHandler(ValueType.JOB);
+    createExporter(b -> b.withHandler(ValueType.JOB, jobHandler));
+    final var record = mockRecord(ValueType.JOB, 1);
+
+    // when - the broker re-delivers the same record after a failed flush
+    exporter.export(record);
+    exporter.export(record);
+
+    // then - the handler runs only once (no re-enqueue that would duplicate the row in the batch)
+    verify(jobHandler, times(1)).export(record);
+    // but a flush is still attempted on each call: a normal flush first, then a forced retry flush
+    verify(rdbmsWriters).flush(false);
+    verify(rdbmsWriters).flush(true);
+  }
+
+  @Test
+  void shouldStillExportNewRecordAfterARetry() {
+    // given
+    final var jobHandler = mockHandler(ValueType.JOB);
+    createExporter(b -> b.withHandler(ValueType.JOB, jobHandler));
+    final var firstRecord = mockRecord(ValueType.JOB, 1);
+    final var newRecord = mockRecord(ValueType.JOB, 2);
+
+    // when - first record is processed, re-delivered (retry), then a new record arrives
+    exporter.export(firstRecord);
+    exporter.export(firstRecord);
+    exporter.export(newRecord);
+
+    // then - the retry is skipped but the genuinely new record is still exported
+    verify(jobHandler, times(1)).export(firstRecord);
+    verify(jobHandler, times(1)).export(newRecord);
+  }
+
   // ------------------------------------------------
   // mocks and stubs
   // ------------------------------------------------


### PR DESCRIPTION
## Description

The `RdbmsExporter` still faces instabilities when the RDBMS itself has availability problems. This PR fixes the following problem:
- When a `flush` failed in the exporter and `DefaultExecutionQueue`, the error is escalated back to the `ExporterDirector` or `ExporterContainer` to trigger an automated retry after some backoff period. Them problem now here is: The record is exported again before the flush is triggered (the handlers are called again and maybe INSERT is added again to the queue). For some handlers and writers we use the `BatchInsertMerger` to compress the inserts. Here we don't check for duplicates, to the same records is tried to be inserted twice in the same transaction => PK violation

What we fix in this PR:
- make the `BatchInsertMerger` idempotent. When the same DbModel with the same key is added again, it is just ignored
- make the RdbmsExporter#export() method idempotent that is does not call the export handlers again, but triggers a forced flush (to retry the flush) when we see a record again
- add a safety guard that the `DefaultExecutionQueue` only accepts a connection with `autoCommit=false`. This is merely a regression assert for the future

## Checklist

- [x] Enable backports when necessary (see reviewer note above).

## Related issues

closes #
