### PR TITLE
feat: enable conversation history by default

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -24,10 +24,6 @@ import {AgentDetails} from './index';
 import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import {mockAgentInstanceHistoryItem} from 'modules/mocks/mockAgentInstanceHistoryItem';
 
-vi.mock('modules/feature-flags', () => ({
-  IS_CONVERSATION_HISTORY_ENABLED: true,
-}));
-
 function createWrapper() {
   const queryClient = getMockQueryClient();
   return ({children}: {children: ReactNode}) => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -37,7 +37,6 @@ import {SectionTitle} from './SectionTitle';
 import {ConversationMessage} from './ConversationMessage';
 import {ConversationHistory} from './ConversationHistory';
 import {LatestAgentMessage} from './ConversationHistory/LatestAgentMessage';
-import {IS_CONVERSATION_HISTORY_ENABLED} from 'modules/feature-flags';
 import {isAgentInstanceActive} from 'modules/queries/agentInstances/agentInstanceStatus';
 
 const STATUS_LABELS: Record<AgentInstanceStatus, string> = {
@@ -124,19 +123,16 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
         <AccordionItem
           data-testid="agent-status-section"
           open
-          disabled={!IS_CONVERSATION_HISTORY_ENABLED}
           title={
             <SectionTitle icon={<StatusIcon status={agentInstance.status} />}>
               Status: {statusLabel}
             </SectionTitle>
           }
         >
-          {IS_CONVERSATION_HISTORY_ENABLED && (
-            <LatestAgentMessage
-              agentInstanceKey={agentInstance.agentInstanceKey}
-              enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
-            />
-          )}
+          <LatestAgentMessage
+            agentInstanceKey={agentInstance.agentInstanceKey}
+            enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
+          />
         </AccordionItem>
         <AccordionItem
           data-testid="agent-usage-section"
@@ -160,24 +156,22 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
             />
           </MetricsRow>
         </AccordionItem>
-        {IS_CONVERSATION_HISTORY_ENABLED && (
-          <AccordionItem
-            data-testid="agent-conversation-history-section"
-            open={isConversationHistoryOpen}
-            onHeadingClick={({isOpen}) => setIsConversationHistoryOpen(isOpen)}
-            title={
-              <SectionTitle icon={<Chat size={16} />}>
-                Conversation history
-              </SectionTitle>
-            }
-          >
-            <ConversationHistory
-              agentInstanceKey={agentInstance.agentInstanceKey}
-              isVisible={isConversationHistoryOpen}
-              enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
-            />
-          </AccordionItem>
-        )}
+        <AccordionItem
+          data-testid="agent-conversation-history-section"
+          open={isConversationHistoryOpen}
+          onHeadingClick={({isOpen}) => setIsConversationHistoryOpen(isOpen)}
+          title={
+            <SectionTitle icon={<Chat size={16} />}>
+              Conversation history
+            </SectionTitle>
+          }
+        >
+          <ConversationHistory
+            agentInstanceKey={agentInstance.agentInstanceKey}
+            isVisible={isConversationHistoryOpen}
+            enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
+          />
+        </AccordionItem>
         <AccordionItem
           data-testid="agent-system-prompt-section"
           title={

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -6,9 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const IS_CONVERSATION_HISTORY_ENABLED =
-  localStorage.getItem('FEATURE_CONVERSATION_HISTORY_ENABLED') === 'true';
-
 const IS_NAV_V2_ENABLED = false;
 
-export {IS_CONVERSATION_HISTORY_ENABLED, IS_NAV_V2_ENABLED};
+export {IS_NAV_V2_ENABLED};


### PR DESCRIPTION
## Description

This PR removes the `IS_CONVERSATION_HISTORY_ENABLED` to enable the agent-instance conversation-history by default.

## Relates issues

relates #51928, #52969
