### PR TITLE
test: multi-physical-tenant authorization integration tests (#55443)

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static io.camunda.client.api.search.enums.OwnerType.GROUP;
+import static io.camunda.client.api.search.enums.OwnerType.MAPPING_RULE;
+import static io.camunda.client.api.search.enums.OwnerType.ROLE;
+import static io.camunda.client.api.search.enums.OwnerType.USER;
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Multi-physical-tenant authorization ITs that share a SINGLE 3-PT broker ({@code default}, {@code
+ * tenanta}, {@code tenantb}), with authorizations and basic auth enabled, multi-tenancy disabled,
+ * and a per-PT admin user seeded into each PT. Sharing one broker avoids the topology-await
+ * contention seen when each IT class booted its own heavy 3-PT RDBMS broker serially.
+ *
+ * <p>Each test isolates itself via unique owner/resource ids (UUID-suffixed), so the methods do not
+ * interfere with each other on the shared broker.
+ *
+ * <p>RDBMS-H2 only — Elasticsearch/OpenSearch variants are skipped because per-PT secondary-storage
+ * schema init (#51996) and the per-PT writer (#51736) are not yet available, so non-default PTs
+ * have no ES/OS indices to authorize against.
+ */
+@ZeebeIntegration
+final class MultiPhysicalTenantAuthorizationIT extends MultiPhysicalTenantAuthorizationTestBase {
+
+  @TestZeebe(autoStart = false)
+  private static final TestStandaloneBroker BROKER = configureBroker();
+
+  private static CamundaClient defaultAdmin;
+  private static CamundaClient tenantAAdmin;
+  private static CamundaClient tenantBAdmin;
+
+  @BeforeAll
+  static void startBroker() {
+    BROKER.start().awaitCompleteTopology();
+    defaultAdmin = defaultAdminClient(BROKER);
+    tenantAAdmin = adminClient(BROKER, TENANT_A);
+    tenantBAdmin = adminClient(BROKER, TENANT_B);
+  }
+
+  @AfterAll
+  static void closeClients() {
+    closeQuietly(defaultAdmin);
+    closeQuietly(tenantAAdmin);
+    closeQuietly(tenantBAdmin);
+  }
+
+  /**
+   * IT-1 — control-plane authorization isolation. AC: a permission granted only in tenantb
+   * authorizes a control-plane operation (deploy) via the tenantb path, but the same operation is
+   * denied (403) via the tenanta path; granting the same in tenanta flips it to allowed.
+   */
+  @Test
+  void shouldAuthorizeControlPlaneInGrantedTenantAndDenyInUngrantedTenant() {
+    // given — a restricted user in each PT, with deploy granted ONLY in tenantb
+    final String userInB = createRestrictedUser(tenantBAdmin, "ctrl-b");
+    final String userInA = createRestrictedUser(tenantAAdmin, "ctrl-a");
+    grantDeployPermission(tenantBAdmin, userInB);
+
+    // when / then — the grant authorizes deploy via tenantb (positive)
+    try (final CamundaClient restrictedInB = restrictedClient(BROKER, TENANT_B, userInB)) {
+      awaitDeployAllowed(restrictedInB, "granted user can deploy via tenantb");
+    }
+
+    // and — the same (ungranted) user is forbidden (403) via tenanta (isolation)
+    try (final CamundaClient restrictedInA = restrictedClient(BROKER, TENANT_A, userInA)) {
+      assertThatThrownBy(() -> deploy(restrictedInA))
+          .as("ungranted user is denied via tenanta — a grant in tenantb must not leak")
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("status: 403")
+          .hasMessageContaining("FORBIDDEN");
+
+      // positive control — granting the same permission in tenanta flips it to allowed
+      grantDeployPermission(tenantAAdmin, userInA);
+      awaitDeployAllowed(restrictedInA, "granting in tenanta flips the denial to allowed");
+    }
+  }
+
+  /**
+   * IT-5 — no cross-PT or default-tenant leakage. AC: grants applied in default or tenanta do NOT
+   * authorize in tenantb; an ungranted tenantb user stays denied (403) despite those grants, and
+   * granting in tenantb itself flips it to allowed (positive control).
+   */
+  @Test
+  void shouldNotAuthorizeInTenantBFromGrantsInDefaultOrTenantA() {
+    // given — deploy granted to a user in default and to a user in tenanta...
+    final String userInDefault = createRestrictedUser(defaultAdmin, "leak-default");
+    final String userInA = createRestrictedUser(tenantAAdmin, "leak-a");
+    grantDeployPermission(defaultAdmin, userInDefault);
+    grantDeployPermission(tenantAAdmin, userInA);
+
+    // ...and a restricted user in tenantb that is NOT granted anything
+    final String userInB = createRestrictedUser(tenantBAdmin, "leak-b");
+
+    try (final CamundaClient restrictedInB = restrictedClient(BROKER, TENANT_B, userInB)) {
+      // then — the tenantb user stays denied across the propagation window (leakage would flip it)
+      Awaitility.await("tenantb user stays denied despite grants in default and tenanta")
+          .during(PROPAGATION_TIMEOUT.dividedBy(6))
+          .atMost(PROPAGATION_TIMEOUT)
+          .untilAsserted(
+              () ->
+                  assertThatThrownBy(() -> deploy(restrictedInB))
+                      .as("grants in default/tenanta must not authorize in tenantb")
+                      .isInstanceOf(ProblemException.class)
+                      .hasMessageContaining("status: 403")
+                      .hasMessageContaining("FORBIDDEN"));
+
+      // positive control — granting in tenantb itself flips the tenantb user to allowed
+      grantDeployPermission(tenantBAdmin, userInB);
+      awaitDeployAllowed(restrictedInB, "granting in tenantb itself authorizes the operation");
+    }
+  }
+
+  /**
+   * IT-2 — data-plane request filtering and cross-PT grant non-leakage. AC: a user granted READ on
+   * specific process definitions in tenantb sees only those via the tenantb path; the search result
+   * reflects the in-context PT's grants, not another PT's.
+   *
+   * <p>To make the negative assertion a genuine control (not vacuously true), the SAME reader
+   * username is mirrored into default and tenanta and granted READ on the {@code ungranted}
+   * definition's id there. If a cross-PT grant leaked into tenantb's authorization view, the reader
+   * would then see {@code ungranted} via tenantb and the test would fail — so the {@code
+   * doesNotContain(ungranted)} assertion specifically proves cross-PT grant non-leakage.
+   */
+  @Test
+  void shouldFilterDataPlaneSearchToInContextTenantGrants() {
+    // given — three process definitions deployed in tenantb, READ granted on only two of them
+    final String suffix = UUID.randomUUID().toString().substring(0, 8);
+    final String granted1 = "granted1-" + suffix;
+    final String granted2 = "granted2-" + suffix;
+    final String ungranted = "ungranted-" + suffix;
+    deployNamed(tenantBAdmin, granted1);
+    deployNamed(tenantBAdmin, granted2);
+    deployNamed(tenantBAdmin, ungranted);
+
+    final String reader = createRestrictedUser(tenantBAdmin, "reader-b");
+    grant(
+        tenantBAdmin,
+        reader,
+        USER,
+        READ_PROCESS_DEFINITION,
+        PROCESS_DEFINITION,
+        granted1,
+        granted2);
+
+    // leak trap — the same reader, mirrored into default and tenanta, IS granted READ on the
+    // 'ungranted' id there; a cross-PT leak would surface that id in the tenantb view below
+    createRestrictedUserNamed(defaultAdmin, reader);
+    createRestrictedUserNamed(tenantAAdmin, reader);
+    grant(defaultAdmin, reader, USER, READ_PROCESS_DEFINITION, PROCESS_DEFINITION, ungranted);
+    grant(tenantAAdmin, reader, USER, READ_PROCESS_DEFINITION, PROCESS_DEFINITION, ungranted);
+
+    // when / then — the reader sees exactly the two granted definitions via tenantb (filtered)
+    try (final CamundaClient readerClient = restrictedClient(BROKER, TENANT_B, reader)) {
+      Awaitility.await("reader sees only the granted process definitions via tenantb")
+          .atMost(PROPAGATION_TIMEOUT)
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                final var ids =
+                    readerClient.newProcessDefinitionSearchRequest().send().join().items().stream()
+                        .map(p -> p.getProcessDefinitionId())
+                        .toList();
+                assertThat(ids)
+                    .as("data-plane search is filtered to the reader's tenantb grants")
+                    .contains(granted1, granted2)
+                    .doesNotContain(ungranted);
+              });
+    }
+  }
+
+  /**
+   * IT-3 — membership-derived authorization across PTs. AC: a permission granted to a GROUP, a ROLE
+   * and a MAPPING_RULE (not the user directly) in tenantb authorizes a member user via tenantb but
+   * is denied (403) via tenanta.
+   *
+   * <p>GROUP and ROLE are fully exercised end-to-end: a member user inherits the grant and deploy
+   * succeeds in tenantb. To prove the grant specifically does not leak (rather than merely that the
+   * identity is PT-scoped), the same username is created independently in tenanta with NO
+   * grant/membership; via tenanta the member authenticates but is unauthorized, so the denial is a
+   * true 403, not a 401. MAPPING_RULE binds OIDC token claims to an identity, so a BASIC-auth user
+   * cannot inherit a mapping-rule grant on this harness; for that kind we instead assert the
+   * mapping-rule authorization record is itself PT-isolated (visible via tenantb, absent via
+   * tenanta), which is the membership-authorization signal observable under basic auth.
+   */
+  @Test
+  void shouldDeriveAuthorizationFromGroupRoleAndMappingRuleMembership() {
+    // GROUP membership — grant deploy to a group in tenantb, add a member user
+    final String suffix = UUID.randomUUID().toString().substring(0, 8);
+    final String groupId = "grp-" + suffix;
+    tenantBAdmin.newCreateGroupCommand().groupId(groupId).name(groupId).send().join();
+    final String groupMember = createRestrictedUser(tenantBAdmin, "grp-member");
+    tenantBAdmin.newAssignUserToGroupCommand().username(groupMember).groupId(groupId).send().join();
+    grant(tenantBAdmin, groupId, GROUP, CREATE, RESOURCE, "*");
+
+    // mirror the SAME username into tenanta independently, with NO grant/membership there, so the
+    // cross-tenant denial is a true 403 (identity exists, unauthorized) not a 401 (unknown
+    // identity)
+    createRestrictedUserNamed(tenantAAdmin, groupMember);
+
+    try (final CamundaClient memberClient = restrictedClient(BROKER, TENANT_B, groupMember)) {
+      awaitDeployAllowed(memberClient, "group member inherits deploy grant via tenantb");
+    }
+    try (final CamundaClient memberInA = restrictedClient(BROKER, TENANT_A, groupMember)) {
+      assertDeployForbidden(memberInA, "group grant in tenantb must not authorize via tenanta");
+    }
+
+    // ROLE membership — grant deploy to a role in tenantb, assign a member user
+    final String roleId = "role-" + suffix;
+    tenantBAdmin.newCreateRoleCommand().roleId(roleId).name(roleId).send().join();
+    final String roleMember = createRestrictedUser(tenantBAdmin, "role-member");
+    tenantBAdmin.newAssignRoleToUserCommand().roleId(roleId).username(roleMember).send().join();
+    grant(tenantBAdmin, roleId, ROLE, CREATE, RESOURCE, "*");
+    // mirror the same username into tenanta (ungranted) so the cross-tenant denial is a true 403
+    createRestrictedUserNamed(tenantAAdmin, roleMember);
+
+    try (final CamundaClient memberClient = restrictedClient(BROKER, TENANT_B, roleMember)) {
+      awaitDeployAllowed(memberClient, "role member inherits deploy grant via tenantb");
+    }
+    try (final CamundaClient memberInA = restrictedClient(BROKER, TENANT_A, roleMember)) {
+      assertDeployForbidden(memberInA, "role grant in tenantb must not authorize via tenanta");
+    }
+
+    // MAPPING_RULE membership — assert the mapping-rule authorization record is PT-isolated
+    final String mappingRuleId = "mr-" + suffix;
+    tenantBAdmin
+        .newCreateMappingRuleCommand()
+        .mappingRuleId(mappingRuleId)
+        .name(mappingRuleId)
+        .claimName("groups")
+        .claimValue("tenantb-deployers")
+        .send()
+        .join();
+    grant(tenantBAdmin, mappingRuleId, MAPPING_RULE, CREATE, RESOURCE, "*");
+
+    Awaitility.await("mapping-rule authorization is visible via tenantb")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(authorizationsForOwner(tenantBAdmin, mappingRuleId))
+                    .as("mapping-rule grant created in tenantb is visible via tenantb")
+                    .isNotEmpty());
+    // assert tenanta stays empty over a short window, so a late-arriving leak fails the test
+    Awaitility.await("mapping-rule grant stays absent via tenanta")
+        .during(PROPAGATION_TIMEOUT.dividedBy(6))
+        .atMost(PROPAGATION_TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThat(authorizationsForOwner(tenantAAdmin, mappingRuleId))
+                    .as("mapping-rule grant in tenantb must NOT be visible via tenanta")
+                    .isEmpty());
+  }
+
+  /**
+   * IT-4 — engine batch operation (off the request thread). AC: a batch operation created via the
+   * tenantb path operates only on tenantb's authorized process instances; instances in
+   * default/tenanta are untouched. This exercises the async/off-request authorization path: item
+   * materialization runs on the engine using the creator's PT-scoped authorization, so the batch
+   * must resolve only tenantb instances.
+   */
+  @Test
+  void shouldScopeBatchOperationToCreatingTenantInstances() {
+    final String suffix = UUID.randomUUID().toString().substring(0, 8);
+    final String processId = "batch-" + suffix;
+
+    // given — the same waiting process deployed and instantiated in default, tenanta and tenantb
+    deployWaitingProcess(defaultAdmin, processId);
+    deployWaitingProcess(tenantAAdmin, processId);
+    deployWaitingProcess(tenantBAdmin, processId);
+    final int instancesPerTenant = 2;
+    createInstances(defaultAdmin, processId, instancesPerTenant);
+    createInstances(tenantAAdmin, processId, instancesPerTenant);
+    createInstances(tenantBAdmin, processId, instancesPerTenant);
+    awaitActiveInstances(defaultAdmin, processId, instancesPerTenant);
+    awaitActiveInstances(tenantAAdmin, processId, instancesPerTenant);
+    awaitActiveInstances(tenantBAdmin, processId, instancesPerTenant);
+
+    // when — a cancel batch operation is created via the tenantb path over all active instances
+    final var batch =
+        tenantBAdmin
+            .newCreateBatchOperationCommand()
+            .processInstanceCancel()
+            .filter(f -> f.processDefinitionId(processId))
+            .send()
+            .join();
+
+    // then — the batch resolves only tenantb's instances (off-request authorization is PT-scoped)
+    Awaitility.await("batch operation materializes only tenantb instances")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final List<BatchOperationItem> items =
+                  tenantBAdmin
+                      .newBatchOperationItemsSearchRequest()
+                      .filter(f -> f.batchOperationKey(batch.getBatchOperationKey()))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items)
+                  .as("batch created via tenantb operates only on tenantb's instances")
+                  .hasSize(instancesPerTenant);
+            });
+
+    // and — default and tenanta instances remain active (untouched by tenantb's batch)
+    Awaitility.await("tenantb instances are cancelled by the batch")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(activeInstanceCount(tenantBAdmin, processId)).isZero());
+    assertThat(activeInstanceCount(defaultAdmin, processId))
+        .as("default instances must be untouched by tenantb's batch")
+        .isEqualTo(instancesPerTenant);
+    assertThat(activeInstanceCount(tenantAAdmin, processId))
+        .as("tenanta instances must be untouched by tenantb's batch")
+        .isEqualTo(instancesPerTenant);
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  private void awaitDeployAllowed(final CamundaClient client, final String reason) {
+    Awaitility.await(reason)
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(deploy(client).getProcesses()).as(reason).isNotEmpty());
+  }
+
+  private static void assertDeployForbidden(final CamundaClient client, final String reason) {
+    assertThatThrownBy(() -> deploy(client))
+        .as(reason)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("status: 403")
+        .hasMessageContaining("FORBIDDEN");
+  }
+
+  private static io.camunda.client.api.response.DeploymentEvent deploy(final CamundaClient client) {
+    final String processId = Strings.newRandomValidBpmnId();
+    return client
+        .newDeployResourceCommand()
+        .addProcessModel(simpleProcess(processId), processId + ".bpmn")
+        .send()
+        .join();
+  }
+
+  private static void deployNamed(final CamundaClient client, final String processId) {
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(simpleProcess(processId), processId + ".bpmn")
+        .send()
+        .join();
+  }
+
+  private static void deployWaitingProcess(final CamundaClient client, final String processId) {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("wait", t -> t.zeebeJobType("never-completed-" + processId))
+            .endEvent()
+            .done();
+    client.newDeployResourceCommand().addProcessModel(model, processId + ".bpmn").send().join();
+  }
+
+  private static void createInstances(
+      final CamundaClient client, final String processId, final int count) {
+    for (int i = 0; i < count; i++) {
+      client.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send().join();
+    }
+  }
+
+  private static void awaitActiveInstances(
+      final CamundaClient client, final String processId, final int expected) {
+    Awaitility.await("instances for '" + processId + "' are active and searchable")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertThat(activeInstanceCount(client, processId)).isEqualTo(expected));
+  }
+
+  private static long activeInstanceCount(final CamundaClient client, final String processId) {
+    return client
+        .newProcessInstanceSearchRequest()
+        .filter(f -> f.processDefinitionId(processId).state(ProcessInstanceState.ACTIVE))
+        .send()
+        .join()
+        .items()
+        .size();
+  }
+
+  private static List<?> authorizationsForOwner(final CamundaClient client, final String ownerId) {
+    return client
+        .newAuthorizationSearchRequest()
+        .filter(f -> f.ownerId(ownerId))
+        .send()
+        .join()
+        .items();
+  }
+
+  private static void closeQuietly(final CamundaClient client) {
+    if (client != null) {
+      client.close();
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
@@ -80,26 +80,30 @@ final class MultiPhysicalTenantAuthorizationIT extends MultiPhysicalTenantAuthor
    */
   @Test
   void shouldAuthorizeControlPlaneInGrantedTenantAndDenyInUngrantedTenant() {
-    // given — a restricted user in each PT, with deploy granted ONLY in tenantb
-    final String userInB = createRestrictedUser(tenantBAdmin, "ctrl-b");
-    final String userInA = createRestrictedUser(tenantAAdmin, "ctrl-a");
-    grantDeployPermission(tenantBAdmin, userInB);
+    // given — the same identity mirrored into both PTs, with deploy granted ONLY in tenantb
+    final String username = "ctrl-" + UUID.randomUUID().toString().substring(0, 8);
+    createRestrictedUserNamed(tenantBAdmin, username);
+    createRestrictedUserNamed(tenantAAdmin, username);
+    grantDeployPermission(tenantBAdmin, username);
 
     // when / then — the grant authorizes deploy via tenantb (positive)
-    try (final CamundaClient restrictedInB = restrictedClient(BROKER, TENANT_B, userInB)) {
+    try (final CamundaClient restrictedInB = restrictedClient(BROKER, TENANT_B, username)) {
       awaitDeployAllowed(restrictedInB, "granted user can deploy via tenantb");
     }
 
-    // and — the same (ungranted) user is forbidden (403) via tenanta (isolation)
-    try (final CamundaClient restrictedInA = restrictedClient(BROKER, TENANT_A, userInA)) {
+    // and — the same identity (same ownerId), ungranted in tenanta, is forbidden (403) via tenanta;
+    // a cross-PT leak by ownerId would flip this denial to allowed and fail the test
+    try (final CamundaClient restrictedInA = restrictedClient(BROKER, TENANT_A, username)) {
       assertThatThrownBy(() -> deploy(restrictedInA))
-          .as("ungranted user is denied via tenanta — a grant in tenantb must not leak")
+          .as(
+              "same identity ungranted in tenanta is denied — a grant in tenantb must not leak"
+                  + " (same ownerId, so a cross-PT leak would flip this to allowed)")
           .isInstanceOf(ProblemException.class)
           .hasMessageContaining("status: 403")
           .hasMessageContaining("FORBIDDEN");
 
       // positive control — granting the same permission in tenanta flips it to allowed
-      grantDeployPermission(tenantAAdmin, userInA);
+      grantDeployPermission(tenantAAdmin, username);
       awaitDeployAllowed(restrictedInA, "granting in tenanta flips the denial to allowed");
     }
   }
@@ -111,30 +115,35 @@ final class MultiPhysicalTenantAuthorizationIT extends MultiPhysicalTenantAuthor
    */
   @Test
   void shouldNotAuthorizeInTenantBFromGrantsInDefaultOrTenantA() {
-    // given — deploy granted to a user in default and to a user in tenanta...
-    final String userInDefault = createRestrictedUser(defaultAdmin, "leak-default");
-    final String userInA = createRestrictedUser(tenantAAdmin, "leak-a");
-    grantDeployPermission(defaultAdmin, userInDefault);
-    grantDeployPermission(tenantAAdmin, userInA);
+    // given — the same identity mirrored into default, tenanta, and tenantb; deploy granted only in
+    // default and tenanta (NOT tenantb), so a cross-PT leak of that grant would flip the tenantb
+    // denial to allowed (same ownerId) and fail the test
+    final String username = "leak-" + UUID.randomUUID().toString().substring(0, 8);
+    createRestrictedUserNamed(defaultAdmin, username);
+    createRestrictedUserNamed(tenantAAdmin, username);
+    createRestrictedUserNamed(tenantBAdmin, username);
+    grantDeployPermission(defaultAdmin, username);
+    grantDeployPermission(tenantAAdmin, username);
 
-    // ...and a restricted user in tenantb that is NOT granted anything
-    final String userInB = createRestrictedUser(tenantBAdmin, "leak-b");
-
-    try (final CamundaClient restrictedInB = restrictedClient(BROKER, TENANT_B, userInB)) {
-      // then — the tenantb user stays denied across the propagation window (leakage would flip it)
-      Awaitility.await("tenantb user stays denied despite grants in default and tenanta")
+    try (final CamundaClient restrictedInB = restrictedClient(BROKER, TENANT_B, username)) {
+      // then — the same identity stays denied via tenantb across the propagation window;
+      // a cross-PT leak from default/tenanta would flip this to allowed (same ownerId)
+      Awaitility.await(
+              "same identity stays denied in tenantb despite grants in default and tenanta")
           .during(PROPAGATION_TIMEOUT.dividedBy(6))
           .atMost(PROPAGATION_TIMEOUT)
           .untilAsserted(
               () ->
                   assertThatThrownBy(() -> deploy(restrictedInB))
-                      .as("grants in default/tenanta must not authorize in tenantb")
+                      .as(
+                          "grants in default/tenanta must not authorize the same identity in tenantb"
+                              + " — a cross-PT leak by ownerId would flip this to allowed")
                       .isInstanceOf(ProblemException.class)
                       .hasMessageContaining("status: 403")
                       .hasMessageContaining("FORBIDDEN"));
 
       // positive control — granting in tenantb itself flips the tenantb user to allowed
-      grantDeployPermission(tenantBAdmin, userInB);
+      grantDeployPermission(tenantBAdmin, username);
       awaitDeployAllowed(restrictedInB, "granting in tenantb itself authorizes the operation");
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
@@ -64,6 +64,9 @@ final class MultiPhysicalTenantAuthorizationIT extends MultiPhysicalTenantAuthor
     defaultAdmin = defaultAdminClient(BROKER);
     tenantAAdmin = adminClient(BROKER, TENANT_A);
     tenantBAdmin = adminClient(BROKER, TENANT_B);
+    awaitAdminReady(defaultAdmin, "default admin can authenticate");
+    awaitAdminReady(tenantAAdmin, "tenanta admin can authenticate");
+    awaitAdminReady(tenantBAdmin, "tenantb admin can authenticate");
   }
 
   @AfterAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
@@ -64,9 +64,9 @@ final class MultiPhysicalTenantAuthorizationIT extends MultiPhysicalTenantAuthor
     defaultAdmin = defaultAdminClient(BROKER);
     tenantAAdmin = adminClient(BROKER, TENANT_A);
     tenantBAdmin = adminClient(BROKER, TENANT_B);
-    awaitAdminReady(defaultAdmin, "default admin can authenticate");
-    awaitAdminReady(tenantAAdmin, "tenanta admin can authenticate");
-    awaitAdminReady(tenantBAdmin, "tenantb admin can authenticate");
+    TENANTS.awaitAdminReady(defaultAdmin);
+    TENANTS.awaitAdminReady(tenantAAdmin);
+    TENANTS.awaitAdminReady(tenantBAdmin);
   }
 
   @AfterAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
@@ -336,12 +336,18 @@ final class MultiPhysicalTenantAuthorizationIT extends MultiPhysicalTenantAuthor
         .atMost(PROPAGATION_TIMEOUT)
         .ignoreExceptions()
         .untilAsserted(() -> assertThat(activeInstanceCount(tenantBAdmin, processId)).isZero());
-    assertThat(activeInstanceCount(defaultAdmin, processId))
-        .as("default instances must be untouched by tenantb's batch")
-        .isEqualTo(instancesPerTenant);
-    assertThat(activeInstanceCount(tenantAAdmin, processId))
-        .as("tenanta instances must be untouched by tenantb's batch")
-        .isEqualTo(instancesPerTenant);
+    Awaitility.await("default and tenanta instances stay untouched by tenantb's batch")
+        .during(PROPAGATION_TIMEOUT.dividedBy(6))
+        .atMost(PROPAGATION_TIMEOUT)
+        .untilAsserted(
+            () -> {
+              assertThat(activeInstanceCount(defaultAdmin, processId))
+                  .as("default instances must be untouched by tenantb's batch")
+                  .isEqualTo(instancesPerTenant);
+              assertThat(activeInstanceCount(tenantAAdmin, processId))
+                  .as("tenanta instances must be untouched by tenantb's batch")
+                  .isEqualTo(instancesPerTenant);
+            });
   }
 
   // --- helpers -------------------------------------------------------------

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
@@ -60,7 +60,7 @@ final class MultiPhysicalTenantAuthorizationIT extends MultiPhysicalTenantAuthor
 
   @BeforeAll
   static void startBroker() {
-    BROKER.start().awaitCompleteTopology();
+    BROKER.start();
     defaultAdmin = defaultAdminClient(BROKER);
     tenantAAdmin = adminClient(BROKER, TENANT_A);
     tenantBAdmin = adminClient(BROKER, TENANT_B);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationTestBase.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationTestBase.java
@@ -115,6 +115,17 @@ abstract class MultiPhysicalTenantAuthorizationTestBase {
   }
 
   /**
+   * Waits until the given PT admin client can authenticate (avoids transient post-startup 401s).
+   */
+  protected static void awaitAdminReady(final CamundaClient admin, final String label) {
+    Awaitility.await(label)
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
+  }
+
+  /**
    * Creates a restricted (no-permissions) user with an exact username in the given PT. Useful for
    * mirroring the same identity into multiple PTs (each PT has its own schema), e.g. to prove a
    * cross-PT denial is a true 403 (identity exists, no grant) rather than a 401 (unknown identity).
@@ -123,11 +134,7 @@ abstract class MultiPhysicalTenantAuthorizationTestBase {
       final CamundaClient admin, final String username) {
     // immediately after startup the per-PT admin user may not yet be initialized in its RDBMS
     // schema, so the admin's own request can transiently 401 — wait until it can authenticate
-    Awaitility.await("per-PT admin can authenticate")
-        .atMost(PROPAGATION_TIMEOUT)
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
+    awaitAdminReady(admin, "per-PT admin can authenticate");
     admin
         .newCreateUserCommand()
         .username(username)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationTestBase.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationTestBase.java
@@ -115,17 +115,6 @@ abstract class MultiPhysicalTenantAuthorizationTestBase {
   }
 
   /**
-   * Waits until the given PT admin client can authenticate (avoids transient post-startup 401s).
-   */
-  protected static void awaitAdminReady(final CamundaClient admin, final String label) {
-    Awaitility.await(label)
-        .atMost(PROPAGATION_TIMEOUT)
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
-  }
-
-  /**
    * Creates a restricted (no-permissions) user with an exact username in the given PT. Useful for
    * mirroring the same identity into multiple PTs (each PT has its own schema), e.g. to prove a
    * cross-PT denial is a true 403 (identity exists, no grant) rather than a 401 (unknown identity).
@@ -134,7 +123,7 @@ abstract class MultiPhysicalTenantAuthorizationTestBase {
       final CamundaClient admin, final String username) {
     // immediately after startup the per-PT admin user may not yet be initialized in its RDBMS
     // schema, so the admin's own request can transiently 401 — wait until it can authenticate
-    awaitAdminReady(admin, "per-PT admin can authenticate");
+    TENANTS.awaitAdminReady(admin);
     admin
         .newCreateUserCommand()
         .username(username)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationTestBase.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationTestBase.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static io.camunda.client.api.search.enums.OwnerType.USER;
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+
+/**
+ * Shared setup for the multi-physical-tenant authorization ITs.
+ *
+ * <p>Boots a single broker that serves three physical tenants ({@code default}, {@code tenanta},
+ * {@code tenantb}), each on its own RDBMS-H2 schema, with authorizations and basic auth enabled and
+ * a per-PT admin user seeded into each PT's own {@code security.initialization}. The control-plane
+ * shape exercised by the ITs is: an admin (full permissions, scoped to its PT) creates a restricted
+ * user at runtime and selectively grants it a permission; the restricted user then attempts a
+ * permission-gated operation and we observe allowed (2xx) vs forbidden (403).
+ *
+ * <p>RDBMS-H2 only — Elasticsearch/OpenSearch variants are skipped because per-PT secondary-storage
+ * schema init (#51996) and the per-PT writer (#51736) are not yet available, so non-default PTs
+ * have no ES/OS indices to authorize against.
+ */
+abstract class MultiPhysicalTenantAuthorizationTestBase {
+
+  protected static final String TENANT_A = "tenanta";
+  protected static final String TENANT_B = "tenantb";
+  protected static final String PT_ADMIN_PASSWORD = "ptadmin";
+  protected static final String RESTRICTED_PASSWORD = "restricted";
+  protected static final Duration PROPAGATION_TIMEOUT = Duration.ofSeconds(30);
+
+  protected static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.rdbmsH2("default"))
+          .withTenant(TENANT_A, Storage.rdbmsH2(TENANT_A))
+          .withTenant(TENANT_B, Storage.rdbmsH2(TENANT_B))
+          .build();
+
+  /**
+   * Configures a broker for the multi-PT authorization scenario: storage + per-PT admin role (via
+   * the helper's {@code configure}), basic auth, authorizations enabled, and a seeded per-PT admin
+   * user for {@code tenanta} and {@code tenantb}.
+   */
+  protected static TestStandaloneBroker configureBroker() {
+    final TestStandaloneBroker broker =
+        TENANTS.configure(
+            new TestStandaloneBroker()
+                .withAuthorizationsEnabled()
+                .withAuthenticationMethod(AuthenticationMethod.BASIC));
+    TENANTS.seedBasicAuthAdminUser(broker, TENANT_A, PT_ADMIN_PASSWORD);
+    TENANTS.seedBasicAuthAdminUser(broker, TENANT_B, PT_ADMIN_PASSWORD);
+    return broker;
+  }
+
+  protected static CamundaClient adminClient(
+      final TestStandaloneBroker broker, final String tenantId) {
+    return TENANTS.newBasicAuthAdminClientBuilder(broker, tenantId, PT_ADMIN_PASSWORD).build();
+  }
+
+  /**
+   * Admin client for the {@code default} PT, which authenticates with the broker's built-in default
+   * user (not a {@code <tenant>-admin} user).
+   */
+  protected static CamundaClient defaultAdminClient(final TestStandaloneBroker broker) {
+    return TENANTS
+        .newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID)
+        .preferRestOverGrpc(true)
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder()
+                .applyEnvironmentOverrides(false)
+                .username(InitializationConfiguration.DEFAULT_USER_USERNAME)
+                .password(InitializationConfiguration.DEFAULT_USER_PASSWORD)
+                .build())
+        .build();
+  }
+
+  protected static CamundaClient restrictedClient(
+      final TestStandaloneBroker broker, final String tenantId, final String username) {
+    return TENANTS
+        .newBasicAuthAdminClientBuilder(broker, tenantId, PT_ADMIN_PASSWORD)
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder()
+                .applyEnvironmentOverrides(false)
+                .username(username)
+                .password(RESTRICTED_PASSWORD)
+                .build())
+        .build();
+  }
+
+  /** Creates a restricted (no-permissions) user in the given PT via the PT's admin client. */
+  protected static String createRestrictedUser(final CamundaClient admin, final String prefix) {
+    return createRestrictedUserNamed(
+        admin, prefix + "-" + UUID.randomUUID().toString().substring(0, 8));
+  }
+
+  /**
+   * Creates a restricted (no-permissions) user with an exact username in the given PT. Useful for
+   * mirroring the same identity into multiple PTs (each PT has its own schema), e.g. to prove a
+   * cross-PT denial is a true 403 (identity exists, no grant) rather than a 401 (unknown identity).
+   */
+  protected static String createRestrictedUserNamed(
+      final CamundaClient admin, final String username) {
+    // immediately after startup the per-PT admin user may not yet be initialized in its RDBMS
+    // schema, so the admin's own request can transiently 401 — wait until it can authenticate
+    Awaitility.await("per-PT admin can authenticate")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
+    admin
+        .newCreateUserCommand()
+        .username(username)
+        .password(RESTRICTED_PASSWORD)
+        .name(username)
+        .email(username + "@example.com")
+        .send()
+        .join();
+    // The user must be queryable via this PT before it can authenticate / be granted against.
+    Awaitility.await("restricted user '" + username + "' exists in its PT")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        admin
+                            .newUsersSearchRequest()
+                            .filter(f -> f.username(username))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+    return username;
+  }
+
+  /** Grants {@code CREATE RESOURCE} (deploy) to a user via the given PT's admin client. */
+  protected static void grantDeployPermission(final CamundaClient admin, final String username) {
+    grant(admin, username, USER, CREATE, RESOURCE, "*");
+  }
+
+  /** Grants a permission to an arbitrary owner (user, group, role, mapping rule) in a PT. */
+  protected static void grant(
+      final CamundaClient admin,
+      final String ownerId,
+      final OwnerType ownerType,
+      final PermissionType permission,
+      final ResourceType resourceType,
+      final String... resourceIds) {
+    for (final String resourceId : resourceIds) {
+      admin
+          .newCreateAuthorizationCommand()
+          .ownerId(ownerId)
+          .ownerType(ownerType)
+          .resourceId(resourceId)
+          .resourceType(resourceType)
+          .permissionTypes(permission)
+          .send()
+          .join();
+    }
+  }
+
+  protected static BpmnModelInstance simpleProcess(final String processId) {
+    return Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * IT-6 — per-physical-tenant authorization enablement.
+ *
+ * <p>AC: a PT with {@code authorizations.enabled=false} allows an operation without any grant,
+ * while a distinct authorization-enabled PT denies the same ungranted operation (403). This proves
+ * authorization enablement is configured per physical tenant (via #55792's per-PT engine security
+ * config). Note: multi-tenancy enablement is cluster-wide, not per-PT — this AC is specifically
+ * about per-PT <em>authorization</em> enablement.
+ *
+ * <p>Two PTs are enough: {@code tenant-off} (authz disabled) and {@code tenant-on} (authz enabled),
+ * plus the mandatory {@code default} PT.
+ *
+ * <p>RDBMS-H2 only — Elasticsearch/OpenSearch variants are skipped because per-PT secondary-storage
+ * schema init (#51996) and the per-PT writer (#51736) are not yet available, so non-default PTs
+ * have no ES/OS indices to authorize against.
+ */
+@ZeebeIntegration
+final class PhysicalTenantAuthorizationEnablementIT {
+
+  private static final String TENANT_OFF = "tenantoff";
+  private static final String TENANT_ON = "tenanton";
+  private static final String ADMIN_PASSWORD = "ptadmin";
+  private static final Duration PROPAGATION_TIMEOUT = Duration.ofSeconds(30);
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.rdbmsH2("default"))
+          .withTenant(TENANT_OFF, Storage.rdbmsH2(TENANT_OFF))
+          .withTenant(TENANT_ON, Storage.rdbmsH2(TENANT_ON))
+          .build();
+
+  @TestZeebe(autoStart = false)
+  private static final TestStandaloneBroker BROKER = configure();
+
+  private static CamundaClient tenantOffAdmin;
+  private static CamundaClient tenantOnAdmin;
+
+  private static TestStandaloneBroker configure() {
+    final TestStandaloneBroker broker =
+        TENANTS.configure(
+            new TestStandaloneBroker()
+                .withAuthorizationsEnabled()
+                .withAuthenticationMethod(AuthenticationMethod.BASIC));
+    TENANTS.seedBasicAuthAdminUser(broker, TENANT_OFF, ADMIN_PASSWORD);
+    TENANTS.seedBasicAuthAdminUser(broker, TENANT_ON, ADMIN_PASSWORD);
+    // disable authorization checks for tenant-off only (per-PT engine security config)
+    broker.withPtConfig(TENANT_OFF, c -> c.getSecurity().getAuthorizations().setEnabled(false));
+    return broker;
+  }
+
+  @BeforeAll
+  static void startBroker() {
+    BROKER.start().awaitCompleteTopology();
+    tenantOffAdmin =
+        TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_OFF, ADMIN_PASSWORD).build();
+    tenantOnAdmin =
+        TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_ON, ADMIN_PASSWORD).build();
+  }
+
+  @AfterAll
+  static void closeClients() {
+    if (tenantOffAdmin != null) {
+      tenantOffAdmin.close();
+    }
+    if (tenantOnAdmin != null) {
+      tenantOnAdmin.close();
+    }
+  }
+
+  @Test
+  void shouldEnforceAuthorizationPerTenantEnablement() {
+    // given — an ungranted restricted user in each PT
+    final String userOff = createRestrictedUser(tenantOffAdmin, "off");
+    final String userOn = createRestrictedUser(tenantOnAdmin, "on");
+
+    // then — via the authz-DISABLED PT, the ungranted user can deploy (no grant required)
+    try (final CamundaClient offClient = restrictedClient(TENANT_OFF, userOff)) {
+      Awaitility.await("ungranted user can deploy via the authz-disabled PT")
+          .atMost(PROPAGATION_TIMEOUT)
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  assertThat(deploy(offClient).getProcesses())
+                      .as("authz-disabled PT allows ungranted operations")
+                      .isNotEmpty());
+    }
+
+    // and — via the authz-ENABLED PT, the same ungranted operation is denied (403)
+    try (final CamundaClient onClient = restrictedClient(TENANT_ON, userOn)) {
+      assertThatThrownBy(() -> deploy(onClient))
+          .as("authz-enabled PT denies ungranted operations")
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("status: 403")
+          .hasMessageContaining("FORBIDDEN");
+    }
+  }
+
+  private static String createRestrictedUser(final CamundaClient admin, final String prefix) {
+    final String username = prefix + "-" + UUID.randomUUID().toString().substring(0, 8);
+    // immediately after startup the per-PT admin user may not yet be initialized in its RDBMS
+    // schema, so the admin's own request can transiently 401 — wait until it can authenticate
+    Awaitility.await("per-PT admin can authenticate")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
+    admin
+        .newCreateUserCommand()
+        .username(username)
+        .password("restricted")
+        .name(username)
+        .email(username + "@example.com")
+        .send()
+        .join();
+    Awaitility.await("restricted user '" + username + "' exists")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        admin
+                            .newUsersSearchRequest()
+                            .filter(f -> f.username(username))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+    return username;
+  }
+
+  private static CamundaClient restrictedClient(final String tenantId, final String username) {
+    return TENANTS
+        .newBasicAuthAdminClientBuilder(BROKER, tenantId, ADMIN_PASSWORD)
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder()
+                .applyEnvironmentOverrides(false)
+                .username(username)
+                .password("restricted")
+                .build())
+        .build();
+  }
+
+  private static DeploymentEvent deploy(final CamundaClient client) {
+    final String processId = Strings.newRandomValidBpmnId();
+    return client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(processId).startEvent().endEvent().done(),
+            processId + ".bpmn")
+        .send()
+        .join();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
@@ -81,11 +81,19 @@ final class PhysicalTenantAuthorizationEnablementIT {
 
   @BeforeAll
   static void startBroker() {
-    BROKER.start().awaitCompleteTopology();
+    BROKER.start();
     tenantOffAdmin =
         TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_OFF, ADMIN_PASSWORD).build();
     tenantOnAdmin =
         TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_ON, ADMIN_PASSWORD).build();
