### PR TITLE
ci: Add target version input to load test workflow

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -247,6 +247,7 @@ jobs:
           |-------|-------|
           | Name | `${{ inputs.name }}` |
           | Ref | `${{ inputs.ref }}` |
+          | Target version | `${{ inputs.target-version }}` |
           | Scenario | `${{ inputs.scenario }}` |
           | Secondary storage | `${{ inputs.secondary-storage-type }}` |
           | Reuse tag | ${{ inputs.reuse-tag || '—' }} |


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adding the display of the target version input in the load test summary table.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
