### PR TITLE
deps: bump opentelemetry-bom to 1.62.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -82,6 +82,8 @@
     <version.msgpack>0.9.12</version.msgpack>
     <version.netty>4.2.15.Final</version.netty>
     <version.objenesis>3.5</version.objenesis>
+    <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
+    <version.opentelemetry>1.62.0</version.opentelemetry>
     <version.opensearch>2.17.1</version.opensearch>
     <version.opensearch-java>3.5.0</version.opensearch-java>
     <version.opensearch.testcontainers>4.1.0</version.opensearch.testcontainers>
@@ -1208,6 +1210,15 @@
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-bom</artifactId>
         <version>${version.protobuf}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${version.opentelemetry}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Fixes CVE-2026-45292 ([GHSA-rcgg-9c38-7xpx](https://github.com/open-telemetry/opentelemetry-java/security/advisories/GHSA-rcgg-9c38-7xpx)): parsing oversized baggage in `opentelemetry-api` and `opentelemetry-extension-trace-propagators` causes unbounded memory allocation and CPU consumption. Because baggage is re-injected into every outgoing request, the effect can fan out to downstream services. Fixed in 1.62.0.

Spring Boot 4.0.x manages `opentelemetry-bom` at 1.55.0. This change adds an explicit `opentelemetry-bom` 1.62.0 override in `parent/pom.xml` to ensure the fixed version is used.

No functional changes.