### PR TITLE
feat: make rdbms database vendor id configurable per tenant

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -86,6 +86,14 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   @NestedConfigurationProperty
   private RdbmsConnectionPool connectionPool = new RdbmsConnectionPool();
 
+  /**
+   * The database vendor id. It is used to determine the dialect to use for the database. If not
+   * set, the dialect is determined automatically.
+   *
+   * <p>Supported values are: h2, postgresql, oracle, mariadb, mysql, mssql
+   */
+  private String databaseVendorId;
+
   public boolean getAutoDdl() {
     return autoDdl;
   }
@@ -228,5 +236,13 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
 
   public void setConnectionPool(final RdbmsConnectionPool connectionPool) {
     this.connectionPool = connectionPool;
+  }
+
+  public String getDatabaseVendorId() {
+    return databaseVendorId;
+  }
+
+  public void setDatabaseVendorId(final String databaseVendorId) {
+    this.databaseVendorId = databaseVendorId;
   }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -190,6 +190,7 @@ data.secondary-storage.rdbms.connection-pool.leak-detection-threshold
 data.secondary-storage.rdbms.connection-pool.max-lifetime
 data.secondary-storage.rdbms.connection-pool.maximum-pool-size
 data.secondary-storage.rdbms.connection-pool.minimum-idle
+data.secondary-storage.rdbms.database-vendor-id
 data.secondary-storage.rdbms.ddl-lock-wait-timeout
 data.secondary-storage.rdbms.export-batch-operation-items-on-creation
 data.secondary-storage.rdbms.flush-interval

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -33,7 +33,6 @@ import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
@@ -74,27 +73,16 @@ public class MyBatisConfiguration {
   }
 
   @Bean
