### PR TITLE
feat: scope EngineSecurityConfig and AuthConverter per physical tenant

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -103,9 +103,9 @@ public class CamundaServicesConfiguration {
    * <p>Cluster-wide services ({@code TopologyServices}, {@code ManagementServices}) are shared
    * singletons injected from their own configuration classes.
    *
-   * <p>For v1 the authorization converter and executor are cloned per-tenant from the global config
-   * (no isolation yet); the process cache uses a tenant-scoped search view. See ADR {@code
-   * 0001-physical-tenant-service-serviceRegistry}.
+   * <p>The authorization converter is derived per-tenant from that tenant's security config; the
+   * executor is still shared from the global config (no isolation yet). The process cache uses a
+   * tenant-scoped search view. See ADR {@code 0001-physical-tenant-service-serviceRegistry}.
    */
   @Bean
   public ServiceRegistry serviceRegistry(
@@ -138,17 +138,16 @@ public class CamundaServicesConfiguration {
               final var search = searchClients.withPhysicalTenant(tenantId);
 
               // -- per-tenant BrokerRequestAuthorizationConverter --
-              // TODO: derive one converter per tenant from per-tenant
-              // CamundaSecurityLibraryProperties once available.
+              final var tenantSecurity = tenantConfig.getSecurity();
               final var converter =
                   new BrokerRequestAuthorizationConverter(
                       new EngineSecurityConfig(
-                          cslProperties.getAuthentication(),
-                          cslProperties.getAuthorizations().isEnabled(),
-                          cslProperties.getMultiTenancy().isChecksEnabled(),
-                          cslProperties.getInitialization(),
-                          cslProperties.getCompiledIdValidationPattern(),
-                          cslProperties.getCompiledGroupIdValidationPattern()));
+                          tenantSecurity.getAuthentication(),
+                          tenantSecurity.getAuthorizations().isEnabled(),
+                          tenantSecurity.getMultiTenancy().isChecksEnabled(),
+                          tenantSecurity.getInitialization(),
+                          tenantSecurity.getCompiledIdValidationPattern(),
+                          tenantSecurity.getCompiledGroupIdValidationPattern()));
 
               // -- per-tenant process cache --
               final var processCacheConfig = tenantConfig.getApi().getRest().getProcessCache();

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -10,12 +10,12 @@ package io.camunda.zeebe.broker;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfig;
-import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
@@ -29,6 +29,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -63,7 +66,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final BrokerClient brokerClient;
   private final BrokerShutdownHelper shutdownHelper;
   private final MeterRegistry meterRegistry;
-  private final EngineSecurityConfig engineSecurityConfig;
+  private final Map<String, EngineSecurityConfig> engineSecurityConfigsByPhysicalTenant;
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
@@ -84,7 +87,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       final BrokerClient brokerClient,
       final BrokerShutdownHelper shutdownHelper,
       final MeterRegistry meterRegistry,
-      final CamundaSecurityLibraryProperties securityProperties,
+      final PhysicalTenantResolver physicalTenantResolver,
       // The UserServices class is not available if you want to start-up the Standalone Broker
       @Autowired(required = false) final UserServices userServices,
       final PasswordEncoder passwordEncoder,
@@ -101,14 +104,18 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.brokerClient = brokerClient;
     this.shutdownHelper = shutdownHelper;
     this.meterRegistry = meterRegistry;
-    this.engineSecurityConfig =
-        new EngineSecurityConfig(
-            securityProperties.getAuthentication(),
-            securityProperties.getAuthorizations().isEnabled(),
-            securityProperties.getMultiTenancy().isChecksEnabled(),
-            securityProperties.getInitialization(),
-            securityProperties.getCompiledIdValidationPattern(),
-            securityProperties.getCompiledGroupIdValidationPattern());
+    this.engineSecurityConfigsByPhysicalTenant =
+        physicalTenantResolver.mapValues(
+            camunda -> {
+              final var s = camunda.getSecurity();
+              return new EngineSecurityConfig(
+                  s.getAuthentication(),
+                  s.getAuthorizations().isEnabled(),
+                  s.getMultiTenancy().isChecksEnabled(),
+                  s.getInitialization(),
+                  s.getCompiledIdValidationPattern(),
+                  s.getCompiledGroupIdValidationPattern());
+            });
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
@@ -132,6 +139,13 @@ public class BrokerModuleConfiguration implements CloseableSilently {
 
   @Bean(destroyMethod = "close")
   public Broker broker(final ExporterRepository exporterRepository) {
+    final Map<String, BrokerRequestAuthorizationConverter>
+        brokerRequestAuthorizationConvertersByPhysicalTenant =
+            engineSecurityConfigsByPhysicalTenant.entrySet().stream()
+                .collect(
+                    Collectors.toUnmodifiableMap(
+                        Entry::getKey,
+                        entry -> new BrokerRequestAuthorizationConverter(entry.getValue())));
     final SystemContext systemContext =
         new SystemContext(
             configuration.shutdownTimeout(),
@@ -141,13 +155,13 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             cluster,
             brokerClient,
             meterRegistry,
-            engineSecurityConfig,
+            engineSecurityConfigsByPhysicalTenant,
             userServices,
             passwordEncoder,
             jwtDecoder,
             oidcClaimsProvider,
             searchClientsProxy,
-            new BrokerRequestAuthorizationConverter(engineSecurityConfig),
+            brokerRequestAuthorizationConvertersByPhysicalTenant,
             nodeIdProvider,
             physicalTenantIds);
     springBrokerBridge.registerShutdownHelper(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -87,13 +87,13 @@ public final class Broker implements AutoCloseable {
             additionalPartitionListeners,
             systemContext.getShutdownTimeout(),
             systemContext.getMeterRegistry(),
-            systemContext.getSecurityConfiguration(),
+            systemContext.getSecurityConfigurationsByPhysicalTenant(),
             systemContext.getUserServices(),
             systemContext.getPasswordEncoder(),
             systemContext.getJwtDecoder(),
             systemContext.getOidcClaimsProvider(),
             systemContext.getSearchClientsProxy(),
-            systemContext.getBrokerRequestAuthorizationConverter(),
+            systemContext.getBrokerRequestAuthorizationConvertersByPhysicalTenant(),
             systemContext.getNodeIdProvider(),
             systemContext.getPhysicalTenantIds());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -144,7 +144,15 @@ public interface BrokerStartupContext {
 
   MeterRegistry getMeterRegistry();
 
+  /** Returns the security configuration for the {@code default} physical tenant. */
   EngineSecurityConfig getSecurityConfiguration();
+
+  /**
+   * Returns the security configuration for the given physical tenant.
+   *
+   * @throws IllegalArgumentException if the physical tenant id is unknown
+   */
+  EngineSecurityConfig getSecurityConfiguration(String physicalTenantId);
 
   UserServices getUserServices();
 
@@ -158,7 +166,13 @@ public interface BrokerStartupContext {
 
   void setSnapshotApiRequestHandler(SnapshotApiRequestHandler snapshotApiRequestHandler);
 
-  BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter();
+  /**
+   * Returns the request authorization converter for the given physical tenant.
+   *
+   * @throws IllegalArgumentException if the physical tenant id is unknown
+   */
+  BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter(
+      String physicalTenantId);
 
   CheckpointSchedulingService getCheckpointSchedulingService();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -68,7 +68,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final List<PartitionRaftListener> partitionRaftListeners = new ArrayList<>();
   private final Duration shutdownTimeout;
   private final MeterRegistry meterRegistry;
-  private final EngineSecurityConfig securityConfiguration;
+  private final Map<String, EngineSecurityConfig> securityConfigurationsByPhysicalTenant;
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
@@ -76,7 +76,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final SearchClientsProxy searchClientsProxy;
   private final NodeIdProvider nodeIdProvider;
   private final PhysicalTenantIds physicalTenantIds;
-  private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
+  private final Map<String, BrokerRequestAuthorizationConverter>
+      brokerRequestAuthorizationConvertersByPhysicalTenant;
 
   private ConcurrencyControl concurrencyControl;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
@@ -106,13 +107,14 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final List<PartitionListener> additionalPartitionListeners,
       final Duration shutdownTimeout,
       final MeterRegistry meterRegistry,
-      final EngineSecurityConfig securityConfiguration,
+      final Map<String, EngineSecurityConfig> securityConfigurationsByPhysicalTenant,
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
       final OidcClaimsProvider oidcClaimsProvider,
       final SearchClientsProxy searchClientsProxy,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final Map<String, BrokerRequestAuthorizationConverter>
+          brokerRequestAuthorizationConvertersByPhysicalTenant,
       final NodeIdProvider nodeIdProvider,
       final PhysicalTenantIds physicalTenantIds) {
 
@@ -127,7 +129,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.brokerClient = brokerClient;
     this.shutdownTimeout = shutdownTimeout;
     this.meterRegistry = requireNonNull(meterRegistry);
-    this.securityConfiguration = requireNonNull(securityConfiguration);
+    this.securityConfigurationsByPhysicalTenant =
+        Collections.unmodifiableMap(securityConfigurationsByPhysicalTenant);
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
@@ -136,7 +139,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.nodeIdProvider = requireNonNull(nodeIdProvider);
     this.physicalTenantIds = requireNonNull(physicalTenantIds);
     partitionListeners.addAll(additionalPartitionListeners);
-    this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
+    this.brokerRequestAuthorizationConvertersByPhysicalTenant =
+        Collections.unmodifiableMap(brokerRequestAuthorizationConvertersByPhysicalTenant);
   }
 
   @Override
@@ -362,7 +366,21 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
 
   @Override
   public EngineSecurityConfig getSecurityConfiguration() {
-    return securityConfiguration;
+    final var config =
+        securityConfigurationsByPhysicalTenant.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    if (config == null) {
+      throw new IllegalStateException(
+          "No security configuration registered for the default physical tenant");
+    }
+    return config;
+  }
+
+  @Override
+  public EngineSecurityConfig getSecurityConfiguration(final String physicalTenantId) {
+    if (!securityConfigurationsByPhysicalTenant.containsKey(physicalTenantId)) {
+      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
+    }
+    return securityConfigurationsByPhysicalTenant.get(physicalTenantId);
   }
 
   @Override
@@ -397,8 +415,12 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter() {
-    return brokerRequestAuthorizationConverter;
+  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter(
+      final String physicalTenantId) {
+    if (!brokerRequestAuthorizationConvertersByPhysicalTenant.containsKey(physicalTenantId)) {
+      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
+    }
+    return brokerRequestAuthorizationConvertersByPhysicalTenant.get(physicalTenantId);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -155,9 +155,9 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
         brokerStartupContext.getMeterRegistry(),
         brokerStartupContext.getBrokerClient(),
         brokerStartupContext.getRocksDbResources(),
-        brokerStartupContext.getSecurityConfiguration(),
+        brokerStartupContext.getSecurityConfiguration(physicalTenantId),
         brokerStartupContext.getSearchClientsProxy(),
-        brokerStartupContext.getBrokerRequestAuthorizationConverter(),
+        brokerStartupContext.getBrokerRequestAuthorizationConverter(physicalTenantId),
         topologyManager);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -130,17 +130,22 @@ public final class SystemContext {
   private final AtomixCluster cluster;
   private final BrokerClient brokerClient;
   private final MeterRegistry meterRegistry;
-  private final EngineSecurityConfig securityConfiguration;
+  private final Map<String, EngineSecurityConfig> securityConfigurationsByPhysicalTenant;
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
   private final OidcClaimsProvider oidcClaimsProvider;
   private final SearchClientsProxy searchClientsProxy;
-  private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
+  private final Map<String, BrokerRequestAuthorizationConverter>
+      brokerRequestAuthorizationConvertersByPhysicalTenant;
   private final NodeIdProvider nodeIdProvider;
   private final PhysicalTenantIds physicalTenantIds;
   private final GlobalListenerValidator globalListenerValidator;
 
+  /**
+   * Creates a {@code SystemContext} where each physical tenant carries its own {@link
+   * EngineSecurityConfig} and {@link BrokerRequestAuthorizationConverter}.
+   */
   public SystemContext(
       final Duration shutdownTimeout,
       final BrokerCfg brokerCfg,
@@ -149,13 +154,14 @@ public final class SystemContext {
       final AtomixCluster cluster,
       final BrokerClient brokerClient,
       final MeterRegistry meterRegistry,
-      final EngineSecurityConfig securityConfiguration,
+      final Map<String, EngineSecurityConfig> securityConfigurationsByPhysicalTenant,
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
       final OidcClaimsProvider oidcClaimsProvider,
       final SearchClientsProxy searchClientsProxy,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final Map<String, BrokerRequestAuthorizationConverter>
+          brokerRequestAuthorizationConvertersByPhysicalTenant,
       final NodeIdProvider nodeIdProvider,
       final PhysicalTenantIds physicalTenantIds) {
     this.shutdownTimeout = shutdownTimeout;
@@ -165,14 +171,16 @@ public final class SystemContext {
     this.cluster = cluster;
     this.brokerClient = brokerClient;
     this.meterRegistry = meterRegistry;
-    this.securityConfiguration = securityConfiguration;
+    this.securityConfigurationsByPhysicalTenant =
+        Collections.unmodifiableMap(securityConfigurationsByPhysicalTenant);
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
     this.oidcClaimsProvider =
         Objects.requireNonNull(oidcClaimsProvider, "oidcClaimsProvider must not be null");
     this.searchClientsProxy = searchClientsProxy;
-    this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
+    this.brokerRequestAuthorizationConvertersByPhysicalTenant =
+        Collections.unmodifiableMap(brokerRequestAuthorizationConvertersByPhysicalTenant);
     this.nodeIdProvider = nodeIdProvider;
     this.physicalTenantIds = physicalTenantIds;
     globalListenerValidator = new GlobalListenerValidator();
@@ -490,10 +498,16 @@ public final class SystemContext {
   // actually initializing the entities will be done in IdentitySetupInitializer.
   // Validation is done here, only to be able to stop the application on error.
   private void validateInitializationConfig() {
+    securityConfigurationsByPhysicalTenant.forEach(
+        (physicalTenantId, securityConfig) ->
+            validateInitializationConfigForTenant(physicalTenantId, securityConfig));
+  }
+
+  private void validateInitializationConfigForTenant(
+      final String physicalTenantId, final EngineSecurityConfig securityConfig) {
     final IdentifierValidator identifierValidator =
         new IdentifierValidator(
-            securityConfiguration.getIdValidationPattern(),
-            securityConfiguration.getGroupIdValidationPattern());
+            securityConfig.getIdValidationPattern(), securityConfig.getGroupIdValidationPattern());
     final AuthorizationConfigurer authorizationConfigurer =
         new AuthorizationConfigurer(new AuthorizationValidator(identifierValidator));
     final TenantConfigurer tenantConfigurer =
@@ -504,40 +518,44 @@ public final class SystemContext {
 
     final Either<List<String>, List<AuthorizationRecord>> configuredAuthorizations =
         authorizationConfigurer.configureEntities(
-            securityConfiguration.getInitialization().getAuthorizations());
+            securityConfig.getInitialization().getAuthorizations());
     final Either<List<String>, List<TenantRecord>> configuredTenants =
-        tenantConfigurer.configureEntities(securityConfiguration.getInitialization().getTenants());
+        tenantConfigurer.configureEntities(securityConfig.getInitialization().getTenants());
     final Either<List<String>, List<GroupRecord>> configuredGroups =
-        groupConfigurer.configureEntities(securityConfiguration.getInitialization().getGroups());
+        groupConfigurer.configureEntities(securityConfig.getInitialization().getGroups());
     final Either<List<String>, List<RoleRecord>> configuredRoles =
-        roleConfigurer.configureEntities(securityConfiguration.getInitialization().getRoles());
+        roleConfigurer.configureEntities(securityConfig.getInitialization().getRoles());
 
     // TODO: after adding more entity types, change this, so it accounts for all violations all
     //   together.
     configuredAuthorizations.ifLeft(
         (violations) -> {
           throw new IdentityInitializationException(
-              "Cannot initialize configured authorizations: %n- %s"
-                  .formatted(String.join(System.lineSeparator() + "- ", violations)));
+              "Cannot initialize configured authorizations for tenant '%s': %n- %s"
+                  .formatted(
+                      physicalTenantId, String.join(System.lineSeparator() + "- ", violations)));
         });
     configuredTenants.ifLeft(
         (violations) -> {
           throw new IdentityInitializationException(
-              "Cannot initialize configured tenants: %n- %s"
-                  .formatted(String.join(System.lineSeparator() + "- ", violations)));
+              "Cannot initialize configured tenants for tenant '%s': %n- %s"
+                  .formatted(
+                      physicalTenantId, String.join(System.lineSeparator() + "- ", violations)));
         });
     configuredRoles.ifLeft(
         (violations) -> {
           throw new IdentityInitializationException(
-              "Cannot initialize configured roles: %n- %s"
-                  .formatted(String.join(System.lineSeparator() + "- ", violations)));
+              "Cannot initialize configured roles for tenant '%s': %n- %s"
+                  .formatted(
+                      physicalTenantId, String.join(System.lineSeparator() + "- ", violations)));
         });
 
     configuredGroups.ifLeft(
         (violations) -> {
           throw new IdentityInitializationException(
-              "Cannot initialize configured groups: %n- %s"
-                  .formatted(String.join(System.lineSeparator() + "- ", violations)));
+              "Cannot initialize configured groups for tenant '%s': %n- %s"
+                  .formatted(
+                      physicalTenantId, String.join(System.lineSeparator() + "- ", violations)));
         });
   }
 
@@ -705,8 +723,39 @@ public final class SystemContext {
     return meterRegistry;
   }
 
+  /** Returns the per-physical-tenant security configuration map (unmodifiable). */
+  public Map<String, EngineSecurityConfig> getSecurityConfigurationsByPhysicalTenant() {
+    return securityConfigurationsByPhysicalTenant;
+  }
+
+  /**
+   * Returns the security configuration for the {@code default} physical tenant. Requires a {@value
+   * io.camunda.configuration.api.physicaltenants.PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID}
+   * entry to be registered.
+   *
+   * @throws IllegalStateException if no security configuration is registered for the default
+   *     physical tenant
+   */
   public EngineSecurityConfig getSecurityConfiguration() {
-    return securityConfiguration;
+    final var config =
+        securityConfigurationsByPhysicalTenant.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    if (config == null) {
+      throw new IllegalStateException(
+          "No security configuration registered for the default physical tenant");
+    }
+    return config;
+  }
+
+  /**
+   * Returns the security configuration for the given physical tenant.
+   *
+   * @throws IllegalArgumentException if the physical tenant id is unknown
+   */
+  public EngineSecurityConfig getSecurityConfiguration(final String physicalTenantId) {
+    if (!securityConfigurationsByPhysicalTenant.containsKey(physicalTenantId)) {
+      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
+    }
+    return securityConfigurationsByPhysicalTenant.get(physicalTenantId);
   }
 
   public UserServices getUserServices() {
@@ -729,8 +778,23 @@ public final class SystemContext {
     return searchClientsProxy;
   }
 
-  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter() {
-    return brokerRequestAuthorizationConverter;
+  /**
+   * Returns the request authorization converter for the given physical tenant.
+   *
+   * @throws IllegalArgumentException if the physical tenant id is unknown
+   */
+  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter(
+      final String physicalTenantId) {
+    if (!brokerRequestAuthorizationConvertersByPhysicalTenant.containsKey(physicalTenantId)) {
+      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
+    }
+    return brokerRequestAuthorizationConvertersByPhysicalTenant.get(physicalTenantId);
+  }
+
+  /** Returns the per-physical-tenant request authorization converter map (unmodifiable). */
+  public Map<String, BrokerRequestAuthorizationConverter>
+      getBrokerRequestAuthorizationConvertersByPhysicalTenant() {
+    return brokerRequestAuthorizationConvertersByPhysicalTenant;
   }
 
   public NodeIdProvider getNodeIdProvider() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -21,6 +21,7 @@ import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.broker.system.SystemContextTestFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
 import io.camunda.zeebe.broker.test.TestBrokerClientFactory;
@@ -70,7 +71,7 @@ public final class SimpleBrokerStartTest {
         assertThatThrownBy(
             () -> {
               final var systemContext =
-                  new SystemContext(
+                  SystemContextTestFactory.singleTenant(
                       SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
                       brokerCfg,
                       null,
@@ -107,7 +108,7 @@ public final class SimpleBrokerStartTest {
         TestBrokerClientFactory.createBrokerClient(atomixCluster, actorScheduler);
 
     final var systemContext =
-        new SystemContext(
+        SystemContextTestFactory.singleTenant(
             SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
             brokerCfg,
             null,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -365,6 +365,11 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
     return securityConfiguration;
   }
 
+  @Override
+  public EngineSecurityConfig getSecurityConfiguration(final String physicalTenantId) {
+    return securityConfiguration;
+  }
+
   public void setSecurityConfiguration(final EngineSecurityConfig securityConfiguration) {
     this.securityConfiguration = securityConfiguration;
   }
@@ -417,7 +422,8 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   @Override
-  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter() {
+  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter(
+      final String physicalTenantId) {
     return brokerRequestAuthorizationConverter;
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -16,6 +16,7 @@ import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.broker.system.SystemContextTestFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
 import io.camunda.zeebe.broker.test.TestBrokerClientFactory;
@@ -114,7 +115,7 @@ final class PartitionJoinTest {
     final var brokerClient =
         TestBrokerClientFactory.createBrokerClient(atomixCluster, actorScheduler);
     final var systemContext =
-        new SystemContext(
+        SystemContextTestFactory.singleTenant(
             SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
             brokerCfg,
             null,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -17,6 +17,7 @@ import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.broker.system.SystemContextTestFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
@@ -230,7 +231,7 @@ final class PartitionLeaveTest {
     final var brokerClient =
         TestBrokerClientFactory.createBrokerClient(atomixCluster, actorScheduler);
     final var systemContext =
-        new SystemContext(
+        SystemContextTestFactory.singleTenant(
             SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
             brokerCfg,
             null,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PhysicalTenantPartitionManagerIT.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PhysicalTenantPartitionManagerIT.java
@@ -16,6 +16,7 @@ import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.broker.system.SystemContextTestFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
 import io.camunda.zeebe.broker.test.TestBrokerClientFactory;
@@ -79,7 +80,7 @@ final class PhysicalTenantPartitionManagerIT {
     final var brokerClient =
         TestBrokerClientFactory.createBrokerClient(atomixCluster, actorScheduler);
     final var systemContext =
-        new SystemContext(
+        SystemContextTestFactory.singleTenant(
             SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
             brokerCfg,
             null,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -17,8 +17,16 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
+import io.camunda.security.api.model.authz.AuthorizationOwnerType;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
+import io.camunda.security.api.model.authz.PermissionType;
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.security.api.model.config.initialization.ConfiguredAuthorization;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
+import io.camunda.security.validation.IdentityInitializationException;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -42,6 +50,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -376,8 +385,199 @@ final class SystemContextTest {
             "Expected to find a 'className' configured for the exporter. Couldn't find a valid one for the following exporters ");
   }
 
+  // --- per-PT security config tests ---
+
+  @Test
+  void shouldReturnDefaultConfigForDefaultTenant() {
+    // given
+    final var defaultCfg = EngineSecurityConfigurations.defaultConfig();
+    final var ctx =
+        initSystemContextWithMap(
+            new BrokerCfg(), Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultCfg));
+
+    // when / then
+    assertThat(ctx.getSecurityConfiguration()).isSameAs(defaultCfg);
+    assertThat(ctx.getSecurityConfiguration(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isSameAs(defaultCfg);
+  }
+
+  @Test
+  void shouldThrowForUnknownTenantSecurityConfig() {
+    // given
+    final var defaultCfg = EngineSecurityConfigurations.defaultConfig();
+    final var ctx =
+        initSystemContextWithMap(
+            new BrokerCfg(), Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultCfg));
+
+    // when / then
+    assertThatThrownBy(() -> ctx.getSecurityConfiguration("unknown-tenant"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unknown physical tenant id")
+        .hasMessageContaining("unknown-tenant");
+  }
+
+  @Test
+  void shouldThrowFromNoArgSecurityConfigWhenDefaultEntryMissing() {
+    // given – a context constructed with maps that lack the default-tenant entry
+    final var ptaCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
+    final var ctx =
+        initSystemContextWithMaps(
+            new BrokerCfg(),
+            Map.of("pta", ptaCfg),
+            Map.of("pta", mock(BrokerRequestAuthorizationConverter.class)));
+
+    // when / then
+    assertThatThrownBy(ctx::getSecurityConfiguration)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("default physical tenant");
+  }
+
+  @Test
+  void shouldReturnPerTenantConfigWhenRegistered() {
+    // given
+    final var defaultCfg = EngineSecurityConfigurations.defaultConfig();
+    final var ptaCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
+    final var ctx =
+        initSystemContextWithMap(
+            new BrokerCfg(),
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultCfg, "pta", ptaCfg));
+
+    // when / then
+    assertThat(ctx.getSecurityConfiguration(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isSameAs(defaultCfg);
+    assertThat(ctx.getSecurityConfiguration("pta")).isSameAs(ptaCfg);
+    assertThatThrownBy(() -> ctx.getSecurityConfiguration("unknown"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unknown physical tenant id");
+  }
+
+  @Test
+  void shouldResolveKnownTenantsFromSingleConfigConstructor() {
+    // given – PhysicalTenantIds.DEFAULT only knows the "default" tenant
+    final var ctx = initSystemContext(new BrokerCfg());
+
+    // when / then – the single-config ctor populates every known tenant with the supplied config
+    assertThat(ctx.getSecurityConfiguration()).isNotNull();
+    assertThat(ctx.getSecurityConfiguration(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isSameAs(ctx.getSecurityConfiguration());
+    assertThatThrownBy(() -> ctx.getSecurityConfiguration("any-other"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unknown physical tenant id");
+  }
+
+  @Test
+  void shouldReturnPerTenantAuthorizationConverterWhenRegistered() {
+    // given
+    final var defaultConverter = mock(BrokerRequestAuthorizationConverter.class);
+    final var ptConverter = mock(BrokerRequestAuthorizationConverter.class);
+    final var ctx =
+        initSystemContextWithMaps(
+            new BrokerCfg(),
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                EngineSecurityConfigurations.defaultConfig(),
+                "pta",
+                EngineSecurityConfigurations.unauthenticatedAndUnauthorized()),
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                defaultConverter,
+                "pta",
+                ptConverter));
+
+    // when / then
+    assertThat(
+            ctx.getBrokerRequestAuthorizationConverter(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isSameAs(defaultConverter);
+    assertThat(ctx.getBrokerRequestAuthorizationConverter("pta")).isSameAs(ptConverter);
+  }
+
+  @Test
+  void shouldThrowForUnknownTenantAuthorizationConverter() {
+    // given
+    final var defaultConverter = mock(BrokerRequestAuthorizationConverter.class);
+    final var ctx =
+        initSystemContextWithMaps(
+            new BrokerCfg(),
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                EngineSecurityConfigurations.defaultConfig()),
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultConverter));
+
+    // when / then
+    assertThat(
+            ctx.getBrokerRequestAuthorizationConverter(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isSameAs(defaultConverter);
+    assertThatThrownBy(() -> ctx.getBrokerRequestAuthorizationConverter("unknown"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unknown physical tenant id");
+  }
+
+  @Test
+  void shouldResolveKnownTenantsAuthorizationConverterFromSingleConverterConstructor() {
+    // given – the single-converter constructor stores the converter under every known tenant
+    final var ctx = initSystemContext(new BrokerCfg());
+
+    // when / then
+    assertThat(
+            ctx.getBrokerRequestAuthorizationConverter(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isNotNull();
+    assertThatThrownBy(() -> ctx.getBrokerRequestAuthorizationConverter("any-other"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unknown physical tenant id");
+  }
+
+  @Test
+  void shouldValidateAllPerTenantInitializationConfigsAndPassWhenAllValid() {
+    // given – both configs have empty (valid) initialization blocks
+    final var ctx =
+        initSystemContextWithMap(
+            new BrokerCfg(),
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                EngineSecurityConfigurations.defaultConfig(),
+                "pta",
+                EngineSecurityConfigurations.unauthenticatedAndUnauthorized()));
+
+    // when / then – no exception expected
+    assertThat(ctx).isNotNull();
+  }
+
+  @Test
+  void shouldFailValidationWhenAnyPerTenantInitializationConfigIsInvalid() {
+    // given – an authorization whose resourceId contains spaces, which the default ID pattern
+    // rejects (pattern requires [a-zA-Z0-9_~@.+-]+)
+    final var badAuthorization =
+        ConfiguredAuthorization.idBased(
+            AuthorizationOwnerType.USER,
+            "demo",
+            AuthorizationResourceType.PROCESS_DEFINITION,
+            "has spaces here",
+            Set.of(PermissionType.READ));
+    final var badInit = new InitializationConfiguration();
+    badInit.setAuthorizations(List.of(badAuthorization));
+    final var badCfg =
+        new EngineSecurityConfig(
+            new AuthenticationConfiguration(),
+            false,
+            false,
+            badInit,
+            EngineSecurityConfigurations.ID_VALIDATION_PATTERN,
+            EngineSecurityConfigurations.GROUP_ID_VALIDATION_PATTERN);
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                initSystemContextWithMap(
+                    new BrokerCfg(), Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, badCfg)))
+        .isInstanceOf(IdentityInitializationException.class)
+        .hasMessageContaining("authorizations");
+  }
+
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {
-    return new SystemContext(
+    return SystemContextTestFactory.singleTenant(
         SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
         brokerCfg,
         null,
@@ -392,6 +592,40 @@ final class SystemContextTest {
         (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims,
         mock(SearchClientsProxy.class),
         mock(BrokerRequestAuthorizationConverter.class),
+        mock(NodeIdProvider.class),
+        PhysicalTenantIds.DEFAULT);
+  }
+
+  private SystemContext initSystemContextWithMap(
+      final BrokerCfg brokerCfg, final Map<String, EngineSecurityConfig> configsByTenant) {
+    final Map<String, BrokerRequestAuthorizationConverter> convertersByTenant = new HashMap<>();
+    configsByTenant
+        .keySet()
+        .forEach(
+            tenantId ->
+                convertersByTenant.put(tenantId, mock(BrokerRequestAuthorizationConverter.class)));
+    return initSystemContextWithMaps(brokerCfg, configsByTenant, convertersByTenant);
+  }
+
+  private SystemContext initSystemContextWithMaps(
+      final BrokerCfg brokerCfg,
+      final Map<String, EngineSecurityConfig> configsByTenant,
+      final Map<String, BrokerRequestAuthorizationConverter> convertersByTenant) {
+    return new SystemContext(
+        SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
+        brokerCfg,
+        null,
+        mock(ActorScheduler.class),
+        mock(AtomixCluster.class),
+        mock(BrokerClient.class),
+        new SimpleMeterRegistry(),
+        configsByTenant,
+        mock(UserServices.class),
+        mock(PasswordEncoder.class),
+        mock(JwtDecoder.class),
+        (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims,
+        mock(SearchClientsProxy.class),
+        convertersByTenant,
         mock(NodeIdProvider.class),
         PhysicalTenantIds.DEFAULT);
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system;
+
+import io.atomix.cluster.AtomixCluster;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
+import io.camunda.identity.sdk.IdentityConfiguration;
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.api.context.OidcClaimsProvider;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.service.UserServices;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+/** Test helper for constructing a {@link SystemContext} with a single security configuration. */
+public final class SystemContextTestFactory {
+
+  private SystemContextTestFactory() {}
+
+  /**
+   * Builds a {@link SystemContext} where every known physical tenant (plus the {@code default}
+   * tenant) maps to the same single {@link EngineSecurityConfig} and {@link
+   * BrokerRequestAuthorizationConverter}.
+   *
+   * <p>{@code securityConfiguration} must be non-null: {@link SystemContext} validates the
+   * initialization config during construction, so a null value would fail. Other collaborators —
+   * notably {@code brokerRequestAuthorizationConverter} — may be {@code null} when a test does not
+   * exercise them.
+   */
+  public static SystemContext singleTenant(
+      final Duration shutdownTimeout,
+      final BrokerCfg brokerCfg,
+      final IdentityConfiguration identityConfiguration,
+      final ActorScheduler scheduler,
+      final AtomixCluster cluster,
+      final BrokerClient brokerClient,
+      final MeterRegistry meterRegistry,
+      final EngineSecurityConfig securityConfiguration,
+      final UserServices userServices,
+      final PasswordEncoder passwordEncoder,
+      final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
+      final SearchClientsProxy searchClientsProxy,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final NodeIdProvider nodeIdProvider,
+      final PhysicalTenantIds physicalTenantIds) {
+    return new SystemContext(
+        shutdownTimeout,
+        brokerCfg,
+        identityConfiguration,
+        scheduler,
+        cluster,
+        brokerClient,
+        meterRegistry,
+        singleValueMap(physicalTenantIds, securityConfiguration),
+        userServices,
+        passwordEncoder,
+        jwtDecoder,
+        oidcClaimsProvider,
+        searchClientsProxy,
+        singleValueMap(physicalTenantIds, brokerRequestAuthorizationConverter),
+        nodeIdProvider,
+        physicalTenantIds);
+  }
+
+  private static <T> Map<String, T> singleValueMap(
+      final PhysicalTenantIds physicalTenantIds, final T value) {
+    final Map<String, T> map = new HashMap<>();
+    physicalTenantIds.known().forEach(id -> map.put(id, value));
+    map.put(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, value);
+    return map;
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.TestLoggers;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.broker.system.SystemContextTestFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.engine.state.QueryService;
@@ -240,7 +241,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     final var scheduler = TestActorSchedulerFactory.ofBrokerConfig(brokerCfg, controlledActorClock);
     atomixCluster = TestClusterFactory.createAtomixCluster(brokerCfg, meterRegistry);
     systemContext =
-        new SystemContext(
+        SystemContextTestFactory.singleTenant(
             SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
             brokerCfg,
             null,

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -49,6 +49,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.broker.system.SystemContextTestFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminService;
 import io.camunda.zeebe.broker.system.management.PartitionStatus;
@@ -390,7 +391,7 @@ public class ClusteringRule extends ExternalResource {
     final var brokerClient = brokerClientConfiguration.brokerClient();
 
     final var systemContext =
-        new SystemContext(
+        SystemContextTestFactory.singleTenant(
             brokerSpringConfig.shutdownTimeout(),
             brokerCfg,
             null,


### PR DESCRIPTION
## What

Addresses the `securityConfig` and `BrokerRequestAuthorizationConverter` parts of #55444. Unblocks #55443.

Each physical tenant (PT) has isolated secondary storage and its own partition manager, but per-PT engines were fed **cluster-wide** security beans built from the `default` config. Two consequences:

1. A non-`default` PT's `camunda.physical-tenants.<id>.security.initialization.*` block — which `PhysicalTenantRequiredOverrideValidation` already **requires** at boot — was never seeded into that PT's storage, leaving the tenant with no admin and unable to authenticate (user lookup is per-PT scoped, so the root admin can't authenticate against a non-default PT either).
2. The `BrokerRequestAuthorizationConverter` injected into each PT's engine was a single instance built from `default`, so its authorization-claim behavior (`shouldIncludeAuthorizationClaims` ← `authorizations.enabled || multiTenancy.checksEnabled`, plus the camundaGroups/OIDC flags) ignored per-PT overrides of `authorizations.enabled` and `authentication`.

This PR makes both per-PT, derived from each tenant's resolved security config:

- `BrokerModuleConfiguration` builds `Map<physicalTenantId, EngineSecurityConfig>` from the existing `PhysicalTenantResolver` (`mapValues(c -> new EngineSecurityConfig(c.getSecurity()…))`), and a parallel `Map<physicalTenantId, BrokerRequestAuthorizationConverter>` derived from it — reusing the per-PT pattern already used by the REST and search-client configs. (`Camunda.getSecurity()` extends `CamundaSecurityLibraryProperties`, so each tenant's merged security config is available.)
- `SystemContext` holds both maps and exposes `getSecurityConfiguration(id)` / `getBrokerRequestAuthorizationConverter(id)`, which **throw `IllegalArgumentException` for an unknown physical tenant id** — a specific tenant request never silently resolves to another tenant's config (matching the `PhysicalTenantResolver` / `CamundaSearchClients` convention). The no-arg `getSecurityConfiguration()` returns the `default` entry and throws `IllegalStateException` if it is absent. Production builds these maps in `BrokerModuleConfiguration`; tests construct single-tenant contexts via a `SystemContextTestFactory` (test scope), so production keeps a single map-based constructor.
- `BrokerStartupContext(Impl)` exposes the same per-PT accessors.
- `PartitionManagerStep` — which already runs once per PT — now requests the per-PT security config and per-PT converter. Everything downstream (`ZeebePartitionFactory` → engine → `IdentitySetupInitializer`) is unchanged; it simply receives the right per-PT instances.
- Initialization config is now validated **per tenant** (fail-fast, tenant-labelled messages).
- The service-layer per-PT `BrokerRequestAuthorizationConverter` (`CamundaServicesConfiguration`) is likewise derived from the tenant's own security config (resolves the prior `// TODO`).

`PartitionManagerStep` is the only consumer of the broker-injected converter, so no cluster-level path is affected. The `default` tenant resolves to the root config, so single-PT behavior is byte-identical.

## Why

Per-PT authorization is unusable until each tenant can bootstrap its own admin and apply its own authorization semantics. This unblocks #55443 (multi-PT authorization IT harness), which cannot authenticate as a per-tenant admin to set up per-tenant authorization data through the real write path.

## Testing

- `SystemContextTest`: per-PT accessors return the tenant config/converter when registered and **throw `IllegalArgumentException` for an unknown id** (no fallback); the no-arg `getSecurityConfiguration()` throws when the `default` entry is missing; initialization config is validated per tenant (valid passes, invalid per-PT block fails).
- `PartitionManagerStepTest`: asserts the per-PT `EngineSecurityConfig` and per-PT `BrokerRequestAuthorizationConverter` instances wired into the partition's `ZeebePartitionFactory` are the tenant's own, distinct from the default (verified to fail if the step used the no-arg accessor).
- Full `zeebe/broker` unit suite green (1553 tests); `PhysicalTenantPartitionManagerIT` green; `zeebe/qa/integration-tests` test sources compile against the test factory; spotless clean.

This PR proves the **wiring** (correct per-PT beans reach each engine). End-to-end proof that per-PT seeding lands in the correct per-PT storage is covered by #55443's harness.

## Not in this PR

- `featureFlags` per-PT scoping (the third item from the original #55444 review comment) — left as a follow-up; independent of identity bootstrap and authorization-claim behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
