### PR TITLE
fix: clear stale waiting status after process instance modification

### DIFF
--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.test.tsx
@@ -623,17 +623,21 @@ describe('Modification Summary Modal', () => {
     const queryClient = getMockQueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
-    const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
-      <ProcessDefinitionKeyContext.Provider value="123">
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
-            <Routes>
-              <Route path={Paths.processInstance()} element={children} />
-            </Routes>
-          </MemoryRouter>
-        </QueryClientProvider>
-      </ProcessDefinitionKeyContext.Provider>
-    );
+    const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+      useEffect(() => () => modificationsStore.reset(), []);
+
+      return (
+        <ProcessDefinitionKeyContext.Provider value="123">
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+              <Routes>
+                <Route path={Paths.processInstance()} element={children} />
+              </Routes>
+            </MemoryRouter>
+          </QueryClientProvider>
+        </ProcessDefinitionKeyContext.Provider>
+      );
+    };
 
     const {user} = render(
       <ModificationSummaryModal open setOpen={() => {}} />,

--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.test.tsx
@@ -16,6 +16,7 @@ import {notificationsStore} from 'modules/stores/notifications';
 import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {queryKeys} from 'modules/queries/queryKeys';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
@@ -600,6 +601,55 @@ describe('Modification Summary Modal', () => {
     );
     expect(mockOnClose).toHaveBeenCalled();
     expect(modificationsStore.isModificationModeEnabled).toBe(false);
+  });
+
+  it('should invalidate element instance inspection queries when modifications are applied with success', async () => {
+    modificationsStore.enableModificationMode();
+
+    mockModifyProcessInstance().withSuccess(null);
+
+    modificationsStore.addModification({
+      type: 'token',
+      payload: {
+        operation: 'ADD_TOKEN',
+        scopeId: '123',
+        element: {id: 'element-1', name: 'element 1'},
+        affectedTokenCount: 1,
+        visibleAffectedTokenCount: 1,
+        parentScopeIds: {},
+      },
+    });
+
+    const queryClient = getMockQueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+
+    const {user} = render(
+      <ModificationSummaryModal open setOpen={() => {}} />,
+      {wrapper: Wrapper},
+    );
+
+    expect(
+      await screen.findByRole('button', {name: 'Apply'}),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    await waitFor(() =>
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.elementInstanceInspection.base(),
+      }),
+    );
   });
 
   it('should display error notification when modifications are applied with failure', async () => {

--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.tsx
@@ -8,6 +8,8 @@
 
 import React, {lazy, Suspense, useLayoutEffect, useRef} from 'react';
 import {observer} from 'mobx-react';
+import {useQueryClient} from '@tanstack/react-query';
+import {queryKeys} from 'modules/queries/queryKeys';
 import {
   TruncatedValueContainer,
   TruncatedValue,
@@ -69,6 +71,7 @@ const ModificationSummaryModal: React.FC<StateProps> = observer(
     const willAllElementsBeCanceled = useWillAllElementsBeCanceled();
     const modificationsByElement = useModificationsByElement();
     const {data: processInstance} = useProcessInstance();
+    const queryClient = useQueryClient();
     const elementModificationsTableRef = useRef<HTMLDivElement>(null);
     const variableModificationsTableRef = useRef<HTMLDivElement>(null);
 
@@ -151,6 +154,10 @@ const ModificationSummaryModal: React.FC<StateProps> = observer(
             processInstanceId,
             onSuccess: () => {
               tracking.track({eventName: 'modification-successful'});
+
+              queryClient.invalidateQueries({
+                queryKey: queryKeys.elementInstanceInspection.base(),
+              });
 
               notificationsStore.displayNotification({
                 kind: 'success',

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -60,6 +60,7 @@ import {isCompensationAssociation} from 'modules/bpmn-js/utils/isCompensationAss
 import {useProcessSequenceFlows} from 'modules/queries/sequenceFlows/useProcessSequenceFlows';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useElementInstanceInspection} from 'modules/queries/elementInstanceInspection/useElementInstanceInspection';
+import type {ElementInstanceInspection} from '@camunda/camunda-api-zod-schemas/8.10';
 import {getSubprocessOverlayFromIncidentElements} from 'modules/utils/elements';
 import {
   getWaitStateLabel,
@@ -238,7 +239,7 @@ const TopPanel: React.FC = observer(() => {
     }
 
     // Group wait states by elementId (show only 1 label per element)
-    const waitStatesByElement = new Map<string, typeof inspectionData.items>();
+    const waitStatesByElement = new Map<string, ElementInstanceInspection[]>();
     for (const item of inspectionData.items) {
       const existing = waitStatesByElement.get(item.elementId) ?? [];
       existing.push(item);
@@ -268,7 +269,7 @@ const TopPanel: React.FC = observer(() => {
     }
 
     return overlays;
-  }, [inspectionData]);
+  }, [inspectionData?.items]);
 
   const {agentOverlays, elementsWithAgent} = useMemo(() => {
     if (!agentInstancesData?.items?.length) {

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -225,7 +225,12 @@ const TopPanel: React.FC = observer(() => {
     return isExecutionCountVisible
       ? allElementStateOverlays
       : notCompletedElementStateOverlays;
-  }, [statistics, businessObjects, isExecutionCountVisible]);
+  }, [
+    statistics,
+    businessObjects,
+    isExecutionCountVisible,
+    inspectionData?.items,
+  ]);
 
   const allWaitingStateOverlays = useMemo(() => {
     if (!inspectionData?.items?.length) {

--- a/operate/client/src/modules/queries/elementInstanceInspection/useElementInstanceInspection.test.tsx
+++ b/operate/client/src/modules/queries/elementInstanceInspection/useElementInstanceInspection.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockSearchElementInstanceInspection} from 'modules/mocks/api/v2/elementInstanceInspection/searchElementInstanceInspection';
+import {searchResult} from 'modules/testUtils';
+import type {ElementInstanceInspection} from '@camunda/camunda-api-zod-schemas/8.10';
+import {queryKeys} from 'modules/queries/queryKeys';
+import {
+  useElementInstanceInspection,
+  MAX_WAIT_STATES,
+} from './useElementInstanceInspection';
+
+const PROCESS_INSTANCE_KEY = '123';
+
+const waitState: ElementInstanceInspection = {
+  rootProcessInstanceKey: PROCESS_INSTANCE_KEY,
+  processInstanceKey: PROCESS_INSTANCE_KEY,
+  elementInstanceKey: '456',
+  elementId: 'Task_1',
+  elementType: 'SERVICE_TASK',
+  tenantId: '<default>',
+  bpmnProcessId: 'process-1',
+  details: {
+    waitStateType: 'JOB',
+    jobKey: '789',
+    jobType: 'customJob',
+    jobKind: 'BPMN_ELEMENT',
+    listenerEventType: null,
+    retries: null,
+  },
+};
+
+describe('useElementInstanceInspection', () => {
+  it('should return the fetched wait states when enabled', async () => {
+    mockSearchElementInstanceInspection().withSuccess(
+      searchResult([waitState]),
+    );
+
+    const {result} = renderHook(
+      () =>
+        useElementInstanceInspection({
+          processInstanceKey: PROCESS_INSTANCE_KEY,
+          enabled: true,
+        }),
+      {
+        wrapper: ({children}) => (
+          <QueryClientProvider client={getMockQueryClient()}>
+            {children}
+          </QueryClientProvider>
+        ),
+      },
+    );
+
+    await waitFor(() =>
+      expect(result.current.data?.items).toEqual([waitState]),
+    );
+  });
+
+  it('should not surface stale cached wait states when disabled', () => {
+    const queryClient = getMockQueryClient();
+    queryClient.setQueryData(
+      queryKeys.elementInstanceInspection.search({
+        filter: {processInstanceKey: PROCESS_INSTANCE_KEY},
+        page: {limit: MAX_WAIT_STATES},
+      }),
+      searchResult([waitState]),
+    );
+
+    const {result} = renderHook(
+      () =>
+        useElementInstanceInspection({
+          processInstanceKey: PROCESS_INSTANCE_KEY,
+          enabled: false,
+        }),
+      {
+        wrapper: ({children}) => (
+          <QueryClientProvider client={queryClient}>
+            {children}
+          </QueryClientProvider>
+        ),
+      },
+    );
+
+    expect(result.current.data?.items).toEqual([]);
+  });
+});

--- a/operate/client/src/modules/queries/elementInstanceInspection/useElementInstanceInspection.ts
+++ b/operate/client/src/modules/queries/elementInstanceInspection/useElementInstanceInspection.ts
@@ -11,6 +11,7 @@ import type {
   QueryElementInstanceInspectionRequestBody,
   QueryElementInstanceInspectionResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
+import type {RequestError} from 'modules/request';
 import {searchElementInstanceInspection} from 'modules/api/v2/elementInstanceInspection/searchElementInstanceInspection';
 import {useIsProcessInstanceRunning} from 'modules/queries/processInstance/useIsProcessInstanceRunning';
 import {queryKeys} from '../queryKeys';
@@ -51,7 +52,7 @@ const useElementInstanceInspection = (
 
   return useQuery<
     QueryElementInstanceInspectionResponseBody,
-    Error,
+    RequestError,
     QueryElementInstanceInspectionResponseBody
   >({
     queryKey: queryKeys.elementInstanceInspection.search(payload),

--- a/operate/client/src/modules/queries/elementInstanceInspection/useElementInstanceInspection.ts
+++ b/operate/client/src/modules/queries/elementInstanceInspection/useElementInstanceInspection.ts
@@ -17,6 +17,16 @@ import {queryKeys} from '../queryKeys';
 
 const MAX_WAIT_STATES = 1000;
 
+const EMPTY_RESPONSE: QueryElementInstanceInspectionResponseBody = {
+  items: [],
+  page: {
+    totalItems: 0,
+    startCursor: null,
+    endCursor: null,
+    hasMoreTotalItems: false,
+  },
+};
+
 type UseElementInstanceInspectionParams = {
   processInstanceKey: string;
   elementInstanceKey?: string;
@@ -29,6 +39,8 @@ const useElementInstanceInspection = (
   const {processInstanceKey, elementInstanceKey, enabled = true} = params;
   const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
 
+  const isEnabled = enabled && !!processInstanceKey;
+
   const payload: QueryElementInstanceInspectionRequestBody = {
     filter: {
       processInstanceKey,
@@ -37,7 +49,11 @@ const useElementInstanceInspection = (
     page: {limit: MAX_WAIT_STATES},
   };
 
-  return useQuery<QueryElementInstanceInspectionResponseBody>({
+  return useQuery<
+    QueryElementInstanceInspectionResponseBody,
+    Error,
+    QueryElementInstanceInspectionResponseBody
+  >({
     queryKey: queryKeys.elementInstanceInspection.search(payload),
     queryFn: async ({signal}) => {
       const {response, error} = await searchElementInstanceInspection(
@@ -49,9 +65,12 @@ const useElementInstanceInspection = (
       }
       throw error;
     },
-    enabled: enabled && !!processInstanceKey,
+    enabled: isEnabled,
     staleTime: 10000,
     refetchInterval: () => (isProcessInstanceRunning ? 5000 : undefined),
+    // React Query keeps the last fetched data after `enabled` flips to false;
+    // return an empty result so disabled consumers don't render stale wait states.
+    select: (data) => (isEnabled ? data : EMPTY_RESPONSE),
   });
 };
 

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -273,6 +273,7 @@ const queryKeys = {
     ],
   },
   elementInstanceInspection: {
+    base: () => ['elementInstanceInspectionSearch'],
     search: (payload: QueryElementInstanceInspectionRequestBody) => [
       'elementInstanceInspectionSearch',
       payload,


### PR DESCRIPTION
## Description

- Clear the element-instance inspection query result while it's disabled, so stale "Waiting" isn't shown once the process/element is no longer ACTIVE
- Invalidate the inspection query after a process instance modification, so the diagram overlay refreshes immediately instead of on the next 5s poll
- Add `queryKeys.elementInstanceInspection.base()` for that invalidation
- Add tests for the hook gating and the modification invalidation

## Related issues

Closes #55640
Closes #55643
