### PR TITLE
Reduce idle token cost for CI skill descriptions

### DIFF
--- a/.claude/skills/ci-fix-failure/SKILL.md
+++ b/.claude/skills/ci-fix-failure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-fix-failure
-description: Diagnose a failing GitHub Actions run in camunda/camunda from a run or job URL - fetch jobs and logs via gh CLI, classify the failure (code/test, flake, workflow config, infra), find the root cause, and propose a concrete fix. Use whenever the user shares a GitHub Actions run URL, job URL, or asks you to look at "why CI failed", "why this job failed", "what broke in this run", or to fix a red check on a PR. Diagnose-and-propose only - get user confirmation before applying or pushing fixes.
+description: Diagnose failing GitHub Actions runs and propose fixes. Use when given a GHA run/job URL, or asked why CI failed, why a job failed, what broke in a run, or to fix a red check on a PR.
 ---
 
 # CI Job Failure Diagnosis

--- a/.claude/skills/ci-incident/SKILL.md
+++ b/.claude/skills/ci-incident/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-incident
-description: Drive response for a CI incident in camunda/camunda by combining incident.io state, Slack channel history, and the repo CI runbooks and incident process docs. Use when asked to resolve a CI incident, respond to an incident, or drive an incident by ID. Full incidents only, not alerts.
+description: Drive CI incident response in camunda/camunda. Use when asked to resolve, respond to, or drive a CI incident by ID. Full incidents only, not alerts.
 ---
 
 # CI Incident Response

--- a/.claude/skills/ci-push-workflow-health/SKILL.md
+++ b/.claude/skills/ci-push-workflow-health/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: ci-push-workflow-health
-description: Analyze CI failure patterns for push-triggered workflow jobs on main and stable/* branches using BigQuery CI Analytics data (ci-30-162810.prod_ci_analytics.build_status_v2). Use when asked about CI health, broken jobs, flaky workflows, failure rates, or push-trigger problems on main or stable branches.
+description: Analyze CI failure patterns for push-triggered workflow jobs on main and stable/* branches. Use when asked about CI health, broken jobs, flaky workflows, failure rates, or push-trigger problems.
 
 ---
 

--- a/.claude/skills/ci-runner-utilization/SKILL.md
+++ b/.claude/skills/ci-runner-utilization/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: ci-runner-utilization
-description: Detect CI runner underutilization and give downsizing recommendations for cost savings. Queries BigQuery CPU/memory metrics from self-hosted runners in camunda/camunda, identifies overprovisioned jobs, and suggests smaller runner types. Use when asked about CI costs, runner sizing, resource waste, underutilization, or right-sizing runners.
+description: Detect CI runner underutilization and recommend downsizing for cost savings. Use when asked about CI costs, runner sizing, resource waste, underutilization, or right-sizing self-hosted runners.
 
 ---
 

--- a/.claude/skills/ci-scheduled-workflow-health/SKILL.md
+++ b/.claude/skills/ci-scheduled-workflow-health/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: ci-scheduled-workflow-health
-description: Generate an HTML health report for all scheduled GitHub Actions workflows in this monorepo. Discovers workflows with `schedule:` triggers from the `main` branch via git, queries the GitHub API for recent run results, extracts `# owner:` metadata from YAML comments, and produces a categorized report (failing, flaky, ok, no runs). Use when asked about CI health, scheduled workflow health, nightly build failures, flaky CI, or workflow ownership.
+description: Generate a health report for scheduled GitHub Actions workflows in this monorepo. Use when asked about scheduled workflow health, nightly build failures, flaky CI, or workflow ownership.
 
 ---
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -150,10 +150,15 @@
 /.claude/skills/load-test-ops/ @camunda/reliability-testing
 
 # CI skills
-/.claude/skills/act-testing/**             @camunda/monorepo-devops-team
-/.claude/skills/ci-security-compliance/**  @camunda/monorepo-devops-team
-/.claude/skills/ci-validation/**           @camunda/monorepo-devops-team
-/.claude/skills/ci-workflow-authoring/**   @camunda/monorepo-devops-team
+/.claude/skills/act-testing/**                   @camunda/monorepo-devops-team
+/.claude/skills/ci-fix-failure/**                @camunda/monorepo-devops-team
+/.claude/skills/ci-incident/**                   @camunda/monorepo-devops-team
+/.claude/skills/ci-push-workflow-health/**       @camunda/monorepo-devops-team
+/.claude/skills/ci-runner-utilization/**         @camunda/monorepo-devops-team
+/.claude/skills/ci-scheduled-workflow-health/**  @camunda/monorepo-devops-team
+/.claude/skills/ci-security-compliance/**        @camunda/monorepo-devops-team
+/.claude/skills/ci-validation/**                 @camunda/monorepo-devops-team
+/.claude/skills/ci-workflow-authoring/**         @camunda/monorepo-devops-team
 
 # Engine-expert skill
 /.claude/skills/engine-expert/  @korthout @camunda/core-features


### PR DESCRIPTION
## Description

Reduce the idle token cost of five CI skill descriptions by removing implementation details from the `description` frontmatter field. The description is loaded in every session (idle state); the body is loaded only on invocation.

**What changed:** Stripped HOW details — BigQuery table names, "fetch logs via gh CLI", "combining incident.io state", "produces a categorized report" — from descriptions. All trigger terms (GHA run/job URL, "why CI failed", "broken jobs", "CI health", "nightly build failures", etc.) are preserved.

**CODEOWNERS fix:** These five CI skills were falling through to the `@camunda/orchestration-cluster` default. They belong in the `# CI skills` section alongside `act-testing` and the other CI skills under `@camunda/monorepo-devops-team`.

## Checklist

- N/A — skill description changes, no backport needed

## Related issues

closes #