+    // gate readiness on per-PT API availability instead of cluster topology
+    for (final CamundaClient admin : new CamundaClient[] {tenantOffAdmin, tenantOnAdmin}) {
+      Awaitility.await("per-PT admin can authenticate")
+          .atMost(PROPAGATION_TIMEOUT)
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
+    }
   }
 
   @AfterAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
@@ -86,14 +86,8 @@ final class PhysicalTenantAuthorizationEnablementIT {
         TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_OFF, ADMIN_PASSWORD).build();
     tenantOnAdmin =
         TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_ON, ADMIN_PASSWORD).build();
-    // gate readiness on per-PT API availability instead of cluster topology
-    for (final CamundaClient admin : new CamundaClient[] {tenantOffAdmin, tenantOnAdmin}) {
-      Awaitility.await("per-PT admin can authenticate")
-          .atMost(PROPAGATION_TIMEOUT)
-          .ignoreExceptions()
-          .untilAsserted(
-              () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
-    }
+    TENANTS.awaitAdminReady(tenantOffAdmin);
+    TENANTS.awaitAdminReady(tenantOnAdmin);
   }
 
   @AfterAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
@@ -78,14 +78,8 @@ final class PhysicalTenantLogicalTenantScopingIT {
     BROKER.start();
     tenantAAdmin = TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_A, ADMIN_PASSWORD).build();
     tenantBAdmin = TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_B, ADMIN_PASSWORD).build();
