### PR TITLE
[SPIKE — do not merge] Slice 2 gRPC PT auth: validate the #55751–#55755 breakdown

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -76,6 +76,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final org.springframework.core.env.Environment environment;
   private final io.camunda.service.registry.ServiceRegistry serviceRegistry;
   private final io.camunda.security.spring.oidc.ScopedJwtDecoderFactory scopedJwtDecoderFactory;
+  private final io.camunda.security.spring.oidc.ScopedOidcClaimsProviderFactory
+      scopedOidcClaimsProviderFactory;
 
   private Broker broker;
 
@@ -102,10 +104,14 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       @Autowired(required = false)
           final io.camunda.service.registry.ServiceRegistry serviceRegistry,
       @Autowired(required = false)
-          final io.camunda.security.spring.oidc.ScopedJwtDecoderFactory scopedJwtDecoderFactory) {
+          final io.camunda.security.spring.oidc.ScopedJwtDecoderFactory scopedJwtDecoderFactory,
+      @Autowired(required = false)
+          final io.camunda.security.spring.oidc.ScopedOidcClaimsProviderFactory
+              scopedOidcClaimsProviderFactory) {
     this.environment = environment;
     this.serviceRegistry = serviceRegistry;
     this.scopedJwtDecoderFactory = scopedJwtDecoderFactory;
+    this.scopedOidcClaimsProviderFactory = scopedOidcClaimsProviderFactory;
     this.configuration = configuration;
     this.identityConfiguration = identityConfiguration;
     this.springBrokerBridge = springBrokerBridge;
@@ -186,10 +192,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     return broker;
   }
 
-  /**
-   * #55755 spike: identical to GatewayModuleConfiguration#buildPtHandlerRegistry (see #55752 stub
-   * note).
-   */
+  /** #55755 spike: identical to GatewayModuleConfiguration#buildPtHandlerRegistry. */
   private java.util.Map<String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
       buildPtHandlerRegistry() {
     final java.util.Map<String, io.camunda.security.api.model.config.AuthenticationConfiguration>
@@ -198,17 +201,11 @@ public class BrokerModuleConfiguration implements CloseableSilently {
                 environment);
     final boolean authEnabled = !engineSecurityConfig.getAuthentication().isUnprotectedApi();
 
-    // STUB for #55752 — replace with CSL ScopedOidcClaimsProviderFactory.
-    final java.util.function.Function<
-            io.camunda.security.api.model.config.AuthenticationConfiguration,
-            io.camunda.security.api.context.OidcClaimsProvider>
-        claimsProviderFactory = cfg -> (jwtClaims, tokenValue) -> jwtClaims;
-
     return io.camunda.zeebe.gateway.interceptors.impl.PhysicalTenantHandlerRegistry.build(
         authConfigsByTenantId,
         authEnabled,
         cfg -> scopedJwtDecoderFactory.buildIssuerAwareDecoder(cfg),
-        claimsProviderFactory,
+        scopedOidcClaimsProviderFactory::buildClaimsProvider,
         ptId -> serviceRegistry.userServices(ptId),
         passwordEncoder);
   }

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -72,6 +72,11 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final NodeIdProvider nodeIdProvider;
   private final PhysicalTenantIds physicalTenantIds;
 
+  // #55755 (spike): per-PT handler registry build inputs for the embedded gateway path.
+  private final org.springframework.core.env.Environment environment;
+  private final io.camunda.service.registry.ServiceRegistry serviceRegistry;
+  private final io.camunda.security.spring.oidc.ScopedJwtDecoderFactory scopedJwtDecoderFactory;
+
   private Broker broker;
 
   @Autowired
@@ -92,7 +97,15 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final OidcClaimsProvider oidcClaimsProvider,
       @Autowired(required = false) final SearchClientsProxy searchClientsProxy,
       final NodeIdProvider nodeIdProvider,
