### PR TITLE
feat: add metadata to cluster variable record

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/ClusterVariableInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/ClusterVariableInstance.java
@@ -27,6 +27,10 @@ public final class ClusterVariableInstance extends UnpackedObject implements DbV
     clusterVariable.getValue().copyFrom(clusterVariableRecord);
   }
 
+  public ClusterVariableRecord getRecord() {
+    return clusterVariable.getValue();
+  }
+
   public DirectBuffer getValueBuffer() {
     return clusterVariable.getValue().getValueBuffer();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -204,6 +205,28 @@ public final class CreateClusterVariableTest {
     final var result = clusterVariableRecordValidator.validateName(clusterVariableRecord);
     // then
     assertThat(result.getLeft().reason()).isEqualTo(rejectionReason);
+  }
+
+  @Test
+  public void shouldCarryMetadataThroughCreateEvent() {
+    // given
+    final var metadata = Map.<String, Object>of("type", "OAUTH2");
+
+    // when
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_META_CREATE")
+            .setGlobalScope()
+            .withValue("\"VALUE\"")
+            .withMetadata(metadata)
+            .create();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.CREATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
   }
 
   static Stream<Arguments> retrieveInvalidClusterVariableName() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableTest.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -252,5 +255,33 @@ public final class DeleteClusterVariableTest {
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
             "Invalid cluster variable name: 'KEY_5'. The variable does not exist in the scope 'GLOBAL'");
+  }
+
+  @Test
+  public void shouldCarryMetadataThroughDeleteEvent() {
+    // given
+    final var metadata = Map.<String, Object>of("type", "OAUTH2");
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_META_DELETE")
+        .setGlobalScope()
+        .withValue("\"VALUE\"")
+        .withMetadata(metadata)
+        .create();
+
+    // when
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_META_DELETE")
+            .setGlobalScope()
+            .withMetadata(metadata)
+            .delete();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.DELETED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableTest.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -317,5 +320,34 @@ public final class UpdateClusterVariableTest {
         .hasIntent(ClusterVariableIntent.UPDATED)
         .hasRecordType(RecordType.EVENT);
     Assertions.assertThat(record2.getValue()).hasValue("\"VALUE_3\"");
+  }
+
+  @Test
+  public void shouldCarryMetadataThroughUpdateEvent() {
+    // given
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_META_UPDATE")
+        .setGlobalScope()
+        .withValue("\"VALUE\"")
+        .create();
+
+    final var metadata = Map.<String, Object>of("type", "OAUTH2");
+
+    // when
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_META_UPDATE")
+            .setGlobalScope()
+            .withValue("\"UPDATED_VALUE\"")
+            .withMetadata(metadata)
+            .update();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.UPDATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/clustervariable/ClusterVariableStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/clustervariable/ClusterVariableStateTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableClusterVariableState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+class ClusterVariableStateTest {
+
+  private MutableProcessingState processingState;
+  private MutableClusterVariableState clusterVariableState;
+
+  @BeforeEach
+  void setup() {
+    clusterVariableState = processingState.getClusterVariableState();
+  }
+
+  @Test
+  void shouldStoreAndRetrieveMetadataForGloballyScopedVariable() {
+    // given
+    final var metadata = Map.<String, Object>of("credentialType", "OAUTH2");
+    final var record =
+        new ClusterVariableRecord()
+            .setName("globalVar")
+            .setGlobalScope()
+            .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"value\"")))
+            .setMetadata(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(metadata)));
+
+    // when
+    clusterVariableState.createGloballyScopedClusterVariable(record);
+
+    // then
+    final var stored =
+        clusterVariableState.getGloballyScopedClusterVariable(BufferUtil.wrapString("globalVar"));
+    assertThat(stored).isPresent();
+    assertThat(stored.get().getRecord().getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
+  }
+
+  @Test
+  void shouldStoreAndRetrieveMetadataForTenantScopedVariable() {
+    // given
+    final var tenantId = "tenant-1";
+    final var metadata = Map.<String, Object>of("credentialType", "API_KEY", "version", "2");
+    final var record =
+        new ClusterVariableRecord()
+            .setName("tenantVar")
+            .setTenantScope()
+            .setTenantId(tenantId)
+            .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"value\"")))
+            .setMetadata(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(metadata)));
+
+    // when
+    clusterVariableState.createTenantScopedClusterVariable(record);
+
+    // then
+    final var stored =
+        clusterVariableState.getTenantScopedClusterVariable(
+            BufferUtil.wrapString("tenantVar"), tenantId);
+    assertThat(stored).isPresent();
+    assertThat(stored.get().getRecord().getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
+  }
+
+  @Test
+  void shouldPreserveUpdatedMetadataOnGloballyScopedVariable() {
+    // given
+    final var initialMetadata = Map.<String, Object>of("credentialType", "API_KEY");
+    final var updatedMetadata = Map.<String, Object>of("credentialType", "OAUTH2", "version", "2");
+    final var record =
+        new ClusterVariableRecord()
+            .setName("updateVar")
+            .setGlobalScope()
+            .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"oldValue\"")))
+            .setMetadata(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(initialMetadata)));
+    clusterVariableState.createGloballyScopedClusterVariable(record);
+
+    // when
+    record
+        .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"newValue\"")))
+        .setMetadata(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(updatedMetadata)));
+    clusterVariableState.updateGloballyScopedClusterVariable(record);
+
+    // then
+    final var stored =
+        clusterVariableState.getGloballyScopedClusterVariable(BufferUtil.wrapString("updateVar"));
+    assertThat(stored).isPresent();
+    assertThat(stored.get().getRecord().getMetadata())
+        .containsExactlyInAnyOrderEntriesOf(updatedMetadata);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableClient.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
 import java.util.Random;
 import java.util.function.LongFunction;
 import org.agrona.DirectBuffer;
