### PR TITLE
fix: align agent instance schemas with OpenAPI spec

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.10.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.72",
+        "@camunda/camunda-api-zod-schemas": "0.0.76",
         "@camunda/camunda-composite-components": "0.25.0",
         "@carbon/elements": "11.90.0",
         "@carbon/react": "1.108.0",
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.72",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.72.tgz",
-      "integrity": "sha512-ZZmQHnvO2QCjq4sARIdcjNub94mKWKJx2xWfjPGuSjWRaRnZKilhqHLLYVBSvjPla9VgIi6lnYj6QT6iKOR/AQ==",
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.76.tgz",
+      "integrity": "sha512-5acIrmoKOsA3leceAFj41jmu6WD2JCjDuhFgB5YQCu+kUZgrCzfth4xaPKfOfvpVDomWgkgk/NelK39j21xKxw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.72",
+    "@camunda/camunda-api-zod-schemas": "0.0.76",
     "@camunda/camunda-composite-components": "0.25.0",
     "@carbon/elements": "11.90.0",
     "@carbon/react": "1.108.0",

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.21.3",
         "@bpmn-io/form-js-viewer": "1.21.3",
-        "@camunda/camunda-api-zod-schemas": "0.0.72",
+        "@camunda/camunda-api-zod-schemas": "0.0.76",
         "@camunda/camunda-composite-components": "0.25.0",
         "@carbon/react": "1.108.0",
         "@monaco-editor/react": "4.7.0",
@@ -578,9 +578,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.72",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.72.tgz",
-      "integrity": "sha512-ZZmQHnvO2QCjq4sARIdcjNub94mKWKJx2xWfjPGuSjWRaRnZKilhqHLLYVBSvjPla9VgIi6lnYj6QT6iKOR/AQ==",
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.76.tgz",
+      "integrity": "sha512-5acIrmoKOsA3leceAFj41jmu6WD2JCjDuhFgB5YQCu+kUZgrCzfth4xaPKfOfvpVDomWgkgk/NelK39j21xKxw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.21.3",
     "@bpmn-io/form-js-viewer": "1.21.3",
-    "@camunda/camunda-api-zod-schemas": "0.0.72",
+    "@camunda/camunda-api-zod-schemas": "0.0.76",
     "@camunda/camunda-composite-components": "0.25.0",
     "@carbon/react": "1.108.0",
     "@monaco-editor/react": "4.7.0",

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
-		"@camunda/camunda-api-zod-schemas": "0.0.75",
+		"@camunda/camunda-api-zod-schemas": "0.0.76",
 		"@camunda/camunda-composite-components": "0.24.0",
 		"@carbon/react": "1.109.0",
 		"@carbon/type": "11.61.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -28,7 +28,7 @@
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
-				"@camunda/camunda-api-zod-schemas": "0.0.75",
+				"@camunda/camunda-api-zod-schemas": "0.0.76",
 				"@camunda/camunda-composite-components": "0.24.0",
 				"@carbon/react": "1.109.0",
 				"@carbon/type": "11.61.0",
