### PR TITLE
Add businessId filter and sort to user task search API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
@@ -72,6 +72,25 @@ public interface UserTaskFilter extends SearchRequestFilter {
   UserTaskFilter assignee(final Consumer<StringProperty> fn);
 
   /**
+   * Filters user tasks by the business ID of their owning process instance. This only works for
+   * user tasks created with 8.10 and onwards. Tasks from prior versions don't contain this data.
+   *
+   * @param businessId the business ID of the owning process instance
+   * @return the updated filter
+   */
+  UserTaskFilter businessId(final String businessId);
+
+  /**
+   * Filters user tasks by the business ID of their owning process instance using {@link
+   * StringProperty} consumer. This only works for user tasks created with 8.10 and onwards. Tasks
+   * from prior versions don't contain this data.
+   *
+   * @param fn the business ID {@link StringProperty} consumer of the user task
+   * @return the updated filter
+   */
+  UserTaskFilter businessId(final Consumer<StringProperty> fn);
+
+  /**
    * Filters user tasks by the specified priority.
    *
    * @param priority the priority of the user task

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/UserTaskSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/UserTaskSort.java
@@ -30,4 +30,6 @@ public interface UserTaskSort extends SearchRequestSort<UserTaskSort> {
   UserTaskSort priority();
 
   UserTaskSort name();
+
+  UserTaskSort businessId();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -83,6 +83,20 @@ public class UserTaskFilterImpl
   }
 
   @Override
+  public UserTaskFilter businessId(final String businessId) {
+    businessId(b -> b.eq(businessId));
+    return this;
+  }
+
+  @Override
+  public UserTaskFilter businessId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setBusinessId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public UserTaskFilter priority(final Integer priority) {
     priority(b -> b.eq(priority));
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/UserTaskSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/UserTaskSortImpl.java
@@ -51,6 +51,11 @@ public class UserTaskSortImpl extends SearchRequestSortBase<UserTaskSort> implem
   }
 
   @Override
+  public UserTaskSort businessId() {
+    return field("businessId");
+  }
+
+  @Override
   protected UserTaskSort self() {
     return this;
   }

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -79,6 +79,30 @@ public final class SearchUserTaskTest extends ClientRestTest {
   }
 
   @Test
+  void shouldSearchUserTaskByBusinessId() {
+    // when
+    client.newUserTaskSearchRequest().filter(f -> f.businessId("order-42")).send().join();
+
+    // then
+    final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
+    assertThat(request.getFilter().getBusinessId().get$Eq()).isEqualTo("order-42");
+  }
+
+  @Test
+  void shouldSearchUserTaskByBusinessIdStringFilter() {
+    // when
+    client
+        .newUserTaskSearchRequest()
+        .filter(f -> f.businessId(b -> b.like("order-*")))
+        .send()
+        .join();
+
+    // then
+    final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
+    assertThat(request.getFilter().getBusinessId().get$Like()).isEqualTo("order-*");
+  }
+
+  @Test
   void shouldSearchUserTaskByName() {
     // when
     client.newUserTaskSearchRequest().filter(f -> f.name("myTask")).send().join();

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -103,6 +103,17 @@ public final class SearchUserTaskTest extends ClientRestTest {
   }
 
   @Test
+  void shouldSearchUserTaskSortByBusinessId() {
+    // when
+    client.newUserTaskSearchRequest().sort(s -> s.businessId().desc()).send().join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getBodyAsString())
+        .contains("\"sort\":[{\"field\":\"businessId\",\"order\":\"DESC\"}]");
+  }
+
+  @Test
   void shouldSearchUserTaskByName() {
     // when
     client.newUserTaskSearchRequest().filter(f -> f.name("myTask")).send().join();

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/UserTaskSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/UserTaskSearchColumn.java
@@ -20,6 +20,7 @@ public enum UserTaskSearchColumn implements SearchColumn<UserTaskEntity> {
   ELEMENT_INSTANCE_KEY("elementInstanceKey"),
   TENANT_ID("tenantId"),
   ASSIGNEE("assignee"),
+  BUSINESS_ID("businessId"),
   FORM_KEY("formKey"),
   PROCESS_DEFINITION_ID("processDefinitionId"),
   PROCESS_DEFINITION_KEY("processDefinitionKey"),

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -271,6 +271,12 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
+      <if test="filter.businessIdOperations != null and !filter.businessIdOperations.isEmpty()">
+        <foreach collection="filter.businessIdOperations" item="operation">
+          AND ut.BUSINESS_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
       <if test="filter.priorityOperations != null and !filter.priorityOperations.isEmpty()">
         <foreach collection="filter.priorityOperations" item="operation">
           AND ut.PRIORITY

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -962,6 +962,9 @@ public class SearchQueryFilterMapper {
       Optional.ofNullable(filter.getAssignee())
           .map(mapToStringOperations())
           .ifPresent(builder::assigneeOperations);
+      Optional.ofNullable(filter.getBusinessId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::businessIdOperations);
       Optional.ofNullable(filter.getPriority())
           .map(mapToIntegerOperations("priority", validationErrors))
           .ifPresent(builder::priorityOperations);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -757,6 +757,7 @@ public class SearchQuerySortRequestMapper {
         case DUE_DATE -> builder.dueDate();
         case PRIORITY -> builder.priority();
         case NAME -> builder.name();
+        case BUSINESS_ID -> builder.businessId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
@@ -356,6 +356,9 @@ public class SimpleSearchQueryMapper {
       ofNullable(filter.getAssignee())
           .map(SimpleSearchQueryMapper::getStringFilter)
           .ifPresent(filterModel::assignee);
+      ofNullable(filter.getBusinessId())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::businessId);
       ofNullable(filter.getPriority())
           .map(SimpleSearchQueryMapper::getIntegerFilter)
           .ifPresent(filterModel::priority);

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
@@ -95,6 +95,7 @@ public class CustomMcpModelPropertiesTest {
             UserTaskFilter.class,
             Set.of(
                 "assignee",
+                "businessId",
                 "completionDate",
                 "creationDate",
                 "dueDate",

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -301,7 +301,15 @@ class UserTaskToolsTest extends OperationalToolsTest {
                   .arguments(
                       Map.of(
                           "filter",
-                          Map.of("state", "CREATED", "assignee", "john.doe", "priority", 50),
+                          Map.of(
+                              "state",
+                              "CREATED",
+                              "assignee",
+                              "john.doe",
+                              "businessId",
+                              "order-42",
+                              "priority",
+                              50),
                           "sort",
                           List.of(Map.of("field", "creationDate", "order", "DESC")),
                           "page",
@@ -334,6 +342,10 @@ class UserTaskToolsTest extends OperationalToolsTest {
       assertThat(filter.assigneeOperations())
           .extracting(Operation::operator, Operation::value)
           .containsExactly(tuple(Operator.EQUALS, "john.doe"));
+
+      assertThat(filter.businessIdOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(tuple(Operator.EQUALS, "order-42"));
 
       assertThat(filter.priorityOperations())
           .extracting(Operation::operator, Operation::value)

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -88,7 +88,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
           23L,
           42L,
           null,
-          null,
+          "businessId-123",
           17L,
           "tenantId",
           null,
@@ -149,6 +149,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     assertThat(userTask.getName()).isEqualTo("Task Name");
     assertThat(userTask.getState()).isEqualTo(UserTaskStateEnum.CREATED);
     assertThat(userTask.getAssignee()).isEqualTo("john.doe");
+    assertThat(userTask.getBusinessId()).isEqualTo("businessId-123");
     assertThat(userTask.getElementId()).isEqualTo("elementId");
     assertThat(userTask.getCandidateGroups()).containsExactly("group1", "group2");
     assertThat(userTask.getCandidateUsers()).containsExactly("user1", "user2");

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -787,6 +787,10 @@
                 "type": "string",
                 "description": "The assignee of the user task."
               },
+              "businessId": {
+                "type": "string",
+                "description": "The business ID of the owning process instance the user task belongs to. This only works for user tasks created with 8.10 and onwards. Tasks from prior versions don't contain this data and cannot be found. "
+              },
               "completionDate": {
                 "type": "object",
                 "properties": {
@@ -981,7 +985,8 @@
                     "followUpDate",
                     "dueDate",
                     "priority",
-                    "name"
+                    "name",
+                    "businessId"
                   ],
                   "description": "The field to sort by."
                 },

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserTaskFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserTaskFixtures.java
@@ -36,6 +36,7 @@ public final class UserTaskFixtures extends CommonFixtures {
             .creationDate(NOW)
             .completionDate(NOW.plusDays(1))
             .assignee(generateRandomString("user"))
+            .businessId(generateRandomString("businessId"))
             .state(UserTaskState.CREATED)
             .formKey(nextKey())
             .processDefinitionKey(nextKey())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -327,6 +327,61 @@ public class UserTaskIT {
   }
 
   @TestTemplate
+  public void shouldFindUserTaskByBusinessIdEq(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String businessId = generateRandomString("businessId");
+    final UserTaskDbModel userTask =
+        UserTaskFixtures.createRandomized(b -> b.businessId(businessId));
+    createAndSaveUserTask(rdbmsService, userTask);
+
+    // when
+    final var searchResult =
+        rdbmsService
+            .getUserTaskReader("default")
+            .search(
+                new UserTaskQuery(
+                    new UserTaskFilter.Builder()
+                        .businessIdOperations(Operation.eq(businessId))
+                        .build(),
+                    UserTaskSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertUserTaskEntity(searchResult.items().getFirst(), userTask);
+  }
+
+  @TestTemplate
+  public void shouldFindUserTaskByBusinessIdLike(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String prefix = generateRandomString("business-transaction");
+    final UserTaskDbModel userTask =
+        UserTaskFixtures.createRandomized(b -> b.businessId(prefix + "-v1"));
+    createAndSaveUserTask(rdbmsService, userTask);
+
+    // when
+    final var searchResult =
+        rdbmsService
+            .getUserTaskReader("default")
+            .search(
+                new UserTaskQuery(
+                    new UserTaskFilter.Builder()
+                        .businessIdOperations(Operation.like(prefix + "*"))
+                        .build(),
+                    UserTaskSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertUserTaskEntity(searchResult.items().getFirst(), userTask);
+  }
+
+  @TestTemplate
   public void shouldFindUserTaskByProcessDefinitionKeyNeq(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -1633,6 +1688,7 @@ public class UserTaskIT {
                     .userTaskKeys(userTask.userTaskKey())
                     .elementIds(userTask.elementId())
                     .assignees(userTask.assignee())
+                    .businessIds(userTask.businessId())
                     .states(userTask.state().name())
                     .processInstanceKeys(userTask.processInstanceKey())
                     .processDefinitionKeys(userTask.processDefinitionKey())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
@@ -114,6 +114,22 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::followUpDate).reversed());
   }
 
+  @TestTemplate
+  public void shouldSortByBusinessIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.businessId().asc(),
+        Comparator.comparing(UserTaskEntity::businessId));
+  }
+
+  @TestTemplate
+  public void shouldSortByBusinessIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.businessId().desc(),
+        Comparator.comparing(UserTaskEntity::businessId).reversed());
+  }
+
   private void testSorting(
       final RdbmsService rdbmsService,
       final Function<Builder, ObjectBuilder<UserTaskSort>> sortBuilder,

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -67,6 +67,7 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     queries.addAll(getCandidateUsersQuery(filter.candidateUserOperations()));
     queries.addAll(getCandidateGroupsQuery(filter.candidateGroupOperations()));
     queries.addAll(getAssigneesQuery(filter.assigneeOperations()));
+    queries.addAll(getBusinessIdQuery(filter.businessIdOperations()));
     queries.addAll(getPrioritiesQuery(filter.priorityOperations()));
     queries.addAll(getStatesQuery(filter.stateOperations()));
     queries.addAll(getTenantQuery(filter.tenantIdOperations()));
@@ -194,6 +195,10 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
 
   private List<SearchQuery> getAssigneesQuery(final List<Operation<String>> assignees) {
     return stringOperations(ASSIGNEE, assignees);
+  }
+
+  private List<SearchQuery> getBusinessIdQuery(final List<Operation<String>> businessIds) {
+    return stringOperations(BUSINESS_ID, businessIds);
   }
 
   private List<SearchQuery> getPrioritiesQuery(final List<Operation<Integer>> priorities) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/UserTaskFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/UserTaskFieldSortingTransformer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients.transformers.sort;
 
+import static io.camunda.webapps.schema.descriptors.template.TaskTemplate.BUSINESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.TaskTemplate.COMPLETION_TIME;
 import static io.camunda.webapps.schema.descriptors.template.TaskTemplate.CREATION_TIME;
 import static io.camunda.webapps.schema.descriptors.template.TaskTemplate.DUE_DATE;
@@ -25,6 +26,7 @@ public class UserTaskFieldSortingTransformer implements FieldSortingTransformer 
       case "dueDate" -> DUE_DATE;
       case "followUpDate" -> FOLLOW_UP_DATE;
       case "name" -> NAME;
+      case "businessId" -> BUSINESS_ID;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
@@ -644,6 +644,25 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
+  public void shouldQueryByBusinessId() {
+    // given
+    final var filter = FilterBuilders.userTask((f) -> f.businessIds("businessId1"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            (t) -> {
+              assertSearchTermQuery(t.must().get(0).queryOption(), "businessId", "businessId1");
+            });
+  }
+
+  @Test
   public void shouldQueryByProcessInstanceVariableValueFilter() {
     // given
     final VariableValueFilter.Builder variableValueFilterBuilder =

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/UserTaskSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/UserTaskSortTest.java
@@ -149,4 +149,30 @@ public class UserTaskSortTest extends AbstractSortTransformerTest {
 
     assertThat(followUpDateAsc).isTrue();
   }
+
+  @Test
+  public void shouldApplySortConditionByBusinessId() {
+    // given
+    final var userTaskStateFilter = FilterBuilders.userTask((f) -> f.states("CREATED"));
+    final var request =
+        SearchQueryBuilders.userTaskSearchQuery(
+            (q) -> q.filter(userTaskStateFilter).sort((s) -> s.businessId().desc()));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    Assertions.assertThat(sort).isNotNull();
+    Assertions.assertThat(sort).hasSize(2); // Assert has key + businessId
+
+    // Check if "businessId" is present in any position
+    final boolean businessIdDesc =
+        sort.stream()
+            .anyMatch(
+                s ->
+                    s.field().field().equals("businessId")
+                        && s.field().order().equals(SortOrder.DESC));
+
+    assertThat(businessIdDesc).isTrue();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -25,6 +25,7 @@ public record UserTaskFilter(
     List<Operation<String>> nameOperations,
     List<Operation<String>> processDefinitionIdOperations,
     List<Operation<String>> assigneeOperations,
+    List<Operation<String>> businessIdOperations,
     List<Operation<Integer>> priorityOperations,
     List<Operation<String>> stateOperations,
     List<Operation<Long>> processInstanceKeyOperations,
@@ -50,6 +51,7 @@ public record UserTaskFilter(
     private List<Operation<String>> nameOperations;
     private List<Operation<String>> processDefinitionIdOperations;
     private List<Operation<String>> assigneeOperations;
+    private List<Operation<String>> businessIdOperations;
     private List<Operation<Integer>> priorityOperations;
     private List<Operation<String>> stateOperations;
     private List<Operation<Long>> processInstanceKeyOperations;
@@ -128,6 +130,21 @@ public record UserTaskFilter(
     public final Builder assigneeOperations(
         final Operation<String> operation, final Operation<String>... operations) {
       return assigneeOperations(collectValues(operation, operations));
+    }
+
+    public Builder businessIdOperations(final List<Operation<String>> operations) {
+      businessIdOperations = addValuesToList(businessIdOperations, operations);
+      return this;
+    }
+
+    public Builder businessIds(final String value, final String... values) {
+      return businessIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder businessIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return businessIdOperations(collectValues(operation, operations));
     }
 
     public Builder priorityOperations(final List<Operation<Integer>> operations) {
@@ -320,6 +337,7 @@ public record UserTaskFilter(
           Objects.requireNonNullElse(nameOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(assigneeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(businessIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(priorityOperations, Collections.emptyList()),
           Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/sort/UserTaskSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/UserTaskSort.java
@@ -55,6 +55,11 @@ public record UserTaskSort(List<FieldSorting> orderings) implements SortOption {
       return this;
     }
 
+    public Builder businessId() {
+      currentOrdering = new FieldSorting("businessId", null);
+      return this;
+    }
+
     @Override
     protected Builder self() {
       return this;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/TaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/TaskTemplate.java
@@ -71,6 +71,7 @@ public class TaskTemplate extends AbstractTemplateDescriptor
   public static final String PROCESS_INSTANCE_ID = "processInstanceId";
   public static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
   public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
+  public static final String BUSINESS_ID = "businessId";
 
   public static final String JOIN_FIELD_NAME = "join";
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -523,6 +523,13 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The assignee of the user task.
+        businessId:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: >
+            The business ID of the owning process instance the user task belongs to. This only
+            works for user tasks created with 8.10 and onwards. Tasks from prior versions don't
+            contain this data and cannot be found.
         priority:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
@@ -622,6 +629,8 @@ components:
           addedInVersion: "8.8"
         - propertyName: tags
           addedInVersion: "8.9"
+        - propertyName: businessId
+          addedInVersion: "8.10"
 
     UserTaskSearchQueryResult:
       description: User task search query response.

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -489,6 +489,7 @@ components:
             - dueDate
             - priority
             - name
+            - businessId
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -556,6 +556,44 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldSearchUserTasksWithBusinessIdSorting() {
+    // given
+    when(userTaskServices.search(any(UserTaskQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    final var request =
+        """
+                {
+                    "sort": [
+                        {
+                            "field": "businessId",
+                            "order": "asc"
+                        }
+                    ]
+                }""";
+    // when / then
+    webClient
+        .post()
+        .uri(USER_TASKS_SEARCH_URL)
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(userTaskServices)
+        .search(
+            eq(
+                new UserTaskQuery.Builder()
+                    .sort(new UserTaskSort.Builder().businessId().asc().build())
+                    .build()),
+            any());
+  }
+
+  @Test
   void shouldInvalidateUserTasksSearchQueryWithEmptyLocalVariableFilter() {
     // given
     final var request =
@@ -791,7 +829,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                           "type": "about:blank",
                           "title": "Bad Request",
                           "status": 400,
-                          "detail": "Unexpected value 'unknownField' for enum field 'field'. Use any of the following values: [creationDate, completionDate, followUpDate, dueDate, priority, name]",
+                          "detail": "Unexpected value 'unknownField' for enum field 'field'. Use any of the following values: [creationDate, completionDate, followUpDate, dueDate, priority, name, businessId]",
                           "instance": "%s"
                         }""",
             USER_TASKS_SEARCH_URL);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -1168,6 +1168,10 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         ops -> new UserTaskFilter.Builder().assigneeOperations(ops).build());
     stringOperationTestCases(
         streamBuilder,
+        "businessId",
+        ops -> new UserTaskFilter.Builder().businessIdOperations(ops).build());
+    stringOperationTestCases(
+        streamBuilder,
         "tenantId",
         ops -> new UserTaskFilter.Builder().tenantIdOperations(ops).build());
 


### PR DESCRIPTION
## Description

Adds support for filtering and sorting user tasks by `businessId` (the business ID of the owning process instance) across the search API stack. This is the search/query counterpart to #55686, which introduced the `businessId` field on user tasks.

### Changes

**Search Domain**
- Added `businessIdOperations` to `UserTaskFilter` with builder methods for exact (`businessIds`) and operation-based (`businessIdOperations`) matching.
- Added `businessId()` sort field to `UserTaskSort`.

**Query Transformer & Sorting**
- Extended `UserTaskFilterTransformer` to translate `businessIdOperations` into Elasticsearch/OpenSearch queries using the `BUSINESS_ID` field constant.
- Extended `UserTaskFieldSortingTransformer` to map the `"businessId"` domain field to the `BUSINESS_ID` index field.

**Gateway / REST API**
- Added `businessId` as a `StringFilterProperty` in the OpenAPI spec (`user-tasks.yaml`), marked as available from version `8.10`.
- Added `BUSINESS_ID` as a valid sort field enum value.
- Updated `SearchQueryFilterMapper` and `SimpleSearchQueryMapper` to map the `businessId` filter field from HTTP request to the domain model.
- Updated `SearchQuerySortRequestMapper` to handle the `BUSINESS_ID` sort case.

**RDBMS**
- Added `BUSINESS_ID` to `UserTaskSearchColumn` enum.
- Added `businessId` filter condition to `UserTaskMapper.xml`.

**Java Client**
- Added `businessId(String)` and `businessId(Consumer<StringProperty>)` filter methods to `UserTaskFilter` interface and its implementation.
- Added `businessId()` sort method to `UserTaskSort` interface and its implementation.

**Tests**
- Unit tests for filter and sort by `businessId` in the query transformer, REST controller, and Java client.
- RDBMS integration tests: `shouldFindUserTaskByBusinessIdEq`, `shouldFindUserTaskByBusinessIdLike`, `shouldSortByBusinessIdAsc`, `shouldSortByBusinessIdDesc`.
- Full-filter test updated to include `businessId`.

### Notes

- `businessId` filtering only works for user tasks created in version 8.10 and onwards; tasks from earlier versions do not contain this data.
- Follows the same filter/sort patterns established by other `UserTaskFilter` fields such as `assignee` and `priority`.

## Related issues

Closes #55686