### PR TITLE
fix: agent-instance schema changes caused type-errors in Operate

### DIFF
--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.3",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.75",
+        "@camunda/camunda-api-zod-schemas": "0.0.76",
         "@camunda/camunda-composite-components": "0.25.0",
         "@carbon/elements": "11.90.0",
         "@carbon/react": "1.108.0",
@@ -459,9 +459,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.75",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.75.tgz",
-      "integrity": "sha512-lEUdvrWvOma8vQ5yrsBmO16z/OFzo6ZZvlD6YJJCGZor3B/cOgyHoxU1yn8AQ92isBfHTa/KxBKtW+rpWXtN4Q==",
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.76.tgz",
+      "integrity": "sha512-5acIrmoKOsA3leceAFj41jmu6WD2JCjDuhFgB5YQCu+kUZgrCzfth4xaPKfOfvpVDomWgkgk/NelK39j21xKxw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.3",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.75",
+    "@camunda/camunda-api-zod-schemas": "0.0.76",
     "@camunda/camunda-composite-components": "0.25.0",
     "@carbon/elements": "11.90.0",
     "@carbon/react": "1.108.0",

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -207,7 +207,7 @@ describe('<ConversationHistory />', () => {
     const item = mockAgentInstanceHistoryItem();
     mockServer.use(
       http.post(
-        endpoints.searchAgentInstanceHistory.getUrl({
+        endpoints.queryAgentInstanceHistory.getUrl({
           agentInstanceKey: AGENT_INSTANCE_KEY,
         }),
         async ({request}) => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -21,8 +21,8 @@ import {mockSearchAgentInstanceHistory} from 'modules/mocks/api/v2/agentInstance
 import {searchResult} from 'modules/testUtils';
 import {Paths} from 'modules/Routes';
 import {AgentDetails} from './index';
-import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import {mockAgentInstanceHistoryItem} from 'modules/mocks/mockAgentInstanceHistoryItem';
+import {mockAgentInstance} from 'modules/mocks/mockAgentInstance';
 
 vi.mock('modules/feature-flags', () => ({
   IS_CONVERSATION_HISTORY_ENABLED: true,
@@ -43,34 +43,7 @@ function createWrapper() {
   };
 }
 
-const mockAgentInstance: AgentInstance = {
-  agentInstanceKey: '2251799813851828',
-  status: 'TOOL_CALLING',
-  definition: {
-    model: 'gpt-4',
-    provider: 'openai',
-    systemPrompt: 'You are a helpful assistant.',
-  },
-  metrics: {
-    inputTokens: 100,
-    outputTokens: 50,
-    modelCalls: 3,
-    toolCalls: 2,
-  },
-  limits: {
-    maxModelCalls: 10,
-    maxToolCalls: 5,
-    maxTokens: 1000,
-  },
-  elementId: 'Activity_1',
-  processInstanceKey: '123456789',
-  processDefinitionKey: '444555666',
-  tenantId: '<default>',
-  creationDate: '2025-01-15T10:00:00.000Z',
-  lastUpdatedDate: '2025-01-15T10:05:00.000Z',
-  completionDate: null,
-  elementInstanceKeys: ['111222333'],
-};
+const agentInstance = mockAgentInstance();
 
 describe('<AgentDetails />', () => {
   beforeEach(() => {
@@ -80,7 +53,7 @@ describe('<AgentDetails />', () => {
   it('should render AI Agent heading and status for TOOL_CALLING', () => {
     render(
       <AgentDetails
-        agentInstance={mockAgentInstance}
+        agentInstance={agentInstance}
         isLoading={false}
         isError={false}
       />,
@@ -97,7 +70,7 @@ describe('<AgentDetails />', () => {
   it('should render status for THINKING', () => {
     render(
       <AgentDetails
-        agentInstance={{...mockAgentInstance, status: 'THINKING'}}
+        agentInstance={{...agentInstance, status: 'THINKING'}}
         isLoading={false}
         isError={false}
       />,
@@ -113,7 +86,7 @@ describe('<AgentDetails />', () => {
   it('should render status for IDLE', () => {
     render(
       <AgentDetails
-        agentInstance={{...mockAgentInstance, status: 'IDLE'}}
+        agentInstance={{...agentInstance, status: 'IDLE'}}
         isLoading={false}
         isError={false}
       />,
@@ -127,7 +100,7 @@ describe('<AgentDetails />', () => {
   it('should render status for COMPLETED', () => {
     render(
       <AgentDetails
-        agentInstance={{...mockAgentInstance, status: 'COMPLETED'}}
+        agentInstance={{...agentInstance, status: 'COMPLETED'}}
         isLoading={false}
         isError={false}
       />,
@@ -143,7 +116,7 @@ describe('<AgentDetails />', () => {
   it('should render status for INITIALIZING', () => {
     render(
       <AgentDetails
-        agentInstance={{...mockAgentInstance, status: 'INITIALIZING'}}
+        agentInstance={{...agentInstance, status: 'INITIALIZING'}}
         isLoading={false}
         isError={false}
       />,
@@ -159,7 +132,7 @@ describe('<AgentDetails />', () => {
   it('should render status for TOOL_DISCOVERY', () => {
     render(
       <AgentDetails
-        agentInstance={{...mockAgentInstance, status: 'TOOL_DISCOVERY'}}
+        agentInstance={{...agentInstance, status: 'TOOL_DISCOVERY'}}
         isLoading={false}
         isError={false}
       />,
@@ -207,7 +180,7 @@ describe('<AgentDetails />', () => {
 
     render(
       <AgentDetails
-        agentInstance={mockAgentInstance}
+        agentInstance={agentInstance}
         isLoading={false}
         isError={false}
       />,
@@ -233,7 +206,7 @@ describe('<AgentDetails />', () => {
   it('should render usage metrics', () => {
     render(
       <AgentDetails
-        agentInstance={mockAgentInstance}
+        agentInstance={agentInstance}
         isLoading={false}
         isError={false}
       />,
@@ -266,7 +239,7 @@ describe('<AgentDetails />', () => {
   it('should render the model provider and name', () => {
     render(
       <AgentDetails
-        agentInstance={mockAgentInstance}
+        agentInstance={agentInstance}
         isLoading={false}
         isError={false}
       />,
@@ -285,7 +258,7 @@ describe('<AgentDetails />', () => {
   it('should render the system prompt with copy and expand options', () => {
     render(
       <AgentDetails
-        agentInstance={mockAgentInstance}
+        agentInstance={agentInstance}
         isLoading={false}
         isError={false}
       />,
@@ -308,15 +281,16 @@ describe('<AgentDetails />', () => {
 
   it('should not fetch the conversation history until its accordion item is opened', async () => {
     const historySpy = vi.fn();
-    mockSearchAgentInstanceHistory(
-      mockAgentInstance.agentInstanceKey,
-    ).withSuccess(searchResult([]), {mockResolverFn: historySpy});
+    mockSearchAgentInstanceHistory(agentInstance.agentInstanceKey).withSuccess(
+      searchResult([]),
+      {mockResolverFn: historySpy},
+    );
     // Latest message is always fetched. Handle first before history spy handler.
     mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
 
     const {user} = render(
       <AgentDetails
-        agentInstance={mockAgentInstance}
+        agentInstance={agentInstance}
         isLoading={false}
         isError={false}
       />,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -41,6 +41,7 @@ import {IS_CONVERSATION_HISTORY_ENABLED} from 'modules/feature-flags';
 import {isAgentInstanceActive} from 'modules/queries/agentInstances/agentInstanceStatus';
 
 const STATUS_LABELS: Record<AgentInstanceStatus, string> = {
+  UNKNOWN: 'Unknown',
   INITIALIZING: 'Initializing',
   THINKING: 'Thinking',
   TOOL_CALLING: 'Calling tools',

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -33,6 +33,7 @@ import type {
   MessageSubscription,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {mockSearchAgentInstances} from 'modules/mocks/api/v2/agentInstances/searchAgentInstances';
+import {mockAgentInstance} from 'modules/mocks/mockAgentInstance';
 
 const PROCESS_INSTANCE_ID = '111222333';
 const PROCESS_DEFINITION_KEY = '444555666';
@@ -937,38 +938,7 @@ describe('<DetailsTab />', () => {
         },
       ]),
     );
-    mockSearchAgentInstances().withSuccess(
-      searchResult([
-        {
-          agentInstanceKey: '2251799813851828',
-          status: 'TOOL_CALLING',
-          definition: {
-            model: 'gpt-4',
-            provider: 'openai',
-            systemPrompt: 'You are a helpful assistant.',
-          },
-          metrics: {
-            inputTokens: 100,
-            outputTokens: 50,
-            modelCalls: 3,
-            toolCalls: 2,
-          },
-          limits: {
-            maxModelCalls: 10,
-            maxToolCalls: 5,
-            maxTokens: 1000,
-          },
-          elementId: 'Task_1',
-          processInstanceKey: '123456789',
-          processDefinitionKey: '444555666',
-          tenantId: '<default>',
-          creationDate: '2025-01-15T10:00:00.000Z',
-          lastUpdatedDate: '2025-01-15T10:05:00.000Z',
-          completionDate: null,
-          elementInstanceKeys: ['123456789'],
-        },
-      ]),
-    );
+    mockSearchAgentInstances().withSuccess(searchResult([mockAgentInstance()]));
 
     render(<DetailsTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),

--- a/operate/client/src/App/ProcessInstance/TopPanel/AgentStatusOverlay/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/AgentStatusOverlay/index.tsx
@@ -11,6 +11,7 @@ import type {AgentInstanceStatus} from '@camunda/camunda-api-zod-schemas/8.10';
 import {AgentStatus, AgentStatusContainer} from './styled';
 
 const AGENT_STATUS_LABELS: Record<AgentInstanceStatus, string | null> = {
+  UNKNOWN: null,
   INITIALIZING: 'Starting...',
   TOOL_DISCOVERY: 'Discovering tools...',
   THINKING: 'Thinking...',

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -26,7 +26,6 @@ import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinit
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchProcessSequenceFlows} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/sequenceFlows';
 import type {
-  AgentInstance,
   ElementInstance,
   ProcessInstance,
   SequenceFlow,
@@ -44,6 +43,7 @@ import {
   SearchParamsUpdater,
   updateSearchParams,
 } from 'modules/testUtils/SearchParamsUpdater';
+import {mockAgentInstance} from 'modules/mocks/mockAgentInstance';
 
 const mockSequenceFlowsV2: SequenceFlow[] = [
   {
@@ -116,26 +116,6 @@ const mockProcessInstance: ProcessInstance = {
   rootProcessInstanceKey: null,
   tags: [],
   businessId: null,
-};
-
-const mockAgentInstance: AgentInstance = {
-  agentInstanceKey: 'agent-key-1',
-  status: 'THINKING',
-  definition: {
-    model: 'gpt-4',
-    provider: 'openai',
-    systemPrompt: 'you are a helpful agent',
-  },
-  metrics: {inputTokens: 0, outputTokens: 0, modelCalls: 0, toolCalls: 0},
-  limits: {maxModelCalls: 10, maxToolCalls: 10, maxTokens: 1000},
-  elementId: 'service-task-1',
-  processInstanceKey: 'instance_id',
-  processDefinitionKey: '2',
-  tenantId: '<default>',
-  creationDate: '2026-05-28',
-  lastUpdatedDate: '2026-05-28',
-  completionDate: null,
-  elementInstanceKeys: [],
 };
 
 const mockElementInstance: ElementInstance = {
@@ -452,7 +432,9 @@ describe('TopPanel', () => {
   });
 
   it('should render the agent status overlay for an active agent instance', async () => {
-    mockSearchAgentInstances().withSuccess(searchResult([mockAgentInstance]));
+    mockSearchAgentInstances().withSuccess(
+      searchResult([mockAgentInstance({status: 'THINKING'})]),
+    );
 
     render(<TopPanel />, {wrapper: getWrapper()});
 

--- a/operate/client/src/modules/api/v2/agentInstances/searchAgentInstanceHistory.ts
+++ b/operate/client/src/modules/api/v2/agentInstances/searchAgentInstanceHistory.ts
@@ -8,19 +8,19 @@
 
 import {
   endpoints,
-  type SearchAgentInstanceHistoryRequestBody,
-  type SearchAgentInstanceHistoryResponseBody,
+  type QueryAgentInstanceHistoryRequestBody,
+  type QueryAgentInstanceHistoryResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {requestWithThrow} from 'modules/request';
 
 const searchAgentInstanceHistory = async (
   agentInstanceKey: string,
-  payload: SearchAgentInstanceHistoryRequestBody,
+  payload: QueryAgentInstanceHistoryRequestBody,
   signal?: AbortSignal,
 ) => {
-  return requestWithThrow<SearchAgentInstanceHistoryResponseBody>({
-    url: endpoints.searchAgentInstanceHistory.getUrl({agentInstanceKey}),
-    method: endpoints.searchAgentInstanceHistory.method,
+  return requestWithThrow<QueryAgentInstanceHistoryResponseBody>({
+    url: endpoints.queryAgentInstanceHistory.getUrl({agentInstanceKey}),
+    method: endpoints.queryAgentInstanceHistory.method,
     body: payload,
     signal,
   });

--- a/operate/client/src/modules/api/v2/agentInstances/searchAgentInstances.ts
+++ b/operate/client/src/modules/api/v2/agentInstances/searchAgentInstances.ts
@@ -18,8 +18,8 @@ const searchAgentInstances = async (
   signal?: AbortSignal,
 ) => {
   return requestWithThrow<QueryAgentInstancesResponseBody>({
-    url: endpoints.searchAgentInstances.getUrl(),
-    method: endpoints.searchAgentInstances.method,
+    url: endpoints.queryAgentInstances.getUrl(),
+    method: endpoints.queryAgentInstances.method,
     body: payload,
     signal,
   });

--- a/operate/client/src/modules/mocks/api/v2/agentInstances/searchAgentInstanceHistory.ts
+++ b/operate/client/src/modules/mocks/api/v2/agentInstances/searchAgentInstanceHistory.ts
@@ -8,7 +8,7 @@
 
 import {mockPostRequest} from '../../mockRequest';
 import {
-  type SearchAgentInstanceHistoryResponseBody,
+  type QueryAgentInstanceHistoryResponseBody,
   endpoints,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
@@ -16,8 +16,8 @@ const mockSearchAgentInstanceHistory = (
   agentInstanceKey: string = ':agentInstanceKey',
   contextPath = '',
 ) =>
-  mockPostRequest<SearchAgentInstanceHistoryResponseBody>(
-    `${contextPath}${endpoints.searchAgentInstanceHistory.getUrl({agentInstanceKey})}`,
+  mockPostRequest<QueryAgentInstanceHistoryResponseBody>(
+    `${contextPath}${endpoints.queryAgentInstanceHistory.getUrl({agentInstanceKey})}`,
   );
 
 export {mockSearchAgentInstanceHistory};

--- a/operate/client/src/modules/mocks/api/v2/agentInstances/searchAgentInstances.ts
+++ b/operate/client/src/modules/mocks/api/v2/agentInstances/searchAgentInstances.ts
@@ -14,7 +14,7 @@ import {
 
 const mockSearchAgentInstances = (contextPath = '') =>
   mockPostRequest<QueryAgentInstancesResponseBody>(
-    `${contextPath}${endpoints.searchAgentInstances.getUrl()}`,
+    `${contextPath}${endpoints.queryAgentInstances.getUrl()}`,
   );
 
 export {mockSearchAgentInstances};

--- a/operate/client/src/modules/mocks/mockAgentInstance.ts
+++ b/operate/client/src/modules/mocks/mockAgentInstance.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+
+function mockAgentInstance(
+  overwrites: Partial<AgentInstance> = {},
+): AgentInstance {
+  return {
+    agentInstanceKey: '2251799813851828',
+    status: 'TOOL_CALLING',
+    definition: {
+      model: 'gpt-4',
+      provider: 'openai',
+      systemPrompt: 'You are a helpful assistant.',
+    },
+    metrics: {
+      inputTokens: 100,
+      outputTokens: 50,
+      modelCalls: 3,
+      toolCalls: 2,
+    },
+    limits: {
+      maxModelCalls: 10,
+      maxToolCalls: 5,
+      maxTokens: 1000,
+    },
+    tools: [],
+    elementId: 'Activity_1',
+    processInstanceKey: '123456789',
+    rootProcessInstanceKey: '123456789',
+    processDefinitionKey: '444555666',
+    processDefinitionId: 'process-def-1',
+    processDefinitionVersion: 1,
+    processDefinitionVersionTag: null,
+    tenantId: '<default>',
+    creationDate: '2025-01-15T10:00:00.000Z',
+    lastUpdatedDate: '2025-01-15T10:05:00.000Z',
+    completionDate: null,
+    elementInstanceKeys: ['111222333'],
+    ...overwrites,
+  };
+}
+
+export {mockAgentInstance};

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
@@ -9,8 +9,8 @@
 import {useInfiniteQuery, type InfiniteData} from '@tanstack/react-query';
 import type {
   QuerySortOrder,
-  SearchAgentInstanceHistoryRequestBody,
-  SearchAgentInstanceHistoryResponseBody,
+  QueryAgentInstanceHistoryRequestBody,
+  QueryAgentInstanceHistoryResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {searchAgentInstanceHistory} from 'modules/api/v2/agentInstances/searchAgentInstanceHistory';
 import {queryKeys} from '../queryKeys';
@@ -21,16 +21,16 @@ type QueryOptions<T> = {
   enabled?: boolean;
   enablePeriodicRefetch?: boolean;
   sortOrder?: QuerySortOrder;
-  select?: (result: InfiniteData<SearchAgentInstanceHistoryResponseBody>) => T;
+  select?: (result: InfiniteData<QueryAgentInstanceHistoryResponseBody>) => T;
 };
 
 const useAgentInstanceHistory = <
-  T = InfiniteData<SearchAgentInstanceHistoryResponseBody>,
+  T = InfiniteData<QueryAgentInstanceHistoryResponseBody>,
 >(
   agentInstanceKey: string,
   options?: QueryOptions<T>,
 ) => {
-  const historyPayload: SearchAgentInstanceHistoryRequestBody = {
+  const historyPayload: QueryAgentInstanceHistoryRequestBody = {
     sort: [{field: 'producedAt', order: options?.sortOrder ?? 'desc'}],
     filter: {commitStatus: 'COMMITTED'},
   };

--- a/operate/client/src/modules/queries/agentInstances/useLatestAgentMessage.ts
+++ b/operate/client/src/modules/queries/agentInstances/useLatestAgentMessage.ts
@@ -7,11 +7,11 @@
  */
 
 import {useQuery} from '@tanstack/react-query';
-import type {SearchAgentInstanceHistoryRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {QueryAgentInstanceHistoryRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
 import {searchAgentInstanceHistory} from 'modules/api/v2/agentInstances/searchAgentInstanceHistory';
 import {queryKeys} from '../queryKeys';
 
-const REQUEST_BODY: SearchAgentInstanceHistoryRequestBody = {
+const REQUEST_BODY: QueryAgentInstanceHistoryRequestBody = {
   sort: [{field: 'producedAt', order: 'desc'}],
   filter: {commitStatus: 'COMMITTED', role: 'ASSISTANT'},
   page: {limit: 1},

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -27,7 +27,7 @@ import type {
   QueryProcessInstanceIncidentsRequestBody,
   QueryProcessInstancesRequestBody,
   QueryUserTasksRequestBody,
-  SearchAgentInstanceHistoryRequestBody,
+  QueryAgentInstanceHistoryRequestBody,
   Variable,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
@@ -44,7 +44,7 @@ const queryKeys = {
   agentInstanceHistory: {
     search: (
       agentInstanceKey: string,
-      payload?: SearchAgentInstanceHistoryRequestBody,
+      payload?: QueryAgentInstanceHistoryRequestBody,
     ) => ['agentInstanceHistorySearch', agentInstanceKey, payload],
     latestAgentMessage: (agentInstanceKey: string) => [
       'agentInstanceHistorySearch',


### PR DESCRIPTION
## Description

This PR bumps `@camunda/camunda-api-zod-schemas` to the latest version in Operate. The version contains some breaking changes around agent instances (new fields, search --> query), which caused type errors. This PR fixes the type error. It introduces a new `mockAgentInstance` mock factory to create agent-instance test data. This will make future changes easier, and test-files do not have to declare a full agent-instances themself anymore.

## Related issues

relates #55711
