### PR TITLE
ci: fix nightly artifact name for stable branches and Aurora deployment ref

### DIFF
--- a/.github/workflows/aurora-async-replication-test.yml
+++ b/.github/workflows/aurora-async-replication-test.yml
@@ -16,7 +16,7 @@ on:
         description: 'Ref of camunda/camunda-deployment-references to use'
         type: string
         required: false
-        default: 'feat/ecs-dual-region-rdbms'
+        default: 'main'
       skip_destroy:
         description: 'Keep the Aurora infrastructure after the run (for debugging; destroy manually!)'
         type: boolean
@@ -28,7 +28,7 @@ on:
         description: 'Ref of camunda/camunda-deployment-references to use'
         type: string
         required: false
-        default: 'feat/ecs-dual-region-rdbms'
+        default: 'main'
       skip_destroy:
         description: 'Keep the Aurora infrastructure after the run (for debugging; destroy manually!)'
         type: boolean
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: camunda/camunda-deployment-references
-          ref: ${{ inputs.deployment_references_ref || 'feat/ecs-dual-region-rdbms' }}
+          ref: ${{ inputs.deployment_references_ref || 'main' }}
           path: camunda-deployment-references
 
       - name: Import secrets from Vault

--- a/.github/workflows/data-layer-nightly-tests.yml
+++ b/.github/workflows/data-layer-nightly-tests.yml
@@ -124,11 +124,20 @@ jobs:
           -P dl-nightly,parallel-tests \
           verify
 
+      - name: Sanitize branch name for artifact names
+        id: sanitize
+        if: always()
+        shell: bash
+        run: |
+          branch="${{ matrix.branch }}"
+          safe_branch="${branch//\//-}"
+          echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
+
       - name: Upload test artifacts on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: data-layer-nightly-test-failures-${{ matrix.branch }}
+          name: data-layer-nightly-test-failures-${{ steps.sanitize.outputs.safe_branch }}
           path: qa/acceptance-tests/target/failsafe-reports/
           retention-days: 7
       - name: Observe build status


### PR DESCRIPTION
## Summary

- Artifact upload for `stable/*` nightly matrix jobs failed because `stable/8.9` contains a `/`, which GHA forbids in artifact names. Applies the same `${branch//\//-}` sanitize pattern already used in other reusable workflows.
- Aurora Async Replication IT was always failing because `deployment_references_ref` defaulted to `feat/ecs-dual-region-rdbms`, a deleted branch in `camunda/camunda-deployment-references`. Changed default to `main`, where the `aurora-global` Terraform module exists.

Diagnosed from: https://github.com/camunda/camunda/actions/runs/28072229000

## Test plan

- [ ] Verify nightly run on `stable/8.9` uploads artifact as `data-layer-nightly-test-failures-stable-8.9`
- [ ] Verify Aurora Async Replication IT reaches the Terraform provisioning step (checkout no longer fails)