### PR TITLE
Fail testbench curl on HTTP error responses

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -156,7 +156,7 @@ jobs:
           variables=$(echo "$substituted_variables" | jq -c .)
 
           # Run the curl command with expanded variables
-          curl -L -X POST "${{ steps.secrets.outputs.TESTBENCH_PROD_REST_ADDRESS }}/v2/process-instances" \
+          curl --fail-with-body -L -X POST "${{ steps.secrets.outputs.TESTBENCH_PROD_REST_ADDRESS }}/v2/process-instances" \
             -H "Authorization: Bearer $access_token" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \


### PR DESCRIPTION
## Description

Without `--fail-with-body`, curl exits 0 on any HTTP 4xx/5xx response, so a 404 from the ingress (e.g. when the testbench cluster is unreachable) silently passes the "Start Test" step and the workflow reports success without having started a test.

Adds `--fail-with-body` so curl exits with code 22 on HTTP error responses while still printing the response body for diagnostics. The `-e` shell flag in the step then propagates the failure correctly.

Seen in: https://github.com/camunda/camunda/actions/runs/27996141772/job/82858634291

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

discussed in https://camunda.slack.com/archives/C013MEVQ4M9/p1782205460701909