### PR TITLE
deps: update micrometer to 1.16.6

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,7 +88,7 @@
     <version.prometheus>1.3.5</version.prometheus>
     <version.protobuf>4.33.6</version.protobuf>
     <version.protobuf-common>2.65.1</version.protobuf-common>
-    <version.micrometer>1.16.5</version.micrometer>
+    <version.micrometer>1.16.6</version.micrometer>
     <version.rocksdbjni>10.2.1</version.rocksdbjni>
     <version.sbe>1.37.1</version.sbe>
     <version.scala>3.8.3</version.scala>


### PR DESCRIPTION
## Description

Bumps `io.micrometer:micrometer-bom` from 1.16.5 to 1.16.6 in `parent/pom.xml` on stable/8.9.

Addresses **CVE-2026-40983** and **CVE-2026-40984**: Micrometer 1.16.0–1.16.5 allow a denial-of-service via specially crafted gRPC requests when an `ObservationRegistry` records observations through `DefaultMeterObservationHandler` (or equivalent custom handler) and the gRPC server is instrumented with `ObservationGrpcServerInterceptor`. Fixed in 1.16.6.

Verified `micrometer-bom` is imported before `spring-boot-dependencies` in `parent/pom.xml`, so this property governs the resolved `micrometer-core` version.

## Checklist

- [ ] Enable backports when necessary.

## Related issues

Security dependency bump — no tracking issue.