### PR TITLE
feat: per tenant document store and validators

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -8,7 +8,9 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -53,6 +55,14 @@ public class Document {
 
   /** In-memory document stores keyed by store id. */
   @NestedConfigurationProperty private Map<String, InMemoryStore> inMemory = new LinkedHashMap<>();
+
+  /**
+   * Optional per-tenant restriction: a flat list of store ids that narrows the inherited catalog to
+   * a subset for this physical tenant (least privilege). Meaningful only on a tenant overlay
+   * ({@code camunda.physical-tenants.<id>.document.assigned}); ignored at the root. An empty list
+   * means "no restriction" — the tenant keeps the full union of inherited and private stores.
+   */
+  private List<String> assigned = new ArrayList<>();
 
   public String getDefaultStoreId() {
     final String value =
@@ -120,6 +130,14 @@ public class Document {
 
   public void setInMemory(final Map<String, InMemoryStore> inMemory) {
     this.inMemory = inMemory;
+  }
+
+  public List<String> getAssigned() {
+    return assigned;
+  }
+
+  public void setAssigned(final List<String> assigned) {
+    this.assigned = assigned;
   }
 
   public static class AwsStore {

--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -8,9 +8,7 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -55,14 +53,6 @@ public class Document {
 
   /** In-memory document stores keyed by store id. */
   @NestedConfigurationProperty private Map<String, InMemoryStore> inMemory = new LinkedHashMap<>();
-
-  /**
-   * Optional per-tenant restriction: a flat list of store ids that narrows the inherited catalog to
-   * a subset for this physical tenant (least privilege). Meaningful only on a tenant overlay
-   * ({@code camunda.physical-tenants.<id>.document.assigned}); ignored at the root. An empty list
-   * means "no restriction" — the tenant keeps the full union of inherited and private stores.
-   */
-  private List<String> assigned = new ArrayList<>();
 
   public String getDefaultStoreId() {
     final String value =
@@ -135,14 +125,6 @@ public class Document {
 
   public void setInMemory(final Map<String, InMemoryStore> inMemory) {
     this.inMemory = inMemory;
-  }
-
-  public List<String> getAssigned() {
-    return assigned;
-  }
-
-  public void setAssigned(final List<String> assigned) {
-    this.assigned = assigned;
   }
 
   public static class AwsStore {

--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -72,7 +72,12 @@ public class Document {
             String.class,
             BackwardsCompatibilityMode.SUPPORTED,
             Set.of("DOCUMENT_DEFAULT_STORE_ID"));
-    return value != null ? value.toLowerCase() : null;
+    return value != null ? normalizeStoreId(value) : null;
+  }
+
+  /** Normalizes a store id to canonical form: trimmed and lowercased. */
+  public static String normalizeStoreId(final String id) {
+    return id.trim().toLowerCase();
   }
 
   public void setDefaultStoreId(final String defaultStoreId) {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidation.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Document;
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Cross-tenant rule: no two physical tenants may resolve to the same {@link DocumentStoreLocation};
+ * sharing one means silently reading and writing to the same backing storage. In-memory stores are
+ * excluded — they are ephemeral and process-local.
+ */
+@NullMarked
+class DocumentStoreIsolationValidation implements CrossTenantValidation {
+
+  @Override
+  public void validate(final Map<String, Camunda> resolvedByTenant) {
+    if (resolvedByTenant.size() <= 1) {
+      return;
+    }
+
+    final Map<DocumentStoreLocation, Set<String>> tenantsByLocation = new LinkedHashMap<>();
+    resolvedByTenant.forEach(
+        (tenantId, camunda) -> {
+          final Document doc = camunda.getDocument();
+          doc.getAws()
+              .forEach(
+                  (storeId, store) ->
+                      tenantsByLocation
+                          .computeIfAbsent(
+                              DocumentStoreLocation.aws(store), k -> new LinkedHashSet<>())
+                          .add(tenantId));
+          doc.getGcp()
+              .forEach(
+                  (storeId, store) ->
+                      tenantsByLocation
+                          .computeIfAbsent(
+                              DocumentStoreLocation.gcp(store), k -> new LinkedHashSet<>())
+                          .add(tenantId));
+          doc.getAzure()
+              .forEach(
+                  (storeId, store) ->
+                      tenantsByLocation
+                          .computeIfAbsent(
+                              DocumentStoreLocation.azure(store), k -> new LinkedHashSet<>())
+                          .add(tenantId));
+          doc.getLocal()
+              .forEach(
+                  (storeId, store) ->
+                      tenantsByLocation
+                          .computeIfAbsent(
+                              DocumentStoreLocation.local(store), k -> new LinkedHashSet<>())
+                          .add(tenantId));
+          // in-memory stores are intentionally skipped: ephemeral and process-local
+        });
+
+    final List<String> collisions = new ArrayList<>();
+    tenantsByLocation.forEach(
+        (location, tenantIds) -> {
+          if (tenantIds.size() > 1) {
+            collisions.add(
+                String.format(
+                    "tenants %s share the same document store location [%s]",
+                    tenantIds, location.describe()));
+          }
+        });
+
+    if (!collisions.isEmpty()) {
+      throw new UnifiedConfigurationException(
+          "Physical tenants must not share a document store location, or they would read and write "
+              + "into the same backing storage. Use a distinct bucket, container, or path per "
+              + "tenant. Conflicts: "
+              + String.join("; ", collisions));
+    }
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
@@ -67,10 +67,6 @@ record DocumentStoreLocation(String provider, List<String> coordinates) {
     if (value == null) {
       return "";
     }
-    String normalized = value.trim().toLowerCase();
-    while (normalized.endsWith("/")) {
-      normalized = normalized.substring(0, normalized.length() - 1);
-    }
-    return normalized;
+    return value.trim().toLowerCase().replaceAll("/+$", "");
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Document.AwsStore;
+import io.camunda.configuration.Document.AzureStore;
+import io.camunda.configuration.Document.GcpStore;
+import io.camunda.configuration.Document.LocalStore;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Location-identity tuple {@code (provider, coordinates)} used to detect whether two physical
+ * tenants would share the same backing storage. In-memory stores are excluded — ephemeral and
+ * process-local, they cannot collide.
+ */
+@NullMarked
+record DocumentStoreLocation(String provider, List<String> coordinates) {
+
+  /**
+   * Creates a location for an AWS S3 store. Region is intentionally excluded because S3 bucket
+   * names are globally unique across regions.
+   */
+  static DocumentStoreLocation aws(final AwsStore store) {
+    return new DocumentStoreLocation(
+        "aws", List.of(normalize(store.getBucketName()), normalize(store.getBucketPath())));
+  }
+
+  static DocumentStoreLocation gcp(final GcpStore store) {
+    return new DocumentStoreLocation(
+        "gcp", List.of(normalize(store.getBucketName()), normalize(store.getPrefix())));
+  }
+
+  /**
+   * Creates a location for an Azure Blob Storage store. Connection string is excluded because it
+   * may contain credentials; endpoint + container name + container path unambiguously identify the
+   * location.
+   */
+  static DocumentStoreLocation azure(final AzureStore store) {
+    return new DocumentStoreLocation(
+        "azure",
+        List.of(
+            normalize(store.getContainerName()),
+            normalize(store.getContainerPath()),
+            normalize(store.getEndpoint())));
+  }
+
+  static DocumentStoreLocation local(final LocalStore store) {
+    return new DocumentStoreLocation("local", List.of(normalize(store.getPath())));
+  }
+
+  String describe() {
+    return String.format("provider=%s, coordinates=%s", provider, coordinates);
+  }
+
+  /**
+   * Normalizes a store coordinate: null → {@code ""}, trimmed, lowercased, trailing slashes
+   * stripped.
+   */
+  private static String normalize(final @Nullable String value) {
+    if (value == null) {
+      return "";
+    }
+    String normalized = value.trim().toLowerCase();
+    while (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    return normalized;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidation.java
@@ -76,7 +76,10 @@ class PhysicalTenantDocumentAssignedValidation implements CrossTenantValidation 
           }
 
           final List<String> unknown =
-              assigned.stream().filter(id -> !knownStoreIds.contains(id)).distinct().toList();
+              assigned.stream()
+                  .filter(id -> !knownStoreIds.contains(Document.normalizeStoreId(id)))
+                  .distinct()
+                  .toList();
           if (!unknown.isEmpty()) {
             errors.add(
                 String.format(

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidation.java
@@ -19,10 +19,10 @@ import java.util.Set;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Cross-tenant rule: every non-default physical tenant must declare a non-empty {@code
- * document.assigned} list referencing only known store ids. Without it a tenant would silently
- * inherit the full root catalog, including stores intended for other tenants. The {@code default}
- * tenant is exempt.
+ * Cross-tenant rule: every non-default physical tenant that has document stores in its resolved
+ * catalog must declare a non-empty {@code document.assigned} list referencing only known store ids.
+ * Without it a tenant would silently inherit the full root catalog, including stores intended for
+ * other tenants. The {@code default} tenant and tenants with no stores are exempt.
  */
 @NullMarked
 class PhysicalTenantDocumentAssignedValidation implements CrossTenantValidation {
@@ -45,6 +45,11 @@ class PhysicalTenantDocumentAssignedValidation implements CrossTenantValidation 
           knownStoreIds.addAll(doc.getAzure().keySet());
           knownStoreIds.addAll(doc.getLocal().keySet());
           knownStoreIds.addAll(doc.getInMemory().keySet());
+
+          if (knownStoreIds.isEmpty()) {
+            // no document stores in catalog — nothing to assign, skip
+            return;
+          }
 
           final List<String> assigned = doc.getAssigned();
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidation.java
@@ -55,11 +55,13 @@ final class PhysicalTenantDocumentAssignedValidation {
           final Document doc = camunda.getDocument();
 
           final Set<String> knownStoreIds = new LinkedHashSet<>();
-          knownStoreIds.addAll(doc.getAws().keySet());
-          knownStoreIds.addAll(doc.getGcp().keySet());
-          knownStoreIds.addAll(doc.getAzure().keySet());
-          knownStoreIds.addAll(doc.getLocal().keySet());
-          knownStoreIds.addAll(doc.getInMemory().keySet());
+          doc.getAws().keySet().forEach(id -> knownStoreIds.add(Document.normalizeStoreId(id)));
+          doc.getGcp().keySet().forEach(id -> knownStoreIds.add(Document.normalizeStoreId(id)));
+          doc.getAzure().keySet().forEach(id -> knownStoreIds.add(Document.normalizeStoreId(id)));
+          doc.getLocal().keySet().forEach(id -> knownStoreIds.add(Document.normalizeStoreId(id)));
+          doc.getInMemory()
+              .keySet()
+              .forEach(id -> knownStoreIds.add(Document.normalizeStoreId(id)));
 
           if (knownStoreIds.isEmpty()) {
             return;

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidation.java
@@ -17,23 +17,38 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
 
 /**
- * Cross-tenant rule: every non-default physical tenant that has document stores in its resolved
- * catalog must declare a non-empty {@code document.assigned} list referencing only known store ids.
- * Without it a tenant would silently inherit the full root catalog, including stores intended for
- * other tenants. The {@code default} tenant and tenants with no stores are exempt.
+ * Validates {@code document.assigned} per physical tenant at startup. {@code assigned} is read from
+ * the environment via {@link Binder} — not a field on the {@link Document} POJO.
+ *
+ * <p>The synthesized {@code default} (absent from {@code camunda.physical-tenants.*}) is exempt; an
+ * explicitly declared {@code default} is validated like any other tenant.
  */
 @NullMarked
-class PhysicalTenantDocumentAssignedValidation implements CrossTenantValidation {
+final class PhysicalTenantDocumentAssignedValidation {
 
-  @Override
-  public void validate(final Map<String, Camunda> resolvedByTenant) {
+  private static final String PHYSICAL_TENANTS_PREFIX = Camunda.PREFIX + ".physical-tenants";
+
+  private PhysicalTenantDocumentAssignedValidation() {}
+
+  static void validate(
+      final Environment environment,
+      final Map<String, Camunda> resolvedByTenant,
+      final Set<String> explicitlyDeclared) {
+    final Binder binder = Binder.get(environment);
     final List<String> errors = new ArrayList<>();
 
     resolvedByTenant.forEach(
         (tenantId, camunda) -> {
-          if (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)) {
+          if (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)
+              && !explicitlyDeclared.contains(tenantId)) {
+            // synthesized default is exempt; explicitly declared default is validated like any
+            // other
             return;
           }
 
@@ -47,24 +62,23 @@ class PhysicalTenantDocumentAssignedValidation implements CrossTenantValidation 
           knownStoreIds.addAll(doc.getInMemory().keySet());
 
           if (knownStoreIds.isEmpty()) {
-            // no document stores in catalog — nothing to assign, skip
             return;
           }
 
-          final List<String> assigned = doc.getAssigned();
+          final List<String> assigned = bindAssigned(binder, tenantId);
 
-          if (assigned.isEmpty()) {
+          if (assigned == null || assigned.isEmpty()) {
             errors.add(
                 String.format(
-                    "non-default physical tenant '%s' must declare a non-empty "
+                    "physical tenant '%s' must declare a non-empty "
                         + "'camunda.physical-tenants.%s.document.assigned' selecting which "
                         + "document stores are available to it",
                     tenantId, tenantId));
             return;
           }
 
-          // Blank entries (e.g. `- ""` in yaml) must be caught here — they would otherwise fall
-          // through to the unknown-id check and render as `[]`, giving a confusing message.
+          // blank entries (e.g. `- ""` in yaml) would otherwise fall through to the unknown-id
+          // check and render as `[]`, giving a confusing message
           if (assigned.stream().anyMatch(String::isBlank)) {
             errors.add(
                 String.format(
@@ -94,5 +108,30 @@ class PhysicalTenantDocumentAssignedValidation implements CrossTenantValidation 
       throw new UnifiedConfigurationException(
           "Invalid physical-tenant document store assignment: " + String.join("; ", errors));
     }
+  }
+
+  /**
+   * Rejects {@code camunda.document.assigned} at the root level. Without this check it would be
+   * silently ignored, since narrowing reads only from the tenant prefix.
+   */
+  public static void validateRootAssignedAbsent(final Environment environment) {
+    final boolean rootAssignedPresent =
+        Binder.get(environment)
+            .bind("camunda.document.assigned", Bindable.listOf(String.class))
+            .isBound();
+    if (rootAssignedPresent) {
+      throw new UnifiedConfigurationException(
+          "'camunda.document.assigned' must not be set at the root level. "
+              + "Declare it per physical tenant under "
+              + "'camunda.physical-tenants.<id>.document.assigned'.");
+    }
+  }
+
+  private static @Nullable List<String> bindAssigned(final Binder binder, final String tenantId) {
+    return binder
+        .bind(
+            PHYSICAL_TENANTS_PREFIX + "." + tenantId + ".document.assigned",
+            Bindable.listOf(String.class))
+        .orElse(null);
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidation.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Document;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Cross-tenant rule: every non-default physical tenant must declare a non-empty {@code
+ * document.assigned} list referencing only known store ids. Without it a tenant would silently
+ * inherit the full root catalog, including stores intended for other tenants. The {@code default}
+ * tenant is exempt.
+ */
+@NullMarked
+class PhysicalTenantDocumentAssignedValidation implements CrossTenantValidation {
+
+  @Override
+  public void validate(final Map<String, Camunda> resolvedByTenant) {
+    final List<String> errors = new ArrayList<>();
+
+    resolvedByTenant.forEach(
+        (tenantId, camunda) -> {
+          if (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)) {
+            return;
+          }
+
+          final Document doc = camunda.getDocument();
+
+          final Set<String> knownStoreIds = new LinkedHashSet<>();
+          knownStoreIds.addAll(doc.getAws().keySet());
+          knownStoreIds.addAll(doc.getGcp().keySet());
+          knownStoreIds.addAll(doc.getAzure().keySet());
+          knownStoreIds.addAll(doc.getLocal().keySet());
+          knownStoreIds.addAll(doc.getInMemory().keySet());
+
+          final List<String> assigned = doc.getAssigned();
+
+          if (assigned.isEmpty()) {
+            errors.add(
+                String.format(
+                    "non-default physical tenant '%s' must declare a non-empty "
+                        + "'camunda.physical-tenants.%s.document.assigned' selecting which "
+                        + "document stores are available to it",
+                    tenantId, tenantId));
+            return;
+          }
+
+          // Blank entries (e.g. `- ""` in yaml) must be caught here — they would otherwise fall
+          // through to the unknown-id check and render as `[]`, giving a confusing message.
+          if (assigned.stream().anyMatch(String::isBlank)) {
+            errors.add(
+                String.format(
+                    "physical tenant '%s' declares a blank entry in "
+                        + "'camunda.physical-tenants.%s.document.assigned'; "
+                        + "every id must be a non-blank store id",
+                    tenantId, tenantId));
+            return;
+          }
+
+          final List<String> unknown =
+              assigned.stream().filter(id -> !knownStoreIds.contains(id)).distinct().toList();
+          if (!unknown.isEmpty()) {
+            errors.add(
+                String.format(
+                    "physical tenant '%s' assigns unknown document store id(s) %s in "
+                        + "'camunda.physical-tenants.%s.document.assigned'; "
+                        + "known store ids are %s",
+                    tenantId, unknown, tenantId, knownStoreIds));
+          }
+        });
+
+    if (!errors.isEmpty()) {
+      throw new UnifiedConfigurationException(
+          "Invalid physical-tenant document store assignment: " + String.join("; ", errors));
+    }
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
@@ -13,7 +13,6 @@ import io.camunda.configuration.Document.AzureStore;
 import io.camunda.configuration.Document.GcpStore;
 import io.camunda.configuration.Document.InMemoryStore;
 import io.camunda.configuration.Document.LocalStore;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -27,10 +26,8 @@ import org.springframework.core.env.Environment;
 /**
  * Resolves a per-tenant {@link Document} by overlaying {@code
  * camunda.physical-tenants.<id>.document.*} on top of the root {@code camunda.document.*} catalog.
- *
- * <p>Uses a snapshot-then-rebind strategy to avoid Spring's {@link Binder} replacing entire map
- * entries on partial field overrides. Root {@code assigned} is always cleared before the overlay so
- * tenants cannot inherit it.
+ * Uses a snapshot-then-rebind strategy so a tenant that overrides only some fields of a shared
+ * store doesn't silently lose the root fields it didn't override.
  */
 @NullMarked
 public final class PhysicalTenantDocumentConfigurations {
@@ -46,10 +43,6 @@ public final class PhysicalTenantDocumentConfigurations {
     final Document doc =
         binder.bind(ROOT_PREFIX, Bindable.of(Document.class)).orElseGet(Document::new);
 
-    // clear `assigned` on root instance — it must never be inherited by tenants
-    doc.setAssigned(new ArrayList<>());
-
-    // snapshot pristine root store POJOs before the tenant overlay mutates them
     final Map<String, AwsStore> rootAws = new LinkedHashMap<>(doc.getAws());
     final Map<String, GcpStore> rootGcp = new LinkedHashMap<>(doc.getGcp());
     final Map<String, AzureStore> rootAzure = new LinkedHashMap<>(doc.getAzure());
@@ -61,18 +54,11 @@ public final class PhysicalTenantDocumentConfigurations {
 
     mergeSharedStores(doc, rootAws, rootGcp, rootAzure, rootLocal, rootInMemory, binder, ptPrefix);
 
-    narrowToAssigned(doc);
+    narrowToAssigned(doc, binder, ptPrefix);
 
     return doc;
   }
 
-  /**
-   * Re-binds the tenant overlay onto the pristine root POJOs for any store id that existed in both
-   * the root catalog and the tenant overlay. Without this step, a tenant that overrides only some
-   * fields of a shared store (e.g. only {@code bucketPath}) would lose all other root-level fields
-   * (e.g. {@code bucketName}, {@code region}) because Spring's {@link Binder} replaces the entire
-   * map entry on the first matching key.
-   */
   private static void mergeSharedStores(
       final Document doc,
       final Map<String, AwsStore> rootAws,
@@ -124,16 +110,11 @@ public final class PhysicalTenantDocumentConfigurations {
         });
   }
 
-  /**
-   * Narrows the resolved document catalog to the ids listed in {@code assigned}. Store ids not in
-   * the list are removed from all provider maps. If the current {@code defaultStoreId} was dropped,
-   * it is reset to {@code null} so downstream code can select a sensible fallback.
-   *
-   * <p>A no-op when {@code assigned} is empty (meaning "no restriction — keep the full catalog").
-   */
-  private static void narrowToAssigned(final Document doc) {
-    final List<String> assigned = doc.getAssigned();
-    if (assigned.isEmpty()) {
+  private static void narrowToAssigned(
+      final Document doc, final Binder binder, final String ptPrefix) {
+    final List<String> assigned =
+        binder.bind(ptPrefix + ".assigned", Bindable.listOf(String.class)).orElse(null);
+    if (assigned == null || assigned.isEmpty()) {
       return;
     }
 
@@ -144,9 +125,7 @@ public final class PhysicalTenantDocumentConfigurations {
       }
     }
 
-    // The provider maps on `doc` must be mutable (LinkedHashMap — matches Document's field
-    // initializer). retainAll modifies the map in-place; Spring's Binder preserves the
-    // initializer's collection type, so this is safe with the current field declaration.
+    // provider maps are LinkedHashMap (Document's field initializer) — retainAll is safe
     doc.getAws().keySet().retainAll(assignedIds);
     doc.getGcp().keySet().retainAll(assignedIds);
     doc.getAzure().keySet().retainAll(assignedIds);

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
@@ -9,11 +9,11 @@ package io.camunda.configuration.physicaltenants;
 
 import io.camunda.configuration.Document;
 import io.camunda.configuration.Document.AwsStore;
-import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.Document.AzureStore;
 import io.camunda.configuration.Document.GcpStore;
 import io.camunda.configuration.Document.InMemoryStore;
 import io.camunda.configuration.Document.LocalStore;
+import io.camunda.configuration.UnifiedConfigurationException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -58,7 +58,7 @@ public final class PhysicalTenantDocumentConfigurations {
 
     validateStoreIdUniqueness(tenantId, doc);
 
-    narrowToAssigned(doc, binder, ptPrefix);
+    narrowToAssigned(tenantId, doc, binder, ptPrefix);
 
     return doc;
   }
@@ -114,7 +114,12 @@ public final class PhysicalTenantDocumentConfigurations {
             doc.getAzure().keySet(),
             doc.getLocal().keySet(),
             doc.getInMemory().keySet())) {
-      keys.forEach(id -> { if (!seen.add(id)) duplicates.add(id); });
+      keys.forEach(
+          id -> {
+            if (!seen.add(id)) {
+              duplicates.add(id);
+            }
+          });
     }
     if (!duplicates.isEmpty()) {
       throw new UnifiedConfigurationException(
@@ -127,7 +132,7 @@ public final class PhysicalTenantDocumentConfigurations {
   }
 
   private static void narrowToAssigned(
-      final Document doc, final Binder binder, final String ptPrefix) {
+      final String tenantId, final Document doc, final Binder binder, final String ptPrefix) {
     final List<String> assigned =
         binder.bind(ptPrefix + ".assigned", Bindable.listOf(String.class)).orElse(null);
     if (assigned == null || assigned.isEmpty()) {
@@ -150,7 +155,14 @@ public final class PhysicalTenantDocumentConfigurations {
 
     final String defaultStoreId = doc.getDefaultStoreId();
     if (defaultStoreId != null && !assignedIds.contains(defaultStoreId)) {
-      doc.setDefaultStoreId(null);
+      throw new UnifiedConfigurationException(
+          "Physical tenant '"
+              + tenantId
+              + "' sets 'default-store-id' to '"
+              + defaultStoreId
+              + "' but that store is not in its 'assigned' list "
+              + assignedIds
+              + ". Either include it in 'assigned' or remove 'default-store-id'.");
     }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Document;
+import io.camunda.configuration.Document.AwsStore;
+import io.camunda.configuration.Document.AzureStore;
+import io.camunda.configuration.Document.GcpStore;
+import io.camunda.configuration.Document.InMemoryStore;
+import io.camunda.configuration.Document.LocalStore;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
+
+/**
+ * Resolves a per-tenant {@link Document} by overlaying {@code
+ * camunda.physical-tenants.<id>.document.*} on top of the root {@code camunda.document.*} catalog.
+ *
+ * <p>Uses a snapshot-then-rebind strategy to avoid Spring's {@link Binder} replacing entire map
+ * entries on partial field overrides. Root {@code assigned} is always cleared before the overlay so
+ * tenants cannot inherit it.
+ */
+@NullMarked
+public final class PhysicalTenantDocumentConfigurations {
+
+  private static final String ROOT_PREFIX = "camunda.document";
+  private static final String PT_PREFIX_TEMPLATE = "camunda.physical-tenants.%s.document";
+
+  private PhysicalTenantDocumentConfigurations() {}
+
+  public static Document forPhysicalTenant(final String tenantId, final Environment environment) {
+    final Binder binder = Binder.get(environment);
+
+    final Document doc =
+        binder.bind(ROOT_PREFIX, Bindable.of(Document.class)).orElseGet(Document::new);
+
+    // clear `assigned` on root instance — it must never be inherited by tenants
+    doc.setAssigned(new ArrayList<>());
+
+    // snapshot pristine root store POJOs before the tenant overlay mutates them
+    final Map<String, AwsStore> rootAws = new LinkedHashMap<>(doc.getAws());
+    final Map<String, GcpStore> rootGcp = new LinkedHashMap<>(doc.getGcp());
+    final Map<String, AzureStore> rootAzure = new LinkedHashMap<>(doc.getAzure());
+    final Map<String, LocalStore> rootLocal = new LinkedHashMap<>(doc.getLocal());
+    final Map<String, InMemoryStore> rootInMemory = new LinkedHashMap<>(doc.getInMemory());
+
+    final String ptPrefix = PT_PREFIX_TEMPLATE.formatted(tenantId);
+    binder.bind(ptPrefix, Bindable.ofInstance(doc));
+
+    mergeSharedStores(doc, rootAws, rootGcp, rootAzure, rootLocal, rootInMemory, binder, ptPrefix);
+
+    narrowToAssigned(doc);
+
+    return doc;
+  }
+
+  /**
+   * Re-binds the tenant overlay onto the pristine root POJOs for any store id that existed in both
+   * the root catalog and the tenant overlay. Without this step, a tenant that overrides only some
+   * fields of a shared store (e.g. only {@code bucketPath}) would lose all other root-level fields
+   * (e.g. {@code bucketName}, {@code region}) because Spring's {@link Binder} replaces the entire
+   * map entry on the first matching key.
+   */
+  private static void mergeSharedStores(
+      final Document doc,
+      final Map<String, AwsStore> rootAws,
+      final Map<String, GcpStore> rootGcp,
+      final Map<String, AzureStore> rootAzure,
+      final Map<String, LocalStore> rootLocal,
+      final Map<String, InMemoryStore> rootInMemory,
+      final Binder binder,
+      final String ptPrefix) {
+
+    rootAws.forEach(
+        (storeId, rootStore) -> {
+          if (doc.getAws().containsKey(storeId)) {
+            binder.bind(ptPrefix + ".aws." + storeId, Bindable.ofInstance(rootStore));
+            doc.getAws().put(storeId, rootStore);
+          }
+        });
+
+    rootGcp.forEach(
+        (storeId, rootStore) -> {
+          if (doc.getGcp().containsKey(storeId)) {
+            binder.bind(ptPrefix + ".gcp." + storeId, Bindable.ofInstance(rootStore));
+            doc.getGcp().put(storeId, rootStore);
+          }
+        });
+
+    rootAzure.forEach(
+        (storeId, rootStore) -> {
+          if (doc.getAzure().containsKey(storeId)) {
+            binder.bind(ptPrefix + ".azure." + storeId, Bindable.ofInstance(rootStore));
+            doc.getAzure().put(storeId, rootStore);
+          }
+        });
+
+    rootLocal.forEach(
+        (storeId, rootStore) -> {
+          if (doc.getLocal().containsKey(storeId)) {
+            binder.bind(ptPrefix + ".local." + storeId, Bindable.ofInstance(rootStore));
+            doc.getLocal().put(storeId, rootStore);
+          }
+        });
+
+    rootInMemory.forEach(
+        (storeId, rootStore) -> {
+          if (doc.getInMemory().containsKey(storeId)) {
+            binder.bind(ptPrefix + ".in-memory." + storeId, Bindable.ofInstance(rootStore));
+            doc.getInMemory().put(storeId, rootStore);
+          }
+        });
+  }
+
+  /**
+   * Narrows the resolved document catalog to the ids listed in {@code assigned}. Store ids not in
+   * the list are removed from all provider maps. If the current {@code defaultStoreId} was dropped,
+   * it is reset to {@code null} so downstream code can select a sensible fallback.
+   *
+   * <p>A no-op when {@code assigned} is empty (meaning "no restriction — keep the full catalog").
+   */
+  private static void narrowToAssigned(final Document doc) {
+    final List<String> assigned = doc.getAssigned();
+    if (assigned.isEmpty()) {
+      return;
+    }
+
+    // Normalize assignedIds to lowercase to match Spring's relaxed binding, which lowercases map
+    // keys. Without normalization, user-typed case (e.g. "Shared-S3") will not match the
+    // lowercased store keys (e.g. "shared-s3"), causing retainAll to drop all stores.
+    final Set<String> assignedIds = new LinkedHashSet<>();
+    for (final String id : assigned) {
+      if (!id.isBlank()) {
+        assignedIds.add(id.toLowerCase());
+      }
+    }
+
+    // The provider maps on `doc` must be mutable (LinkedHashMap — matches Document's field
+    // initializer). retainAll modifies the map in-place; Spring's Binder preserves the
+    // initializer's collection type, so this is safe with the current field declaration.
+    doc.getAws().keySet().retainAll(assignedIds);
+    doc.getGcp().keySet().retainAll(assignedIds);
+    doc.getAzure().keySet().retainAll(assignedIds);
+    doc.getLocal().keySet().retainAll(assignedIds);
+    doc.getInMemory().keySet().retainAll(assignedIds);
+
+    final String defaultStoreId = doc.getDefaultStoreId();
+    if (defaultStoreId != null && !assignedIds.contains(defaultStoreId)) {
+      doc.setDefaultStoreId(null);
+    }
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
@@ -71,42 +71,32 @@ public final class PhysicalTenantDocumentConfigurations {
 
     rootAws.forEach(
         (storeId, rootStore) -> {
-          if (doc.getAws().containsKey(storeId)) {
-            binder.bind(ptPrefix + ".aws." + storeId, Bindable.ofInstance(rootStore));
-            doc.getAws().put(storeId, rootStore);
-          }
+          binder.bind(ptPrefix + ".aws." + storeId, Bindable.ofInstance(rootStore));
+          doc.getAws().put(storeId, rootStore);
         });
 
     rootGcp.forEach(
         (storeId, rootStore) -> {
-          if (doc.getGcp().containsKey(storeId)) {
-            binder.bind(ptPrefix + ".gcp." + storeId, Bindable.ofInstance(rootStore));
-            doc.getGcp().put(storeId, rootStore);
-          }
+          binder.bind(ptPrefix + ".gcp." + storeId, Bindable.ofInstance(rootStore));
+          doc.getGcp().put(storeId, rootStore);
         });
 
     rootAzure.forEach(
         (storeId, rootStore) -> {
-          if (doc.getAzure().containsKey(storeId)) {
-            binder.bind(ptPrefix + ".azure." + storeId, Bindable.ofInstance(rootStore));
-            doc.getAzure().put(storeId, rootStore);
-          }
+          binder.bind(ptPrefix + ".azure." + storeId, Bindable.ofInstance(rootStore));
+          doc.getAzure().put(storeId, rootStore);
         });
 
     rootLocal.forEach(
         (storeId, rootStore) -> {
-          if (doc.getLocal().containsKey(storeId)) {
-            binder.bind(ptPrefix + ".local." + storeId, Bindable.ofInstance(rootStore));
-            doc.getLocal().put(storeId, rootStore);
-          }
+          binder.bind(ptPrefix + ".local." + storeId, Bindable.ofInstance(rootStore));
+          doc.getLocal().put(storeId, rootStore);
         });
 
     rootInMemory.forEach(
         (storeId, rootStore) -> {
-          if (doc.getInMemory().containsKey(storeId)) {
-            binder.bind(ptPrefix + ".in-memory." + storeId, Bindable.ofInstance(rootStore));
-            doc.getInMemory().put(storeId, rootStore);
-          }
+          binder.bind(ptPrefix + ".in-memory." + storeId, Bindable.ofInstance(rootStore));
+          doc.getInMemory().put(storeId, rootStore);
         });
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
@@ -14,7 +14,6 @@ import io.camunda.configuration.Document.GcpStore;
 import io.camunda.configuration.Document.InMemoryStore;
 import io.camunda.configuration.Document.LocalStore;
 import io.camunda.configuration.UnifiedConfigurationException;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -106,7 +105,7 @@ public final class PhysicalTenantDocumentConfigurations {
 
   private static void validateStoreIdUniqueness(final String tenantId, final Document doc) {
     final Set<String> seen = new LinkedHashSet<>();
-    final List<String> duplicates = new ArrayList<>();
+    final Set<String> duplicates = new LinkedHashSet<>();
     for (final Set<String> keys :
         List.of(
             doc.getAws().keySet(),
@@ -116,8 +115,9 @@ public final class PhysicalTenantDocumentConfigurations {
             doc.getInMemory().keySet())) {
       keys.forEach(
           id -> {
-            if (!seen.add(id)) {
-              duplicates.add(id);
+            final String normalizedId = Document.normalizeStoreId(id);
+            if (!seen.add(normalizedId)) {
+              duplicates.add(normalizedId);
             }
           });
     }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
@@ -137,13 +137,10 @@ public final class PhysicalTenantDocumentConfigurations {
       return;
     }
 
-    // Normalize assignedIds to lowercase to match Spring's relaxed binding, which lowercases map
-    // keys. Without normalization, user-typed case (e.g. "Shared-S3") will not match the
-    // lowercased store keys (e.g. "shared-s3"), causing retainAll to drop all stores.
     final Set<String> assignedIds = new LinkedHashSet<>();
     for (final String id : assigned) {
       if (!id.isBlank()) {
-        assignedIds.add(id.toLowerCase());
+        assignedIds.add(Document.normalizeStoreId(id));
       }
     }
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentConfigurations.java
@@ -9,10 +9,12 @@ package io.camunda.configuration.physicaltenants;
 
 import io.camunda.configuration.Document;
 import io.camunda.configuration.Document.AwsStore;
+import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.Document.AzureStore;
 import io.camunda.configuration.Document.GcpStore;
 import io.camunda.configuration.Document.InMemoryStore;
 import io.camunda.configuration.Document.LocalStore;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -53,6 +55,8 @@ public final class PhysicalTenantDocumentConfigurations {
     binder.bind(ptPrefix, Bindable.ofInstance(doc));
 
     mergeSharedStores(doc, rootAws, rootGcp, rootAzure, rootLocal, rootInMemory, binder, ptPrefix);
+
+    validateStoreIdUniqueness(tenantId, doc);
 
     narrowToAssigned(doc, binder, ptPrefix);
 
@@ -98,6 +102,28 @@ public final class PhysicalTenantDocumentConfigurations {
           binder.bind(ptPrefix + ".in-memory." + storeId, Bindable.ofInstance(rootStore));
           doc.getInMemory().put(storeId, rootStore);
         });
+  }
+
+  private static void validateStoreIdUniqueness(final String tenantId, final Document doc) {
+    final Set<String> seen = new LinkedHashSet<>();
+    final List<String> duplicates = new ArrayList<>();
+    for (final Set<String> keys :
+        List.of(
+            doc.getAws().keySet(),
+            doc.getGcp().keySet(),
+            doc.getAzure().keySet(),
+            doc.getLocal().keySet(),
+            doc.getInMemory().keySet())) {
+      keys.forEach(id -> { if (!seen.add(id)) duplicates.add(id); });
+    }
+    if (!duplicates.isEmpty()) {
+      throw new UnifiedConfigurationException(
+          "Physical tenant '"
+              + tenantId
+              + "' has duplicate document store id(s) across provider types: "
+              + duplicates
+              + ". Store ids must be unique across aws, gcp, azure, local, and in-memory.");
+    }
   }
 
   private static void narrowToAssigned(

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -71,7 +71,9 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
   private static final List<CrossTenantValidation> CROSS_TENANT_VALIDATIONS =
       List.of(
           new SecondaryStorageIsolationValidation(),
-          new SecondaryStorageTypeHomogeneityValidation());
+          new SecondaryStorageTypeHomogeneityValidation(),
+          new DocumentStoreIsolationValidation(),
+          new PhysicalTenantDocumentAssignedValidation());
 
   private final Map<String, Camunda> resolved;
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -72,8 +72,7 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
       List.of(
           new SecondaryStorageIsolationValidation(),
           new SecondaryStorageTypeHomogeneityValidation(),
-          new DocumentStoreIsolationValidation(),
-          new PhysicalTenantDocumentAssignedValidation());
+          new DocumentStoreIsolationValidation());
 
   private final Map<String, Camunda> resolved;
 
@@ -91,6 +90,7 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
     PhysicalTenantOverridePolicyValidation.validate(environment);
     PhysicalTenantRequiredOverrideValidation.validate(environment);
     PhysicalTenantAssignedProvidersValidation.validate(environment);
+    PhysicalTenantDocumentAssignedValidation.validateRootAssignedAbsent(environment);
     final Map<String, Camunda> resolvedPhysicalTenants = new LinkedHashMap<>();
     final Binder binder = Binder.get(environment);
     for (final String physicalTenantId : physicalTenantIds) {
@@ -113,7 +113,9 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
     if (!resolvedPhysicalTenants.containsKey(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)) {
       resolvedPhysicalTenants.put(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camunda);
     }
-    CROSS_TENANT_VALIDATIONS.forEach(validation -> validation.validate(resolvedPhysicalTenants));
+    CROSS_TENANT_VALIDATIONS.forEach(v -> v.validate(resolvedPhysicalTenants));
+    PhysicalTenantDocumentAssignedValidation.validate(
+        environment, resolvedPhysicalTenants, physicalTenantIds);
     return new PhysicalTenantResolver(resolvedPhysicalTenants);
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -104,6 +104,8 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
           .setAuthentication(
               PhysicalTenantAuthenticationConfigurations.forPhysicalTenant(
                   physicalTenantId, environment));
+      physicalTenant.setDocument(
+          PhysicalTenantDocumentConfigurations.forPhysicalTenant(physicalTenantId, environment));
       resolvedPhysicalTenants.put(physicalTenantId, physicalTenant);
     }
     if (!resolvedPhysicalTenants.containsKey(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)) {

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/DocumentStoreIsolationValidationTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Document.AwsStore;
+import io.camunda.configuration.Document.InMemoryStore;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class DocumentStoreIsolationValidationTest {
+
+  private final DocumentStoreIsolationValidation validation =
+      new DocumentStoreIsolationValidation();
+
+  @BeforeEach
+  void setUp() {
+    UnifiedConfigurationHelper.setCustomEnvironment(new MockEnvironment());
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldFailWhenTwoTenantsShareBucketAndPath() {
+    // given
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("my-bucket", "shared/path", "us-east-1"),
+            "tenantb", awsCamunda("my-bucket", "shared/path", "us-east-1"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldPassWhenPathsDiffer() {
+    // given
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("my-bucket", "tenant-a/docs", "us-east-1"),
+            "tenantb", awsCamunda("my-bucket", "tenant-b/docs", "us-east-1"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailIgnoringRegionDifference() {
+    // given S3 bucket names are globally unique, so region is not part of the identity
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("global-bucket", "shared/path", "us-east-1"),
+            "tenantb", awsCamunda("global-bucket", "shared/path", "eu-west-1"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldTreatTrailingSlashAsEquivalentToNoSlash() {
+    // given normalizer strips trailing slashes, so "shared" and "shared/" resolve to the same
+    // location
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", awsCamunda("my-bucket", "shared", "us-east-1"),
+            "tenantb", awsCamunda("my-bucket", "shared/", "us-east-1"));
+
+    // when / then error reports normalized value "shared", not "shared/"
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageNotContaining("shared/");
+  }
+
+  @Test
+  void shouldNormalizeNullBucketPath() {
+    // given normalize maps null → "" and "" → "", so they collide
+    final Map<String, Camunda> resolved = new LinkedHashMap<>();
+    resolved.put("tenanta", awsCamunda("docs", null, "eu-west-1"));
+    resolved.put("tenantb", awsCamunda("docs", "", "eu-west-1"));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldNeverCollideOnInMemoryStores() {
+    // given in-memory stores are ephemeral and process-local, excluded from collision detection
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", inMemoryCamunda("mem-store"),
+            "tenantb", inMemoryCamunda("mem-store"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassForSingleTenant() {
+    // given
+    final Map<String, Camunda> resolved =
+        tenants("default", awsCamunda("my-bucket", "default/path", "us-east-1"));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailWhenTenantInheritsRootLocationAndCollidesWithDefault() {
+    // given a non-default tenant that omits a document override inherits the root location;
+    // the resolved config is identical to the default tenant's — a collision must be rejected
+    final Camunda defaultTenant = awsCamunda("shared-bucket", "root/path", "us-east-1");
+    final Camunda tenantA = awsCamunda("shared-bucket", "root/path", "us-east-1");
+    final Map<String, Camunda> resolved = tenants("default", defaultTenant, "tenanta", tenantA);
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("must not share a document store location")
+        .withMessageContaining("default")
+        .withMessageContaining("tenanta");
+  }
+
+  // --- helpers ---------------------------------------------------------------------------------
+
+  private static Camunda awsCamunda(
+      final String bucketName, final String bucketPath, final String region) {
+    final Camunda camunda = new Camunda();
+    final AwsStore store = new AwsStore();
+    store.setBucketName(bucketName);
+    store.setBucketPath(bucketPath);
+    store.setRegion(region);
+    final Map<String, AwsStore> aws = new LinkedHashMap<>();
+    aws.put("shared-s3", store);
+    camunda.getDocument().setAws(aws);
+    return camunda;
+  }
+
+  private static Camunda inMemoryCamunda(final String storeId) {
+    final Camunda camunda = new Camunda();
+    final Map<String, InMemoryStore> inMemory = new LinkedHashMap<>();
+    inMemory.put(storeId, new InMemoryStore());
+    camunda.getDocument().setInMemory(inMemory);
+    return camunda;
+  }
+
+  private static Map<String, Camunda> tenants(final Object... idThenCamunda) {
+    final Map<String, Camunda> map = new LinkedHashMap<>();
+    for (int i = 0; i < idThenCamunda.length; i += 2) {
+      map.put((String) idThenCamunda[i], (Camunda) idThenCamunda[i + 1]);
+    }
+    return map;
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidationTest.java
@@ -41,6 +41,17 @@ class PhysicalTenantDocumentAssignedValidationTest {
   }
 
   @Test
+  void shouldPassWhenNonDefaultTenantHasNoDocumentStores() {
+    // given a non-default tenant with no document stores in its catalog
+    final Camunda camunda = new Camunda();
+    camunda.getDocument().setAssigned(new ArrayList<>());
+    final Map<String, Camunda> resolved = tenants("tenanta", camunda);
+
+    // when / then no stores → nothing to assign → validation is a no-op
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
   void shouldPassWhenDefaultTenantOmitsAssigned() {
     // given
     final Map<String, Camunda> resolved =

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidationTest.java
@@ -16,10 +16,9 @@ import io.camunda.configuration.Document.AwsStore;
 import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,12 +26,12 @@ import org.springframework.mock.env.MockEnvironment;
 
 class PhysicalTenantDocumentAssignedValidationTest {
 
-  private final PhysicalTenantDocumentAssignedValidation validation =
-      new PhysicalTenantDocumentAssignedValidation();
+  private MockEnvironment environment;
 
   @BeforeEach
   void setUp() {
-    UnifiedConfigurationHelper.setCustomEnvironment(new MockEnvironment());
+    environment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(environment);
   }
 
   @AfterEach
@@ -42,114 +41,114 @@ class PhysicalTenantDocumentAssignedValidationTest {
 
   @Test
   void shouldPassWhenNonDefaultTenantHasNoDocumentStores() {
-    // given a non-default tenant with no document stores in its catalog
-    final Camunda camunda = new Camunda();
-    camunda.getDocument().setAssigned(new ArrayList<>());
-    final Map<String, Camunda> resolved = tenants("tenanta", camunda);
-
-    // when / then no stores → nothing to assign → validation is a no-op
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    assertThatCode(() -> validate(tenants("tenanta", new Camunda()), Set.of()))
+        .doesNotThrowAnyException();
   }
 
   @Test
   void shouldPassWhenDefaultTenantOmitsAssigned() {
-    // given
+    // synthesized default (absent from explicitlyDeclared) is exempt
     final Map<String, Camunda> resolved =
-        tenants(
-            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWithStore("store-a", List.of()));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+        tenants(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWithStore("store-a"));
+    assertThatCode(() -> validate(resolved, Set.of())).doesNotThrowAnyException();
   }
 
   @Test
   void shouldFailWhenNonDefaultTenantOmitsAssigned() {
-    // given
-    final Map<String, Camunda> resolved =
-        tenants("tenanta", camundaWithStore("store-a", List.of()));
-
-    // when / then
     assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
+        .isThrownBy(() -> validate(tenants("tenanta", camundaWithStore("store-a")), Set.of()))
         .withMessageContaining("tenanta")
         .withMessageContaining("must declare a non-empty");
   }
 
   @Test
   void shouldFailWhenAssignedContainsUnknownStoreId() {
-    // given
-    final Map<String, Camunda> resolved =
-        tenants("tenanta", camundaWithStore("store-a", List.of("unknown-id")));
-
-    // when / then
+    environment.setProperty("camunda.physical-tenants.tenanta.document.assigned[0]", "unknown-id");
     assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
+        .isThrownBy(() -> validate(tenants("tenanta", camundaWithStore("store-a")), Set.of()))
         .withMessageContaining("tenanta")
         .withMessageContaining("unknown-id");
   }
 
   @Test
   void shouldPassWhenAssignedContainsOnlyKnownIds() {
-    // given
-    final Map<String, Camunda> resolved =
-        tenants("tenanta", camundaWithStore("store-a", List.of("store-a")));
-
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+    environment.setProperty("camunda.physical-tenants.tenanta.document.assigned[0]", "store-a");
+    assertThatCode(() -> validate(tenants("tenanta", camundaWithStore("store-a")), Set.of()))
+        .doesNotThrowAnyException();
   }
 
   @Test
   void shouldAcceptAssignedIdWithDifferentCaseOrWhitespace() {
-    // given assigned contains "Shared-S3" (mixed-case) and " store-a " (whitespace), while the
-    // store keys in the catalog are lowercased by Spring's relaxed binding
-    final Map<String, Camunda> resolved =
-        tenants("tenanta", camundaWithStore("store-a", List.of("Shared-S3", " store-a ")));
-
-    // when / then only truly unknown ids appear in the unknown list; " store-a " normalizes to
-    // "store-a" and is accepted — only "Shared-S3" has no matching store
+    // " store-a " normalizes to "store-a" and passes; "Shared-S3" has no matching store and fails
+    environment.setProperty("camunda.physical-tenants.tenanta.document.assigned[0]", "Shared-S3");
+    environment.setProperty("camunda.physical-tenants.tenanta.document.assigned[1]", " store-a ");
     assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
+        .isThrownBy(() -> validate(tenants("tenanta", camundaWithStore("store-a")), Set.of()))
         .withMessageContaining("unknown document store id(s) [Shared-S3]");
   }
 
   @Test
   void shouldFailOnBlankAssignedEntry() {
-    // given blank entry (e.g. `- ""` in yaml) — must be rejected, not treated as unknown id
-    final Map<String, Camunda> resolved =
-        tenants("tenanta", camundaWithStore("store-a", List.of("")));
-
-    // when / then
+    // blank entries must be caught before the unknown-id check; otherwise they render as `[]`
+    environment.setProperty("camunda.physical-tenants.tenanta.document.assigned[0]", "");
     assertThatExceptionOfType(UnifiedConfigurationException.class)
-        .isThrownBy(() -> validation.validate(resolved))
+        .isThrownBy(() -> validate(tenants("tenanta", camundaWithStore("store-a")), Set.of()))
         .withMessageContaining("tenanta")
         .withMessageContaining("blank entry");
   }
 
   @Test
   void shouldPassWhenDefaultTenantIsExemptInMultiTenantDeployment() {
-    // given
-    final Camunda defaultTenant = camundaWithStore("store-default", List.of());
-    final Camunda tenantA = camundaWithStore("store-a", List.of("store-a"));
+    environment.setProperty("camunda.physical-tenants.tenanta.document.assigned[0]", "store-a");
     final Map<String, Camunda> resolved =
-        tenants(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultTenant, "tenanta", tenantA);
+        tenants(
+            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+            camundaWithStore("store-default"),
+            "tenanta",
+            camundaWithStore("store-a"));
+    assertThatCode(() -> validate(resolved, Set.of())).doesNotThrowAnyException();
+  }
 
-    // when / then
-    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  @Test
+  void shouldFailWhenExplicitDefaultDeclaresStoresWithoutAssigned() {
+    // explicitly declared default is validated like any other tenant
+    final Map<String, Camunda> resolved =
+        tenants(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWithStore("store-a"));
+    final Set<String> explicitlyDeclared = Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validate(resolved, explicitlyDeclared))
+        .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+        .withMessageContaining("must declare a non-empty");
+  }
+
+  @Test
+  void shouldPassWhenExplicitDefaultAssignsKnownStore() {
+    environment.setProperty(
+        "camunda.physical-tenants."
+            + PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID
+            + ".document.assigned[0]",
+        "store-a");
+    final Map<String, Camunda> resolved =
+        tenants(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWithStore("store-a"));
+    final Set<String> explicitlyDeclared = Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThatCode(() -> validate(resolved, explicitlyDeclared)).doesNotThrowAnyException();
   }
 
   // --- helpers ---------------------------------------------------------------------------------
 
-  private static Camunda camundaWithStore(final String storeId, final List<String> assigned) {
+  private void validate(final Map<String, Camunda> resolved, final Set<String> explicitlyDeclared) {
+    PhysicalTenantDocumentAssignedValidation.validate(environment, resolved, explicitlyDeclared);
+  }
+
+  private static Camunda camundaWithStore(final String storeId) {
     final Camunda camunda = new Camunda();
     final Document doc = camunda.getDocument();
-
     final AwsStore store = new AwsStore();
     store.setBucketName("bucket-" + storeId);
     store.setBucketPath("path/" + storeId);
     final Map<String, AwsStore> aws = new LinkedHashMap<>();
     aws.put(storeId, store);
     doc.setAws(aws);
-    doc.setAssigned(new ArrayList<>(assigned));
     return camunda;
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidationTest.java
@@ -99,6 +99,20 @@ class PhysicalTenantDocumentAssignedValidationTest {
   }
 
   @Test
+  void shouldAcceptAssignedIdWithDifferentCaseOrWhitespace() {
+    // given assigned contains "Shared-S3" (mixed-case) and " store-a " (whitespace), while the
+    // store keys in the catalog are lowercased by Spring's relaxed binding
+    final Map<String, Camunda> resolved =
+        tenants("tenanta", camundaWithStore("store-a", List.of("Shared-S3", " store-a ")));
+
+    // when / then only truly unknown ids appear in the unknown list; " store-a " normalizes to
+    // "store-a" and is accepted — only "Shared-S3" has no matching store
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("unknown document store id(s) [Shared-S3]");
+  }
+
+  @Test
   void shouldFailOnBlankAssignedEntry() {
     // given blank entry (e.g. `- ""` in yaml) — must be rejected, not treated as unknown id
     final Map<String, Camunda> resolved =

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentAssignedValidationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Document;
+import io.camunda.configuration.Document.AwsStore;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class PhysicalTenantDocumentAssignedValidationTest {
+
+  private final PhysicalTenantDocumentAssignedValidation validation =
+      new PhysicalTenantDocumentAssignedValidation();
+
+  @BeforeEach
+  void setUp() {
+    UnifiedConfigurationHelper.setCustomEnvironment(new MockEnvironment());
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldPassWhenDefaultTenantOmitsAssigned() {
+    // given
+    final Map<String, Camunda> resolved =
+        tenants(
+            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWithStore("store-a", List.of()));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailWhenNonDefaultTenantOmitsAssigned() {
+    // given
+    final Map<String, Camunda> resolved =
+        tenants("tenanta", camundaWithStore("store-a", List.of()));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("must declare a non-empty");
+  }
+
+  @Test
+  void shouldFailWhenAssignedContainsUnknownStoreId() {
+    // given
+    final Map<String, Camunda> resolved =
+        tenants("tenanta", camundaWithStore("store-a", List.of("unknown-id")));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("unknown-id");
+  }
+
+  @Test
+  void shouldPassWhenAssignedContainsOnlyKnownIds() {
+    // given
+    final Map<String, Camunda> resolved =
+        tenants("tenanta", camundaWithStore("store-a", List.of("store-a")));
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailOnBlankAssignedEntry() {
+    // given blank entry (e.g. `- ""` in yaml) — must be rejected, not treated as unknown id
+    final Map<String, Camunda> resolved =
+        tenants("tenanta", camundaWithStore("store-a", List.of("")));
+
+    // when / then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("blank entry");
+  }
+
+  @Test
+  void shouldPassWhenDefaultTenantIsExemptInMultiTenantDeployment() {
+    // given
+    final Camunda defaultTenant = camundaWithStore("store-default", List.of());
+    final Camunda tenantA = camundaWithStore("store-a", List.of("store-a"));
+    final Map<String, Camunda> resolved =
+        tenants(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultTenant, "tenanta", tenantA);
+
+    // when / then
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  // --- helpers ---------------------------------------------------------------------------------
+
+  private static Camunda camundaWithStore(final String storeId, final List<String> assigned) {
+    final Camunda camunda = new Camunda();
+    final Document doc = camunda.getDocument();
+
+    final AwsStore store = new AwsStore();
+    store.setBucketName("bucket-" + storeId);
+    store.setBucketPath("path/" + storeId);
+    final Map<String, AwsStore> aws = new LinkedHashMap<>();
+    aws.put(storeId, store);
+    doc.setAws(aws);
+    doc.setAssigned(new ArrayList<>(assigned));
+    return camunda;
+  }
+
+  private static Map<String, Camunda> tenants(final Object... idThenCamunda) {
+    final Map<String, Camunda> map = new LinkedHashMap<>();
+    for (int i = 0; i < idThenCamunda.length; i += 2) {
+      map.put((String) idThenCamunda[i], (Camunda) idThenCamunda[i + 1]);
+    }
+    return map;
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -141,7 +141,7 @@ class PhysicalTenantDocumentOverlayTest {
   }
 
   @Test
-  void shouldNotNarrowCatalogWhenRootAssignedIsSet() {
+  void shouldRejectRootAssignedEvenThoughTenantOverlayWouldIgnoreIt() {
     // narrowing reads only from the tenant prefix, so root assigned has no effect
     environment
         .getPropertySources()
@@ -152,10 +152,10 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.shared-s3.bucket-name", "root-bucket",
                     "camunda.document.assigned[0]", "shared-s3")));
 
-    final Document doc =
-        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
-
-    assertThat(doc.getAws()).containsKey("shared-s3");
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
+            () -> PhysicalTenantDocumentAssignedValidation.validateRootAssignedAbsent(environment))
+        .withMessageContaining("camunda.document.assigned");
   }
 
   @Test

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -181,6 +181,42 @@ class PhysicalTenantDocumentOverlayTest {
   }
 
   @Test
+  void shouldFailWhenSameStoreIdUsedAcrossProviders() {
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.abc.bucket-name", "aws-bucket",
+                    "camunda.document.gcp.abc.bucket-name", "gcp-bucket")));
+
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
+            () -> PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment))
+        .withMessageContaining("abc");
+  }
+
+  @Test
+  void shouldFailWhenTenantPrivateStoreIdCollidesWithRootStoreId() {
+    // tenant introduces a private gcp store with the same id as a root aws store
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.abc.bucket-name", "aws-bucket",
+                    "camunda.physical-tenants.tenanta.document.gcp.abc.bucket-name",
+                        "gcp-bucket")));
+
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
+            () -> PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment))
+        .withMessageContaining("abc");
+  }
+
+  @Test
   void shouldFailWhenRootAssignedIsSet() {
     environment.setProperty("camunda.document.assigned[0]", "some-store");
 

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -159,8 +159,9 @@ class PhysicalTenantDocumentOverlayTest {
   }
 
   @Test
-  void shouldResetDefaultStoreIdWhenDefaultDroppedByAssigned() {
-    // default-store-id points to shared-s3, but assigned only includes other-store
+  void shouldFailWhenDefaultStoreIdExcludedByAssigned() {
+    // default-store-id points to shared-s3 but assigned only includes other-store —
+    // misconfiguration
     environment
         .getPropertySources()
         .addFirst(
@@ -172,12 +173,32 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.other-store.bucket-name", "other-docs",
                     "camunda.physical-tenants.tenanta.document.assigned[0]", "other-store")));
 
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
+            () -> PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("shared-s3")
+        .withMessageContaining("assigned");
+  }
+
+  @Test
+  void shouldKeepDefaultStoreIdWhenIncludedInAssigned() {
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.default-store-id", "shared-s3",
+                    "camunda.document.aws.shared-s3.bucket-name", "global-docs",
+                    "camunda.document.aws.other-store.bucket-name", "other-docs",
+                    "camunda.physical-tenants.tenanta.document.assigned[0]", "shared-s3")));
+
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    assertThat(doc.getAws()).containsKey("other-store");
-    assertThat(doc.getAws()).doesNotContainKey("shared-s3");
-    assertThat(doc.getDefaultStoreId()).isNullOrEmpty();
+    assertThat(doc.getAws()).containsOnlyKeys("shared-s3");
+    assertThat(doc.getDefaultStoreId()).isEqualTo("shared-s3");
   }
 
   @Test

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -8,8 +8,11 @@
 package io.camunda.configuration.physicaltenants;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.configuration.Document;
+import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -35,7 +38,6 @@ class PhysicalTenantDocumentOverlayTest {
 
   @Test
   void shouldInheritRootStoreWhenTenantHasNoOverride() {
-    // given
     environment
         .getPropertySources()
         .addFirst(
@@ -46,11 +48,9 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.shared-s3.bucket-path", "root/path",
                     "camunda.document.aws.shared-s3.region", "us-east-1")));
 
-    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then
     assertThat(doc.getAws()).containsKey("shared-s3");
     assertThat(doc.getAws().get("shared-s3").getBucketName()).isEqualTo("root-bucket");
     assertThat(doc.getAws().get("shared-s3").getBucketPath()).isEqualTo("root/path");
@@ -59,7 +59,7 @@ class PhysicalTenantDocumentOverlayTest {
 
   @Test
   void shouldOverrideOnlyTheFieldTenantSets() {
-    // given tenant overrides only bucket-path; other root fields must survive
+    // tenant overrides only bucket-path; root's bucket-name and region must survive
     environment
         .getPropertySources()
         .addFirst(
@@ -72,11 +72,9 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.physical-tenants.tenanta.document.aws.shared-s3.bucket-path",
                         "tenant-a/path")));
 
-    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then
     assertThat(doc.getAws().get("shared-s3").getBucketPath()).isEqualTo("tenant-a/path");
     assertThat(doc.getAws().get("shared-s3").getBucketName()).isEqualTo("root-bucket");
     assertThat(doc.getAws().get("shared-s3").getRegion()).isEqualTo("us-east-1");
@@ -84,7 +82,6 @@ class PhysicalTenantDocumentOverlayTest {
 
   @Test
   void shouldAddTenantPrivateStore() {
-    // given
     environment
         .getPropertySources()
         .addFirst(
@@ -98,11 +95,9 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.physical-tenants.tenanta.document.aws.private-s3.bucket-path",
                         "tenanta/private")));
 
-    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then both the inherited root store and the new private store are present
     assertThat(doc.getAws()).containsKey("shared-s3");
     assertThat(doc.getAws()).containsKey("private-s3");
     assertThat(doc.getAws().get("private-s3").getBucketName()).isEqualTo("private-bucket");
@@ -110,7 +105,6 @@ class PhysicalTenantDocumentOverlayTest {
 
   @Test
   void shouldNarrowToAssignedWhenDeclared() {
-    // given
     environment
         .getPropertySources()
         .addFirst(
@@ -123,17 +117,14 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.other-store.bucket-path", "other/path",
                     "camunda.physical-tenants.tenanta.document.assigned[0]", "shared-s3")));
 
-    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then only the assigned store survives
     assertThat(doc.getAws()).containsOnlyKeys("shared-s3");
   }
 
   @Test
   void shouldNotNarrowWhenAssignedIsEmpty() {
-    // given
     environment
         .getPropertySources()
         .addFirst(
@@ -143,17 +134,15 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.store-a.bucket-name", "bucket-a",
                     "camunda.document.aws.store-b.bucket-name", "bucket-b")));
 
-    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then full catalog survives — empty assigned means no restriction
     assertThat(doc.getAws()).containsKeys("store-a", "store-b");
   }
 
   @Test
-  void shouldClearAssignedFromRoot() {
-    // given root has assigned set — must never be inherited by tenants
+  void shouldNotNarrowCatalogWhenRootAssignedIsSet() {
+    // narrowing reads only from the tenant prefix, so root assigned has no effect
     environment
         .getPropertySources()
         .addFirst(
@@ -163,18 +152,15 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.shared-s3.bucket-name", "root-bucket",
                     "camunda.document.assigned[0]", "shared-s3")));
 
-    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then
-    assertThat(doc.getAssigned()).isEmpty();
     assertThat(doc.getAws()).containsKey("shared-s3");
   }
 
   @Test
   void shouldResetDefaultStoreIdWhenDefaultDroppedByAssigned() {
-    // given default-store-id points to shared-s3, but tenant's assigned only includes other-store
+    // default-store-id points to shared-s3, but assigned only includes other-store
     environment
         .getPropertySources()
         .addFirst(
@@ -186,13 +172,29 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.other-store.bucket-name", "other-docs",
                     "camunda.physical-tenants.tenanta.document.assigned[0]", "other-store")));
 
-    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then shared-s3 is dropped along with the default-store-id
     assertThat(doc.getAws()).containsKey("other-store");
     assertThat(doc.getAws()).doesNotContainKey("shared-s3");
     assertThat(doc.getDefaultStoreId()).isNullOrEmpty();
+  }
+
+  @Test
+  void shouldFailWhenRootAssignedIsSet() {
+    environment.setProperty("camunda.document.assigned[0]", "some-store");
+
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
+            () -> PhysicalTenantDocumentAssignedValidation.validateRootAssignedAbsent(environment))
+        .withMessageContaining("camunda.document.assigned")
+        .withMessageContaining("physical-tenants.<id>.document.assigned");
+  }
+
+  @Test
+  void shouldPassWhenRootAssignedIsAbsent() {
+    assertThatCode(
+            () -> PhysicalTenantDocumentAssignedValidation.validateRootAssignedAbsent(environment))
+        .doesNotThrowAnyException();
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -18,11 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
-/**
- * Unit tests for {@link PhysicalTenantDocumentConfigurations#forPhysicalTenant}: verifies the
- * two-phase overlay strategy that correctly merges per-tenant document overrides on top of the root
- * document catalog.
- */
 class PhysicalTenantDocumentOverlayTest {
 
   private MockEnvironment environment;
@@ -40,7 +35,7 @@ class PhysicalTenantDocumentOverlayTest {
 
   @Test
   void shouldInheritRootStoreWhenTenantHasNoOverride() {
-    // given a root catalog with a single AWS store and no tenant-specific document config
+    // given
     environment
         .getPropertySources()
         .addFirst(
@@ -51,11 +46,11 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.shared-s3.bucket-path", "root/path",
                     "camunda.document.aws.shared-s3.region", "us-east-1")));
 
-    // when resolving the document for a tenant that has no document overrides
+    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then the root store is inherited unchanged
+    // then
     assertThat(doc.getAws()).containsKey("shared-s3");
     assertThat(doc.getAws().get("shared-s3").getBucketName()).isEqualTo("root-bucket");
     assertThat(doc.getAws().get("shared-s3").getBucketPath()).isEqualTo("root/path");
@@ -64,8 +59,7 @@ class PhysicalTenantDocumentOverlayTest {
 
   @Test
   void shouldOverrideOnlyTheFieldTenantSets() {
-    // given a root AWS store with bucket-name, bucket-path, and region, and a tenant that overrides
-    // only bucket-path — the other fields must survive from the root
+    // given tenant overrides only bucket-path; other root fields must survive
     environment
         .getPropertySources()
         .addFirst(
@@ -78,11 +72,11 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.physical-tenants.tenanta.document.aws.shared-s3.bucket-path",
                         "tenant-a/path")));
 
-    // when resolving the document for tenanta
+    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then only the overridden field changes; root fields are preserved
+    // then
     assertThat(doc.getAws().get("shared-s3").getBucketPath()).isEqualTo("tenant-a/path");
     assertThat(doc.getAws().get("shared-s3").getBucketName()).isEqualTo("root-bucket");
     assertThat(doc.getAws().get("shared-s3").getRegion()).isEqualTo("us-east-1");
@@ -90,8 +84,7 @@ class PhysicalTenantDocumentOverlayTest {
 
   @Test
   void shouldAddTenantPrivateStore() {
-    // given a root catalog with one AWS store and a tenant declaring an additional private store
-    // not present in the root
+    // given
     environment
         .getPropertySources()
         .addFirst(
@@ -105,7 +98,7 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.physical-tenants.tenanta.document.aws.private-s3.bucket-path",
                         "tenanta/private")));
 
-    // when resolving the document for tenanta
+    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
@@ -117,7 +110,7 @@ class PhysicalTenantDocumentOverlayTest {
 
   @Test
   void shouldNarrowToAssignedWhenDeclared() {
-    // given a root catalog with two AWS stores and a tenant declaring assigned: [shared-s3]
+    // given
     environment
         .getPropertySources()
         .addFirst(
@@ -130,17 +123,17 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.other-store.bucket-path", "other/path",
                     "camunda.physical-tenants.tenanta.document.assigned[0]", "shared-s3")));
 
-    // when resolving the document for tenanta
+    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then only the assigned store survives; the other root store is dropped
+    // then only the assigned store survives
     assertThat(doc.getAws()).containsOnlyKeys("shared-s3");
   }
 
   @Test
   void shouldNotNarrowWhenAssignedIsEmpty() {
-    // given a root catalog with two stores and a tenant declaring no assigned list
+    // given
     environment
         .getPropertySources()
         .addFirst(
@@ -150,18 +143,17 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.store-a.bucket-name", "bucket-a",
                     "camunda.document.aws.store-b.bucket-name", "bucket-b")));
 
-    // when resolving the document for a tenant with no assigned declaration
+    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then the full catalog survives — an empty assigned list means no restriction
+    // then full catalog survives — empty assigned means no restriction
     assertThat(doc.getAws()).containsKeys("store-a", "store-b");
   }
 
   @Test
   void shouldClearAssignedFromRoot() {
-    // given a root catalog that (hypothetically) has assigned set — this should never be
-    // inherited by tenants; the overlay clears assigned before applying the tenant overlay
+    // given root has assigned set — must never be inherited by tenants
     environment
         .getPropertySources()
         .addFirst(
@@ -171,20 +163,18 @@ class PhysicalTenantDocumentOverlayTest {
                     "camunda.document.aws.shared-s3.bucket-name", "root-bucket",
                     "camunda.document.assigned[0]", "shared-s3")));
 
-    // when resolving the document for a tenant that declares no assigned of its own
+    // when
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then the root's assigned is cleared — the tenant sees the full catalog, not the root's
-    // restriction
+    // then
     assertThat(doc.getAssigned()).isEmpty();
     assertThat(doc.getAws()).containsKey("shared-s3");
   }
 
   @Test
   void shouldResetDefaultStoreIdWhenDefaultDroppedByAssigned() {
-    // given root catalog with two stores; default-store-id points to shared-s3, but tenanta's
-    // assigned list only includes other-store — so shared-s3 (and the default) must be dropped
+    // given default-store-id points to shared-s3, but tenant's assigned only includes other-store
     environment
         .getPropertySources()
         .addFirst(
@@ -200,7 +190,7 @@ class PhysicalTenantDocumentOverlayTest {
     final Document doc =
         PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
 
-    // then only other-store survives; shared-s3 is dropped along with the default-store-id
+    // then shared-s3 is dropped along with the default-store-id
     assertThat(doc.getAws()).containsKey("other-store");
     assertThat(doc.getAws()).doesNotContainKey("shared-s3");
     assertThat(doc.getDefaultStoreId()).isNullOrEmpty();

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantDocumentOverlayTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Document;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Unit tests for {@link PhysicalTenantDocumentConfigurations#forPhysicalTenant}: verifies the
+ * two-phase overlay strategy that correctly merges per-tenant document overrides on top of the root
+ * document catalog.
+ */
+class PhysicalTenantDocumentOverlayTest {
+
+  private MockEnvironment environment;
+
+  @BeforeEach
+  void setUp() {
+    environment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(environment);
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldInheritRootStoreWhenTenantHasNoOverride() {
+    // given a root catalog with a single AWS store and no tenant-specific document config
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.shared-s3.bucket-name", "root-bucket",
+                    "camunda.document.aws.shared-s3.bucket-path", "root/path",
+                    "camunda.document.aws.shared-s3.region", "us-east-1")));
+
+    // when resolving the document for a tenant that has no document overrides
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then the root store is inherited unchanged
+    assertThat(doc.getAws()).containsKey("shared-s3");
+    assertThat(doc.getAws().get("shared-s3").getBucketName()).isEqualTo("root-bucket");
+    assertThat(doc.getAws().get("shared-s3").getBucketPath()).isEqualTo("root/path");
+    assertThat(doc.getAws().get("shared-s3").getRegion()).isEqualTo("us-east-1");
+  }
+
+  @Test
+  void shouldOverrideOnlyTheFieldTenantSets() {
+    // given a root AWS store with bucket-name, bucket-path, and region, and a tenant that overrides
+    // only bucket-path — the other fields must survive from the root
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.shared-s3.bucket-name", "root-bucket",
+                    "camunda.document.aws.shared-s3.bucket-path", "root/path",
+                    "camunda.document.aws.shared-s3.region", "us-east-1",
+                    "camunda.physical-tenants.tenanta.document.aws.shared-s3.bucket-path",
+                        "tenant-a/path")));
+
+    // when resolving the document for tenanta
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then only the overridden field changes; root fields are preserved
+    assertThat(doc.getAws().get("shared-s3").getBucketPath()).isEqualTo("tenant-a/path");
+    assertThat(doc.getAws().get("shared-s3").getBucketName()).isEqualTo("root-bucket");
+    assertThat(doc.getAws().get("shared-s3").getRegion()).isEqualTo("us-east-1");
+  }
+
+  @Test
+  void shouldAddTenantPrivateStore() {
+    // given a root catalog with one AWS store and a tenant declaring an additional private store
+    // not present in the root
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.shared-s3.bucket-name", "root-bucket",
+                    "camunda.document.aws.shared-s3.bucket-path", "root/path",
+                    "camunda.physical-tenants.tenanta.document.aws.private-s3.bucket-name",
+                        "private-bucket",
+                    "camunda.physical-tenants.tenanta.document.aws.private-s3.bucket-path",
+                        "tenanta/private")));
+
+    // when resolving the document for tenanta
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then both the inherited root store and the new private store are present
+    assertThat(doc.getAws()).containsKey("shared-s3");
+    assertThat(doc.getAws()).containsKey("private-s3");
+    assertThat(doc.getAws().get("private-s3").getBucketName()).isEqualTo("private-bucket");
+  }
+
+  @Test
+  void shouldNarrowToAssignedWhenDeclared() {
+    // given a root catalog with two AWS stores and a tenant declaring assigned: [shared-s3]
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.shared-s3.bucket-name", "root-bucket",
+                    "camunda.document.aws.shared-s3.bucket-path", "root/path",
+                    "camunda.document.aws.other-store.bucket-name", "other-bucket",
+                    "camunda.document.aws.other-store.bucket-path", "other/path",
+                    "camunda.physical-tenants.tenanta.document.assigned[0]", "shared-s3")));
+
+    // when resolving the document for tenanta
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then only the assigned store survives; the other root store is dropped
+    assertThat(doc.getAws()).containsOnlyKeys("shared-s3");
+  }
+
+  @Test
+  void shouldNotNarrowWhenAssignedIsEmpty() {
+    // given a root catalog with two stores and a tenant declaring no assigned list
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.store-a.bucket-name", "bucket-a",
+                    "camunda.document.aws.store-b.bucket-name", "bucket-b")));
+
+    // when resolving the document for a tenant with no assigned declaration
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then the full catalog survives — an empty assigned list means no restriction
+    assertThat(doc.getAws()).containsKeys("store-a", "store-b");
+  }
+
+  @Test
+  void shouldClearAssignedFromRoot() {
+    // given a root catalog that (hypothetically) has assigned set — this should never be
+    // inherited by tenants; the overlay clears assigned before applying the tenant overlay
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.aws.shared-s3.bucket-name", "root-bucket",
+                    "camunda.document.assigned[0]", "shared-s3")));
+
+    // when resolving the document for a tenant that declares no assigned of its own
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then the root's assigned is cleared — the tenant sees the full catalog, not the root's
+    // restriction
+    assertThat(doc.getAssigned()).isEmpty();
+    assertThat(doc.getAws()).containsKey("shared-s3");
+  }
+
+  @Test
+  void shouldResetDefaultStoreIdWhenDefaultDroppedByAssigned() {
+    // given root catalog with two stores; default-store-id points to shared-s3, but tenanta's
+    // assigned list only includes other-store — so shared-s3 (and the default) must be dropped
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.document.default-store-id", "shared-s3",
+                    "camunda.document.aws.shared-s3.bucket-name", "global-docs",
+                    "camunda.document.aws.other-store.bucket-name", "other-docs",
+                    "camunda.physical-tenants.tenanta.document.assigned[0]", "other-store")));
+
+    // when
+    final Document doc =
+        PhysicalTenantDocumentConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then only other-store survives; shared-s3 is dropped along with the default-store-id
+    assertThat(doc.getAws()).containsKey("other-store");
+    assertThat(doc.getAws()).doesNotContainKey("shared-s3");
+    assertThat(doc.getDefaultStoreId()).isNullOrEmpty();
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
@@ -144,6 +144,7 @@ class PhysicalTenantResolverTest {
             "camunda.document.aws.aws1.bucket-name", "root-bucket",
             "camunda.data.secondary-storage.elasticsearch.index-prefix", "default",
             "camunda.physical-tenants.tenanta.document.aws.aws1.bucket-name", "tenant-bucket",
+            "camunda.physical-tenants.tenanta.document.assigned[0]", "aws1",
             "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
                 "tenanta"),
         "tenanta");

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -227,6 +227,7 @@ data.secondary-storage.retention
 data.secondary-storage.type
 data.snapshot-period
 data.wait-states.enabled
+document.assigned
 document.default-store-id
 document.thread-pool-size
 expression.timeout

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -227,7 +227,6 @@ data.secondary-storage.retention
 data.secondary-storage.type
 data.snapshot-period
 data.wait-states.enabled
-document.assigned
 document.default-store-id
 document.thread-pool-size
 expression.timeout

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -75,7 +75,10 @@ public final class CamundaDocumentStoreConfigurationLoader
       final Map<String, DocumentStoreConfigurationRecord> storesById,
       final BiFunction<String, T, DocumentStoreConfigurationRecord> factory) {
     storeConfigs.forEach(
-        (id, store) -> storesById.put(id.toLowerCase(), factory.apply(id.toLowerCase(), store)));
+        (id, store) -> {
+          final String normalizedId = Document.normalizeStoreId(id);
+          storesById.put(normalizedId, factory.apply(normalizedId, store));
+        });
   }
 
   private DocumentStoreConfigurationRecord toAwsStore(


### PR DESCRIPTION
## Description

- documents bind root config and per physical tenant overlay
- added Validation
   - `DocumentStoreIsolationValidation`
     - No two physical tenants share the same document store location (provider, bucket/container, path)
     - Implicit inheritance counts — a tenant that omits overrides collides with default
     - In-memory stores are not location-comparable (excluded)
  - `PhysicalTenantDocumentAssignedValidation`
     - Every non-default tenant with document stores must explicitly opt in via document.assigned
     - Every id in assigned must exist in the tenant's resolved store catalog
     - assigned entries must be non-blank
- Added UT that covers these scenarios 

---

## Manually tested the following scenarios
- physical tenant configuration present, document overlay -- doc configuration ([ref](https://docs.google.com/document/d/1hLdPXbKNZvijRxwFn-N1QUW8pAMXX4vZtrrnpAr9TGM/edit?tab=t.tl54tsmcckua#heading=h.xp6crmj0r5wj))
- plain UC, default physical tenant
- plain legacy document configuration
- legacy mixed with UC

---

## Acceptance Criteria -- Per tenant document store services 
- [x] Each tenant's `DocumentServices` is backed by a registry built from that tenant's `camunda.document.*`
- [x] Global `EnvironmentConfigurationLoader` is no longer used for per-tenant store resolution
- [x] Each tenant retains its own registry/executor
- [x] Single-tenant deployments (`default` only) are unchanged

## Acceptance Criteria -- Cross tenant validation
- [x] Startup fails with a descriptive error naming the conflicting tenants when two tenants resolve to the same `(provider, bucket/container, path)` tuple
- [x] A tenant omitting `camunda.document.*` override that would inherit the root location triggers the collision error
- [x] Single-tenant deployments (`default` only) do not trigger the validator
- [x] Unit tests cover: no collision (passes), direct collision, implicit inheritance collision

## Related issues

closes #55170
closes #55171