### PR TITLE
fix: Flakey Audit Log ITs

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthenticationIT.java
@@ -20,12 +20,10 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogAuthenticationIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
@@ -38,10 +38,8 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogAuthorizationsIT {
   protected static final boolean USE_REST_API = true;
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogIdentityOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogIdentityOperationsIT.java
@@ -30,10 +30,8 @@ import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogIdentityOperationsIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogIdentityOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogIdentityOperationsIT.java
@@ -442,12 +442,11 @@ public class AuditLogIdentityOperationsIT {
 
     // when
     client.newUnassignUserFromGroupCommand().username(username).groupId(groupId).send().join();
-    awaitAuditLogEntry(
-        client, AuditLogEntityTypeEnum.GROUP, AuditLogOperationTypeEnum.UNASSIGN, groupId);
+    final var auditLogs =
+        awaitAuditLogEntry(
+            client, AuditLogEntityTypeEnum.GROUP, AuditLogOperationTypeEnum.UNASSIGN, groupId);
 
     // then
-    final var auditLogs =
-        findAuditLogs(client, AuditLogEntityTypeEnum.GROUP, AuditLogOperationTypeEnum.UNASSIGN);
     final var result = findByEntityKey(auditLogs, groupId);
     assertAuditLog(
         result, AuditLogEntityTypeEnum.GROUP, AuditLogOperationTypeEnum.UNASSIGN, groupId);
@@ -513,16 +512,14 @@ public class AuditLogIdentityOperationsIT {
         .claimValue("updated-value")
         .send()
         .join();
-    awaitAuditLogEntry(
-        client,
-        AuditLogEntityTypeEnum.MAPPING_RULE,
-        AuditLogOperationTypeEnum.UPDATE,
-        mappingRuleId);
+    final var auditLogs =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.MAPPING_RULE,
+            AuditLogOperationTypeEnum.UPDATE,
+            mappingRuleId);
 
     // then
-    final var auditLogs =
-        findAuditLogs(
-            client, AuditLogEntityTypeEnum.MAPPING_RULE, AuditLogOperationTypeEnum.UPDATE);
     final var result = findByEntityKey(auditLogs, mappingRuleId);
     assertAuditLog(
         result,
@@ -552,16 +549,14 @@ public class AuditLogIdentityOperationsIT {
 
     // when
     client.newDeleteMappingRuleCommand(mappingRuleId).send().join();
-    awaitAuditLogEntry(
-        client,
-        AuditLogEntityTypeEnum.MAPPING_RULE,
-        AuditLogOperationTypeEnum.DELETE,
-        mappingRuleId);
+    final var auditLogs =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.MAPPING_RULE,
+            AuditLogOperationTypeEnum.DELETE,
+            mappingRuleId);
 
     // then
-    final var auditLogs =
-        findAuditLogs(
-            client, AuditLogEntityTypeEnum.MAPPING_RULE, AuditLogOperationTypeEnum.DELETE);
     assertAuditLog(
         findByEntityKey(auditLogs, mappingRuleId),
         AuditLogEntityTypeEnum.MAPPING_RULE,
@@ -629,16 +624,14 @@ public class AuditLogIdentityOperationsIT {
             PermissionType.READ_DECISION_DEFINITION, PermissionType.READ_DECISION_INSTANCE)
         .send()
         .join();
-    awaitAuditLogEntry(
-        client,
-        AuditLogEntityTypeEnum.AUTHORIZATION,
-        AuditLogOperationTypeEnum.UPDATE,
-        authorizationKey);
+    final var auditLogs =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.AUTHORIZATION,
+            AuditLogOperationTypeEnum.UPDATE,
+            authorizationKey);
 
     // then
-    final var auditLogs =
-        findAuditLogs(
-            client, AuditLogEntityTypeEnum.AUTHORIZATION, AuditLogOperationTypeEnum.UPDATE);
     final var result = findByEntityKey(auditLogs, authorizationKey);
     assertAuditLog(
         result,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -51,7 +51,6 @@ import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Acceptance tests for audit log entries related to process operations. This test class verifies
@@ -59,7 +58,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  * through the audit log search REST API endpoint using the Camunda Client.
  */
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogProcessOperationsIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogResourceOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogResourceOperationsIT.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Acceptance tests for audit log entries related to resource operations. This test class verifies
@@ -41,7 +40,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  * search REST API endpoint using the Camunda Client.
  */
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogResourceOperationsIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
@@ -37,10 +37,8 @@ import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogSearchClientIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
@@ -26,10 +26,8 @@ import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogUserTaskOperationsIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogWithoutAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogWithoutAuthorizationsIT.java
@@ -23,7 +23,6 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -33,7 +32,6 @@ import org.junit.jupiter.params.provider.ValueSource;
  * identity claims were dropped along with authorization claims.
  */
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogWithoutAuthorizationsIT {
 
   @MultiDbTestApplication


### PR DESCRIPTION
## Description

`awaitAuditLogEntry` returns the confirmed list when polling succeeds, but four test methods were discarding that value and re-querying via `findAuditLogs` without any retry logic. Because the search backend is eventually consistent, the re-query could hit a stale shard and miss the entry, causing non-deterministic test failures.

Fix: capture and use the return value of `awaitAuditLogEntry` directly, eliminating the redundant second query in `shouldTrackGroupRemoveAssignment`, `shouldTrackMappingRuleUpdate`, `shouldTrackMappingRuleDelete`, and `shouldTrackAuthorizationUpdate`.

Also remove the `@DisableOnAwsOs` annotations. There is nothing in these tests that should break when running on AWS OS, and we should maintain test parity across all supported environments.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