-    // wait for per-PT admin users to become ready (avoids transient post-startup 401s)
-    for (final CamundaClient admin : new CamundaClient[] {tenantAAdmin, tenantBAdmin}) {
-      Awaitility.await("per-PT admin can authenticate")
-          .atMost(PROPAGATION_TIMEOUT)
-          .ignoreExceptions()
-          .untilAsserted(
-              () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
-    }
+    TENANTS.awaitAdminReady(tenantAAdmin);
+    TENANTS.awaitAdminReady(tenantBAdmin);
   }
 
   @AfterAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * IT-3b — logical-tenant scoping within physical tenants.
+ *
+ * <p>AC: with multi-tenancy enabled cluster-wide, a logical tenant {@code T} (and the data assigned
+ * to it) is created only inside physical tenant tenantb; a tenant-scoped read for {@code T} returns
+ * that data via the tenantb path and excludes it via the tenanta path. This shows logical tenants
+ * are themselves contained within a physical tenant's own schema — a logical tenant id created in
+ * one PT does not resolve in another.
+ *
+ * <p>Multi-tenancy is a cluster-wide toggle (not per-PT); the per-PT containment comes from each
+ * PT's independent schema.
+ *
+ * <p>RDBMS-H2 only — Elasticsearch/OpenSearch variants are skipped because per-PT secondary-storage
+ * schema init (#51996) and the per-PT writer (#51736) are not yet available, so non-default PTs
+ * have no ES/OS indices to read from.
+ */
+@ZeebeIntegration
+final class PhysicalTenantLogicalTenantScopingIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String ADMIN_PASSWORD = "ptadmin";
+  private static final Duration PROPAGATION_TIMEOUT = Duration.ofSeconds(30);
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.rdbmsH2("default"))
+          .withTenant(TENANT_A, Storage.rdbmsH2(TENANT_A))
+          .withTenant(TENANT_B, Storage.rdbmsH2(TENANT_B))
+          .build();
+
+  @TestZeebe(autoStart = false)
+  private static final TestStandaloneBroker BROKER = configure();
+
+  private static CamundaClient tenantAAdmin;
+  private static CamundaClient tenantBAdmin;
+
+  private static TestStandaloneBroker configure() {
+    final TestStandaloneBroker broker =
+        TENANTS.configure(
+            new TestStandaloneBroker()
+                .withAuthorizationsEnabled()
+                .withAuthenticationMethod(AuthenticationMethod.BASIC)
+                .withMultiTenancyEnabled());
+    TENANTS.seedBasicAuthAdminUser(broker, TENANT_A, ADMIN_PASSWORD);
+    TENANTS.seedBasicAuthAdminUser(broker, TENANT_B, ADMIN_PASSWORD);
+    return broker;
+  }
+
+  @BeforeAll
+  static void startBroker() {
+    BROKER.start().awaitCompleteTopology();
+    tenantAAdmin = TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_A, ADMIN_PASSWORD).build();
+    tenantBAdmin = TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_B, ADMIN_PASSWORD).build();
+  }
+
+  @AfterAll
+  static void closeClients() {
+    if (tenantAAdmin != null) {
+      tenantAAdmin.close();
+    }
+    if (tenantBAdmin != null) {
+      tenantBAdmin.close();
+    }
+  }
+
+  @Test
+  void shouldScopeLogicalTenantDataToItsPhysicalTenant() {
+    // given — a logical tenant T created only in tenantb, with the tenantb admin assigned to it
+    final String suffix = UUID.randomUUID().toString().substring(0, 8);
+    final String logicalTenant = "logical-" + suffix;
+    final String processId = "scoped-" + suffix;
+    tenantBAdmin.newCreateTenantCommand().tenantId(logicalTenant).name(logicalTenant).send().join();
+    tenantBAdmin
+        .newAssignUserToTenantCommand()
+        .username(TENANTS.adminUsername(TENANT_B))
+        .tenantId(logicalTenant)
+        .send()
+        .join();
+
+    // and — a process deployed under logical tenant T via the tenantb path
+    Awaitility.await("process deployed under logical tenant T via tenantb")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        tenantBAdmin
+                            .newDeployResourceCommand()
+                            .addProcessModel(
+                                Bpmn.createExecutableProcess(processId)
+                                    .startEvent()
+                                    .endEvent()
+                                    .done(),
+                                processId + ".bpmn")
+                            .tenantId(logicalTenant)
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+
+    // then — a tenant-scoped read for T returns the data via the tenantb path
+    Awaitility.await("logical-tenant-scoped read returns the data via tenantb")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var ids =
+                  tenantBAdmin
+                      .newProcessDefinitionSearchRequest()
+                      .filter(f -> f.tenantId(logicalTenant))
+                      .send()
+                      .join()
+                      .items()
+                      .stream()
+                      .map(p -> p.getProcessDefinitionId())
+                      .toList();
+              assertThat(ids)
+                  .as("logical tenant T's data is visible via its own physical tenant (tenantb)")
+                  .contains(processId);
+            });
+
+    // and — the same logical-tenant-scoped read via the tenanta path excludes the data:
+    // the logical tenant id T was created only in tenantb's schema, so it does not resolve here
+    // assert the exclusion holds continuously over a short window, so a late-arriving leak fails
+    Awaitility.await("logical tenant T's data stays absent via tenanta")
+        .during(PROPAGATION_TIMEOUT.dividedBy(6))
+        .atMost(PROPAGATION_TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var idsViaA =
+                  tenantAAdmin
+                      .newProcessDefinitionSearchRequest()
+                      .filter(f -> f.tenantId(logicalTenant))
+                      .send()
+                      .join()
+                      .items()
+                      .stream()
+                      .map(p -> p.getProcessDefinitionId())
+                      .toList();
+              assertThat(idsViaA)
+                  .as("logical tenant T's data must NOT be visible via a different PT (tenanta)")
+                  .doesNotContain(processId);
+            });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
@@ -78,6 +78,14 @@ final class PhysicalTenantLogicalTenantScopingIT {
     BROKER.start().awaitCompleteTopology();
     tenantAAdmin = TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_A, ADMIN_PASSWORD).build();
     tenantBAdmin = TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_B, ADMIN_PASSWORD).build();
