### PR TITLE
docs: expand RAC acronym on first use in ADR-0006

### DIFF
--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0006-propagating-physical-tenant-context-across-async-authorization-reads.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0006-propagating-physical-tenant-context-across-async-authorization-reads.md
@@ -25,7 +25,7 @@ That premise does not hold against the implementation. Membership is **lazy** (i
 ```java
 // UsageMetricsServices.search(...) — request thread builds the security context, then:
 CompletableFuture.supplyAsync(() ->                 // common ForkJoinPool
-    authClient.usageMetricStatistics(query));        // RAC fires the lazy membership supplier HERE
+    authClient.usageMetricStatistics(query));        // the ResourceAccessController (RAC) fires the lazy membership supplier HERE
 ```
 
 The chain that fails:


### PR DESCRIPTION
Follow-up to #55663 (merged) addressing review feedback: the `RAC` shorthand was used without being defined.

Spells out `ResourceAccessController` (RAC) at its first occurrence in the Context section so the acronym is defined before its later uses.

Addresses https://github.com/camunda/camunda/pull/55663#discussion_r3459427922