### PR TITLE
Reduce idle token cost for CI skill descriptions

### DIFF
--- a/.claude/skills/ci-fix-failure/SKILL.md
+++ b/.claude/skills/ci-fix-failure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-fix-failure
-description: Diagnose a failing GitHub Actions run in camunda/camunda from a run or job URL - fetch jobs and logs via gh CLI, classify the failure (code/test, flake, workflow config, infra), find the root cause, and propose a concrete fix. Use whenever the user shares a GitHub Actions run URL, job URL, or asks you to look at "why CI failed", "why this job failed", "what broke in this run", or to fix a red check on a PR. Diagnose-and-propose only - get user confirmation before applying or pushing fixes.
+description: Diagnose failing GitHub Actions runs and propose fixes. Use when given a GHA run/job URL, or asked why CI failed, why a job failed, what broke in a run, or to fix a red check on a PR.
 ---
 
 # CI Job Failure Diagnosis

--- a/.claude/skills/ci-incident/SKILL.md
+++ b/.claude/skills/ci-incident/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-incident
-description: Drive response for a CI incident in camunda/camunda by combining incident.io state, Slack channel history, and the repo CI runbooks and incident process docs. Use when asked to resolve a CI incident, respond to an incident, or drive an incident by ID. Full incidents only, not alerts.
+description: Drive CI incident response in camunda/camunda. Use when asked to resolve, respond to, or drive a CI incident by ID. Full incidents only, not alerts.
 ---
 
 # CI Incident Response

--- a/.claude/skills/ci-push-workflow-health/SKILL.md
+++ b/.claude/skills/ci-push-workflow-health/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: ci-push-workflow-health
-description: Analyze CI failure patterns for push-triggered workflow jobs on main and stable/* branches using BigQuery CI Analytics data (ci-30-162810.prod_ci_analytics.build_status_v2). Use when asked about CI health, broken jobs, flaky workflows, failure rates, or push-trigger problems on main or stable branches.
+description: Analyze CI failure patterns for push-triggered workflow jobs on main and stable/* branches. Use when asked about CI health, broken jobs, flaky workflows, failure rates, or push-trigger problems.
 
 ---
 

--- a/.claude/skills/ci-runner-utilization/SKILL.md
+++ b/.claude/skills/ci-runner-utilization/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: ci-runner-utilization
-description: Detect CI runner underutilization and give downsizing recommendations for cost savings. Queries BigQuery CPU/memory metrics from self-hosted runners in camunda/camunda, identifies overprovisioned jobs, and suggests smaller runner types. Use when asked about CI costs, runner sizing, resource waste, underutilization, or right-sizing runners.
+description: Detect CI runner underutilization and recommend downsizing for cost savings. Use when asked about CI costs, runner sizing, resource waste, underutilization, or right-sizing self-hosted runners.
 
 ---
 

--- a/.claude/skills/ci-scheduled-workflow-health/SKILL.md
+++ b/.claude/skills/ci-scheduled-workflow-health/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: ci-scheduled-workflow-health
-description: Generate an HTML health report for all scheduled GitHub Actions workflows in this monorepo. Discovers workflows with `schedule:` triggers from the `main` branch via git, queries the GitHub API for recent run results, extracts `# owner:` metadata from YAML comments, and produces a categorized report (failing, flaky, ok, no runs). Use when asked about CI health, scheduled workflow health, nightly build failures, flaky CI, or workflow ownership.
+description: Generate a health report for scheduled GitHub Actions workflows in this monorepo. Use when asked about scheduled workflow health, nightly build failures, flaky CI, or workflow ownership.
 
 ---
 


### PR DESCRIPTION
## Description

Trims the `description` frontmatter in five CI skills owned by `@camunda/monorepo-devops-team`. Skill descriptions are loaded in every Claude Code session; the body is only loaded on invocation. Stripping implementation details and workflow steps from descriptions — keeping only the summary sentence and trigger phrases — reduces idle token cost by ~50%. No trigger phrases were removed.

| Skill | Before | After | Saved |
|-------|-------:|------:|------:|
| `ci-fix-failure` | ~120 tokens | ~48 tokens | ~72 tokens |
| `ci-incident` | ~61 tokens | ~35 tokens | ~26 tokens |
| `ci-push-workflow-health` | ~66 tokens | ~40 tokens | ~26 tokens |
| `ci-runner-utilization` | ~68 tokens | ~39 tokens | ~29 tokens |
| `ci-scheduled-workflow-health` | ~89 tokens | ~35 tokens | ~54 tokens |
| **Total** | **~404 tokens** | **~197 tokens** | **~207 tokens** |

CODEOWNERS ownership for these skills is updated in #55819.

## Checklist

- N/A — skill description changes only, no backport needed

## Related issues

related to https://github.com/camunda/camunda/pull/55821