+    // wait for per-PT admin users to become ready (avoids transient post-startup 401s)
+    for (final CamundaClient admin : new CamundaClient[] {tenantAAdmin, tenantBAdmin}) {
+      Awaitility.await("per-PT admin can authenticate")
+          .atMost(PROPAGATION_TIMEOUT)
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
+    }
   }
 
   @AfterAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
@@ -75,7 +75,7 @@ final class PhysicalTenantLogicalTenantScopingIT {
 
   @BeforeAll
   static void startBroker() {
-    BROKER.start().awaitCompleteTopology();
+    BROKER.start();
     tenantAAdmin = TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_A, ADMIN_PASSWORD).build();
     tenantBAdmin = TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_B, ADMIN_PASSWORD).build();
     // wait for per-PT admin users to become ready (avoids transient post-startup 401s)

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -13,6 +13,7 @@ import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -89,21 +90,20 @@ public final class PhysicalTenantsITHelper {
    * defaultRoles.admin} assignment {@link #configure} already sets) into the given tenant's own
    * {@code security.initialization}, so the user can authenticate via that tenant's REST path once
    * authorizations and basic auth are enabled. Basic-auth specific (an OIDC variant would seed a
-   * mapping rule instead). Additive to {@link #configure}; call both.
+   * mapping rule instead). Appends the per-PT admin user to the tenant's existing initialization
+   * users list; call in addition to {@link #configure}.
    */
   public TestStandaloneBroker seedBasicAuthAdminUser(
       final TestStandaloneBroker broker, final String tenantId, final String password) {
     final String username = adminUsername(tenantId);
     broker.withPtConfig(
         tenantId,
-        camunda ->
-            camunda
-                .getSecurity()
-                .getInitialization()
-                .setUsers(
-                    List.of(
-                        new ConfiguredUser(
-                            username, password, username, username + "@example.com"))));
+        camunda -> {
+          final var init = camunda.getSecurity().getInitialization();
+          final var users = new ArrayList<>(init.getUsers());
+          users.add(new ConfiguredUser(username, password, username, username + "@example.com"));
+          init.setUsers(users);
+        });
     return broker;
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -7,12 +7,16 @@
  */
 package io.camunda.zeebe.qa.util.cluster;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -22,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import org.awaitility.Awaitility;
 
 /**
  * Reusable helper for booting a single {@link TestStandaloneBroker} that serves several physical
@@ -56,6 +61,8 @@ import java.util.UUID;
 public final class PhysicalTenantsITHelper {
 
   public static final String DEFAULT_TENANT_ID = "default";
+
+  private static final Duration ADMIN_READY_TIMEOUT = Duration.ofSeconds(30);
 
   private final Map<String, Storage> tenants;
 
@@ -110,6 +117,20 @@ public final class PhysicalTenantsITHelper {
   /** The conventional admin username for a physical tenant: {@code <tenantId>-admin}. */
   public String adminUsername(final String tenantId) {
     return tenantId + "-admin";
+  }
+
+  /**
+   * Waits until the given physical-tenant admin client can authenticate, tolerating the transient
+   * 401s that occur immediately after startup until the PT's admin user is initialized in its
+   * schema. Prefer this over cluster-topology readiness checks for a multi-PT broker, whose
+   * partition-id-keyed topology cannot represent the per-PT raft groups.
+   */
+  public void awaitAdminReady(final CamundaClient admin) {
+    Awaitility.await("per-PT admin can authenticate")
+        .atMost(ADMIN_READY_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -8,8 +8,10 @@
 package io.camunda.zeebe.qa.util.cluster;
 
 import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
 import java.net.URI;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -80,6 +82,51 @@ public final class PhysicalTenantsITHelper {
           }
         });
     return broker;
+  }
+
+  /**
+   * Seeds a basic-auth per-PT admin {@code <tenantId>-admin} user (matching the {@code
+   * defaultRoles.admin} assignment {@link #configure} already sets) into the given tenant's own
+   * {@code security.initialization}, so the user can authenticate via that tenant's REST path once
+   * authorizations and basic auth are enabled. Basic-auth specific (an OIDC variant would seed a
+   * mapping rule instead). Additive to {@link #configure}; call both.
+   */
+  public TestStandaloneBroker seedBasicAuthAdminUser(
+      final TestStandaloneBroker broker, final String tenantId, final String password) {
+    final String username = adminUsername(tenantId);
+    broker.withPtConfig(
+        tenantId,
+        camunda ->
+            camunda
+                .getSecurity()
+                .getInitialization()
+                .setUsers(
+                    List.of(
+                        new ConfiguredUser(
+                            username, password, username, username + "@example.com"))));
+    return broker;
+  }
+
+  /** The conventional admin username for a physical tenant: {@code <tenantId>-admin}. */
+  public String adminUsername(final String tenantId) {
+    return tenantId + "-admin";
+  }
+
+  /**
+   * Builds an authenticated, REST-first client for the basic-auth per-PT admin user (see {@link
+   * #seedBasicAuthAdminUser}). The client is scoped to the tenant's REST path and authenticates
+   * over basic auth.
+   */
+  public CamundaClientBuilder newBasicAuthAdminClientBuilder(
+      final TestGateway<?> gateway, final String tenantId, final String password) {
+    return newClientBuilder(gateway, tenantId)
+        .preferRestOverGrpc(true)
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder()
+                .applyEnvironmentOverrides(false)
+                .username(adminUsername(tenantId))
+                .password(password)
+                .build());
   }
 
   public CamundaClientBuilder newClientBuilder(

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -86,12 +86,12 @@ public final class PhysicalTenantsITHelper {
   }
 
   /**
-   * Seeds a basic-auth per-PT admin {@code <tenantId>-admin} user (matching the {@code
-   * defaultRoles.admin} assignment {@link #configure} already sets) into the given tenant's own
-   * {@code security.initialization}, so the user can authenticate via that tenant's REST path once
-   * authorizations and basic auth are enabled. Basic-auth specific (an OIDC variant would seed a
-   * mapping rule instead). Appends the per-PT admin user to the tenant's existing initialization
-   * users list; call in addition to {@link #configure}.
+   * Seeds a basic-auth per-PT admin {@code <tenantId>-admin} user for a non-{@code default}
+   * physical tenant (matching the {@code defaultRoles.admin} assignment {@link #configure} sets)
+   * into that tenant's {@code security.initialization}, so the user can authenticate via the
+   * tenant-prefixed REST path once authorizations and basic auth are enabled. Basic-auth specific
+   * (an OIDC variant would seed a mapping rule instead). Appends the per-PT admin user to the
+   * tenant's existing initialization users list; call in addition to {@link #configure}.
    */
   public TestStandaloneBroker seedBasicAuthAdminUser(
       final TestStandaloneBroker broker, final String tenantId, final String password) {


### PR DESCRIPTION
## What

Integration-test coverage for #55443 — proving authorization is physical-tenant (PT) correct end-to-end on RDBMS. **Stacked on #55792** (per-PT `EngineSecurityConfig` wiring): this PR's base is the `pt-per-pt-security-config` branch and will be retargeted to `main` once #55792 merges.

Builds on the landed `PhysicalTenantsITHelper` + `TestStandaloneBroker` / `@ZeebeIntegration` harness:
- **`PhysicalTenantsITHelper`** extended additively — `seedAdminUser(...)` (the helper already assigned the per-PT `defaultRoles.admin` but did not seed the user itself) and `newAdminClientBuilder(...)` for an authenticated per-PT client. Existing `configure`/`newClientBuilder` untouched, so `PhysicalTenantIsolationIT` is unaffected.
- **`MultiPhysicalTenantAuthorizationTestBase`** — shared setup for a 3-PT broker (`default`, `tenanta`, `tenantb`, each RDBMS-H2) with authorizations + basic auth enabled and a per-PT admin seeded into each.

### Tests (all 7 acceptance criteria)

`MultiPhysicalTenantAuthorizationIT` shares **one** 3-PT broker across its methods (each isolates via UUID-suffixed ids), avoiding the topology-await contention of booting a heavy 3-PT broker per IT class:
- **IT-1** control-plane isolation — a grant only in tenantb authorizes deploy via tenantb but is 403 via tenanta; granting in tenanta flips it to allowed.
- **IT-2** data-plane request filtering — a user granted READ on specific process definitions sees only those via tenantb.
- **IT-3** membership-derived authorization — grant to a GROUP / ROLE / MAPPING_RULE in tenantb authorizes a member via tenantb, denied via tenanta. The member is mirrored into tenanta **without** a grant, so the cross-PT denial is a true **403** (membership isolation, not just identity isolation).
- **IT-4** engine batch operation (off the request thread) — a cancel batch created via tenantb operates only on tenantb's instances; `default`/tenanta instances are untouched (exercises the async/off-request PT-scoped authorization path).
- **IT-5** no cross-PT / `default` leakage — grants in `default`/tenanta do not authorize in tenantb (positive controls rule out vacuous passes).

Separate classes (distinct broker configs):
- **IT-6** `PhysicalTenantAuthorizationEnablementIT` — a PT with `authorizations.enabled=false` allows an ungranted op while a distinct authz-enabled PT denies it (403). Confirms per-PT authorization enablement actually overrides the cluster default (a behavioral confirmation of #55792).
- **IT-3b** `PhysicalTenantLogicalTenantScopingIT` — with multi-tenancy enabled cluster-wide, a logical tenant created in tenantb is visible via tenantb's tenant-scoped read and excluded via tenanta's.
- **IT-7** `SinglePhysicalTenantAuthorizationRegressionIT` — the plain single-PT (unprefixed, default-tenant) authorization path is unperturbed.

All green: 9 tests, 0 failures across the 4 new/changed classes + the existing `PhysicalTenantIsolationIT` (5 broker boots, no contention).

## Notes for review

- **Mapping-rule enforcement needs OIDC.** Mapping rules bind token claims to identities, so under basic auth a member can't inherit a mapping-rule grant; IT-3 covers the mapping-rule case as authorization-record PT-isolation rather than end-to-end enforcement. End-to-end mapping-rule enforcement would need an OIDC harness.
- ES/OS variants are skipped until the per-PT writer (#51736) and schema init (#51996) land; the CamundaExporter writes one static index-prefix, so non-default PTs have no isolated ES/OS indices yet. RDBMS-only for now.

Closes #55443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
