### PR TITLE
feat: per-PT durable web-session storage via PhysicalTenantScoped

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SessionStoreAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SessionStoreAdapter.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.context.request.RequestContextHolder;
 
 /**
  * Host-supplied {@link SessionStorePort} that backs the library's web-session lifecycle with OC's
@@ -106,10 +105,9 @@ public class SessionStoreAdapter implements SessionStorePort {
 
   @Override
   public void delete(final String sessionId) {
-    if (RequestContextHolder.getRequestAttributes() != null) {
-      sessionClients
-          .withPhysicalTenant(PhysicalTenantContext.current())
-          .deletePersistentWebSession(sessionId);
+    final String currentTenant = PhysicalTenantContext.currentOrNull();
+    if (currentTenant != null) {
+      sessionClients.withPhysicalTenant(currentTenant).deletePersistentWebSession(sessionId);
     } else {
       for (final String physicalTenantId : physicalTenants.known()) {
         sessionClients.withPhysicalTenant(physicalTenantId).deletePersistentWebSession(sessionId);

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SessionStoreAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SessionStoreAdapter.java
@@ -7,17 +7,22 @@
  */
 package io.camunda.authentication.config.spi;
 
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.clients.PersistentWebSessionClient;
+import io.camunda.search.clients.tenant.PhysicalTenantScoped;
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.security.api.model.session.PersistentSession;
 import io.camunda.security.core.port.out.SessionStorePort;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
