### PR TITLE
Reduce idle token cost for frontend/engine skill descriptions

### DIFF
--- a/.claude/skills/engine-expert/SKILL.md
+++ b/.claude/skills/engine-expert/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: engine-expert
-description: Use when implementing new capabilities or fixing bugs in the Zeebe workflow engine in zeebe/engine/ — BPMN process execution, DMN decision evaluation, job lifecycle, user/identity management, batch operations, process variables, deployments, signals, messages, timers, multi-tenancy, or authorization. Use when adding or modifying processors, event appliers, state classes, record value types, intents, or engine tests.
+description: Use when implementing or fixing Zeebe engine code in zeebe/engine/ — BPMN process execution, DMN decision evaluation, job lifecycle, user/identity management, batch operations, variables, deployments, signals, messages, timers, multi-tenancy, or authorization. Also when modifying processors, event appliers, state classes, record value types, intents, or engine tests.
 
 ---
 

--- a/.claude/skills/frontend-feature/SKILL.md
+++ b/.claude/skills/frontend-feature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: frontend-feature
-description: Use when creating new pages, components, modules, or features in the orchestration cluster webapp at webapp/client/apps/orchestration-cluster-webapp/. Use when adding routes, data loading, forms, API integration, or UI components. Trigger whenever someone is building or modifying frontend feature code in webapp/client/, even for small changes like adding a column, filter, or panel.
+description: Use when building or modifying pages, components, modules, routes, data loading, forms, API integration, or UI features — including small changes like a column, filter, or panel — in the orchestration cluster webapp (webapp/client/apps/orchestration-cluster-webapp/).
 
 ---
 

--- a/.claude/skills/frontend-integration-test/SKILL.md
+++ b/.claude/skills/frontend-integration-test/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: frontend-integration-test
-description: Use when writing, modifying, or debugging Playwright-based tests in the orchestration cluster webapp — integration tests, visual regression tests, or accessibility tests. Use when working with MSW network-level mocking via @msw/playwright, Page Object Models, axe-core accessibility checks, or screenshot comparisons. Trigger whenever someone is working in the test/ directory of the OC webapp at webapp/client/apps/orchestration-cluster-webapp/test/.
+description: Use when writing, modifying, or debugging Playwright tests in the orchestration cluster webapp — integration tests, visual regression, or accessibility tests; MSW mocking, Page Object Models, or axe-core. Test directory: webapp/client/apps/orchestration-cluster-webapp/test/.
 
 ---
 

--- a/.claude/skills/frontend-migrator/SKILL.md
+++ b/.claude/skills/frontend-migrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: frontend-migrator
-description: Use when migrating, porting, rewriting, or moving frontend code from operate/client/ or tasklist/client/ to the orchestration cluster webapp at webapp/client/apps/orchestration-cluster-webapp/. Trigger whenever someone mentions migrating a legacy page, component, or module to the new unified frontend, converting React Router to TanStack Router, replacing MobX stores with TanStack Query or URL state, rewriting styled-components as SCSS modules, or converting legacy test patterns to Vitest browser mode. Also use when someone asks how a legacy pattern maps to the new architecture, even for small questions like "how would I write this Operate component in the new app?" or "what's the equivalent of this Tasklist store in the unified frontend?"
+description: Use when migrating, porting, or rewriting frontend code from operate/client/ or tasklist/client/ to the orchestration cluster webapp. Trigger when migrating legacy pages/components, converting React Router to TanStack Router, replacing MobX with TanStack Query, rewriting styled-components as SCSS, converting legacy tests to Vitest browser mode, or asking how a legacy pattern maps to the new app.
 
 ---
 

--- a/.claude/skills/frontend-operate-migrator/SKILL.md
+++ b/.claude/skills/frontend-operate-migrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-operate-migrator
-description: Operate-specific context for migrating operate/client/ pages into webapp/client/apps/orchestration-cluster-webapp/. Always read frontend-migrator first — this skill adds Operate-specific overrides, the migration loop protocol, and page-by-page context.
+description: Use when migrating any Operate page from operate/client/ to the orchestration cluster webapp. Always read frontend-migrator first — this skill adds Operate-specific overrides, the migration loop protocol, and page-by-page context.
 ---
 
 # Operate Migration — Pod-Specific Context

