### PR TITLE
fix: mark process definitions as deleted on resource deletion to stop Connector re-subscription

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
@@ -11,11 +11,14 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.bool;
 import static io.camunda.search.clients.query.SearchQueryBuilders.intTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.not;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.FORM_ID;
+import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.IS_DELETED;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.RESOURCE_NAME;
@@ -51,6 +54,7 @@ public class ProcessDefinitionFilterTransformer
     ofNullable(stringTerms(VERSION_TAG, filter.versionTags())).ifPresent(queries::add);
     ofNullable(stringTerms(TENANT_ID, filter.tenantIds())).ifPresent(queries::add);
     ofNullable(getHasStartFormQuery(filter.hasStartForm())).ifPresent(queries::add);
+    queries.add(not(term(IS_DELETED, true)));
     return and(queries);
   }
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import org.junit.jupiter.api.Test;
+
+class ProcessDefinitionFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldExcludeDeletedProcessDefinitionsByDefault() {
+    // given — empty filter (no explicit criteria)
+    final var filter = FilterBuilders.processDefinition(f -> f);
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then — the query must contain a mustNot(isDeleted=true) clause
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              final var mustNot = boolQuery.mustNot();
+              assertThat(mustNot).isNotEmpty();
+              final var deletedClause =
+                  mustNot.stream()
+                      .filter(q -> q.queryOption() instanceof SearchTermQuery)
+                      .map(q -> (SearchTermQuery) q.queryOption())
+                      .filter(t -> "isDeleted".equals(t.field()))
+                      .findFirst();
+              assertThat(deletedClause)
+                  .isPresent()
+                  .get()
+                  .satisfies(t -> assertThat(t.value().booleanValue()).isTrue());
+            });
+  }
+
+  @Test
+  void shouldQueryByProcessDefinitionKey() {
+    // given
+    final var filter = FilterBuilders.processDefinition(f -> f.processDefinitionKeys(123L));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then — multiple conditions are combined into a must clause; the isDeleted exclusion is
+    // one of the must sub-clauses (itself a mustNot bool query)
+    assertThat(searchQuery.queryOption()).isInstanceOf(SearchBoolQuery.class);
+    final var boolQuery = (SearchBoolQuery) searchQuery.queryOption();
+    final var hasDeletedExclusion =
+        boolQuery.must().stream()
+            .anyMatch(
+                q ->
+                    q.queryOption() instanceof SearchBoolQuery inner
+                        && inner.mustNot().stream()
+                            .anyMatch(
+                                mn ->
+                                    mn.queryOption() instanceof SearchTermQuery t
+                                        && "isDeleted".equals(t.field())
+                                        && t.value().booleanValue()));
+    assertThat(hasDeletedExclusion).isTrue();
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionQueryTransformerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchExistsQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
+import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.query.SearchTermsQuery;
 import io.camunda.search.clients.types.TypedValue;
@@ -22,11 +23,37 @@ import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.security.core.authz.TenantCheck;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public final class ProcessDefinitionQueryTransformerTest extends AbstractTransformerTest {
+
+  /**
+   * Extracts the non-isDeleted criterion from a must-combined query. When the filter has exactly
+   * one user-supplied criterion, the top-level query is a bool must that combines that criterion
+   * with the mandatory isDeleted=false exclusion.
+   */
+  private static Optional<SearchQuery> findCriterion(final SearchQuery query, final String field) {
+    if (query.queryOption() instanceof final SearchBoolQuery boolQuery) {
+      return boolQuery.must().stream()
+          .filter(
+              q ->
+                  !(q.queryOption() instanceof SearchBoolQuery inner && !inner.mustNot().isEmpty()))
+          .filter(q -> matchesField(q, field))
+          .findFirst();
+    }
+    return Optional.empty();
+  }
+
+  private static boolean matchesField(final SearchQuery q, final String field) {
+    return switch (q.queryOption()) {
+      case final SearchTermQuery t -> field.equals(t.field());
+      case final SearchTermsQuery t -> field.equals(t.field());
+      default -> false;
+    };
+  }
 
   @Test
   public void shouldQueryByProcessDefinitionKey() {
@@ -35,9 +62,10 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     // when
     final var searchRequest = transformQuery(filter);
 
-    // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
+    // then — single criterion + isDeleted exclusion → outer bool/must
+    final var criterion = findCriterion(searchRequest, "key");
+    assertThat(criterion).isPresent();
+    assertThat(criterion.get().queryOption())
         .isInstanceOfSatisfying(
             SearchTermQuery.class,
             t -> {
@@ -54,8 +82,9 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
+    final var criterion = findCriterion(searchRequest, "name");
+    assertThat(criterion).isPresent();
+    assertThat(criterion.get().queryOption())
         .isInstanceOfSatisfying(
             SearchTermQuery.class,
             t -> {
@@ -73,8 +102,9 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
+    final var criterion = findCriterion(searchRequest, "bpmnProcessId");
+    assertThat(criterion).isPresent();
+    assertThat(criterion.get().queryOption())
         .isInstanceOfSatisfying(
             SearchTermQuery.class,
             t -> {
@@ -91,8 +121,9 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
+    final var criterion = findCriterion(searchRequest, "version");
+    assertThat(criterion).isPresent();
+    assertThat(criterion.get().queryOption())
         .isInstanceOfSatisfying(
             SearchTermQuery.class,
             t -> {
@@ -109,21 +140,38 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     // when
     final var searchRequest = transformQuery(filter);
 
-    // then
+    // then — outer must combines the hasStartForm bool with the isDeleted exclusion bool
     assertThat(searchRequest.queryOption())
         .isInstanceOfSatisfying(
             SearchBoolQuery.class,
-            boolQuery -> {
-              final var boolQueryMustOrNot = hasStartForm ? boolQuery.must() : boolQuery.mustNot();
-              assertThat(boolQueryMustOrNot).hasSize(1);
-              final var innerQuery = boolQueryMustOrNot.get(0).queryOption();
-
-              assertThat(boolQueryMustOrNot).hasSize(1);
-
-              assertThat(innerQuery).isInstanceOf(SearchExistsQuery.class);
-
-              final var existsQuery = (SearchExistsQuery) innerQuery;
-              assertThat(existsQuery.field()).isEqualTo("formId");
+            outerBool -> {
+              // find the inner bool that encodes the hasStartForm check
+              final var startFormClause =
+                  outerBool.must().stream()
+                      .filter(
+                          q ->
+                              q.queryOption() instanceof SearchBoolQuery inner
+                                  && inner.mustNot().stream()
+                                      .noneMatch(
+                                          mn ->
+                                              mn.queryOption() instanceof SearchTermQuery t
+                                                  && ProcessIndex.IS_DELETED.equals(t.field())))
+                      .findFirst();
+              assertThat(startFormClause).isPresent();
+              assertThat(startFormClause.get().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchBoolQuery.class,
+                      boolQuery -> {
+                        final var boolQueryMustOrNot =
+                            hasStartForm ? boolQuery.must() : boolQuery.mustNot();
+                        assertThat(boolQueryMustOrNot).hasSize(1);
+                        assertThat(boolQueryMustOrNot.get(0).queryOption())
+                            .isInstanceOf(SearchExistsQuery.class);
+                        assertThat(
+                                ((SearchExistsQuery) boolQueryMustOrNot.get(0).queryOption())
+                                    .field())
+                            .isEqualTo("formId");
+                      });
             });
   }
 
@@ -135,8 +183,9 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
+    final var criterion = findCriterion(searchRequest, "versionTag");
+    assertThat(criterion).isPresent();
+    assertThat(criterion.get().queryOption())
         .isInstanceOfSatisfying(
             SearchTermQuery.class,
             t -> {
@@ -153,8 +202,9 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
+    final var criterion = findCriterion(searchRequest, "tenantId");
+    assertThat(criterion).isPresent();
+    assertThat(criterion.get().queryOption())
         .isInstanceOfSatisfying(
             SearchTermQuery.class,
             t -> {
@@ -172,8 +222,9 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
+    final var criterion = findCriterion(searchRequest, "resourceName");
+    assertThat(criterion).isPresent();
+    assertThat(criterion.get().queryOption())
         .isInstanceOfSatisfying(
             SearchTermQuery.class,
             t -> {
@@ -196,15 +247,22 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchQuery =
         transformQuery(FilterBuilders.processDefinition(b -> b), resourceAccessChecks);
 
-    // then
-    final var queryVariant = searchQuery.queryOption();
-    assertThat(queryVariant)
+    // then — combined: filterQuery (isDeleted exclusion) + authQuery
+    assertThat(searchQuery.queryOption())
         .isInstanceOfSatisfying(
-            SearchTermsQuery.class,
-            t -> {
-              assertThat(t.field()).isEqualTo(ProcessIndex.BPMN_PROCESS_ID);
-              assertThat(t.values()).hasSize(2);
-              assertThat(t.values().stream().map(TypedValue::stringValue).toList())
+            SearchBoolQuery.class,
+            boolQuery -> {
+              final var authClause =
+                  boolQuery.must().stream()
+                      .filter(
+                          q ->
+                              q.queryOption() instanceof SearchTermsQuery t
+                                  && ProcessIndex.BPMN_PROCESS_ID.equals(t.field()))
+                      .findFirst();
+              assertThat(authClause).isPresent();
+              final var termsQuery = (SearchTermsQuery) authClause.get().queryOption();
+              assertThat(termsQuery.values()).hasSize(2);
+              assertThat(termsQuery.values().stream().map(TypedValue::stringValue).toList())
                   .containsExactlyInAnyOrder("1", "2");
             });
   }
@@ -238,8 +296,21 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchQuery =
         transformQuery(FilterBuilders.processDefinition(b -> b), resourceAccessChecks);
 
-    // then
-    assertThat(searchQuery).isNull();
+    // then — only the isDeleted exclusion remains (no other filters or checks)
+    assertThat(searchQuery).isNotNull();
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              assertThat(boolQuery.mustNot()).hasSize(1);
+              assertThat(boolQuery.mustNot().get(0).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      t -> {
+                        assertThat(t.field()).isEqualTo(ProcessIndex.IS_DELETED);
+                        assertThat(t.value().booleanValue()).isTrue();
+                      });
+            });
   }
 
   @Test
@@ -253,15 +324,22 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchQuery =
         transformQuery(FilterBuilders.processDefinition(b -> b), resourceAccessChecks);
 
-    // then
-    final var queryVariant = searchQuery.queryOption();
-    assertThat(queryVariant)
+    // then — combined: filterQuery (isDeleted exclusion) + tenantQuery
+    assertThat(searchQuery.queryOption())
         .isInstanceOfSatisfying(
-            SearchTermsQuery.class,
-            t -> {
-              assertThat(t.field()).isEqualTo(ProcessIndex.TENANT_ID);
-              assertThat(t.values()).hasSize(2);
-              assertThat(t.values().stream().map(TypedValue::stringValue).toList())
+            SearchBoolQuery.class,
+            boolQuery -> {
+              final var tenantClause =
+                  boolQuery.must().stream()
+                      .filter(
+                          q ->
+                              q.queryOption() instanceof SearchTermsQuery t
+                                  && ProcessIndex.TENANT_ID.equals(t.field()))
+                      .findFirst();
+              assertThat(tenantClause).isPresent();
+              final var termsQuery = (SearchTermsQuery) tenantClause.get().queryOption();
+              assertThat(termsQuery.values()).hasSize(2);
+              assertThat(termsQuery.values().stream().map(TypedValue::stringValue).toList())
                   .containsExactlyInAnyOrder("a", "b");
             });
   }
@@ -277,8 +355,18 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
     final var searchQuery =
         transformQuery(FilterBuilders.processDefinition(b -> b), resourceAccessChecks);
 
-    // then
-    assertThat(searchQuery).isNull();
+    // then — only the isDeleted exclusion remains
+    assertThat(searchQuery).isNotNull();
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              assertThat(boolQuery.mustNot()).hasSize(1);
+              assertThat(boolQuery.mustNot().get(0).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      t -> assertThat(t.field()).isEqualTo(ProcessIndex.IS_DELETED));
+            });
   }
 
   @Test
@@ -298,7 +386,7 @@ public final class ProcessDefinitionQueryTransformerTest extends AbstractTransfo
             FilterBuilders.processDefinition(b -> b.processDefinitionIds("abc")),
             resourceAccessChecks);
 
-    // then
+    // then — 3 top-level must clauses: filter+isDeleted, auth check, tenant check
     final var queryVariant = searchQuery.queryOption();
     assertThat(queryVariant)
         .isInstanceOfSatisfying(SearchBoolQuery.class, t -> assertThat(t.must()).hasSize(3));

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ProcessIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ProcessIndex.java
@@ -31,6 +31,7 @@ public class ProcessIndex extends AbstractIndexDescriptor implements Prio4Backup
   public static final String FORM_KEY = "formKey";
   public static final String IS_FORM_EMBEDDED = "isFormEmbedded";
   public static final String IS_PUBLIC = "isPublic";
+  public static final String IS_DELETED = "isDeleted";
 
   public ProcessIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessEntity.java
@@ -30,6 +30,7 @@ public class ProcessEntity implements ExporterEntity<ProcessEntity>, TenantOwned
   @BeforeVersion880 private Boolean isFormEmbedded;
   @BeforeVersion880 private Boolean isPublic;
   @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private Boolean isDeleted;
 
   public String getName() {
     return name;
@@ -78,7 +79,8 @@ public class ProcessEntity implements ExporterEntity<ProcessEntity>, TenantOwned
         formId,
         formKey,
         isFormEmbedded,
-        isPublic);
+        isPublic,
+        isDeleted);
   }
 
   @Override
@@ -104,7 +106,8 @@ public class ProcessEntity implements ExporterEntity<ProcessEntity>, TenantOwned
         && Objects.equals(formId, that.formId)
         && Objects.equals(formKey, that.formKey)
         && Objects.equals(isFormEmbedded, that.isFormEmbedded)
-        && Objects.equals(isPublic, that.isPublic);
+        && Objects.equals(isPublic, that.isPublic)
+        && Objects.equals(isDeleted, that.isDeleted);
   }
 
   @Override
@@ -147,6 +150,8 @@ public class ProcessEntity implements ExporterEntity<ProcessEntity>, TenantOwned
         + ", tenantId='"
         + tenantId
         + '\''
+        + ", isDeleted="
+        + isDeleted
         + "} "
         + super.toString();
   }
@@ -260,6 +265,15 @@ public class ProcessEntity implements ExporterEntity<ProcessEntity>, TenantOwned
 
   public ProcessEntity setIsPublic(final Boolean isPublic) {
     this.isPublic = isPublic;
+    return this;
+  }
+
+  public Boolean getIsDeleted() {
+    return isDeleted;
+  }
+
+  public ProcessEntity setIsDeleted(final Boolean isDeleted) {
+    this.isDeleted = isDeleted;
     return this;
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/operate-process.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/operate-process.json
@@ -56,6 +56,9 @@
       },
       "tenantId": {
         "type": "keyword"
+      },
+      "isDeleted": {
+        "type": "boolean"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/operate-process.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/operate-process.json
@@ -56,6 +56,9 @@
       },
       "tenantId": {
         "type": "keyword"
+      },
+      "isDeleted": {
+        "type": "boolean"
       }
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -50,7 +50,8 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
 
   @Override
   public boolean handlesRecord(final Record<Process> record) {
-    return record.getIntent().equals(ProcessIntent.CREATED);
+    final var intent = record.getIntent();
+    return intent.equals(ProcessIntent.CREATED) || intent.equals(ProcessIntent.DELETED);
   }
 
   @Override
@@ -72,6 +73,14 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
         .setBpmnProcessId(process.getBpmnProcessId())
         .setVersion(process.getVersion())
         .setTenantId(ExporterUtil.tenantOrDefault(process.getTenantId()));
+
+    if (record.getIntent().equals(ProcessIntent.DELETED)) {
+      entity.setIsDeleted(true);
+      processCache.remove(process.getProcessDefinitionKey());
+      return;
+    }
+
+    entity.setIsDeleted(false);
     final byte[] byteArray = process.getResource();
 
     final String bpmn = new String(byteArray, StandardCharsets.UTF_8);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
@@ -48,10 +48,20 @@ public class ProcessHandlerTest {
   }
 
   @Test
-  void shouldHandleRecord() {
+  void shouldHandleCreatedRecord() {
     // given
     final Record<Process> processRecord =
         factory.generateRecord(ValueType.PROCESS, r -> r.withIntent(ProcessIntent.CREATED));
+
+    // when - then
+    assertThat(underTest.handlesRecord(processRecord)).isTrue();
+  }
+
+  @Test
+  void shouldHandleDeletedRecord() {
+    // given
+    final Record<Process> processRecord =
+        factory.generateRecord(ValueType.PROCESS, r -> r.withIntent(ProcessIntent.DELETED));
 
     // when - then
     assertThat(underTest.handlesRecord(processRecord)).isTrue();
@@ -311,6 +321,72 @@ public class ProcessHandlerTest {
             CachedProcessEntity::versionTag,
             CachedProcessEntity::hasUserTasks)
         .containsExactly("testProcessName", "processTag", false);
+  }
+
+  @Test
+  void shouldMarkEntityAsDeletedAndEvictCacheOnDeletedRecord() throws IOException {
+    // given — first create the process so it's in the cache
+    final long expectedId = 123;
+    final var resource = getClass().getClassLoader().getResource("process/test-process.bpmn");
+    assertThat(resource).isNotNull();
+    final ImmutableProcess processRecordValue =
+        ImmutableProcess.builder()
+            .from(factory.generateObject(ImmutableProcess.class))
+            .withProcessDefinitionKey(expectedId)
+            .withBpmnProcessId("testProcessId")
+            .withVersionTag("processTag")
+            .withResource(Files.readAllBytes(Path.of(resource.getPath())))
+            .build();
+
+    final Record<Process> createRecord =
+        factory.generateRecord(
+            ValueType.PROCESS,
+            r -> r.withIntent(ProcessIntent.CREATED).withValue(processRecordValue));
+    final ProcessEntity createdEntity = new ProcessEntity();
+    underTest.updateEntity(createRecord, createdEntity);
+    assertThat(processCache.get(expectedId)).isPresent();
+
+    // when — process is deleted
+    final Record<Process> deleteRecord =
+        factory.generateRecord(
+            ValueType.PROCESS,
+            r -> r.withIntent(ProcessIntent.DELETED).withValue(processRecordValue));
+    final ProcessEntity deletedEntity = new ProcessEntity();
+    underTest.updateEntity(deleteRecord, deletedEntity);
+
+    // then
+    assertThat(deletedEntity.getIsDeleted()).isTrue();
+    assertThat(deletedEntity.getId()).isEqualTo(String.valueOf(expectedId));
+    assertThat(deletedEntity.getKey()).isEqualTo(expectedId);
+    assertThat(processCache.get(expectedId)).isEmpty();
+  }
+
+  @Test
+  void shouldMarkEntityAsNotDeletedOnCreatedRecord() throws IOException {
+    // given
+    final long expectedId = 456;
+    final var resource = getClass().getClassLoader().getResource("process/test-process.bpmn");
+    assertThat(resource).isNotNull();
+    final ImmutableProcess processRecordValue =
+        ImmutableProcess.builder()
+            .from(factory.generateObject(ImmutableProcess.class))
+            .withProcessDefinitionKey(expectedId)
+            .withBpmnProcessId("testProcessId")
+            .withVersionTag("processTag")
+            .withResource(Files.readAllBytes(Path.of(resource.getPath())))
+            .build();
+
+    final Record<Process> processRecord =
+        factory.generateRecord(
+            ValueType.PROCESS,
+            r -> r.withIntent(ProcessIntent.CREATED).withValue(processRecordValue));
+
+    // when
+    final ProcessEntity processEntity = new ProcessEntity();
+    underTest.updateEntity(processRecord, processEntity);
+
+    // then
+    assertThat(processEntity.getIsDeleted()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Description

When a process definition is deleted via `DELETE /v2/resources/{resourceKey}`, Zeebe emits a `ProcessIntent.DELETED` record. The Camunda Exporter's `ProcessHandler` was not handling this intent, so the Elasticsearch/OpenSearch document was never updated. The process remained visible in `/v2/process-definitions/search`, allowing Inbound Connectors to keep subscribing to it.

**Root cause:** `ProcessHandler.handlesRecord()` only accepted `ProcessIntent.CREATED`, ignoring `DELETED`. No `isDeleted` field existed on the process index.

**Fix:**
- Add `isDeleted` field to `ProcessEntity` and the ES/OS index mappings.
- Handle `ProcessIntent.DELETED` in `ProcessHandler`: set `isDeleted=true` and evict the process from the in-memory cache.
- Add `not(term(isDeleted=true))` filter in `ProcessDefinitionFilterTransformer` so deleted processes are excluded from all queries without any API changes (old documents without the field are not affected).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #SUPPORT-33467