@@ -11039,13 +11039,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.75",
+				"@camunda/camunda-api-zod-schemas": "0.0.76",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.75",
+			"version": "0.0.76",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.9.3",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.75",
+		"@camunda/camunda-api-zod-schemas": "0.0.76",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.0.76
+
+### 🩹 Fixes
+
+- Align agent instance types with their latest OpenAPI spec
+  - Add `UNKNOWN` to agent instance status enum
+  - Add available tools as `tools` to agent instances
+  - Add `rootProcessInstanceKey`, `processDefinitionId`, `processDefinitionVersion`, and `processDefinitionVersionTag` to agent instances
+- Reword `searchAgentInstances` -> `queryAgentInstances` and `searchAgentInstanceHistory` -> `queryAgentInstanceHistory` to align with the wording throughout the library
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.75
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
@@ -20,6 +20,7 @@ import {
 import {documentReferenceSchema} from './document';
 
 const agentInstanceStatusSchema = z.enum([
+	'UNKNOWN',
 	'COMPLETED',
 	'IDLE',
 	'INITIALIZING',
@@ -51,15 +52,27 @@ const agentInstanceLimitsSchema = z.object({
 });
 type AgentInstanceLimits = z.infer<typeof agentInstanceLimitsSchema>;
 
+const agentToolSchema = z.object({
+	name: z.string(),
+	description: z.string().nullable(),
+	elementId: z.string().nullable(),
+});
+type AgentTool = z.infer<typeof agentToolSchema>;
+
 const agentInstanceSchema = z.object({
 	agentInstanceKey: z.string(),
 	status: agentInstanceStatusSchema,
 	definition: agentInstanceDefinitionSchema,
 	metrics: agentInstanceMetricsSchema,
 	limits: agentInstanceLimitsSchema,
+	tools: z.array(agentToolSchema),
 	elementId: z.string(),
 	processInstanceKey: z.string(),
+	rootProcessInstanceKey: z.string(),
 	processDefinitionKey: z.string(),
+	processDefinitionId: z.string(),
+	processDefinitionVersion: z.number(),
+	processDefinitionVersionTag: z.string().nullable(),
 	tenantId: z.string(),
 	creationDate: z.string(),
 	lastUpdatedDate: z.string(),
@@ -74,7 +87,11 @@ const agentInstanceFilterSchema = z
 		status: getEnumFilterSchema(agentInstanceStatusSchema),
 		elementId: basicStringFilterSchema,
 		processInstanceKey: basicStringFilterSchema,
+		rootProcessInstanceKey: basicStringFilterSchema,
 		processDefinitionKey: basicStringFilterSchema,
+		processDefinitionId: basicStringFilterSchema,
+		processDefinitionVersion: advancedIntegerFilterSchema,
+		processDefinitionVersionTag: basicStringFilterSchema,
 		tenantId: basicStringFilterSchema,
 		creationDate: advancedDateTimeFilterSchema,
 		lastUpdatedDate: advancedDateTimeFilterSchema,
@@ -85,7 +102,18 @@ const agentInstanceFilterSchema = z
 type AgentInstanceFilter = z.infer<typeof agentInstanceFilterSchema>;
 
 const queryAgentInstancesRequestBodySchema = getQueryRequestBodySchema({
-	sortFields: ['creationDate', 'lastUpdatedDate', 'completionDate', 'status'] as const,
+	sortFields: [
+		'agentInstanceKey',
+		'status',
+		'elementId',
+		'processInstanceKey',
+		'rootProcessInstanceKey',
+		'processDefinitionKey',
+		'tenantId',
+		'creationDate',
+		'lastUpdatedDate',
+		'completionDate',
+	] as const,
 	filter: agentInstanceFilterSchema,
 });
 type QueryAgentInstancesRequestBody = z.infer<typeof queryAgentInstancesRequestBodySchema>;
@@ -189,21 +217,21 @@ const createAgentInstanceHistoryItemResponseBodySchema = z.object({
 });
 type CreateAgentInstanceHistoryItemResponseBody = z.infer<typeof createAgentInstanceHistoryItemResponseBodySchema>;
 
-const searchAgentInstanceHistoryRequestBodySchema = getQueryRequestBodySchema({
+const queryAgentInstanceHistoryRequestBodySchema = getQueryRequestBodySchema({
 	sortFields: ['producedAt', 'historyItemKey', 'iteration'] as const,
 	filter: agentInstanceHistoryFilterSchema,
 });
-type SearchAgentInstanceHistoryRequestBody = z.infer<typeof searchAgentInstanceHistoryRequestBodySchema>;
+type QueryAgentInstanceHistoryRequestBody = z.infer<typeof queryAgentInstanceHistoryRequestBodySchema>;
 
-const searchAgentInstanceHistoryResponseBodySchema = getQueryResponseBodySchema(agentInstanceHistoryItemSchema);
-type SearchAgentInstanceHistoryResponseBody = z.infer<typeof searchAgentInstanceHistoryResponseBodySchema>;
+const queryAgentInstanceHistoryResponseBodySchema = getQueryResponseBodySchema(agentInstanceHistoryItemSchema);
+type QueryAgentInstanceHistoryResponseBody = z.infer<typeof queryAgentInstanceHistoryResponseBodySchema>;
 
 const getAgentInstance: Endpoint<{agentInstanceKey: string}> = {
 	method: 'GET',
 	getUrl: ({agentInstanceKey}) => `/${API_VERSION}/agent-instances/${agentInstanceKey}`,
 };
 
-const searchAgentInstances: Endpoint = {
+const queryAgentInstances: Endpoint = {
 	method: 'POST',
 	getUrl: () => `/${API_VERSION}/agent-instances/search`,
 };
@@ -213,7 +241,7 @@ const createAgentInstanceHistoryItem: Endpoint<{agentInstanceKey: string}> = {
 	getUrl: ({agentInstanceKey}) => `/${API_VERSION}/agent-instances/${agentInstanceKey}/history`,
 };
 
-const searchAgentInstanceHistory: Endpoint<{agentInstanceKey: string}> = {
+const queryAgentInstanceHistory: Endpoint<{agentInstanceKey: string}> = {
 	method: 'POST',
 	getUrl: ({agentInstanceKey}) => `/${API_VERSION}/agent-instances/${agentInstanceKey}/history/search`,
 };
@@ -223,6 +251,7 @@ export {
 	agentInstanceDefinitionSchema,
 	agentInstanceMetricsSchema,
 	agentInstanceLimitsSchema,
+	agentToolSchema,
 	agentInstanceSchema,
 	agentInstanceFilterSchema,
 	queryAgentInstancesRequestBodySchema,
@@ -240,18 +269,19 @@ export {
 	agentInstanceHistoryFilterSchema,
 	createAgentInstanceHistoryItemRequestBodySchema,
 	createAgentInstanceHistoryItemResponseBodySchema,
-	searchAgentInstanceHistoryRequestBodySchema,
-	searchAgentInstanceHistoryResponseBodySchema,
+	queryAgentInstanceHistoryRequestBodySchema,
+	queryAgentInstanceHistoryResponseBodySchema,
 	getAgentInstance,
-	searchAgentInstances,
+	queryAgentInstances,
 	createAgentInstanceHistoryItem,
-	searchAgentInstanceHistory,
+	queryAgentInstanceHistory,
 };
 export type {
 	AgentInstanceStatus,
 	AgentInstanceDefinition,
 	AgentInstanceMetrics,
 	AgentInstanceLimits,
+	AgentTool,
 	AgentInstance,
 	AgentInstanceFilter,
 	QueryAgentInstancesRequestBody,
@@ -269,6 +299,6 @@ export type {
 	AgentInstanceHistoryFilter,
 	CreateAgentInstanceHistoryItemRequestBody,
 	CreateAgentInstanceHistoryItemResponseBody,
-	SearchAgentInstanceHistoryRequestBody,
-	SearchAgentInstanceHistoryResponseBody,
+	QueryAgentInstanceHistoryRequestBody,
+	QueryAgentInstanceHistoryResponseBody,
 };

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
@@ -10,9 +10,9 @@ import {getCurrentUser} from './authentication';
 import {activateAdHocSubProcessActivities} from './ad-hoc-sub-process';
 import {
 	getAgentInstance,
-	searchAgentInstances,
+	queryAgentInstances,
 	createAgentInstanceHistoryItem,
-	searchAgentInstanceHistory,
+	queryAgentInstanceHistory,
 } from './agent-instance';
 import {
 	createAuthorization,
@@ -197,9 +197,9 @@ const endpoints = {
 
 	activateAdHocSubProcessActivities,
 	getAgentInstance,
-	searchAgentInstances,
+	queryAgentInstances,
 	createAgentInstanceHistoryItem,
-	searchAgentInstanceHistory,
+	queryAgentInstanceHistory,
 	createAuthorization,
 	updateAuthorization,
 	getAuthorization,
@@ -429,6 +429,7 @@ export {
 	agentInstanceDefinitionSchema,
 	agentInstanceMetricsSchema,
 	agentInstanceLimitsSchema,
+	agentToolSchema,
 	agentInstanceSchema,
 	agentInstanceFilterSchema,
 	queryAgentInstancesRequestBodySchema,
@@ -446,12 +447,13 @@ export {
 	agentInstanceHistoryFilterSchema,
 	createAgentInstanceHistoryItemRequestBodySchema,
 	createAgentInstanceHistoryItemResponseBodySchema,
-	searchAgentInstanceHistoryRequestBodySchema,
-	searchAgentInstanceHistoryResponseBodySchema,
+	queryAgentInstanceHistoryRequestBodySchema,
+	queryAgentInstanceHistoryResponseBodySchema,
 	type AgentInstanceStatus,
 	type AgentInstanceDefinition,
 	type AgentInstanceMetrics,
 	type AgentInstanceLimits,
+	type AgentTool,
 	type AgentInstance,
 	type AgentInstanceFilter,
 	type QueryAgentInstancesRequestBody,
@@ -469,8 +471,8 @@ export {
 	type AgentInstanceHistoryFilter,
 	type CreateAgentInstanceHistoryItemRequestBody,
 	type CreateAgentInstanceHistoryItemResponseBody,
-	type SearchAgentInstanceHistoryRequestBody,
-	type SearchAgentInstanceHistoryResponseBody,
+	type QueryAgentInstanceHistoryRequestBody,
+	type QueryAgentInstanceHistoryResponseBody,
 } from './agent-instance';
 export {
 	activityTypeSchema,

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.75",
+	"version": "0.0.76",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

Updates the agent instances schemas to align with the OpenAPI spec. See changelog entry for change description. Aside from aligning the with OpenAPI spec, there was an inconsistency in `agent-instance.ts`. Other schemas and endpoints refer to the search as "query", but `agent-instance.ts` has used "search". This PR aligns it with other parts of the library.

## Checklist

- [x] **Release package**
- [x] Bump version Tasklist, and Admin (Operate will be bumped in a follow-up PR, to fix 53 type-problems there).

## Related issues

relates #55711
