### PR TITLE
fix: add @DefaultValue to RaftCfg.FlushConfig to prevent silent flush disable

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import java.time.Duration;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 
 public final class RaftCfg implements ConfigurationEntry {
   public static final boolean DEFAULT_ENABLE_PRIORITY_ELECTION = true;
@@ -43,7 +44,9 @@ public final class RaftCfg implements ConfigurationEntry {
         + '}';
   }
 
-  public record FlushConfig(boolean enabled, Duration delayTime) {
+  public record FlushConfig(
+      @DefaultValue("true") boolean enabled,
+      @DefaultValue("PT0S") Duration delayTime) {
     public FlushConfig(final boolean enabled, final Duration delayTime) {
       this.enabled = enabled;
       this.delayTime = delayTime == null ? Duration.ZERO : delayTime;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -367,6 +367,33 @@ public final class BrokerCfgTest {
   }
 
   @Test
+  public void shouldEnableFlushByDefault() {
+    // given
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+
+    // when
+    final ClusterCfg clusterCfg = cfg.getCluster();
+
+    // then
+    assertThat(clusterCfg.getRaft().getFlush().enabled()).isTrue();
+    assertThat(clusterCfg.getRaft().getFlush().delayTime()).isEqualTo(Duration.ZERO);
+  }
+
+  @Test
+  public void shouldPreserveFlushEnabledWhenOnlyDelayTimeIsSet() {
+    // given
+    environment.put("zeebe.broker.cluster.raft.flush.delayTime", "15s");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+    final ClusterCfg clusterCfg = cfg.getCluster();
+
+    // then
+    assertThat(clusterCfg.getRaft().getFlush().enabled()).isTrue();
+    assertThat(clusterCfg.getRaft().getFlush().delayTime()).isEqualTo(Duration.ofSeconds(15));
+  }
+
+  @Test
   public void shouldSetEnablePriorityElectionFromConfig() {
     // given
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);


### PR DESCRIPTION
Fixes #55423

## Description

When only `flush.delayTime` is configured without `flush.enabled`, Spring Boot 
constructor-binds a fresh `FlushConfig` record where the unset `enabled` field 
falls back to Java's primitive default `false`, silently disabling explicit Raft 
flush entirely.

Add `@DefaultValue("true")` to `enabled` and `@DefaultValue("PT0S")` to `delayTime` 
so partial binding preserves the safe defaults.

## Checklist


## Related issues

closes #55423 
