### PR TITLE
deps: bump opentelemetry-bom to 1.62.0

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -52,6 +52,8 @@
     <apache.http5-core.version>5.3.6</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
     <spring.boot.version>3.5.15</spring.boot.version>
+    <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
+    <opentelemetry.version>1.62.0</opentelemetry.version>
     <spring.version>6.2.19</spring.version>
     <spring.security.version>6.5.11</spring.security.version>
     <version.tomcat>10.1.55</version.tomcat>
@@ -115,6 +117,14 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
         <version>${log4j2.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -77,6 +77,8 @@
     <version.msgpack>0.9.8</version.msgpack>
     <version.netty>4.1.133.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
+    <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
+    <version.opentelemetry>1.62.0</version.opentelemetry>
     <version.opensearch>2.9.0</version.opensearch>
     <version.opensearch.testcontainers>2.1.0</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
@@ -991,6 +993,18 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
         <version>${version.jetty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!--
+        Override Spring Boot's opentelemetry version to address CVE-2026-45292.
+        Must be declared before spring-boot-dependencies so this version wins.
+      -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${version.opentelemetry}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Fixes CVE-2026-45292 ([GHSA-rcgg-9c38-7xpx](https://github.com/open-telemetry/opentelemetry-java/security/advisories/GHSA-rcgg-9c38-7xpx)): parsing oversized baggage in `opentelemetry-api` and `opentelemetry-extension-trace-propagators` causes unbounded memory allocation and CPU consumption. Because baggage is re-injected into every outgoing request, the effect can fan out to downstream services. Fixed in 1.62.0.

The `elasticsearch-java` client pulls in `opentelemetry-api` transitively. Spring Boot 3.5.15 manages `opentelemetry-bom` at 1.49.0. This change adds an explicit `opentelemetry-bom` 1.62.0 override in both `parent/pom.xml` and `optimize/pom.xml` (Optimize manages its own BOM imports independently from the parent).

No functional changes.