### PR TITLE
deps: bump camunda-security-library to 0.1.0-alpha35

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha34</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha35</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Description

Bumps `version.camunda-security-library` `0.1.0-alpha34 → 0.1.0-alpha35`.

alpha35 ships **`ScopedOidcClaimsProviderFactory`** (camunda/camunda-security-library#447), which the per-PT gRPC handler registry (#55753) will use to build a per-physical-tenant `OidcClaimsProvider` from an `AuthenticationConfiguration`. This bump makes that factory available on the classpath and as an autowirable bean. The per-PT wiring that actually calls `buildClaimsProvider(...)` lands in #55753 (registry) and is exercised end-to-end by #55754 (interceptor) — adding a monorepo wrapper here would be redundant, so this PR is the bump only.

## Behavior change in alpha35 (validated non-breaking here)

alpha35 also makes CSL's cluster-level `OidcClaimsProvider` (`OidcClaimsProviderConfiguration`) **fail fast** (`IllegalStateException`) when userinfo augmentation is enabled but no issuer→userInfoUri mapping can be derived (no provider, no `userInfoUri`, or a non-iterable `ClientRegistrationRepository`) — previously a WARN-and-continue.

Validated non-breaking in this repo:
- Full-repo build (`./mvnw install -Dquickly -T1C`) is green — no alpha34→alpha35 API breaks.
- Userinfo augmentation defaults **off**; the only place it is enabled is `OidcBearerUserInfoClaimGapIT`, whose WireMock discovery stub exposes a `userinfo_endpoint`, so the mapping is non-empty and the fail-fast does not trigger — all 3 of its tests pass.
- `authentication` module suite green (302 unit + 11 IT).
- No other test/config enables augmentation, and nothing in the monorepo constructs the CSL OIDC beans directly.

## Acceptance criteria (#55752)

- [x] `version.camunda-security-library` bumped to the release containing `ScopedOidcClaimsProviderFactory`.
- [x] The per-PT `OidcClaimsProvider` is obtainable gateway-side from a per-PT `AuthenticationConfiguration` (via the now-available `ScopedOidcClaimsProviderFactory` bean) for use by #55753.
- [ ] _(End-to-end: per-PT augmentation actually runs for the target PT, and disabled/unset configs noop — exercised by #55753 + #55754, which depend on this bump.)_

Parent: #54896 — Physical Tenants Identity, Slice 2 (gRPC). Design: ADR-0006.

Closes #55752

🤖 Generated with [Claude Code](https://claude.com/claude-code)