### PR TITLE
refactor: clean-up unused singleton service beans

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -446,65 +446,9 @@ public class CamundaServicesConfiguration {
     return builder.build();
   }
 
-  // -- default-tenant service beans --
-  //
-  // Consumers that are not yet physical-tenant aware (currently the MCP gateway tools) still inject
-  // individual {@code *Services} singletons. We expose the default tenant's instances from the
-  // serviceRegistry so those consumers keep working until they are migrated to resolve the tenant
-  // per
-  // request. Making the MCP gateway physical-tenant aware is tracked by
-  // https://github.com/camunda/camunda/issues/52573.
-
-  @Bean
-  public TopologyServices topologyServices(final ServiceRegistry serviceRegistry) {
-    return serviceRegistry.topologyServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-  }
-
-  @Bean
-  public ProcessInstanceServices processInstanceServices(final ServiceRegistry serviceRegistry) {
-    return serviceRegistry.processInstanceServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-  }
-
-  @Bean
-  public ProcessDefinitionServices processDefinitionServices(
-      final ServiceRegistry serviceRegistry) {
-    return serviceRegistry.processDefinitionServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-  }
-
-  @Bean
-  public UserTaskServices userTaskServices(final ServiceRegistry serviceRegistry) {
-    return serviceRegistry.userTaskServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-  }
-
-  @Bean
-  public IncidentServices incidentServices(final ServiceRegistry serviceRegistry) {
-    return serviceRegistry.incidentServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-  }
-
-  @Bean
-  public JobServices<JobActivationResult> jobServices(final ServiceRegistry serviceRegistry) {
-    return serviceRegistry.jobServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-  }
-
-  @Bean
-  public VariableServices variableServices(final ServiceRegistry serviceRegistry) {
-    return serviceRegistry.variableServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-  }
-
-  @Bean
-  public MessageServices messageServices(final ServiceRegistry serviceRegistry) {
-    return serviceRegistry.messageServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-  }
-
-  @Bean
-  public MessageSubscriptionServices messageSubscriptionServices(
-      final ServiceRegistry serviceRegistry) {
-    return serviceRegistry.messageSubscriptionServices(
-        PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-  }
-
-  // This is required by BrokerModuleConfiguration that requires UserServices for Basic auth
-  // TODO we need to make it physical tenant aware
+  // UserServices bean is used by BrokerModuleConfiguration and GatewayModuleConfiguration for Basic
+  // auth in gRPC
+  // TODO to be removed by https://github.com/camunda/camunda/issues/55753
   @Bean
   public UserServices userServices(final ServiceRegistry serviceRegistry) {
     return serviceRegistry.userServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
These beans were needed for MCP before https://github.com/camunda/camunda/issues/52573

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
