### PR TITLE
ci: Update CPT connectors image version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -836,7 +836,7 @@
         "/testing/camunda-process-test-java/pom\\.xml$/"
       ],
       "matchStrings": [
-        "<io\\.camunda\\.process\\.test\\.connectorsDockerImageVersion>(?<currentValue>[^<]+)</io\\.camunda\\.process\\.test\\.connectorsDockerImageVersion>"
+        "<io\\.camunda\\.process\\.test\\.connectorsDockerImageVersion>(?<currentValue>\\d+\\.\\d+\\.\\d+)</io\\.camunda\\.process\\.test\\.connectorsDockerImageVersion>"
       ],
       "depNameTemplate": "camunda/connectors-bundle",
       "datasourceTemplate": "docker"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -92,6 +92,39 @@
       "enabled": false
     },
     {
+      "description": "For stable branches, keep the connectors bundle Docker image override in process test on the latest patch level.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "camunda/connectors-bundle"
+      ],
+      "matchBaseBranches": [
+        "/^stable\\/8\\..*/"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "enabled": true
+    },
+    {
+      "description": "For stable branches, prevent minor/major connectors bundle Docker image updates in process test.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "camunda/connectors-bundle"
+      ],
+      "matchBaseBranches": [
+        "/^stable\\/8\\..*/"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Disable npm patch updates for frontend apps on stable branches.",
       "matchManagers": [
         "npm"
@@ -795,6 +828,18 @@
       "matchStrings": [
         "<!-- renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+) -->\\s*<[^>]+>(?<currentValue>[^<]+)</"
       ]
+    },
+    {
+      "description": "Track the connectors bundle Docker image override in process test pom.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/testing/camunda-process-test-java/pom\\.xml$/"
+      ],
+      "matchStrings": [
+        "<io\\.camunda\\.process\\.test\\.connectorsDockerImageVersion>(?<currentValue>[^<]+)</io\\.camunda\\.process\\.test\\.connectorsDockerImageVersion>"
+      ],
+      "depNameTemplate": "camunda/connectors-bundle",
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
## Description

On the stable branches, CPT refers to a fixed Connector's image version in the POM file.

Use Renovate to update the image version to the latest available patch version.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to https://github.com/camunda/camunda/issues/50779