### PR TITLE
fix: "load test setup" installation with long names

### DIFF
--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -109,21 +109,6 @@ install: check-deadline install-load-test-setup install-storage install-platform
 .PHONY: install-stable
 install-stable: check-deadline install-load-test-setup install-storage install-platform-stable install-load-test install-elasticsearch-exporter
 
-# Install the load-test-setup Helm Chart
-.PHONY: install-load-test-setup
-install-load-test-setup: create-namespace
-	helm upgrade --install --take-ownership --create-namespace \
-		$(namespace)-load-test-setup $(helm_chart_load_test_setup) \
-		--namespace $(namespace) \
-		$(load_test_setup_values) $(additional_load_test_setup_configuration)
-
-.PHONY: template-load-test-setup
-template-load-test-setup: create-namespace
-	helm template $(namespace) $(helm_chart_load_test_setup) \
-		$(load_test_setup_values) \
-		$(additional_load_test_setup_configuration) \
-		--output-dir .
-
 # Fail fast if the namespace TTL deadline (read from load-test-setup-values.yaml,
 # the single source of truth) is today or in the past — the TTL cleanup
 # workflow will delete the namespace and undo the install. To extend, edit
@@ -241,6 +226,17 @@ install-platform-stable:
 		$(_scenario_platform_flags) \
 		$(additional_platform_configuration)
 
+# Install the load-test-setup Helm Chart
+.PHONY: install-load-test-setup
+install-load-test-setup: create-namespace
+	helm upgrade load-test-setup $(helm_chart_load_test_setup) \
+		--install \
+		--namespace $(namespace) \
+		--reset-then-reuse-values \
+		--render-subchart-notes \
+		--take-ownership --create-namespace \
+		$(load_test_setup_values) $(additional_load_test_setup_configuration)
+
 # Install/upgrade load test helm chart
 .PHONY: install-load-test
 install-load-test:
@@ -269,6 +265,13 @@ template-stable:
 		$(platform_values_stable) \
 		$(_scenario_platform_flags) \
 		$(additional_platform_configuration) \
+		--output-dir .
+
+.PHONY: template-load-test-setup
+template-load-test-setup:
+	helm template load-test-setup $(helm_chart_load_test_setup) \
+		$(load_test_setup_values) \
+		$(additional_load_test_setup_configuration) \
 		--output-dir .
 
 # Generates templates from the load test helm chart


### PR DESCRIPTION
## Description

The Helm release name for the new "load test setup" Helm Chart can be too long, as we suffixed it with `-load-test-setup`.

This simplifies the name by just using `load-test-setup`, without the name of the namespace inside the release name. Since we are not supposed to install multiple instances of this same Helm Chart in a single namespace, the risk of name collision doesn't really exist.

Also:

* Moved the Make targets closer to the other similar targets in the makefile
* Rewrote the `helm upgrade` to make it more similar to the other similar commands


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/actions/runs/28072572069/job/83111249474
* https://camunda.slack.com/archives/C0ANMGS3D4Y/p1782271582343409
