### PR TITLE
feat: add metric tags to conversation history and usage section

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AgentMetrics/MetricCard.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AgentMetrics/MetricCard.tsx
@@ -27,7 +27,7 @@ const MetricCard: React.FC<MetricCardProps> = ({title, value, children}) => {
   return (
     <MetricCardContainer aria-labelledby={id}>
       <MetricCardTitle id={id}>{title}</MetricCardTitle>
-      <MetricCardValue>{value}</MetricCardValue>
+      <MetricCardValue>{value.toLocaleString()}</MetricCardValue>
       {children}
     </MetricCardContainer>
   );
@@ -56,7 +56,9 @@ const LimitIndicator: React.FC<LimitIndicatorProps> = ({current, limit}) => {
         aria-valuenow={clampedUsage}
         aria-valuetext={`${current} of ${limit} limit (${usage.toFixed(0)}%)`}
       ></LimitMeter>
-      <MetricHelperText aria-hidden="true">of {limit} limit</MetricHelperText>
+      <MetricHelperText aria-hidden="true">
+        of {limit.toLocaleString()} limit
+      </MetricHelperText>
     </LimitMeterContainer>
   );
 };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AgentMetrics/TokensUsedMetric.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AgentMetrics/TokensUsedMetric.tsx
@@ -28,11 +28,11 @@ const TokensUsedMetric: React.FC<TokensUsedMetricProps> = ({
       <TokenBreakdownContainer>
         <TokenBreakdown $dotColor="var(--cds-interactive)">
           <span>Input</span>
-          <span>{inputTokens}</span>
+          <span>{inputTokens.toLocaleString()}</span>
         </TokenBreakdown>
         <TokenBreakdown $dotColor="var(--cds-support-warning)">
           <span>Output</span>
-          <span>{outputTokens}</span>
+          <span>{outputTokens.toLocaleString()}</span>
         </TokenBreakdown>
       </TokenBreakdownContainer>
     </MetricCard>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -460,15 +460,22 @@ describe('<ConversationHistory />', () => {
     );
 
     const message = within(screen.getByTestId('conversation-message-1'));
-    expect(message.getByText('150 tokens')).toBeInTheDocument();
-    expect(message.getByText('1.23s')).toBeInTheDocument();
+    expect(message.getByTestId('message-token-metric')).toHaveTextContent(
+      '150 tokens',
+    );
+    expect(message.getByTestId('message-duration-metric')).toHaveTextContent(
+      '1.23s',
+    );
     expect(message.getByText('Input: 100 · Output: 50')).toBeInTheDocument();
 
-    const noMetricsMessage = within(
+    const messageNoMetrics = within(
       screen.getByTestId('conversation-message-2'),
     );
-    expect(noMetricsMessage.queryByText(/tokens/)).not.toBeInTheDocument();
-    expect(noMetricsMessage.queryByText(/ s$/)).not.toBeInTheDocument();
-    expect(noMetricsMessage.queryByText(/ ms$/)).not.toBeInTheDocument();
+    expect(
+      messageNoMetrics.queryByTestId('message-token-metric'),
+    ).not.toBeInTheDocument();
+    expect(
+      messageNoMetrics.queryByTestId('message-duration-metric'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -427,4 +427,48 @@ describe('<ConversationHistory />', () => {
       assistantMessage.getByRole('button', {name: '"search" tool call.'}),
     ).toBeDisabled();
   });
+
+  it('should render metrics when they are available for a message', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '1',
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'Here is my answer.'}],
+          metrics: {inputTokens: 100, outputTokens: 50, durationMs: 1234},
+        }),
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '2',
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'Here is my answer.'}],
+          metrics: null,
+        }),
+      ]),
+    );
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+        isVisible
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    const message = within(screen.getByTestId('conversation-message-1'));
+    expect(message.getByText('150 tokens')).toBeInTheDocument();
+    expect(message.getByText('1.23s')).toBeInTheDocument();
+    expect(message.getByText('Input: 100 · Output: 50')).toBeInTheDocument();
+
+    const noMetricsMessage = within(
+      screen.getByTestId('conversation-message-2'),
+    );
+    expect(noMetricsMessage.queryByText(/tokens/)).not.toBeInTheDocument();
+    expect(noMetricsMessage.queryByText(/ s$/)).not.toBeInTheDocument();
+    expect(noMetricsMessage.queryByText(/ ms$/)).not.toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -74,6 +74,7 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
           actor={item.role}
           content={item.content}
           toolCalls={item.toolCalls}