-  public RdbmsDatabaseIdProvider databaseIdProvider(
-      @Value("${camunda.data.secondary-storage.rdbms.database-vendor-id:}") final String vendorId) {
-    return new RdbmsDatabaseIdProvider(vendorId);
-  }
-
-  @Bean
-  public RdbmsDataSources rdbmsDataSources(
-      final PhysicalTenantResolver physicalTenantResolver,
-      final RdbmsDatabaseIdProvider databaseIdProvider)
+  public RdbmsDataSources rdbmsDataSources(final PhysicalTenantResolver physicalTenantResolver)
       throws IOException {
     return RdbmsDataSources.of(
         physicalTenantResolver.mapValues(
-            camunda -> camunda.getData().getSecondaryStorage().getRdbms()),
-        databaseIdProvider);
+            camunda -> camunda.getData().getSecondaryStorage().getRdbms()));
   }
 
   @Bean
   public Map<String, SqlSessionFactory> sqlSessionFactories(
-      final RdbmsDataSources rdbmsDataSources,
-      final PhysicalTenantResolver physicalTenantResolver,
-      final DatabaseIdProvider databaseIdProvider)
+      final RdbmsDataSources rdbmsDataSources, final PhysicalTenantResolver physicalTenantResolver)
       throws Exception {
     final var factories = new LinkedHashMap<String, SqlSessionFactory>();
     for (final var tenantId : rdbmsDataSources.physicalTenantIds()) {
@@ -109,7 +97,7 @@ public class MyBatisConfiguration {
           tenantId,
           buildSqlSessionFactory(
               rdbmsDataSources.dataSourceFor(tenantId),
-              databaseIdProvider,
+              rdbmsDataSources.databaseIdProviderFor(tenantId),
               rdbmsDataSources.vendorPropertiesFor(tenantId),
               prefix));
     }

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDataSources.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDataSources.java
@@ -11,11 +11,13 @@ import com.zaxxer.hikari.HikariDataSource;
 import io.camunda.configuration.Rdbms;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.config.VendorDatabasePropertiesLoader;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.sql.DataSource;
+import org.apache.ibatis.mapping.DatabaseIdProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.jdbc.DatabaseDriver;
@@ -38,26 +40,30 @@ public final class RdbmsDataSources implements AutoCloseable {
 
   private final Map<String, HikariDataSource> dataSources;
   private final Map<String, VendorDatabaseProperties> vendorProperties;
+  private final Map<String, DatabaseIdProvider> databaseIdProviders;
 
   private RdbmsDataSources(
       final Map<String, HikariDataSource> dataSources,
-      final Map<String, VendorDatabaseProperties> vendorProperties) {
+      final Map<String, VendorDatabaseProperties> vendorProperties,
+      final Map<String, DatabaseIdProvider> databaseIdProviders) {
     this.dataSources = dataSources;
     this.vendorProperties = vendorProperties;
+    this.databaseIdProviders = databaseIdProviders;
   }
 
-  public static RdbmsDataSources of(
-      final Map<String, Rdbms> physicalTenantConfigs,
-      final RdbmsDatabaseIdProvider databaseIdProvider)
+  public static RdbmsDataSources of(final Map<String, Rdbms> physicalTenantConfigs)
       throws IOException {
     final var dataSources = new LinkedHashMap<String, HikariDataSource>();
     final var vendorProperties = new LinkedHashMap<String, VendorDatabaseProperties>();
+    final var databaseIdProviders = new LinkedHashMap<String, DatabaseIdProvider>();
     for (final var entry : physicalTenantConfigs.entrySet()) {
       final var currentPhysicalTenantId = entry.getKey();
       final var rdbms = entry.getValue();
       try {
         final var ds = buildDataSource(currentPhysicalTenantId, rdbms);
         dataSources.put(currentPhysicalTenantId, ds);
+        final var databaseIdProvider = new RdbmsDatabaseIdProvider(rdbms.getDatabaseVendorId());
+        databaseIdProviders.put(currentPhysicalTenantId, databaseIdProvider);
         final var databaseId = databaseIdProvider.getDatabaseId(ds);
         LOGGER.info(
             "Detected databaseId '{}' for physical tenant '{}'",
@@ -74,7 +80,7 @@ public final class RdbmsDataSources implements AutoCloseable {
         throw e;
       }
     }
-    return new RdbmsDataSources(dataSources, vendorProperties);
+    return new RdbmsDataSources(dataSources, vendorProperties, databaseIdProviders);
   }
 
   public Set<String> physicalTenantIds() {
@@ -101,6 +107,15 @@ public final class RdbmsDataSources implements AutoCloseable {
           "No VendorDatabaseProperties configured for physical tenant " + physicalTenantId);
     }
     return props;
+  }
+
+  public DatabaseIdProvider databaseIdProviderFor(final String physicalTenantId) {
+    final var databaseIdProvider = databaseIdProviders.get(physicalTenantId);
+    if (databaseIdProvider == null) {
+      throw new IllegalArgumentException(
+          "No DatabaseIdProvider configured for physical tenant " + physicalTenantId);
+    }
+    return databaseIdProvider;
   }
 
   @Override
@@ -130,7 +145,8 @@ public final class RdbmsDataSources implements AutoCloseable {
     return ds;
   }
 
-  private static void closeQuietly(final HikariDataSource ds) {
+  @VisibleForTesting
+  static void closeQuietly(final HikariDataSource ds) {
     try {
       ds.close();
     } catch (final Exception e) {

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
@@ -28,8 +28,6 @@ import org.springframework.mock.env.MockEnvironment;
 class MyBatisConfigurationPerTenantIT {
 
   private static final MyBatisConfiguration MY_BATIS = new MyBatisConfiguration();
-  private static final RdbmsDatabaseIdProvider DATABASE_ID_PROVIDER =
-      new RdbmsDatabaseIdProvider(null);
 
   @BeforeAll
   @AfterAll
@@ -104,10 +102,8 @@ class MyBatisConfigurationPerTenantIT {
     env.getPropertySources().addFirst(new MapPropertySource("test", props));
     final var resolver = PhysicalTenantResolver.of(env, new Camunda());
     final var dataSources =
-        RdbmsDataSources.of(
-            resolver.mapValues(c -> c.getData().getSecondaryStorage().getRdbms()),
-            DATABASE_ID_PROVIDER);
-    final var factories = MY_BATIS.sqlSessionFactories(dataSources, resolver, DATABASE_ID_PROVIDER);
+        RdbmsDataSources.of(resolver.mapValues(c -> c.getData().getSecondaryStorage().getRdbms()));
+    final var factories = MY_BATIS.sqlSessionFactories(dataSources, resolver);
     final var bundles = MY_BATIS.rdbmsMapperBundles(factories, dataSources);
     return new TenantFixture(dataSources, factories, bundles);
   }

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDataSourcesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDataSourcesTest.java
@@ -9,11 +9,9 @@ package io.camunda.application.commons.rdbms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import com.zaxxer.hikari.HikariDataSource;
 import io.camunda.configuration.Rdbms;
@@ -23,14 +21,11 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 
 class RdbmsDataSourcesTest {
-
-  private static final RdbmsDatabaseIdProvider DATABASE_ID_PROVIDER =
-      new RdbmsDatabaseIdProvider(null);
 
   private static Rdbms h2Rdbms() {
     final var rdbms = new Rdbms();
@@ -45,8 +40,7 @@ class RdbmsDataSourcesTest {
   void shouldBuildDataSourceForSinglePhysicalTenant() throws Exception {
     final var rdbms = h2Rdbms();
     try (final var registry =
-        RdbmsDataSources.of(
-            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms), DATABASE_ID_PROVIDER)) {
+        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms))) {
 
       // then
       final var ds =
@@ -71,8 +65,7 @@ class RdbmsDataSourcesTest {
     rdbms.setConnectionPool(pool);
 
     try (final var registry =
-        RdbmsDataSources.of(
-            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms), DATABASE_ID_PROVIDER)) {
+        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms))) {
 
       final var ds =
           (HikariDataSource) registry.dataSourceFor(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
@@ -91,7 +84,7 @@ class RdbmsDataSourcesTest {
     configs.put("tenant-a", h2Rdbms());
     configs.put("tenant-b", h2Rdbms());
 
-    try (final var registry = RdbmsDataSources.of(configs, DATABASE_ID_PROVIDER)) {
+    try (final var registry = RdbmsDataSources.of(configs)) {
       assertThat(registry.dataSourceFor("tenant-a")).isNotNull();
       assertThat(registry.dataSourceFor("tenant-b")).isNotNull();
       assertThat(registry.vendorPropertiesFor("tenant-a")).isNotNull();
@@ -102,9 +95,7 @@ class RdbmsDataSourcesTest {
   @Test
   void shouldThrowWhenLookingUpUnknownPhysicalTenantDataSource() throws Exception {
     try (final var registry =
-        RdbmsDataSources.of(
-            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, h2Rdbms()),
-            DATABASE_ID_PROVIDER)) {
+        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, h2Rdbms()))) {
       assertThatThrownBy(() -> registry.dataSourceFor("missing"))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("missing");
@@ -114,9 +105,7 @@ class RdbmsDataSourcesTest {
   @Test
   void shouldThrowWhenLookingUpUnknownPhysicalTenantVendorProperties() throws Exception {
     try (final var registry =
-        RdbmsDataSources.of(
-            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, h2Rdbms()),
-            DATABASE_ID_PROVIDER)) {
+        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, h2Rdbms()))) {
       assertThatThrownBy(() -> registry.vendorPropertiesFor("missing"))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("missing");
@@ -131,7 +120,7 @@ class RdbmsDataSourcesTest {
 
     final HikariDataSource dsA;
     final HikariDataSource dsB;
-    try (final var registry = RdbmsDataSources.of(configs, DATABASE_ID_PROVIDER)) {
+    try (final var registry = RdbmsDataSources.of(configs)) {
       dsA = (HikariDataSource) registry.dataSourceFor("tenant-a");
       dsB = (HikariDataSource) registry.dataSourceFor("tenant-b");
       assertThat(dsA.isClosed()).isFalse();
@@ -143,28 +132,30 @@ class RdbmsDataSourcesTest {
   }
 
   @Test
-  void shouldCloseAlreadyOpenedDataSourcesWhenLaterTenantFails() throws Exception {
-    final var configs = new LinkedHashMap<String, Rdbms>();
-    configs.put("tenant-a", h2Rdbms());
-    configs.put("tenant-b", h2Rdbms());
+  void shouldCloseAlreadyOpenedDataSourcesWhenLaterTenantFails() {
+    try (final MockedStatic<RdbmsDataSources> spy =
+        mockStatic(RdbmsDataSources.class, CALLS_REAL_METHODS)) {
+      // given: tenant-a initialises normally; tenant-b carries an invalid databaseVendorId so that
+      // RdbmsDatabaseIdProvider.getDatabaseId throws, triggering the cleanup path.
+      final var tenantBRdbms = h2Rdbms();
+      tenantBRdbms.setDatabaseVendorId("unsupported");
 
-    // tenant-a → real H2 detection succeeds; tenant-b → throws during databaseId resolution.
-    final var capturingProvider = spy(new RdbmsDatabaseIdProvider(null));
-    doCallRealMethod()
-        .doThrow(new RuntimeException("boom on tenant-b"))
-        .when(capturingProvider)
-        .getDatabaseId(any(DataSource.class));
+      final var configs = new LinkedHashMap<String, Rdbms>();
+      configs.put("tenant-a", h2Rdbms());
+      configs.put("tenant-b", tenantBRdbms);
 
-    assertThatThrownBy(() -> RdbmsDataSources.of(configs, capturingProvider))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("boom on tenant-b");
+      // when / then
+      assertThatThrownBy(() -> RdbmsDataSources.of(configs))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("unsupported");
 
-    final var captor = ArgumentCaptor.forClass(DataSource.class);
-    verify(capturingProvider, times(2)).getDatabaseId(captor.capture());
-    for (final var ds : captor.getAllValues()) {
-      assertThat(((HikariDataSource) ds).isClosed())
-          .as("opened HikariDataSource should be closed on failure")
-          .isTrue();
+      final var captor = ArgumentCaptor.forClass(HikariDataSource.class);
+      spy.verify(() -> RdbmsDataSources.closeQuietly(captor.capture()), times(2));
+      for (final var dataSource : captor.getAllValues()) {
+        assertThat(dataSource.isClosed())
+            .as("opened HikariDataSource should be closed on failure")
+            .isTrue();
+      }
     }
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDatabaseIdProviderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDatabaseIdProviderTest.java
@@ -15,16 +15,19 @@ import static org.mockito.Mockito.when;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 class RdbmsDatabaseIdProviderTest {
 
-  @Test
-  void shouldReturnOverrideWhenSet() {
+  @ParameterizedTest
+  @ValueSource(strings = {"h2", "postgresql", "mysql", "mariadb", "oracle", "mssql"})
+  void shouldReturnOverrideWhenSet(final String override) {
     final var dataSource = mock(DataSource.class);
-    final var databaseIdProvider = new RdbmsDatabaseIdProvider("h2");
+    final var databaseIdProvider = new RdbmsDatabaseIdProvider(override);
 
-    assertThat(databaseIdProvider.getDatabaseId(dataSource)).isEqualTo("h2");
+    assertThat(databaseIdProvider.getDatabaseId(dataSource)).isEqualTo(override);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR updates the RDBMS secondary-storage wiring in `dist/` to allow configuring the database vendor id (dialect selection) per physical tenant, instead of relying on a single, cluster-wide `DatabaseIdProvider`.

Changes:
* Add `databaseVendorId` to the `configuration` module’s `Rdbms` config and include it in the physical-tenant overridable properties list.
* Make `RdbmsDataSources` create and retain a dedicated MyBatis `DatabaseIdProvider` per physical tenant, based on that tenant’s `Rdbms` config, so that it can be used in building the MyBatis SqlFactories

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to https://github.com/camunda/camunda/issues/52040
