### PR TITLE
deps: update micrometer to 1.15.12

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -82,7 +82,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>4.31.1</version.protobuf>
     <version.protobuf-common>2.59.2</version.protobuf-common>
-    <version.micrometer>1.15.11</version.micrometer>
+    <version.micrometer>1.15.12</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.2</version.sbe>
     <version.scala>2.13.18</version.scala>


### PR DESCRIPTION
## Description

Bumps `io.micrometer:micrometer-bom` from 1.15.11 to 1.15.12 in `parent/pom.xml` on stable/8.7.

Addresses **CVE-2026-40983** and **CVE-2026-40984**: Micrometer 1.15.0–1.15.11 allow a denial-of-service via specially crafted gRPC requests when an `ObservationRegistry` records observations through `DefaultMeterObservationHandler` (or equivalent custom handler) and the gRPC server is instrumented with `ObservationGrpcServerInterceptor`. Fixed in 1.15.12.

Verified `micrometer-bom` is imported before `spring-boot-dependencies` in `parent/pom.xml`, so this property governs the resolved `micrometer-core` version.

## Checklist

- [ ] Enable backports when necessary.

## Related issues

Security dependency bump — no tracking issue.