### PR TITLE
ci: dedup triage dispatch per spec file instead of per branch

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml
@@ -1,0 +1,127 @@
+# description: Daily cleanup — closes open failing-test-fix PRs from the previous
+#              day that were not merged. Runs before the morning triage so the triage
+#              agent starts each day with no in-flight bot PRs blocking dispatch.
+#
+# Pairing:
+#   03:00 UTC Mon-Fri  c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml (this)
+#   04:00 UTC Mon-Fri  c8-orchestration-cluster-e2e-nightly-triage.yml
+#
+# Targets: PRs labelled "failing-test-fix" opened by the nightly fix agent.
+#
+# Single exception: PRs labelled "do-not-close" are kept across days. That label is
+# the only way for a reviewer to hold a bot PR. Review comments alone do NOT keep a
+# PR alive — merge it the same day or apply the label.
+# type: CI
+# owner: @camunda/qa-engineering
+---
+name: Close Stale Fix PRs
+
+on:
+  schedule:
+    - cron: '0 3 * * 1-5' # 03:00 UTC Mon-Fri, 1h before triage
+  workflow_dispatch:
+    inputs:
+      stale_days:
+        description: 'Close PRs untouched for N days (default 1 — daily fresh start)'
+        default: '1'
+        required: false
+      dry_run:
+        description: 'Print actions but do not close anything'
+        type: boolean
+        default: false
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  TEST_OWNER: '@camunda/qa-engineering'
+
+jobs:
+  close-stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Identify and close stale fix PRs
+        env:
+          GH_TOKEN:   ${{ secrets.GITHUB_TOKEN }}
+          STALE_DAYS: ${{ inputs.stale_days || '1' }}
+          DRY_RUN:    ${{ inputs.dry_run || 'false' }}
+          REPO:       ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          cutoff_epoch=$(date -u -d "${STALE_DAYS} days ago" +%s 2>/dev/null \
+                       || date -u -v-"${STALE_DAYS}"d +%s)
+          echo "Closing PRs not updated since $(date -u -d "@${cutoff_epoch}" +%FT%TZ 2>/dev/null || echo "${STALE_DAYS} days ago")"
+          echo "Dry-run: ${DRY_RUN}"
+
+          # Pull all open PRs with the bot label, excluding those held by do-not-close.
+          mapfile -t prs < <(
+            gh pr list \
+              --repo "$REPO" \
+              --state open \
+              --limit 200 \
+              --json number,url,title,createdAt,labels \
+              --jq '
+                .[] |
+                select(
+                  ([.labels[].name] | any(. == "failing-test-fix"))
+                  and ([.labels[].name] | any(. == "do-not-close") | not)
+                ) |
+                @json
+              '
+          )
+
+          closed=0
+          kept=0
+          for raw in "${prs[@]}"; do
+            number=$(echo "$raw"  | jq -r '.number')
+            title=$(echo "$raw"   | jq -r '.title')
+            created=$(echo "$raw" | jq -r '.createdAt')
+
+            created_epoch=$(date -u -d "$created" +%s 2>/dev/null \
+                          || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$created" +%s 2>/dev/null \
+                          || echo 0)
+
+            if [ "$created_epoch" -ge "$cutoff_epoch" ]; then
+              echo "  KEEP   #$number — created $created (within window): $title"
+              kept=$((kept + 1))
+              continue
+            fi
+
+            echo "  CLOSE  #$number — created $created: $title"
+            if [ "$DRY_RUN" != "true" ]; then
+              gh pr close "$number" \
+                --repo "$REPO" \
+                --delete-branch \
+                --comment "Closed by close-stale-fix-prs workflow: bot PRs are closed daily before triage. Add the \`do-not-close\` label to hold this PR across the daily reset, or re-trigger the fix agent to start fresh." \
+                || echo "::warning::Failed to close #$number"
+            fi
+            closed=$((closed + 1))
+          done
+
+          echo ""
+          echo "Result: ${closed} closed, ${kept} kept"
+          {
+            printf '## Close Stale Fix PRs\n\n'
+            printf 'Threshold: **%s days**, dry-run: **%s**\n\n' "$STALE_DAYS" "$DRY_RUN"
+            printf -- '- Closed: **%s**\n' "$closed"
+            printf -- '- Kept (within window or `do-not-close` label): **%s**\n' "$kept"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Checkout
+        if: always()
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml
@@ -12,7 +12,7 @@
 # the only way for a reviewer to hold a bot PR. Review comments alone do NOT keep a
 # PR alive — merge it the same day or apply the label.
 # type: CI
-# owner: @camunda/qa-engineering
+# owner: @camunda/test-automation-team
 ---
 name: Close Stale Fix PRs
 
@@ -36,7 +36,7 @@ permissions:
   pull-requests: write
 
 env:
-  TEST_OWNER: '@camunda/qa-engineering'
+  TEST_OWNER: '@camunda/test-automation-team'
 
 jobs:
   close-stale:

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml
@@ -109,7 +109,7 @@ jobs:
             printf '## Close Stale Fix PRs\n\n'
             printf 'Threshold: **%s days**, dry-run: **%s**\n\n' "$STALE_DAYS" "$DRY_RUN"
             printf -- '- Closed: **%s**\n' "$closed"
-            printf -- '- Kept (within window or `do-not-close` label): **%s**\n' "$kept"
+            printf -- "- Kept (within window or \`do-not-close\` label): **%s**\n" "$kept"
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Checkout
         if: always()

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       stale_days:
-        description: 'Close PRs untouched for N days (default 1 — daily fresh start)'
+        description: 'Close PRs created more than N days ago (default 1 — daily fresh start)'
         default: '1'
         required: false
       dry_run:
@@ -55,7 +55,7 @@ jobs:
 
           cutoff_epoch=$(date -u -d "${STALE_DAYS} days ago" +%s 2>/dev/null \
                        || date -u -v-"${STALE_DAYS}"d +%s)
-          echo "Closing PRs not updated since $(date -u -d "@${cutoff_epoch}" +%FT%TZ 2>/dev/null || echo "${STALE_DAYS} days ago")"
+          echo "Closing PRs created before $(date -u -d "@${cutoff_epoch}" +%FT%TZ 2>/dev/null || echo "${STALE_DAYS} days ago")"
           echo "Dry-run: ${DRY_RUN}"
 
           # Pull all open PRs with the bot label, excluding those held by do-not-close.

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -126,20 +126,21 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
+            secret/data/products/qa/ci/common GH_TOKEN ;
             secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
 
-      - name: Configure git
+      - name: Configure git with bot PAT
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
         run: |
           git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
-          git config --global user.name  "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name  "Nightly Fix Agent"
+          git config --global user.email "nightly-fix-agent@camunda.com"
 
       - name: Ensure failing-test-fix label exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
         run: |
           gh label create "failing-test-fix" \
             --repo "${{ github.repository }}" \
@@ -216,7 +217,7 @@ jobs:
       - name: Run Claude Code fix agent
         env:
           ANTHROPIC_API_KEY:   ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
-          GH_TOKEN:            ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN:            ${{ steps.secrets.outputs.GH_TOKEN }}
           VERSION:             ${{ github.event.inputs.version }}
           TARGET_REF:          ${{ steps.target.outputs.ref }}
           SAFE_VERSION:        ${{ steps.target.outputs.safe_version }}
@@ -385,7 +386,7 @@ jobs:
       - name: Re-label PRs (idempotent)
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
           REPO:     ${{ github.repository }}
         run: |
           if [ -f /tmp/fix-meta.json ]; then

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -128,6 +128,7 @@ jobs:
           secrets: |
             secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
+            secret/data/products/qa/ci/common GH_TOKEN | GH_TOKEN_PAT ;
 
       - name: Generate GitHub App Token
         id: github-token
@@ -172,7 +173,13 @@ jobs:
         env:
           GOPRIVATE: github.com/camunda/*
           GOTOOLCHAIN: auto
+          GH_TOKEN_PAT: ${{ steps.secrets.outputs.GH_TOKEN_PAT }}
         run: |
+          # workspace-cli is a private repo; the qa-processes app token doesn't have access.
+          # Add a more-specific insteadOf for workspace-cli that uses the Vault PAT.
+          # Git selects the longest-matching insteadOf, so this wins over the global
+          # qa-processes rewrite set in "Configure git with bot PAT".
+          git config --global url."https://x-access-token:${GH_TOKEN_PAT}@github.com/camunda/workspace-cli".insteadOf "https://github.com/camunda/workspace-cli"
           go install github.com/camunda/workspace-cli/cmd/workspace@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -126,21 +126,35 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
-            secret/data/products/qa/ci/common GH_TOKEN ;
             secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
 
+      - name: Generate GitHub App Token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: camunda
+
       - name: Configure git with bot PAT
         env:
-          TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+          TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
           git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
-          git config --global user.name  "Nightly Fix Agent"
-          git config --global user.email "nightly-fix-agent@camunda.com"
+          git config --global user.name  "qa-processes[bot]"
+          git config --global user.email "qa-processes[bot]@users.noreply.github.com"
 
       - name: Ensure failing-test-fix label exists
         env:
-          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
           gh label create "failing-test-fix" \
             --repo "${{ github.repository }}" \
@@ -217,7 +231,7 @@ jobs:
       - name: Run Claude Code fix agent
         env:
           ANTHROPIC_API_KEY:   ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
-          GH_TOKEN:            ${{ steps.secrets.outputs.GH_TOKEN }}
+          GH_TOKEN:            ${{ steps.github-token.outputs.token }}
           VERSION:             ${{ github.event.inputs.version }}
           TARGET_REF:          ${{ steps.target.outputs.ref }}
           SAFE_VERSION:        ${{ steps.target.outputs.safe_version }}
@@ -386,7 +400,7 @@ jobs:
       - name: Re-label PRs (idempotent)
         if: always()
         env:
-          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
           REPO:     ${{ github.repository }}
         run: |
           if [ -f /tmp/fix-meta.json ]; then

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -145,7 +145,7 @@ jobs:
           owner: camunda
           repositories: camunda
 
-      - name: Configure git with bot PAT
+      - name: Configure git with GitHub App token
         env:
           TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
@@ -178,7 +178,7 @@ jobs:
           # workspace-cli is a private repo; the qa-processes app token doesn't have access.
           # Add a more-specific insteadOf for workspace-cli that uses the Vault PAT.
           # Git selects the longest-matching insteadOf, so this wins over the global
-          # qa-processes rewrite set in "Configure git with bot PAT".
+          # qa-processes rewrite set in "Configure git with GitHub App token".
           git config --global url."https://x-access-token:${GH_TOKEN_PAT}@github.com/camunda/workspace-cli".insteadOf "https://github.com/camunda/workspace-cli"
           go install github.com/camunda/workspace-cli/cmd/workspace@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -134,9 +134,9 @@ jobs:
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
         with:
           github-app-id-vault-key: GITHUB_APP_ID
-          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
           github-app-private-key-vault-key: GITHUB_APP_SECRET
-          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
           vault-auth-method: approle
           vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
@@ -149,8 +149,8 @@ jobs:
           TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
           git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
-          git config --global user.name  "qa-processes[bot]"
-          git config --global user.email "qa-processes[bot]@users.noreply.github.com"
+          git config --global user.name  "quality-assurance-ci[bot]"
+          git config --global user.email "quality-assurance-ci[bot]@users.noreply.github.com"
 
       - name: Ensure failing-test-fix label exists
         env:

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -129,32 +129,17 @@ jobs:
             secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
 
-      - name: Generate GitHub App Token
-        id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
-        with:
-          github-app-id-vault-key: GITHUB_APP_ID
-          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
-          github-app-private-key-vault-key: GITHUB_APP_SECRET
-          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
-          vault-auth-method: approle
-          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          vault-url: ${{ secrets.VAULT_ADDR }}
-          owner: camunda
-          repositories: camunda
-
-      - name: Configure git with bot PAT
+      - name: Configure git
         env:
-          TOKEN: ${{ steps.github-token.outputs.token }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
-          git config --global user.name  "quality-assurance-ci[bot]"
-          git config --global user.email "quality-assurance-ci[bot]@users.noreply.github.com"
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Ensure failing-test-fix label exists
         env:
-          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh label create "failing-test-fix" \
             --repo "${{ github.repository }}" \
@@ -231,7 +216,7 @@ jobs:
       - name: Run Claude Code fix agent
         env:
           ANTHROPIC_API_KEY:   ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
-          GH_TOKEN:            ${{ steps.github-token.outputs.token }}
+          GH_TOKEN:            ${{ secrets.GITHUB_TOKEN }}
           VERSION:             ${{ github.event.inputs.version }}
           TARGET_REF:          ${{ steps.target.outputs.ref }}
           SAFE_VERSION:        ${{ steps.target.outputs.safe_version }}
@@ -400,7 +385,7 @@ jobs:
       - name: Re-label PRs (idempotent)
         if: always()
         env:
-          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO:     ${{ github.repository }}
         run: |
           if [ -f /tmp/fix-meta.json ]; then

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -76,8 +76,22 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
-            secret/data/products/qa/ci/common GH_TOKEN ;
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
+
+      - name: Generate GitHub App Token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: camunda
 
       - name: Show tool versions
         run: |
@@ -87,7 +101,7 @@ jobs:
       - name: Scan nightly workflows and extract failures
         id: scan
         env:
-          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
           REPO:     ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -245,7 +259,7 @@ jobs:
       - name: Normalize, filter and group by version
         id: group
         env:
-          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
           REPO:     ${{ github.repository }}
           DAILY_CAP: ${{ github.event.inputs.daily_cap || '4' }}
         run: |
@@ -447,7 +461,7 @@ jobs:
       - name: Write job summary
         if: always()
         env:
-          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
           REPO:     ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -626,12 +640,26 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
-            secret/data/products/qa/ci/common GH_TOKEN ;
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
+
+      - name: Generate GitHub App Token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: camunda
 
       - name: Dispatch one fix-agent run per version
         env:
-          GH_TOKEN:                  ${{ steps.secrets.outputs.GH_TOKEN }}
+          GH_TOKEN:                  ${{ steps.github-token.outputs.token }}
           REPO:                      ${{ github.repository }}
           DISPATCHES_B64:            ${{ needs.triage.outputs.dispatches }}
           TRIAGE_RUN_URL:            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -298,11 +298,34 @@ jobs:
 
           echo "After normalization + filtering: $(jq 'length' /tmp/failures_normalized.json)"
 
-          # Determine which versions have open failing-test-fix PRs (dedup)
-          open_pr_versions=$(gh pr list --repo "$REPO" \
+          # Determine which test files are already covered by open failing-test-fix PRs.
+          # Build a map: base_ref -> [spec file paths already being fixed on that branch].
+          # This allows partial dispatch: if a branch has an open PR but the new failures
+          # are in different files, a fix agent is still dispatched for those files.
+          covered_files_map='{}'
+          open_pr_base_refs='[]'
+          open_pr_nums=$(gh pr list --repo "$REPO" \
             --search "label:failing-test-fix is:open" \
-            --json baseRefName --jq '[.[].baseRefName] | unique' 2>/dev/null || echo '[]')
-          echo "Open failing-test-fix PR base refs: $open_pr_versions"
+            --json number --jq '.[].number' 2>/dev/null || echo '')
+          for pr_num in $open_pr_nums; do
+            [ -z "$pr_num" ] && continue
+            base_ref=$(gh pr view "$pr_num" --repo "$REPO" --json baseRefName \
+              --jq '.baseRefName' 2>/dev/null || echo '')
+            [ -z "$base_ref" ] && continue
+            pr_files=$(gh pr view "$pr_num" --repo "$REPO" --json files \
+              --jq '[.files[].path
+                     | select(test("qa/c8-orchestration-cluster-e2e-test-suite/.*\\.spec\\.[jt]s$"))
+                     | sub("^.*/qa/c8-orchestration-cluster-e2e-test-suite/"; "")
+                     | sub("^qa/c8-orchestration-cluster-e2e-test-suite/"; "")]' \
+              2>/dev/null || echo '[]')
+            covered_files_map=$(echo "$covered_files_map" | jq \
+              --arg ref "$base_ref" --argjson files "$pr_files" \
+              '. + {($ref): ((.[$ref] // []) + $files | unique)}')
+            open_pr_base_refs=$(echo "$open_pr_base_refs" | jq \
+              --arg ref "$base_ref" '. + [$ref] | unique')
+          done
+          echo "Open failing-test-fix PR base refs: $open_pr_base_refs"
+          echo "Covered spec files per branch: $(echo "$covered_files_map" | jq -c '.')"
 
           # Build dispatch payloads, one per version.
           # Sources:
@@ -352,7 +375,7 @@ jobs:
           # Build dispatch payloads from test failures
           if [ -s /tmp/failures_normalized.json ]; then
             jq --slurpfile run_ids /tmp/run_ids.json \
-               --argjson openrefs "$open_pr_versions" \
+               --argjson covered "$covered_files_map" \
                --argjson cap "${DAILY_CAP}" '
               # group failures by version
               sort_by(.version) | group_by(.version)
@@ -362,8 +385,17 @@ jobs:
                   ref: (if .[0].version == "main" then "main" else ("stable/" + .[0].version) end)
                 })
               | map(select(.test_specs | length > 0))
