### PR TITLE
deps: bump opentelemetry-bom to 1.62.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,6 +76,8 @@
     <version.msgpack>0.9.12</version.msgpack>
     <version.netty>4.1.134.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
+    <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
+    <version.opentelemetry>1.62.0</version.opentelemetry>
     <version.opensearch>2.9.0</version.opensearch>
     <version.opensearch-java>2.9.1</version.opensearch-java>
     <version.opensearch.testcontainers>4.0.1</version.opensearch.testcontainers>
@@ -1071,6 +1073,15 @@
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-bom</artifactId>
         <version>${version.protobuf}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${version.opentelemetry}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Fixes CVE-2026-45292 ([GHSA-rcgg-9c38-7xpx](https://github.com/open-telemetry/opentelemetry-java/security/advisories/GHSA-rcgg-9c38-7xpx)): parsing oversized baggage in `opentelemetry-api` and `opentelemetry-extension-trace-propagators` causes unbounded memory allocation and CPU consumption. Because baggage is re-injected into every outgoing request, the effect can fan out to downstream services. Fixed in 1.62.0.

The `elasticsearch-java` client pulls in `opentelemetry-api` transitively. Spring Boot 3.5.15 manages `opentelemetry-bom` at 1.49.0. This change adds an explicit `opentelemetry-bom` 1.62.0 override in `parent/pom.xml` to ensure the fixed version is used.

No functional changes.