+import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.context.request.RequestContextHolder;
 
 /**
  * Host-supplied {@link SessionStorePort} that backs the library's web-session lifecycle with OC's
@@ -29,6 +34,10 @@ import org.slf4j.LoggerFactory;
  * exhausted the failure is logged and swallowed so a storage blip never propagates into the session
  * save path. This resilience policy lives here (rather than in the library) because it inspects the
  * search-specific {@link CamundaSearchException} reasons to decide what is transient.
+ *
+ * <p>Read and write operations ({@link #get}, {@link #upsert}, and in-request {@link #delete}) are
+ * routed to the physical tenant resolved from the current request context. Background operations
+ * ({@link #getAll} and off-request {@link #delete}) fan out across all known physical tenants.
  */
 public class SessionStoreAdapter implements SessionStorePort {
 
@@ -45,10 +54,14 @@ public class SessionStoreAdapter implements SessionStorePort {
               .retryOnException(SessionStoreAdapter::isTransientFailure)
               .build());
 
-  private final PersistentWebSessionClient persistentWebSessionClient;
+  private final PhysicalTenantScoped<PersistentWebSessionClient> sessionClients;
+  private final PhysicalTenantIds physicalTenants;
 
-  public SessionStoreAdapter(final PersistentWebSessionClient persistentWebSessionClient) {
-    this.persistentWebSessionClient = persistentWebSessionClient;
+  public SessionStoreAdapter(
+      final PhysicalTenantScoped<PersistentWebSessionClient> sessionClients,
+      final PhysicalTenantIds physicalTenants) {
+    this.sessionClients = sessionClients;
+    this.physicalTenants = physicalTenants;
   }
 
   private static boolean isTransientFailure(final Throwable throwable) {
@@ -63,16 +76,18 @@ public class SessionStoreAdapter implements SessionStorePort {
 
   @Override
   public PersistentSession get(final String sessionId) {
-    return toPersistentSession(persistentWebSessionClient.getPersistentWebSession(sessionId));
+    return toPersistentSession(
+        sessionClients
+            .withPhysicalTenant(PhysicalTenantContext.current())
+            .getPersistentWebSession(sessionId));
   }
 
   @Override
   public void upsert(final PersistentSession session) {
+    final var client = sessionClients.withPhysicalTenant(PhysicalTenantContext.current());
     final var entity = toEntity(session);
     try {
-      Retry.decorateRunnable(
-              UPSERT_RETRY, () -> persistentWebSessionClient.upsertPersistentWebSession(entity))
-          .run();
+      Retry.decorateRunnable(UPSERT_RETRY, () -> client.upsertPersistentWebSession(entity)).run();
     } catch (final CamundaSearchException e) {
       LOGGER.warn(
           "Failed to save web session to persistent storage after {} attempts: {} (reason: {})",
@@ -91,15 +106,28 @@ public class SessionStoreAdapter implements SessionStorePort {
 
   @Override
   public void delete(final String sessionId) {
-    persistentWebSessionClient.deletePersistentWebSession(sessionId);
+    if (RequestContextHolder.getRequestAttributes() != null) {
+      sessionClients
+          .withPhysicalTenant(PhysicalTenantContext.current())
+          .deletePersistentWebSession(sessionId);
+    } else {
+      for (final String physicalTenantId : physicalTenants.known()) {
+        sessionClients.withPhysicalTenant(physicalTenantId).deletePersistentWebSession(sessionId);
+      }
+    }
   }
 
   @Override
   public List<PersistentSession> getAll() {
-    final var items = persistentWebSessionClient.getAllPersistentWebSessions().items();
-    return items == null
-        ? List.of()
-        : items.stream().map(SessionStoreAdapter::toPersistentSession).toList();
+    final var result = new ArrayList<PersistentSession>();
+    for (final String physicalTenantId : physicalTenants.known()) {
+      final var items =
+          sessionClients.withPhysicalTenant(physicalTenantId).getAllPersistentWebSessions().items();
+      if (items != null) {
+        items.stream().map(SessionStoreAdapter::toPersistentSession).forEach(result::add);
+      }
+    }
+    return result;
   }
 
   private static PersistentSession toPersistentSession(final PersistentWebSessionEntity entity) {

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SessionStoreAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SessionStoreAdapterTest.java
@@ -10,30 +10,57 @@ package io.camunda.authentication.config.spi;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.clients.PersistentWebSessionClient;
+import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.session.PersistentSession;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 class SessionStoreAdapterTest {
+
+  @BeforeEach
+  void setUpRequestContext() {
+    final var req = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(req, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
+  }
+
+  @AfterEach
+  void clearRequestContext() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  private static SessionStoreAdapter adapterWith(final PersistentWebSessionClient client) {
+    final var provider =
+        new PhysicalTenantScopedPersistentWebSessionClient(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, client));
+    return new SessionStoreAdapter(provider, PhysicalTenantIds.DEFAULT);
+  }
 
   @Test
   void shouldMapAndUpsertSession() {
     // given
     final var client = new PersistentWebSessionClientStub();
-    final var adapter = new SessionStoreAdapter(client);
+    final var adapter = adapterWith(client);
     final var attributes = Map.of("a", new byte[] {1, 2, 3});
     final var session = new PersistentSession("s1", 100L, 200L, 1800L, attributes);
 
@@ -54,7 +81,7 @@ class SessionStoreAdapterTest {
   void shouldMapStoredEntityToPersistentSessionOnGet() {
     // given
     final var client = new PersistentWebSessionClientStub();
-    final var adapter = new SessionStoreAdapter(client);
+    final var adapter = adapterWith(client);
     final var attributes = Map.of("a", new byte[] {4, 5});
     client.upsertPersistentWebSession(
         new PersistentWebSessionEntity("s1", 100L, 200L, 1800L, attributes));
@@ -74,7 +101,7 @@ class SessionStoreAdapterTest {
   @Test
   void shouldReturnNullOnGetWhenAbsent() {
     // given
-    final var adapter = new SessionStoreAdapter(new PersistentWebSessionClientStub());
+    final var adapter = adapterWith(new PersistentWebSessionClientStub());
 
     // when / then
     assertThat(adapter.get("missing")).isNull();
@@ -84,7 +111,7 @@ class SessionStoreAdapterTest {
   void shouldDeleteSession() {
     // given
     final var client = new PersistentWebSessionClientStub();
-    final var adapter = new SessionStoreAdapter(client);
+    final var adapter = adapterWith(client);
     client.upsertPersistentWebSession(
         new PersistentWebSessionEntity("s1", 100L, 200L, 1800L, Map.of()));
 
@@ -99,7 +126,7 @@ class SessionStoreAdapterTest {
   void shouldReturnAllSessionsAsPersistentSessions() {
     // given
     final var client = new PersistentWebSessionClientStub();
-    final var adapter = new SessionStoreAdapter(client);
+    final var adapter = adapterWith(client);
     client.upsertPersistentWebSession(
         new PersistentWebSessionEntity("s1", 100L, 200L, 1800L, Map.of()));
     client.upsertPersistentWebSession(
@@ -138,7 +165,7 @@ class SessionStoreAdapterTest {
             throw exceptionSupplier.get();
           }
         };
-    final var adapter = new SessionStoreAdapter(failingClient);
+    final var adapter = adapterWith(failingClient);
 
     // when / then
     assertThatNoException()
@@ -158,7 +185,7 @@ class SessionStoreAdapterTest {
             throw new CamundaSearchException("Invalid argument", Reason.INVALID_ARGUMENT);
           }
         };
-    final var adapter = new SessionStoreAdapter(failingClient);
+    final var adapter = adapterWith(failingClient);
 
     // when / then
     assertThatNoException()
@@ -180,7 +207,7 @@ class SessionStoreAdapterTest {
             super.upsertPersistentWebSession(entity);
           }
         };
-    final var adapter = new SessionStoreAdapter(client);
+    final var adapter = adapterWith(client);
 
     // when
     adapter.upsert(new PersistentSession("s1", 100L, 200L, 1800L, Map.of()));
@@ -188,6 +215,128 @@ class SessionStoreAdapterTest {
     // then
     assertThat(upsertAttempts.get()).isEqualTo(3);
     assertThat(adapter.get("s1")).isNotNull();
+  }
+
+  @Test
+  void shouldRouteGetToCorrectPhysicalTenant() {
+    // given
+    final var ptaClient = new PersistentWebSessionClientStub();
+    final var ptbClient = new PersistentWebSessionClientStub();
+    ptaClient.upsertPersistentWebSession(
+        new PersistentWebSessionEntity("ptaSession", 100L, 200L, 1800L, Map.of()));
+    final var provider =
+        new PhysicalTenantScopedPersistentWebSessionClient(
+            Map.of("pta", ptaClient, "ptb", ptbClient));
+    final PhysicalTenantIds tenants = () -> java.util.Set.of("pta", "ptb");
+    final var adapter = new SessionStoreAdapter(provider, tenants);
+
+    // when / then — request context set to "pta" returns the session
+    setRequestContext("pta");
+    assertThat(adapter.get("ptaSession")).isNotNull();
+    assertThat(adapter.get("ptaSession").id()).isEqualTo("ptaSession");
+
+    // when / then — request context set to "ptb" returns null (not stored there)
+    setRequestContext("ptb");
+    assertThat(adapter.get("ptaSession")).isNull();
+  }
+
+  @Test
+  void shouldRouteUpsertToCorrectPhysicalTenant() {
+    // given
+    final var ptaClient = new PersistentWebSessionClientStub();
+    final var ptbClient = new PersistentWebSessionClientStub();
+    final var provider =
+        new PhysicalTenantScopedPersistentWebSessionClient(
+            Map.of("pta", ptaClient, "ptb", ptbClient));
+    final PhysicalTenantIds tenants = () -> java.util.Set.of("pta", "ptb");
+    final var adapter = new SessionStoreAdapter(provider, tenants);
+    final var session = new PersistentSession("s1", 100L, 200L, 1800L, Map.of());
+
+    // when
+    setRequestContext("pta");
+    adapter.upsert(session);
+
+    // then
+    assertThat(ptaClient.getPersistentWebSession("s1")).isNotNull();
+    assertThat(ptbClient.getPersistentWebSession("s1")).isNull();
+  }
+
+  @Test
+  void shouldRouteInRequestDeleteToCorrectPhysicalTenant() {
+    // given
+    final var ptaClient = new PersistentWebSessionClientStub();
+    final var ptbClient = new PersistentWebSessionClientStub();
+    ptaClient.upsertPersistentWebSession(
+        new PersistentWebSessionEntity("s1", 100L, 200L, 1800L, Map.of()));
+    ptbClient.upsertPersistentWebSession(
+        new PersistentWebSessionEntity("s1", 100L, 200L, 1800L, Map.of()));
+    final var provider =
+        new PhysicalTenantScopedPersistentWebSessionClient(
+            Map.of("pta", ptaClient, "ptb", ptbClient));
+    final PhysicalTenantIds tenants = () -> java.util.Set.of("pta", "ptb");
+    final var adapter = new SessionStoreAdapter(provider, tenants);
+
+    // when — delete in context of "pta"
+    setRequestContext("pta");
+    adapter.delete("s1");
+
+    // then — only removed from "pta", "ptb" is untouched
+    assertThat(ptaClient.getPersistentWebSession("s1")).isNull();
+    assertThat(ptbClient.getPersistentWebSession("s1")).isNotNull();
+  }
+
+  @Test
+  void shouldFanOutDeleteAcrossAllTenantsWhenOffRequest() {
+    // given
+    final var ptaClient = new PersistentWebSessionClientStub();
+    final var ptbClient = new PersistentWebSessionClientStub();
+    ptaClient.upsertPersistentWebSession(
+        new PersistentWebSessionEntity("s1", 100L, 200L, 1800L, Map.of()));
+    ptbClient.upsertPersistentWebSession(
+        new PersistentWebSessionEntity("s1", 100L, 200L, 1800L, Map.of()));
+    final var provider =
+        new PhysicalTenantScopedPersistentWebSessionClient(
+            Map.of("pta", ptaClient, "ptb", ptbClient));
+    final PhysicalTenantIds tenants = () -> java.util.Set.of("pta", "ptb");
+    final var adapter = new SessionStoreAdapter(provider, tenants);
+
+    // when — no request context (background sweep)
+    RequestContextHolder.resetRequestAttributes();
+    adapter.delete("s1");
+
+    // then — removed from both stores
+    assertThat(ptaClient.getPersistentWebSession("s1")).isNull();
+    assertThat(ptbClient.getPersistentWebSession("s1")).isNull();
+  }
+
+  @Test
+  void shouldAggregateGetAllAcrossAllPhysicalTenants() {
+    // given
+    final var ptaClient = new PersistentWebSessionClientStub();
+    final var ptbClient = new PersistentWebSessionClientStub();
+    ptaClient.upsertPersistentWebSession(
+        new PersistentWebSessionEntity("s1", 100L, 200L, 1800L, Map.of()));
+    ptbClient.upsertPersistentWebSession(
+        new PersistentWebSessionEntity("s2", 100L, 200L, 1800L, Map.of()));
+    final var provider =
+        new PhysicalTenantScopedPersistentWebSessionClient(
+            Map.of("pta", ptaClient, "ptb", ptbClient));
+    final PhysicalTenantIds tenants = () -> java.util.Set.of("pta", "ptb");
+    final var adapter = new SessionStoreAdapter(provider, tenants);
+
+    // when — off-request (no RequestContextHolder setup)
+    RequestContextHolder.resetRequestAttributes();
+    final var sessions = adapter.getAll();
+
+    // then
+    assertThat(sessions).hasSize(2);
+    assertThat(sessions).extracting(PersistentSession::id).containsExactlyInAnyOrder("s1", "s2");
+  }
+
+  private static void setRequestContext(final String physicalTenantId) {
+    final var req = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(req, physicalTenantId);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
   }
 
   static class PersistentWebSessionClientStub implements PersistentWebSessionClient {

--- a/dist/src/main/java/io/camunda/application/commons/identity/PhysicalTenantScopedPersistentWebSessionClientFactory.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/PhysicalTenantScopedPersistentWebSessionClientFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.identity;
+
+import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
+import io.camunda.db.rdbms.read.service.PersistentWebSessionRdbmsClient;
+import io.camunda.db.rdbms.write.RdbmsMapperBundle;
+import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
+import io.camunda.search.clients.DocumentBasedSearchClient;
+import io.camunda.search.clients.DocumentBasedWriteClient;
+import io.camunda.search.clients.PersistentWebSessionClient;
+import io.camunda.search.clients.PersistentWebSessionSearchImpl;
+import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.descriptors.index.PersistentWebSessionIndexDescriptor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Builds the per-physical-tenant {@link PhysicalTenantScopedPersistentWebSessionClient} from
+ * secondary-storage inputs, keeping the construction logic out of {@link
+ * WebSessionRepositoryConfiguration}. One {@link PersistentWebSessionClient} is created per
+ * physical tenant from that tenant's storage handles.
+ */
+public final class PhysicalTenantScopedPersistentWebSessionClientFactory {
+
+  private PhysicalTenantScopedPersistentWebSessionClientFactory() {}
+
+  /**
+   * Builds a provider for Elasticsearch/OpenSearch: one {@link PersistentWebSessionSearchImpl} per
+   * physical tenant from that tenant's document search client and index descriptors.
+   *
+   * @throws IllegalStateException if a tenant has no {@link IndexDescriptors}, or its search client
+   *     does not also implement {@link DocumentBasedWriteClient}
+   */
+  public static PhysicalTenantScopedPersistentWebSessionClient fromDocumentSearchClients(
+      final Map<String, DocumentBasedSearchClient> physicalTenantDocumentSearchClients,
+      final Map<String, IndexDescriptors> physicalTenantScopedIndexDescriptors) {
+    final var byTenant = new LinkedHashMap<String, PersistentWebSessionClient>();
+    physicalTenantDocumentSearchClients.forEach(
+        (tenantId, client) -> {
+          final var descriptors = physicalTenantScopedIndexDescriptors.get(tenantId);
+          if (descriptors == null) {
+            throw new IllegalStateException(
+                "Missing IndexDescriptors for physical tenant '" + tenantId + "'");
+          }
+          if (!(client instanceof final DocumentBasedWriteClient writeClient)) {
+            throw new IllegalStateException(
+                "Search client for physical tenant '"
+                    + tenantId
+                    + "' does not implement DocumentBasedWriteClient: "
+                    + client.getClass().getName());
+          }
+          final var descriptor = descriptors.get(PersistentWebSessionIndexDescriptor.class);
+          byTenant.put(
+              tenantId, new PersistentWebSessionSearchImpl(client, writeClient, descriptor));
+        });
+    return new PhysicalTenantScopedPersistentWebSessionClient(Map.copyOf(byTenant));
+  }
+
+  /**
+   * Builds a provider for RDBMS: one {@link PersistentWebSessionRdbmsClient} per physical tenant
+   * from that tenant's {@link RdbmsMapperBundle}.
+   */
+  public static PhysicalTenantScopedPersistentWebSessionClient fromRdbmsMapperBundles(
+      final Map<String, RdbmsMapperBundle> rdbmsMapperBundles) {
+    final var byTenant = new LinkedHashMap<String, PersistentWebSessionClient>();
+    rdbmsMapperBundles.forEach(
+        (tenantId, bundle) -> {
+          final var mapper = bundle.persistentWebSessionMapper();
+          byTenant.put(
+              tenantId,
+              new PersistentWebSessionRdbmsClient(
+                  new PersistentWebSessionDbReader(mapper),
+                  new PersistentWebSessionWriter(mapper)));
+        });
+    return new PhysicalTenantScopedPersistentWebSessionClient(Map.copyOf(byTenant));
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -9,24 +9,31 @@ package io.camunda.application.commons.identity;
 
 import io.camunda.authentication.config.spi.SessionStoreAdapter;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
 import io.camunda.db.rdbms.read.service.PersistentWebSessionRdbmsClient;
+import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.DocumentBasedWriteClient;
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.clients.PersistentWebSessionSearchImpl;
+import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
+import io.camunda.search.clients.tenant.PhysicalTenantScoped;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.security.core.port.out.SessionStorePort;
 import io.camunda.security.spring.annotation.ConditionalOnPersistentWebSessionEnabled;
 import io.camunda.security.spring.session.WebSessionConfiguration;
 import io.camunda.security.spring.session.WebSessionRepository;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.index.PersistentWebSessionIndexDescriptor;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -71,31 +78,53 @@ public class WebSessionRepositoryConfiguration {
     return new PersistentWebSessionIndexDescriptor(indexPrefix, isElasticsearch);
   }
 
-  @Bean
+  @Bean("persistentWebSessionClientProvider")
   @ConditionalOnSecondaryStorageType({
     SecondaryStorageType.elasticsearch,
     SecondaryStorageType.opensearch
   })
-  public PersistentWebSessionClient persistentWebSessionClientSearch(
-      final DocumentBasedSearchClient searchClient,
-      final DocumentBasedWriteClient writeClient,
-      final PersistentWebSessionIndexDescriptor descriptor) {
-    return new PersistentWebSessionSearchImpl(searchClient, writeClient, descriptor);
+  public PhysicalTenantScoped<PersistentWebSessionClient> persistentWebSessionClientProviderSearch(
+      final Map<String, DocumentBasedSearchClient> physicalTenantDocumentSearchClients,
+      final Map<String, IndexDescriptors> physicalTenantScopedIndexDescriptors) {
+    final var byTenant = new LinkedHashMap<String, PersistentWebSessionClient>();
+    physicalTenantDocumentSearchClients.forEach(
+        (tenantId, client) -> {
+          final var descriptors = physicalTenantScopedIndexDescriptors.get(tenantId);
+          if (descriptors == null) {
+            throw new IllegalStateException(
+                "Missing IndexDescriptors for physical tenant '" + tenantId + "'");
+          }
+          final var descriptor = descriptors.get(PersistentWebSessionIndexDescriptor.class);
+          byTenant.put(
+              tenantId,
+              new PersistentWebSessionSearchImpl(
+                  client, (DocumentBasedWriteClient) client, descriptor));
+        });
+    return new PhysicalTenantScopedPersistentWebSessionClient(Map.copyOf(byTenant));
   }
 
-  @Bean
+  @Bean("persistentWebSessionClientProvider")
   @ConditionalOnSecondaryStorageType(SecondaryStorageType.rdbms)
-  public PersistentWebSessionClient persistentWebSessionClientRdbms(
-      final PersistentWebSessionDbReader persistentWebSessionDbReader,
-      final PersistentWebSessionWriter persistentWebSessionWriter) {
-    return new PersistentWebSessionRdbmsClient(
-        persistentWebSessionDbReader, persistentWebSessionWriter);
+  public PhysicalTenantScoped<PersistentWebSessionClient> persistentWebSessionClientProviderRdbms(
+      final Map<String, RdbmsMapperBundle> rdbmsMapperBundles) {
+    final var byTenant = new LinkedHashMap<String, PersistentWebSessionClient>();
+    rdbmsMapperBundles.forEach(
+        (tenantId, bundle) -> {
+          final var mapper = bundle.persistentWebSessionMapper();
+          byTenant.put(
+              tenantId,
+              new PersistentWebSessionRdbmsClient(
+                  new PersistentWebSessionDbReader(mapper),
+                  new PersistentWebSessionWriter(mapper)));
+        });
+    return new PhysicalTenantScopedPersistentWebSessionClient(Map.copyOf(byTenant));
   }
 
   @Bean
   public SessionStorePort sessionStorePort(
-      final PersistentWebSessionClient persistentWebSessionClient) {
-    return new SessionStoreAdapter(persistentWebSessionClient);
+      final PhysicalTenantScoped<PersistentWebSessionClient> sessionClientProvider,
+      final PhysicalTenantIds physicalTenants) {
+    return new SessionStoreAdapter(sessionClientProvider, physicalTenants);
   }
 
   @Bean("webSessionDeletionUncaughtExceptionHandler")

--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -94,11 +94,16 @@ public class WebSessionRepositoryConfiguration {
             throw new IllegalStateException(
                 "Missing IndexDescriptors for physical tenant '" + tenantId + "'");
           }
+          if (!(client instanceof final DocumentBasedWriteClient writeClient)) {
+            throw new IllegalStateException(
+                "Search client for physical tenant '"
+                    + tenantId
+                    + "' does not implement DocumentBasedWriteClient: "
+                    + client.getClass().getName());
+          }
           final var descriptor = descriptors.get(PersistentWebSessionIndexDescriptor.class);
           byTenant.put(
-              tenantId,
-              new PersistentWebSessionSearchImpl(
-                  client, (DocumentBasedWriteClient) client, descriptor));
+              tenantId, new PersistentWebSessionSearchImpl(client, writeClient, descriptor));
         });
     return new PhysicalTenantScopedPersistentWebSessionClient(Map.copyOf(byTenant));
   }

--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -11,16 +11,10 @@ import io.camunda.authentication.config.spi.SessionStoreAdapter;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
-import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
-import io.camunda.db.rdbms.read.service.PersistentWebSessionRdbmsClient;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
-import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.search.clients.DocumentBasedSearchClient;
-import io.camunda.search.clients.DocumentBasedWriteClient;
 import io.camunda.search.clients.PersistentWebSessionClient;
-import io.camunda.search.clients.PersistentWebSessionSearchImpl;
-import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
 import io.camunda.search.clients.tenant.PhysicalTenantScoped;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.security.core.port.out.SessionStorePort;
@@ -32,7 +26,6 @@ import io.camunda.webapps.schema.descriptors.index.PersistentWebSessionIndexDesc
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.lang.Thread.UncaughtExceptionHandler;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,43 +79,16 @@ public class WebSessionRepositoryConfiguration {
   public PhysicalTenantScoped<PersistentWebSessionClient> persistentWebSessionClientProviderSearch(
       final Map<String, DocumentBasedSearchClient> physicalTenantDocumentSearchClients,
       final Map<String, IndexDescriptors> physicalTenantScopedIndexDescriptors) {
-    final var byTenant = new LinkedHashMap<String, PersistentWebSessionClient>();
-    physicalTenantDocumentSearchClients.forEach(
-        (tenantId, client) -> {
-          final var descriptors = physicalTenantScopedIndexDescriptors.get(tenantId);
-          if (descriptors == null) {
-            throw new IllegalStateException(
-                "Missing IndexDescriptors for physical tenant '" + tenantId + "'");
-          }
-          if (!(client instanceof final DocumentBasedWriteClient writeClient)) {
-            throw new IllegalStateException(
-                "Search client for physical tenant '"
-                    + tenantId
-                    + "' does not implement DocumentBasedWriteClient: "
-                    + client.getClass().getName());
-          }
-          final var descriptor = descriptors.get(PersistentWebSessionIndexDescriptor.class);
-          byTenant.put(
-              tenantId, new PersistentWebSessionSearchImpl(client, writeClient, descriptor));
-        });
-    return new PhysicalTenantScopedPersistentWebSessionClient(Map.copyOf(byTenant));
+    return PhysicalTenantScopedPersistentWebSessionClientFactory.fromDocumentSearchClients(
+        physicalTenantDocumentSearchClients, physicalTenantScopedIndexDescriptors);
   }
 
   @Bean("persistentWebSessionClientProvider")
   @ConditionalOnSecondaryStorageType(SecondaryStorageType.rdbms)
   public PhysicalTenantScoped<PersistentWebSessionClient> persistentWebSessionClientProviderRdbms(
       final Map<String, RdbmsMapperBundle> rdbmsMapperBundles) {
-    final var byTenant = new LinkedHashMap<String, PersistentWebSessionClient>();
-    rdbmsMapperBundles.forEach(
-        (tenantId, bundle) -> {
-          final var mapper = bundle.persistentWebSessionMapper();
-          byTenant.put(
-              tenantId,
-              new PersistentWebSessionRdbmsClient(
-                  new PersistentWebSessionDbReader(mapper),
-                  new PersistentWebSessionWriter(mapper)));
-        });
-    return new PhysicalTenantScopedPersistentWebSessionClient(Map.copyOf(byTenant));
+    return PhysicalTenantScopedPersistentWebSessionClientFactory.fromRdbmsMapperBundles(
+        rdbmsMapperBundles);
   }
 
   @Bean

--- a/dist/src/test/java/io/camunda/application/commons/identity/PhysicalTenantScopedPersistentWebSessionClientFactoryTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/PhysicalTenantScopedPersistentWebSessionClientFactoryTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
+import io.camunda.db.rdbms.write.RdbmsMapperBundle;
+import io.camunda.search.clients.DocumentBasedSearchClient;
+import io.camunda.search.clients.DocumentBasedWriteClient;
+import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PhysicalTenantScopedPersistentWebSessionClientFactoryTest {
+
+  @Test
+  void shouldBuildRdbmsProviderPerTenant() {
+    // given
+    final var mockMapper1 = mock(PersistentWebSessionMapper.class);
+    final var mockBundle1 = mock(RdbmsMapperBundle.class);
+    when(mockBundle1.persistentWebSessionMapper()).thenReturn(mockMapper1);
+
+    final var mockMapper2 = mock(PersistentWebSessionMapper.class);
+    final var mockBundle2 = mock(RdbmsMapperBundle.class);
+    when(mockBundle2.persistentWebSessionMapper()).thenReturn(mockMapper2);
+
+    final var bundles = Map.of("t1", mockBundle1, "t2", mockBundle2);
+
+    // when
+    final PhysicalTenantScopedPersistentWebSessionClient provider =
+        PhysicalTenantScopedPersistentWebSessionClientFactory.fromRdbmsMapperBundles(bundles);
+
+    // then
+    assertThat(provider.withPhysicalTenant("t1")).isNotNull();
+    assertThat(provider.withPhysicalTenant("t2")).isNotNull();
+    assertThatThrownBy(() -> provider.withPhysicalTenant("unknown-pt"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldBuildSearchProviderPerTenant() {
+    // given
+    final var searchClient =
+        mock(
+            DocumentBasedSearchClient.class,
+            withSettings().extraInterfaces(DocumentBasedWriteClient.class));
+    final var descriptors = new IndexDescriptors("test", /* isElasticsearch= */ true);
+
+    // when
+    final PhysicalTenantScopedPersistentWebSessionClient provider =
+        PhysicalTenantScopedPersistentWebSessionClientFactory.fromDocumentSearchClients(
+            Map.of("t1", searchClient), Map.of("t1", descriptors));
+
+    // then
+    assertThat(provider.withPhysicalTenant("t1")).isNotNull();
+  }
+
+  @Test
+  void shouldThrowWhenSearchClientHasNoIndexDescriptors() {
+    // given
+    final var searchClient =
+        mock(
+            DocumentBasedSearchClient.class,
+            withSettings().extraInterfaces(DocumentBasedWriteClient.class));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                PhysicalTenantScopedPersistentWebSessionClientFactory.fromDocumentSearchClients(
+                    Map.of("missing-pt", searchClient), Map.of()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("missing-pt");
+  }
+
+  @Test
+  void shouldThrowWhenSearchClientIsNotWriteClient() {
+    // given — plain mock, does NOT implement DocumentBasedWriteClient
+    final var readOnlyClient = mock(DocumentBasedSearchClient.class);
+    final var descriptors = new IndexDescriptors("test", /* isElasticsearch= */ true);
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                PhysicalTenantScopedPersistentWebSessionClientFactory.fromDocumentSearchClients(
+                    Map.of("t1", readOnlyClient), Map.of("t1", descriptors)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("t1")
+        .hasMessageContaining("DocumentBasedWriteClient");
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.identity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -81,6 +82,13 @@ class WebSessionRepositoryConfigurationTest {
               assertThat(ctx)
                   .getBean(SessionStorePort.class)
                   .isInstanceOf(SessionStoreAdapter.class);
+              final var provider =
+                  ctx.getBean(PhysicalTenantScopedPersistentWebSessionClient.class);
+              assertThat(provider.withPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+                  .as("provider must resolve the configured default physical tenant")
+                  .isNotNull();
+              assertThatThrownBy(() -> provider.withPhysicalTenant("unknown-pt"))
+                  .isInstanceOf(IllegalStateException.class);
             });
   }
 
@@ -114,6 +122,13 @@ class WebSessionRepositoryConfigurationTest {
               assertThat(ctx)
                   .getBean(SessionStorePort.class)
                   .isInstanceOf(SessionStoreAdapter.class);
+              final var provider =
+                  ctx.getBean(PhysicalTenantScopedPersistentWebSessionClient.class);
+              assertThat(provider.withPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+                  .as("provider must resolve the configured default physical tenant")
+                  .isNotNull();
+              assertThatThrownBy(() -> provider.withPhysicalTenant("unknown-pt"))
+                  .isInstanceOf(IllegalStateException.class);
             });
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
@@ -10,14 +10,18 @@ package io.camunda.application.commons.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import io.camunda.authentication.config.spi.SessionStoreAdapter;
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
+import io.camunda.search.clients.DocumentBasedSearchClient;
+import io.camunda.search.clients.DocumentBasedWriteClient;
 import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.security.core.port.out.SessionStorePort;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -71,6 +75,39 @@ class WebSessionRepositoryConfigurationTest {
   void shouldWirePerTenantClientProviderForRdbms() {
     runner
         .withPropertyValues("camunda.security.session.persistent.enabled=true")
+        .run(
+            ctx -> {
+              assertThat(ctx).hasSingleBean(PhysicalTenantScopedPersistentWebSessionClient.class);
+              assertThat(ctx)
+                  .getBean(SessionStorePort.class)
+                  .isInstanceOf(SessionStoreAdapter.class);
+            });
+  }
+
+  @Test
+  void shouldWirePerTenantClientProviderForElasticsearch() {
+    // given — a search client stub that implements both read and write interfaces
+    final var searchClient =
+        mock(
+            DocumentBasedSearchClient.class,
+            withSettings().extraInterfaces(DocumentBasedWriteClient.class));
+    final var descriptors = new IndexDescriptors("test", /* isElasticsearch= */ true);
+
+    new WebApplicationContextRunner()
+        .withBean(ConnectConfiguration.class, ConnectConfiguration::new)
+        .withBean(
+            "physicalTenantDocumentSearchClients",
+            Map.class,
+            () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, searchClient))
+        .withBean(
+            "physicalTenantScopedIndexDescriptors",
+            Map.class,
+            () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, descriptors))
+        .withBean(PhysicalTenantIds.class, () -> PhysicalTenantIds.DEFAULT)
+        .withUserConfiguration(WebSessionRepositoryConfiguration.class)
+        .withPropertyValues(
+            "camunda.data.secondary-storage.type=elasticsearch",
+            "camunda.security.session.persistent.enabled=true")
         .run(
             ctx -> {
               assertThat(ctx).hasSingleBean(PhysicalTenantScopedPersistentWebSessionClient.class);

--- a/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
@@ -9,11 +9,17 @@ package io.camunda.application.commons.identity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
-import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
+import io.camunda.authentication.config.spi.SessionStoreAdapter;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
+import io.camunda.db.rdbms.write.RdbmsMapperBundle;
+import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.security.core.port.out.SessionStorePort;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 
@@ -23,8 +29,15 @@ class WebSessionRepositoryConfigurationTest {
       new WebApplicationContextRunner()
           .withBean(ConnectConfiguration.class, ConnectConfiguration::new)
           .withBean(
-              PersistentWebSessionDbReader.class, () -> mock(PersistentWebSessionDbReader.class))
-          .withBean(PersistentWebSessionWriter.class, () -> mock(PersistentWebSessionWriter.class))
+              "rdbmsMapperBundles",
+              Map.class,
+              () -> {
+                final var mockMapper = mock(PersistentWebSessionMapper.class);
+                final var mockBundle = mock(RdbmsMapperBundle.class);
+                when(mockBundle.persistentWebSessionMapper()).thenReturn(mockMapper);
+                return Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, mockBundle);
+              })
+          .withBean(PhysicalTenantIds.class, () -> PhysicalTenantIds.DEFAULT)
           .withUserConfiguration(WebSessionRepositoryConfiguration.class)
           .withPropertyValues("camunda.data.secondary-storage.type=rdbms");
 
@@ -52,5 +65,18 @@ class WebSessionRepositoryConfigurationTest {
     runner
         .withPropertyValues("camunda.security.session.persistent.enabled=false")
         .run(ctx -> assertThat(ctx).doesNotHaveBean("webSessionDeletionUncaughtExceptionHandler"));
+  }
+
+  @Test
+  void shouldWirePerTenantClientProviderForRdbms() {
+    runner
+        .withPropertyValues("camunda.security.session.persistent.enabled=true")
+        .run(
+            ctx -> {
+              assertThat(ctx).hasSingleBean(PhysicalTenantScopedPersistentWebSessionClient.class);
+              assertThat(ctx)
+                  .getBean(SessionStorePort.class)
+                  .isInstanceOf(SessionStoreAdapter.class);
+            });
   }
 }

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -566,6 +566,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-exporter</artifactId>
       <scope>test</scope>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -566,11 +566,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-exporter</artifactId>
       <scope>test</scope>
@@ -747,6 +742,16 @@
             <dep>io.camunda:camunda-exporter</dep>
             <dep>org.springframework.boot:spring-boot-starter-log4j2</dep>
           </ignoredUnusedDeclaredDependencies>
+          <!--
+            The servlet API (jakarta.servlet.HttpServletRequest, used by web-session tests to
+            set up a request scope) is provided transitively by both jakarta.servlet-api and the
+            embedded Tomcat jar; the analyzer attributes it to either one depending on classpath
+            order. Ignore both so the test does not need to declare a direct dependency on either.
+          -->
+          <ignoredUsedUndeclaredDependencies>
+            <dep>org.apache.tomcat.embed:tomcat-embed-core</dep>
+            <dep>jakarta.servlet:jakarta.servlet-api</dep>
+          </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PhysicalTenantWebSessionIsolationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PhysicalTenantWebSessionIsolationIT.java
@@ -22,6 +22,7 @@ import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
 import io.camunda.security.api.model.session.PersistentSession;
 import io.camunda.security.core.port.out.SessionStorePort;
 import io.camunda.spring.utils.PhysicalTenantContext;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,7 +92,8 @@ class PhysicalTenantWebSessionIsolationIT {
 
   private static PersistentSession session(final String id) {
     final long now = System.currentTimeMillis();
-    return new PersistentSession(id, now, now, 1800L, Map.of("test", "v".getBytes()));
+    return new PersistentSession(
+        id, now, now, 1800L, Map.of("test", "v".getBytes(StandardCharsets.UTF_8)));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PhysicalTenantWebSessionIsolationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PhysicalTenantWebSessionIsolationIT.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.websession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.config.spi.SessionStoreAdapter;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
+import io.camunda.db.rdbms.read.service.PersistentWebSessionRdbmsClient;
+import io.camunda.db.rdbms.write.RdbmsMapperBundle;
+import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.search.clients.PersistentWebSessionClient;
+import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
+import io.camunda.security.api.model.session.PersistentSession;
+import io.camunda.security.core.port.out.SessionStorePort;
+import io.camunda.spring.utils.PhysicalTenantContext;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Tag("rdbms")
+class PhysicalTenantWebSessionIsolationIT {
+
+  private static final String URL_TENANTA =
+      "jdbc:h2:mem:ws-isol-tenanta;DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
+  private static final String TENANT_A = "tenanta";
+  private static final String DEFAULT_TENANT = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
+  private CamundaRdbmsTestApplication app;
+  private CamundaRdbmsTestApplication app2;
+
+  @BeforeEach
+  void setUp() {
+    app = buildApp().start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+    if (app2 != null) {
+      app2.close();
+      app2 = null;
+    }
+    if (app != null) {
+      app.close();
+      app = null;
+    }
+  }
+
+  private static CamundaRdbmsTestApplication buildApp() {
+    return new CamundaRdbmsTestApplication(
+            RdbmsTestConfiguration.class, SessionStoreConfiguration.class)
+        .withH2()
+        .withProperty(
+            "camunda.physical-tenants." + TENANT_A + ".data.secondary-storage.rdbms.url",
+            URL_TENANTA)
+        .withProperty(
+            "camunda.physical-tenants." + TENANT_A + ".data.secondary-storage.rdbms.username", "sa")
+        .withProperty(
+            "camunda.physical-tenants." + TENANT_A + ".data.secondary-storage.rdbms.password", "")
+        .withProperty(
+            "camunda.physical-tenants."
+                + TENANT_A
+                + ".security.initialization.default-roles.admin.users[0]",
+            TENANT_A + "-admin");
+  }
+
+  private static void setRequestContext(final String tenantId) {
+    final var req = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(req, tenantId);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
+  }
+
+  private static PersistentSession session(final String id) {
+    final long now = System.currentTimeMillis();
+    return new PersistentSession(id, now, now, 1800L, Map.of("test", "v".getBytes()));
+  }
+
+  @Test
+  void shouldIsolateSessionsAcrossPhysicalTenants() {
+    // given
+    final var adapter = app.bean(SessionStorePort.class);
+    final String id = UUID.randomUUID().toString();
+    final PersistentSession session = session(id);
+
+    // when — write as tenanta
+    setRequestContext(TENANT_A);
+    adapter.upsert(session);
+
+    // then — tenanta can read it
+    final PersistentSession found = adapter.get(id);
+    assertThat(found).isNotNull();
+    assertThat(found.id()).isEqualTo(id);
+
+    // and — default cannot read it
+    setRequestContext(DEFAULT_TENANT);
+    assertThat(adapter.get(id)).isNull();
+  }
+
+  @Test
+  void shouldSurviveRestartInCorrectPhysicalTenantStore() {
+    // given — write via app1
+    final var adapter1 = app.bean(SessionStorePort.class);
+    final String id = UUID.randomUUID().toString();
+
+    setRequestContext(TENANT_A);
+    adapter1.upsert(session(id));
+
+    // simulate restart: close app1, start fresh app2 with same H2 URLs
+    app.close();
+    app = null;
+    app2 = buildApp().start();
+
+    // when — read from app2 as tenanta
+    final var adapter2 = app2.bean(SessionStorePort.class);
+    setRequestContext(TENANT_A);
+    final PersistentSession found = adapter2.get(id);
+
+    // then
+    assertThat(found).isNotNull();
+    assertThat(found.id()).isEqualTo(id);
+  }
+
+  @Test
+  void shouldAggregateGetAllAcrossAllPhysicalTenants() {
+    // given — one session per PT
+    final var adapter = app.bean(SessionStorePort.class);
+    final String defaultId = UUID.randomUUID().toString();
+    final String tenantaId = UUID.randomUUID().toString();
+
+    setRequestContext(DEFAULT_TENANT);
+    adapter.upsert(session(defaultId));
+
+    setRequestContext(TENANT_A);
+    adapter.upsert(session(tenantaId));
+
+    // when — off-request getAll
+    RequestContextHolder.resetRequestAttributes();
+    final List<PersistentSession> all = adapter.getAll();
+
+    // then — both sessions present (may contain more from prior tests)
+    assertThat(all).extracting(PersistentSession::id).contains(defaultId, tenantaId);
+  }
+
+  @Test
+  void shouldFanOutDeleteAcrossAllPhysicalTenantsWhenOffRequest() {
+    // given — write same session ID to both PT stores
+    final var adapter = app.bean(SessionStorePort.class);
+    final String id = UUID.randomUUID().toString();
+    final PersistentSession s = session(id);
+
+    setRequestContext(DEFAULT_TENANT);
+    adapter.upsert(s);
+
+    setRequestContext(TENANT_A);
+    adapter.upsert(s);
+
+    // when — off-request delete
+    RequestContextHolder.resetRequestAttributes();
+    adapter.delete(id);
+
+    // then — gone from both stores
+    setRequestContext(DEFAULT_TENANT);
+    assertThat(adapter.get(id)).isNull();
+
+    setRequestContext(TENANT_A);
+    assertThat(adapter.get(id)).isNull();
+  }
+
+  /** Wires {@link SessionStorePort} directly from per-PT RDBMS infra, no condition gating. */
+  @Configuration
+  static class SessionStoreConfiguration {
+
+    @Bean
+    SessionStorePort sessionStorePort(
+        final Map<String, RdbmsMapperBundle> rdbmsMapperBundles,
+        final PhysicalTenantIds physicalTenants) {
+      final var byTenant = new LinkedHashMap<String, PersistentWebSessionClient>();
+      rdbmsMapperBundles.forEach(
+          (tenantId, bundle) -> {
+            final var mapper = bundle.persistentWebSessionMapper();
+            byTenant.put(
+                tenantId,
+                new PersistentWebSessionRdbmsClient(
+                    new PersistentWebSessionDbReader(mapper),
+                    new PersistentWebSessionWriter(mapper)));
+          });
+      final var provider = new PhysicalTenantScopedPersistentWebSessionClient(Map.copyOf(byTenant));
+      return new SessionStoreAdapter(provider, physicalTenants);
+    }
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/PhysicalTenantScopedPersistentWebSessionClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/PhysicalTenantScopedPersistentWebSessionClient.java
@@ -10,6 +10,12 @@ package io.camunda.search.clients;
 import io.camunda.search.clients.tenant.PhysicalTenantScoped;
 import java.util.Map;
 
+/**
+ * Immutable {@link PhysicalTenantScoped} provider that resolves a {@link
+ * PersistentWebSessionClient} by physical tenant id from a pre-built, per-tenant client map.
+ *
+ * @throws IllegalStateException if the requested physical tenant has no registered client
+ */
 public final class PhysicalTenantScopedPersistentWebSessionClient
     implements PhysicalTenantScoped<PersistentWebSessionClient> {
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/PhysicalTenantScopedPersistentWebSessionClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/PhysicalTenantScopedPersistentWebSessionClient.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.clients.tenant.PhysicalTenantScoped;
+import java.util.Map;
+
+public final class PhysicalTenantScopedPersistentWebSessionClient
+    implements PhysicalTenantScoped<PersistentWebSessionClient> {
+
+  private final Map<String, PersistentWebSessionClient> clientsByPhysicalTenant;
+
+  public PhysicalTenantScopedPersistentWebSessionClient(
+      final Map<String, PersistentWebSessionClient> clientsByPhysicalTenant) {
+    this.clientsByPhysicalTenant = Map.copyOf(clientsByPhysicalTenant);
+  }
+
+  @Override
+  public PersistentWebSessionClient withPhysicalTenant(final String physicalTenantId) {
+    final PersistentWebSessionClient client = clientsByPhysicalTenant.get(physicalTenantId);
+    if (client == null) {
+      throw new IllegalStateException(
+          "No persistent web session client registered for physical tenant '"
+              + physicalTenantId
+              + "'");
+    }
+    return client;
+  }
+}

--- a/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantContext.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantContext.java
@@ -96,7 +96,7 @@ public final class PhysicalTenantContext {
    * PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} for an unstamped request), otherwise from a value
    * propagated onto this thread (e.g. by {@code PhysicalTenantPropagatingExecutorService}).
    */
-  static String currentOrNull() {
+  public static String currentOrNull() {
     final RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
     if (attributes != null) {
       final String value =


### PR DESCRIPTION
Closes #55315

## Summary

Makes each physical tenant's (PT) web sessions route to and persist in that tenant's own secondary storage (RDBMS or ES/OS), enforcing session isolation across PTs and enabling restart-surviving sessions per PT schema.

Uses the existing `PhysicalTenantScoped<T>` provider abstraction (same mechanism as `SearchClientReadersFactory` and `CamundaSearchClients`) rather than an adapter-owned client map, per ADR-0027 Decision 6. The new `PhysicalTenantScopedPersistentWebSessionClient` is fail-loud on unknown tenants, matching `CamundaSearchClients` and `RdbmsWriterFactory`.

`SessionStorePort` contract is unchanged; single-tenant (default-only) behaviour is unchanged.

## Acceptance criteria coverage

| Criterion | Proven by |
|---|---|
| A PT's sessions are written to / read from that PT's isolated schema | IT `PhysicalTenantWebSessionIsolationIT#shouldIsolateSessionsAcrossPhysicalTenants` — session written under `tenanta` is readable as `tenanta`, `null` as `default` |
| A session survives a restart in the correct PT store | IT `#shouldSurviveRestartInCorrectPhysicalTenantStore` — write → close app → start fresh app → read back from the same per-PT H2 |
| Request-scoped `get`/`upsert`/`delete` route to the current PT | unit `SessionStoreAdapterTest#shouldRouteGetToCorrectPhysicalTenant`, `#shouldRouteUpsertToCorrectPhysicalTenant` |
| Expiry sweep (off-request) evicts across **all** PT stores | unit `SessionStoreAdapterTest#shouldFanOutDeleteAcrossAllTenantsWhenOffRequest` + IT `#shouldFanOutDeleteAcrossAllPhysicalTenantsWhenOffRequest` |
| `getAll` aggregates across all PT stores | unit `SessionStoreAdapterTest#shouldAggregateGetAllAcrossAllPhysicalTenants` + IT `#shouldAggregateGetAllAcrossAllPhysicalTenants` |
| Conditional per-PT provider beans wire for both backends, with correct PT resolution | config `WebSessionRepositoryConfigurationTest#shouldWirePerTenantClientProviderForRdbms` / `#shouldWirePerTenantClientProviderForElasticsearch` — assert the provider resolves the configured PT and fails loud on an unknown one |
| `SessionStorePort` contract unchanged; single-tenant behaviour unchanged | interface untouched; config tests wire with a default-only PT set |

## Testing topology

The IT exercises the full adapter → provider → per-PT RDBMS client → isolated H2 path with two PTs. The conditional host wiring (`@ConditionalOnSecondaryStorageType` provider beans building the provider from the real per-PT source maps) is covered by `WebSessionRepositoryConfigurationTest` for both RDBMS and ES/OS. Together they cover the chain end to end.