### PR TITLE
Silence RejectedExecutionException on executor shutdown in archiver

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTask.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTask.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.util.ExponentialBackoff;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -82,6 +83,12 @@ public final class ReschedulingTask implements RunnableTask {
         .thenAccept(unused -> executionCounter.incrementAndGet())
         .exceptionally(
             error -> {
+              final var cause = error.getCause() != null ? error.getCause() : error;
+              if (closed && cause instanceof RejectedExecutionException) {
+                logger.debug(
+                    "Task {} was rejected because executor is shutting down; not retrying", task);
+                return null;
+              }
               logger.error(
                   "Unexpected error occurred while rescheduling task {} (bug in error handling code?);"
                       + " task will NOT be retried",

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTaskTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTaskTest.java
@@ -8,7 +8,12 @@
 package io.camunda.zeebe.exporter.common.tasks;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CompletableFuture;
@@ -179,6 +184,26 @@ final class ReschedulingTaskTest {
     inOrder
         .verify(EXECUTOR, Mockito.timeout(5_000).times(1))
         .schedule(task, 12L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void shouldLogDebugNotErrorWhenRejectedDuringShutdown() throws InterruptedException {
+    // given
+    final var future = new CompletableFuture<Integer>();
+    when(archiverJob.execute()).thenReturn(future);
+    final var mockLogger = mock(Logger.class);
+    final var localExecutor = new ScheduledThreadPoolExecutor(1);
+    final var task = new ReschedulingTask(archiverJob, 1, 10, 1000, localExecutor, mockLogger);
+
+    // when - task is started, closed, executor shut down, then the in-flight future completes
+    task.run();
+    task.close();
+    localExecutor.shutdown();
+    future.complete(1);
+
+    // then - DEBUG log for shutdown rejection, no ERROR log
+    verify(mockLogger, timeout(5_000).atLeastOnce()).debug(anyString(), any(Object.class));
+    verify(mockLogger, never()).error(anyString(), any(Object.class), any(Throwable.class));
   }
 
   @Test

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTaskTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTaskTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.common.tasks;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -202,7 +203,10 @@ final class ReschedulingTaskTest {
     future.complete(1);
 
     // then - DEBUG log for shutdown rejection, no ERROR log
-    verify(mockLogger, timeout(5_000).atLeastOnce()).debug(anyString(), any(Object.class));
+    verify(mockLogger, timeout(5_000).times(1))
+        .debug(
+            eq("Task {} was rejected because executor is shutting down; not retrying"),
+            any(Object.class));
     verify(mockLogger, never()).error(anyString(), any(Object.class), any(Throwable.class));
   }
 

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTaskTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/tasks/ReschedulingTaskTest.java
@@ -188,7 +188,7 @@ final class ReschedulingTaskTest {
   }
 
   @Test
-  void shouldLogDebugNotErrorWhenRejectedDuringShutdown() throws InterruptedException {
+  void shouldLogDebugNotErrorWhenRejectedDuringShutdown() {
     // given
     final var future = new CompletableFuture<Integer>();
     when(archiverJob.execute()).thenReturn(future);


### PR DESCRIPTION
## Description

When the `ScheduledThreadPoolExecutor` shuts down while an Elasticsearch response is still in-flight, `CompletableFuture` continuation stages in `ReschedulingTask.run()` try to submit work to the shut-down executor and throw `RejectedExecutionException`. This reached the terminal `.exceptionally()` handler and was logged at `ERROR` level with a misleading "task will NOT be retried" message, even though this is expected shutdown noise — Zeebe resumes archiving on the next startup.

The fix adds a guard in the terminal `.exceptionally()` handler: if `closed=true` (which is set before `executor.shutdown()` in `BackgroundTaskManager.close()`) and the cause is a `RejectedExecutionException`, log at `DEBUG` instead. Genuine unexpected errors still log at `ERROR`.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55650