### PR TITLE
feat: expose per-PT AuthenticationConfiguration from the authentication module

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -83,6 +83,10 @@ public final class PhysicalTenantAuthConfigurations {
 
   // Valid tenant id: lowercase alphanumeric, no dashes — so the yaml form
   // (camunda.physical-tenants.<id>.*) and its relaxed-binding env-var form address the same tenant.
+  // Intentionally duplicated from PhysicalTenantResolver (configuration module): it is a one-line
+  // rule, and no module that both 'configuration' and 'authentication' depend on fits a plain-Java
+  // validator (spring-utils is Spring-specific; depending on 'configuration' would invert the
+  // dependency). Keep the two in sync.
   private static final Pattern VALID_TENANT_ID = Pattern.compile("[a-z0-9]+");
 
   /**
@@ -131,6 +135,9 @@ public final class PhysicalTenantAuthConfigurations {
    * <p>Tenant ids must be lowercase alphanumeric ({@code [a-z0-9]+}) — no dashes. This matches the
    * constraint enforced by {@code PhysicalTenantResolver} to keep yaml and env-var forms addressing
    * the same tenant.
+   *
+   * <p>Package-private so {@code PhysicalTenantScopeProvider} can delegate to it; must not be
+   * tightened to {@code private}.
    */
   static Set<String> discoverExplicitTenantIds(final Environment environment) {
     final Set<String> tenants = new LinkedHashSet<>();

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.authentication.pt;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
@@ -93,6 +95,32 @@ public final class PhysicalTenantAuthConfigurations {
   private static final String DEFAULT_SLOT_ASSIGNED_ID = OidcConfiguration.DEFAULT_REGISTRATION_ID;
 
   private PhysicalTenantAuthConfigurations() {}
+
+  /**
+   * Returns a map from physical-tenant id to its resolved {@link AuthenticationConfiguration},
+   * always including the {@code default} tenant even when no PTs are explicitly configured.
+   *
+   * <p>The map contains one entry per explicitly configured physical tenant (discovered via {@link
+   * #discoverExplicitTenantIds}) plus a {@code default} entry. Each value is computed via {@link
+   * #forPhysicalTenant(String, Environment)}. The map is insertion-ordered ({@link LinkedHashMap})
+   * with {@code default} always present; explicit tenant order is discovery order.
+   *
+   * @param environment Spring {@link Environment} used for both discovery and config binding
+   * @return stable, insertion-ordered map of tenant id → merged auth config
+   */
+  public static Map<String, AuthenticationConfiguration> forAllPhysicalTenants(
+      final Environment environment) {
+    final Set<String> tenantIds = discoverExplicitTenantIds(environment);
+    final Map<String, AuthenticationConfiguration> result = new LinkedHashMap<>();
+    result.put(
+        DEFAULT_PHYSICAL_TENANT_ID, forPhysicalTenant(DEFAULT_PHYSICAL_TENANT_ID, environment));
+    for (final String tenantId : tenantIds) {
+      if (!tenantId.equals(DEFAULT_PHYSICAL_TENANT_ID)) {
+        result.put(tenantId, forPhysicalTenant(tenantId, environment));
+      }
+    }
+    return result;
+  }
 
   /**
    * Walks the {@link Environment} and returns the set of explicitly configured physical-tenant ids

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -16,9 +16,14 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.springframework.boot.context.properties.bind.BindResult;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
 import org.springframework.core.env.Environment;
 
 /**
@@ -69,6 +74,14 @@ public final class PhysicalTenantAuthConfigurations {
   private static final String PT_PREFIX_TEMPLATE =
       "camunda.physical-tenants.%s.security.authentication";
 
+  private static final String PHYSICAL_TENANTS_PREFIX = "camunda.physical-tenants";
+  private static final ConfigurationPropertyName PHYSICAL_TENANTS_PREFIX_NAME =
+      ConfigurationPropertyName.of(PHYSICAL_TENANTS_PREFIX);
+
+  // Valid tenant id: lowercase alphanumeric, no dashes — so the yaml form
+  // (camunda.physical-tenants.<id>.*) and its relaxed-binding env-var form address the same tenant.
+  static final Pattern VALID_TENANT_ID = Pattern.compile("[a-z0-9]+");
+
   /**
    * Reserved {@code providers.assigned} id for the unnamed default slot — CSL's {@link
    * OidcConfiguration#DEFAULT_REGISTRATION_ID} ({@code "oidc"}), the registration id of the default
@@ -80,6 +93,40 @@ public final class PhysicalTenantAuthConfigurations {
   private static final String DEFAULT_SLOT_ASSIGNED_ID = OidcConfiguration.DEFAULT_REGISTRATION_ID;
 
   private PhysicalTenantAuthConfigurations() {}
+
+  /**
+   * Walks the {@link Environment} and returns the set of explicitly configured physical-tenant ids
+   * (those with at least one key under {@code camunda.physical-tenants.<id>.*}).
+   *
+   * <p>Tenant ids must be lowercase alphanumeric ({@code [a-z0-9]+}) — no dashes. This matches the
+   * constraint enforced by {@code PhysicalTenantResolver} to keep yaml and env-var forms addressing
+   * the same tenant.
+   */
+  static Set<String> discoverExplicitTenantIds(final Environment environment) {
+    final Set<String> tenants = new LinkedHashSet<>();
+    for (final ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
+      if (source instanceof final IterableConfigurationPropertySource iter) {
+        iter.stream()
+            .filter(PHYSICAL_TENANTS_PREFIX_NAME::isAncestorOf)
+            .forEach(
+                name -> {
+                  if (name.getNumberOfElements()
+                      > PHYSICAL_TENANTS_PREFIX_NAME.getNumberOfElements()) {
+                    final String tenantId =
+                        name.getElement(
+                            PHYSICAL_TENANTS_PREFIX_NAME.getNumberOfElements(),
+                            ConfigurationPropertyName.Form.UNIFORM);
+                    if (tenantId != null
+                        && !tenantId.isEmpty()
+                        && VALID_TENANT_ID.matcher(tenantId).matches()) {
+                      tenants.add(tenantId);
+                    }
+                  }
+                });
+      }
+    }
+    return tenants;
+  }
 
   /**
    * Produces a merged {@link AuthenticationConfiguration} for the given physical tenant id. The

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -13,6 +13,7 @@ import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
 import io.camunda.security.api.model.config.oidc.OidcProvidersConfiguration;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -82,7 +83,7 @@ public final class PhysicalTenantAuthConfigurations {
 
   // Valid tenant id: lowercase alphanumeric, no dashes — so the yaml form
   // (camunda.physical-tenants.<id>.*) and its relaxed-binding env-var form address the same tenant.
-  static final Pattern VALID_TENANT_ID = Pattern.compile("[a-z0-9]+");
+  private static final Pattern VALID_TENANT_ID = Pattern.compile("[a-z0-9]+");
 
   /**
    * Reserved {@code providers.assigned} id for the unnamed default slot — CSL's {@link
@@ -102,11 +103,12 @@ public final class PhysicalTenantAuthConfigurations {
    *
    * <p>The map contains one entry per explicitly configured physical tenant (discovered via {@link
    * #discoverExplicitTenantIds}) plus a {@code default} entry. Each value is computed via {@link
-   * #forPhysicalTenant(String, Environment)}. The map is insertion-ordered ({@link LinkedHashMap})
-   * with {@code default} always present; explicit tenant order is discovery order.
+   * #forPhysicalTenant(String, Environment)}. The returned map is unmodifiable and
+   * insertion-ordered with {@code default} always present; explicit tenant order is discovery
+   * order.
    *
    * @param environment Spring {@link Environment} used for both discovery and config binding
-   * @return stable, insertion-ordered map of tenant id → merged auth config
+   * @return unmodifiable, insertion-ordered map of tenant id → merged auth config
    */
   public static Map<String, AuthenticationConfiguration> forAllPhysicalTenants(
       final Environment environment) {
@@ -119,7 +121,7 @@ public final class PhysicalTenantAuthConfigurations {
         result.put(tenantId, forPhysicalTenant(tenantId, environment));
       }
     }
-    return result;
+    return Collections.unmodifiableMap(result);
   }
 
   /**

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantScopeProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantScopeProvider.java
@@ -14,16 +14,10 @@ import io.camunda.security.api.context.CamundaSecurityScopeProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
-import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
-import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
-import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
 import org.springframework.core.env.Environment;
 
 /**
@@ -60,17 +54,6 @@ import org.springframework.core.env.Environment;
 public final class PhysicalTenantScopeProvider implements CamundaSecurityScopeProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(PhysicalTenantScopeProvider.class);
-  private static final String PHYSICAL_TENANTS_PREFIX = "camunda.physical-tenants";
-  private static final ConfigurationPropertyName PREFIX_NAME =
-      ConfigurationPropertyName.of(PHYSICAL_TENANTS_PREFIX);
-
-  // Valid tenant id: lowercase alphanumeric, no dashes — so the yaml form
-  // (camunda.physical-tenants.<id>.*) and its relaxed-binding env-var form address the same tenant.
-  // Intentionally duplicated from PhysicalTenantResolver (configuration module): it is a one-line
-  // rule, and no module that both 'configuration' and 'authentication' depend on fits a plain-Java
-  // validator (spring-utils is Spring-specific; depending on 'configuration' would invert the
-  // dependency). Keep the two in sync.
-  private static final Pattern VALID_TENANT_ID = Pattern.compile("[a-z0-9]+");
 
   private final Environment environment;
   private final List<ScopedSecurityDescriptor> descriptors;
@@ -161,36 +144,7 @@ public final class PhysicalTenantScopeProvider implements CamundaSecurityScopePr
     return String.join(", ", parts);
   }
 
-  /**
-   * Walks the {@link Environment} and returns the set of explicitly configured physical-tenant ids
-   * (those with at least one key under {@code camunda.physical-tenants.<id>.*}).
-   *
-   * <p>Tenant ids must be lowercase alphanumeric ({@code [a-z0-9]+}) — no dashes. This matches the
-   * constraint enforced by {@code PhysicalTenantResolver} to keep yaml and env-var forms addressing
-   * the same tenant.
-   */
   private static Set<String> discoverExplicitTenantIds(final Environment environment) {
-    final Set<String> tenants = new LinkedHashSet<>();
-    for (final ConfigurationPropertySource source : ConfigurationPropertySources.get(environment)) {
-      if (source instanceof final IterableConfigurationPropertySource iter) {
-        iter.stream()
-            .filter(PREFIX_NAME::isAncestorOf)
-            .forEach(
-                name -> {
-                  if (name.getNumberOfElements() > PREFIX_NAME.getNumberOfElements()) {
-                    final String tenantId =
-                        name.getElement(
-                            PREFIX_NAME.getNumberOfElements(),
-                            ConfigurationPropertyName.Form.UNIFORM);
-                    if (tenantId != null
-                        && !tenantId.isEmpty()
-                        && VALID_TENANT_ID.matcher(tenantId).matches()) {
-                      tenants.add(tenantId);
-                    }
-                  }
-                });
-      }
-    }
-    return tenants;
+    return PhysicalTenantAuthConfigurations.discoverExplicitTenantIds(environment);
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -651,8 +651,9 @@ class PhysicalTenantAuthConfigurationsTest {
     // when
     final var result = PhysicalTenantAuthConfigurations.forAllPhysicalTenants(env);
 
-    // then
-    assertThat(result).containsKeys("default", "tenanta", "tenantb");
+    // then — exactly these ids, no extras, and "default" first (documented order)
+    assertThat(result).containsOnlyKeys("default", "tenanta", "tenantb");
+    assertThat(result.keySet().iterator().next()).isEqualTo("default");
     // each entry equals what forPhysicalTenant returns for the same id
     for (final var entry : result.entrySet()) {
       final AuthenticationConfiguration direct =

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -688,6 +688,23 @@ class PhysicalTenantAuthConfigurationsTest {
     assertThat(result.get("default").getOidc().getClientId()).isEqualTo("explicit-default-client");
   }
 
+  @Test
+  void shouldReturnUnmodifiableMap() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root"));
+
+    // when
+    final var result = PhysicalTenantAuthConfigurations.forAllPhysicalTenants(env);
+
+    // then — the public cross-module accessor returns an unmodifiable map
+    assertThat(result).isUnmodifiable();
+  }
+
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -582,6 +582,113 @@ class PhysicalTenantAuthConfigurationsTest {
   }
 
   // -------------------------------------------------------------------------
+  // forAllPhysicalTenants
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldReturnOnlyDefaultWhenNoPtsConfigured() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root"));
+
+    // when
+    final var result = PhysicalTenantAuthConfigurations.forAllPhysicalTenants(env);
+
+    // then
+    assertThat(result).containsOnlyKeys("default");
+    final AuthenticationConfiguration defaultCfg = result.get("default");
+    assertThat(defaultCfg.getOidc().getClientId()).isEqualTo("root-client");
+    assertThat(defaultCfg.getOidc().getIssuerUri()).isEqualTo("http://idp/root");
+  }
+
+  @Test
+  void shouldReturnDefaultEqualToForPhysicalTenantDefault() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                "camunda.security.authentication.oidc.client-id", "root-client",
+                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root"));
+
+    // when
+    final var result = PhysicalTenantAuthConfigurations.forAllPhysicalTenants(env);
+    final AuthenticationConfiguration direct =
+        PhysicalTenantAuthConfigurations.forPhysicalTenant("default", env);
+
+    // then
+    final AuthenticationConfiguration fromMap = result.get("default");
+    assertThat(fromMap.getMethod()).isEqualTo(direct.getMethod());
+    assertThat(fromMap.getOidc().getClientId()).isEqualTo(direct.getOidc().getClientId());
+    assertThat(fromMap.getOidc().getIssuerUri()).isEqualTo(direct.getOidc().getIssuerUri());
+  }
+
+  @Test
+  void shouldReturnAllConfiguredPtsPlusDefault() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method",
+                "oidc",
+                "camunda.security.authentication.oidc.client-id",
+                "root-client",
+                "camunda.security.authentication.oidc.issuer-uri",
+                "http://idp/root",
+                "camunda.physical-tenants.tenanta.security.authentication.oidc.client-id",
+                "tenanta-client",
+                "camunda.physical-tenants.tenanta.security.authentication.oidc.issuer-uri",
+                "http://idp/tenanta",
+                "camunda.physical-tenants.tenantb.security.authentication.oidc.client-id",
+                "tenantb-client",
+                "camunda.physical-tenants.tenantb.security.authentication.oidc.issuer-uri",
+                "http://idp/tenantb"));
+
+    // when
+    final var result = PhysicalTenantAuthConfigurations.forAllPhysicalTenants(env);
+
+    // then
+    assertThat(result).containsKeys("default", "tenanta", "tenantb");
+    // each entry equals what forPhysicalTenant returns for the same id
+    for (final var entry : result.entrySet()) {
+      final AuthenticationConfiguration direct =
+          PhysicalTenantAuthConfigurations.forPhysicalTenant(entry.getKey(), env);
+      assertThat(entry.getValue().getMethod()).isEqualTo(direct.getMethod());
+      assertThat(entry.getValue().getOidc().getClientId())
+          .isEqualTo(direct.getOidc().getClientId());
+      assertThat(entry.getValue().getOidc().getIssuerUri())
+          .isEqualTo(direct.getOidc().getIssuerUri());
+    }
+  }
+
+  @Test
+  void shouldNotDuplicateDefaultWhenExplicitlyConfigured() {
+    // given — "default" appears as explicit PT overlay
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method",
+                "oidc",
+                "camunda.security.authentication.oidc.client-id",
+                "root-client",
+                "camunda.security.authentication.oidc.issuer-uri",
+                "http://idp/root",
+                "camunda.physical-tenants.default.security.authentication.oidc.client-id",
+                "explicit-default-client"));
+
+    // when
+    final var result = PhysicalTenantAuthConfigurations.forAllPhysicalTenants(env);
+
+    // then — only one "default" entry, no duplication
+    assertThat(result).containsOnlyKeys("default");
+    assertThat(result.get("default").getOidc().getClientId()).isEqualTo("explicit-default-client");
+  }
+
+  // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
 

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -622,9 +622,7 @@ class PhysicalTenantAuthConfigurationsTest {
 
     // then
     final AuthenticationConfiguration fromMap = result.get("default");
-    assertThat(fromMap.getMethod()).isEqualTo(direct.getMethod());
-    assertThat(fromMap.getOidc().getClientId()).isEqualTo(direct.getOidc().getClientId());
-    assertThat(fromMap.getOidc().getIssuerUri()).isEqualTo(direct.getOidc().getIssuerUri());
+    assertThat(fromMap).usingRecursiveComparison().isEqualTo(direct);
   }
 
   @Test
