### PR TITLE
test: enable C3 nav V2 across OC apps (flag flip)

### DIFF
--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -8,4 +8,4 @@
 
 export const featureFlags = [];
 
-export const IS_NAV_V2_ENABLED = false;
+export const IS_NAV_V2_ENABLED = true;

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -6,6 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const IS_NAV_V2_ENABLED = false;
+const IS_NAV_V2_ENABLED = true;
 
 export {IS_NAV_V2_ENABLED};

--- a/optimize/client/src/modules/feature-flags.ts
+++ b/optimize/client/src/modules/feature-flags.ts
@@ -6,6 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const IS_NAV_V2_ENABLED = false;
+const IS_NAV_V2_ENABLED = true;
 
 export {IS_NAV_V2_ENABLED};

--- a/tasklist/client/src/modules/featureFlags.tsx
+++ b/tasklist/client/src/modules/featureFlags.tsx
@@ -6,6 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const IS_NAV_V2_ENABLED = false;
+const IS_NAV_V2_ENABLED = true;
 
 export {IS_NAV_V2_ENABLED};


### PR DESCRIPTION
## ⚠️ Testing branch — do not merge

Flips `IS_NAV_V2_ENABLED` to `true` for all four orchestration-cluster apps so the C3 nav V2 surface can be exercised end-to-end:

- Tasklist — `tasklist/client/src/modules/featureFlags.tsx`
- Optimize — `optimize/client/src/modules/feature-flags.ts`
- Operate — `operate/client/src/modules/feature-flags.ts`
- Admin/Identity — `identity/client/src/feature-flags.ts`

## Purpose

Base for validating the V2 nav before rollout — cross-component navigation, feature parity with the old nav (theme/i18n/notifications/license per app), and navigation back to Hub. See the test outline + the enablement plan in **camunda/camunda-hub#25463** ("Before the switch").

## Expected CI

**App unit/e2e tests that assert the V1 nav will fail here until migrated to V2** — that migration is exactly the "Before the switch" prerequisite work (#25463). This branch intentionally surfaces those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)