### PR TITLE
refactor: broker cleanup after addition of physical tenants

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -162,7 +162,6 @@ public class Cluster implements Cloneable {
    */
   private String zone;
 
-  private boolean sendOnLegacySubject = false;
   private boolean receiveOnLegacySubject = true;
 
   public NodeIdProvider getNodeIdProvider() {
@@ -341,14 +340,6 @@ public class Cluster implements Cloneable {
     this.receiveOnLegacySubject = receiveOnLegacySubject;
   }
 
-  public boolean isSendOnLegacySubject() {
-    return sendOnLegacySubject;
-  }
-
-  public void setSendOnLegacySubject(final boolean sendOnLegacySubject) {
-    this.sendOnLegacySubject = sendOnLegacySubject;
-  }
-
   public String getZone() {
     return zone;
   }
@@ -400,8 +391,6 @@ public class Cluster implements Cloneable {
         + compressionAlgorithm
         + ", globalListeners="
         + globalListeners
-        + ", sendOnLegacySubject="
-        + sendOnLegacySubject
         + ", receiveOnLegacySubject="
         + receiveOnLegacySubject
         + ", zone='"

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -430,7 +430,6 @@ public class BrokerBasedPropertiesOverride {
 
     populateFromPartitioning(override);
 
-    override.getExperimental().setSendOnLegacySubject(cluster.isSendOnLegacySubject());
     override.getExperimental().setReceiveOnLegacySubject(cluster.isReceiveOnLegacySubject());
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
@@ -205,7 +205,6 @@ public class GatewayBasedPropertiesOverride {
     override.getCluster().setInitialContactPoints(cluster.getInitialContactPoints());
     override.getCluster().setClusterName(cluster.getName());
     override.getCluster().setMemberId(cluster.getGatewayId());
-    override.getCluster().setSendOnLegacySubject(cluster.isSendOnLegacySubject());
 
     override
         .getCluster()

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -65,7 +65,6 @@ cluster.raft.segment-preallocation-strategy
 cluster.raft.snapshot-chunk-size
 cluster.raft.snapshot-request-timeout
 cluster.receive-on-legacy-subject
-cluster.send-on-legacy-subject
 cluster.size
 cluster.zone
 data.secondary-storage.rdbms.max-varchar-field-length

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -285,7 +285,6 @@ camunda: # Type: io.camunda.configuration.Camunda
     # The number of replicas for each partition in the cluster. The replication factor cannot be greater
     # than the number of nodes in the cluster.
     replication-factor: 1 # Type: Integer, Env: CAMUNDA_CLUSTER_REPLICATIONFACTOR
-    send-on-legacy-subject: true # Type: Boolean, Env: CAMUNDA_CLUSTER_SENDONLEGACYSUBJECT
     # The number of nodes in the cluster.
     size: 1 # Type: Integer, Env: CAMUNDA_CLUSTER_SIZE
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -30,9 +30,7 @@ public class RaftPartitionConfig {
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
   private static final int DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD = 100;
-  private static final String DEFAULT_TENANT_NAME = "default";
   private static final boolean DEFAULT_RECEIVE_ON_LEGACY_SUBJECT = true;
-  private static final boolean DEFAULT_SEND_ON_LEGACY_SUBJECT = false;
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -48,10 +46,7 @@ public class RaftPartitionConfig {
   private EntryValidator entryValidator;
   private Duration configurationChangeTimeout;
   private int snapshotChunkSize;
-  private String tenantName = DEFAULT_TENANT_NAME;
-  private String legacyGroupName;
   private boolean receiveOnLegacySubject = DEFAULT_RECEIVE_ON_LEGACY_SUBJECT;
-  private boolean sendOnLegacySubject = DEFAULT_SEND_ON_LEGACY_SUBJECT;
 
   /**
    * Returns the Raft leader election timeout.
@@ -216,36 +211,12 @@ public class RaftPartitionConfig {
     this.entryValidator = entryValidator;
   }
 
-  public String getTenantName() {
-    return tenantName;
-  }
-
-  public void setTenantName(final String tenantName) {
-    this.tenantName = tenantName;
-  }
-
-  public String getLegacyGroupName() {
-    return legacyGroupName;
-  }
-
-  public void setLegacyGroupName(final String legacyGroupName) {
-    this.legacyGroupName = legacyGroupName;
-  }
-
   public boolean isReceiveOnLegacySubject() {
     return receiveOnLegacySubject;
   }
 
   public void setReceiveOnLegacySubject(final boolean receiveOnLegacySubject) {
     this.receiveOnLegacySubject = receiveOnLegacySubject;
-  }
-
-  public boolean isSendOnLegacySubject() {
-    return sendOnLegacySubject;
-  }
-
-  public void setSendOnLegacySubject(final boolean sendOnLegacySubject) {
-    this.sendOnLegacySubject = sendOnLegacySubject;
   }
 
   @Override
@@ -275,12 +246,8 @@ public class RaftPartitionConfig {
         + maxQuorumResponseTimeout
         + ", preferSnapshotReplicationThreshold="
         + preferSnapshotReplicationThreshold
-        + ", tenantName="
-        + tenantName
         + ", receiveOnLegacySubject="
         + receiveOnLegacySubject
-        + ", sendOnLegacySubject="
-        + sendOnLegacySubject
         + '}';
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -43,6 +43,7 @@ import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.atomix.utils.serializer.Serializer;
 import io.camunda.zeebe.journal.SegmentInfo;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
@@ -319,47 +320,30 @@ public class RaftPartitionServer implements HealthMonitorable {
   }
 
   private RaftServerCommunicator createServerProtocol() {
-    final var legacySubjects = createLegacySubjects();
-    final var tenantSubjects = createTenantSubjects();
+    final var partitionId = partition.id().id();
+    final var partitionGroup = partition.id().group();
 
-    final var sendingSubject =
-        config.isSendOnLegacySubject() && legacySubjects != null ? legacySubjects : tenantSubjects;
+    final var sendingSubject = PARTITION_NAME_FORMAT.formatted(partitionGroup, partitionId);
+    final var sendingContext = new RaftMessageContext(sendingSubject);
 
-    final List<RaftMessageContext> receivingSubjects;
-    if (config.isReceiveOnLegacySubject() && legacySubjects != null) {
-      receivingSubjects = List.of(legacySubjects, tenantSubjects);
-    } else {
-      receivingSubjects = List.of(tenantSubjects);
-    }
+    final var receivingSubjects =
+        partitionGroup.equals(Protocol.DEFAULT_PARTITION_GROUP_NAME)
+                && config.isReceiveOnLegacySubject()
+            ? List.of(
+                PARTITION_NAME_FORMAT.formatted("raft-partition", partitionId),
+                PARTITION_NAME_FORMAT.formatted(partitionGroup, partitionId))
+            : List.of(PARTITION_NAME_FORMAT.formatted(partitionGroup, partitionId));
+    final var receivingContext = receivingSubjects.stream().map(RaftMessageContext::new).toList();
 
     return new RaftServerCommunicator(
-        sendingSubject,
-        receivingSubjects,
+        sendingContext,
+        receivingContext,
         Serializer.using(RaftNamespaces.RAFT_PROTOCOL),
         clusterCommunicator,
         requestTimeout,
         snapshotRequestTimeout,
         configurationChangeTimeout,
         new RaftRequestMetrics(partition.name(), meterRegistry));
-  }
-
-  private RaftMessageContext createLegacySubjects() {
-    final var legacyGroupName = config.getLegacyGroupName();
-    if (legacyGroupName == null) {
-      return null;
-    }
-    // The legacy subject uses the old group name (set to "raft-partition" for the default engine)
-    // so that new brokers can still receive messages from old brokers that have not been upgraded
-    // yet. This is decoupled from partition.name() because the GROUP_NAME constant was changed to
-    // "default" as part of #50538. Only the default engine sets this — non-default engines have no
-    // legacy subjects to listen on.
-    final var legacyPrefix = PARTITION_NAME_FORMAT.formatted(legacyGroupName, partition.id().id());
-    return new RaftMessageContext(legacyPrefix);
-  }
-
-  private RaftMessageContext createTenantSubjects() {
-    final var tenantPrefix = getPartitionNameWithTenantPrefix();
-    return new RaftMessageContext(tenantPrefix);
   }
 
   public CompletableFuture<Void> stepDown() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -378,12 +378,6 @@ public class RaftPartitionServer implements HealthMonitorable {
     return server.getContext().getTailSegments(index);
   }
 
-  private String getPartitionNameWithTenantPrefix() {
-    final var tenantName = config.getTenantName();
-    final var partitionId = partition.id().id();
-    return PARTITION_NAME_FORMAT.formatted(tenantName, partitionId);
-  }
-
   @VisibleForTesting
   public RaftServer getServer() {
     return server;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerReceiverSubjectsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerReceiverSubjectsTest.java
@@ -20,6 +20,7 @@ import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -40,10 +41,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class RaftServerReceiverSubjectsTest {
 
   private static final String PARTITION_GROUP = "group";
+  private static final String DEFAULT_GROUP = Protocol.DEFAULT_PARTITION_GROUP_NAME;
+  private static final String LEGACY_GROUP = "raft-partition";
   private static final MemberId MEMBER_ID = new MemberId("0");
   private static final PartitionId PARTITION_ID = new PartitionId(PARTITION_GROUP, 1);
-  private static final PartitionMetadata METADATA =
-      new PartitionMetadata(PARTITION_ID, Set.of(), Map.of(), 1, MEMBER_ID);
 
   @Mock private ClusterMembershipService clusterMembershipService;
   @AutoClose private MeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -51,9 +52,12 @@ public class RaftServerReceiverSubjectsTest {
   @Mock private ReceivableSnapshotStore receivableSnapshotStore;
 
   private RaftPartitionServer createRaftPartitionServer(
-      final RaftPartitionConfig raftPartitionConfig, final Path tempDir) {
+      final String group, final RaftPartitionConfig raftPartitionConfig, final Path tempDir) {
+    final var metadata =
+        new PartitionMetadata(
+            new PartitionId(group, PARTITION_ID.id()), Set.of(), Map.of(), 1, MEMBER_ID);
     final var raftPartition =
-        new RaftPartition(METADATA, raftPartitionConfig, tempDir.toFile(), meterRegistry);
+        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
     return new RaftPartitionServer(
         raftPartition,
         raftPartitionConfig,
@@ -61,47 +65,43 @@ public class RaftServerReceiverSubjectsTest {
         clusterMembershipService,
         clusterCommunicationService,
         receivableSnapshotStore,
-        METADATA,
+        metadata,
         meterRegistry);
   }
 
   @ParameterizedTest
-  @MethodSource("provideConfigurations")
-  void shouldRegisterSubjects(final RaftPartitionConfig config, @TempDir final Path tempDir) {
+  @MethodSource("provideScenarios")
+  void shouldRegisterSubjects(
+      final String group,
+      final boolean receiveOnLegacySubject,
+      final Map<String, Integer> expectedHandlersByGroup,
+      @TempDir final Path tempDir) {
     // given
-    final var legacyReceiverSubjectsDisabled = config.isReceiveOnLegacySubject();
-    final var engineName = config.getTenantName();
+    final var config = createConfig(receiveOnLegacySubject);
 
     // when
-    createRaftPartitionServer(config, tempDir);
+    createRaftPartitionServer(group, config, tempDir);
 
     // then
-    assertLegacySubjectsRegistered(legacyReceiverSubjectsDisabled);
-    assertEngineAwareSubjectsRegistered(engineName);
+    expectedHandlersByGroup.forEach(this::assertSubjectsRegistered);
   }
 
   @ParameterizedTest
-  @MethodSource("provideConfigurations")
-  void shouldUnregisterSubjects(final RaftPartitionConfig config, @TempDir final Path tempDir) {
+  @MethodSource("provideScenarios")
+  void shouldUnregisterSubjects(
+      final String group,
+      final boolean receiveOnLegacySubject,
+      final Map<String, Integer> expectedHandlersByGroup,
+      @TempDir final Path tempDir) {
     // given
-    final var server = createRaftPartitionServer(config, tempDir);
-    final var receiveOnLegacySubject = config.isReceiveOnLegacySubject();
-    final var engineName = config.getTenantName();
+    final var config = createConfig(receiveOnLegacySubject);
+    final var server = createRaftPartitionServer(group, config, tempDir);
 
     // when
     server.stop().join();
 
     // then
-    assertLegacySubjectsUnregistered(receiveOnLegacySubject);
-    assertEngineAwareSubjectsUnregistered(engineName);
-  }
-
-  void assertLegacySubjectsRegistered(final boolean receiveOnLegacySubject) {
-    assertSubjectsRegistered(PARTITION_GROUP, receiveOnLegacySubject ? 1 : 0);
-  }
-
-  void assertEngineAwareSubjectsRegistered(final String engineName) {
-    assertSubjectsRegistered(engineName, 1);
+    expectedHandlersByGroup.forEach(this::assertSubjectsUnregistered);
   }
 
   void assertSubjectsRegistered(final String prefix, final int expected) {
@@ -132,14 +132,6 @@ public class RaftServerReceiverSubjectsTest {
         .replyTo(eq(subjectPrefix.formatted("transfer")), any(), any(), any());
   }
 
-  void assertLegacySubjectsUnregistered(final boolean receiveOnLegacySubject) {
-    assertSubjectsUnregistered(PARTITION_GROUP, receiveOnLegacySubject ? 1 : 0);
-  }
-
-  void assertEngineAwareSubjectsUnregistered(final String engineName) {
-    assertSubjectsUnregistered(engineName, 1);
-  }
-
   void assertSubjectsUnregistered(final String prefix, final int expected) {
     final var partitionName = PARTITION_NAME_FORMAT.formatted(prefix, PARTITION_ID.id()) + "-%s";
     final var expectedNumberOfInvocations = expected > 0 ? times(expected) : never();
@@ -168,47 +160,20 @@ public class RaftServerReceiverSubjectsTest {
         .unsubscribe(eq(partitionName.formatted("transfer")));
   }
 
-  static Stream<Arguments> provideConfigurations() {
+  static Stream<Arguments> provideScenarios() {
     return Stream.of(
-        Arguments.of(createDefaultConfig()),
-        Arguments.of(createConfigAndDisableReceiveOnLegacySubject()),
-        Arguments.of(createConfigWithEngineName()),
-        Arguments.of(createConfigWithEngineNameAndDisableReceiveOnLegacySubject()));
+        // the default group receives on both the legacy and the default subject
+        Arguments.of(DEFAULT_GROUP, true, Map.of(LEGACY_GROUP, 1, DEFAULT_GROUP, 1)),
+        // with legacy receive disabled, the default group receives only on its own subject
+        Arguments.of(DEFAULT_GROUP, false, Map.of(LEGACY_GROUP, 0, DEFAULT_GROUP, 1)),
+        // a non-default group never receives on the legacy subject, regardless of the flag
+        Arguments.of(PARTITION_GROUP, true, Map.of(LEGACY_GROUP, 0, PARTITION_GROUP, 1)));
   }
 
-  static RaftPartitionConfig createDefaultConfig() {
+  static RaftPartitionConfig createConfig(final boolean receiveOnLegacySubject) {
     final var raftPartitionConfig = new RaftPartitionConfig();
-    final var raftStorageConfig = new RaftStorageConfig();
-    raftPartitionConfig.setLegacyGroupName(PARTITION_GROUP);
-    raftPartitionConfig.setStorageConfig(raftStorageConfig);
-    return raftPartitionConfig;
-  }
-
-  static RaftPartitionConfig createConfigAndDisableReceiveOnLegacySubject() {
-    final var raftPartitionConfig = new RaftPartitionConfig();
-    final var raftStorageConfig = new RaftStorageConfig();
-    raftPartitionConfig.setLegacyGroupName(PARTITION_GROUP);
-    raftPartitionConfig.setReceiveOnLegacySubject(false);
-    raftPartitionConfig.setStorageConfig(raftStorageConfig);
-    return raftPartitionConfig;
-  }
-
-  static RaftPartitionConfig createConfigWithEngineName() {
-    final var raftPartitionConfig = new RaftPartitionConfig();
-    final var raftStorageConfig = new RaftStorageConfig();
-    raftPartitionConfig.setLegacyGroupName(PARTITION_GROUP);
-    raftPartitionConfig.setTenantName("foo");
-    raftPartitionConfig.setStorageConfig(raftStorageConfig);
-    return raftPartitionConfig;
-  }
-
-  static RaftPartitionConfig createConfigWithEngineNameAndDisableReceiveOnLegacySubject() {
-    final var raftPartitionConfig = new RaftPartitionConfig();
-    final var raftStorageConfig = new RaftStorageConfig();
-    raftPartitionConfig.setLegacyGroupName(PARTITION_GROUP);
-    raftPartitionConfig.setTenantName("foo");
-    raftPartitionConfig.setReceiveOnLegacySubject(false);
-    raftPartitionConfig.setStorageConfig(raftStorageConfig);
+    raftPartitionConfig.setStorageConfig(new RaftStorageConfig());
+    raftPartitionConfig.setReceiveOnLegacySubject(receiveOnLegacySubject);
     return raftPartitionConfig;
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerSenderSubjectsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerSenderSubjectsTest.java
@@ -81,12 +81,10 @@ public class RaftServerSenderSubjectsTest {
         meterRegistry);
   }
 
-  private RaftPartitionConfig createRaftPartitionConfig(final boolean sendOnLegacySubject) {
+  private RaftPartitionConfig createRaftPartitionConfig() {
     final var raftPartitionConfig = new RaftPartitionConfig();
     final var raftStorageConfig = new RaftStorageConfig();
 
-    raftPartitionConfig.setSendOnLegacySubject(sendOnLegacySubject);
-    raftPartitionConfig.setLegacyGroupName(PARTITION_GROUP);
     raftPartitionConfig.setStorageConfig(raftStorageConfig);
 
     return raftPartitionConfig;
@@ -95,18 +93,15 @@ public class RaftServerSenderSubjectsTest {
   @ParameterizedTest
   @MethodSource("provideScenarios")
   void shouldCallWithCorrectSubject(
-      final boolean sendOnLegacySubject,
       final String subjectSuffix,
       final Consumer<RaftServerProtocol> applier,
       @TempDir final Path tempDir) {
     // given
-    final var config = createRaftPartitionConfig(sendOnLegacySubject);
+    final var config = createRaftPartitionConfig();
     final var server = createRaftPartitionServer(config, tempDir);
     final var protocol = server.getServer().getContext().getProtocol();
 
-    final var prefixSubject =
-        PARTITION_NAME_FORMAT.formatted(
-            sendOnLegacySubject ? PARTITION_GROUP : config.getTenantName(), 1);
+    final var prefixSubject = PARTITION_NAME_FORMAT.formatted(PARTITION_GROUP, 1);
     final var subject = "%s-%s".formatted(prefixSubject, subjectSuffix);
 
     // when
@@ -119,28 +114,17 @@ public class RaftServerSenderSubjectsTest {
 
   static Stream<Arguments> provideScenarios() {
     return Stream.of(
-        Arguments.of(true, "append", applyAppendRequestV1()),
-        Arguments.of(true, "append-versioned", applyAppendRequestV2()),
-        Arguments.of(true, "configure", configureRequest()),
-        Arguments.of(true, "force-configure", forceConfigureRequest()),
-        Arguments.of(true, "install", installRequest()),
-        Arguments.of(true, "join", joinRequest()),
-        Arguments.of(true, "leave", leaveRequest()),
-        Arguments.of(true, "poll", pollRequest()),
-        Arguments.of(true, "reconfigure", reconfigureRequest()),
-        Arguments.of(true, "vote", voteRequest()),
-        Arguments.of(true, "transfer", transferRequest()),
-        Arguments.of(false, "append", applyAppendRequestV1()),
-        Arguments.of(false, "append-versioned", applyAppendRequestV2()),
-        Arguments.of(false, "configure", configureRequest()),
-        Arguments.of(false, "force-configure", forceConfigureRequest()),
-        Arguments.of(false, "install", installRequest()),
-        Arguments.of(false, "join", joinRequest()),
-        Arguments.of(false, "leave", leaveRequest()),
-        Arguments.of(false, "poll", pollRequest()),
-        Arguments.of(false, "reconfigure", reconfigureRequest()),
-        Arguments.of(false, "vote", voteRequest()),
-        Arguments.of(false, "transfer", transferRequest()));
+        Arguments.of("append", applyAppendRequestV1()),
+        Arguments.of("append-versioned", applyAppendRequestV2()),
+        Arguments.of("configure", configureRequest()),
+        Arguments.of("force-configure", forceConfigureRequest()),
+        Arguments.of("install", installRequest()),
+        Arguments.of("join", joinRequest()),
+        Arguments.of("leave", leaveRequest()),
+        Arguments.of("poll", pollRequest()),
+        Arguments.of("reconfigure", reconfigureRequest()),
+        Arguments.of("vote", voteRequest()),
+        Arguments.of("transfer", transferRequest()));
   }
 
   static Consumer<RaftServerProtocol> applyAppendRequestV1() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -150,7 +150,7 @@ public final class PartitionManagerImpl
     managementService =
         new DefaultPartitionManagementService(
             clusterServices.getMembershipService(), clusterServices.getCommunicationService());
-    raftPartitionFactory = new RaftPartitionFactory(partitionGroup, brokerCfg);
+    raftPartitionFactory = new RaftPartitionFactory(brokerCfg);
     RocksDbSharedCacheMetrics.registerAllocationStrategy(
         brokerMeterRegistry,
         brokerCfg.getExperimental().getRocksdb().getMemoryAllocationStrategy());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -31,18 +31,11 @@ import org.slf4j.Logger;
 
 public final class RaftPartitionFactory {
   public static final String GROUP_NAME = Protocol.DEFAULT_PARTITION_GROUP_NAME;
-  private static final String LEGACY_GROUP_NAME = "raft-partition";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
-  private final String partitionGroup;
   private final BrokerCfg brokerCfg;
 
-  public RaftPartitionFactory(final String partitionGroup, final BrokerCfg brokerCfg) {
-    this.partitionGroup = partitionGroup;
+  public RaftPartitionFactory(final BrokerCfg brokerCfg) {
     this.brokerCfg = brokerCfg;
-  }
-
-  public String partitionGroup() {
-    return partitionGroup;
   }
 
   public RaftPartition createRaftPartition(
@@ -122,17 +115,8 @@ public final class RaftPartitionFactory {
     partitionConfig.setPreferSnapshotReplicationThreshold(
         brokerCfg.getExperimental().getRaft().getPreferSnapshotReplicationThreshold());
 
-    final var tenantName = partitionMetadata.id().group();
-    partitionConfig.setTenantName(tenantName);
-    partitionConfig.setSendOnLegacySubject(brokerCfg.getExperimental().isSendOnLegacySubject());
     partitionConfig.setReceiveOnLegacySubject(
         brokerCfg.getExperimental().isReceiveOnLegacySubject());
-    // Only the default partition group needs legacy subject support for backward compatibility with
-    // brokers that still use the old "raft-partition" group name. Non-default partition groups have
-    // no legacy subjects to listen on.
-    if (GROUP_NAME.equals(tenantName)) {
-      partitionConfig.setLegacyGroupName(LEGACY_GROUP_NAME);
-    }
 
     return new RaftPartition(
         partitionMetadata, partitionConfig, partitionDirectory.toFile(), partitionMeterRegistry);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -23,9 +23,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
   public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
   public static final boolean DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH = false;
   public static final boolean DEFAULT_VERSION_CHECK_ENABLED = true;
-  private static final boolean DEFAULT_SEND_ON_LEGACY_SUBJECT = false;
   private static final boolean DEFAULT_RECEIVE_ON_LEGACY_SUBJECT = true;
-  private static final String DEFAULT_TENANT_NAME = "default";
 
   private boolean continuousBackups = false;
 
@@ -38,9 +36,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
   private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
   private boolean disableExplicitRaftFlush = DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH;
-  private boolean sendOnLegacySubject = DEFAULT_SEND_ON_LEGACY_SUBJECT;
   private boolean receiveOnLegacySubject = DEFAULT_RECEIVE_ON_LEGACY_SUBJECT;
-  private String defaultTenantName = DEFAULT_TENANT_NAME;
   private RocksdbCfg rocksdb = new RocksdbCfg();
   private ExperimentalRaftCfg raft = new ExperimentalRaftCfg();
   private PartitioningCfg partitioning = new PartitioningCfg();
@@ -167,28 +163,12 @@ public class ExperimentalCfg implements ConfigurationEntry {
     this.features = features;
   }
 
-  public boolean isSendOnLegacySubject() {
-    return sendOnLegacySubject;
-  }
-
-  public void setSendOnLegacySubject(final boolean sendOnLegacySubject) {
-    this.sendOnLegacySubject = sendOnLegacySubject;
-  }
-
   public boolean isReceiveOnLegacySubject() {
     return receiveOnLegacySubject;
   }
 
   public void setReceiveOnLegacySubject(final boolean receiveOnLegacySubject) {
     this.receiveOnLegacySubject = receiveOnLegacySubject;
-  }
-
-  public String getDefaultTenantName() {
-    return defaultTenantName;
-  }
-
-  public void setDefaultTenantName(final String defaultTenantName) {
-    this.defaultTenantName = defaultTenantName;
   }
 
   @Override
@@ -212,12 +192,8 @@ public class ExperimentalCfg implements ConfigurationEntry {
         + engine
         + ", features="
         + features
-        + ", sendOnLegacySubject="
-        + sendOnLegacySubject
         + ", receiveOnLegacySubject="
         + receiveOnLegacySubject
-        + ", defaultTenantName="
-        + defaultTenantName
         + '}';
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
@@ -29,6 +30,9 @@ import java.util.List;
 public interface PartitionContext {
 
   int getPartitionId();
+
+  /** Returns the composite partition id, including the partition group it belongs to. */
+  PartitionId partitionId();
 
   RaftPartition getRaftPartition();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.security.configuration.EngineSecurityConfig;
@@ -80,7 +81,7 @@ public class PartitionStartupAndTransitionContextImpl
   private final TypedRecordProcessorsFactory typedRecordProcessorsFactory;
   private final CommandApiService commandApiService;
   private final PersistedSnapshotStore persistedSnapshotStore;
-  private final Integer partitionId;
+  private final PartitionId partitionId;
   private final int maxFragmentSize;
   private final ExporterRepository exporterRepository;
   private final PartitionProcessingState partitionProcessingState;
@@ -159,7 +160,7 @@ public class PartitionStartupAndTransitionContextImpl
     this.persistedSnapshotStore = persistedSnapshotStore;
     this.partitionListeners = Collections.unmodifiableList(partitionListeners);
     this.partitionRaftListeners = Collections.unmodifiableList(partitionRaftListeners);
-    partitionId = raftPartition.id().id();
+    partitionId = raftPartition.id();
     this.actorSchedulingService = actorSchedulingService;
     maxFragmentSize = (int) brokerCfg.getNetwork().getMaxMessageSizeInBytes();
     this.exporterRepository = exporterRepository;
@@ -185,6 +186,11 @@ public class PartitionStartupAndTransitionContextImpl
 
   @Override
   public int getPartitionId() {
+    return partitionId.id();
+  }
+
+  @Override
+  public PartitionId partitionId() {
     return partitionId;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
@@ -76,7 +76,7 @@ public final class BackupApiRequestHandlerStep implements PartitionTransitionSte
             checkpointState,
             checkpointMetadataState,
             backupRangeState,
-            context.getRaftPartition().id(),
+            context.partitionId(),
             isBackupEnabled);
     context.getActorSchedulingService().submitActor(requestHandler).onComplete(installed);
     installed.onComplete(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -119,7 +119,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
     final var exporterFilter = SkipPositionsFilter.of(skipRecords);
     final ExporterMode exporterMode =
         targetRole == Role.LEADER ? ExporterMode.ACTIVE : ExporterMode.PASSIVE;
-    final var tenantName = context.getRaftPartition().getPartitionConfig().getTenantName();
+    final var tenantName = context.partitionId().group();
     final ExporterDirectorContext exporterCtx =
         new ExporterDirectorContext()
             .id(EXPORTER_PROCESSOR_ID)

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/InterPartitionCommandServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/InterPartitionCommandServiceStep.java
@@ -15,8 +15,10 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandReceiverActor;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderService;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.List;
+import java.util.Objects;
 
 public final class InterPartitionCommandServiceStep implements PartitionTransitionStep {
 
@@ -94,13 +96,13 @@ public final class InterPartitionCommandServiceStep implements PartitionTransiti
     final var logStreamWriter = context.getLogStream().newLogStreamWriter();
 
     final var config = context.getBrokerCfg().getExperimental();
-    final var partitionId = context.getPartitionId();
-    final var legacyReceivingSubject = LEGACY_TOPIC_PREFIX + partitionId;
-    final var receivingSubject =
-        TOPIC_PREFIX.formatted(config.getDefaultTenantName()) + partitionId;
+    final var partitionId = context.partitionId();
+    final var legacyReceivingSubject = LEGACY_TOPIC_PREFIX + partitionId.id();
+    final var receivingSubject = TOPIC_PREFIX.formatted(partitionId.group()) + partitionId.id();
 
     final var receivingSubjects =
         config.isReceiveOnLegacySubject()
+                && Objects.equals(partitionId.group(), Protocol.DEFAULT_PARTITION_GROUP_NAME)
             ? List.of(legacyReceivingSubject, receivingSubject)
             : List.of(receivingSubject);
 
@@ -129,15 +131,12 @@ public final class InterPartitionCommandServiceStep implements PartitionTransiti
   private ActorFuture<Void> installSender(final PartitionTransitionContext context) {
     final ActorFuture<Void> future = context.getConcurrencyControl().createFuture();
 
-    final var config = context.getBrokerCfg().getExperimental();
-    final var sendingSubject =
-        config.isSendOnLegacySubject()
-            ? LEGACY_TOPIC_PREFIX
-            : TOPIC_PREFIX.formatted(config.getDefaultTenantName());
+    final var partitionId = context.partitionId();
+    final var sendingSubject = TOPIC_PREFIX.formatted(partitionId.group());
 
     final var sender =
         new InterPartitionCommandSenderService(
-            context.getClusterCommunicationService(), context.getPartitionId(), sendingSubject);
+            context.getClusterCommunicationService(), sendingSubject);
     final var actorStarted = context.getActorSchedulingService().submitActor(sender);
     actorStarted.onComplete(
         (ignore, error) -> {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
@@ -23,7 +23,7 @@ public class SnapshotApiHandlerTransitionStep implements PartitionTransitionStep
   public ActorFuture<Void> prepareTransition(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     if (context.getCurrentRole().isLeader()) {
-      context.getSnapshotApiRequestHandler().removeTransferService(context.getRaftPartition().id());
+      context.getSnapshotApiRequestHandler().removeTransferService(context.partitionId());
     }
     return CompletableActorFuture.completed();
   }
@@ -40,9 +40,7 @@ public class SnapshotApiHandlerTransitionStep implements PartitionTransitionStep
               (from, to) ->
                   context.snapshotCopy().copySnapshot(from, to, Set.of(ColumnFamilyScope.GLOBAL)),
               context.getSnapshotApiRequestHandler());
-      context
-          .getSnapshotApiRequestHandler()
-          .addTransferService(context.getRaftPartition().id(), service);
+      context.getSnapshotApiRequestHandler().addTransferService(context.partitionId(), service);
     }
     return CompletableActorFuture.completed();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
@@ -23,14 +23,10 @@ public final class InterPartitionCommandSenderService extends Actor
     implements InterPartitionCommandSender, CheckpointListener, TopologyPartitionListener {
 
   final InterPartitionCommandSenderImpl commandSender;
-  final int partitionId;
 
   public InterPartitionCommandSenderService(
-      final ClusterCommunicationService communicationService,
-      final int partitionId,
-      final String sendingSubjectPrefix) {
+      final ClusterCommunicationService communicationService, final String sendingSubjectPrefix) {
     commandSender = new InterPartitionCommandSenderImpl(communicationService, sendingSubjectPrefix);
-    this.partitionId = partitionId;
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
@@ -229,7 +229,7 @@ public final class RaftPartitionFactoryTest {
   }
 
   private RaftPartition buildRaftPartition(final BrokerCfg brokerCfg) {
-    return new RaftPartitionFactory("test", brokerCfg)
+    return new RaftPartitionFactory(brokerCfg)
         .createRaftPartition(
             new PartitionMetadata(
                 PartitionId.from("test", 1),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.security.configuration.EngineSecurityConfig;
@@ -40,6 +41,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -103,6 +105,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public int getPartitionId() {
     return 1;
+  }
+
+  @Override
+  public PartitionId partitionId() {
+    return PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, getPartitionId());
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionConfig;
-import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
@@ -74,7 +73,6 @@ class ExporterDirectorPartitionTransitionStepTest {
 
     final var raftPartition = mock(RaftPartition.class);
     final var raftPartitionConfig = new RaftPartitionConfig();
-    raftPartitionConfig.setTenantName(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     when(raftPartition.getPartitionConfig()).thenReturn(raftPartitionConfig);
     transitionContext.setRaftPartition(raftPartition);
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -45,8 +45,6 @@ public final class ClusterCfg {
   private ConfigManagerCfg configManager = ConfigManagerCfg.defaultConfig();
   private DataSize socketSendBuffer = null;
   private DataSize socketReceiveBuffer = null;
-  private boolean sendOnLegacySubject = false;
-  private String defaultTenantName = "default";
 
   public String getMemberId() {
     return memberId;
@@ -180,24 +178,6 @@ public final class ClusterCfg {
     return this;
   }
 
-  public boolean isSendOnLegacySubject() {
-    return sendOnLegacySubject;
-  }
-
-  public ClusterCfg setSendOnLegacySubject(final boolean sendOnLegacySubject) {
-    this.sendOnLegacySubject = sendOnLegacySubject;
-    return this;
-  }
-
-  public String getDefaultTenantName() {
-    return defaultTenantName;
-  }
-
-  public ClusterCfg setDefaultTenantName(final String defaultTenantName) {
-    this.defaultTenantName = defaultTenantName;
-    return this;
-  }
-
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -212,9 +192,7 @@ public final class ClusterCfg {
         messageCompression,
         configManager,
         socketSendBuffer,
-        socketReceiveBuffer,
-        defaultTenantName,
-        sendOnLegacySubject);
+        socketReceiveBuffer);
   }
 
   @Override
@@ -237,9 +215,7 @@ public final class ClusterCfg {
         && Objects.equals(messageCompression, that.messageCompression)
         && Objects.equals(configManager, that.configManager)
         && Objects.equals(socketSendBuffer, that.socketSendBuffer)
-        && Objects.equals(socketReceiveBuffer, that.socketReceiveBuffer)
-        && Objects.equals(defaultTenantName, that.defaultTenantName)
-        && Objects.equals(sendOnLegacySubject, that.sendOnLegacySubject);
+        && Objects.equals(socketReceiveBuffer, that.socketReceiveBuffer);
   }
 
   @Override
@@ -272,10 +248,6 @@ public final class ClusterCfg {
         + socketSendBuffer
         + ", socketReceiveBuffer="
         + socketReceiveBuffer
-        + ", sendOnLegacySubject="
-        + sendOnLegacySubject
-        + ", tenantName="
-        + defaultTenantName
         + '}';
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
@@ -46,18 +46,6 @@ public class RaftServerForwardCompatibilityIT {
 
     return Stream.of(
         Arguments.of(
-            "8.9 Mode with Embedded Gateway",
-            createTestClusterWithBrokerConfiguration(
-                RaftServerForwardCompatibilityIT::configure89Mode)),
-        Arguments.of(
-            "8.9 to 8.10 Upgrade with Embedded Gateway",
-            createTestClusterWithBrokerConfiguration(
-                RaftServerForwardCompatibilityIT::configure89To810Mode)),
-        Arguments.of(
-            "8.10 Mode with Embedded Gateway",
-            createTestClusterWithBrokerConfiguration(
-                RaftServerForwardCompatibilityIT::configure810Mode)),
-        Arguments.of(
             "8.10 to 8.11 Upgrade with Embedded Gateway",
             createTestClusterWithBrokerConfiguration(
                 RaftServerForwardCompatibilityIT::configure810To811Mode)),
@@ -66,29 +54,9 @@ public class RaftServerForwardCompatibilityIT {
             createTestClusterWithBrokerConfiguration(
                 RaftServerForwardCompatibilityIT::configure811Mode)),
         Arguments.of(
-            "8.9 Mode with Standalone Gateway",
-            createTestClusterWithStandaloneGateway(
-                RaftServerForwardCompatibilityIT::configure89Mode, true)),
-        Arguments.of(
-            "8.9 to 8.10 Upgrade with Standalone Gateway (sendOnLegacySubject = true)",
-            createTestClusterWithStandaloneGateway(
-                RaftServerForwardCompatibilityIT::configure89To810Mode, true)),
-        Arguments.of(
-            "8.9 to 8.10 Upgrade with Standalone Gateway (sendOnLegacySubject = false)",
-            createTestClusterWithStandaloneGateway(
-                RaftServerForwardCompatibilityIT::configure89To810Mode, false)),
-        Arguments.of(
-            "8.10 Mode with Standalone Gateway",
-            createTestClusterWithStandaloneGateway(
-                RaftServerForwardCompatibilityIT::configure810Mode, false)),
-        Arguments.of(
-            "8.10 to 8.11 Upgrade with Standalone Gateway",
-            createTestClusterWithStandaloneGateway(
-                RaftServerForwardCompatibilityIT::configure810To811Mode, false)),
-        Arguments.of(
             "8.11 Mode with Standalone Gateway",
             createTestClusterWithStandaloneGateway(
-                RaftServerForwardCompatibilityIT::configure811Mode, false)));
+                RaftServerForwardCompatibilityIT::configure811Mode)));
   }
 
   static TestCluster createTestClusterWithBrokerConfiguration(
@@ -102,8 +70,7 @@ public class RaftServerForwardCompatibilityIT {
   }
 
   static TestCluster createTestClusterWithStandaloneGateway(
-      final BiConsumer<MemberId, TestStandaloneBroker> brokerConfigurationApplier,
-      final boolean gatewaySendOnLegacySubject) {
+      final BiConsumer<MemberId, TestStandaloneBroker> brokerConfigurationApplier) {
     return TestCluster.builder()
         .withBrokersCount(PARTITION_COUNT)
         .withPartitionsCount(PARTITION_COUNT)
@@ -111,54 +78,7 @@ public class RaftServerForwardCompatibilityIT {
         .withBrokerConfig(brokerConfigurationApplier)
         .withEmbeddedGateway(false)
         .withGatewaysCount(1)
-        .withGatewayConfig(
-            m -> m.withClusterConfig(c -> c.setSendOnLegacySubject(gatewaySendOnLegacySubject)))
         .build();
-  }
-
-  /**
-   * 8.9.x cluster with the following configuration:
-   *
-   * <ul>
-   *   <li>Sending: All nodes send with subject: "raft-partition-partition-*"
-   *   <li>Receiving: All nodes listen to subjects: "default-partition-*" and
-   *       "raft-partition-partition-*"
-   * </ul>
-   */
-  static void configure89Mode(final MemberId memberId, final TestStandaloneBroker broker) {
-    broker.withClusterConfig(c -> c.setSendOnLegacySubject(true));
-  }
-
-  /**
-   * Simulating upgrade path from 8.9 to 8.10 cluster with the following configuration:
-   *
-   * <ul>
-   *   <li>Sending (Node "0"): Node sends with subject: "default-partition-*"
-   *   <li>Sending (Node "1" and "2"): Nodes send with subject: "raft-partition-partition-*"
-   *   <li>Receiving: All nodes listen to subjects: "default-partition-*" and
-   *       "raft-partition-partition-*"
-   * </ul>
-   */
-  static void configure89To810Mode(final MemberId memberId, final TestStandaloneBroker broker) {
-    if (memberId.id().equals(MEMBER_NODE_ID_0)) {
-      broker.withClusterConfig(c -> c.setSendOnLegacySubject(false));
-    } else {
-      // 8.9 nodes still send on legacy subjects
-      broker.withClusterConfig(c -> c.setSendOnLegacySubject(true));
-    }
-  }
-
-  /**
-   * Simulating future 8.10 cluster with the following configuration:
-   *
-   * <ul>
-   *   <li>Sending: All nodes send with subject: "default-partition-*"
-   *   <li>Receiving: All nodes listen to subjects: "default-partition-*" and
-   *       "raft-partition-partition-*"
-   * </ul>
-   */
-  static void configure810Mode(final MemberId memberId, final TestStandaloneBroker broker) {
-    broker.withClusterConfig(c -> c.setSendOnLegacySubject(false));
   }
 
   /**
@@ -172,12 +92,8 @@ public class RaftServerForwardCompatibilityIT {
    * </ul>
    */
   static void configure810To811Mode(final MemberId memberId, final TestStandaloneBroker broker) {
-    broker.withClusterConfig(c -> c.setSendOnLegacySubject(false));
     if (memberId.id().equals(MEMBER_NODE_ID_0)) {
-      broker.withClusterConfig(
-          c -> {
-            c.setReceiveOnLegacySubject(false);
-          });
+      broker.withClusterConfig(c -> c.setReceiveOnLegacySubject(false));
     }
   }
 
@@ -190,10 +106,6 @@ public class RaftServerForwardCompatibilityIT {
    * </ul>
    */
   static void configure811Mode(final MemberId memberId, final TestStandaloneBroker broker) {
-    broker.withClusterConfig(
-        c -> {
-          c.setSendOnLegacySubject(false);
-          c.setReceiveOnLegacySubject(false);
-        });
+    broker.withClusterConfig(c -> c.setReceiveOnLegacySubject(false));
   }
 }

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupMetadata;
 import io.camunda.zeebe.backup.management.BackupMetadataSyncer;
-import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.partitioning.topology.StaticConfigurationGenerator;
@@ -329,8 +328,7 @@ public class RestoreManager implements CloseableSilently {
         new PartitionDistribution(
             StaticConfigurationGenerator.getStaticConfiguration(configuration, localMember)
                 .generatePartitionDistribution());
-    final var raftPartitionFactory =
-        new RaftPartitionFactory(PartitionManagerImpl.DEFAULT_GROUP_NAME, configuration);
+    final var raftPartitionFactory = new RaftPartitionFactory(configuration);
 
     return clusterTopology.partitions().stream()
         .filter(partitionMetadata -> partitionMetadata.members().contains(localMember))


### PR DESCRIPTION
Groundwork for physical tenants: make a partition's composite `PartitionId` (partition group + id) the single source of truth for its group/tenant across the startup and transition contexts, and remove the parallel `tenantName` / `legacyGroupName` / `sendOnLegacySubject` plumbing that is no longer needed.

Closes #55118.

### Changes

- **Expose the composite `PartitionId` on the partition context.** `PartitionContext` now exposes `partitionId()` returning the full `PartitionId` (group + id) instead of only the numeric id, and the startup/transition context stores it directly. Consumers (snapshot transfer, backup API request handler) use it instead of reconstructing it from the default group.
- **Derive the tenant/group name from the `PartitionId`.** The exporter director transition step reads the tenant name from `partitionId().group()` rather than from `RaftPartitionConfig.getTenantName()`.
- **Remove the ability to send on legacy subjects.** Every broker in the current and previous version already receives on the new subjects, so we no longer send on the legacy ones. The `sendOnLegacySubject` configuration and the `tenantName` / `legacyGroupName` fields on `RaftPartitionConfig` are removed; receiving on legacy subjects is retained for the default group for backwards compatibility. As a result `RaftPartitionFactory` no longer needs the partition group passed into its constructor.
- **Remove an unused method** (`getPartitionNameWithTenantPrefix`) from `RaftPartitionServer`.

No behavioral change for a default-only cluster.

### Stacked PRs

Two bug fixes that were originally on this branch have been split into their own draft PRs stacked on top of this one:

- #55942 — fix: restore to the tenant's partition directory
- #55943 — fix: broker health accounts for all physical tenants' partitions
