### PR TITLE
fix: set backwards.compat.version to previous minor baseline on minor releases

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -96,8 +96,18 @@ jobs:
     steps:
       - name: Output Inputs
         run: echo "${{ toJSON(github.event.inputs) }}"
-        # This step generates a GitHub App token to be used in Git operations as a workaround  for
-        # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
+      - name: Parse Release Version
+        run: |
+          if [[ "${RELEASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "RELEASE_MAJOR=${BASH_REMATCH[1]}" >> "$GITHUB_ENV"
+            echo "RELEASE_MINOR=${BASH_REMATCH[2]}" >> "$GITHUB_ENV"
+            echo "RELEASE_PATCH=${BASH_REMATCH[3]}" >> "$GITHUB_ENV"
+            echo "IS_STABLE_VERSION=true" >> "$GITHUB_ENV"
+          else
+            echo "IS_STABLE_VERSION=false" >> "$GITHUB_ENV"
+          fi
+      # This step generates a GitHub App token to be used in Git operations as a workaround  for
+      # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
       - name: Generate GitHub token
         id: github-token
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
@@ -297,15 +307,26 @@ jobs:
           retention-days: 5
       - name: Update Compat Version
         run: |
-          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Skipping updating the compat version as ${RELEASE_VERSION} is not a stable version"
+          if [[ "$IS_STABLE_VERSION" != "true" ]]; then
+            echo "Skipping: ${RELEASE_VERSION} is not a stable version"
             exit 0
           fi
 
-          ./mvnw -B versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion="${RELEASE_VERSION}" -P\!include-optimize
+          if [[ "$RELEASE_PATCH" == "0" ]]; then
+            PREV_MINOR=$((RELEASE_MINOR - 1))
+            if [[ "$PREV_MINOR" -lt 0 ]]; then
+              echo "ERROR: Cannot compute previous minor for ${RELEASE_VERSION} (MINOR=0). Set the 'backwards.compat.version' property in parent/pom.xml to the last stable minor baseline (e.g. 8.X.0) before re-running."
+              exit 1
+            fi
+            COMPAT_VERSION="${RELEASE_MAJOR}.${PREV_MINOR}.0"
+            ./mvnw -B versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion="${COMPAT_VERSION}" -P\!include-optimize
+          else
+            echo "Patch release: backwards.compat.version not updated (stays at minor baseline)"
+          fi
+
           FILE=$(./mvnw -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout -P\!include-optimize)
           rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"
-          git commit -am "build(project): update java compat versions"
+          git diff --quiet HEAD || git commit -am "build(project): update java compat versions"
       - name: Delete version-specific allowed API breaking changes
         run: |
           IFS=$'\n' readarray -t files <<< "$(find . -name 'ignored-changes.json')"

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -329,6 +329,11 @@ jobs:
           FILE=$(./mvnw -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout -P\!include-optimize)
           rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"
           git diff --quiet HEAD || git commit -am "build(project): update java compat versions"
+      - name: Debug Compat Version
+        if: ${{ inputs.dryRun }}
+        run: |
+          echo "=== Compat Version after Update Compat Version step ==="
+          ./mvnw -B help:evaluate -Dexpression=backwards.compat.version -q -DforceStdout -P\!include-optimize
       - name: Delete version-specific allowed API breaking changes
         run: |
           IFS=$'\n' readarray -t files <<< "$(find . -name 'ignored-changes.json')"

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -99,10 +99,12 @@ jobs:
       - name: Parse Release Version
         run: |
           if [[ "${RELEASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            echo "RELEASE_MAJOR=${BASH_REMATCH[1]}" >> "$GITHUB_ENV"
-            echo "RELEASE_MINOR=${BASH_REMATCH[2]}" >> "$GITHUB_ENV"
-            echo "RELEASE_PATCH=${BASH_REMATCH[3]}" >> "$GITHUB_ENV"
-            echo "IS_STABLE_VERSION=true" >> "$GITHUB_ENV"
+            {
+              echo "RELEASE_MAJOR=${BASH_REMATCH[1]}"
+              echo "RELEASE_MINOR=${BASH_REMATCH[2]}"
+              echo "RELEASE_PATCH=${BASH_REMATCH[3]}"
+              echo "IS_STABLE_VERSION=true"
+            } >> "$GITHUB_ENV"
           else
             echo "IS_STABLE_VERSION=false" >> "$GITHUB_ENV"
           fi
@@ -315,7 +317,7 @@ jobs:
           if [[ "$RELEASE_PATCH" == "0" ]]; then
             PREV_MINOR=$((RELEASE_MINOR - 1))
             if [[ "$PREV_MINOR" -lt 0 ]]; then
-              echo "ERROR: Cannot compute previous minor for ${RELEASE_VERSION} (MINOR=0). Set the 'backwards.compat.version' property in parent/pom.xml to the last stable minor baseline (e.g. 8.X.0) before re-running."
+              echo "ERROR: Cannot compute previous minor for ${RELEASE_VERSION} (MINOR=0). Please set 'backwards.compat.version' in parent/pom.xml to the last stable release from the previous release line (e.g. 8.<minor>.<patch> for a 9.0.0 release), then re-run the workflow."
               exit 1
             fi
             COMPAT_VERSION="${RELEASE_MAJOR}.${PREV_MINOR}.0"

--- a/.github/workflows/update-backwards-compat-version.yml
+++ b/.github/workflows/update-backwards-compat-version.yml
@@ -1,0 +1,203 @@
+# type: CI Helper - Post-release
+# owner: @camunda/monorepo-devops-team
+name: Update Backwards Compat Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'The minor version that was just released (e.g. 8.10.0). main''s backwards.compat.version will be updated to this value.'
+        type: string
+        required: true
+      userSlackId:
+        description: 'The Slack ID of the user to notify on failure, no mention if omitted.'
+        type: string
+        required: false
+      dryRun:
+        description: 'Whether to perform a dry run where no changes are pushed and no PR is opened, defaults to true.'
+        type: boolean
+        default: true
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+jobs:
+  update-backwards-compat-version:
+    name: "Update backwards.compat.version to ${{ inputs.releaseVersion }} on main"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+      - name: Validate Release Version
+        env:
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
+        run: |
+          if [[ ! "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+            echo "ERROR: releaseVersion '${RELEASE_VERSION}' is not a minor release (expected format: X.Y.0)"
+            exit 1
+          fi
+      - name: Git User Setup
+        run: |
+          git config --global user.email "github-actions[update-backwards-compat-version]"
+          git config --global user.name "github-actions[update-backwards-compat-version]@users.noreply.github.com"
+      - name: Get current backwards.compat.version from ./parent/pom.xml
+        id: get-current-compat-version
+        uses: mavrosxristoforos/get-xml-info@cc0a00b30a53c3adf0ea2cbfd8314cea394fbbad # 2.1.0
+        with:
+          xml-file: './parent/pom.xml'
+          xpath: '//*[local-name()="backwards.compat.version"]'
+      - uses: ./.github/actions/setup-build
+        if: ${{ steps.get-current-compat-version.outputs.info != inputs.releaseVersion }}
+        with:
+          maven-cache-key-modifier: backwards-compat-update
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Create branch and update backwards.compat.version
+        id: update
+        if: ${{ steps.get-current-compat-version.outputs.info != inputs.releaseVersion }}
+        env:
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
+          BRANCH: ci/update-backwards-compat-version-${{ inputs.releaseVersion }}
+        run: |
+          git checkout -b "${BRANCH}"
+          ./mvnw -B versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion="${RELEASE_VERSION}" -pl parent
+          git commit -am "build(project): update backwards.compat.version to ${RELEASE_VERSION} after minor release"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+      - name: Debug backwards.compat.version after update
+        if: ${{ steps.update.outcome == 'success' && inputs.dryRun }}
+        run: |
+          echo "=== backwards.compat.version after update ==="
+          ./mvnw -B help:evaluate -Dexpression=backwards.compat.version -q -DforceStdout -pl parent
+          echo "=== git diff ==="
+          git show --stat HEAD
+      - name: Push branch
+        if: ${{ steps.update.outcome == 'success' && !inputs.dryRun }}
+        env:
+          BRANCH: ${{ steps.update.outputs.branch }}
+        run: git push origin "${BRANCH}"
+      - name: Open PR to main
+        id: pr
+        if: ${{ steps.update.outcome == 'success' && !inputs.dryRun }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
+          BRANCH: ${{ steps.update.outputs.branch }}
+        run: |
+          url=$(gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "${BRANCH}" \
+            --title "build(project): update backwards.compat.version to ${RELEASE_VERSION} after minor release" \
+            --body "After the \`${RELEASE_VERSION}\` minor release, \`backwards.compat.version\` on \`main\` should point to \`${RELEASE_VERSION}\` so that CI validates future development against the newly shipped minor.")
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+          number=$(gh pr view "$url" --repo "$GITHUB_REPOSITORY" --json number --jq '.number')
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+      - name: Resolve PR outputs
+        id: resolve-pr
+        if: always()
+        env:
+          UPDATE_OUTCOME: ${{ steps.update.outcome }}
+          DRY_RUN: ${{ inputs.dryRun }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          if [[ "$UPDATE_OUTCOME" == "skipped" ]]; then
+            echo "pr_url=already-up-to-date" >> "$GITHUB_OUTPUT"
+            echo "pr_number=already-up-to-date" >> "$GITHUB_OUTPUT"
+          elif [[ "$DRY_RUN" == "true" ]]; then
+            echo "pr_url=https://example.com" >> "$GITHUB_OUTPUT"
+            echo "pr_number=dry-run-pr-not-created" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+            echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Import Camunda Secrets
+        id: camunda-secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG;
+      - name: Notify Camunda of completion
+        if: success()
+        uses: camunda-community-hub/camunda-platform-8-github-action@0fe490e4cf6f0cf59a5c86a127c4354b4b1fc3b7 # 8.3.0
+        with:
+          clientConfig: ${{ steps.camunda-secrets.outputs.CLIENT_CONFIG }}
+          operation: publishMessage
+          messageName: 'backwards-compat-version-pr-created'
+          correlationKey: 'backwards-compat-update-${{ inputs.releaseVersion }}'
+          timeToLive: '240000'
+          variables: |
+            {
+              "workflow_run": {
+                "name": "Update Backwards Compat Version",
+                "conclusion": "success",
+                "head_branch": "${{ steps.update.outputs.branch }}"
+              },
+              "backwards_compat_pr_url": "${{ steps.resolve-pr.outputs.pr_url }}",
+              "backwards_compat_pr_number": "${{ steps.resolve-pr.outputs.pr_number }}",
+              "compat_version": "${{ inputs.releaseVersion }}"
+            }
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  notify:
+    name: Send Slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [update-backwards-compat-version]
+    if: ${{ failure() && !inputs.dryRun }}
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+      - name: Send failure Slack notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Updating backwards.compat.version* to `${{ inputs.releaseVersion }}` on `main` failed!\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ inputs.userSlackId != '' && format('<@{0}>', inputs.userSlackId) || '' }} Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/update-backwards-compat-version.yml
+++ b/.github/workflows/update-backwards-compat-version.yml
@@ -201,3 +201,16 @@ jobs:
                 }
               ]
             }
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,6 +43,8 @@
 /.github/workflows/preview-env*                          @camunda/monorepo-devops-team
 /.github/workflows/reject-updates-using-merge-commit.yml @camunda/monorepo-devops-team
 /.github/workflows/renovatelint.yml                      @camunda/monorepo-devops-team
+/.github/workflows/update-backwards-compat-version.yml   @camunda/monorepo-devops-team
+/.github/workflows/update-identity.yml                   @camunda/monorepo-devops-team
 /.github/workflows/retry-workflow.yml                    @camunda/monorepo-devops-team
 /.github/workflows/statistics-daily.yml                  @camunda/monorepo-devops-team
 /.github/workflows/zeebe-release-stable-dry-run.yml      @camunda/monorepo-devops-team


### PR DESCRIPTION
## Summary

- Fixes `backwards.compat.version` being set to the current release version (e.g. `8.9.0 → 8.9.0`) instead of the previous minor baseline (`8.9.0 → 8.8.0`), which caused backwards-compat CI to silently compare a release against itself
- Patch releases now skip the compat version update entirely — the property stays at the minor baseline set when the minor was cut
- Extracts version parsing into a dedicated `Parse Release Version` step at the top of the `release` job, replacing ad-hoc `cut -d'.'` calls in `Update Compat Version`
- Adds `git diff --quiet HEAD ||` guard before `git commit` to prevent a failing commit on patch releases where nothing changed
- Introduces `update-backwards-compat-version.yml`: a post-release helper workflow that updates `main`'s `backwards.compat.version` after a minor ships and opens a PR; triggered by camunda/camunda-release#124

Related to #51405

## Test plan

### `camunda-platform-release.yml` — Update Compat Version fix

- [x] Trigger a dry-run release with `dryRun=true`, `releaseVersion=8.10.0` — confirm `backwards.compat.version` is set to `8.9.0` on the release branch. https://github.com/camunda/camunda/actions/runs/28098520797/job/83194018908#step:18:35
<img width="572" height="865" alt="image" src="https://github.com/user-attachments/assets/abb81418-b11e-488e-98e8-6a96266a9f38" />

- [x] Trigger a dry-run patch release with `dryRun=true`, `releaseVersion=8.10.1` — confirm `backwards.compat.version` is unchanged https://github.com/camunda/camunda/actions/runs/28098563415/job/83194167589#step:18:35
<img width="572" height="865" alt="image" src="https://github.com/user-attachments/assets/010e02fb-347c-440c-9a08-bc86fb058704" />


### `update-backwards-compat-version.yml` — new post-release workflow

- [ ] After merge, trigger a dry-run dispatch (`dryRun=true`, `releaseVersion=8.10.0`) — confirm the workflow creates the branch, updates the property, and emits the correct placeholder PR outputs without pushing

🤖 Generated with [Claude Code](https://claude.com/claude-code)