+          metrics={item.metrics}
           onToolCallClick={(toolCall) => {
             if (toolCall.elementId !== null) {
               selectElement({elementId: toolCall.elementId});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import {useReducer} from 'react';
-import {Button} from '@carbon/react';
+import {Button, Tag, Tooltip} from '@carbon/react';
 import {Document, Maximize} from '@carbon/react/icons';
 import type {
   AgentInstanceHistoryItem,
@@ -24,6 +24,8 @@ import {
   AttachmentsContainer,
   AttachmentsLabel,
   AttachmentButton,
+  MessageHeader,
+  MetricsContainer,
 } from './styled';
 import {MarkdownMessage} from './MarkdownMessage';
 import {RichTextEditorModal} from 'modules/components/RichTextEditorModal';
@@ -31,6 +33,7 @@ import {RichTextEditorModal} from 'modules/components/RichTextEditorModal';
 type Actor = AgentInstanceHistoryRole | 'SYSTEM';
 type ContentItem = AgentInstanceHistoryItem['content'][number];
 type ToolCall = AgentInstanceHistoryItem['toolCalls'][number];
+type Metrics = AgentInstanceHistoryItem['metrics'];
 
 const readableTitleByActor: Record<Actor, string> = {
   SYSTEM: 'System prompt',
@@ -46,10 +49,15 @@ const labelByActor: Record<Actor, string> = {
   TOOL_RESULT: 'Tool Result',
 };
 
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(2)}s`;
+}
+
 type ConversationMessageProps = {
   actor: Actor;
   content: ContentItem[];
   historyItemKey?: string;
+  metrics?: Metrics | null;
   toolCalls?: ToolCall[];
   onToolCallClick?: (toolCall: ToolCall) => void;
 };
@@ -58,6 +66,7 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
   actor,
   content,
   historyItemKey,
+  metrics = null,
   toolCalls = [],
   onToolCallClick,
 }) => {
@@ -76,7 +85,25 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
       data-testid={`conversation-message${historyItemKey ? `-${historyItemKey}` : ''}`}
       aria-label={readableTitleByActor[actor]}
     >
-      <ActorLabel>{labelByActor[actor]}</ActorLabel>
+      <MessageHeader>
+        <ActorLabel>{labelByActor[actor]}</ActorLabel>
+        {metrics !== null && (
+          <MetricsContainer>
+            <Tooltip
+              description={`Input: ${metrics.inputTokens.toLocaleString()} · Output: ${metrics.outputTokens.toLocaleString()}`}
+              align="bottom"
+            >
+              <Tag type="gray" size="sm">
+                {(metrics.inputTokens + metrics.outputTokens).toLocaleString()}
+                &nbsp;tokens
+              </Tag>
+            </Tooltip>
+            <Tag type="gray" size="sm">
+              {formatDuration(metrics.durationMs)}
+            </Tag>
+          </MetricsContainer>
+        )}
+      </MessageHeader>
       {content.map((entry, index) => {
         switch (entry.contentType) {
           case 'DOCUMENT': {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -93,12 +93,12 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
               description={`Input: ${metrics.inputTokens.toLocaleString()} · Output: ${metrics.outputTokens.toLocaleString()}`}
               align="bottom"
             >
-              <Tag type="gray" size="sm">
+              <Tag data-testid="message-token-metric" type="gray" size="sm">
                 {(metrics.inputTokens + metrics.outputTokens).toLocaleString()}
                 &nbsp;tokens
               </Tag>
             </Tooltip>
-            <Tag type="gray" size="sm">
+            <Tag data-testid="message-duration-metric" type="gray" size="sm">
               {formatDuration(metrics.durationMs)}
             </Tag>
           </MetricsContainer>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
@@ -63,7 +63,7 @@ const MessageActions = styled.div`
 const MessageBlock = styled.div`
   display: flex;
   gap: var(--cds-spacing-03);
-  max-height: 160px;
+  max-height: 360px;
 
   &:hover ${MessageActions} {
     opacity: 1;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
@@ -28,6 +28,20 @@ const Container = styled.article<{$actor: ActorType}>`
   border-radius: 4px;
 `;
 
+const MessageHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+`;
+
+const MetricsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-02);
+  --cds-tooltip-padding-block: var(--cds-spacing-02);
+  --cds-tooltip-padding-inline: var(--cds-spacing-03);
+`;
+
 const ActorLabel = styled.h5`
   font-size: var(--cds-label-01-font-size);
   font-weight: var(--cds-heading-compact-01-font-weight);
@@ -126,6 +140,8 @@ const AttachmentButton = styled.button`
 
 export {
   Container,
+  MessageHeader,
+  MetricsContainer,
   MessageBlock,
   ActorLabel,
   TextContent,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -205,12 +205,18 @@ describe('<AgentDetails />', () => {
       {wrapper: createWrapper()},
     );
 
-    const modelCalls = screen.getByRole('article', {name: 'Model Calls'});
+    const section = within(screen.getByTestId('agent-usage-section'));
+
+    const sectionHeader = section.getByRole('button', {name: 'Usage'});
+    expect(sectionHeader).toHaveTextContent('3 model calls');
+    expect(sectionHeader).toHaveTextContent('150 tokens');
+
+    const modelCalls = section.getByRole('article', {name: 'Model Calls'});
     expect(modelCalls).toBeInTheDocument();
     expect(within(modelCalls).getByText('3')).toBeInTheDocument();
     expect(within(modelCalls).getByText('of 10 limit')).toBeInTheDocument();
 
-    const tokensUsed = screen.getByRole('article', {name: 'Tokens Used'});
+    const tokensUsed = section.getByRole('article', {name: 'Tokens Used'});
     expect(tokensUsed).toBeInTheDocument();
     expect(within(tokensUsed).getByText('150')).toBeInTheDocument();
     expect(within(tokensUsed).getByText('of 1000 limit')).toBeInTheDocument();
@@ -219,7 +225,7 @@ describe('<AgentDetails />', () => {
     expect(within(tokensUsed).getByText('Output')).toBeInTheDocument();
     expect(within(tokensUsed).getByText('50')).toBeInTheDocument();
 
-    const toolsCalled = screen.getByRole('article', {name: 'Tools Called'});
+    const toolsCalled = section.getByRole('article', {name: 'Tools Called'});
     expect(toolsCalled).toBeInTheDocument();
     expect(within(toolsCalled).getByText('2')).toBeInTheDocument();
     expect(within(toolsCalled).getByText('of 5 limit')).toBeInTheDocument();

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -219,7 +219,7 @@ describe('<AgentDetails />', () => {
     const tokensUsed = section.getByRole('article', {name: 'Tokens Used'});
     expect(tokensUsed).toBeInTheDocument();
     expect(within(tokensUsed).getByText('150')).toBeInTheDocument();
-    expect(within(tokensUsed).getByText('of 1000 limit')).toBeInTheDocument();
+    expect(within(tokensUsed).getByText('of 1,000 limit')).toBeInTheDocument();
     expect(within(tokensUsed).getByText('Input')).toBeInTheDocument();
     expect(within(tokensUsed).getByText('100')).toBeInTheDocument();
     expect(within(tokensUsed).getByText('Output')).toBeInTheDocument();

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -219,7 +219,9 @@ describe('<AgentDetails />', () => {
     const tokensUsed = section.getByRole('article', {name: 'Tokens Used'});
     expect(tokensUsed).toBeInTheDocument();
     expect(within(tokensUsed).getByText('150')).toBeInTheDocument();
-    expect(within(tokensUsed).getByText('of 1,000 limit')).toBeInTheDocument();
+    expect(
+      within(tokensUsed).getByText(`of ${(1000).toLocaleString()} limit`),
+    ).toBeInTheDocument();
     expect(within(tokensUsed).getByText('Input')).toBeInTheDocument();
     expect(within(tokensUsed).getByText('100')).toBeInTheDocument();
     expect(within(tokensUsed).getByText('Output')).toBeInTheDocument();

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -136,7 +136,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
             <SectionTitle icon={<MeterAlt size={16} />}>
               Usage
               <Tag type="gray" size="sm">
-                {metrics.modelCalls} model calls
+                {metrics.modelCalls.toLocaleString()} model calls
               </Tag>
               <Tag type="gray" size="sm">
                 {(metrics.inputTokens + metrics.outputTokens).toLocaleString()}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -11,7 +11,7 @@ import type {
   AgentInstance,
   AgentInstanceStatus,
 } from '@camunda/camunda-api-zod-schemas/8.10';
-import {Accordion, AccordionItem, AccordionSkeleton} from '@carbon/react';
+import {Accordion, AccordionItem, AccordionSkeleton, Tag} from '@carbon/react';
 import {
   CircleDash,
   WarningFilled,
@@ -131,8 +131,18 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
         ></AccordionItem>
         <AccordionItem
           data-testid="agent-usage-section"
+          aria-label="Usage"
           title={
-            <SectionTitle icon={<MeterAlt size={16} />}>Usage</SectionTitle>
+            <SectionTitle icon={<MeterAlt size={16} />}>
+              Usage
+              <Tag type="gray" size="sm">
+                {metrics.modelCalls} model calls
+              </Tag>
+              <Tag type="gray" size="sm">
+                {(metrics.inputTokens + metrics.outputTokens).toLocaleString()}
+                &nbsp;tokens
+              </Tag>
+            </SectionTitle>
           }
         >
           <MetricsRow>


### PR DESCRIPTION
## Description

This PR adds metric tags to the usage section and conversation history. I also snuck in some other improvements that aligns the implementation with the latest prototype.

- Applied `toLocaleString()` to numbers visible in metric cards (`50000 -> 50,000`).
- Increased the conversation messages max content height to `360px` (seen in latest prototype).
- Added metric tags for model calls and total tokens used to the usage section header
- Added metrics tags for tokens used and duration to conversation messages.

> [!NOTE]
> Currently the connector publishes metrics for all message types, which are then empty metrics, i.e. `{inputTokens: 0, outputTokens: 0, durationMs: 0}`. They currently still get displayed. If the connector does not change, we should consider ignoring them (again). [See Slack thread](https://camunda.slack.com/archives/C0AH08C7UA2/p1782221633937459).

## Related issues

closes #55713