@@ -67,6 +68,12 @@ public final class ClusterVariableClient {
 
   public ClusterVariableClient withTenantId(final String tenantId) {
     clusterVariableRecord.setTenantId(tenantId);
+    return this;
+  }
+
+  public ClusterVariableClient withMetadata(final Map<String, Object> metadata) {
+    clusterVariableRecord.setMetadata(
+        new UnsafeBuffer(MsgPackConverter.convertToMsgPack(metadata)));
     return this;
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-cluster-variable-template.json
@@ -33,6 +33,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "metadata": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-cluster-variable-template.json
@@ -39,6 +39,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "metadata": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -17,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -27,6 +29,7 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private static final StringValue VALUE_KEY = new StringValue("value");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue SCOPE_KEY = new StringValue("scope");
+  private static final StringValue METADATA_KEY = new StringValue("metadata");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp =
@@ -34,13 +37,15 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private final EnumProperty<ClusterVariableScope> scopeProp =
       new EnumProperty<>(SCOPE_KEY, ClusterVariableScope.class, ClusterVariableScope.UNSPECIFIED);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
+  private final DocumentProperty metadataProp = new DocumentProperty(METADATA_KEY);
 
   public ClusterVariableRecord() {
-    super(4);
+    super(5);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(metadataProp);
   }
 
   @Override
@@ -99,6 +104,21 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   public ClusterVariableRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
     return this;
+  }
+
+  @Override
+  public Map<String, Object> getMetadata() {
+    return MsgPackConverter.convertToMap(metadataProp.getValue());
+  }
+
+  public ClusterVariableRecord setMetadata(final DirectBuffer metadata) {
+    metadataProp.setValue(metadata);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getMetadataBuffer() {
+    return metadataProp.getValue();
   }
 
   @JsonIgnore

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceMigrationPlan;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceModificationPlan;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalSubscriptionRecord;
@@ -3283,6 +3284,52 @@ final class JsonSerializableToJsonTest {
         """
                 {
                   "time": 0
+                }
+                """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////// ClusterVariableRecord
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // ////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ClusterVariableRecord (global scope with metadata)",
+        (Supplier<ClusterVariableRecord>)
+            () ->
+                new ClusterVariableRecord()
+                    .setName("myVar")
+                    .setGlobalScope()
+                    .setTenantId("<default>")
+                    .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("42")))
+                    .setMetadata(
+                        new UnsafeBuffer(
+                            MsgPackConverter.convertToMsgPack(Map.of("credentialType", "OAUTH2")))),
+        """
+                {
+                  "name": "myVar",
+                  "value": "42",
+                  "scope": "GLOBAL",
+                  "tenantId": "<default>",
+                  "metadata": { "credentialType": "OAUTH2" }
+                }
+                """
+      },
+      {
+        "ClusterVariableRecord (tenant scope without metadata)",
+        (Supplier<ClusterVariableRecord>)
+            () ->
+                new ClusterVariableRecord()
+                    .setName("tenantVar")
+                    .setTenantScope()
+                    .setTenantId("tenant-1")
+                    .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("42"))),
+        """
+                {
+                  "name": "tenantVar",
+                  "value": "42",
+                  "scope": "TENANT",
+                  "tenantId": "tenant-1",
+                  "metadata": {}
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecordTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 final class ClusterVariableRecordTest {
 
   @Test
-  void shouldRoundTripMetadataViaMsgPack() {
+  void shouldRoundTripFieldsViaMsgPack() {
     // given
     final Map<String, Object> metadata = Map.of("credentialType", "OAUTH2", "version", "1");
     final var original =
@@ -34,22 +34,32 @@ final class ClusterVariableRecordTest {
     copy.copyFrom(original);
 
     // then
+    assertThat(copy.getName()).isEqualTo(original.getName());
+    assertThat(copy.getScope()).isEqualTo(original.getScope());
+    assertThat(copy.getTenantId()).isEqualTo(original.getTenantId());
+    assertThat(copy.getValue()).isEqualTo(original.getValue());
     assertThat(copy.getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
   }
 
   @Test
-  void shouldDeserializeAsEmptyMapWhenMetadataFieldAbsent() {
-    // given — a record written without the metadata field (simulates old serialised records)
-    final var legacy = new ClusterVariableRecord();
-    legacy.setName("myVar");
-    legacy.setScope(ClusterVariableScope.GLOBAL);
-    legacy.setTenantId("<default>");
-    legacy.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"value\"")));
+  void shouldReturnEmptyMetadataIfNotSet() {
+    // given
+    final var original =
+        new ClusterVariableRecord()
+            .setName("myVar")
+            .setScope(ClusterVariableScope.GLOBAL)
+            .setTenantId("<default>")
+            .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"value\"")));
 
+    // when
     final var copy = new ClusterVariableRecord();
-    copy.copyFrom(legacy);
+    copy.copyFrom(original);
 
     // then
+    assertThat(copy.getName()).isEqualTo(original.getName());
+    assertThat(copy.getScope()).isEqualTo(original.getScope());
+    assertThat(copy.getTenantId()).isEqualTo(original.getTenantId());
+    assertThat(copy.getValue()).isEqualTo(original.getValue());
     assertThat(copy.getMetadata()).isEmpty();
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecordTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
+import java.util.Map;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class ClusterVariableRecordTest {
+
+  @Test
+  void shouldRoundTripMetadataViaMsgPack() {
+    // given
+    final Map<String, Object> metadata = Map.of("credentialType", "OAUTH2", "version", "1");
+    final var original =
+        new ClusterVariableRecord()
+            .setName("myVar")
+            .setScope(ClusterVariableScope.GLOBAL)
+            .setTenantId("<default>")
+            .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"value\"")))
+            .setMetadata(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(metadata)));
+
+    // when
+    final var copy = new ClusterVariableRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
+  }
+
+  @Test
+  void shouldDeserializeAsEmptyMapWhenMetadataFieldAbsent() {
+    // given — a record written without the metadata field (simulates old serialised records)
+    final var legacy = new ClusterVariableRecord();
+    legacy.setName("myVar");
+    legacy.setScope(ClusterVariableScope.GLOBAL);
+    legacy.setTenantId("<default>");
+    legacy.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"value\"")));
+
+    final var copy = new ClusterVariableRecord();
+    copy.copyFrom(legacy);
+
+    // then
+    assertThat(copy.getMetadata()).isEmpty();
+  }
+}

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -17,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -27,6 +29,7 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private static final StringValue VALUE_KEY = new StringValue("value");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue SCOPE_KEY = new StringValue("scope");
+  private static final StringValue METADATA_KEY = new StringValue("metadata");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp =
@@ -34,13 +37,15 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private final EnumProperty<ClusterVariableScope> scopeProp =
       new EnumProperty<>(SCOPE_KEY, ClusterVariableScope.class, ClusterVariableScope.UNSPECIFIED);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
+  private final DocumentProperty metadataProp = new DocumentProperty(METADATA_KEY);
 
   public ClusterVariableRecord() {
-    super(4);
+    super(5);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(metadataProp);
   }
 
   @Override
@@ -99,6 +104,21 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   public ClusterVariableRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
     return this;
+  }
+
+  @Override
+  public Map<String, Object> getMetadata() {
+    return MsgPackConverter.convertToMap(metadataProp.getValue());
+  }
+
+  public ClusterVariableRecord setMetadata(final DirectBuffer metadata) {
+    metadataProp.setValue(metadata);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getMetadataBuffer() {
+    return metadataProp.getValue();
   }
 
   @JsonIgnore

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
@@ -69,12 +69,10 @@ public interface ClusterVariableRecordValue extends RecordValue, TenantOwned {
   ClusterVariableScope getScope();
 
   /**
-   * Returns the metadata attached to this cluster variable.
+   * Returns the metadata attached to this cluster variable. The engine stores, replicates, and
+   * exports the map as-is without validating its contents.
    *
-   * <p>The engine stores, replicates, and exports the map as-is without validating its contents.
-   * Records serialized without this field deserialize with an empty map.
-   *
-   * @return the metadata map (never {@code null}, may be empty)
+   * @return the metadata map
    */
   Map<String, Object> getMetadata();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.Map;
 import org.immutables.value.Value;
 
 /**
@@ -31,6 +32,7 @@ import org.immutables.value.Value;
  *   <li>{@link #getName()} – the unique name of the cluster variable.
  *   <li>{@link #getValue()} – the current value of the cluster variable, as a deserialized object.
  *   <li>{@link #getScope()} – the current scope of the cluster variable.
+ *   <li>{@link #getMetadata()} – the metadata attached to this cluster variable.
  * </ul>
  *
  * @see RecordValue;
@@ -65,4 +67,14 @@ public interface ClusterVariableRecordValue extends RecordValue, TenantOwned {
    * @return the variable scope (never {@code null})
    */
   ClusterVariableScope getScope();
+
+  /**
+   * Returns the metadata attached to this cluster variable.
+   *
+   * <p>The engine stores, replicates, and exports the map as-is without validating its contents.
+   * Records serialized without this field deserialize with an empty map.
+   *
+   * @return an immutable metadata map (never {@code null}, may be empty)
+   */
+  Map<String, Object> getMetadata();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
@@ -74,7 +74,7 @@ public interface ClusterVariableRecordValue extends RecordValue, TenantOwned {
    * <p>The engine stores, replicates, and exports the map as-is without validating its contents.
    * Records serialized without this field deserialize with an empty map.
    *
-   * @return an immutable metadata map (never {@code null}, may be empty)
+   * @return the metadata map (never {@code null}, may be empty)
    */
   Map<String, Object> getMetadata();
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds a metadata field to the cluster variable record. As part of the field addition, we do have to insert the metadata field in the ES/OS template to avoid breaking the strict mapping rule.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55083
