### PR TITLE
ci: fix Zizmor warnings for load test CI workflows

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -29,6 +29,7 @@ defaults:
 
 env:
   TEST_OWNER: '@camunda/reliability-testing'
+  REUSE_TAG: ${{ inputs.reuse-tag }}
 
 jobs:
   benchmark-data:
@@ -40,12 +41,12 @@ jobs:
       benchmark: ${{ steps.data.outputs.benchmark }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Collect benchmark data
         id: data
         run: |
-          var=${{ inputs.reuse-tag || '' }}
-          # ${#var} will return the length of the string
-          if [[ ${#var} -eq 0 ]]; then
+          if [[ -z "${REUSE_TAG}" ]]; then
             echo "Creating new daily load test benchmark"
             echo "benchmark=medic-daily-$(date --utc "+%Y-%m-%d")-$(git rev-parse --short HEAD)-test" >> "$GITHUB_OUTPUT"
           else
@@ -54,9 +55,8 @@ jobs:
             # medic-daily-2025-12-18-b1bd4006-test-b1bd400
             # $ echo ${tag%-*}
             # medic-daily-2025-12-18-b1bd4006-test
-            tag=${{ inputs.reuse-tag }}
-            var=${tag%-*}
-            echo "Re-creating daily load test, with name: $var and tag: $tag"
+            var=${REUSE_TAG%-*}
+            echo "Re-creating daily load test, with name: $var and tag: $REUSE_TAG"
             echo "benchmark=$var" >> "$GITHUB_OUTPUT"
           fi
       - name: Observe build status
@@ -115,6 +115,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
+          persist-credentials: false
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -177,6 +178,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
+          persist-credentials: false
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -198,6 +200,8 @@ jobs:
     permissions: { }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
@@ -267,6 +271,8 @@ jobs:
     permissions: { }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/camunda-delete-load-test.yml
+++ b/.github/workflows/camunda-delete-load-test.yml
@@ -40,6 +40,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Teleport
         uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
         with:

--- a/.github/workflows/camunda-ecs-weekly-load-test.yml
+++ b/.github/workflows/camunda-ecs-weekly-load-test.yml
@@ -57,8 +57,9 @@ defaults:
 
 env:
   AWS_REGION: eu-west-1
-  ENVIRONMENT: ${{ inputs.environment || 'prod' }}
+  ENV: ${{ inputs.environment || 'prod' }}
   IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
+  IMAGE_TAG: ${{ inputs.image_tag }}
 
 jobs:
   prepare:
@@ -76,6 +77,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Import secrets from Vault
         id: secrets
@@ -99,7 +102,6 @@ jobs:
 
       - name: Validate environment input
         run: |
-          ENV="${{ env.ENVIRONMENT }}"
           if [ "$ENV" != "prod" ] && [ "$ENV" != "dev" ]; then
             echo "::error::Invalid environment '${ENV}'. Must be 'prod' or 'dev'."
             exit 1
@@ -119,7 +121,6 @@ jobs:
 
           # Previous benchmark: find from currently running ECS services.
           # Note: This calculation does not allow two weekly benchmarks to run, but this is an acceptable for now.
-          ENV="${{ env.ENVIRONMENT }}"
           if [ "$ENV" = "dev" ]; then
             ECS_CLUSTER="camunda-dev-cluster"
             SERVICE_PREFIX="dev-weekly-"
@@ -161,32 +162,36 @@ jobs:
       - name: Resolve docker images
         id: resolve_images
         run: |
-          IMAGE_TAG="${{ inputs.image_tag }}"
           {
-            echo "camunda_image=${{ env.IMAGE_REPOSITORY }}/camunda:${IMAGE_TAG}"
-            echo "starter_image=${{ env.IMAGE_REPOSITORY }}/starter:${IMAGE_TAG}"
-            echo "worker_image=${{ env.IMAGE_REPOSITORY }}/worker:${IMAGE_TAG}"
+            echo "camunda_image=${IMAGE_REPOSITORY}/camunda:${IMAGE_TAG}"
+            echo "starter_image=${IMAGE_REPOSITORY}/starter:${IMAGE_TAG}"
+            echo "worker_image=${IMAGE_REPOSITORY}/worker:${IMAGE_TAG}"
           } >> "$GITHUB_OUTPUT"
           echo "✅ Using images with tag: ${IMAGE_TAG}"
 
       - name: Summary
         run: |
-          PREV="${{ steps.names.outputs.previous }}"
           {
             echo "## 📋 ECS Weekly Benchmark Plan"
             echo "| Item | Value |"
             echo "|------|-------|"
-            echo "| Current benchmark | \`${{ steps.names.outputs.current }}\` |"
+            echo "| Current benchmark | \`${NAMES_CURRENT}\` |"
             if [ -n "$PREV" ]; then
               echo "| Previous benchmark | \`${PREV}\` |"
             else
               echo "| Previous benchmark | _(none found)_ |"
             fi
-            echo "| Image tag | \`${{ inputs.image_tag }}\` |"
-            echo "| Camunda image | \`${{ steps.resolve_images.outputs.camunda_image }}\` |"
-            echo "| Starter image | \`${{ steps.resolve_images.outputs.starter_image }}\` |"
-            echo "| Worker image | \`${{ steps.resolve_images.outputs.worker_image }}\` |"
+            echo "| Image tag | \`${IMAGE_TAG}\` |"
+            echo "| Camunda image | \`${RESOLVE_IMAGES_CAMUNDA_IMAGE}\` |"
+            echo "| Starter image | \`${RESOLVE_IMAGES_STARTER_IMAGE}\` |"
+            echo "| Worker image | \`${RESOLVE_IMAGES_WORKER_IMAGE}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          PREV: ${{ steps.names.outputs.previous }}
+          NAMES_CURRENT: ${{ steps.names.outputs.current }}
+          RESOLVE_IMAGES_CAMUNDA_IMAGE: ${{ steps.resolve_images.outputs.camunda_image }}
+          RESOLVE_IMAGES_STARTER_IMAGE: ${{ steps.resolve_images.outputs.starter_image }}
+          RESOLVE_IMAGES_WORKER_IMAGE: ${{ steps.resolve_images.outputs.worker_image }}
 
       - name: Observe build status
         if: always()
@@ -210,6 +215,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Checkout camunda-load-tests-ecs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -217,6 +224,7 @@ jobs:
           repository: camunda/camunda-load-tests-ecs
           ref: main
           path: camunda-load-tests-ecs
+          persist-credentials: false
 
       - name: Import secrets from Vault
         id: secrets
@@ -242,12 +250,16 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Destroy previous load test
-        working-directory: camunda-load-tests-ecs/aws/load_test/${{ env.ENVIRONMENT }}
-        run: make destroy BENCHMARK_NAME="${{ needs.prepare.outputs.previous_benchmark_name }}"
+        working-directory: camunda-load-tests-ecs/aws/load_test/${{ env.ENV }}
+        run: make destroy BENCHMARK_NAME="${PREPARE_PREVIOUS_BENCHMARK_NAME}"
+        env:
+          PREPARE_PREVIOUS_BENCHMARK_NAME: ${{ needs.prepare.outputs.previous_benchmark_name }}
 
       - name: Destroy previous benchmark
-        working-directory: camunda-load-tests-ecs/aws/benchmark/${{ env.ENVIRONMENT }}
-        run: make destroy-with-bucket BENCHMARK_NAME="${{ needs.prepare.outputs.previous_benchmark_name }}"
+        working-directory: camunda-load-tests-ecs/aws/benchmark/${{ env.ENV }}
+        run: make destroy-with-bucket BENCHMARK_NAME="${PREPARE_PREVIOUS_BENCHMARK_NAME}"
+        env:
+          PREPARE_PREVIOUS_BENCHMARK_NAME: ${{ needs.prepare.outputs.previous_benchmark_name }}
 
       - name: Observe build status
         if: always()
@@ -271,6 +283,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Checkout camunda-load-tests-ecs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -278,6 +292,7 @@ jobs:
           repository: camunda/camunda-load-tests-ecs
           ref: main
           path: camunda-load-tests-ecs
+          persist-credentials: false
 
       - name: Import secrets from Vault
         id: secrets
@@ -304,9 +319,8 @@ jobs:
 
       - name: Validate benchmark name length
         run: |
-          NAME="${{ needs.prepare.outputs.current_benchmark_name }}"
           MAX_PREFIX_LEN=20
-          if [ "${{ env.ENVIRONMENT }}" = "dev" ]; then
+          if [ "${ENV}" = "dev" ]; then
             PREFIX="dev-${NAME}"
           else
             PREFIX="${NAME}"
@@ -316,22 +330,23 @@ jobs:
             exit 1
           fi
           echo "✅ PREFIX '${PREFIX}' (${#PREFIX} chars) is within the ${MAX_PREFIX_LEN} char limit"
+        env:
+          NAME: ${{ needs.prepare.outputs.current_benchmark_name }}
 
       - name: Deploy benchmark infrastructure
-        working-directory: camunda-load-tests-ecs/aws/benchmark/${{ env.ENVIRONMENT }}
-        run: >
-          make deploy
-          BENCHMARK_NAME="${{ needs.prepare.outputs.current_benchmark_name }}"
-          CAMUNDA_IMAGE="${{ needs.prepare.outputs.camunda_image }}"
+        working-directory: camunda-load-tests-ecs/aws/benchmark/${{ env.ENV }}
+        run: make deploy BENCHMARK_NAME="${BENCHMARK_NAME}" CAMUNDA_IMAGE="${CAMUNDA_IMAGE}"
+        env:
+          BENCHMARK_NAME: ${{ needs.prepare.outputs.current_benchmark_name }}
+          CAMUNDA_IMAGE: ${{ needs.prepare.outputs.camunda_image }}
 
       - name: Deploy load test
-        working-directory: camunda-load-tests-ecs/aws/load_test/${{ env.ENVIRONMENT }}
-        run: >
-          make deploy
-          BENCHMARK_NAME="${{ needs.prepare.outputs.current_benchmark_name }}"
-          FORCE_NEW_DEPLOYMENT=false
-          STARTER_IMAGE="${{ needs.prepare.outputs.starter_image }}"
-          WORKER_IMAGE="${{ needs.prepare.outputs.worker_image }}"
+        working-directory: camunda-load-tests-ecs/aws/load_test/${{ env.ENV }}
+        run: make deploy BENCHMARK_NAME="${BENCHMARK_NAME}" FORCE_NEW_DEPLOYMENT=false STARTER_IMAGE="${STARTER_IMAGE}" WORKER_IMAGE="${WORKER_IMAGE}"
+        env:
+          BENCHMARK_NAME: ${{ needs.prepare.outputs.current_benchmark_name }}
+          STARTER_IMAGE: ${{ needs.prepare.outputs.starter_image }}
+          WORKER_IMAGE: ${{ needs.prepare.outputs.worker_image }}
 
       - name: Output deployment info
         run: |
@@ -339,11 +354,16 @@ jobs:
             echo "## 🚀 ECS Benchmark Deployed"
             echo "| Item | Value |"
             echo "|------|-------|"
-            echo "| Benchmark | \`${{ needs.prepare.outputs.current_benchmark_name }}\` |"
-            echo "| Camunda image | \`${{ needs.prepare.outputs.camunda_image }}\` |"
-            echo "| Starter image | \`${{ needs.prepare.outputs.starter_image }}\` |"
-            echo "| Worker image | \`${{ needs.prepare.outputs.worker_image }}\` |"
+            echo "| Benchmark | \`${PREPARE_CURRENT_BENCHMARK_NAME}\` |"
+            echo "| Camunda image | \`${PREPARE_CAMUNDA_IMAGE}\` |"
+            echo "| Starter image | \`${PREPARE_STARTER_IMAGE}\` |"
+            echo "| Worker image | \`${PREPARE_WORKER_IMAGE}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          PREPARE_CURRENT_BENCHMARK_NAME: ${{ needs.prepare.outputs.current_benchmark_name }}
+          PREPARE_CAMUNDA_IMAGE: ${{ needs.prepare.outputs.camunda_image }}
+          PREPARE_STARTER_IMAGE: ${{ needs.prepare.outputs.starter_image }}
+          PREPARE_WORKER_IMAGE: ${{ needs.prepare.outputs.worker_image }}
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/camunda-load-test-metrics.yaml
+++ b/.github/workflows/camunda-load-test-metrics.yaml
@@ -48,6 +48,9 @@ defaults:
     shell: bash
 
 env:
+  AT: ${{ inputs.at }}
+  DURATION_SECONDS: ${{ inputs.duration-seconds }}
+  NAMESPACE: ${{ inputs.namespace }}
   PROM_URL: https://ci-monitor.benchmark.camunda.cloud
 
 jobs:
@@ -58,16 +61,10 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    env:
-      NAMESPACE: ${{ inputs.namespace }}
-      DURATION_SECONDS: ${{ inputs.duration-seconds }}
-      AT: ${{ inputs.at }}
     outputs:
       results-json: ${{ steps.run-queries.outputs.results-json }}
     steps:
       - name: Validate namespace prefix
-        env:
-          NAMESPACE: ${{ inputs.namespace }}
         run: |
           if [[ ! "$NAMESPACE" =~ ^c8- ]]; then
             echo "::error::Namespace '$NAMESPACE' must start with 'c8-' (e.g. c8-pgoyal-quicker-pr-1234)."
@@ -76,6 +73,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Import Prometheus credentials from Vault
         id: secrets

--- a/.github/workflows/camunda-load-test-smoke-dispatch.yml
+++ b/.github/workflows/camunda-load-test-smoke-dispatch.yml
@@ -35,10 +35,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: detect
         name: Detect which setup versions changed
         run: |
-          changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          changed=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")
 
           run_all=false
           if echo "$changed" | grep -qE '\.github/workflows/camunda-load-test'; then

--- a/.github/workflows/camunda-load-test-smoke.yml
+++ b/.github/workflows/camunda-load-test-smoke.yml
@@ -50,6 +50,7 @@ concurrency:
 env:
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
+  TARGET_VERSION: ${{ inputs.target-version }}
 
 defaults:
   run:
@@ -74,16 +75,20 @@ jobs:
           max_length: 10
       - id: compute-namespace
         name: Compute safe namespace from PR author, number and version
+        env:
+          AUTHOR: ${{ steps.sanitize-author.outputs.branch_name || github.actor }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.run_id }}
         run: |
-          author="${{ steps.sanitize-author.outputs.branch_name || github.actor }}"
-          pr_number="${{ github.event.pull_request.number || github.run_id }}"
-          version_slug="${{ inputs.target-version || 'main' }}"
+          author="${AUTHOR}"
+          pr_number="${PR_NUMBER}"
+          version_slug="${TARGET_VERSION:-main}"
           version_slug_sanitized="${version_slug//-/}"
           echo "namespace=c8-smoke-${author}-${pr_number}-${version_slug_sanitized}" >> "$GITHUB_OUTPUT"
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
+          persist-credentials: false
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-load-test-ttl-cleanup.yml
+++ b/.github/workflows/camunda-load-test-ttl-cleanup.yml
@@ -15,6 +15,7 @@ on:
         required: false
 
 env:
+  DATE: ${{ inputs.date }}
   TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
@@ -38,6 +39,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
@@ -48,7 +51,7 @@ jobs:
           location: europe-west1-b
       - name: Delete namespaces eligible for deletion
         id: delete-namespaces
-        run: .github/scripts/clean-up-load-test-namespaces.sh --execute "${{ inputs.date }}"
+        run: .github/scripts/clean-up-load-test-namespaces.sh --execute "${DATE}"
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -110,6 +113,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Teleport
         uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
         with:
@@ -123,7 +128,7 @@ jobs:
           kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Delete namespaces eligible for deletion
         id: delete-namespaces
-        run: .github/scripts/clean-up-load-test-namespaces.sh --execute "${{ inputs.date }}"
+        run: .github/scripts/clean-up-load-test-namespaces.sh --execute "${DATE}"
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -227,12 +227,33 @@ on:
         required: false
 
 env:
-  CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
-  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe  # change this to "infra-benchmark-dev-github-action-zeebe" when experimenting
-  HELM_CHART: camunda-platform-8.10
   # Namespaces MUST start with c8 due to access policy
   NAMESPACE: ${{ startsWith(inputs.name, 'c8-') && inputs.name || format('c8-{0}', inputs.name) }}
+
+  CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe  # change this to "infra-benchmark-dev-github-action-zeebe" when experimenting
+
+  BUILD_FRONTEND: ${{ inputs.build-frontend }}
+  CONNECTORS_TAG: ${{ inputs.connectors-tag }}
+  ENABLE_CHAOS: ${{ inputs.enable-chaos }}
+  ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
+  ENABLE_OPTIMIZE_METRICS: ${{ inputs.enable-optimize-report-metrics }}
+  HELM_CHART: camunda-platform-8.10
+  IDENTITY_TAG: ${{ inputs.identity-tag }}
   IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
+  LOAD_TEST_LOAD: ${{ inputs.load-test-load }}
+  NAME: ${{ inputs.name }}
+  OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
+  ORCHESTRATION_TAG: ${{ inputs.orchestration-tag }}
+  PERFORM_READ_BENCHMARKS: ${{ inputs.perform-read-benchmarks }}
+  PLATFORM_HELM_VALUES: ${{ inputs.platform-helm-values }}
+  REF: ${{ inputs.ref }}
+  REUSE_TAG: ${{ inputs.reuse-tag}}
+  SCENARIO: ${{ inputs.scenario }}
+  SECONDARY_STORAGE_TYPE: ${{ inputs.secondary-storage-type }}
+  STABLE_VMS: ${{ inputs.stable-vms }}
+  TARGET_VERSION: ${{ inputs.target-version }}
+  TTL: ${{ inputs.ttl }}
 
 defaults:
   run:
@@ -248,32 +269,32 @@ jobs:
     steps:
       - name: Show summary
         run: |-
-          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
-          ## Load test: `${{ env.NAMESPACE }}`
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Load test: \`${NAMESPACE}\`
 
-          > 📊 **[Open Grafana Dashboard](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${{ env.NAMESPACE }})**
+          > 📊 **[Open Grafana Dashboard](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${NAMESPACE})**
 
           | Input | Value |
           |-------|-------|
-          | Name | `${{ inputs.name }}` |
-          | Ref | `${{ inputs.ref }}` |
-          | Target version | `${{ inputs.target-version }}` |
-          | Scenario | `${{ inputs.scenario }}` |
-          | Secondary storage | `${{ inputs.secondary-storage-type }}` |
-          | Reuse tag | ${{ inputs.reuse-tag || '—' }} |
-          | Orchestration tag | ${{ inputs.orchestration-tag || '—' }} |
-          | Load test load | ${{ inputs.load-test-load || '—' }} |
-          | Platform helm values | ${{ inputs.platform-helm-values || '—' }} |
-          | TTL (days) | `${{ inputs.ttl }}` |
-          | Stable VMs | `${{ inputs.stable-vms }}` |
-          | Enable Optimize | `${{ inputs.enable-optimize }}` |
-          | Enable chaos | `${{ inputs.enable-chaos }}` |
-          | Enable Optimize report metrics | `${{ inputs.enable-optimize-report-metrics }}` |
-          | Build frontend | `${{ inputs.build-frontend }}` |
-          | Perform read benchmarks | `${{ inputs.perform-read-benchmarks }}` |
-          | Optimize tag | ${{ inputs.optimize-tag || '—' }} |
-          | Identity tag | ${{ inputs.identity-tag || '—' }} |
-          | Connectors tag | ${{ inputs.connectors-tag || '—' }} |
+          | Name | \`${NAME}\` |
+          | Ref | \`${REF}\` |
+          | Target version | \`${TARGET_VERSION}\` |
+          | Scenario | \`${SCENARIO}\` |
+          | Secondary storage | \`${SECONDARY_STORAGE_TYPE}\` |
+          | Reuse tag | \`${REUSE_TAG:-—}\` |
+          | Orchestration tag | \`${ORCHESTRATION_TAG:-—}\` |
+          | Load test load | \`${LOAD_TEST_LOAD:-—}\` |
+          | Platform Helm values | \`${PLATFORM_HELM_VALUES:-—}\` |
+          | TTL (days) | \`${TTL}\` |
+          | Stable VMs | \`${STABLE_VMS}\` |
+          | Enable Optimize | \`${ENABLE_OPTIMIZE}\` |
+          | Enable Optimize report metrics | \`${ENABLE_OPTIMIZE_METRICS}\` |
+          | Enable chaos | \`${ENABLE_CHAOS}\` |
+          | Build frontend | \`${BUILD_FRONTEND}\` |
+          | Perform read benchmarks | \`${PERFORM_READ_BENCHMARKS}\` |
+          | Optimize tag | \`${OPTIMIZE_TAG:-—}\` |
+          | Identity tag | \`${IDENTITY_TAG:-—}\` |
+          | Connectors tag | \`${CONNECTORS_TAG:-—}\` |
           EOF
 
   calculate-image-tag:
@@ -292,21 +313,18 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
+
       - name: Get image tag
         id: image-tag
         if: ${{ inputs.orchestration-tag == '' && inputs.reuse-tag == '' }}
         run: |
-          image_tag="${{ inputs.name }}-$(git rev-parse --short HEAD)"
+          image_tag="${NAME}-$(git rev-parse --short HEAD)"
           echo "image-tag=${image_tag}" >> "$GITHUB_OUTPUT"
           echo "**Built image tag:** \`${image_tag}\`" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Validate Docker image tags exist
         if: ${{ inputs.orchestration-tag != '' || inputs.optimize-tag != '' || inputs.identity-tag != '' || inputs.connectors-tag != '' }}
-        env:
-          ORCHESTRATION_TAG: ${{ inputs.orchestration-tag }}
-          ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
-          OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
-          IDENTITY_TAG: ${{ inputs.identity-tag }}
-          CONNECTORS_TAG: ${{ inputs.connectors-tag }}
         run: |
           validate_image() {
             local image="$1"
@@ -370,6 +388,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -453,6 +472,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -462,9 +482,13 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl load-tests/load-tester -am install
       - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${IMAGE_REPOSITORY}/starter:${IMAGE_TAG}"
+        env:
+          IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
       - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${IMAGE_REPOSITORY}/worker:${IMAGE_TAG}"
+        env:
+          IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -500,7 +524,9 @@ jobs:
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Build and push image
         working-directory: ./load-tests/metrics-exporter
-        run: make docker IMAGE=registry.camunda.cloud/team-reliability-testing/metrics-exporter:${{ needs.calculate-image-tag.outputs.image-tag }} DOCKER_PUSH=true
+        run: make docker "IMAGE=registry.camunda.cloud/team-reliability-testing/metrics-exporter:${IMAGE_TAG}" DOCKER_PUSH=true
+        env:
+          IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
 
       - name: Observe build status
         if: always()
@@ -536,12 +562,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
+
       # camunda-platform-8.10 requires Helm CLI v4; runners ship v3.x.
       - name: Set up Helm
         uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         with:
           tool_versions: |
             helm 4.2.0
+
       # Authenticate with Teleport
       - name: Set up Teleport
         uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
@@ -590,89 +619,90 @@ jobs:
           cd load-tests/setup
           # The namespace label created-by will not be able resolve the actual user which triggered
           # the GitHub action by default. We need to correctly configure the git user here to make it work
-          git config user.name ${{ github.actor }}
+          git config user.name "${GITHUB_ACTOR}"
           # Render the load-test folder. newLoadTest.sh no longer creates the namespace — that
           # happens on `make install` via `kubectl apply -f resources/namespace.yaml`.
-          ./newLoadTest.sh --target-version ${{ inputs.target-version || 'main' }} ${{ env.NAMESPACE }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
+          ./newLoadTest.sh --target-version "${TARGET_VERSION}" "${NAMESPACE}" "${SECONDARY_STORAGE_TYPE}" "${TTL}" "${ENABLE_OPTIMIZE}"
+
       - name: Install latest Camunda Platform
+        env:
+          BUILD_METRICS_EXPORTER_RESULT: ${{ needs.build-metrics-exporter-image.result }}
+          CALCULATED_IMAGE_TAG: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          CAMUNDA_REPO: ${{ inputs.orchestration-tag != '' && 'camunda/camunda' || 'team-zeebe/camunda' }}
+          IMAGE_REGISTRY: ${{ inputs.orchestration-tag != '' && 'docker.io' || 'registry.camunda.cloud' }}
+          INSTALL_TARGET: ${{ inputs.stable-vms && 'install-stable' || 'install' }}
+          OPTIMIZE_REPO: ${{ inputs.orchestration-tag != '' && 'camunda/optimize' || 'team-zeebe/optimize' }}
         run: |
-          cd load-tests/setup/${{ env.NAMESPACE }}
+          cd "load-tests/setup/${NAMESPACE}"
 
           # Build load test configuration
-          load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
-                            --set global.image.repository=${{ env.IMAGE_REPOSITORY }} \
+          load_test_config="--set global.image.tag=${CALCULATED_IMAGE_TAG} \
+                            --set global.image.repository=${IMAGE_REPOSITORY} \
                             --set global.image.pullSecrets[0].name=harbor-registry \
-                            --set global.performReadBenchmarks=${{inputs.perform-read-benchmarks}}"
+                            --set global.performReadBenchmarks=${PERFORM_READ_BENCHMARKS}"
 
           # Enable the load-tester Optimize report-evaluation meter via chart extraConfig
           # (binds to the Spring property load-tester.optimize.report-evaluation-enabled; off by default).
-          if [[ "${{ inputs.enable-optimize-report-metrics }}" == "true" ]]; then
+          if [[ "${ENABLE_OPTIMIZE_METRICS}" == "true" ]]; then
             load_test_config="$load_test_config --set global.extraConfig.load-tester.optimize.report-evaluation-enabled=true"
           fi
 
           # Append custom load test inputs
-          load_test_config="$load_test_config ${{ inputs.load-test-load }}"
+          load_test_config="$load_test_config ${LOAD_TEST_LOAD}"
 
           # Resolve image registry/repository: Docker Hub when orchestration-tag is set, internal registry otherwise
           # optimize_repo is only consumed in the custom build path where orchestration-tag is empty
-          image_registry="${{ inputs.orchestration-tag != '' && 'docker.io' || 'registry.camunda.cloud' }}"
-          camunda_repo="${{ inputs.orchestration-tag != '' && 'camunda/camunda' || 'team-zeebe/camunda' }}"
-          optimize_repo="${{ inputs.orchestration-tag != '' && 'camunda/optimize' || 'team-zeebe/optimize' }}"
-          image_tag="${{ needs.calculate-image-tag.outputs.image-tag }}"
 
           # Build platform configuration
-          additional_platform_config="--set global.image.tag=${image_tag} \
-            --set orchestration.image.registry=${image_registry} \
-            --set orchestration.image.repository=${camunda_repo} \
-            --set orchestration.image.tag=${image_tag}"
+          additional_platform_config="--set global.image.tag=${CALCULATED_IMAGE_TAG} \
+            --set orchestration.image.registry=${IMAGE_REGISTRY} \
+            --set orchestration.image.repository=${CAMUNDA_REPO} \
+            --set orchestration.image.tag=${CALCULATED_IMAGE_TAG}"
 
           additional_load_test_setup_configuration=""
 
           # Append optimize image config: optimize-tag wins if set, otherwise custom builds use internal registry
-          if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
-            if [[ -n "${{ inputs.optimize-tag }}" ]]; then
+          if [[ "${ENABLE_OPTIMIZE}" == "true" ]]; then
+            if [[ -n "${OPTIMIZE_TAG}" ]]; then
               # Explicit optimize tag provided: use it directly (Docker Hub image)
-              additional_platform_config+=" \
-                --set optimize.image.tag=${{ inputs.optimize-tag }}"
-            elif [[ -z "${{ inputs.orchestration-tag }}" ]]; then
+              additional_platform_config+="--set optimize.image.tag=${OPTIMIZE_TAG}"
+            elif [[ -z "${ORCHESTRATION_TAG}" ]]; then
               # Custom build without explicit optimize tag: use the built image from internal registry
               additional_platform_config+=" \
-                --set optimize.image.registry=${image_registry} \
-                --set optimize.image.repository=${optimize_repo} \
-                --set optimize.image.tag=${image_tag}"
+                --set optimize.image.registry=${IMAGE_REGISTRY} \
+                --set optimize.image.repository=${OPTIMIZE_REPO} \
+                --set optimize.image.tag=${CALCULATED_IMAGE_TAG}"
             fi
           fi
 
           # Append identity image config if a dedicated tag is provided
-          if [[ -n "${{ inputs.identity-tag }}" ]]; then
-            additional_platform_config+=" \
-              --set identity.image.tag=${{ inputs.identity-tag }}"
+          if [[ -n "${IDENTITY_TAG}" ]]; then
+            additional_platform_config+="--set identity.image.tag=${IDENTITY_TAG}"
           fi
 
           # Append connectors image config if a dedicated tag is provided
-          if [[ -n "${{ inputs.connectors-tag }}" ]]; then
-            additional_platform_config+=" \
-              --set connectors.image.tag=${{ inputs.connectors-tag }}"
+          if [[ -n "${CONNECTORS_TAG}" ]]; then
+            additional_platform_config+="--set connectors.image.tag=${CONNECTORS_TAG}"
           fi
 
           # Append user-provided helm values if present
-          if [[ -n "${{ inputs.platform-helm-values }}" ]]; then
-            additional_platform_config+=" ${{ inputs.platform-helm-values }}"
+          if [[ -n "${PLATFORM_HELM_VALUES}" ]]; then
+            additional_platform_config+=" ${PLATFORM_HELM_VALUES}"
           fi
 
           # Pin the metrics-exporter image to the tag built by build-metrics-exporter-image.
           # If the image has been skipped, keep using the "latest" tag, which
           # is assuming to be always published by the dedicated CI running on
           # the main branch.
-          if [[ "${{ needs.build-metrics-exporter-image.result }}" == "success" ]]; then
-            additional_load_test_setup_configuration+="--set metricsExporter.image.tag=${image_tag}"
+          if [[ "${BUILD_METRICS_EXPORTER_RESULT}" == "success" ]]; then
+            additional_load_test_setup_configuration+="--set metricsExporter.image.tag=${CALCULATED_IMAGE_TAG}"
           fi
 
-          make ${{ inputs.stable-vms && 'install-stable' || 'install' }} \
-            scenario=${{ inputs.scenario }} \
-            secondary_storage=${{ inputs.secondary-storage-type }} \
-            enable_optimize=${{ inputs.enable-optimize }} \
-            chaos=${{ inputs.enable-chaos }} \
+          make "${INSTALL_TARGET}" \
+            scenario="${SCENARIO}" \
+            secondary_storage="${SECONDARY_STORAGE_TYPE}" \
+            enable_optimize="${ENABLE_OPTIMIZE}" \
+            chaos="${ENABLE_CHAOS}" \
             additional_platform_configuration="$additional_platform_config" \
             additional_load_test_configuration="$load_test_config" \
             additional_load_test_setup_configuration="$additional_load_test_setup_configuration"
@@ -680,7 +710,7 @@ jobs:
       - name: Annotate namespace with workflow run URL
         run: |
           # Traceability annotation, applied after `make install` has created the namespace.
-          kubectl annotate namespace ${{ env.NAMESPACE }} \
+          kubectl annotate namespace "${NAMESPACE}" \
             "github.com/workflow-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --overwrite
 
@@ -688,22 +718,24 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Camunda platform \`${{ inputs.name }}\` values
+            ## Camunda platform \`${NAME}\` values
             \`\`\`yaml
-            $(helm get values ${{ env.NAMESPACE }} -n ${{ env.NAMESPACE }})
+            $(helm get values "${NAMESPACE}" -n "${NAMESPACE}")
             \`\`\`
           EOF
+
       - name: Summarize load test deployment
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
             # Load test
-            The test has been set up successfully. You can observe it [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${{ env.NAMESPACE }})
-            ## Load test \`${{ inputs.name }}\` values
+            The test has been set up successfully. You can observe it [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${NAMESPACE})
+            ## Load test \`${NAME}\` values
             \`\`\`yaml
-            $(helm get values ${{ env.NAMESPACE }}-test -n ${{ env.NAMESPACE }})
+            $(helm get values "${NAMESPACE}-test" -n "${NAMESPACE}")
             \`\`\`
           EOF
+
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -70,15 +70,20 @@ jobs:
       - id: compute-namespace
         name: Compute safe namespace from PR author, number and the database type
         run: |
-          author="${{ steps.sanitize-author.outputs.branch_name }}"
-          db_type="${{ steps.sanitize-db-type.outputs.branch_name }}"
-          pr_number="${{ github.event.pull_request.number }}"
+          author="${AUTHOR}"
+          db_type="${DB_TYPE}"
+          pr_number="${PR_NUMBER}"
           echo "namespace=c8-${author}-pr-${pr_number}-${db_type}" >> "$GITHUB_OUTPUT"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ steps.sanitize-author.outputs.branch_name }}
+          DB_TYPE: ${{ steps.sanitize-db-type.outputs.branch_name }}
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
+          persist-credentials: false
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -112,6 +117,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Wait for load test to stabilize
         run: sleep 1800  # 30 minutes
       - name: Observe build status
@@ -147,6 +154,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Teleport
         uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
         with:
@@ -232,6 +241,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Convert queries.yaml to JSON for render step
         run: yq -o=json '.' load-tests/docs/scripts/queries.yaml > /tmp/queries.json
       - name: Build comparison markdown
@@ -266,6 +277,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Post comparison comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -322,15 +335,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
       - name: Comment PR with profiling results
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          STORAGE_TYPE: ${{ needs.sanitize-branch-name.outputs.storage-type }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
+
+            const repo = process.env.REPO;
+            const runID = process.env.RUN_ID;
+            const storageType = process.env.STORAGE_TYPE;
+
+            const runURL = `https://github.com/${repo}/actions/runs/${runID}`;
 
             // List all downloaded artifacts
             const artifactPath = 'artifacts';
@@ -343,12 +368,12 @@ jobs:
               run_id: context.runId,
             });
 
-            let comment = '## Profiling Results - ${{ needs.sanitize-branch-name.outputs.storage-type }}\n\n';
+            let comment = `## Profiling Results - ${storageType}\n\n`;
             comment += 'The benchmark has been profiled with the following events:\n\n';
             comment += '| Event | Pod | Artifact |\n';
             comment += '|-------|-----|----------|\n';
 
-            const artifactPrefix = 'flamegraph-${{ needs.sanitize-branch-name.outputs.storage-type }}';
+            const artifactPrefix = `flamegraph-${storageType}`;
             const regex = new RegExp(artifactPrefix + '-(\\w+)-(\\w+-\\d+)');
             artifacts.forEach(artifact => {
               const match = artifact.match(regex);
@@ -359,7 +384,7 @@ jobs:
                 // Find the artifact ID for this artifact name
                 const artifactInfo = workflowArtifacts.artifacts.find(a => a.name === artifact);
                 if (artifactInfo) {
-                  const downloadUrl = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${artifactInfo.id}`;
+                  const downloadUrl = `${runURL}/artifacts/${artifactInfo.id}`;
                   comment += `| ${event} | ${pod} | [Download](${downloadUrl}) |\n`;
                 } else {
                   comment += `| ${event} | ${pod} | N/A |\n`;
@@ -367,7 +392,7 @@ jobs:
               }
             });
 
-            comment += '\n📊 [View all artifacts and workflow summary](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\n';
+            comment += `\n📊 [View all artifacts and workflow summary](${runURL})\n`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -112,6 +112,8 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/camunda-scheduled-release-load-tests.yml
+++ b/.github/workflows/camunda-scheduled-release-load-tests.yml
@@ -114,6 +114,8 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -176,6 +178,8 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/camunda-verify-load-test.yml
+++ b/.github/workflows/camunda-verify-load-test.yml
@@ -14,6 +14,7 @@ on:
 env:
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
+  NAMESPACE: ${{ inputs.namespace }}
 
 jobs:
   verify:
@@ -25,6 +26,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
         with:
           proxy: camunda.teleport.sh:443
@@ -35,9 +38,7 @@ jobs:
           token: ${{ env.TELEPORT_JOIN_TOKEN }}
           kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Verify Load test
-        env:
-          NAMESPACE: ${{ inputs.namespace }}
-        run: load-tests/docs/scripts/verify-test.sh ${{ env.NAMESPACE }}
+        run: load-tests/docs/scripts/verify-test.sh "${NAMESPACE}"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -31,6 +31,7 @@ defaults:
 env:
   TEST_OWNER: '@camunda/reliability-testing'
   IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
+  REUSE_TAG: ${{ inputs.reuse-tag }}
 
 jobs:
   test-data:
@@ -42,10 +43,10 @@ jobs:
       image-tag: ${{ steps.data.outputs.image-tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Collect test data
         id: data
-        env:
-          REUSE_TAG: ${{ inputs.reuse-tag }}
         run: |
           if [[ -z "$REUSE_TAG" ]]; then
             echo "Creating new weekly test tag"
@@ -75,6 +76,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -145,6 +148,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -154,9 +159,13 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: ./mvnw -B -DskipTests -DskipChecks -P\!include-optimize -pl load-tests/load-tester -am install
       - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ needs.test-data.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${IMAGE_REPOSITORY}/starter:${IMAGE_TAG}"
+        env:
+          IMAGE_TAG: ${{ needs.test-data.outputs.image-tag }}
       - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ needs.test-data.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${IMAGE_REPOSITORY}/worker:${IMAGE_TAG}"
+        env:
+          IMAGE_TAG: ${{ needs.test-data.outputs.image-tag }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -271,6 +280,8 @@ jobs:
     permissions: { }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Import Slack webhook from Vault
         id: slack-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -55,6 +55,11 @@ env:
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 
+  DATABASE: ${{ inputs.database }}
+  NAME: ${{ inputs.name }}
+  POD: ${{ inputs.pod }}
+  PROFILER_OPTIONS: ${{ inputs.profiler_options }}
+
 jobs:
   profile-all-pods:
     name: Profile ${{ matrix.event }} on ${{ matrix.pod }}
@@ -76,6 +81,8 @@ jobs:
             event: alloc
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Teleport
         uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
         with:
@@ -91,10 +98,13 @@ jobs:
 
       - name: Set right namespace
         run: |
-          kubectl config set-context --current --namespace=${{ inputs.name }}
+          kubectl config set-context --current --namespace="${NAME}"
       - name: Execute profiling
+        env:
+          POD: ${{ matrix.pod }}
+          EVENT: ${{ matrix.event }}
         run: >
-          ./load-tests/docs/scripts/executeProfiling.sh ${{ matrix.pod }} ${{ matrix.event }} "${{ inputs.database }}" "${{ inputs.profiler_options }}"
+          ./load-tests/docs/scripts/executeProfiling.sh "${POD}" "${EVENT}" "${DATABASE}" "${PROFILER_OPTIONS}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: flamegraph-${{ inputs.database }}-${{ matrix.event }}-${{ matrix.pod }}
@@ -103,9 +113,12 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Profiling \`${{ inputs.name }}\` - ${{ matrix.event }} on ${{ matrix.pod }}
-            Async profiling (${{ matrix.event }}) has been executed on ${{ inputs.name }}-${{ matrix.pod }}. Please download the artifact.
+            ## Profiling \`${NAME}\` - ${EVENT} on ${POD}
+            Async profiling (${EVENT}) has been executed on ${NAME}-${POD}. Please download the artifact.
           EOF
+        env:
+          POD: ${{ matrix.pod }}
+          EVENT: ${{ matrix.event }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -127,6 +140,8 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Teleport
         uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
         with:
@@ -141,10 +156,10 @@ jobs:
           kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Set right namespace
         run: |
-          kubectl config set-context --current --namespace=${{ inputs.name }}
+          kubectl config set-context --current --namespace="${NAME}"
       - name: Execute profiling
         run: >
-          ./load-tests/docs/scripts/executeProfiling.sh ${{ inputs.pod }} cpu "${{ inputs.database }}" "${{ inputs.profiler_options }}"
+          ./load-tests/docs/scripts/executeProfiling.sh "${POD}" cpu "${DATABASE}" "${PROFILER_OPTIONS}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: flamegraph-${{ inputs.database }}-cpu-${{ inputs.pod }}
@@ -153,8 +168,8 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Profiling \`${{ inputs.name }}\` - CPU on ${{ inputs.pod }}
-            Async profiling (CPU) has been executed on ${{ inputs.name }}-${{ inputs.pod }}. Please download the artifact.
+            ## Profiling \`${NAME}\` - CPU on ${POD}
+            Async profiling (CPU) has been executed on ${NAME}-${POD}. Please download the artifact.
           EOF
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

This doesn't fix all the error messages, but should fix all the easy ones.

This has been automatically changed using:

```
find .github/workflows/ -name "*load-test*" -print0 | xargs -0 zizmor --fix=unsafe-only
```

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
