### PR TITLE
feat: align wait state zod schema with API

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
-		"@camunda/camunda-api-zod-schemas": "0.0.74",
+		"@camunda/camunda-api-zod-schemas": "0.0.75",
 		"@camunda/camunda-composite-components": "0.24.0",
 		"@carbon/react": "1.109.0",
 		"@carbon/type": "11.61.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -28,7 +28,7 @@
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
-				"@camunda/camunda-api-zod-schemas": "0.0.74",
+				"@camunda/camunda-api-zod-schemas": "0.0.75",
 				"@camunda/camunda-composite-components": "0.24.0",
 				"@carbon/react": "1.109.0",
 				"@carbon/type": "11.61.0",
@@ -11039,13 +11039,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.74",
+				"@camunda/camunda-api-zod-schemas": "0.0.75",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.74",
+			"version": "0.0.75",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.9.3",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.74",
+		"@camunda/camunda-api-zod-schemas": "0.0.75",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.75
+
+### 🚀 Enhancements
+
+- Align element instance wait state (inspection) schemas with the OpenAPI definition for 8.10 ([#55099](https://github.com/camunda/camunda/issues/55099))
+
+### ❤️ Contributors
+
+- Daniel Kelemen ([@danielkelemen](https://github.com/danielkelemen))
+
 ## v0.0.74
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/element-instance-inspection.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/element-instance-inspection.ts
@@ -16,39 +16,94 @@ import {
 	type Endpoint,
 } from './common';
 import {elementInstanceTypeSchema} from './element-instance';
+import {jobKindSchema, listenerEventTypeSchema} from './job';
 
-const waitStateTypeSchema = z.enum(['JOB', 'MESSAGE', 'TIMER', 'SIGNAL', 'CONDITION', 'CHILD_INSTANCE']);
+const waitStateTypeSchema = z.enum(['JOB', 'MESSAGE', 'USER_TASK', 'TIMER', 'SIGNAL', 'CONDITION']);
 type WaitStateType = z.infer<typeof waitStateTypeSchema>;
 
-const waitStateDetailsSchema = z.record(z.string(), z.unknown());
+const waitStateElementTypeSchema = elementInstanceTypeSchema;
+type WaitStateElementType = z.infer<typeof waitStateElementTypeSchema>;
+
+const jobWaitStateDetailsSchema = z.object({
+	waitStateType: z.literal('JOB'),
+	jobKey: z.string(),
+	jobType: z.string(),
+	jobKind: jobKindSchema,
+	listenerEventType: listenerEventTypeSchema.nullable(),
+	retries: z.number().int().nullable(),
+});
+type JobWaitStateDetails = z.infer<typeof jobWaitStateDetailsSchema>;
+
+const messageWaitStateDetailsSchema = z.object({
+	waitStateType: z.literal('MESSAGE'),
+	messageName: z.string(),
+	correlationKey: z.string().nullable(),
+});
+type MessageWaitStateDetails = z.infer<typeof messageWaitStateDetailsSchema>;
+
+const userTaskWaitStateDetailsSchema = z.object({
+	waitStateType: z.literal('USER_TASK'),
+	taskKey: z.string(),
+	dueDate: z.string().nullable(),
+});
+type UserTaskWaitStateDetails = z.infer<typeof userTaskWaitStateDetailsSchema>;
+
+const timerWaitStateDetailsSchema = z.object({
+	waitStateType: z.literal('TIMER'),
+	// UNIX epoch timestamp in milliseconds.
+	dueDate: z.number().int().nullable(),
+	repetitions: z.number().int().nullable(),
+});
+type TimerWaitStateDetails = z.infer<typeof timerWaitStateDetailsSchema>;
+
+const signalWaitStateDetailsSchema = z.object({
+	waitStateType: z.literal('SIGNAL'),
+	signalName: z.string(),
+});
+type SignalWaitStateDetails = z.infer<typeof signalWaitStateDetailsSchema>;
+
+const conditionWaitStateDetailsSchema = z.object({
+	waitStateType: z.literal('CONDITION'),
+	expression: z.string(),
+	events: z.array(z.string()),
+});
+type ConditionWaitStateDetails = z.infer<typeof conditionWaitStateDetailsSchema>;
+
+const waitStateDetailsSchema = z.discriminatedUnion('waitStateType', [
+	jobWaitStateDetailsSchema,
+	messageWaitStateDetailsSchema,
+	userTaskWaitStateDetailsSchema,
+	timerWaitStateDetailsSchema,
+	signalWaitStateDetailsSchema,
+	conditionWaitStateDetailsSchema,
+]);
 type WaitStateDetails = z.infer<typeof waitStateDetailsSchema>;
 
-const elementInstanceInspectionSchema = z
-	.object({
-		rootProcessInstanceKey: z.string(),
-		processInstanceKey: z.string(),
-		elementInstanceKey: z.string(),
-		elementId: z.string(),
-		elementType: elementInstanceTypeSchema,
-		details: waitStateDetailsSchema,
-	})
-	.transform((data) => ({
-		...data,
-		waitStateType: data.details['waitStateType'] as WaitStateType,
-	}));
+const elementInstanceInspectionSchema = z.object({
+	rootProcessInstanceKey: z.string().nullable(),
+	processInstanceKey: z.string(),
+	elementInstanceKey: z.string(),
+	elementId: z.string(),
+	elementType: waitStateElementTypeSchema,
+	tenantId: z.string(),
+	bpmnProcessId: z.string(),
+	details: waitStateDetailsSchema,
+});
 type ElementInstanceInspection = z.infer<typeof elementInstanceInspectionSchema>;
 
 const queryElementInstanceInspectionFilterSchema = z
 	.object({
 		processInstanceKey: advancedStringFilterSchema,
+		rootProcessInstanceKey: advancedStringFilterSchema,
 		elementInstanceKey: advancedStringFilterSchema,
 		elementId: advancedStringFilterSchema,
+		elementType: z.union([waitStateElementTypeSchema, getEnumFilterSchema(waitStateElementTypeSchema)]),
 		waitStateType: z.union([waitStateTypeSchema, getEnumFilterSchema(waitStateTypeSchema)]),
 	})
 	.partial();
 
 const queryElementInstanceInspectionRequestBodySchema = getQueryRequestBodySchema({
-	sortFields: ['elementInstanceKey', 'processInstanceKey', 'elementId', 'waitStateType'] as const,
+	sortFields: ['elementInstanceKey', 'processInstanceKey', 'rootProcessInstanceKey', 'elementId'] as const,
 	filter: queryElementInstanceInspectionFilterSchema,
 });
 type QueryElementInstanceInspectionRequestBody = z.infer<typeof queryElementInstanceInspectionRequestBodySchema>;
@@ -65,7 +120,14 @@ const queryElementInstanceInspection: Endpoint = {
 
 export {
 	waitStateTypeSchema,
+	waitStateElementTypeSchema,
 	waitStateDetailsSchema,
+	jobWaitStateDetailsSchema,
+	messageWaitStateDetailsSchema,
+	userTaskWaitStateDetailsSchema,
+	timerWaitStateDetailsSchema,
+	signalWaitStateDetailsSchema,
+	conditionWaitStateDetailsSchema,
 	elementInstanceInspectionSchema,
 	queryElementInstanceInspectionRequestBodySchema,
 	queryElementInstanceInspectionResponseBodySchema,
@@ -74,7 +136,14 @@ export {
 
 export type {
 	WaitStateType,
+	WaitStateElementType,
 	WaitStateDetails,
+	JobWaitStateDetails,
+	MessageWaitStateDetails,
+	UserTaskWaitStateDetails,
+	TimerWaitStateDetails,
+	SignalWaitStateDetails,
+	ConditionWaitStateDetails,
 	ElementInstanceInspection,
 	QueryElementInstanceInspectionRequestBody,
 	QueryElementInstanceInspectionResponseBody,

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.74",
+	"version": "0.0.75",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

- **Schema:** Replaced the loose `details` record with a `z.discriminatedUnion` on `waitStateType` (job/message/user-task/timer/signal/condition), added `USER_TASK` and the `tenantId`/`bpmnProcessId` fields, made `rootProcessInstanceKey` nullable, and corrected the inspection filter and sort fields to match the OpenAPI contract.

## Related issues

related to https://github.com/camunda/camunda/issues/55099