--- a/.claude/skills/frontend-unit-test/SKILL.md
+++ b/.claude/skills/frontend-unit-test/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: frontend-unit-test
-description: Use when writing, modifying, or debugging unit tests in the orchestration cluster webapp at webapp/client/apps/orchestration-cluster-webapp/. Use when working with Vitest browser mode, MSW mocking, vitest-browser-react rendering, or any *.test.tsx file in the OC webapp's src/ directory. Trigger whenever someone needs to create, fix, or understand a frontend unit test in webapp/client/.
+description: Use when writing, modifying, or debugging unit tests (*.test.tsx) in the orchestration cluster webapp (webapp/client/apps/orchestration-cluster-webapp/src/). Covers Vitest browser mode, MSW mocking, and vitest-browser-react rendering.
 
 ---
 

--- a/.claude/skills/operate-frontend/SKILL.md
+++ b/.claude/skills/operate-frontend/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: operate-frontend
-description: Use when fixing bugs, making changes, writing tests, or understanding code in the Operate legacy frontend at operate/client/. Trigger for any work touching operate/client/src/, including component changes, test modifications, API hook updates, styled-components edits, MobX store changes, or React Router route adjustments. Also use when someone asks about Operate frontend patterns, conventions, or architecture. This is the legacy process monitoring UI being phased out in favor of the orchestration cluster webapp.
+description: Use for any work in the Operate legacy frontend (operate/client/) — bugs, changes, tests, components, API hooks, styled-components, MobX stores, React Router, or questions about Operate patterns, conventions, or architecture.
 
 ---
 

--- a/.claude/skills/tasklist-frontend/SKILL.md
+++ b/.claude/skills/tasklist-frontend/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: tasklist-frontend
-description: Use when building, changing, or testing features in the Tasklist pod area of the orchestration cluster webapp at webapp/client/apps/orchestration-cluster-webapp/src/tasklist/. Trigger whenever someone is adding or modifying Tasklist pages, modules, components, hooks, stores, or Tasklist routes — even for small changes like adding a column, filter, panel, or schema. Also use when someone asks about Tasklist pod structure, conventions, or where Tasklist code belongs.
+description: Use when building, changing, or testing Tasklist features in the orchestration cluster webapp (webapp/client/apps/orchestration-cluster-webapp/src/tasklist/). Trigger for Tasklist pages, modules, components, hooks, stores, routes, or schema — even small changes like a column, filter, or panel — and questions about Tasklist pod structure and conventions.
 
 ---
 


### PR DESCRIPTION
## Description

Trims the `description` frontmatter in eight frontend/engine skills owned by `@camunda/core-features`. Skill descriptions are loaded in every Claude Code session; the body is only loaded on invocation. Stripping verbose preambles, redundant restatements, and duplicate path mentions — keeping only the summary sentence and trigger phrases — saves **~326 tokens per session** across the eight skills (~36% reduction). No trigger phrases were removed.

| Skill | Before | After | Saved |
|---|---|---|---|
| `engine-expert` | ~105 | ~92 | ~13 |
| `frontend-feature` | ~96 | ~67 | ~29 |
| `frontend-integration-test` | ~113 | ~69 | ~44 |
| `frontend-migrator` | ~187 | ~100 | ~87 |
| `frontend-operate-migrator` | ~62 | ~49 | ~13 |
| `frontend-unit-test` | ~97 | ~58 | ~39 |
| `operate-frontend` | ~129 | ~56 | ~73 |
| `tasklist-frontend` | ~117 | ~89 | ~28 |
| **Total** | **~906** | **~580** | **~326** |

CODEOWNERS ownership for these skills is updated in #55819.

## Checklist

- N/A — skill description changes, no backport needed

## Related issues

related to https://github.com/camunda/camunda/pull/55820