-              # dedup against open PRs
-              | map(select((.ref as $ref | $openrefs | index($ref)) == null))
+              # per-file dedup: remove specs whose file is already covered by an open PR on this branch.
+              # A version is only skipped entirely when every failing spec is already being fixed.
+              # If some specs are in files not yet covered, dispatch proceeds for those specs only.
+              | map(
+                  .ref as $ref |
+                  .test_specs |= map(
+                    . as $spec |
+                    select(($covered[$ref] // []) | index($spec.file) == null)
+                  )
+                )
+              | map(select(.test_specs | length > 0))
               # attach run IDs
               | map(. + {
                   e2e_run_id:       ($run_ids[0][(.version + "/e2e")]       // ""),
@@ -387,7 +419,7 @@ jobs:
           # (e.g. api_es has test failures while api_rdbms crashes before producing results).
           jq --slurpfile run_ids /tmp/run_ids.json \
              --argjson wf_failures "$workflow_failures" \
-             --argjson openrefs "$open_pr_versions" \
+             --argjson openrefs "$open_pr_base_refs" \
              --argjson cap "${DAILY_CAP}" '
             . as $test_dispatches |
             $wf_failures

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -76,8 +76,8 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
+            secret/data/products/qa/ci/common GH_TOKEN ;
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
-
 
       - name: Show tool versions
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Scan nightly workflows and extract failures
         id: scan
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
           REPO:     ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -245,7 +245,7 @@ jobs:
       - name: Normalize, filter and group by version
         id: group
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
           REPO:     ${{ github.repository }}
           DAILY_CAP: ${{ github.event.inputs.daily_cap || '4' }}
         run: |
@@ -447,7 +447,7 @@ jobs:
       - name: Write job summary
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
           REPO:     ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -626,12 +626,12 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
+            secret/data/products/qa/ci/common GH_TOKEN ;
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
-
 
       - name: Dispatch one fix-agent run per version
         env:
-          GH_TOKEN:                  ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN:                  ${{ steps.secrets.outputs.GH_TOKEN }}
           REPO:                      ${{ github.repository }}
           DISPATCHES_B64:            ${{ needs.triage.outputs.dispatches }}
           TRIAGE_RUN_URL:            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -325,6 +325,7 @@ jobs:
           open_pr_base_refs='[]'
           open_pr_nums=$(gh pr list --repo "$REPO" \
             --search "label:failing-test-fix is:open" \
+            --limit 200 \
             --json number --jq '.[].number' 2>/dev/null || echo '')
           for pr_num in $open_pr_nums; do
             [ -z "$pr_num" ] && continue

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -83,9 +83,9 @@ jobs:
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
         with:
           github-app-id-vault-key: GITHUB_APP_ID
-          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
           github-app-private-key-vault-key: GITHUB_APP_SECRET
-          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
           vault-auth-method: approle
           vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
@@ -647,9 +647,9 @@ jobs:
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
         with:
           github-app-id-vault-key: GITHUB_APP_ID
-          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
           github-app-private-key-vault-key: GITHUB_APP_SECRET
-          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
           vault-auth-method: approle
           vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -78,20 +78,6 @@ jobs:
           secrets: |
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
 
-      - name: Generate GitHub App Token
-        id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
-        with:
-          github-app-id-vault-key: GITHUB_APP_ID
-          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
-          github-app-private-key-vault-key: GITHUB_APP_SECRET
-          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
-          vault-auth-method: approle
-          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          vault-url: ${{ secrets.VAULT_ADDR }}
-          owner: camunda
-          repositories: camunda
 
       - name: Show tool versions
         run: |
@@ -101,7 +87,7 @@ jobs:
       - name: Scan nightly workflows and extract failures
         id: scan
         env:
-          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO:     ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -259,7 +245,7 @@ jobs:
       - name: Normalize, filter and group by version
         id: group
         env:
-          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO:     ${{ github.repository }}
           DAILY_CAP: ${{ github.event.inputs.daily_cap || '4' }}
         run: |
@@ -461,7 +447,7 @@ jobs:
       - name: Write job summary
         if: always()
         env:
-          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO:     ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -642,24 +628,10 @@ jobs:
           secrets: |
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
 
-      - name: Generate GitHub App Token
-        id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
-        with:
-          github-app-id-vault-key: GITHUB_APP_ID
-          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
-          github-app-private-key-vault-key: GITHUB_APP_SECRET
-          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
-          vault-auth-method: approle
-          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          vault-url: ${{ secrets.VAULT_ADDR }}
-          owner: camunda
-          repositories: camunda
 
       - name: Dispatch one fix-agent run per version
         env:
-          GH_TOKEN:                  ${{ steps.github-token.outputs.token }}
+          GH_TOKEN:                  ${{ secrets.GITHUB_TOKEN }}
           REPO:                      ${{ github.repository }}
           DISPATCHES_B64:            ${{ needs.triage.outputs.dispatches }}
           TRIAGE_RUN_URL:            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -33,6 +33,11 @@ on:
         description: 'Slack channel to post to (default: c8-orchestration-cluster-e2e-test-results; override for testing)'
         required: false
         default: ''
+      danger_force_redispatch:
+        description: '⚠️ DANGER: bypass the same-day cooldown and re-dispatch all eligible versions even if already dispatched today. For testing only. Default: false.'
+        type: boolean
+        default: false
+        required: false
 
 # Minimal at workflow level. Triage job only needs to read; dispatch job
 # bumps actions: write to trigger the fix workflow (zizmor: excessive-permissions).
@@ -625,7 +630,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
+      contents: write  # required to commit ledger to nightly-triage-state branch
       actions: write   # required to dispatch the fix workflow
       pull-requests: read
 
@@ -657,6 +662,17 @@ jobs:
           owner: camunda
           repositories: camunda
 
+      - name: Checkout (for ledger git operations)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.github-token.outputs.token }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "qa-processes[bot]"
+          git config user.email "qa-processes[bot]@users.noreply.github.com"
+
       - name: Dispatch one fix-agent run per version
         env:
           GH_TOKEN:                  ${{ steps.github-token.outputs.token }}
@@ -667,20 +683,66 @@ jobs:
           SLACK_CHANNEL:             ${{ needs.triage.outputs.slack_channel }}
           FIX_AGENT_REF:             ${{ github.ref_name }}
           SEND_SLACK_NOTIFICATION:   ${{ github.event_name == 'schedule' || github.event.inputs.send_slack_notification == 'true' }}
+          DANGER_FORCE_REDISPATCH:   ${{ inputs.danger_force_redispatch || 'false' }}
         run: |
           set -euo pipefail
 
           echo '[]' > /tmp/fix_agent_runs.json
 
+          # ---------------------------------------------------------------------------
+          # Load (or initialise) ledger from the nightly-triage-state branch.
+          # Cooldown model: skip a version already dispatched today (same UTC calendar
+          # day). DANGER_FORCE_REDISPATCH=true bypasses the cooldown for testing.
+          # ---------------------------------------------------------------------------
+          STATE_BRANCH="nightly-triage-state"
+          LEDGER_PATH="ledger.json"
+          today_utc=$(date -u +%F)
+          now_iso=$(date -u +%FT%TZ)
+
+          git fetch origin "$STATE_BRANCH" 2>/dev/null || true
+          if git rev-parse --verify "origin/${STATE_BRANCH}" >/dev/null 2>&1; then
+            wt_tmp=/tmp/ledger-read-wt
+            rm -rf "$wt_tmp"
+            if git worktree add -f "$wt_tmp" "origin/${STATE_BRANCH}" 2>/dev/null; then
+              if [ -f "${wt_tmp}/ledger.json" ]; then
+                cp "${wt_tmp}/ledger.json" "$LEDGER_PATH"
+                echo "Loaded ledger ($(jq 'length' "$LEDGER_PATH") entries)"
+              else
+                echo '{}' > "$LEDGER_PATH"
+                echo "State branch exists but no ledger.json — starting fresh"
+              fi
+              git worktree remove --force "$wt_tmp" 2>/dev/null || rm -rf "$wt_tmp"
+            else
+              echo '{}' > "$LEDGER_PATH"
+            fi
+          else
+            echo '{}' > "$LEDGER_PATH"
+            echo "State branch '${STATE_BRANCH}' does not exist — starting fresh"
+          fi
+          if ! jq -e . "$LEDGER_PATH" >/dev/null 2>&1; then
+            echo "::warning::Ledger is not valid JSON — resetting"
+            echo '{}' > "$LEDGER_PATH"
+          fi
+
           # Decode the base64-encoded dispatches payload from the triage job.
           DISPATCHES_JSON=$(echo "${DISPATCHES_B64}" | base64 -d)
 
-          echo "$DISPATCHES_JSON" | jq -c '.[]' | while read -r d; do
+          while IFS= read -r d; do
             version=$(echo "$d" | jq -r '.version')
             specs=$(echo "$d" | jq -c '.test_specs')
             e2e=$(echo "$d"   | jq -r '.e2e_run_id')
             api_es=$(echo "$d" | jq -r '.api_es_run_id')
             api_rdbms=$(echo "$d" | jq -r '.api_rdbms_run_id')
+
+            # Cooldown check — skip if already dispatched today (unless danger mode)
+            ledger_entry=$(jq -c --arg v "$version" '.[$v] // null' "$LEDGER_PATH")
+            if [ "$ledger_entry" != "null" ]; then
+              dispatched_date=$(echo "$ledger_entry" | jq -r '.dispatched_at // ""' | cut -c1-10)
+              if [ "$dispatched_date" = "$today_utc" ] && [ "$DANGER_FORCE_REDISPATCH" != "true" ]; then
+                echo "Version $version: already dispatched today ($dispatched_date) — skipping (use danger_force_redispatch to override)"
+                continue
+              fi
+            fi
 
             echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')"
             dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -739,7 +801,50 @@ jobs:
               '. += [{"version": $v, "run_id": $id, "run_url": ("https://github.com/" + $repo + "/actions/runs/" + $id), "run_label": $label, "test_count": $count}]' \
               /tmp/fix_agent_runs.json > /tmp/fix_agent_runs.json.tmp
             mv /tmp/fix_agent_runs.json.tmp /tmp/fix_agent_runs.json
-          done
+
+            # Update ledger — record this version as dispatched today
+            jq --arg v "$version" --arg now "$now_iso" \
+              '.[$v] = {state: "dispatched", dispatched_at: $now}' \
+              "$LEDGER_PATH" > "${LEDGER_PATH}.tmp" && mv "${LEDGER_PATH}.tmp" "$LEDGER_PATH"
+          done < <(echo "$DISPATCHES_JSON" | jq -c '.[]')
+
+      - name: Commit ledger to state branch
+        if: always() && hashFiles('ledger.json') != ''
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          STATE_BRANCH=nightly-triage-state
+
+          # Create the branch if it doesn't exist yet (first run).
+          if ! git ls-remote --exit-code --heads origin "$STATE_BRANCH" >/dev/null 2>&1; then
+            echo "Creating state branch '$STATE_BRANCH' for the first time"
+            git checkout --orphan "$STATE_BRANCH"
+            git rm -rf . 2>/dev/null || true
+            git clean -fdx -e ledger.json
+            git add ledger.json
+            git commit -m "init triage ledger ($(date -u +%F))"
+            git push -u origin "$STATE_BRANCH"
+          else
+            # Worktree-based update so we don't disturb the current checkout
+            wt=/tmp/state-update
+            rm -rf "$wt"
+            git fetch origin "$STATE_BRANCH"
+            git worktree add "$wt" "origin/$STATE_BRANCH"
+            cp ledger.json "$wt/ledger.json"
+            (
+              cd "$wt"
+              git add ledger.json
+              if git diff --cached --quiet; then
+                echo "Ledger unchanged — nothing to commit"
+              else
+                git commit -m "ledger: $(date -u +%F)"
+                git push origin "HEAD:${STATE_BRANCH}"
+              fi
+            )
+            git worktree remove --force "$wt" || rm -rf "$wt"
+          fi
 
       - name: Write dispatch summary
         if: always()

--- a/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
@@ -1,7 +1,7 @@
 # description: Runs Request Validation tests on the C8 Orchestration Cluster REST API for 8.8+ versions nightly
 # test location: /qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/request-validation
 # type: CI
-# owner: @camunda/qa-engineering
+# owner: @camunda-ex-team
 ---
 name: C8 Orchestration Cluster V2 Stateless Tests Nightly
 
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  TEST_OWNER: '@camunda/qa-engineering'
+  TEST_OWNER: '@camunda-ex-team'
 
 jobs:
   request-validation-tests:


### PR DESCRIPTION
## Description

Two complementary fixes for the nightly triage dispatch pipeline:

### 1. Per-spec-file dedup in triage (`c8-orchestration-cluster-e2e-nightly-triage.yml`)

The dedup guard used `baseRefName` as the uniqueness key: any open `failing-test-fix` PR on a branch blocked **all** fix-agent dispatches for that branch, even when new nightly failures were in completely different spec files.

**Concrete example**: PR #55297 (RDBMS propagation timeout, open since June 16) blocked dispatch for today's Identity \"Delete user\" dialog failures in `tests/identity/users.spec.ts` etc. — zero file overlap.

**Fix**: Replace branch-level dedup with per-spec-file dedup.
- For each open `failing-test-fix` PR, fetch its changed `.spec.[jt]s` files via `gh pr view --json files`
- Build a map `{ base_ref -> [covered spec files] }`
- Filter individual `test_specs` entries whose `.file` is already covered; drop a version only when every failing spec is covered
- Workflow-level failures (no test specs) keep the original branch-level guard

### 2. Close Stale Fix PRs workflow (`c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml`)

Add a daily cleanup workflow (mirroring `close-stale-fix-prs.yml` in `camunda/c8-cross-component-e2e-tests`) that closes `failing-test-fix` bot PRs older than 1 day before each morning triage run.

- Runs at **03:00 UTC Mon–Fri** (1h before the 04:00 triage)
- PRs labelled `do-not-close` are exempt — that label is the only way to hold a bot PR across the daily reset
- `workflow_dispatch` with `stale_days` and `dry_run` inputs for manual use
- Closes PR and deletes the branch; leaves a comment explaining the reset

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Observed during triage run: https://github.com/camunda/camunda/actions/runs/28076860689
Blocked by: https://github.com/camunda/camunda/pull/55297 (RDBMS fix, open since Jun 16)