@@ -658,11 +656,7 @@ class PhysicalTenantAuthConfigurationsTest {
     for (final var entry : result.entrySet()) {
       final AuthenticationConfiguration direct =
           PhysicalTenantAuthConfigurations.forPhysicalTenant(entry.getKey(), env);
-      assertThat(entry.getValue().getMethod()).isEqualTo(direct.getMethod());
-      assertThat(entry.getValue().getOidc().getClientId())
-          .isEqualTo(direct.getOidc().getClientId());
-      assertThat(entry.getValue().getOidc().getIssuerUri())
-          .isEqualTo(direct.getOidc().getIssuerUri());
+      assertThat(entry.getValue()).usingRecursiveComparison().isEqualTo(direct);
     }
   }
 


### PR DESCRIPTION
## Description

Foundation step for **Slice 2 (gRPC)** of the Physical Tenants Identity epic. Exposes, in the `authentication` module, a per-physical-tenant (PT) `AuthenticationConfiguration` map that the gRPC gateway will later use to build one auth handler per PT.

Adds `PhysicalTenantAuthConfigurations.forAllPhysicalTenants(Environment)` returning an unmodifiable `Map<String, AuthenticationConfiguration>` keyed by PT id — one entry per explicitly configured tenant plus the synthesized `default`, each resolved via the existing `forPhysicalTenant(id, env)`. Unlike `PhysicalTenantScopeProvider`, the map **always** contains `default` (even with no PTs configured), so the gRPC registry always has at least the default handler to build.

PT id discovery (the env walk + `[a-z0-9]+` validation) is centralized in `PhysicalTenantAuthConfigurations` so this accessor and `PhysicalTenantScopeProvider` share one implementation.

`AuthenticationHandler` is a `gateway-grpc` type, so per ADR-0006 (Decision A) the handler registry is built gateway-side. This module therefore exposes only the framework-neutral `AuthenticationConfiguration`, keeping the dependency direction `gateway → authentication` (no `gateway-grpc` dependency added).

## Acceptance criteria

- [x] One entry per configured PT plus `default`; value equals `forPhysicalTenant(id, env)`.
- [x] No PTs configured → map contains only `default` (root config).
- [x] `authentication` module gains no `gateway-grpc` dependency.
- [x] No `@Configuration` introduced (framework-neutral static helper), so the paired `ApplicationContextRunner` AC does not apply.

Parent: #54896 — Physical Tenants Identity, Slice 2 (gRPC). Design: ADR-0006.

Closes #55751

🤖 Generated with [Claude Code](https://claude.com/claude-code)