### PR TITLE
55695 tool calls tile

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -16,6 +16,7 @@ import static io.camunda.optimize.service.dashboard.AgenticControlDashboardServi
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_TOOL_CALLS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_CONSUMERS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_OUTLIER_BANDS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_TREND_REPORT_ID;
@@ -1369,6 +1370,74 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   // ---------------------------------------------------------------------------
+  // Total tool calls (single number, scoped by fleet view vs process drill-down)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldSumToolCallsAcrossAllCompletedAgenticInstances() {
+    // given completed agentic instances with known tool-call totals across two processes
+    final ProcessInstanceDto a = agenticInstanceWithToolCalls(PROC_KEY, 5L).build();
+    final ProcessInstanceDto b = agenticInstanceWithToolCalls(PROC_KEY, 10L).build();
+    final ProcessInstanceDto c = agenticInstanceWithToolCalls("other-agent-process", 15L).build();
+    // running agentic — excluded by completedInstancesOnly
+    final ProcessInstanceDto running =
+        agenticInstanceWithToolCalls(PROC_KEY, 100L)
+            .state(ProcessInstanceConstants.ACTIVE_STATE)
+            .endDate(null)
+            .duration(null)
+            .build();
+    // completed non-agentic — excluded by hasAgentInstances
+    final ProcessInstanceDto nonAgentic = completedInstance(PROC_KEY).build();
+
+    persistProcessInstances(List.of(a, b, c, running, nonAgentic));
+
+    // fleet view (L0, no definition scope): 5 + 10 + 15 = 30
+    assertThat(evaluateNumber(KPI_TOOL_CALLS_REPORT_ID, noExtraFilters())).isEqualTo(30.0);
+  }
+
+  @Test
+  void shouldScopeToolCallsToSelectedProcessDefinition() {
+    final String procKeyA = "proc-tools-a";
+    final String procKeyB = "proc-tools-b";
+
+    persistProcessInstances(
+        List.of(
+            agenticInstanceWithToolCalls(procKeyA, 7L).build(),
+            agenticInstanceWithToolCalls(procKeyA, 8L).build(),
+            agenticInstanceWithToolCalls(procKeyB, 100L).build()));
+
+    // drill-down (L1) to procKeyA only: 7 + 8 = 15 (procKeyB excluded)
+    assertThat(
+            evaluateNumber(
+                KPI_TOOL_CALLS_REPORT_ID,
+                withDefinitions(List.of(new ReportDataDefinitionDto(procKeyA)))))
+        .isEqualTo(15.0);
+  }
+
+  @Test
+  void shouldScopeToolCallsByDateFilter() {
+    // capture one reference point so the window math stays deterministic across clock boundaries
+    final OffsetDateTime now = OffsetDateTime.now();
+    // within last-1-day window
+    final ProcessInstanceDto recent =
+        agenticInstanceWithToolCalls(PROC_KEY, 12L)
+            .startDate(now.minusHours(3))
+            .endDate(now.minusHours(2))
+            .build();
+    // outside the window — must not be added to the total
+    final ProcessInstanceDto old =
+        agenticInstanceWithToolCalls(PROC_KEY, 999L)
+            .startDate(now.minusDays(10))
+            .endDate(now.minusDays(9))
+            .build();
+
+    persistProcessInstances(List.of(recent, old));
+
+    assertThat(evaluateNumber(KPI_TOOL_CALLS_REPORT_ID, rollingEndDateFilter(1L, DateUnit.DAYS)))
+        .isEqualTo(12.0);
+  }
+
+  // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 
@@ -1414,6 +1483,16 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   private ProcessInstanceDto.ProcessInstanceDtoBuilder agenticInstanceWithDuration(
       final String processDefinitionKey, final long duration) {
     return agenticInstanceWithTokens(processDefinitionKey, 0L, 0L).duration(duration);
+  }
+
+  /**
+   * Builds a completed agentic {@link ProcessInstanceDto} with the given total tool-call count. The
+   * TOOL_CALLS view property sums the per-instance rollup {@code agentTotalToolCalls}, which the
+   * exporter computes across the instance's agent instances — so the test sets it directly.
+   */
+  private ProcessInstanceDto.ProcessInstanceDtoBuilder agenticInstanceWithToolCalls(
+      final String processDefinitionKey, final long toolCalls) {
+    return agenticInstanceWithTokens(processDefinitionKey, 0L, 0L).agentTotalToolCalls(toolCalls);
   }
 
   /**

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -106,6 +106,8 @@ public class AgenticControlDashboardService {
   public static final String FAILURE_RATE_BY_VERSION_NAME = "agenticFailureRateByVersionName";
   public static final String FAILURE_RATE_BY_VERSION_DESCRIPTION =
       "agenticFailureRateByVersionDescription";
+  public static final String KPI_TOOL_CALLS_NAME = "agenticKpiToolCallsName";
+  public static final String KPI_TOOL_CALLS_DESCRIPTION = "agenticKpiToolCallsDescription";
 
   public static final String DURATION_STABILITY_NAME = "agenticDurationStabilityName";
   public static final String DURATION_STABILITY_DESCRIPTION = "agenticDurationStabilityDescription";
@@ -143,6 +145,9 @@ public class AgenticControlDashboardService {
   public static final String FAILURE_RATE_BY_VERSION_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-failure-rate-by-version".getBytes(StandardCharsets.UTF_8))
           .toString();
+  public static final String KPI_TOOL_CALLS_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-tool-calls-total".getBytes(StandardCharsets.UTF_8))
+          .toString();
 
   private static final long INSTANCE_END_DATE_ROLLING_DAYS = 30L;
 
@@ -153,9 +158,12 @@ public class AgenticControlDashboardService {
   // When set, the frontend only renders the tile at the dashboard root (L0) and hides it once a
   // single process is selected, where a per-process breakdown is no longer meaningful.
   private static final String TILE_CONFIG_VISIBLE_IN_L0_ONLY = "visibleInL0Only";
+  // When set, the frontend only renders the tile once a single process is selected (L1).
+  private static final String TILE_CONFIG_VISIBLE_IN_L1_ONLY = "visibleInL1Only";
   // Section values that group tiles within the dashboard layout.
   private static final String TILE_SECTION_TOKEN = "token";
   private static final String TILE_SECTION_DURATION = "duration";
+  private static final String TILE_SECTION_RELIABILITY_AND_TOOL_CALLS = "reliabilityAndToolCalls";
 
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(AgenticControlDashboardService.class);
@@ -201,6 +209,7 @@ public class AgenticControlDashboardService {
     tiles.add(buildP50DurationReport());
     tiles.add(buildP95DurationReport());
     tiles.add(buildFailureRateByVersionReport());
+    tiles.add(buildTotalToolCallsReport());
 
     // Always upsert the dashboard too — tile list can grow across versions and the cold-start
     // guard would leave an existing deployment stuck on the old layout.
@@ -629,7 +638,53 @@ public class AgenticControlDashboardService {
         FAILURE_RATE_BY_VERSION_REPORT_ID,
         new PositionDto(0, 8),
         new DimensionDto(18, 2),
-        Map.of("visibleInL1Only", true, "section", "reliabilityAndToolCalls"));
+        Map.of(
+            TILE_CONFIG_VISIBLE_IN_L1_ONLY,
+            true,
+            TILE_CONFIG_SECTION,
+            TILE_SECTION_RELIABILITY_AND_TOOL_CALLS));
+  }
+
+  // Total tool calls made by agents, rendered as a single full-width number. Reuses the
+  // AGENT_INSTANCE / TOOL_CALLS view property, which sums the per-process-instance rollup
+  // agentTotalToolCalls, so the SUM across instances is the correct total (no double counting). The
+  // tile is visible in both scopes: at L0 it totals across all agent-bearing instances; at L1 the
+  // frontend's process scope narrows it to the selected definition.
+  private DashboardReportTileDto buildTotalToolCallsReport() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.AGENT_INSTANCE, ViewProperty.TOOL_CALLS))
+            .groupBy(new NoneGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.NUMBER)
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .aggregationTypes(
+                        new LinkedHashSet<>(
+                            Collections.singletonList(new AggregationDto(AggregationType.SUM))))
+                    .build())
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .buildList())
+            .agenticControlReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        KPI_TOOL_CALLS_REPORT_ID,
+        null,
+        reportData,
+        KPI_TOOL_CALLS_NAME,
+        KPI_TOOL_CALLS_DESCRIPTION,
+        null);
+    return buildTile(
+        KPI_TOOL_CALLS_REPORT_ID,
+        new PositionDto(0, 6),
+        new DimensionDto(18, 2),
+        Map.of(TILE_CONFIG_SECTION, TILE_SECTION_RELIABILITY_AND_TOOL_CALLS));
   }
 
   private DashboardDefinitionRestDto buildAgentDashboard(final List<DashboardReportTileDto> tiles) {

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -1597,7 +1597,9 @@
       "agenticKpiDurationP95Name": "P95-Ausführungsdauer",
       "agenticKpiDurationP95Description": "95. Perzentil der Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum.",
       "agenticFailureRateByVersionName": "Vorfallsrate nach Prozessversion",
-      "agenticFailureRateByVersionDescription": "Prozentsatz der abgeschlossenen agentischen Prozessinstanzen mit einem gelösten Vorfall, aufgeschlüsselt nach Prozessdefinitionsversion."
+      "agenticFailureRateByVersionDescription": "Prozentsatz der abgeschlossenen agentischen Prozessinstanzen mit einem gelösten Vorfall, aufgeschlüsselt nach Prozessdefinitionsversion.",
+      "agenticKpiToolCallsName": "Tool-Aufrufe gesamt",
+      "agenticKpiToolCallsDescription": "Gesamtzahl der Tool-Aufrufe durch Agenten in abgeschlossenen agentischen Prozessinstanzen im gewählten Zeitraum."
     }
   },
   "managementDashboard": {

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -1597,7 +1597,9 @@
       "agenticKpiDurationP95Name": "P95 execution duration",
       "agenticKpiDurationP95Description": "95th percentile execution duration of completed agentic process instances in the selected period.",
       "agenticFailureRateByVersionName": "Failure rate by process version",
-      "agenticFailureRateByVersionDescription": "Percentage of completed agentic process instances that encountered a resolved incident, broken down by process definition version."
+      "agenticFailureRateByVersionDescription": "Percentage of completed agentic process instances that encountered a resolved incident, broken down by process definition version.",
+      "agenticKpiToolCallsName": "Total tool calls",
+      "agenticKpiToolCallsDescription": "Total number of tool calls made by agents in completed agentic process instances in the selected period."
     }
   },
   "managementDashboard": {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -93,7 +93,7 @@ public class AgenticControlDashboardServiceTest {
     assertThat(saved.isAgenticControlDashboard()).isTrue();
     assertThat(saved.isManagementDashboard()).isFalse();
     assertThat(saved.getCollectionId()).isNull();
-    assertThat(saved.getTiles()).hasSize(12);
+    assertThat(saved.getTiles()).hasSize(13);
   }
 
   @Test
@@ -179,7 +179,8 @@ public class AgenticControlDashboardServiceTest {
             AgenticControlDashboardService.TOKEN_CONSUMERS_REPORT_ID,
             AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID,
             AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID,
-            AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_REPORT_ID);
+            AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_REPORT_ID,
+            AgenticControlDashboardService.KPI_TOOL_CALLS_REPORT_ID);
   }
 
   @Test
@@ -240,7 +241,7 @@ public class AgenticControlDashboardServiceTest {
     underTest.reconcile();
 
     // then reports are upserted and dashboard tiles are updated, but dashboard is not recreated
-    verify(reportWriter, times(12))
+    verify(reportWriter, times(13))
         .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
     verify(dashboardWriter, never()).saveDashboard(any());
     verify(dashboardWriter).updateDashboard(any(), any());
@@ -345,7 +346,9 @@ public class AgenticControlDashboardServiceTest {
               AgenticControlDashboardService.DURATION_STABILITY_NAME,
               AgenticControlDashboardService.DURATION_STABILITY_DESCRIPTION,
               AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_NAME,
-              AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_DESCRIPTION);
+              AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_DESCRIPTION,
+              AgenticControlDashboardService.KPI_TOOL_CALLS_NAME,
+              AgenticControlDashboardService.KPI_TOOL_CALLS_DESCRIPTION);
     }
   }
 
@@ -728,6 +731,68 @@ public class AgenticControlDashboardServiceTest {
             .orElseThrow();
     assertThat(failureRateTile.getConfiguration())
         .isEqualTo(Map.of("section", "reliabilityAndToolCalls", "visibleInL1Only", true));
+  }
+
+  @Test
+  void shouldSeedTotalToolCallsReportAsSummedNumber() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+    final ArgumentCaptor<ProcessReportDataDto> dataCaptor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+
+    // when
+    underTest.reconcile();
+
+    // then the report is upserted with the deterministic ID and localization keys
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.KPI_TOOL_CALLS_REPORT_ID),
+            isNull(),
+            dataCaptor.capture(),
+            eq(AgenticControlDashboardService.KPI_TOOL_CALLS_NAME),
+            eq(AgenticControlDashboardService.KPI_TOOL_CALLS_DESCRIPTION),
+            isNull());
+
+    final ProcessReportDataDto reportData = dataCaptor.getValue();
+    // view: AGENT_INSTANCE + TOOL_CALLS, summed into a single number with no grouping
+    assertThat(reportData.getView().getEntity()).isEqualTo(ProcessViewEntity.AGENT_INSTANCE);
+    assertThat(reportData.getView().getProperties()).containsExactly(ViewProperty.TOOL_CALLS);
+    assertThat(reportData.getGroupBy().getType()).isEqualTo(ProcessGroupByType.NONE);
+    assertThat(reportData.getVisualization()).isEqualTo(ProcessVisualization.NUMBER);
+    assertThat(reportData.getConfiguration().getAggregationTypes())
+        .extracting(AggregationDto::getType)
+        .containsExactly(AggregationType.SUM);
+    // filters: completedInstancesOnly + hasAgentInstances (scope is applied per-request by the
+    // frontend, so the seeded report carries no definitions)
+    assertThat(reportData.getFilter())
+        .hasAtLeastOneElementOfType(CompletedInstancesOnlyFilterDto.class);
+    assertThat(reportData.getFilter()).hasAtLeastOneElementOfType(HasAgentInstancesFilterDto.class);
+    assertThat(reportData.getDefinitions()).isEmpty();
+    assertThat(reportData.isAgenticControlReport()).isTrue();
+  }
+
+  @Test
+  void shouldPlaceTotalToolCallsTileFullWidthVisibleInBothScopes() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then a single full-width tile in the reliability section, with no L0/L1-only flag, so the
+    // number renders in both the fleet (L0) and drill-down (L1) views
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    final List<DashboardReportTileDto> toolCallsTiles =
+        saved.getTiles().stream()
+            .filter(t -> AgenticControlDashboardService.KPI_TOOL_CALLS_REPORT_ID.equals(t.getId()))
+            .toList();
+    assertThat(toolCallsTiles).hasSize(1);
+
+    final DashboardReportTileDto toolCallsTile = toolCallsTiles.getFirst();
+    assertThat(toolCallsTile.getConfiguration())
+        .isEqualTo(Map.of("section", "reliabilityAndToolCalls"));
+    assertThat(toolCallsTile.getDimensions().getWidth()).isEqualTo(18);
+    assertThat(toolCallsTile.getDimensions().getHeight()).isEqualTo(2);
   }
 
   @SuppressWarnings("unchecked")

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.tsx
@@ -37,13 +37,13 @@ beforeEach(() => {
 });
 
 it('should show a loading state while the dashboard is being fetched', () => {
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
 
   expect(node.find('Loading')).toExist();
 });
 
 it('should load the agentic dashboard on mount', async () => {
-  shallow(<AgenticControlPlane />);
+  shallow(<AgenticControlPlane/>);
 
   await runAllEffects();
 
@@ -51,7 +51,7 @@ it('should load the agentic dashboard on mount', async () => {
 });
 
 it('should render the dashboard once tiles are loaded', async () => {
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
 
   await runAllEffects();
 
@@ -60,7 +60,7 @@ it('should render the dashboard once tiles are loaded', async () => {
 });
 
 it('should pass the default Last 30 days filter to DashboardRenderer', async () => {
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
 
   await runAllEffects();
 
@@ -77,16 +77,16 @@ it('should pass the default Last 30 days filter to DashboardRenderer', async () 
       },
     },
   ];
-  expect(
-    node.find('.kpi-section').find('DashboardRenderer').prop('filter')
-  ).toEqual(expectedFilter);
-  expect(
-    node.find('.token-section').find('DashboardRenderer').prop('filter')
-  ).toEqual(expectedFilter);
+  expect(node.find('.kpi-section').find('DashboardRenderer').prop('filter')).toEqual(
+    expectedFilter
+  );
+  expect(node.find('.token-section').find('DashboardRenderer').prop('filter')).toEqual(
+    expectedFilter
+  );
 });
 
 it('should update the filter when the date preset changes', async () => {
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
 
   await runAllEffects();
 
@@ -105,16 +105,16 @@ it('should update the filter when the date preset changes', async () => {
       },
     },
   ];
-  expect(
-    node.find('.kpi-section').find('DashboardRenderer').prop('filter')
-  ).toEqual(expectedFilter);
-  expect(
-    node.find('.token-section').find('DashboardRenderer').prop('filter')
-  ).toEqual(expectedFilter);
+  expect(node.find('.kpi-section').find('DashboardRenderer').prop('filter')).toEqual(
+    expectedFilter
+  );
+  expect(node.find('.token-section').find('DashboardRenderer').prop('filter')).toEqual(
+    expectedFilter
+  );
 });
 
 it('should render the page header with title and description', async () => {
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
 
   await runAllEffects();
 
@@ -126,13 +126,11 @@ it('should pass the loaded tiles to DashboardRenderer', async () => {
   const tiles = [{id: 'report-1', position: {x: 0, y: 0}, dimensions: {width: 4, height: 3}}];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
 
   await runAllEffects();
 
-  expect(
-    node.find('.kpi-section').find('DashboardRenderer').prop('tiles')
-  ).toEqual(tiles);
+  expect(node.find('.kpi-section').find('DashboardRenderer').prop('tiles')).toEqual(tiles);
 });
 
 it('should hide visibleInL0Only tiles when a process is selected', async () => {
@@ -143,15 +141,14 @@ it('should hide visibleInL0Only tiles when a process is selected', async () => {
   ];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
   await runAllEffects();
 
   (node.find('FilterBar').prop('onProcessScopeChange') as (v: string) => void)('my-process');
 
-  const visibleTiles = node
-    .find('.kpi-section')
-    .find('DashboardRenderer')
-    .prop('tiles') as {id: string}[];
+  const visibleTiles = node.find('.kpi-section').find('DashboardRenderer').prop('tiles') as {
+    id: string;
+  }[];
   expect(visibleTiles.map((t) => t.id)).toEqual(['l1-tile', 'common-tile']);
 });
 
@@ -163,26 +160,26 @@ it('should hide visibleInL1Only tiles when no process is selected (L0)', async (
   ];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
   await runAllEffects();
 
-  const visibleTiles = node
-    .find('.kpi-section')
-    .find('DashboardRenderer')
-    .prop('tiles') as {id: string}[];
+  const visibleTiles = node.find('.kpi-section').find('DashboardRenderer').prop('tiles') as {
+    id: string;
+  }[];
   expect(visibleTiles.map((t) => t.id)).toEqual(['l0-tile', 'common-tile']);
 });
 
 it('should include definitions in evaluate calls when a process is selected', async () => {
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
   await runAllEffects();
 
   (node.find('FilterBar').prop('onProcessScopeChange') as (v: string) => void)('my-process');
 
-  const loadTile = node
-    .find('.kpi-section')
-    .find('DashboardRenderer')
-    .prop('loadTile') as (id: string, filter: unknown[], params: unknown) => void;
+  const loadTile = node.find('.kpi-section').find('DashboardRenderer').prop('loadTile') as (
+    id: string,
+    filter: unknown[],
+    params: unknown
+  ) => void;
   loadTile('report-id', [], {});
 
   expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, [
@@ -191,16 +188,53 @@ it('should include definitions in evaluate calls when a process is selected', as
 });
 
 it('should pass empty definitions in evaluate calls when no process is selected', async () => {
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
   await runAllEffects();
 
-  const loadTile = node
-    .find('.kpi-section')
-    .find('DashboardRenderer')
-    .prop('loadTile') as (id: string, filter: unknown[], params: unknown) => void;
+  const loadTile = node.find('.kpi-section').find('DashboardRenderer').prop('loadTile') as (
+    id: string,
+    filter: unknown[],
+    params: unknown
+  ) => void;
   loadTile('report-id', [], {});
 
   expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, []);
+});
+
+it('should render a reliabilityAndToolCalls tile in its section in both L0 and L1', async () => {
+  // the Total tool calls tile carries no L0/L1-only flag, so it must show in both scopes
+  const tiles = [
+    {
+      id: 'tool-calls',
+      configuration: {section: 'reliabilityAndToolCalls'},
+      position: {x: 0, y: 6},
+      dimensions: {width: 18, height: 2},
+    },
+  ];
+  (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
+
+  const node = shallow(<AgenticControlPlane/>);
+  await runAllEffects();
+
+  // L0 (fleet view — no process selected)
+  expect(
+    (
+      node.find('.reliabilityAndToolCalls-section').find('DashboardRenderer').prop('tiles') as {
+        id: string;
+      }[]
+    ).map((t) => t.id)
+  ).toEqual(['tool-calls']);
+
+  // L1 (process drill-down)
+  (node.find('FilterBar').prop('onProcessScopeChange') as (v: string) => void)('my-process');
+
+  expect(
+    (
+      node.find('.reliabilityAndToolCalls-section').find('DashboardRenderer').prop('tiles') as {
+        id: string;
+      }[]
+    ).map((t) => t.id)
+  ).toEqual(['tool-calls']);
 });
 
 it('should inject the configured top-N limit when evaluating a tile with a topN config', async () => {
@@ -209,13 +243,14 @@ it('should inject the configured top-N limit when evaluating a tile with a topN 
   ];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
   await runAllEffects();
 
-  const loadTile = node
-    .find('.token-section')
-    .find('DashboardRenderer')
-    .prop('loadTile') as (id: string, filter: unknown[], params: unknown) => void;
+  const loadTile = node.find('.token-section').find('DashboardRenderer').prop('loadTile') as (
+    id: string,
+    filter: unknown[],
+    params: unknown
+  ) => void;
   loadTile('consumers', [], {});
 
   expect(evaluateReport).toHaveBeenCalledWith('consumers', [], {limit: 10}, [], 'week');
@@ -225,13 +260,14 @@ it('should not inject a limit for token tiles without a topN config', async () =
   const tiles = [{id: 'token-trend', configuration: {section: 'token'}, position: {x: 0, y: 0}}];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane />);
+  const node = shallow(<AgenticControlPlane/>);
   await runAllEffects();
 
-  const loadTile = node
-    .find('.token-section')
-    .find('DashboardRenderer')
-    .prop('loadTile') as (id: string, filter: unknown[], params: unknown) => void;
+  const loadTile = node.find('.token-section').find('DashboardRenderer').prop('loadTile') as (
+    id: string,
+    filter: unknown[],
+    params: unknown
+  ) => void;
   loadTile('token-trend', [], {});
 
   expect(evaluateReport).toHaveBeenCalledWith('token-trend', [], {}, [], 'week');


### PR DESCRIPTION
## Description


Adds the tool call KPI tile in the "Reliability & tool calls" section.

**Changes**
- Backend: `buildTotalToolCallsReport()` in `AgenticControlDashboardService` + deterministic report id, registered in `reconcile()`.
- Localization: `agenticKpiToolCallsName` / `Description` in `en.json` + `de.json`.
- Refactor (separate commit): extracted `reliabilityAndToolCalls` section + `visibleInL1Only` tile-config constants.
- Tests: unit assertions for the report/tile shape; integration tests for fleet (L0), scoped (L1), and date-filtered totals.


Closes #55695