-      final PhysicalTenantIds physicalTenantIds) {
+      final PhysicalTenantIds physicalTenantIds,
+      final org.springframework.core.env.Environment environment,
+      @Autowired(required = false)
+          final io.camunda.service.registry.ServiceRegistry serviceRegistry,
+      @Autowired(required = false)
+          final io.camunda.security.spring.oidc.ScopedJwtDecoderFactory scopedJwtDecoderFactory) {
+    this.environment = environment;
+    this.serviceRegistry = serviceRegistry;
+    this.scopedJwtDecoderFactory = scopedJwtDecoderFactory;
     this.configuration = configuration;
     this.identityConfiguration = identityConfiguration;
     this.springBrokerBridge = springBrokerBridge;
@@ -132,6 +145,14 @@ public class BrokerModuleConfiguration implements CloseableSilently {
 
   @Bean(destroyMethod = "close")
   public Broker broker(final ExporterRepository exporterRepository) {
+    // #55755 (spike): build the per-PT handler registry here (Spring has Environment,
+    // ServiceRegistry,
+    // ScopedJwtDecoderFactory, passwordEncoder) and thread it through SystemContext to the embedded
+    // Gateway. This proves the SAME registry reaches both construction sites without a fat shared
+    // change — the standalone path (GatewayModuleConfiguration) builds it identically.
+    final java.util.Map<String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
+        ptHandlerRegistry = buildPtHandlerRegistry();
+
     final SystemContext systemContext =
         new SystemContext(
             configuration.shutdownTimeout(),
@@ -149,7 +170,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             searchClientsProxy,
             new BrokerRequestAuthorizationConverter(engineSecurityConfig),
             nodeIdProvider,
-            physicalTenantIds);
+            physicalTenantIds,
+            ptHandlerRegistry);
     springBrokerBridge.registerShutdownHelper(
         (errorCode, reason) -> shutdownHelper.initiateShutdown(errorCode, reason));
     broker =
@@ -162,6 +184,33 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     startBroker();
 
     return broker;
+  }
+
+  /**
+   * #55755 spike: identical to GatewayModuleConfiguration#buildPtHandlerRegistry (see #55752 stub
+   * note).
+   */
+  private java.util.Map<String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
+      buildPtHandlerRegistry() {
+    final java.util.Map<String, io.camunda.security.api.model.config.AuthenticationConfiguration>
+        authConfigsByTenantId =
+            io.camunda.authentication.pt.PhysicalTenantAuthConfigurations.forAllPhysicalTenants(
+                environment);
+    final boolean authEnabled = !engineSecurityConfig.getAuthentication().isUnprotectedApi();
+
+    // STUB for #55752 — replace with CSL ScopedOidcClaimsProviderFactory.
+    final java.util.function.Function<
+            io.camunda.security.api.model.config.AuthenticationConfiguration,
+            io.camunda.security.api.context.OidcClaimsProvider>
+        claimsProviderFactory = cfg -> (jwtClaims, tokenValue) -> jwtClaims;
+
+    return io.camunda.zeebe.gateway.interceptors.impl.PhysicalTenantHandlerRegistry.build(
+        authConfigsByTenantId,
+        authEnabled,
+        cfg -> scopedJwtDecoderFactory.buildIssuerAwareDecoder(cfg),
+        claimsProviderFactory,
+        ptId -> serviceRegistry.userServices(ptId),
+        passwordEncoder);
   }
 
   protected void startBroker() {

--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
@@ -9,20 +9,27 @@ package io.camunda.zeebe.gateway;
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.GatewayBasedConfiguration;
+import io.camunda.authentication.pt.PhysicalTenantAuthConfigurations;
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.security.api.context.OidcClaimsProvider;
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.security.spring.oidc.ScopedJwtDecoderFactory;
 import io.camunda.service.UserServices;
+import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler;
+import io.camunda.zeebe.gateway.interceptors.impl.PhysicalTenantHandlerRegistry;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +40,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
@@ -68,6 +76,11 @@ public class GatewayModuleConfiguration implements CloseableSilently {
   private final int maxVariableNameLength;
   private final PhysicalTenantIds physicalTenantIds;
 
+  // #55754/#55752 (spike) wiring inputs for the per-PT handler registry.
+  private final Environment environment;
+  private final ServiceRegistry serviceRegistry;
+  private final ScopedJwtDecoderFactory scopedJwtDecoderFactory;
+
   private Gateway gateway;
 
   @Autowired
@@ -85,7 +98,13 @@ public class GatewayModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final OidcClaimsProvider oidcClaimsProvider,
       final MeterRegistry meterRegistry,
       final GatewayRestConfiguration gatewayRestConfiguration,
-      final PhysicalTenantIds physicalTenantIds) {
+      final PhysicalTenantIds physicalTenantIds,
+      final Environment environment,
+      @Autowired(required = false) final ServiceRegistry serviceRegistry,
+      @Autowired(required = false) final ScopedJwtDecoderFactory scopedJwtDecoderFactory) {
+    this.environment = environment;
+    this.serviceRegistry = serviceRegistry;
+    this.scopedJwtDecoderFactory = scopedJwtDecoderFactory;
     this.configuration = configuration;
     this.engineSecurityConfig =
         new EngineSecurityConfig(
@@ -126,6 +145,10 @@ public class GatewayModuleConfiguration implements CloseableSilently {
     // topology to be set up, otherwise the callback may be lost
     brokerClient.getTopologyManager().addTopologyListener(jobStreamClient);
 
+    // #55753/#55754 (spike): build the per-PT AuthenticationHandler registry and use the additive
+    // Gateway ctor. The registry covers every PT id from forAllPhysicalTenants (incl. default).
+    final Map<String, AuthenticationHandler> ptHandlerRegistry = buildPtHandlerRegistry();
+
     gateway =
         new Gateway(
             configuration.shutdownTimeout(),
@@ -134,13 +157,10 @@ public class GatewayModuleConfiguration implements CloseableSilently {
             brokerClient,
             actorScheduler,
             jobStreamClient.streamer(),
-            userServices,
-            passwordEncoder,
-            jwtDecoder,
-            oidcClaimsProvider,
             meterRegistry,
             maxVariableNameLength,
-            physicalTenantIds);
+            physicalTenantIds,
+            ptHandlerRegistry);
     springGatewayBridge.registerGatewayStatusSupplier(gateway::getStatus);
     springGatewayBridge.registerClusterStateSupplier(
         () ->
@@ -154,6 +174,34 @@ public class GatewayModuleConfiguration implements CloseableSilently {
     LOGGER.info("Standalone gateway is started!");
 
     return gateway;
+  }
+
+  /**
+   * #55753 spike: build the per-PT {@link AuthenticationHandler} registry from the per-PT auth
+   * config map (#55751). OIDC decoders come from the CSL {@link ScopedJwtDecoderFactory}; BASIC
+   * user services from the {@link ServiceRegistry}.
+   *
+   * <p>STUB: the per-PT {@link OidcClaimsProvider} factory does not exist in CSL yet (#55752 —
+   * needs a new ScopedOidcClaimsProviderFactory). Here we fall back to the JWT-only no-op claims
+   * provider so the seam compiles. The real implementation MUST replace this with a per-PT,
+   * userinfo-aware provider built from the PT's AuthenticationConfiguration.
+   */
+  private Map<String, AuthenticationHandler> buildPtHandlerRegistry() {
+    final Map<String, AuthenticationConfiguration> authConfigsByTenantId =
+        PhysicalTenantAuthConfigurations.forAllPhysicalTenants(environment);
+    final boolean authEnabled = !engineSecurityConfig.getAuthentication().isUnprotectedApi();
+
+    // STUB for #55752 — replace with CSL ScopedOidcClaimsProviderFactory.buildClaimsProvider(cfg).
+    final java.util.function.Function<AuthenticationConfiguration, OidcClaimsProvider>
+        claimsProviderFactory = cfg -> (jwtClaims, tokenValue) -> jwtClaims;
+
+    return PhysicalTenantHandlerRegistry.build(
+        authConfigsByTenantId,
+        authEnabled,
+        cfg -> scopedJwtDecoderFactory.buildIssuerAwareDecoder(cfg),
+        claimsProviderFactory,
+        ptId -> serviceRegistry.userServices(ptId),
+        passwordEncoder);
   }
 
   @Override

--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
@@ -16,6 +16,7 @@ import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.spring.oidc.ScopedJwtDecoderFactory;
+import io.camunda.security.spring.oidc.ScopedOidcClaimsProviderFactory;
 import io.camunda.service.UserServices;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -80,6 +81,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
   private final Environment environment;
   private final ServiceRegistry serviceRegistry;
   private final ScopedJwtDecoderFactory scopedJwtDecoderFactory;
+  private final ScopedOidcClaimsProviderFactory scopedOidcClaimsProviderFactory;
 
   private Gateway gateway;
 
@@ -101,10 +103,13 @@ public class GatewayModuleConfiguration implements CloseableSilently {
       final PhysicalTenantIds physicalTenantIds,
       final Environment environment,
       @Autowired(required = false) final ServiceRegistry serviceRegistry,
-      @Autowired(required = false) final ScopedJwtDecoderFactory scopedJwtDecoderFactory) {
+      @Autowired(required = false) final ScopedJwtDecoderFactory scopedJwtDecoderFactory,
+      @Autowired(required = false)
+          final ScopedOidcClaimsProviderFactory scopedOidcClaimsProviderFactory) {
     this.environment = environment;
     this.serviceRegistry = serviceRegistry;
     this.scopedJwtDecoderFactory = scopedJwtDecoderFactory;
+    this.scopedOidcClaimsProviderFactory = scopedOidcClaimsProviderFactory;
     this.configuration = configuration;
     this.engineSecurityConfig =
         new EngineSecurityConfig(
@@ -178,28 +183,20 @@ public class GatewayModuleConfiguration implements CloseableSilently {
 
   /**
    * #55753 spike: build the per-PT {@link AuthenticationHandler} registry from the per-PT auth
-   * config map (#55751). OIDC decoders come from the CSL {@link ScopedJwtDecoderFactory}; BASIC
+   * config map (#55751). OIDC decoders come from the CSL {@link ScopedJwtDecoderFactory}; per-PT
+   * {@link OidcClaimsProvider}s from the CSL {@link ScopedOidcClaimsProviderFactory} (#55752); BASIC
    * user services from the {@link ServiceRegistry}.
-   *
-   * <p>STUB: the per-PT {@link OidcClaimsProvider} factory does not exist in CSL yet (#55752 —
-   * needs a new ScopedOidcClaimsProviderFactory). Here we fall back to the JWT-only no-op claims
-   * provider so the seam compiles. The real implementation MUST replace this with a per-PT,
-   * userinfo-aware provider built from the PT's AuthenticationConfiguration.
    */
   private Map<String, AuthenticationHandler> buildPtHandlerRegistry() {
     final Map<String, AuthenticationConfiguration> authConfigsByTenantId =
         PhysicalTenantAuthConfigurations.forAllPhysicalTenants(environment);
     final boolean authEnabled = !engineSecurityConfig.getAuthentication().isUnprotectedApi();
 
-    // STUB for #55752 — replace with CSL ScopedOidcClaimsProviderFactory.buildClaimsProvider(cfg).
-    final java.util.function.Function<AuthenticationConfiguration, OidcClaimsProvider>
-        claimsProviderFactory = cfg -> (jwtClaims, tokenValue) -> jwtClaims;
-
     return PhysicalTenantHandlerRegistry.build(
         authConfigsByTenantId,
         authEnabled,
         cfg -> scopedJwtDecoderFactory.buildIssuerAwareDecoder(cfg),
-        claimsProviderFactory,
+        scopedOidcClaimsProviderFactory::buildClaimsProvider,
         ptId -> serviceRegistry.userServices(ptId),
         passwordEncoder);
   }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-SNAPSHOT</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha35</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha34</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-SNAPSHOT</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -95,7 +95,8 @@ public final class Broker implements AutoCloseable {
             systemContext.getSearchClientsProxy(),
             systemContext.getBrokerRequestAuthorizationConverter(),
             systemContext.getNodeIdProvider(),
-            systemContext.getPhysicalTenantIds());
+            systemContext.getPhysicalTenantIds(),
+            systemContext.getPtHandlerRegistry());
 
     brokerStartupActor = new BrokerStartupActor(startupContext);
     scheduler.submitActor(brokerStartupActor);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -154,6 +154,9 @@ public interface BrokerStartupContext {
 
   OidcClaimsProvider getOidcClaimsProvider();
 
+  java.util.Map<String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
+      getPtHandlerRegistry();
+
   SnapshotApiRequestHandler getSnapshotApiRequestHandler();
 
   void setSnapshotApiRequestHandler(SnapshotApiRequestHandler snapshotApiRequestHandler);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -76,6 +76,9 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final SearchClientsProxy searchClientsProxy;
   private final NodeIdProvider nodeIdProvider;
   private final PhysicalTenantIds physicalTenantIds;
+  private final java.util.Map<
+          String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
+      ptHandlerRegistry;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   private ConcurrencyControl concurrencyControl;
@@ -114,8 +117,11 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final NodeIdProvider nodeIdProvider,
-      final PhysicalTenantIds physicalTenantIds) {
+      final PhysicalTenantIds physicalTenantIds,
+      final java.util.Map<String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
+          ptHandlerRegistry) {
 
+    this.ptHandlerRegistry = ptHandlerRegistry;
     this.brokerInfo = requireNonNull(brokerInfo);
     this.configuration = requireNonNull(configuration);
     this.springBrokerBridge = requireNonNull(springBrokerBridge);
@@ -383,6 +389,12 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public OidcClaimsProvider getOidcClaimsProvider() {
     return oidcClaimsProvider;
+  }
+
+  @Override
+  public java.util.Map<String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
+      getPtHandlerRegistry() {
+    return ptHandlerRegistry;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -51,7 +51,8 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
             brokerStartupContext.getJwtDecoder(),
             brokerStartupContext.getOidcClaimsProvider(),
             brokerStartupContext.getMeterRegistry(),
-            brokerStartupContext.getPhysicalTenantIds());
+            brokerStartupContext.getPhysicalTenantIds(),
+            brokerStartupContext.getPtHandlerRegistry());
 
     final var embeddedGatewayServiceFuture = embeddedGatewayService.start();
     concurrencyControl.runOnCompletion(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -44,10 +44,15 @@ public final class EmbeddedGatewayService implements AutoCloseable {
       final JwtDecoder jwtDecoder,
       final OidcClaimsProvider oidcClaimsProvider,
       final MeterRegistry meterRegistry,
-      final PhysicalTenantIds physicalTenantIds) {
+      final PhysicalTenantIds physicalTenantIds,
+      final java.util.Map<String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
+          ptHandlerRegistry) {
     this.concurrencyControl = concurrencyControl;
     this.brokerClient = brokerClient;
     this.jobStreamClient = jobStreamClient;
+    // #55755 (spike): embedded path uses the additive registry-based Gateway ctor. The legacy
+    // single-tenant deps (userServices/passwordEncoder/jwtDecoder/oidcClaimsProvider) are no longer
+    // passed here — the handlers in the registry carry them per-PT.
     gateway =
         new Gateway(
             shutdownTimeout,
@@ -56,13 +61,10 @@ public final class EmbeddedGatewayService implements AutoCloseable {
             brokerClient,
             actorScheduler,
             jobStreamClient.streamer(),
-            userServices,
-            passwordEncoder,
-            jwtDecoder,
-            oidcClaimsProvider,
             meterRegistry,
             configuration.getExperimental().getEngine().getValidators().getMaxNameFieldLength(),
-            physicalTenantIds);
+            physicalTenantIds,
+            ptHandlerRegistry);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -139,6 +139,9 @@ public final class SystemContext {
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
   private final NodeIdProvider nodeIdProvider;
   private final PhysicalTenantIds physicalTenantIds;
+  private final java.util.Map<
+          String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
+      ptHandlerRegistry;
   private final GlobalListenerValidator globalListenerValidator;
 
   public SystemContext(
@@ -157,7 +160,10 @@ public final class SystemContext {
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final NodeIdProvider nodeIdProvider,
-      final PhysicalTenantIds physicalTenantIds) {
+      final PhysicalTenantIds physicalTenantIds,
+      final java.util.Map<String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
+          ptHandlerRegistry) {
+    this.ptHandlerRegistry = ptHandlerRegistry;
     this.shutdownTimeout = shutdownTimeout;
     this.brokerCfg = brokerCfg;
     this.identityConfiguration = identityConfiguration;
@@ -735,6 +741,11 @@ public final class SystemContext {
 
   public NodeIdProvider getNodeIdProvider() {
     return nodeIdProvider;
+  }
+
+  public java.util.Map<String, io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler>
+      getPtHandlerRegistry() {
+    return ptHandlerRegistry;
   }
 
   public PhysicalTenantIds getPhysicalTenantIds() {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationMetrics;
 import io.camunda.zeebe.gateway.interceptors.impl.ContextInjectingInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.DecoratedInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.InterceptorRepository;
+import io.camunda.zeebe.gateway.interceptors.impl.PhysicalTenantAuthInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.PhysicalTenantInterceptor;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc;
@@ -66,6 +67,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -108,6 +110,11 @@ public final class Gateway implements CloseableSilently {
   private final MeterRegistry meterRegistry;
   private final int maxVariableNameLength;
   private final PhysicalTenantIds physicalTenantIds;
+
+  // #55754 (spike): per-PT handler registry. When non-null, the merged PT-aware interceptor is used
+  // instead of the legacy PhysicalTenantInterceptor + AuthenticationInterceptor pair. Additive so
+  // the legacy ctor path still works until #55755 deletes it.
+  private final Map<String, AuthenticationHandler> ptHandlerRegistry;
 
   @VisibleForTesting
   public Gateway(
@@ -163,6 +170,45 @@ public final class Gateway implements CloseableSilently {
     this.meterRegistry = meterRegistry;
     this.maxVariableNameLength = maxVariableNameLength;
     this.physicalTenantIds = physicalTenantIds;
+    ptHandlerRegistry = null;
+
+    healthManager = new GatewayHealthManagerImpl();
+  }
+
+  /**
+   * Additive constructor (#55754, spike) that takes a pre-built per-PT {@link
+   * AuthenticationHandler} registry (#55753). When present, the gateway uses the merged {@link
+   * PhysicalTenantAuthInterceptor} for both PT-id stamping and authentication, dropping the legacy
+   * standalone {@link PhysicalTenantInterceptor}. The legacy decoder / claimsProvider /
+   * userServices args are no longer needed on this path (they are baked into the handlers in the
+   * registry).
+   */
+  public Gateway(
+      final Duration shutdownDuration,
+      final GatewayCfg gatewayCfg,
+      final EngineSecurityConfig securityConfiguration,
+      final BrokerClient brokerClient,
+      final ActorSchedulingService actorSchedulingService,
+      final ClientStreamer<JobActivationProperties> jobStreamer,
+      final MeterRegistry meterRegistry,
+      final int maxVariableNameLength,
+      final PhysicalTenantIds physicalTenantIds,
+      final Map<String, AuthenticationHandler> ptHandlerRegistry) {
+    shutdownTimeout = shutdownDuration;
+    this.gatewayCfg = gatewayCfg;
+    this.securityConfiguration = securityConfiguration;
+    this.brokerClient = brokerClient;
+    this.actorSchedulingService = actorSchedulingService;
+    this.jobStreamer = jobStreamer;
+    // Legacy single-tenant auth deps are unused on the registry path; null them out.
+    userServices = null;
+    passwordEncoder = null;
+    jwtDecoder = null;
+    oidcClaimsProvider = (jwtClaims, tokenValue) -> jwtClaims;
+    this.meterRegistry = meterRegistry;
+    this.maxVariableNameLength = maxVariableNameLength;
+    this.physicalTenantIds = physicalTenantIds;
+    this.ptHandlerRegistry = Objects.requireNonNull(ptHandlerRegistry);
 
     healthManager = new GatewayHealthManagerImpl();
   }
@@ -431,18 +477,32 @@ public final class Gateway implements CloseableSilently {
     // chain
     Collections.reverse(interceptors);
     interceptors.add(new ContextInjectingInterceptor(queryApi));
-    interceptors.add(new PhysicalTenantInterceptor(physicalTenantIds));
 
-    if (!securityConfiguration.getAuthentication().isUnprotectedApi()) {
-      final var authMethod = securityConfiguration.getAuthentication().getMethod();
+    final var authConfig = securityConfiguration.getAuthentication();
+    final var authEnabled = !authConfig.isUnprotectedApi();
+
+    if (ptHandlerRegistry != null) {
+      // #55754 path: merged PT-aware interceptor (stamp + authenticate). Drops the standalone
+      // PhysicalTenantInterceptor below.
+      interceptors.add(
+          new PhysicalTenantAuthInterceptor(
+              physicalTenantIds.known(),
+              ptHandlerRegistry,
+              authEnabled,
+              new AuthenticationMetrics(meterRegistry, authConfig.getMethod())));
+      return ServerInterceptors.intercept(service, interceptors);
+    }
+
+    // Legacy single-tenant path (kept additive until #55755).
+    interceptors.add(new PhysicalTenantInterceptor(physicalTenantIds));
+    if (authEnabled) {
+      final var authMethod = authConfig.getMethod();
       final var handler =
           switch (authMethod) {
             case BASIC -> basicAuth();
             case OIDC ->
                 new AuthenticationHandler.Oidc(
-                    jwtDecoder,
-                    oidcClaimsProvider,
-                    securityConfiguration.getAuthentication().getOidc());
+                    jwtDecoder, oidcClaimsProvider, authConfig.getOidc());
           };
       interceptors.add(
           new AuthenticationInterceptor(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/PhysicalTenantAuthInterceptor.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/PhysicalTenantAuthInterceptor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.camunda.zeebe.gateway.protocol.GrpcHeaders;
+import io.camunda.zeebe.util.Either.Left;
+import io.camunda.zeebe.util.Either.Right;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Merged physical-tenant + authentication interceptor (#55754).
+ *
+ * <p>Reads the {@code Camunda-Physical-Tenant} header once, stamps the resolved id into the gRPC
+ * {@link Context} (consumed downstream by {@code EndpointManager} for partition-group routing),
+ * then selects the per-PT {@link AuthenticationHandler} from the registry and authenticates — but
+ * ONLY when the API is not unprotected. Stamp happens for every call including unprotected ones.
+ *
+ * <p>Fail-fast at registry build time (see {@code PhysicalTenantHandlerRegistry}) ensures every
+ * known PT id is represented; unknown ids are rejected at request time with {@link
+ * Status#NOT_FOUND}.
+ */
+public final class PhysicalTenantAuthInterceptor implements ServerInterceptor {
+
+  private static final Metadata.Key<String> AUTH_KEY =
+      Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+
+  private final Set<String> knownTenantIds;
+  private final Map<String, AuthenticationHandler> handlersByTenantId;
+  private final boolean authEnabled;
+  private final AuthenticationMetrics metrics;
+
+  public PhysicalTenantAuthInterceptor(
+      final Set<String> knownTenantIds,
+      final Map<String, AuthenticationHandler> handlersByTenantId,
+      final boolean authEnabled,
+      final AuthenticationMetrics metrics) {
+    this.knownTenantIds = Set.copyOf(knownTenantIds);
+    this.handlersByTenantId = Map.copyOf(handlersByTenantId);
+    this.authEnabled = authEnabled;
+    this.metrics = metrics;
+  }
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      final ServerCall<ReqT, RespT> call,
+      final Metadata headers,
+      final ServerCallHandler<ReqT, RespT> next) {
+
+    // --- Step 1: resolve + stamp physical tenant id (always, even for unprotected calls) ---
+    final var tenantHeaderValue = headers.get(GrpcHeaders.PHYSICAL_TENANT);
+    final var tenantId = tenantHeaderValue != null ? tenantHeaderValue : DEFAULT_PHYSICAL_TENANT_ID;
+
+    if (!knownTenantIds.contains(tenantId)) {
+      call.close(
+          Status.NOT_FOUND.withDescription("Unknown physical tenant: " + tenantId), new Metadata());
+      return new ServerCall.Listener<>() {};
+    }
+
+    final Context contextWithTenant =
+        Context.current().withValue(InterceptorUtil.getPhysicalTenantIdKey(), tenantId);
+
+    // --- Step 2: authenticate (only for protected APIs) ---
+    if (!authEnabled) {
+      return Contexts.interceptCall(contextWithTenant, call, headers, next);
+    }
+
+    final var authorization = headers.get(AUTH_KEY);
+    if (authorization == null) {
+      call.close(
+          Status.UNAUTHENTICATED.augmentDescription(
+              "Expected authentication information at header with key [%s], but found nothing"
+                  .formatted(AUTH_KEY.name())),
+          new Metadata());
+      return new ServerCall.Listener<>() {};
+    }
+
+    final var latencyTimer = metrics.startLatencySample();
+    final var handler = handlersByTenantId.get(tenantId);
+    return switch (handler.authenticate(authorization)) {
+      case Left<Status, Context>(final var status) -> {
+        metrics.recordFailureLatency(latencyTimer);
+        call.close(status, new Metadata());
+        yield new ServerCall.Listener<>() {};
+      }
+      case Right<Status, Context>(final var authContext) -> {
+        metrics.recordSuccessLatency(latencyTimer);
+        // Merge PT tenant stamp with the auth context values produced by the handler
+        final var merged =
+            authContext.withValue(InterceptorUtil.getPhysicalTenantIdKey(), tenantId);
+        yield Contexts.interceptCall(merged, call, headers, next);
+      }
+    };
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/PhysicalTenantHandlerRegistry.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/PhysicalTenantHandlerRegistry.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import io.camunda.security.api.context.OidcClaimsProvider;
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.service.UserServices;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+/**
+ * Gateway-side registry of per-physical-tenant {@link AuthenticationHandler}s (#55753).
+ *
+ * <p>Built from the per-PT {@link AuthenticationConfiguration} map produced by {@code
+ * PhysicalTenantAuthConfigurations.forAllPhysicalTenants(Environment)} (#55751). Lives in the
+ * gateway module because {@link AuthenticationHandler} is a gateway-grpc type — the authentication
+ * module must not depend on gateway-grpc.
+ *
+ * <p>Fail-fast: any PT handler build failure (including {@code default}) throws, failing startup.
+ * No log-and-skip.
+ *
+ * <p>The OIDC and BASIC factory functions are injected so the caller (the standalone {@code
+ * GatewayModuleConfiguration} or the embedded broker path) supplies the per-PT decoder /
+ * claims-provider / user-services lookups it has access to.
+ */
+public final class PhysicalTenantHandlerRegistry {
+
+  private PhysicalTenantHandlerRegistry() {}
+
+  /**
+   * @param authConfigsByTenantId per-PT merged auth config (from #55751)
+   * @param authEnabled whether the (cluster-global) API is protected
+   * @param decoderFactory PT id + config -> JwtDecoder (CSL ScopedJwtDecoderFactory in real impl)
+   * @param claimsProviderFactory PT id + config -> OidcClaimsProvider (NEW CSL factory in real impl
+   *     — see #55752; stubbed in the spike)
+   * @param userServicesForTenant PT id -> UserServices (ServiceRegistry.userServices(ptId))
+   * @param passwordEncoder shared password encoder for BASIC
+   */
+  public static Map<String, AuthenticationHandler> build(
+      final Map<String, AuthenticationConfiguration> authConfigsByTenantId,
+      final boolean authEnabled,
+      final Function<AuthenticationConfiguration, JwtDecoder> decoderFactory,
+      final Function<AuthenticationConfiguration, OidcClaimsProvider> claimsProviderFactory,
+      final Function<String, UserServices> userServicesForTenant,
+      final PasswordEncoder passwordEncoder) {
+
+    final Map<String, AuthenticationHandler> registry = new LinkedHashMap<>();
+
+    if (!authEnabled) {
+      // Unprotected: no handlers needed. The interceptor validates PT ids against the known-ids
+      // set (the authConfigsByTenantId key set), not against this map.
+      return registry;
+    }
+
+    authConfigsByTenantId.forEach(
+        (tenantId, authConfig) -> {
+          final AuthenticationHandler handler;
+          // Auth method is cluster-global; we read it off each PT's merged config (it is
+          // re-asserted from root per #55751, so all PTs carry the same method).
+          final var method = authConfig.getMethod();
+          try {
+            handler =
+                switch (method) {
+                  case OIDC ->
+                      new AuthenticationHandler.Oidc(
+                          decoderFactory.apply(authConfig),
+                          claimsProviderFactory.apply(authConfig),
+                          authConfig.getOidc());
+                  case BASIC ->
+                      new AuthenticationHandler.BasicAuth(
+                          userServicesForTenant.apply(tenantId), passwordEncoder);
+                };
+          } catch (final Exception e) {
+            // Fail-fast: a single PT (incl. default) failing fails startup.
+            throw new IllegalStateException(
+                "Failed to build AuthenticationHandler for physical tenant '" + tenantId + "'", e);
+          }
+          registry.put(tenantId, handler);
+        });
+
+    return registry;
+  }
+}


### PR DESCRIPTION
## ⚠️ Throwaway spike — NOT for merge

This is a quick'n'dirty end-to-end spike for **Slice 2 (gRPC)** of Physical Tenants Identity (parent #54896), opened to make the integration findings concrete and reviewable. It will be **closed, not merged**. CI will be red on purpose (tests not updated; see below). Based on the #55751 branch (PR #55758), so the diff shows only the spike delta.

**Goal:** the five planned sub-issues (#55751–#55755) are individually well-scoped — this validates that the pieces actually *fit together* when wired as one path. Wires a single OIDC PT bearer-token gRPC call end-to-end: per-PT config → claims provider → per-PT `AuthenticationHandler` registry → merged PT-aware interceptor → both gateway construction sites.

**Main sources compile green** across `authentication`, `zeebe/gateway-grpc`, `zeebe/broker`, `dist`.

## Fit verdict

| Seam / issue | Verdict | Note |
|---|---|---|
| #55751 → #55753 | ✅ **HOLDS** | `forAllPhysicalTenants(env)` is a clean source; `default` always present, registry needs no special-casing. |
| #55752 per-PT `OidcClaimsProvider` | 🔴 **BLOCKED-ON-CSL** | Needs a **new CSL factory** — not monorepo code. See below. |
| #55753 gateway-side registry, fail-fast | ✅ **HOLDS** | `PhysicalTenantHandlerRegistry` in gateway-grpc (correct module); BASIC via `ServiceRegistry.userServices`, OIDC decoder via `ScopedJwtDecoderFactory.buildIssuerAwareDecoder` (both exist); fail-fast throws on any PT build failure incl. `default`. Only compiles today because the claims-provider arg is stubbed. |
| #55754 merged interceptor + additive `Gateway` ctor + standalone wiring | ✅ **HOLDS** | `PhysicalTenantAuthInterceptor` reads the header once, stamps the `Context` key `EndpointManager.getPhysicalTenantId()` consumes, gates auth on `isUnprotectedApi()`. Additive ctor; legacy retained; standalone site wired. |
| #55755 embedded broker path | 🟡 **ADJUST** | Reachable, but the chafing seam as predicted — threading touched **6 files** (`BrokerModuleConfiguration`→`SystemContext`→`Broker`→`BrokerStartupContext(+Impl)`→`EmbeddedGatewayServiceStep`→`EmbeddedGatewayService`→`Gateway`). Sound, but wider than one seam. |

## The big finding — #55752 needs a new CSL factory (verified)

`OidcClaimsProvider` is constructed today **only** in CSL's `OidcClaimsProviderConfiguration` (`camunda-security-library-spring-boot-starter`), via `new CachingOidcClaimsProvider(...)`. The issuer→userInfoUri map it needs is built by a **private** method keyed on a Spring `ClientRegistrationRepository`, not on an `AuthenticationConfiguration`. There is **no** existing CSL path from a bare `AuthenticationConfiguration` to an `OidcClaimsProvider`.

Verified against the CSL jars: `ScopedJwtDecoderFactory` ✅, `ScopedClientRegistrationFactory` ✅, `OidcClaimsProviderConfiguration` ✅ — but **no** scoped claims-provider factory exists.

➡️ **The clean fix is a new `ScopedOidcClaimsProviderFactory` in CSL** (paralleling `ScopedJwtDecoderFactory`): `OidcClaimsProvider buildClaimsProvider(AuthenticationConfiguration)`, reusing `ScopedClientRegistrationFactory` to build the issuer→userInfoUri map. In the spike it's stubbed as a JWT-only no-op so the seams compile. **This is the one place the real implementation hits a wall.**

## Recommended breakdown adjustments

1. **#55752 → CSL deliverable + version bump, not monorepo.** Re-scope as: (a) a CSL PR adding `ScopedOidcClaimsProviderFactory`, (b) a CSL release, (c) a monorepo CSL-version bump + wiring. The current ~300 LOC estimate is misattributed across repos. This is the chain's critical-path / long-lead item.
2. **Pull the registry builder into #55753 as a shared Spring bean.** `buildPtHandlerRegistry(...)` ended up duplicated verbatim in `GatewayModuleConfiguration` (#55754) and `BrokerModuleConfiguration` (#55755). If #55753 exposes `@Bean Map<String, AuthenticationHandler> ptHandlerRegistry(...)`, both sites just inject it.
3. **Reconsider the #55754/#55755 split.** If the registry is a shared bean (point 2), #55755 collapses from 6-file ctor-threading to "inject the bean at both sites" — much of the embedded plumbing disappears. The two may partially merge.

## LOC reality vs estimates
- #55752: ~30 LOC monorepo stub; the real ~300 LOC lives in **CSL**.
- #55753: registry class ~70 LOC; estimate fits only if it absorbs the shared bean + fail-fast tests.
- #55754: ~210 LOC production; 700 only with the interceptor/auth test rewrites (which are real).
- #55755: ~70 LOC plumbing; 450 only once broker test fixtures (`MockBrokerStartupContext`, `SystemContextTest`, `EmbeddedBrokerRule`) are updated.

## Stubbed/hacked (real-impl walls)
1. Claims provider — JWT-only no-op (the CSL blocker).
2. Additive `Gateway` ctor nulls the legacy single-tenant args on the registry path; legacy ctor + `PhysicalTenantInterceptor` to be deleted once #55755 lands.
3. `EmbeddedGatewayService` still accepts now-dead legacy args.
4. Test compile skipped — pre-existing unrelated stale-jar failure (`SupportedVersions.TEST_ELASTICSEARCH_VERSION`) + expected ctor-signature breaks in gateway/broker test fixtures.

Parent: #54896. Design: ADR-0006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)