### PR TITLE
Fix missing CODEOWNERS entries for CI and frontend skills

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -13,6 +13,9 @@ CODEOWNERS                  @camunda/orchestration-cluster
 
 AGENTS.md                   @camunda/orchestration-cluster
 CLAUDE.md                   @camunda/orchestration-cluster
+/.claude/skills/README.md   @camunda/orchestration-cluster
+/.claude/skills/create-issue/ @camunda/orchestration-cluster
+/.claude/skills/grill-me/   @camunda/orchestration-cluster
 CHANGELOG.md                @camunda/orchestration-cluster
 CODE_OF_CONDUCT.md          @camunda/orchestration-cluster
 CONTRIBUTING.md             @camunda/orchestration-cluster
@@ -55,6 +58,9 @@ buf.yaml                    @camunda/orchestration-cluster
 ################################
 
 /.claude/skills/act-testing/ @camunda/monorepo-devops-team
+/.claude/skills/agentic-workflows/ @camunda/monorepo-devops-team
+/.claude/skills/ci-fix-failure/ @camunda/monorepo-devops-team
+/.claude/skills/ci-incident/ @camunda/monorepo-devops-team
 /.claude/skills/ci-push-workflow-health/ @camunda/monorepo-devops-team
 /.claude/skills/ci-scheduled-workflow-health/ @camunda/monorepo-devops-team
 /.claude/skills/ci-runner-utilization/ @camunda/monorepo-devops-team
@@ -212,6 +218,7 @@ mwnw*                       @camunda/monorepo-devops-team
 /.claude/skills/frontend-migrator/         @camunda/core-features
 /.claude/skills/frontend-unit-test/        @camunda/core-features
 /.claude/skills/operate-frontend/          @camunda/core-features
+/.claude/skills/tasklist-frontend/         @camunda/core-features
 
 # optimize / BI team
 /zeebe/exporter-filter/        @camunda/core-features

--- a/.codeowners
+++ b/.codeowners
@@ -13,7 +13,6 @@ CODEOWNERS                  @camunda/orchestration-cluster
 
 AGENTS.md                   @camunda/orchestration-cluster
 CLAUDE.md                   @camunda/orchestration-cluster
-/.claude/skills/            @camunda/orchestration-cluster
 CHANGELOG.md                @camunda/orchestration-cluster
 CODE_OF_CONDUCT.md          @camunda/orchestration-cluster
 CONTRIBUTING.md             @camunda/orchestration-cluster

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -146,10 +146,14 @@
 # AI Assistant Instructions
 /CLAUDE.md      @camunda/orchestration-cluster
 /AGENTS.md      @camunda/orchestration-cluster
+/.claude/skills/README.md    @camunda/orchestration-cluster
+/.claude/skills/create-issue/ @camunda/orchestration-cluster
+/.claude/skills/grill-me/    @camunda/orchestration-cluster
 /.claude/skills/load-test-ops/ @camunda/reliability-testing
 
 # CI skills
 /.claude/skills/act-testing/**                   @camunda/monorepo-devops-team
+/.claude/skills/agentic-workflows/**             @camunda/monorepo-devops-team
 /.claude/skills/ci-fix-failure/**                @camunda/monorepo-devops-team
 /.claude/skills/ci-incident/**                   @camunda/monorepo-devops-team
 /.claude/skills/ci-push-workflow-health/**       @camunda/monorepo-devops-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -146,7 +146,6 @@
 # AI Assistant Instructions
 /CLAUDE.md      @camunda/orchestration-cluster
 /AGENTS.md      @camunda/orchestration-cluster
-/.claude/skills/ @camunda/orchestration-cluster
 /.claude/skills/load-test-ops/ @camunda/reliability-testing
 
 # CI skills

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -150,10 +150,15 @@
 /.claude/skills/load-test-ops/ @camunda/reliability-testing
 
 # CI skills
-/.claude/skills/act-testing/**             @camunda/monorepo-devops-team
-/.claude/skills/ci-security-compliance/**  @camunda/monorepo-devops-team
-/.claude/skills/ci-validation/**           @camunda/monorepo-devops-team
-/.claude/skills/ci-workflow-authoring/**   @camunda/monorepo-devops-team
+/.claude/skills/act-testing/**                   @camunda/monorepo-devops-team
+/.claude/skills/ci-fix-failure/**                @camunda/monorepo-devops-team
+/.claude/skills/ci-incident/**                   @camunda/monorepo-devops-team
+/.claude/skills/ci-push-workflow-health/**       @camunda/monorepo-devops-team
+/.claude/skills/ci-runner-utilization/**         @camunda/monorepo-devops-team
+/.claude/skills/ci-scheduled-workflow-health/**  @camunda/monorepo-devops-team
+/.claude/skills/ci-security-compliance/**        @camunda/monorepo-devops-team
+/.claude/skills/ci-validation/**                 @camunda/monorepo-devops-team
+/.claude/skills/ci-workflow-authoring/**         @camunda/monorepo-devops-team
 
 # Engine-expert skill
 /.claude/skills/engine-expert/  @korthout @camunda/core-features
@@ -164,6 +169,7 @@
 /.claude/skills/frontend-migrator/         @camunda/core-features
 /.claude/skills/frontend-unit-test/        @camunda/core-features
 /.claude/skills/operate-frontend/          @camunda/core-features
+/.claude/skills/tasklist-frontend/         @camunda/core-features
 
 # MCP gateway
 /gateways/gateway-mcp @camunda/connectors-agentic-ai


### PR DESCRIPTION
## Description

Ensures every skill under `.claude/skills/` has an explicit owner in both `CODEOWNERS` and `.codeowners`, then removes the catch-all fallback entries that were masking gaps.

**Why:** A catch-all `/.claude/skills/` rule silently assigned all unowned skills to `@camunda/orchestration-cluster`, hiding that many skills had no designated team. Removing the fallback makes missing ownership a visible, actionable error — new skills will fail the ownership check until they get an explicit entry.

**What changed:**
- Assigned six skills that were implicitly falling through to their correct teams: CI skills (`ci-fix-failure`, `ci-incident`, `ci-push-workflow-health`, `ci-runner-utilization`, `ci-scheduled-workflow-health`) to `@camunda/monorepo-devops-team`, and `tasklist-frontend` to `@camunda/core-features`.
- Assigned four skills with no entry in either file: `agentic-workflows` to `@camunda/monorepo-devops-team`; `README.md`, `create-issue`, and `grill-me` to `@camunda/orchestration-cluster`.
- Removed the `/.claude/skills/` catch-all from both `CODEOWNERS` and `.codeowners`.

## Checklist

- N/A — CODEOWNERS only, no backport needed

## Related issues

Noticed due to automatic review requests in:
- https://github.com/camunda/camunda/pull/55820
- https://github.com/camunda/camunda/pull/55821