### PR TITLE
fix: fail cluster startup when physical tenant is missconfigured

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantScopeProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantScopeProvider.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.bind.BindException;
 import org.springframework.core.env.Environment;
 
 /**
@@ -111,13 +112,10 @@ public final class PhysicalTenantScopeProvider implements CamundaSecurityScopePr
           tenantId,
           basePath,
           describeProviders(authConfig));
-    } catch (final IllegalStateException e) {
-      // Log the exception itself (last arg) so the full cause chain — e.g. a deeply-nested Spring
-      // Binder failure — is captured for operator diagnostics, not just its top-level message.
-      LOG.warn(
-          "Skipping scoped security chain for physical tenant '{}': {}",
-          tenantId,
-          e.getMessage(),
+    } catch (final BindException | IllegalStateException e) {
+      throw new IllegalStateException(
+          "Failed to build scoped security configuration for physical tenant '%s': %s — cluster startup aborted."
+              .formatted(tenantId, e.getMessage()),
           e);
     }
   }

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopeProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopeProviderTest.java
@@ -8,6 +8,7 @@
 package io.camunda.authentication.pt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
 import java.util.List;
@@ -182,6 +183,44 @@ class PhysicalTenantScopeProviderTest {
     final var env = env(Map.of("camunda.security.authentication.method", "oidc"));
 
     assertThat(new PhysicalTenantScopeProvider(env).get()).isEmpty();
+  }
+
+  @Test
+  void shouldFailStartupWhenPhysicalTenantConfigCannotBeBuilt() {
+    // given — an invalid enum value for `method` under a PT overlay causes Binder to throw
+    final var env =
+        env(
+            Map.of(
+                "camunda.physical-tenants.badtenant.security.authentication.method",
+                "NOT_A_VALID_METHOD"));
+
+    // when / then
+    assertThatThrownBy(() -> new PhysicalTenantScopeProvider(env))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("badtenant");
+  }
+
+  @Test
+  void shouldFailStartupWhenDefaultTenantConfigCannotBeBuilt() {
+    // given — keep the root config valid and activate PT mode via a non-default tenant, then put an
+    // invalid value specifically under the default overlay prefix so only
+    // forPhysicalTenant("default")
+    // fails — ensuring the implicit default alias follows the same fail-fast rule independently.
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.authentication.method", "oidc",
+                // A non-default tenant activates PT mode so the default alias is attempted
+                "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.tenanta.client-id",
+                    "pt-client",
+                // Invalid value under the default overlay — triggers a Binder failure only when
+                // forPhysicalTenant("default", env) is called
+                "camunda.physical-tenants.default.security.authentication.method",
+                    "NOT_A_VALID_METHOD"));
+
+    assertThatThrownBy(() -> new PhysicalTenantScopeProvider(env))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("default");
   }
 
   private static MockEnvironment env(final Map<String, String> properties) {


### PR DESCRIPTION
## Description

Fail fast if any configured physical tenant's security configuration cannot be
resolved/built. The whole cluster startup will now fail instead of silently starting without that
tenant's chain. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55606
