### PR TITLE
refactor: scope RdbmsService to a single physical tenant

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -54,210 +54,198 @@ import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.Builder;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.RdbmsWriters;
-import java.util.Map;
 import java.util.function.Consumer;
 
 /**
- * A holder for all rdbms services. Reads are served per physical tenant: each {@code getXxxReader}
- * accessor takes a {@code physicalTenantId} and returns the reader backed by that tenant's own
- * datasource.
+ * A holder for all rdbms services scoped to a single physical tenant. Each instance is bound to one
+ * physical tenant's datasource and is created on demand via {@link RdbmsServiceFactory}; readers,
+ * writers and the replication status provider it exposes all operate against that tenant's storage.
  */
 public class RdbmsService {
 
   private final RdbmsWriterFactory rdbmsWriterFactory;
-  private final Map<String, RdbmsTenantReaders> tenantReaders;
+  private final RdbmsTenantReaders tenantReaders;
   private final ReplicationLogStatusProviderFactory replicationLogStatusProviderFactory;
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
-      final Map<String, RdbmsTenantReaders> tenantReaders,
+      final RdbmsTenantReaders tenantReaders,
       final ReplicationLogStatusProviderFactory replicationLogStatusProviderFactory) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
-    this.tenantReaders = Map.copyOf(tenantReaders);
+    this.tenantReaders = tenantReaders;
     this.replicationLogStatusProviderFactory = replicationLogStatusProviderFactory;
   }
 
-  private RdbmsTenantReaders readers(final String physicalTenantId) {
-    final var readers = tenantReaders.get(physicalTenantId);
-    if (readers == null) {
-      throw new IllegalArgumentException(
-          "No RDBMS readers for physical tenant '%s'; known physical tenants: %s"
-              .formatted(physicalTenantId, tenantReaders.keySet()));
-    }
-    return readers;
+  public AuthorizationDbReader getAuthorizationReader() {
+    return tenantReaders.authorizationReader();
   }
 
-  public AuthorizationDbReader getAuthorizationReader(final String physicalTenantId) {
-    return readers(physicalTenantId).authorizationReader();
+  public AuditLogDbReader getAuditLogReader() {
+    return tenantReaders.auditLogReader();
   }
 
-  public AuditLogDbReader getAuditLogReader(final String physicalTenantId) {
-    return readers(physicalTenantId).auditLogReader();
+  public DecisionDefinitionDbReader getDecisionDefinitionReader() {
+    return tenantReaders.decisionDefinitionReader();
   }
 
-  public DecisionDefinitionDbReader getDecisionDefinitionReader(final String physicalTenantId) {
-    return readers(physicalTenantId).decisionDefinitionReader();
+  public DecisionInstanceDbReader getDecisionInstanceReader() {
+    return tenantReaders.decisionInstanceReader();
   }
 
-  public DecisionInstanceDbReader getDecisionInstanceReader(final String physicalTenantId) {
-    return readers(physicalTenantId).decisionInstanceReader();
+  public DecisionRequirementsDbReader getDecisionRequirementsReader() {
+    return tenantReaders.decisionRequirementsReader();
   }
 
-  public DecisionRequirementsDbReader getDecisionRequirementsReader(final String physicalTenantId) {
-    return readers(physicalTenantId).decisionRequirementsReader();
+  public FlowNodeInstanceDbReader getFlowNodeInstanceReader() {
+    return tenantReaders.flowNodeInstanceReader();
   }
 
-  public FlowNodeInstanceDbReader getFlowNodeInstanceReader(final String physicalTenantId) {
-    return readers(physicalTenantId).flowNodeInstanceReader();
+  public GroupDbReader getGroupReader() {
+    return tenantReaders.groupReader();
   }
 
-  public GroupDbReader getGroupReader(final String physicalTenantId) {
-    return readers(physicalTenantId).groupReader();
+  public GroupMemberDbReader getGroupMemberReader() {
+    return tenantReaders.groupMemberReader();
   }
 
-  public GroupMemberDbReader getGroupMemberReader(final String physicalTenantId) {
-    return readers(physicalTenantId).groupMemberReader();
+  public IncidentDbReader getIncidentReader() {
+    return tenantReaders.incidentReader();
   }
 
-  public IncidentDbReader getIncidentReader(final String physicalTenantId) {
-    return readers(physicalTenantId).incidentReader();
+  public ProcessDefinitionDbReader getProcessDefinitionReader() {
+    return tenantReaders.processDefinitionReader();
   }
 
-  public ProcessDefinitionDbReader getProcessDefinitionReader(final String physicalTenantId) {
-    return readers(physicalTenantId).processDefinitionReader();
+  public ProcessInstanceDbReader getProcessInstanceReader() {
+    return tenantReaders.processInstanceReader();
   }
 
-  public ProcessInstanceDbReader getProcessInstanceReader(final String physicalTenantId) {
-    return readers(physicalTenantId).processInstanceReader();
+  public TenantDbReader getTenantReader() {
+    return tenantReaders.tenantReader();
   }
 
-  public TenantDbReader getTenantReader(final String physicalTenantId) {
-    return readers(physicalTenantId).tenantReader();
+  public TenantMemberDbReader getTenantMemberReader() {
+    return tenantReaders.tenantMemberReader();
   }
 
-  public TenantMemberDbReader getTenantMemberReader(final String physicalTenantId) {
-    return readers(physicalTenantId).tenantMemberReader();
+  public VariableDbReader getVariableReader() {
+    return tenantReaders.variableReader();
   }
 
-  public VariableDbReader getVariableReader(final String physicalTenantId) {
-    return readers(physicalTenantId).variableReader();
+  public ClusterVariableDbReader getClusterVariableReader() {
+    return tenantReaders.clusterVariableReader();
   }
 
-  public ClusterVariableDbReader getClusterVariableReader(final String physicalTenantId) {
-    return readers(physicalTenantId).clusterVariableReader();
+  public WaitStateDbReader getWaitStateReader() {
+    return tenantReaders.waitStateReader();
   }
 
-  public WaitStateDbReader getWaitStateReader(final String physicalTenantId) {
-    return readers(physicalTenantId).waitStateReader();
+  public RoleDbReader getRoleReader() {
+    return tenantReaders.roleReader();
   }
 
-  public RoleDbReader getRoleReader(final String physicalTenantId) {
-    return readers(physicalTenantId).roleReader();
+  public RoleMemberDbReader getRoleMemberReader() {
+    return tenantReaders.roleMemberReader();
   }
 
-  public RoleMemberDbReader getRoleMemberReader(final String physicalTenantId) {
-    return readers(physicalTenantId).roleMemberReader();
+  public UserDbReader getUserReader() {
+    return tenantReaders.userReader();
   }
 
-  public UserDbReader getUserReader(final String physicalTenantId) {
-    return readers(physicalTenantId).userReader();
+  public UserTaskDbReader getUserTaskReader() {
+    return tenantReaders.userTaskReader();
   }
 
-  public UserTaskDbReader getUserTaskReader(final String physicalTenantId) {
-    return readers(physicalTenantId).userTaskReader();
+  public FormDbReader getFormReader() {
+    return tenantReaders.formReader();
   }
 
-  public FormDbReader getFormReader(final String physicalTenantId) {
-    return readers(physicalTenantId).formReader();
+  public MappingRuleDbReader getMappingRuleReader() {
+    return tenantReaders.mappingRuleReader();
   }
 
-  public MappingRuleDbReader getMappingRuleReader(final String physicalTenantId) {
-    return readers(physicalTenantId).mappingRuleReader();
+  public BatchOperationDbReader getBatchOperationReader() {
+    return tenantReaders.batchOperationReader();
   }
 
-  public BatchOperationDbReader getBatchOperationReader(final String physicalTenantId) {
-    return readers(physicalTenantId).batchOperationReader();
+  public SequenceFlowDbReader getSequenceFlowReader() {
+    return tenantReaders.sequenceFlowReader();
   }
 
-  public SequenceFlowDbReader getSequenceFlowReader(final String physicalTenantId) {
-    return readers(physicalTenantId).sequenceFlowReader();
+  public UsageMetricsDbReader getUsageMetricReader() {
+    return tenantReaders.usageMetricsReader();
   }
 
-  public UsageMetricsDbReader getUsageMetricReader(final String physicalTenantId) {
-    return readers(physicalTenantId).usageMetricsReader();
+  public UsageMetricTUDbReader getUsageMetricTUReader() {
+    return tenantReaders.usageMetricsTUReader();
   }
 
-  public UsageMetricTUDbReader getUsageMetricTUReader(final String physicalTenantId) {
-    return readers(physicalTenantId).usageMetricsTUReader();
+  public BatchOperationItemDbReader getBatchOperationItemReader() {
+    return tenantReaders.batchOperationItemReader();
   }
 
-  public BatchOperationItemDbReader getBatchOperationItemReader(final String physicalTenantId) {
-    return readers(physicalTenantId).batchOperationItemReader();
+  public JobDbReader getJobReader() {
+    return tenantReaders.jobReader();
   }
 
-  public JobDbReader getJobReader(final String physicalTenantId) {
-    return readers(physicalTenantId).jobReader();
+  public JobMetricsBatchDbReader getJobMetricsBatchDbReader() {
+    return tenantReaders.jobMetricsBatchReader();
   }
 
-  public JobMetricsBatchDbReader getJobMetricsBatchDbReader(final String physicalTenantId) {
-    return readers(physicalTenantId).jobMetricsBatchReader();
-  }
-
-  public MessageSubscriptionDbReader getMessageSubscriptionReader(final String physicalTenantId) {
-    return readers(physicalTenantId).messageSubscriptionReader();
+  public MessageSubscriptionDbReader getMessageSubscriptionReader() {
+    return tenantReaders.messageSubscriptionReader();
   }
 
   public ProcessDefinitionMessageSubscriptionStatisticsDbReader
-      getProcessDefinitionMessageSubscriptionStatisticsDbReader(final String physicalTenantId) {
-    return readers(physicalTenantId).processDefinitionMessageSubscriptionStatisticsReader();
+      getProcessDefinitionMessageSubscriptionStatisticsDbReader() {
+    return tenantReaders.processDefinitionMessageSubscriptionStatisticsReader();
   }
 
-  public CorrelatedMessageSubscriptionDbReader getCorrelatedMessageSubscriptionReader(
-      final String physicalTenantId) {
-    return readers(physicalTenantId).correlatedMessageSubscriptionReader();
+  public CorrelatedMessageSubscriptionDbReader getCorrelatedMessageSubscriptionReader() {
+    return tenantReaders.correlatedMessageSubscriptionReader();
   }
 
-  public ProcessDefinitionInstanceStatisticsDbReader getProcessDefinitionInstanceStatisticsReader(
-      final String physicalTenantId) {
-    return readers(physicalTenantId).processDefinitionInstanceStatisticsReader();
+  public ProcessDefinitionInstanceStatisticsDbReader
+      getProcessDefinitionInstanceStatisticsReader() {
+    return tenantReaders.processDefinitionInstanceStatisticsReader();
   }
 
   public ProcessDefinitionInstanceVersionStatisticsDbReader
-      getProcessDefinitionInstanceVersionStatisticsReader(final String physicalTenantId) {
-    return readers(physicalTenantId).processDefinitionInstanceVersionStatisticsReader();
+      getProcessDefinitionInstanceVersionStatisticsReader() {
+    return tenantReaders.processDefinitionInstanceVersionStatisticsReader();
   }
 
   public IncidentProcessInstanceStatisticsByErrorDbReader
-      getIncidentProcessInstanceStatisticsByErrorDbReader(final String physicalTenantId) {
-    return readers(physicalTenantId).incidentProcessInstanceStatisticsByErrorReader();
+      getIncidentProcessInstanceStatisticsByErrorDbReader() {
+    return tenantReaders.incidentProcessInstanceStatisticsByErrorReader();
   }
 
   public IncidentProcessInstanceStatisticsByDefinitionDbReader
-      getIncidentProcessInstanceStatisticsByDefinitionReader(final String physicalTenantId) {
-    return readers(physicalTenantId).incidentProcessInstanceStatisticsByDefinitionReader();
+      getIncidentProcessInstanceStatisticsByDefinitionReader() {
+    return tenantReaders.incidentProcessInstanceStatisticsByDefinitionReader();
   }
 
-  public HistoryDeletionDbReader getHistoryDeletionDbReader(final String physicalTenantId) {
-    return readers(physicalTenantId).historyDeletionReader();
+  public HistoryDeletionDbReader getHistoryDeletionDbReader() {
+    return tenantReaders.historyDeletionReader();
   }
 
-  public AgentInstanceDbReader getAgentInstanceDbReader(final String physicalTenantId) {
-    return readers(physicalTenantId).agentInstanceReader();
+  public AgentInstanceDbReader getAgentInstanceDbReader() {
+    return tenantReaders.agentInstanceReader();
   }
 
-  public GlobalListenerDbReader getGlobalListenerDbReader(final String physicalTenantId) {
-    return readers(physicalTenantId).globalListenerReader();
+  public GlobalListenerDbReader getGlobalListenerDbReader() {
+    return tenantReaders.globalListenerReader();
   }
 
-  public DeployedResourceDbReader getResourceDbReader(final String physicalTenantId) {
-    return readers(physicalTenantId).deployedResourceReader();
+  public DeployedResourceDbReader getResourceDbReader() {
+    return tenantReaders.deployedResourceReader();
   }
 
   public ReplicationLogStatusProvider getReplicationLogStatusProvider() {
     return replicationLogStatusProviderFactory.create();
   }
 
-  public RdbmsWriters createWriter(final long partitionId) { // todo fix in all itests afterwards?
+  public RdbmsWriters createWriter(final long partitionId) {
     return createWriter(new RdbmsWriterConfig.Builder().partitionId((int) partitionId).build());
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsServiceFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsServiceFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import io.camunda.db.rdbms.read.RdbmsTenantReaders;
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProviderFactory;
+import io.camunda.db.rdbms.write.RdbmsMapperBundle;
+import io.camunda.db.rdbms.write.RdbmsWriterFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
+
+/**
+ * Creates {@link RdbmsService} instances scoped to a single physical tenant. Each physical tenant
+ * connects to its own RDBMS through its own datasource, so the service is built on demand once the
+ * physical tenant is known (e.g. from the exporter {@code Context} at configure time) by combining
+ * that tenant's {@link RdbmsMapperBundle} and {@link RdbmsTenantReaders}.
+ */
+public class RdbmsServiceFactory {
+  private final Map<String, RdbmsMapperBundle> rdbmsMapperBundles;
+  private final Map<String, RdbmsTenantReaders> rdbmsTenantReaders;
+  private final MeterRegistry meterRegistry;
+
+  public RdbmsServiceFactory(
+      final Map<String, RdbmsMapperBundle> rdbmsMapperBundles,
+      final Map<String, RdbmsTenantReaders> rdbmsTenantReaders,
+      final MeterRegistry meterRegistry) {
+    this.rdbmsMapperBundles = rdbmsMapperBundles;
+    this.rdbmsTenantReaders = rdbmsTenantReaders;
+    this.meterRegistry = meterRegistry;
+  }
+
+  public RdbmsService createRdbmsService(final String physicalTenantId) {
+    final var rdbmsMapperBundle = rdbmsMapperBundles.get(physicalTenantId);
+    if (rdbmsMapperBundle == null) {
+      throw new IllegalArgumentException(
+          "Missing RDBMS mapper bundle for physical tenant '%s'".formatted(physicalTenantId));
+    }
+    final var rdbmsTenantReader = rdbmsTenantReaders.get(physicalTenantId);
+    if (rdbmsTenantReader == null) {
+      throw new IllegalArgumentException(
+          "Missing RDBMS readers for physical tenant '%s'".formatted(physicalTenantId));
+    }
+    final var rdbmsWriterFactory = new RdbmsWriterFactory(rdbmsMapperBundle, meterRegistry);
+    final var replicationLogStatusProviderFactory =
+        new ReplicationLogStatusProviderFactory(
+            rdbmsMapperBundle.vendorDatabaseProperties(),
+            rdbmsMapperBundle.replicationStatusMapper());
+    return new RdbmsService(
+        rdbmsWriterFactory, rdbmsTenantReader, replicationLogStatusProviderFactory);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -10,32 +10,23 @@ package io.camunda.db.rdbms.write;
 import io.camunda.db.rdbms.write.queue.DefaultExecutionQueue;
 import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.Map;
 
 public class RdbmsWriterFactory {
 
-  private final Map<String, RdbmsMapperBundle> mapperBundles;
+  private final RdbmsMapperBundle mapperBundle;
   private final MeterRegistry meterRegistry;
 
   public RdbmsWriterFactory(
-      final Map<String, RdbmsMapperBundle> mapperBundles, final MeterRegistry meterRegistry) {
-    this.mapperBundles = mapperBundles;
+      final RdbmsMapperBundle mapperBundle, final MeterRegistry meterRegistry) {
+    this.mapperBundle = mapperBundle;
     this.meterRegistry = meterRegistry;
   }
 
   public RdbmsWriters createWriter(final RdbmsWriterConfig config) {
-    final var bundle = mapperBundles.get(config.physicalTenantId());
-    if (bundle == null) {
-      throw new IllegalArgumentException(
-          "No RdbmsMapperBundle registered for physical tenant '"
-              + config.physicalTenantId()
-              + "'. Known tenants: "
-              + mapperBundles.keySet());
-    }
     final var metrics = new RdbmsWriterMetrics(meterRegistry, config.partitionId());
     final var executionQueue =
         new DefaultExecutionQueue(
-            bundle.sqlSessionFactory(),
+            mapperBundle.sqlSessionFactory(),
             config.partitionId(),
             config.queueSize(),
             config.queueMemoryLimit(),
@@ -43,31 +34,31 @@ public class RdbmsWriterFactory {
     return new RdbmsWriters(
         config,
         executionQueue,
-        new ExporterPositionService(executionQueue, bundle.exporterPositionMapper()),
+        new ExporterPositionService(executionQueue, mapperBundle.exporterPositionMapper()),
         metrics,
-        bundle.auditLogMapper(),
-        bundle.decisionInstanceMapper(),
-        bundle.decisionDefinitionMapper(),
-        bundle.decisionRequirementsMapper(),
-        bundle.flowNodeInstanceMapper(),
-        bundle.incidentMapper(),
-        bundle.processInstanceMapper(),
-        bundle.processDefinitionMapper(),
-        bundle.purgeMapper(),
-        bundle.userTaskMapper(),
-        bundle.variableMapper(),
-        bundle.vendorDatabaseProperties(),
-        bundle.jobMapper(),
-        bundle.jobMetricsBatchMapper(),
-        bundle.sequenceFlowMapper(),
-        bundle.usageMetricMapper(),
-        bundle.usageMetricTUMapper(),
-        bundle.batchOperationMapper(),
-        bundle.messageSubscriptionMapper(),
-        bundle.correlatedMessageSubscriptionMapper(),
-        bundle.clusterVariableMapper(),
-        bundle.historyDeletionMapper(),
-        bundle.agentInstanceMapper(),
-        bundle.waitStateMapper());
+        mapperBundle.auditLogMapper(),
+        mapperBundle.decisionInstanceMapper(),
+        mapperBundle.decisionDefinitionMapper(),
+        mapperBundle.decisionRequirementsMapper(),
+        mapperBundle.flowNodeInstanceMapper(),
+        mapperBundle.incidentMapper(),
+        mapperBundle.processInstanceMapper(),
+        mapperBundle.processDefinitionMapper(),
+        mapperBundle.purgeMapper(),
+        mapperBundle.userTaskMapper(),
+        mapperBundle.variableMapper(),
+        mapperBundle.vendorDatabaseProperties(),
+        mapperBundle.jobMapper(),
+        mapperBundle.jobMetricsBatchMapper(),
+        mapperBundle.sequenceFlowMapper(),
+        mapperBundle.usageMetricMapper(),
+        mapperBundle.usageMetricTUMapper(),
+        mapperBundle.batchOperationMapper(),
+        mapperBundle.messageSubscriptionMapper(),
+        mapperBundle.correlatedMessageSubscriptionMapper(),
+        mapperBundle.clusterVariableMapper(),
+        mapperBundle.historyDeletionMapper(),
+        mapperBundle.agentInstanceMapper(),
+        mapperBundle.waitStateMapper());
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsServiceFactoryTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsServiceFactoryTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.db.rdbms.read.RdbmsTenantReaders;
+import io.camunda.db.rdbms.write.RdbmsMapperBundle;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Map;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class RdbmsServiceFactoryTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"a", "b"})
+  void shouldRejectUnknownPhysicalTenant(final String physicalTenantId) {
+    // given
+    final Map<String, RdbmsMapperBundle> mapperBundle = Map.of("a", mock(RdbmsMapperBundle.class));
+    final Map<String, RdbmsTenantReaders> readers = Map.of("b", mock(RdbmsTenantReaders.class));
+    final var factory = new RdbmsServiceFactory(mapperBundle, readers, new SimpleMeterRegistry());
+
+    // when / then
+    assertThatThrownBy(() -> factory.createRdbmsService(physicalTenantId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Missing RDBMS")
+        .hasMessageContaining("physical tenant '%s'".formatted(physicalTenantId));
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterFactoryTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterFactoryTest.java
@@ -8,7 +8,6 @@
 package io.camunda.db.rdbms.write;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
@@ -49,52 +48,39 @@ import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.sql.WaitStateMapper;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.util.Map;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.junit.jupiter.api.Test;
 
-class RdbmsWriterFactoryTenantRoutingTest {
+class RdbmsWriterFactoryTest {
 
   @Test
-  void shouldRouteToBundleForRequestedTenant() {
+  void shouldCreateWriterFromBundle() {
     // given
-    final var defaultBundle = newBundle();
-    final var tenantABundle = newBundle();
-    final var factory =
-        new RdbmsWriterFactory(
-            Map.of("default", defaultBundle, "tenantA", tenantABundle), new SimpleMeterRegistry());
+    final var factory = new RdbmsWriterFactory(newBundle(), new SimpleMeterRegistry());
 
     // when
-    final var defaultWriters =
+    final var writers =
         factory.createWriter(new RdbmsWriterConfig.Builder().partitionId(0).build());
-    final var tenantAWriters =
-        factory.createWriter(
-            new RdbmsWriterConfig.Builder().partitionId(0).physicalTenantId("tenantA").build());
 
     // then
-    assertThat(defaultWriters).isNotNull();
-    assertThat(tenantAWriters).isNotNull();
-    assertThat(defaultWriters).isNotSameAs(tenantAWriters);
-    assertThat(defaultWriters.getExecutionQueue()).isNotSameAs(tenantAWriters.getExecutionQueue());
+    assertThat(writers).isNotNull();
   }
 
   @Test
-  void shouldRejectUnknownTenant() {
+  void shouldCreateIsolatedWritersPerCall() {
     // given
-    final var factory =
-        new RdbmsWriterFactory(Map.of("default", newBundle()), new SimpleMeterRegistry());
+    final var factory = new RdbmsWriterFactory(newBundle(), new SimpleMeterRegistry());
 
-    // when / then
-    assertThatThrownBy(
-            () ->
-                factory.createWriter(
-                    new RdbmsWriterConfig.Builder()
-                        .partitionId(0)
-                        .physicalTenantId("unknown")
-                        .build()))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("unknown")
-        .hasMessageContaining("default");
+    // when
+    final var writersPartition0 =
+        factory.createWriter(new RdbmsWriterConfig.Builder().partitionId(0).build());
+    final var writersPartition1 =
+        factory.createWriter(new RdbmsWriterConfig.Builder().partitionId(1).build());
+
+    // then
+    assertThat(writersPartition0).isNotSameAs(writersPartition1);
+    assertThat(writersPartition0.getExecutionQueue())
+        .isNotSameAs(writersPartition1.getExecutionQueue());
   }
 
   private static RdbmsMapperBundle newBundle() {

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -15,7 +15,6 @@ import io.camunda.db.rdbms.PerTenantSchemaConfig;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
-import io.camunda.db.rdbms.sql.ReplicationStatusMapper;
 import io.camunda.db.rdbms.sql.TableMetricsMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.zeebe.util.VersionUtil;
@@ -146,18 +145,12 @@ public class MyBatisConfiguration {
     return factoryBean.getObject();
   }
 
-  // TODO: the next 3 mappers are the last remaining default-tenant-only mappers. They should be
+  // TODO: the next 2 mappers are the last remaining default-tenant-only mappers. They should be
   // refactored to support multi-tenancy, and then these beans can be removed.
   @Bean
   TableMetricsMapper tableMetricsMapper(
       final Map<String, RdbmsMapperBundle> allRdbmsMapperBundles) {
     return allRdbmsMapperBundles.get(DEFAULT_PHYSICAL_TENANT_ID).tableMetricsMapper();
-  }
-
-  @Bean
-  ReplicationStatusMapper replicationStatusMapper(
-      final Map<String, RdbmsMapperBundle> allRdbmsMapperBundles) {
-    return allRdbmsMapperBundles.get(DEFAULT_PHYSICAL_TENANT_ID).replicationStatusMapper();
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -14,16 +14,13 @@ import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
-import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.RdbmsTenantReaders;
-import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProviderFactory;
 import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
 import io.camunda.db.rdbms.read.service.RdbmsTableRowCountMetrics;
 import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
-import io.camunda.db.rdbms.sql.ReplicationStatusMapper;
 import io.camunda.db.rdbms.sql.TableMetricsMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
-import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.search.clients.CamundaSearchClients;
 import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
@@ -74,20 +71,6 @@ public class RdbmsConfiguration {
   public PersistentWebSessionWriter persistentWebSessionWriter(
       final PersistentWebSessionMapper persistentWebSessionMapper) {
     return new PersistentWebSessionWriter(persistentWebSessionMapper);
-  }
-
-  @Bean
-  public ReplicationLogStatusProviderFactory replicationLogStatusProviderFactory(
-      final RdbmsDataSources rdbmsDataSources,
-      final ReplicationStatusMapper replicationStatusMapper) {
-    return new ReplicationLogStatusProviderFactory(
-        rdbmsDataSources.vendorPropertiesFor(DEFAULT_PHYSICAL_TENANT_ID), replicationStatusMapper);
-  }
-
-  @Bean
-  public RdbmsWriterFactory rdbmsWriterFactory(
-      final Map<String, RdbmsMapperBundle> rdbmsMapperBundles, final MeterRegistry meterRegistry) {
-    return new RdbmsWriterFactory(rdbmsMapperBundles, meterRegistry);
   }
 
   @Bean
@@ -154,12 +137,11 @@ public class RdbmsConfiguration {
   }
 
   @Bean
-  public RdbmsService rdbmsService(
-      final RdbmsWriterFactory rdbmsWriterFactory,
+  public RdbmsServiceFactory rdbmsServiceFactory(
+      final Map<String, RdbmsMapperBundle> rdbmsMapperBundles,
       final Map<String, RdbmsTenantReaders> rdbmsTenantReaders,
-      final ReplicationLogStatusProviderFactory replicationLogStatusProviderFactory) {
-    return new RdbmsService(
-        rdbmsWriterFactory, rdbmsTenantReaders, replicationLogStatusProviderFactory);
+      final MeterRegistry meterRegistry) {
+    return new RdbmsServiceFactory(rdbmsMapperBundles, rdbmsTenantReaders, meterRegistry);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
@@ -12,7 +12,7 @@ import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
-import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.exporter.rdbms.RdbmsExporterFactory;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
@@ -32,9 +32,9 @@ public class RdbmsExporterConfiguration {
 
   @Bean
   public RdbmsExporterFactory rdbmsExporterFactory(
-      final RdbmsService rdbmsService,
+      final RdbmsServiceFactory rdbmsServiceFactory,
       final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry) {
-    return new RdbmsExporterFactory(rdbmsService, rdbmsSchemaManagerRegistry);
+    return new RdbmsExporterFactory(rdbmsServiceFactory, rdbmsSchemaManagerRegistry);
   }
 
   @Bean

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
@@ -8,7 +8,6 @@
 package io.camunda.application.commons.rdbms;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfigurationHelper;
@@ -48,36 +47,19 @@ class MyBatisConfigurationPerTenantIT {
   }
 
   @Test
-  void shouldRouteWriterFactoryByPhysicalTenantId() throws Exception {
+  void shouldBuildIsolatedWritersPerTenant() throws Exception {
     try (final var fixture = wireTenants(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, "tenantb")) {
-      final var writerFactory = fixture.writerFactory();
-
       final var defaultWriters =
-          writerFactory.createWriter(new RdbmsWriterConfig.Builder().partitionId(1).build());
+          fixture
+              .writerFactory(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+              .createWriter(new RdbmsWriterConfig.Builder().partitionId(1).build());
       final var tenantBWriters =
-          writerFactory.createWriter(
-              new RdbmsWriterConfig.Builder().partitionId(1).physicalTenantId("tenantb").build());
+          fixture
+              .writerFactory("tenantb")
+              .createWriter(new RdbmsWriterConfig.Builder().partitionId(1).build());
 
       assertThat(defaultWriters.getExecutionQueue())
           .isNotSameAs(tenantBWriters.getExecutionQueue());
-    }
-  }
-
-  @Test
-  void shouldRejectUnknownPhysicalTenantId() throws Exception {
-    try (final var fixture = wireTenants(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)) {
-      final var writerFactory = fixture.writerFactory();
-
-      assertThatThrownBy(
-              () ->
-                  writerFactory.createWriter(
-                      new RdbmsWriterConfig.Builder()
-                          .partitionId(1)
-                          .physicalTenantId("unknown")
-                          .build()))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("unknown")
-          .hasMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     }
   }
 
@@ -114,8 +96,8 @@ class MyBatisConfigurationPerTenantIT {
       java.util.Map<String, io.camunda.db.rdbms.write.RdbmsMapperBundle> bundles)
       implements AutoCloseable {
 
-    RdbmsWriterFactory writerFactory() {
-      return new RdbmsWriterFactory(bundles, new SimpleMeterRegistry());
+    RdbmsWriterFactory writerFactory(final String physicalTenantId) {
+      return new RdbmsWriterFactory(bundles.get(physicalTenantId), new SimpleMeterRegistry());
     }
 
     @Override

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.it.rdbms.db;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
@@ -40,7 +42,8 @@ public class HistoryCleanupIT {
 
   @Autowired JdbcTemplate jdbcTemplate;
 
-  @Autowired RdbmsService rdbmsService;
+  @Autowired RdbmsServiceFactory rdbmsServiceFactory;
+  RdbmsService rdbmsService;
 
   HistoryCleanupService historyCleanupService;
 
@@ -48,11 +51,11 @@ public class HistoryCleanupIT {
 
   @BeforeEach
   void setUp() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     final var config = new RdbmsWriterConfig.Builder().partitionId(0).build();
     rdbmsWriters = rdbmsService.createWriter(config);
     historyCleanupService =
-        new HistoryCleanupService(
-            config, rdbmsWriters, rdbmsService.getProcessInstanceReader("default"));
+        new HistoryCleanupService(config, rdbmsWriters, rdbmsService.getProcessInstanceReader());
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/ManualUserDatabaseIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/ManualUserDatabaseIT.java
@@ -71,7 +71,7 @@ public class ManualUserDatabaseIT {
     rdbmsWriter.flush();
 
     // Verify we can read the data back
-    final var reader = rdbmsService.getProcessInstanceReader("default");
+    final var reader = rdbmsService.getProcessInstanceReader();
     final var result = reader.findOne(processInstanceKey);
 
     assertThat(result).isPresent();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
@@ -42,15 +42,12 @@ public class PurgerIT {
     rdbmsWriters.getRdbmsPurger().purgeRdbms();
 
     Assertions.assertThat(
-            rdbmsService
-                .getProcessInstanceReader("default")
-                .search(ProcessInstanceQuery.of(b -> b))
-                .total())
+            rdbmsService.getProcessInstanceReader().search(ProcessInstanceQuery.of(b -> b)).total())
         .isZero();
 
     Assertions.assertThat(
             rdbmsService
-                .getProcessDefinitionReader("default")
+                .getProcessDefinitionReader()
                 .search(ProcessDefinitionQuery.of(b -> b))
                 .total())
         .isZero();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
@@ -58,7 +58,7 @@ public class RdbmsFlushRollbackIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID_BASIC_ROLLBACK);
     final FlowNodeInstanceDbReader flowNodeInstanceReader =
-        rdbmsService.getFlowNodeInstanceReader("default");
+        rdbmsService.getFlowNodeInstanceReader();
 
     final var duplicateAuditLogKey = "atomicity-duplicate-key";
     final var firstAuditLog = createRandomized(b -> b.auditLogKey(duplicateAuditLogKey));
@@ -198,7 +198,7 @@ public class RdbmsFlushRollbackIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID_HOOK);
     final FlowNodeInstanceDbReader flowNodeInstanceReader =
-        rdbmsService.getFlowNodeInstanceReader("default");
+        rdbmsService.getFlowNodeInstanceReader();
 
     final AtomicInteger hookCallCount = new AtomicInteger(0);
     rdbmsWriters
@@ -256,7 +256,7 @@ public class RdbmsFlushRollbackIT {
     final ExporterPositionService exporterPositionService =
         rdbmsWriters.getExporterPositionService();
     final FlowNodeInstanceDbReader flowNodeInstanceReader =
-        rdbmsService.getFlowNodeInstanceReader("default");
+        rdbmsService.getFlowNodeInstanceReader();
 
     // Seed the exporter position
     exporterPositionService.createWithoutQueue(
@@ -388,7 +388,7 @@ public class RdbmsFlushRollbackIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID_DUPLICATE_INSERT);
     final FlowNodeInstanceDbReader flowNodeInstanceReader =
-        rdbmsService.getFlowNodeInstanceReader("default");
+        rdbmsService.getFlowNodeInstanceReader();
 
     final var flowNodeInstance = FlowNodeInstanceFixtures.createRandomized(b -> b);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
@@ -167,7 +167,7 @@ public class AgentInstanceFilterIT {
       final CamundaRdbmsTestApplication testApplication, final AgentInstanceFilter filter) {
     return testApplication
         .getRdbmsService()
-        .getAgentInstanceDbReader("default")
+        .getAgentInstanceDbReader()
         .search(
             new AgentInstanceQuery(
                 filter, AgentInstanceSort.of(b -> b), SearchQueryPage.of(b -> b)),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
@@ -38,7 +38,7 @@ public class AgentInstanceIT {
     final var entity =
         testApplication
             .getRdbmsService()
-            .getAgentInstanceDbReader("default")
+            .getAgentInstanceDbReader()
             .getByKey(model.agentInstanceKey(), ResourceAccessChecks.disabled());
 
     assertThat(entity).isNotNull();
@@ -51,7 +51,7 @@ public class AgentInstanceIT {
     final var entity =
         testApplication
             .getRdbmsService()
-            .getAgentInstanceDbReader("default")
+            .getAgentInstanceDbReader()
             .getByKey(Long.MIN_VALUE, ResourceAccessChecks.disabled());
 
     assertThat(entity).isNull();
@@ -65,7 +65,7 @@ public class AgentInstanceIT {
     final var result =
         testApplication
             .getRdbmsService()
-            .getAgentInstanceDbReader("default")
+            .getAgentInstanceDbReader()
             .search(
                 new AgentInstanceQuery(
                     new AgentInstanceFilter.Builder().processDefinitionIds(processId).build(),
@@ -87,7 +87,7 @@ public class AgentInstanceIT {
     final var result =
         testApplication
             .getRdbmsService()
-            .getAgentInstanceDbReader("default")
+            .getAgentInstanceDbReader()
             .search(
                 new AgentInstanceQuery(
                     new AgentInstanceFilter.Builder().processDefinitionIds(processId).build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java
@@ -200,7 +200,7 @@ public class AgentInstanceSortIT {
     final var items =
         testApplication
             .getRdbmsService()
-            .getAgentInstanceDbReader("default")
+            .getAgentInstanceDbReader()
             .search(
                 new AgentInstanceQuery(
                     new AgentInstanceFilter.Builder().processDefinitionIds(procDefId).build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogHistoryCleanupIT.java
@@ -33,9 +33,8 @@ public class AuditLogHistoryCleanupIT {
     final var config = new RdbmsWriterConfig.Builder().partitionId(0).build();
     final var rdbmsWriter = rdbmsService.createWriter(config);
     final var historyCleanupService =
-        new HistoryCleanupService(
-            config, rdbmsWriter, rdbmsService.getProcessInstanceReader("default"));
-    final var auditLogReader = rdbmsService.getAuditLogReader("default");
+        new HistoryCleanupService(config, rdbmsWriter, rdbmsService.getProcessInstanceReader());
+    final var auditLogReader = rdbmsService.getAuditLogReader();
 
     final OffsetDateTime now = OffsetDateTime.now();
     final OffsetDateTime scheduledCleanupDate = now.plus(HistoryConfig.DEFAULT_HISTORY_TTL);
@@ -61,9 +60,8 @@ public class AuditLogHistoryCleanupIT {
     final var config = new RdbmsWriterConfig.Builder().partitionId(0).build();
     final var rdbmsWriter = rdbmsService.createWriter(config);
     final var historyCleanupService =
-        new HistoryCleanupService(
-            config, rdbmsWriter, rdbmsService.getProcessInstanceReader("default"));
-    final var auditLogReader = rdbmsService.getAuditLogReader("default");
+        new HistoryCleanupService(config, rdbmsWriter, rdbmsService.getProcessInstanceReader());
+    final var auditLogReader = rdbmsService.getAuditLogReader();
 
     final OffsetDateTime now = OffsetDateTime.now();
     final OffsetDateTime scheduledCleanupDate = now.plus(HistoryConfig.DEFAULT_HISTORY_TTL);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
@@ -54,7 +54,7 @@ public class AuditLogIT {
   public void shouldGetAuditLogById(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var original = AuditLogFixtures.createRandomized(b -> b);
     createAndSaveAuditLog(rdbmsWriters, original);
@@ -70,7 +70,7 @@ public class AuditLogIT {
   public void shouldFindAuditLogByEntityType(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var original = AuditLogFixtures.createRandomized(b -> b);
     createAndSaveAuditLog(rdbmsWriters, original);
@@ -95,7 +95,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var original = AuditLogFixtures.createRandomized(b -> b);
     createAndSaveAuditLog(rdbmsWriters, original);
@@ -121,7 +121,7 @@ public class AuditLogIT {
   public void shouldFindAllAuditLogsPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final Long processInstanceKey = nextKey();
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.processInstanceKey(processInstanceKey));
@@ -144,7 +144,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final Long processInstanceKey = nextKey();
     createAndSaveRandomAuditLogs(rdbmsWriters, 120, b -> b.processInstanceKey(processInstanceKey));
@@ -167,7 +167,7 @@ public class AuditLogIT {
   public void shouldFindAuditLogWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var original = AuditLogFixtures.createRandomized(b -> b);
     createAndSaveAuditLog(rdbmsWriters, original);
@@ -202,7 +202,7 @@ public class AuditLogIT {
   public void shouldFindAuditLogWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var processInstanceKey = nextKey();
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.processInstanceKey(processInstanceKey));
@@ -241,7 +241,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     // Create audit logs with different categories
     final var adminLog =
@@ -282,7 +282,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var processDefId1 = "process-def-1";
     final var processDefId2 = "process-def-2";
@@ -328,7 +328,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var processDefId1 = "process-def-1";
     final var processDefId2 = "process-def-2";
@@ -381,7 +381,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var processDefId1 = "process-def-1";
     final var processDefId2 = "process-def-2";
@@ -433,7 +433,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var processDefId1 = "process-def-1";
     final var processDefId2 = "process-def-2";
@@ -483,7 +483,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var processDefId1 = "process-def-1";
     final var processDefId2 = "process-def-2";
@@ -544,7 +544,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     // Create audit logs
     AuditLogFixtures.createAndSaveAuditLog(
@@ -573,7 +573,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final Long processInstanceKey = nextKey();
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.processInstanceKey(processInstanceKey));
@@ -593,7 +593,7 @@ public class AuditLogIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
     final var processDefId1 = "process-def-1";
     final var processDefId2 = "process-def-2";
@@ -661,7 +661,7 @@ public class AuditLogIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
     final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
 
     final var processDefinitionKey1 = nextKey();
@@ -710,7 +710,7 @@ public class AuditLogIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
     final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
 
     final var processInstanceKey1 = nextKey();
@@ -750,7 +750,7 @@ public class AuditLogIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
     final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
 
     final var processInstanceKey1 = nextKey();
@@ -818,7 +818,7 @@ public class AuditLogIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
     final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
 
     final var processInstanceKey1 = nextKey();
@@ -861,7 +861,7 @@ public class AuditLogIT {
 
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
     final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.processDefinitionKey(processDefinitionKey1));
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.processDefinitionKey(processDefinitionKey2));
@@ -901,7 +901,7 @@ public class AuditLogIT {
 
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
     final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.decisionEvaluationKey(decisionInstanceKey1));
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.decisionEvaluationKey(decisionInstanceKey2));
@@ -941,7 +941,7 @@ public class AuditLogIT {
 
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
     final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.decisionRequirementsKey(decisionReqKey1));
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.decisionRequirementsKey(decisionReqKey2));
@@ -978,7 +978,7 @@ public class AuditLogIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
     final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
 
     final var processInstanceKey = nextKey();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogSortIT.java
@@ -120,7 +120,7 @@ public class AuditLogSortIT {
       final Function<Builder, ObjectBuilder<AuditLogSort>> sortBuilder,
       final Comparator<AuditLogEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuditLogDbReader reader = rdbmsService.getAuditLogReader("default");
+    final AuditLogDbReader reader = rdbmsService.getAuditLogReader();
 
     final var actorId = nextStringId();
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.actorId(actorId));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
@@ -42,8 +42,7 @@ public class AuthorizationIT {
   public void shouldSaveAndFindByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuthorizationDbReader authorizationReader =
-        rdbmsService.getAuthorizationReader("default");
+    final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
 
     final var authorization = AuthorizationFixtures.createRandomized(b -> b);
     createAndSaveAuthorization(rdbmsWriters, authorization);
@@ -61,8 +60,7 @@ public class AuthorizationIT {
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuthorizationDbReader authorizationReader =
-        rdbmsService.getAuthorizationReader("default");
+    final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
 
     final var authorization =
         AuthorizationFixtures.createRandomized(
@@ -97,8 +95,7 @@ public class AuthorizationIT {
   public void shouldSaveAndDelete(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuthorizationDbReader authorizationReader =
-        rdbmsService.getAuthorizationReader("default");
+    final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
 
     final var authorization = AuthorizationFixtures.createRandomized(b -> b);
     createAndSaveAuthorization(rdbmsWriters, authorization);
@@ -120,8 +117,7 @@ public class AuthorizationIT {
   public void shouldFindByResourceId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuthorizationDbReader authorizationReader =
-        rdbmsService.getAuthorizationReader("default");
+    final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
 
     final var authorization = AuthorizationFixtures.createRandomized(b -> b);
     createAndSaveAuthorization(rdbmsWriters, authorization);
@@ -147,8 +143,7 @@ public class AuthorizationIT {
   public void shouldFindByAuthorizedResourceId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuthorizationDbReader authorizationReader =
-        rdbmsService.getAuthorizationReader("default");
+    final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
 
     final var authorization = AuthorizationFixtures.createRandomized(b -> b);
     createAndSaveAuthorization(rdbmsWriters, authorization);
@@ -174,8 +169,7 @@ public class AuthorizationIT {
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuthorizationDbReader authorizationReader =
-        rdbmsService.getAuthorizationReader("default");
+    final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
 
     createAndSaveRandomAuthorizations(rdbmsWriters, b -> b.ownerType("TEST"));
 
@@ -195,8 +189,7 @@ public class AuthorizationIT {
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuthorizationDbReader authorizationReader =
-        rdbmsService.getAuthorizationReader("default");
+    final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
 
     createAndSaveRandomAuthorizations(rdbmsWriters, 120, b -> b.ownerType("TEST_MORE"));
 
@@ -217,8 +210,7 @@ public class AuthorizationIT {
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuthorizationDbReader authorizationReader =
-        rdbmsService.getAuthorizationReader("default");
+    final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
 
     final var authorization = AuthorizationFixtures.createRandomized(b -> b);
     createAndSaveRandomAuthorizations(rdbmsWriters);
@@ -247,8 +239,7 @@ public class AuthorizationIT {
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuthorizationDbReader authorizationReader =
-        rdbmsService.getAuthorizationReader("default");
+    final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
 
     createAndSaveRandomAuthorizations(rdbmsWriters, b -> b.ownerType("ITEST"));
     final var sort =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
@@ -122,7 +122,7 @@ public class AuthorizationSortIT {
       final Function<Builder, ObjectBuilder<AuthorizationSort>> sortBuilder,
       final Comparator<AuthorizationEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final AuthorizationDbReader reader = rdbmsService.getAuthorizationReader("default");
+    final AuthorizationDbReader reader = rdbmsService.getAuthorizationReader();
 
     final var requirementsKey = nextKey();
     createAndSaveRandomAuthorizations(rdbmsWriters, b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSpecificFilterIT.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.it.rdbms.db.authorization;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures.createAndSaveAuthorization;
 import static io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures.createAndSaveRandomAuthorizations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.AuthorizationDbModel;
@@ -39,7 +41,8 @@ import org.springframework.test.context.TestPropertySource;
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class AuthorizationSpecificFilterIT {
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private AuthorizationDbReader authorizationReader;
 
@@ -47,8 +50,9 @@ public class AuthorizationSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    authorizationReader = rdbmsService.getAuthorizationReader("default");
+    authorizationReader = rdbmsService.getAuthorizationReader();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationHistoryCleanupIT.java
@@ -35,11 +35,10 @@ public class BatchOperationHistoryCleanupIT {
     final var config = new RdbmsWriterConfig.Builder().partitionId(0).build();
     final var rdbmsWriter = rdbmsService.createWriter(config);
     final var historyCleanupService =
-        new HistoryCleanupService(
-            config, rdbmsWriter, rdbmsService.getProcessInstanceReader("default"));
-    final var batchOperationReader = rdbmsService.getBatchOperationReader("default");
-    final var batchOperationItemReader = rdbmsService.getBatchOperationItemReader("default");
-    final var auditLogReader = rdbmsService.getAuditLogReader("default");
+        new HistoryCleanupService(config, rdbmsWriter, rdbmsService.getProcessInstanceReader());
+    final var batchOperationReader = rdbmsService.getBatchOperationReader();
+    final var batchOperationItemReader = rdbmsService.getBatchOperationItemReader();
+    final var auditLogReader = rdbmsService.getAuditLogReader();
 
     final var batchOperation =
         BatchOperationFixtures.createAndSaveBatchOperation(rdbmsWriter, b -> b);
@@ -80,11 +79,10 @@ public class BatchOperationHistoryCleanupIT {
     final var config = new RdbmsWriterConfig.Builder().partitionId(0).build();
     final var rdbmsWriter = rdbmsService.createWriter(config);
     final var historyCleanupService =
-        new HistoryCleanupService(
-            config, rdbmsWriter, rdbmsService.getProcessInstanceReader("default"));
-    final var batchOperationReader = rdbmsService.getBatchOperationReader("default");
-    final var batchOperationItemReader = rdbmsService.getBatchOperationItemReader("default");
-    final var auditLogReader = rdbmsService.getAuditLogReader("default");
+        new HistoryCleanupService(config, rdbmsWriter, rdbmsService.getProcessInstanceReader());
+    final var batchOperationReader = rdbmsService.getBatchOperationReader();
+    final var batchOperationItemReader = rdbmsService.getBatchOperationItemReader();
+    final var auditLogReader = rdbmsService.getAuditLogReader();
 
     final var batchOperation =
         BatchOperationFixtures.createAndSaveBatchOperation(rdbmsWriter, b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -679,7 +679,7 @@ public class BatchOperationIT {
 
     final var searchResult =
         rdbmsService
-            .getBatchOperationReader("default")
+            .getBatchOperationReader()
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
@@ -704,7 +704,7 @@ public class BatchOperationIT {
 
     final var searchResult =
         rdbmsService
-            .getBatchOperationReader("default")
+            .getBatchOperationReader()
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
@@ -735,7 +735,7 @@ public class BatchOperationIT {
 
     final var searchResult =
         rdbmsService
-            .getBatchOperationReader("default")
+            .getBatchOperationReader()
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
@@ -764,7 +764,7 @@ public class BatchOperationIT {
 
     final var searchResult =
         rdbmsService
-            .getBatchOperationReader("default")
+            .getBatchOperationReader()
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
@@ -792,7 +792,7 @@ public class BatchOperationIT {
 
     final var searchResult =
         rdbmsService
-            .getBatchOperationReader("default")
+            .getBatchOperationReader()
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder().operationTypes(operationType.name()).build(),
@@ -817,7 +817,7 @@ public class BatchOperationIT {
 
     final var searchResult =
         rdbmsService
-            .getBatchOperationItemReader("default")
+            .getBatchOperationItemReader()
             .search(
                 new BatchOperationItemQuery(
                     new BatchOperationItemFilter.Builder()
@@ -842,7 +842,7 @@ public class BatchOperationIT {
 
     final var searchResult =
         rdbmsService
-            .getBatchOperationReader("default")
+            .getBatchOperationReader()
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder().operationTypes(operationType.name()).build(),
@@ -866,7 +866,7 @@ public class BatchOperationIT {
 
     final var searchResult =
         rdbmsService
-            .getBatchOperationItemReader("default")
+            .getBatchOperationItemReader()
             .search(
                 new BatchOperationItemQuery(
                     new BatchOperationItemFilter.Builder()
@@ -903,7 +903,7 @@ public class BatchOperationIT {
 
     final var searchResult =
         rdbmsService
-            .getBatchOperationItemReader("default")
+            .getBatchOperationItemReader()
             .search(
                 new BatchOperationItemQuery(
                     new BatchOperationItemFilter.Builder()
@@ -937,7 +937,7 @@ public class BatchOperationIT {
   private static SearchQueryResult<BatchOperationEntity> getBatchOperation(
       final RdbmsService rdbmsService, final BatchOperationDbModel batchOperation) {
     return rdbmsService
-        .getBatchOperationReader("default")
+        .getBatchOperationReader()
         .search(
             new BatchOperationQuery(
                 new BatchOperationFilter.Builder()
@@ -950,7 +950,7 @@ public class BatchOperationIT {
   private static SearchQueryResult<BatchOperationItemEntity> getBatchOperationItems(
       final RdbmsService rdbmsService, final String batchOperationKey) {
     return rdbmsService
-        .getBatchOperationItemReader("default")
+        .getBatchOperationItemReader()
         .search(
             new BatchOperationItemQuery(
                 new BatchOperationItemFilter.Builder()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationItemSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationItemSortIT.java
@@ -72,7 +72,7 @@ public class BatchOperationItemSortIT {
           sortBuilder,
       final Comparator<BatchOperationItemEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final BatchOperationItemDbReader reader = rdbmsService.getBatchOperationItemReader("default");
+    final BatchOperationItemDbReader reader = rdbmsService.getBatchOperationItemReader();
 
     final var batchOperation = createAndSaveBatchOperation(rdbmsWriters, b -> b);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationSortIT.java
@@ -31,8 +31,7 @@ public class BatchOperationSortIT {
   @TestTemplate
   public void shouldSortIdAsc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final BatchOperationDbReader batchOperationReader =
-        rdbmsService.getBatchOperationReader("default");
+    final BatchOperationDbReader batchOperationReader = rdbmsService.getBatchOperationReader();
 
     BatchOperationFixtures.createAndSaveRandomBatchOperations(
         rdbmsService.createWriter(1L), b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -50,7 +50,7 @@ public class ClusterVariableIT {
     final var instance =
         testApplication
             .getRdbmsService()
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .getTenantScopedClusterVariable(
                 randomizedVariable.name(),
                 randomizedVariable.tenantId(),
@@ -72,7 +72,7 @@ public class ClusterVariableIT {
     final var instance =
         testApplication
             .getRdbmsService()
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .getGloballyScopedClusterVariable(
                 randomizedVariable.name(),
                 CommonFixtures.resourceAccessChecksFromResourceIds(
@@ -96,7 +96,7 @@ public class ClusterVariableIT {
 
     final var instance =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .getTenantScopedClusterVariable(
                 randomizedVariable.name(),
                 randomizedVariable.tenantId(),
@@ -121,7 +121,7 @@ public class ClusterVariableIT {
 
     final var instance =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .getGloballyScopedClusterVariable(
                 randomizedVariable.name(),
                 CommonFixtures.resourceAccessChecksFromResourceIds(
@@ -144,7 +144,7 @@ public class ClusterVariableIT {
 
     final var searchResult =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 new ClusterVariableQuery(
                     new ClusterVariableFilter.Builder()
@@ -169,7 +169,7 @@ public class ClusterVariableIT {
 
     final var searchResult =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 new ClusterVariableQuery(
                     new ClusterVariableFilter.Builder().values("value").scopes("GLOBAL").build(),
@@ -192,7 +192,7 @@ public class ClusterVariableIT {
 
     final var searchResult =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 new ClusterVariableQuery(
                     new ClusterVariableFilter.Builder()
@@ -219,7 +219,7 @@ public class ClusterVariableIT {
 
     final var searchResult =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 new ClusterVariableQuery(
                     new ClusterVariableFilter.Builder()
@@ -238,8 +238,7 @@ public class ClusterVariableIT {
   public void shouldFindClusterVariableWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final ClusterVariableDbReader clusterVariableReader =
-        rdbmsService.getClusterVariableReader("default");
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
 
     final String tenantId = CommonFixtures.nextStringId();
     final String variableName = CommonFixtures.nextStringId();
@@ -275,8 +274,7 @@ public class ClusterVariableIT {
   public void shouldFindClusterVariableWithSearchAfter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final ClusterVariableDbReader clusterVariableReader =
-        rdbmsService.getClusterVariableReader("default");
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
 
     final String tenantId = CommonFixtures.nextStringId();
     ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedTenantId(
@@ -316,8 +314,7 @@ public class ClusterVariableIT {
   public void shouldUpdateTenantClusterVariable(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ClusterVariableDbReader clusterVariableReader =
-        rdbmsService.getClusterVariableReader("default");
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
 
     final ClusterVariableDbModel clusterVariable =
         ClusterVariableFixtures.createRandomTenantClusterVariable(generateRandomString(100));
@@ -348,8 +345,7 @@ public class ClusterVariableIT {
   public void shouldUpdateGlobalClusterVariable(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ClusterVariableDbReader clusterVariableReader =
-        rdbmsService.getClusterVariableReader("default");
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
 
     final ClusterVariableDbModel clusterVariable =
         ClusterVariableFixtures.createRandomGlobalClusterVariable(generateRandomString(100));
@@ -379,8 +375,7 @@ public class ClusterVariableIT {
   public void shouldDeleteTenantClusterVariable(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ClusterVariableDbReader clusterVariableReader =
-        rdbmsService.getClusterVariableReader("default");
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
 
     final ClusterVariableDbModel clusterVariable =
         ClusterVariableFixtures.createRandomTenantClusterVariable(generateRandomString(100));
@@ -416,8 +411,7 @@ public class ClusterVariableIT {
   public void shouldDeleteGlobalClusterVariable(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ClusterVariableDbReader clusterVariableReader =
-        rdbmsService.getClusterVariableReader("default");
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
 
     final ClusterVariableDbModel clusterVariable =
         ClusterVariableFixtures.createRandomGlobalClusterVariable(generateRandomString(100));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableSortIT.java
@@ -105,7 +105,7 @@ public class ClusterVariableSortIT {
 
     final var searchResult =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 new ClusterVariableQuery(
                     new ClusterVariableFilter.Builder()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableValueFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableValueFilterIT.java
@@ -357,7 +357,7 @@ public class ClusterVariableValueFilterIT {
     // when we search for it, we should find one
     final var searchResult =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 new ClusterVariableQuery(
                     clusterVariableFilter,
@@ -399,7 +399,7 @@ public class ClusterVariableValueFilterIT {
     // when we search for it, we should find one
     final var searchResult =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 new ClusterVariableQuery(
                     clusterVariableFilter,
@@ -441,7 +441,7 @@ public class ClusterVariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 ClusterVariableQuery.of(
                     b ->
@@ -486,7 +486,7 @@ public class ClusterVariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 ClusterVariableQuery.of(
                     b ->
@@ -531,7 +531,7 @@ public class ClusterVariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 ClusterVariableQuery.of(
                     b ->
@@ -575,7 +575,7 @@ public class ClusterVariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 ClusterVariableQuery.of(
                     b ->
@@ -619,7 +619,7 @@ public class ClusterVariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 ClusterVariableQuery.of(
                     b ->
@@ -663,7 +663,7 @@ public class ClusterVariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 ClusterVariableQuery.of(
                     b ->
@@ -708,7 +708,7 @@ public class ClusterVariableValueFilterIT {
 
     final var searchResult =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .search(
                 new ClusterVariableQuery(
                     builder.build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
@@ -44,7 +44,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionReader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var original = CorrelatedMessageSubscriptionFixtures.createRandomized(b -> b);
     createAndSaveCorrelatedMessageSubscription(rdbmsWriters, original);
@@ -63,7 +63,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionReader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var original = CorrelatedMessageSubscriptionFixtures.createRandomized(b -> b);
     createAndSaveCorrelatedMessageSubscription(rdbmsWriters, original);
@@ -87,7 +87,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var original = CorrelatedMessageSubscriptionFixtures.createRandomized(b -> b);
     createAndSaveCorrelatedMessageSubscription(rdbmsWriters, original);
@@ -112,7 +112,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var original = CorrelatedMessageSubscriptionFixtures.createRandomized(b -> b);
     createAndSaveCorrelatedMessageSubscription(rdbmsWriters, original);
@@ -136,7 +136,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var original = CorrelatedMessageSubscriptionFixtures.createRandomized(b -> b);
     createAndSaveCorrelatedMessageSubscription(rdbmsWriters, original);
@@ -159,7 +159,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final String processDefinitionId = CorrelatedMessageSubscriptionFixtures.nextStringId();
     createAndSaveRandomCorrelatedMessageSubscriptions(
@@ -184,7 +184,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final String processDefinitionId = CorrelatedMessageSubscriptionFixtures.nextStringId();
     createAndSaveRandomCorrelatedMessageSubscriptions(
@@ -210,7 +210,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var original = CorrelatedMessageSubscriptionFixtures.createRandomized(b -> b);
     createAndSaveCorrelatedMessageSubscription(rdbmsWriters, original);
@@ -250,7 +250,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var processDefinitionKey = nextKey();
     createAndSaveRandomCorrelatedMessageSubscriptions(
@@ -291,7 +291,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var processDefinitionKey = nextKey();
     // 16 subscriptions without a businessId and 4 with one. Sorted ascending, businessId is
@@ -345,7 +345,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var processDefinitionKey = nextKey();
     createAndSaveRandomCorrelatedMessageSubscriptions(
@@ -382,7 +382,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -425,7 +425,7 @@ public class CorrelatedMessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final CorrelatedMessageSubscriptionDbReader reader =
-        rdbmsService.getCorrelatedMessageSubscriptionReader("default");
+        rdbmsService.getCorrelatedMessageSubscriptionReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
@@ -40,7 +40,7 @@ public class DecisionDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionDbReader decisionDefinitionReader =
-        rdbmsService.getDecisionDefinitionReader("default");
+        rdbmsService.getDecisionDefinitionReader();
 
     final var decisionDefinition = DecisionDefinitionFixtures.createRandomized(b -> b);
     createAndSaveDecisionDefinition(rdbmsWriters, decisionDefinition);
@@ -69,7 +69,7 @@ public class DecisionDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionDbReader decisionDefinitionReader =
-        rdbmsService.getDecisionDefinitionReader("default");
+        rdbmsService.getDecisionDefinitionReader();
 
     final var decisionDefinition =
         DecisionDefinitionFixtures.createRandomized(
@@ -112,7 +112,7 @@ public class DecisionDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionDbReader decisionDefinitionReader =
-        rdbmsService.getDecisionDefinitionReader("default");
+        rdbmsService.getDecisionDefinitionReader();
 
     final var decisionDefinition = DecisionDefinitionFixtures.createRandomized(b -> b);
     createAndSaveDecisionDefinition(rdbmsWriters, decisionDefinition);
@@ -139,7 +139,7 @@ public class DecisionDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionDbReader decisionDefinitionReader =
-        rdbmsService.getDecisionDefinitionReader("default");
+        rdbmsService.getDecisionDefinitionReader();
 
     final var decisionDefinition = DecisionDefinitionFixtures.createRandomized(b -> b);
     createAndSaveDecisionDefinition(rdbmsWriters, decisionDefinition);
@@ -164,7 +164,7 @@ public class DecisionDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionDbReader decisionDefinitionReader =
-        rdbmsService.getDecisionDefinitionReader("default");
+        rdbmsService.getDecisionDefinitionReader();
 
     final String decisionDefinitionId = DecisionDefinitionFixtures.nextStringId();
     createAndSaveRandomDecisionDefinitions(
@@ -189,7 +189,7 @@ public class DecisionDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionDbReader decisionDefinitionReader =
-        rdbmsService.getDecisionDefinitionReader("default");
+        rdbmsService.getDecisionDefinitionReader();
 
     final String decisionDefinitionId = DecisionDefinitionFixtures.nextStringId();
     createAndSaveRandomDecisionDefinitions(
@@ -215,7 +215,7 @@ public class DecisionDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionDbReader decisionDefinitionReader =
-        rdbmsService.getDecisionDefinitionReader("default");
+        rdbmsService.getDecisionDefinitionReader();
 
     createAndSaveRandomDecisionDefinitions(rdbmsWriters);
 
@@ -236,7 +236,7 @@ public class DecisionDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionDbReader decisionDefinitionReader =
-        rdbmsService.getDecisionDefinitionReader("default");
+        rdbmsService.getDecisionDefinitionReader();
 
     final var decisionDefinition = DecisionDefinitionFixtures.createRandomized(b -> b);
     createAndSaveRandomDecisionDefinitions(rdbmsWriters);
@@ -270,7 +270,7 @@ public class DecisionDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionDbReader decisionDefinitionReader =
-        rdbmsService.getDecisionDefinitionReader("default");
+        rdbmsService.getDecisionDefinitionReader();
 
     createAndSaveRandomDecisionDefinitions(rdbmsWriters, b -> b.tenantId("search-after-123456"));
     final var sort =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSortIT.java
@@ -174,7 +174,7 @@ public class DecisionDefinitionSortIT {
       final Function<Builder, ObjectBuilder<DecisionDefinitionSort>> sortBuilder,
       final Comparator<DecisionDefinitionEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DecisionDefinitionDbReader reader = rdbmsService.getDecisionDefinitionReader("default");
+    final DecisionDefinitionDbReader reader = rdbmsService.getDecisionDefinitionReader();
 
     final var requirementsKey = nextKey();
     createAndSaveRandomDecisionDefinitions(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.it.rdbms.db.decisiondefinition;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveDecisionDefinition;
 import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
@@ -33,7 +35,8 @@ import org.springframework.test.context.TestPropertySource;
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class DecisionDefinitionSpecificFilterIT {
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private DecisionDefinitionDbReader decisionDefinitionReader;
 
@@ -41,8 +44,9 @@ public class DecisionDefinitionSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    decisionDefinitionReader = rdbmsService.getDecisionDefinitionReader("default");
+    decisionDefinitionReader = rdbmsService.getDecisionDefinitionReader();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
@@ -53,7 +53,7 @@ public class DecisionInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionInstanceDbReader decisionInstanceReader =
-        rdbmsService.getDecisionInstanceReader("default");
+        rdbmsService.getDecisionInstanceReader();
 
     final var original = DecisionInstanceFixtures.createRandomized(b -> b);
     createAndSaveDecisionInstance(rdbmsWriters, original);
@@ -83,7 +83,7 @@ public class DecisionInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionInstanceDbReader decisionInstanceReader =
-        rdbmsService.getDecisionInstanceReader("default");
+        rdbmsService.getDecisionInstanceReader();
 
     final var original = DecisionInstanceFixtures.createRandomized(b -> b);
     createAndSaveDecisionInstance(rdbmsWriters, original);
@@ -109,7 +109,7 @@ public class DecisionInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionInstanceDbReader decisionInstanceReader =
-        rdbmsService.getDecisionInstanceReader("default");
+        rdbmsService.getDecisionInstanceReader();
 
     final var original = DecisionInstanceFixtures.createRandomized(b -> b);
     createAndSaveDecisionInstance(rdbmsWriters, original);
@@ -134,7 +134,7 @@ public class DecisionInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionInstanceDbReader decisionInstanceReader =
-        rdbmsService.getDecisionInstanceReader("default");
+        rdbmsService.getDecisionInstanceReader();
 
     final var decisionDefinition =
         DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinition(rdbmsWriters, b -> b);
@@ -163,7 +163,7 @@ public class DecisionInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionInstanceDbReader decisionInstanceReader =
-        rdbmsService.getDecisionInstanceReader("default");
+        rdbmsService.getDecisionInstanceReader();
 
     final var decisionDefinition =
         DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinition(rdbmsWriters, b -> b);
@@ -195,7 +195,7 @@ public class DecisionInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionInstanceDbReader decisionInstanceReader =
-        rdbmsService.getDecisionInstanceReader("default");
+        rdbmsService.getDecisionInstanceReader();
 
     final var decisionDefinition =
         DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinition(rdbmsWriters, b -> b);
@@ -239,7 +239,7 @@ public class DecisionInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionInstanceDbReader decisionInstanceReader =
-        rdbmsService.getDecisionInstanceReader("default");
+        rdbmsService.getDecisionInstanceReader();
 
     final var decisionDefinition =
         DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinition(rdbmsWriters, b -> b);
@@ -294,7 +294,7 @@ public class DecisionInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionInstanceDbReader decisionInstanceReader =
-        rdbmsService.getDecisionInstanceReader("default");
+        rdbmsService.getDecisionInstanceReader();
 
     final var original =
         DecisionInstanceFixtures.createRandomized(
@@ -312,7 +312,7 @@ public class DecisionInstanceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DecisionInstanceDbReader reader = rdbmsService.getDecisionInstanceReader("default");
+    final DecisionInstanceDbReader reader = rdbmsService.getDecisionInstanceReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -354,7 +354,7 @@ public class DecisionInstanceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DecisionInstanceDbReader reader = rdbmsService.getDecisionInstanceReader("default");
+    final DecisionInstanceDbReader reader = rdbmsService.getDecisionInstanceReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -396,7 +396,7 @@ public class DecisionInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionInstanceDbReader decisionInstanceReader =
-        rdbmsService.getDecisionInstanceReader("default");
+        rdbmsService.getDecisionInstanceReader();
 
     final var largeResult = "x".repeat(9_000);
     final var largeOutput = "y".repeat(10_000);
@@ -449,7 +449,7 @@ public class DecisionInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionInstanceDbReader decisionInstanceReader =
-        rdbmsService.getDecisionInstanceReader("default");
+        rdbmsService.getDecisionInstanceReader();
 
     final var decisionInstanceKey = DecisionInstanceFixtures.nextKey();
     final var decisionInstanceId = decisionInstanceKey + "-1";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
@@ -189,7 +189,7 @@ public class DecisionInstanceSortIT {
       final Function<Builder, ObjectBuilder<DecisionInstanceSort>> sortBuilder,
       final Comparator<DecisionInstanceEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DecisionInstanceDbReader reader = rdbmsService.getDecisionInstanceReader("default");
+    final DecisionInstanceDbReader reader = rdbmsService.getDecisionInstanceReader();
 
     final var decisionDefinition =
         DecisionDefinitionFixtures.createAndSaveDecisionDefinition(rdbmsWriters, b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.it.rdbms.db.decisioninstance;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
 import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveDecisionInstance;
 import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
@@ -41,7 +43,8 @@ public class DecisionInstanceSpecificFilterIT {
   public static final OffsetDateTime NOW = OffsetDateTime.now();
   public static final OffsetDateTime THEN = OffsetDateTime.parse("2020-01-01T00:00:00Z");
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private DecisionInstanceDbReader decisionInstanceReader;
 
@@ -49,8 +52,9 @@ public class DecisionInstanceSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    decisionInstanceReader = rdbmsService.getDecisionInstanceReader("default");
+    decisionInstanceReader = rdbmsService.getDecisionInstanceReader();
 
     final var decisionDefinitionKey = nextKey();
     final var decisionDefinition =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
@@ -42,7 +42,7 @@ public class DecisionRequirementsIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsDbReader decisionRequirementsReader =
-        rdbmsService.getDecisionRequirementsReader("default");
+        rdbmsService.getDecisionRequirementsReader();
 
     final var decisionRequirements = DecisionRequirementsFixtures.createRandomized(b -> b);
     createAndSaveDecisionRequirement(rdbmsWriters, decisionRequirements);
@@ -68,7 +68,7 @@ public class DecisionRequirementsIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsDbReader decisionRequirementsReader =
-        rdbmsService.getDecisionRequirementsReader("default");
+        rdbmsService.getDecisionRequirementsReader();
 
     final var decisionRequirements =
         DecisionRequirementsFixtures.createRandomized(
@@ -106,7 +106,7 @@ public class DecisionRequirementsIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsDbReader decisionRequirementsReader =
-        rdbmsService.getDecisionRequirementsReader("default");
+        rdbmsService.getDecisionRequirementsReader();
 
     final var decisionRequirements = DecisionRequirementsFixtures.createRandomized(b -> b);
     createAndSaveDecisionRequirement(rdbmsWriters, decisionRequirements);
@@ -133,7 +133,7 @@ public class DecisionRequirementsIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsDbReader decisionRequirementsReader =
-        rdbmsService.getDecisionRequirementsReader("default");
+        rdbmsService.getDecisionRequirementsReader();
 
     final var decisionRequirements = DecisionRequirementsFixtures.createRandomized(b -> b);
     createAndSaveDecisionRequirement(rdbmsWriters, decisionRequirements);
@@ -158,7 +158,7 @@ public class DecisionRequirementsIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsDbReader decisionRequirementsReader =
-        rdbmsService.getDecisionRequirementsReader("default");
+        rdbmsService.getDecisionRequirementsReader();
 
     final String decisionRequirementsId = DecisionRequirementsFixtures.nextStringId();
     createAndSaveRandomDecisionRequirements(
@@ -191,7 +191,7 @@ public class DecisionRequirementsIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsDbReader decisionRequirementsReader =
-        rdbmsService.getDecisionRequirementsReader("default");
+        rdbmsService.getDecisionRequirementsReader();
 
     final String decisionRequirementsId = DecisionRequirementsFixtures.nextStringId();
     createAndSaveRandomDecisionRequirements(
@@ -218,7 +218,7 @@ public class DecisionRequirementsIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsDbReader decisionRequirementsReader =
-        rdbmsService.getDecisionRequirementsReader("default");
+        rdbmsService.getDecisionRequirementsReader();
 
     final var decisionRequirements = DecisionRequirementsFixtures.createRandomized(b -> b);
     createAndSaveRandomDecisionRequirements(rdbmsWriters);
@@ -251,7 +251,7 @@ public class DecisionRequirementsIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsDbReader decisionRequirementsReader =
-        rdbmsService.getDecisionRequirementsReader("default");
+        rdbmsService.getDecisionRequirementsReader();
 
     createAndSaveRandomDecisionRequirements(rdbmsWriters, b -> b.tenantId("search-after-123456"));
     final var sort =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSortIT.java
@@ -108,8 +108,7 @@ public class DecisionRequirementsSortIT {
       final Function<Builder, ObjectBuilder<DecisionRequirementsSort>> sortBuilder,
       final Comparator<DecisionRequirementsEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DecisionRequirementsDbReader reader =
-        rdbmsService.getDecisionRequirementsReader("default");
+    final DecisionRequirementsDbReader reader = rdbmsService.getDecisionRequirementsReader();
 
     final var tenantId = nextStringId();
     createAndSaveRandomDecisionRequirements(rdbmsWriters, b -> b.tenantId(tenantId));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSpecificFilterIT.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.it.rdbms.db.decisionrequirements;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveDecisionRequirement;
 import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures;
@@ -32,7 +34,8 @@ import org.springframework.test.context.TestPropertySource;
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class DecisionRequirementsSpecificFilterIT {
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private DecisionRequirementsDbReader decisionRequirementsReader;
 
@@ -40,8 +43,9 @@ public class DecisionRequirementsSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    decisionRequirementsReader = rdbmsService.getDecisionRequirementsReader("default");
+    decisionRequirementsReader = rdbmsService.getDecisionRequirementsReader();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceIT.java
@@ -43,7 +43,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final DeployedResourceDbModel resource = DeployedResourceFixtures.createRandomized(b -> b);
     createAndSaveDeployedResource(rdbmsWriters, resource);
@@ -70,7 +70,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final DeployedResourceDbModel resource = DeployedResourceFixtures.createRandomized(b -> b);
     createAndSaveDeployedResource(rdbmsWriters, resource);
@@ -98,7 +98,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final DeployedResourceDbModel resource = DeployedResourceFixtures.createRandomized(b -> b);
     createAndSaveDeployedResource(rdbmsWriters, resource);
@@ -126,7 +126,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final String uniqueType = "FORM-" + nextKey();
     final DeployedResourceDbModel resource =
@@ -154,7 +154,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final Long deploymentKey = nextKey();
     final DeployedResourceDbModel resource =
@@ -182,7 +182,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final Long deploymentKey = nextKey();
     final DeployedResourceDbModel resource =
@@ -214,7 +214,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final String versionTag = "v-unique-" + nextKey();
     final DeployedResourceDbModel resource =
@@ -242,7 +242,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final String tenantId = "tenant-unique-" + nextKey();
     final DeployedResourceDbModel resource =
@@ -270,7 +270,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final DeployedResourceDbModel resource = DeployedResourceFixtures.createRandomized(b -> b);
     createAndSaveDeployedResource(rdbmsWriters, resource);
@@ -306,7 +306,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final Long deploymentKey = nextKey();
     createAndSaveRandomDeployedResources(rdbmsWriters, b -> b.deploymentKey(deploymentKey));
@@ -332,7 +332,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final Long deploymentKey = nextKey();
     createAndSaveRandomDeployedResources(rdbmsWriters, 120, b -> b.deploymentKey(deploymentKey));
@@ -359,7 +359,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final Long deploymentKey = nextKey();
     createAndSaveRandomDeployedResources(rdbmsWriters, b -> b.deploymentKey(deploymentKey));
@@ -402,7 +402,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final Long deploymentKey = nextKey();
     final var resource1 =
@@ -437,7 +437,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final DeployedResourceDbModel resource = createAndSaveDeployedResource(rdbmsWriters, b -> b);
     createAndSaveRandomDeployedResources(rdbmsWriters);
@@ -461,7 +461,7 @@ public class DeployedResourceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
 
     final DeployedResourceDbModel resource = createAndSaveDeployedResource(rdbmsWriters, b -> b);
     createAndSaveRandomDeployedResources(rdbmsWriters);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceSortIT.java
@@ -113,7 +113,7 @@ public class DeployedResourceSortIT {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(0L);
     createAndSaveRandomDeployedResources(rdbmsWriters, 20, b -> b.deploymentKey(deploymentKey));
 
-    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader("default");
+    final DeployedResourceDbReader reader = rdbmsService.getResourceDbReader();
     final var results =
         reader
             .search(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
@@ -47,7 +47,7 @@ public class FlowNodeInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     final var flowNodeInstance =
         FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(rdbmsWriters);
@@ -60,8 +60,7 @@ public class FlowNodeInstanceIT {
   public void shouldSaveLogAndResolveIncident(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader elementInstanceReader =
-        rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader elementInstanceReader = rdbmsService.getFlowNodeInstanceReader();
 
     final FlowNodeInstanceDbModel original =
         FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(rdbmsWriters, b -> b);
@@ -90,7 +89,7 @@ public class FlowNodeInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     final var flowNodeInstance =
         FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(rdbmsWriters);
@@ -116,7 +115,7 @@ public class FlowNodeInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     final var flowNodeInstance =
         FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(rdbmsWriters);
@@ -141,7 +140,7 @@ public class FlowNodeInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     final var flowNodeInstance =
         FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(rdbmsWriters);
@@ -163,7 +162,7 @@ public class FlowNodeInstanceIT {
   public void shouldFindAllElementInstancePaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     final var processDefinitionId = nextStringId();
     createAndSaveRandomFlowNodeInstances(
@@ -187,7 +186,7 @@ public class FlowNodeInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     final var processDefinitionId = nextStringId();
     createAndSaveRandomFlowNodeInstances(
@@ -213,7 +212,7 @@ public class FlowNodeInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     final var processDefinitionId = nextStringId();
     createAndSaveRandomFlowNodeInstances(
@@ -238,7 +237,7 @@ public class FlowNodeInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstances(rdbmsWriters);
     final var instance = FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance(rdbmsWriters);
@@ -299,7 +298,7 @@ public class FlowNodeInstanceIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final FlowNodeInstanceDbReader flowNodeInstanceReader =
-        rdbmsService.getFlowNodeInstanceReader("default");
+        rdbmsService.getFlowNodeInstanceReader();
 
     final var processDefinition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -344,7 +343,7 @@ public class FlowNodeInstanceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -386,7 +385,7 @@ public class FlowNodeInstanceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSortIT.java
@@ -161,7 +161,7 @@ public class FlowNodeInstanceSortIT {
       final Function<Builder, ObjectBuilder<FlowNodeInstanceSort>> sortBuilder,
       final Comparator<FlowNodeInstanceEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader("default");
+    final FlowNodeInstanceDbReader reader = rdbmsService.getFlowNodeInstanceReader();
 
     final var processDefinitionKey = nextKey();
     createAndSaveRandomFlowNodeInstances(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSpecificFilterIT.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.it.rdbms.db.flownodeinstance;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstance;
 import static io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures;
@@ -37,7 +39,8 @@ public class FlowNodeInstanceSpecificFilterIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private FlowNodeInstanceDbReader elementInstanceReader;
 
@@ -45,8 +48,9 @@ public class FlowNodeInstanceSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    elementInstanceReader = rdbmsService.getFlowNodeInstanceReader("default");
+    elementInstanceReader = rdbmsService.getFlowNodeInstanceReader();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/form/FormIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/form/FormIT.java
@@ -38,8 +38,7 @@ public class FormIT {
     final FormDbModel randomizedForm = FormFixtures.createRandomized();
     createAndSaveForm(rdbmsService, randomizedForm);
 
-    final var form =
-        rdbmsService.getFormReader("default").findOne(randomizedForm.formKey()).orElse(null);
+    final var form = rdbmsService.getFormReader().findOne(randomizedForm.formKey()).orElse(null);
     assertFormEntity(form, randomizedForm);
   }
 
@@ -54,8 +53,7 @@ public class FormIT {
         randomizedForm.copy(b -> ((FormDbModelBuilder) b).isDeleted(true));
     rdbmsService.createWriter(1L).getFormWriter().update(updatedModel);
 
-    final var form =
-        rdbmsService.getFormReader("default").findOne(randomizedForm.formKey()).orElse(null);
+    final var form = rdbmsService.getFormReader().findOne(randomizedForm.formKey()).orElse(null);
     assertFormEntity(form, updatedModel);
   }
 
@@ -68,7 +66,7 @@ public class FormIT {
 
     final var searchResult =
         rdbmsService
-            .getFormReader("default")
+            .getFormReader()
             .search(
                 new FormQuery(
                     new FormFilter.Builder().formIds(randomizedForm.formId()).build(),
@@ -90,7 +88,7 @@ public class FormIT {
 
     final var searchResult =
         rdbmsService
-            .getFormReader("default")
+            .getFormReader()
             .search(
                 new FormQuery(
                     new FormFilter.Builder().tenantId(randomizedForm.tenantId()).build(),
@@ -112,7 +110,7 @@ public class FormIT {
 
     final var searchResult =
         rdbmsService
-            .getFormReader("default")
+            .getFormReader()
             .search(
                 new FormQuery(
                     new FormFilter.Builder().formIds(id).build(),
@@ -134,7 +132,7 @@ public class FormIT {
 
     final var searchResult =
         rdbmsService
-            .getFormReader("default")
+            .getFormReader()
             .search(
                 new FormQuery(
                     new FormFilter.Builder().formIds(id).build(),
@@ -150,7 +148,7 @@ public class FormIT {
   @TestTemplate
   public void shouldFindFormWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final FormDbReader formReader = rdbmsService.getFormReader("default");
+    final FormDbReader formReader = rdbmsService.getFormReader();
 
     final String id = FormFixtures.nextStringId();
     createAndSaveRandomForms(rdbmsService, id);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/form/FormSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/form/FormSortIT.java
@@ -32,7 +32,7 @@ public class FormSortIT {
   @TestTemplate
   public void shouldSortFormsByVersionAsc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final FormDbReader formReader = rdbmsService.getFormReader("default");
+    final FormDbReader formReader = rdbmsService.getFormReader();
 
     final String id = FormFixtures.nextStringId();
     createAndSaveRandomForms(rdbmsService, id);
@@ -51,7 +51,7 @@ public class FormSortIT {
   @TestTemplate
   public void shouldSortFormsByVersionDesc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final FormDbReader formReader = rdbmsService.getFormReader("default");
+    final FormDbReader formReader = rdbmsService.getFormReader();
 
     final String id = FormFixtures.nextStringId();
     createAndSaveRandomForms(rdbmsService, id);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerFilterIT.java
@@ -49,7 +49,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -82,7 +82,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -115,7 +115,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -143,7 +143,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -173,7 +173,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -203,7 +203,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -235,7 +235,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -270,7 +270,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -305,7 +305,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -340,7 +340,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -375,7 +375,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -410,7 +410,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -439,7 +439,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder().afterNonGlobal(true).build(),
@@ -469,7 +469,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -504,7 +504,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -539,7 +539,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -574,7 +574,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -609,7 +609,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -644,7 +644,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -683,7 +683,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -722,7 +722,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()
@@ -761,7 +761,7 @@ public class GlobalListenerFilterIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
@@ -44,7 +44,7 @@ public class GlobalListenerIT {
     final var entity =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .getGlobalListener(
                 globalListener.listenerId(),
                 globalListener.listenerType(),
@@ -68,7 +68,7 @@ public class GlobalListenerIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder().types(testIdentifier).build(),
@@ -94,7 +94,7 @@ public class GlobalListenerIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder().types(testIdentifier).build(),
@@ -130,7 +130,7 @@ public class GlobalListenerIT {
     final var instance =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .getGlobalListener(
                 globalListener.listenerId(),
                 globalListener.listenerType(),
@@ -160,7 +160,7 @@ public class GlobalListenerIT {
     final var instance =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .getGlobalListener(
                 globalListener.listenerId(),
                 globalListener.listenerType(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerSortIT.java
@@ -172,7 +172,7 @@ public class GlobalListenerSortIT {
     final var searchResult =
         testApplication
             .getRdbmsService()
-            .getGlobalListenerDbReader("default")
+            .getGlobalListenerDbReader()
             .search(
                 new GlobalListenerQuery(
                     new GlobalListenerFilter.Builder()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
@@ -47,7 +47,7 @@ public class GroupIT {
   public void shouldSaveAndFindByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader groupReader = rdbmsService.getGroupReader("default");
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveGroup(rdbmsWriters, group);
@@ -61,7 +61,7 @@ public class GroupIT {
   public void shouldSaveAndFindById(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader groupReader = rdbmsService.getGroupReader("default");
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveGroup(rdbmsWriters, group);
@@ -75,7 +75,7 @@ public class GroupIT {
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader groupReader = rdbmsService.getGroupReader("default");
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveGroup(rdbmsWriters, group);
@@ -94,7 +94,7 @@ public class GroupIT {
   public void shouldSaveAndDelete(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader groupReader = rdbmsService.getGroupReader("default");
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveGroup(rdbmsWriters, group);
@@ -112,7 +112,7 @@ public class GroupIT {
   public void shouldFindByName(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader groupReader = rdbmsService.getGroupReader("default");
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveGroup(rdbmsWriters, group);
@@ -139,7 +139,7 @@ public class GroupIT {
   public void shouldFindByGroupIds(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader groupReader = rdbmsService.getGroupReader("default");
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
     final var group1 = GroupFixtures.createRandomized(b -> b);
     final var group2 = GroupFixtures.createRandomized(b -> b);
@@ -164,7 +164,7 @@ public class GroupIT {
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader groupReader = rdbmsService.getGroupReader("default");
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
     createAndSaveRandomGroupsWithMembers(rdbmsWriters, b -> b.name("John Doe"));
 
@@ -184,7 +184,7 @@ public class GroupIT {
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader groupReader = rdbmsService.getGroupReader("default");
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
     createAndSaveRandomGroupsWithMembers(rdbmsWriters, 120, b -> b.name("Jane More"));
 
@@ -205,7 +205,7 @@ public class GroupIT {
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader groupReader = rdbmsService.getGroupReader("default");
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveRandomGroups(rdbmsWriters);
@@ -227,7 +227,7 @@ public class GroupIT {
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader groupReader = rdbmsService.getGroupReader("default");
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
 
     createAndSaveRandomGroups(rdbmsWriters, b -> b.name("Alice Doe"));
     final var sort = GroupSort.of(s -> s.name().asc().groupId().asc());
@@ -259,7 +259,7 @@ public class GroupIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveGroup(rdbmsWriters, group);
     final var user = UserFixtures.createRandomized(b -> b);
@@ -285,7 +285,7 @@ public class GroupIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveGroup(rdbmsWriters, group);
     final var user = UserFixtures.createRandomized(b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupMemberIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupMemberIT.java
@@ -40,7 +40,7 @@ public class GroupMemberIT {
   public void shouldFindGroupMember(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupMemberDbReader reader = rdbmsService.getGroupMemberReader("default");
+    final GroupMemberDbReader reader = rdbmsService.getGroupMemberReader();
 
     final var group = GroupFixtures.createAndSaveGroup(rdbmsWriters, b -> b);
     final var userid1 = "user-" + UUID.randomUUID();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSortIT.java
@@ -72,7 +72,7 @@ public class GroupSortIT {
       final Function<Builder, ObjectBuilder<GroupSort>> sortBuilder,
       final Comparator<GroupEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final GroupDbReader reader = rdbmsService.getGroupReader("default");
+    final GroupDbReader reader = rdbmsService.getGroupReader();
 
     final var name = nextStringId();
     createAndSaveRandomGroups(rdbmsWriters, b -> b.name(name));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.rdbms.db.group;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveGroup;
 import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveRandomGroups;
 import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createRandomized;
@@ -14,6 +15,7 @@ import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveTenant
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.GroupDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.TenantMemberDbModel;
@@ -42,7 +44,8 @@ import org.springframework.test.context.TestPropertySource;
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class GroupSpecificFilterIT {
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private GroupDbReader groupReader;
 
@@ -50,8 +53,9 @@ public class GroupSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    groupReader = rdbmsService.getGroupReader("default");
+    groupReader = rdbmsService.getGroupReader();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/history/ProcessInstanceHistory.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/history/ProcessInstanceHistory.java
@@ -71,7 +71,7 @@ public abstract class ProcessInstanceHistory {
   protected long processInstanceCount(
       final RdbmsService rdbmsService, final List<Long> processInstanceKeys) {
     return entityCount(
-        rdbmsService.getProcessInstanceReader("default"),
+        rdbmsService.getProcessInstanceReader(),
         ProcessInstanceQuery.of(
             b ->
                 b.filter(
@@ -83,38 +83,38 @@ public abstract class ProcessInstanceHistory {
   protected long flowNodeInstanceCount(
       final RdbmsService rdbmsService, final long processInstanceKey) {
     return entityCount(
-        rdbmsService.getFlowNodeInstanceReader("default"),
+        rdbmsService.getFlowNodeInstanceReader(),
         FlowNodeInstanceQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
   }
 
   protected long userTaskCount(final RdbmsService rdbmsService, final long processInstanceKey) {
     return entityCount(
-        rdbmsService.getUserTaskReader("default"),
+        rdbmsService.getUserTaskReader(),
         UserTaskQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
   }
 
   protected long variableCount(final RdbmsService rdbmsService, final long processInstanceKey) {
     return entityCount(
-        rdbmsService.getVariableReader("default"),
+        rdbmsService.getVariableReader(),
         VariableQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
   }
 
   protected long incidentCount(final RdbmsService rdbmsService, final long processInstanceKey) {
     return entityCount(
-        rdbmsService.getIncidentReader("default"),
+        rdbmsService.getIncidentReader(),
         IncidentQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
   }
 
   protected long decisionInstanceCount(
       final RdbmsService rdbmsService, final long processInstanceKey) {
     return entityCount(
-        rdbmsService.getDecisionInstanceReader("default"),
+        rdbmsService.getDecisionInstanceReader(),
         DecisionInstanceQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
   }
 
   protected long auditLogCount(final RdbmsService rdbmsService, final long processInstanceKey) {
     return entityCount(
-        rdbmsService.getAuditLogReader("default"),
+        rdbmsService.getAuditLogReader(),
         AuditLogQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historycleanup/HistoryCleanupIT.java
@@ -34,9 +34,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     final var writers = testApplication.getRdbmsService().createWriter(0);
     final var historyCleanupService =
         new HistoryCleanupService(
-            RdbmsWriterConfig.builder().build(),
-            writers,
-            rdbmsService.getProcessInstanceReader("default"));
+            RdbmsWriterConfig.builder().build(), writers, rdbmsService.getProcessInstanceReader());
 
     final long rootProcessInstanceKey = ProcessInstanceFixtures.nextKey();
     createRandomProcessWithRelevantRelatedData(
@@ -80,7 +78,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
                 .history(HistoryConfig.builder().historyCleanupBatchSize(10).build())
                 .build(),
             writers,
-            rdbmsService.getProcessInstanceReader("default"));
+            rdbmsService.getProcessInstanceReader());
 
     final long rootProcessInstanceKey = ProcessInstanceFixtures.nextKey();
     createRandomProcessWithRelevantRelatedData(
@@ -114,9 +112,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     final var writers = testApplication.getRdbmsService().createWriter(0);
     final var historyCleanupService =
         new HistoryCleanupService(
-            RdbmsWriterConfig.builder().build(),
-            writers,
-            rdbmsService.getProcessInstanceReader("default"));
+            RdbmsWriterConfig.builder().build(), writers, rdbmsService.getProcessInstanceReader());
 
     final long rootProcessInstanceKey = ProcessInstanceFixtures.nextKey();
     createRandomProcessWithRelevantRelatedData(
@@ -157,7 +153,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
                 .history(HistoryConfig.builder().historyCleanupBatchSize(10).build())
                 .build(),
             writers,
-            rdbmsService.getProcessInstanceReader("default"));
+            rdbmsService.getProcessInstanceReader());
 
     final long rootProcessInstanceKey = ProcessInstanceFixtures.nextKey();
 
@@ -196,9 +192,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     final var writers = testApplication.getRdbmsService().createWriter(0);
     final var historyCleanupService =
         new HistoryCleanupService(
-            RdbmsWriterConfig.builder().build(),
-            writers,
-            rdbmsService.getProcessInstanceReader("default"));
+            RdbmsWriterConfig.builder().build(), writers, rdbmsService.getProcessInstanceReader());
 
     final long processInstanceKey =
         createRandomProcessWithRelevantRelatedData(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionIT.java
@@ -40,7 +40,7 @@ public class HistoryDeletionIT {
   void setUp() {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    historyDeletionReader = rdbmsService.getHistoryDeletionDbReader("default");
+    historyDeletionReader = rdbmsService.getHistoryDeletionDbReader();
     historyDeletionWriter = rdbmsWriters.getHistoryDeletionWriter();
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
@@ -38,9 +38,9 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
     final var historyDeletionService =
         new HistoryDeletionService(
             writers,
-            rdbmsService.getHistoryDeletionDbReader("default"),
-            rdbmsService.getProcessInstanceReader("default"),
-            rdbmsService.getDecisionInstanceReader("default"),
+            rdbmsService.getHistoryDeletionDbReader(),
+            rdbmsService.getProcessInstanceReader(),
+            rdbmsService.getDecisionInstanceReader(),
             new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10000),
             InstantSource.system());
 
@@ -84,9 +84,9 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
     final var historyDeletionService =
         new HistoryDeletionService(
             writers,
-            rdbmsService.getHistoryDeletionDbReader("default"),
-            rdbmsService.getProcessInstanceReader("default"),
-            rdbmsService.getDecisionInstanceReader("default"),
+            rdbmsService.getHistoryDeletionDbReader(),
+            rdbmsService.getProcessInstanceReader(),
+            rdbmsService.getDecisionInstanceReader(),
             new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10),
             InstantSource.system());
 
@@ -129,9 +129,9 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
     final var historyDeletionService =
         new HistoryDeletionService(
             writers,
-            rdbmsService.getHistoryDeletionDbReader("default"),
-            rdbmsService.getProcessInstanceReader("default"),
-            rdbmsService.getDecisionInstanceReader("default"),
+            rdbmsService.getHistoryDeletionDbReader(),
+            rdbmsService.getProcessInstanceReader(),
+            rdbmsService.getDecisionInstanceReader(),
             new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10000),
             InstantSource.system());
 
@@ -166,16 +166,15 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
     writers.flush();
 
     // pre-condition: lookup rows exist for the target
-    assertThat(rdbmsService.getVariableReader("default").findLookupVariableNames(targetPdKey))
+    assertThat(rdbmsService.getVariableReader().findLookupVariableNames(targetPdKey))
         .containsExactlyInAnyOrder(varNameA, varNameB);
 
     // when
     historyDeletionService.deleteHistory(0);
 
     // then: target lookup rows removed; control untouched
-    assertThat(rdbmsService.getVariableReader("default").findLookupVariableNames(targetPdKey))
-        .isEmpty();
-    assertThat(rdbmsService.getVariableReader("default").findLookupVariableNames(controlPdKey))
+    assertThat(rdbmsService.getVariableReader().findLookupVariableNames(targetPdKey)).isEmpty();
+    assertThat(rdbmsService.getVariableReader().findLookupVariableNames(controlPdKey))
         .containsExactly(controlVarName);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -56,7 +56,7 @@ public class IncidentIT {
   public void shouldSaveAndFindIncidentByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final var original = IncidentFixtures.createRandomized(b -> b);
     createAndSaveIncident(rdbmsWriters, original);
@@ -71,7 +71,7 @@ public class IncidentIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final var original = IncidentFixtures.createRandomized(b -> b.errorMessage("x".repeat(9000)));
     createAndSaveIncident(rdbmsWriters, original);
@@ -86,7 +86,7 @@ public class IncidentIT {
   public void shouldSaveAndResolveIncident(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final var original = IncidentFixtures.createRandomized(b -> b);
     createAndSaveIncident(rdbmsWriters, original);
@@ -105,7 +105,7 @@ public class IncidentIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final var original = IncidentFixtures.createRandomized(b -> b);
     rdbmsWriters.getIncidentWriter().create(original);
@@ -123,7 +123,7 @@ public class IncidentIT {
   public void shouldFindIncidentByBpmnProcessId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final var original = IncidentFixtures.createRandomized(b -> b);
     createAndSaveIncident(rdbmsWriters, original);
@@ -150,7 +150,7 @@ public class IncidentIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final var original = IncidentFixtures.createRandomized(b -> b);
     createAndSaveIncident(rdbmsWriters, original);
@@ -174,7 +174,7 @@ public class IncidentIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final var original = IncidentFixtures.createRandomized(b -> b);
     createAndSaveIncident(rdbmsWriters, original);
@@ -195,7 +195,7 @@ public class IncidentIT {
   public void shouldFindAllIncidentPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final String processDefinitionId = IncidentFixtures.nextStringId();
     createAndSaveRandomIncidents(rdbmsWriters, b -> b.processDefinitionId(processDefinitionId));
@@ -218,7 +218,7 @@ public class IncidentIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final String processDefinitionId = IncidentFixtures.nextStringId();
     createAndSaveRandomIncidents(
@@ -242,7 +242,7 @@ public class IncidentIT {
   public void shouldFindIncidentWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final var original = IncidentFixtures.createRandomized(b -> b);
     createAndSaveIncident(rdbmsWriters, original);
@@ -281,7 +281,7 @@ public class IncidentIT {
   public void shouldFindIncidentWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
 
     final var processDefinitionKey = nextKey();
     createAndSaveRandomIncidents(rdbmsWriters, b -> b.processDefinitionKey(processDefinitionKey));
@@ -333,7 +333,7 @@ public class IncidentIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader reader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader reader = rdbmsService.getIncidentReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -375,7 +375,7 @@ public class IncidentIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader reader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader reader = rdbmsService.getIncidentReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -417,7 +417,7 @@ public class IncidentIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final IncidentProcessInstanceStatisticsByErrorDbReader reader =
-        rdbmsService.getIncidentProcessInstanceStatisticsByErrorDbReader("default");
+        rdbmsService.getIncidentProcessInstanceStatisticsByErrorDbReader();
 
     // Ensure a clean slate for deterministic totals
     rdbmsWriters.getRdbmsPurger().purgeRdbms();
@@ -495,7 +495,7 @@ public class IncidentIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final IncidentProcessInstanceStatisticsByErrorDbReader reader =
-        rdbmsService.getIncidentProcessInstanceStatisticsByErrorDbReader("default");
+        rdbmsService.getIncidentProcessInstanceStatisticsByErrorDbReader();
 
     // Ensure a clean slate for deterministic totals
     rdbmsWriters.getRdbmsPurger().purgeRdbms();
@@ -646,7 +646,7 @@ public class IncidentIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final IncidentProcessInstanceStatisticsByDefinitionDbReader reader =
-        rdbmsService.getIncidentProcessInstanceStatisticsByDefinitionReader("default");
+        rdbmsService.getIncidentProcessInstanceStatisticsByDefinitionReader();
 
     final var errorHashCode = 1337;
 
@@ -726,7 +726,7 @@ public class IncidentIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final IncidentProcessInstanceStatisticsByDefinitionDbReader reader =
-        rdbmsService.getIncidentProcessInstanceStatisticsByDefinitionReader("default");
+        rdbmsService.getIncidentProcessInstanceStatisticsByDefinitionReader();
 
     final var errorHashCode = 7331;
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSortIT.java
@@ -139,7 +139,7 @@ public class IncidentSortIT {
       final Function<Builder, ObjectBuilder<IncidentSort>> sortBuilder,
       final Comparator<IncidentEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final IncidentDbReader reader = rdbmsService.getIncidentReader("default");
+    final IncidentDbReader reader = rdbmsService.getIncidentReader();
 
     final var key = nextKey();
     createAndSaveRandomIncidents(rdbmsWriters, b -> b.flowNodeInstanceKey(key));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSpecificFilterIT.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.it.rdbms.db.incident;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.NOW;
 import static io.camunda.it.rdbms.db.fixtures.IncidentFixtures.createAndSaveIncident;
 import static io.camunda.it.rdbms.db.fixtures.IncidentFixtures.createAndSaveRandomIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.IncidentDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
@@ -38,7 +40,8 @@ import org.springframework.test.context.TestPropertySource;
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class IncidentSpecificFilterIT {
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private IncidentDbReader incidentDbReader;
 
@@ -46,8 +49,9 @@ public class IncidentSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    incidentDbReader = rdbmsService.getIncidentReader("default");
+    incidentDbReader = rdbmsService.getIncidentReader();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
@@ -47,7 +47,7 @@ public class JobIT {
   public void shouldSaveAndFindJobByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader processInstanceReader = rdbmsService.getJobReader("default");
+    final JobDbReader processInstanceReader = rdbmsService.getJobReader();
 
     final var original = JobFixtures.createRandomized(b -> b);
     createAndSaveJob(rdbmsWriters, original);
@@ -68,7 +68,7 @@ public class JobIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader jobReader = rdbmsService.getJobReader("default");
+    final JobDbReader jobReader = rdbmsService.getJobReader();
 
     final var original = JobFixtures.createRandomized(b -> b.errorMessage("x".repeat(9000)));
     createAndSaveJob(rdbmsWriters, original);
@@ -84,7 +84,7 @@ public class JobIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader jobReader = rdbmsService.getJobReader("default");
+    final JobDbReader jobReader = rdbmsService.getJobReader();
 
     final var errorMessage = "x".repeat(9000);
 
@@ -105,7 +105,7 @@ public class JobIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader processInstanceReader = rdbmsService.getJobReader("default");
+    final JobDbReader processInstanceReader = rdbmsService.getJobReader();
 
     final var original = JobFixtures.createRandomized(b -> b);
     createAndSaveJob(rdbmsWriters, original);
@@ -132,7 +132,7 @@ public class JobIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader jobReader = rdbmsService.getJobReader("default");
+    final JobDbReader jobReader = rdbmsService.getJobReader();
 
     final String processDefinitionId = JobFixtures.nextStringId();
     final int targetPartitionId = 7;
@@ -167,7 +167,7 @@ public class JobIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader processInstanceReader = rdbmsService.getJobReader("default");
+    final JobDbReader processInstanceReader = rdbmsService.getJobReader();
 
     final var original = JobFixtures.createRandomized(b -> b);
     createAndSaveJob(rdbmsWriters, original);
@@ -190,7 +190,7 @@ public class JobIT {
   public void shouldFindJobByAuthorizedTenantId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader processInstanceReader = rdbmsService.getJobReader("default");
+    final JobDbReader processInstanceReader = rdbmsService.getJobReader();
 
     final var original = JobFixtures.createRandomized(b -> b);
     createAndSaveJob(rdbmsWriters, original);
@@ -211,7 +211,7 @@ public class JobIT {
   public void shouldFindAllJobPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader processInstanceReader = rdbmsService.getJobReader("default");
+    final JobDbReader processInstanceReader = rdbmsService.getJobReader();
 
     final String processDefinitionId = JobFixtures.nextStringId();
     createAndSaveRandomJobs(rdbmsWriters, b -> b.processDefinitionId(processDefinitionId));
@@ -234,7 +234,7 @@ public class JobIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader processInstanceReader = rdbmsService.getJobReader("default");
+    final JobDbReader processInstanceReader = rdbmsService.getJobReader();
 
     final String processDefinitionId = JobFixtures.nextStringId();
     createAndSaveRandomJobs(rdbmsWriters, 120, b -> b.processDefinitionId(processDefinitionId));
@@ -257,7 +257,7 @@ public class JobIT {
   public void shouldFindJobWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader processInstanceReader = rdbmsService.getJobReader("default");
+    final JobDbReader processInstanceReader = rdbmsService.getJobReader();
 
     final var original = JobFixtures.createRandomized(b -> b);
     createAndSaveJob(rdbmsWriters, original);
@@ -291,7 +291,7 @@ public class JobIT {
   public void shouldFindJobWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader processInstanceReader = rdbmsService.getJobReader("default");
+    final JobDbReader processInstanceReader = rdbmsService.getJobReader();
 
     final var processDefinitionKey = nextKey();
     createAndSaveRandomJobs(rdbmsWriters, b -> b.processDefinitionKey(processDefinitionKey));
@@ -346,7 +346,7 @@ public class JobIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader jobReader = rdbmsService.getJobReader("default");
+    final JobDbReader jobReader = rdbmsService.getJobReader();
 
     final var original =
         JobFixtures.createRandomized(
@@ -404,7 +404,7 @@ public class JobIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader reader = rdbmsService.getJobReader("default");
+    final JobDbReader reader = rdbmsService.getJobReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -446,7 +446,7 @@ public class JobIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader reader = rdbmsService.getJobReader("default");
+    final JobDbReader reader = rdbmsService.getJobReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -487,7 +487,7 @@ public class JobIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader jobReader = rdbmsService.getJobReader("default");
+    final JobDbReader jobReader = rdbmsService.getJobReader();
 
     final var processDefinitionKey = nextKey();
     final var target =
@@ -514,7 +514,7 @@ public class JobIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader jobReader = rdbmsService.getJobReader("default");
+    final JobDbReader jobReader = rdbmsService.getJobReader();
 
     final var processDefinitionKey = nextKey();
     final var low =
@@ -545,7 +545,7 @@ public class JobIT {
     // given — a job with NULL priority (pre-8.10) and a job with explicit priority
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader jobReader = rdbmsService.getJobReader("default");
+    final JobDbReader jobReader = rdbmsService.getJobReader();
 
     final var processDefinitionKey = nextKey();
     createAndSaveJob(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobSortIT.java
@@ -121,7 +121,7 @@ public class JobSortIT {
       final Function<Builder, ObjectBuilder<JobSort>> sortBuilder,
       final Comparator<JobEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final JobDbReader reader = rdbmsService.getJobReader("default");
+    final JobDbReader reader = rdbmsService.getJobReader();
 
     final var processDefinitionId = nextStringId();
     createAndSaveRandomJobs(rdbmsWriters, b -> b.processDefinitionId(processDefinitionId));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
@@ -91,7 +91,7 @@ public class JobMetricsBatchIT {
   void setUp() {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    jobMetricsBatchReader = rdbmsService.getJobMetricsBatchDbReader("default");
+    jobMetricsBatchReader = rdbmsService.getJobMetricsBatchDbReader();
     jobMetricsBatchWriter = rdbmsWriters.getJobMetricsBatchWriter();
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleIT.java
@@ -47,7 +47,7 @@ public class MappingRuleIT {
 
     final var mappingRule =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .findOne(randomizedMappingRule.mappingRuleId())
             .orElse(null);
     assertThat(mappingRule).isNotNull();
@@ -65,8 +65,7 @@ public class MappingRuleIT {
 
     // Verify the mapping rule is saved
     final var mappingRuleId = randomizedMappingRule.mappingRuleId();
-    final var mappingRule =
-        rdbmsService.getMappingRuleReader("default").findOne(mappingRuleId).orElse(null);
+    final var mappingRule = rdbmsService.getMappingRuleReader().findOne(mappingRuleId).orElse(null);
     assertThat(mappingRule).isNotNull();
     assertThat(mappingRule).usingRecursiveComparison().isEqualTo(randomizedMappingRule);
 
@@ -76,8 +75,7 @@ public class MappingRuleIT {
     writer.flush();
 
     // Verify the mapping rule is deleted
-    final var deletedMappingRuleResult =
-        rdbmsService.getMappingRuleReader("default").findOne(mappingRuleId);
+    final var deletedMappingRuleResult = rdbmsService.getMappingRuleReader().findOne(mappingRuleId);
     assertThat(deletedMappingRuleResult).isEmpty();
   }
 
@@ -93,7 +91,7 @@ public class MappingRuleIT {
     // Search for the mapping rule by claimName
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 new MappingRuleQuery(
                     new MappingRuleFilter.Builder()
@@ -123,7 +121,7 @@ public class MappingRuleIT {
     // Search for the mapping rule by claimValue
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 new MappingRuleQuery(
                     new MappingRuleFilter.Builder()
@@ -155,7 +153,7 @@ public class MappingRuleIT {
     // Search for the mapping rule by claimValue
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 new MappingRuleQuery(
                     new MappingRuleFilter.Builder()
@@ -189,7 +187,7 @@ public class MappingRuleIT {
     // Search for the mapping rule by claimValue
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 MappingRuleQuery.of(b -> b),
                 CommonFixtures.resourceAccessChecksFromResourceIds(
@@ -214,7 +212,7 @@ public class MappingRuleIT {
 
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 new MappingRuleQuery(
                     new MappingRuleFilter.Builder().claimName(claimName).build(),
@@ -237,7 +235,7 @@ public class MappingRuleIT {
 
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 new MappingRuleQuery(
                     new MappingRuleFilter.Builder().claimName(claimName).build(),
@@ -255,7 +253,7 @@ public class MappingRuleIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final MappingRuleDbReader mappingRuleReader = rdbmsService.getMappingRuleReader("default");
+    final MappingRuleDbReader mappingRuleReader = rdbmsService.getMappingRuleReader();
 
     final String claimName = "claimName-" + MappingRuleFixtures.nextStringId();
     createAndSaveRandomMappingRules(rdbmsWriters, b -> b.claimName(claimName));
@@ -303,7 +301,7 @@ public class MappingRuleIT {
     writer.flush();
 
     // then
-    final var mappingRule = rdbmsService.getMappingRuleReader("default").findOne(mappingRuleId);
+    final var mappingRule = rdbmsService.getMappingRuleReader().findOne(mappingRuleId);
     assertThat(mappingRule)
         .isPresent()
         .get()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSortIT.java
@@ -41,7 +41,7 @@ public class MappingRuleSortIT {
 
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 new MappingRuleQuery(
                     new MappingRuleFilter.Builder().claimName(claimName).build(),
@@ -63,7 +63,7 @@ public class MappingRuleSortIT {
 
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 new MappingRuleQuery(
                     new MappingRuleFilter.Builder().claimName(claimName).build(),
@@ -85,7 +85,7 @@ public class MappingRuleSortIT {
 
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 new MappingRuleQuery(
                     new MappingRuleFilter.Builder().claimName(claimName).build(),
@@ -108,7 +108,7 @@ public class MappingRuleSortIT {
 
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 new MappingRuleQuery(
                     new MappingRuleFilter.Builder().claimName(claimName).build(),
@@ -130,7 +130,7 @@ public class MappingRuleSortIT {
 
     final var searchResult =
         rdbmsService
-            .getMappingRuleReader("default")
+            .getMappingRuleReader()
             .search(
                 new MappingRuleQuery(
                     new MappingRuleFilter.Builder().name(name).build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSpecificFilterIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.rdbms.db.mappingrules;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveGroup;
 import static io.camunda.it.rdbms.db.fixtures.MappingRuleFixtures.*;
 import static io.camunda.it.rdbms.db.fixtures.MappingRuleFixtures.createAndSaveMappingRule;
@@ -15,6 +16,7 @@ import static io.camunda.security.api.model.authz.EntityType.MAPPING_RULE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.GroupMemberDbModel;
@@ -41,7 +43,8 @@ import org.springframework.test.context.TestPropertySource;
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class MappingRuleSpecificFilterIT {
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private MappingRuleDbReader mappingRuleReader;
 
@@ -49,8 +52,9 @@ public class MappingRuleSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    mappingRuleReader = rdbmsService.getMappingRuleReader("default");
+    mappingRuleReader = rdbmsService.getMappingRuleReader();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionIT.java
@@ -44,7 +44,7 @@ public class MessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final MessageSubscriptionDbReader messageSubscriptionReader =
-        rdbmsService.getMessageSubscriptionReader("default");
+        rdbmsService.getMessageSubscriptionReader();
 
     final var subscriptionDbModel = MessageSubscriptionFixtures.createRandomized(b -> b);
     MessageSubscriptionFixtures.createAndSaveMessageSubscription(rdbmsWriters, subscriptionDbModel);
@@ -62,7 +62,7 @@ public class MessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final MessageSubscriptionDbReader messageSubscriptionReader =
-        rdbmsService.getMessageSubscriptionReader("default");
+        rdbmsService.getMessageSubscriptionReader();
 
     final var subscription = MessageSubscriptionFixtures.createRandomized(b -> b);
     MessageSubscriptionFixtures.createAndSaveMessageSubscription(rdbmsWriters, subscription);
@@ -86,7 +86,7 @@ public class MessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final MessageSubscriptionDbReader messageSubscriptionReader =
-        rdbmsService.getMessageSubscriptionReader("default");
+        rdbmsService.getMessageSubscriptionReader();
 
     final var messageName = "message-" + UUID.randomUUID();
 
@@ -110,7 +110,7 @@ public class MessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final MessageSubscriptionDbReader messageSubscriptionReader =
-        rdbmsService.getMessageSubscriptionReader("default");
+        rdbmsService.getMessageSubscriptionReader();
 
     final var messageName = "message-more-" + UUID.randomUUID();
     MessageSubscriptionFixtures.createAndSaveRandomMessageSubscriptions(
@@ -135,7 +135,7 @@ public class MessageSubscriptionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionMessageSubscriptionStatisticsDbReader statisticsReader =
-        rdbmsService.getProcessDefinitionMessageSubscriptionStatisticsDbReader("default");
+        rdbmsService.getProcessDefinitionMessageSubscriptionStatisticsDbReader();
 
     final var messageName = "message-stats-pagination-" + UUID.randomUUID();
     final var processDefinitionKey1 = 101L;
@@ -235,7 +235,7 @@ public class MessageSubscriptionIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final MessageSubscriptionDbReader reader = rdbmsService.getMessageSubscriptionReader("default");
+    final MessageSubscriptionDbReader reader = rdbmsService.getMessageSubscriptionReader();
 
     final var subscription1 =
         MessageSubscriptionFixtures.createAndSaveMessageSubscription(rdbmsWriters, b -> b);
@@ -289,7 +289,7 @@ public class MessageSubscriptionIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final MessageSubscriptionDbReader reader = rdbmsService.getMessageSubscriptionReader("default");
+    final MessageSubscriptionDbReader reader = rdbmsService.getMessageSubscriptionReader();
 
     final var subscription1 =
         MessageSubscriptionFixtures.createAndSaveMessageSubscription(rdbmsWriters, b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionSortIT.java
@@ -56,7 +56,7 @@ public class MessageSubscriptionSortIT {
           sortBuilder,
       final Comparator<MessageSubscriptionEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final MessageSubscriptionDbReader reader = rdbmsService.getMessageSubscriptionReader("default");
+    final MessageSubscriptionDbReader reader = rdbmsService.getMessageSubscriptionReader();
 
     final var messageName = nextStringId();
     MessageSubscriptionFixtures.createAndSaveRandomMessageSubscriptions(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionSpecificFilterIT.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.it.rdbms.db.messagesubscription;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
@@ -48,7 +50,8 @@ public class MessageSubscriptionSpecificFilterIT {
   private static final String PROCESS_DEFINITION_NAME = "processDefinitionName";
   private static final Integer PROCESS_DEFINITION_VERSION = 15;
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private MessageSubscriptionDbReader messageSubscriptionDbReader;
 
@@ -56,8 +59,9 @@ public class MessageSubscriptionSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    messageSubscriptionDbReader = rdbmsService.getMessageSubscriptionReader("default");
+    messageSubscriptionDbReader = rdbmsService.getMessageSubscriptionReader();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
@@ -54,7 +54,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionDbReader processDefinitionReader =
-        rdbmsService.getProcessDefinitionReader("default");
+        rdbmsService.getProcessDefinitionReader();
 
     final var processDefinition = ProcessDefinitionFixtures.createRandomized(b -> b);
     createAndSaveProcessDefinition(rdbmsWriters, processDefinition);
@@ -75,7 +75,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionDbReader processDefinitionReader =
-        rdbmsService.getProcessDefinitionReader("default");
+        rdbmsService.getProcessDefinitionReader();
 
     final var processDefinition =
         ProcessDefinitionFixtures.createRandomized(
@@ -108,7 +108,7 @@ public class ProcessDefinitionIT {
       final CamundaRdbmsTestApplication testApplication) {
     final var rdbmsService = testApplication.getRdbmsService();
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final var processDefinitionReader = rdbmsService.getProcessDefinitionReader("default");
+    final var processDefinitionReader = rdbmsService.getProcessDefinitionReader();
 
     final var processDefinitionId =
         RandomStringUtils.insecure()
@@ -138,7 +138,7 @@ public class ProcessDefinitionIT {
       final CamundaRdbmsTestApplication testApplication) {
     final var rdbmsService = testApplication.getRdbmsService();
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final var processDefinitionReader = rdbmsService.getProcessDefinitionReader("default");
+    final var processDefinitionReader = rdbmsService.getProcessDefinitionReader();
 
     final var name = "カマンダ";
 
@@ -160,7 +160,7 @@ public class ProcessDefinitionIT {
       final CamundaRdbmsTestApplication testApplication) {
     final var rdbmsService = testApplication.getRdbmsService();
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final var processDefinitionReader = rdbmsService.getProcessDefinitionReader("default");
+    final var processDefinitionReader = rdbmsService.getProcessDefinitionReader();
 
     final var name = "ü".repeat(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH);
 
@@ -183,7 +183,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionDbReader processDefinitionReader =
-        rdbmsService.getProcessDefinitionReader("default");
+        rdbmsService.getProcessDefinitionReader();
 
     final var processDefinition = createAndSaveRandomProcessDefinition(rdbmsWriters, b -> b);
     createAndSaveRandomProcessDefinitions(rdbmsWriters);
@@ -208,7 +208,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionDbReader processDefinitionReader =
-        rdbmsService.getProcessDefinitionReader("default");
+        rdbmsService.getProcessDefinitionReader();
 
     final var processDefinition = createAndSaveRandomProcessDefinition(rdbmsWriters, b -> b);
     createAndSaveRandomProcessDefinitions(rdbmsWriters);
@@ -231,7 +231,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionDbReader processDefinitionReader =
-        rdbmsService.getProcessDefinitionReader("default");
+        rdbmsService.getProcessDefinitionReader();
 
     final String processDefinitionId = ProcessDefinitionFixtures.nextStringId();
     createAndSaveRandomProcessDefinitions(
@@ -256,7 +256,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionDbReader processDefinitionReader =
-        rdbmsService.getProcessDefinitionReader("default");
+        rdbmsService.getProcessDefinitionReader();
 
     final String processDefinitionId = ProcessDefinitionFixtures.nextStringId();
     createAndSaveRandomProcessDefinitions(
@@ -282,7 +282,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionDbReader processDefinitionReader =
-        rdbmsService.getProcessDefinitionReader("default");
+        rdbmsService.getProcessDefinitionReader();
 
     createAndSaveRandomProcessDefinitions(rdbmsWriters);
 
@@ -302,7 +302,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionDbReader processDefinitionReader =
-        rdbmsService.getProcessDefinitionReader("default");
+        rdbmsService.getProcessDefinitionReader();
 
     final var processDefinition = ProcessDefinitionFixtures.createRandomized(b -> b);
     createAndSaveRandomProcessDefinitions(rdbmsWriters);
@@ -336,7 +336,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionDbReader processDefinitionReader =
-        rdbmsService.getProcessDefinitionReader("default");
+        rdbmsService.getProcessDefinitionReader();
 
     createAndSaveRandomProcessDefinitions(rdbmsWriters, b -> b.versionTag("search-after-123456"));
     final var sort =
@@ -376,7 +376,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsDbReader =
-        rdbmsService.getProcessDefinitionInstanceStatisticsReader("default");
+        rdbmsService.getProcessDefinitionInstanceStatisticsReader();
 
     final var processDefinition =
         createAndSaveProcessDefinition(
@@ -428,7 +428,7 @@ public class ProcessDefinitionIT {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionInstanceVersionStatisticsDbReader
         processDefinitionInstanceVersionStatisticsDbReader =
-            rdbmsService.getProcessDefinitionInstanceVersionStatisticsReader("default");
+            rdbmsService.getProcessDefinitionInstanceVersionStatisticsReader();
 
     final var processDefinitionV1 =
         createAndSaveProcessDefinition(
@@ -501,7 +501,7 @@ public class ProcessDefinitionIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessDefinitionDbReader processDefinitionReader =
-        rdbmsService.getProcessDefinitionReader("default");
+        rdbmsService.getProcessDefinitionReader();
 
     final var processDefinition1 = ProcessDefinitionFixtures.createRandomized(b -> b);
     final var processDefinition2 = ProcessDefinitionFixtures.createRandomized(b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSortIT.java
@@ -138,7 +138,7 @@ public class ProcessDefinitionSortIT {
       final Function<Builder, ObjectBuilder<ProcessDefinitionSort>> sortBuilder,
       final Comparator<ProcessDefinitionEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessDefinitionDbReader reader = rdbmsService.getProcessDefinitionReader("default");
+    final ProcessDefinitionDbReader reader = rdbmsService.getProcessDefinitionReader();
 
     final var versionTag = nextStringId();
     createAndSaveRandomProcessDefinitions(rdbmsWriters, b -> b.versionTag(versionTag));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.it.rdbms.db.processdefinition;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
 import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveRandomProcessDefinitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
@@ -31,7 +33,8 @@ import org.springframework.test.context.TestPropertySource;
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class ProcessDefinitionSpecificFilterIT {
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private ProcessDefinitionDbReader processDefinitionReader;
 
@@ -39,8 +42,9 @@ public class ProcessDefinitionSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    processDefinitionReader = rdbmsService.getProcessDefinitionReader("default");
+    processDefinitionReader = rdbmsService.getProcessDefinitionReader();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -50,8 +50,7 @@ public class ProcessInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final Long processInstanceKey = nextKey();
     final long rootProcessInstanceKey = nextKey();
@@ -91,8 +90,7 @@ public class ProcessInstanceIT {
   public void shouldSaveLogAndResolveIncident(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final ProcessInstanceDbModel original = ProcessInstanceFixtures.createRandomized(b -> b);
     createAndSaveProcessInstance(rdbmsWriters, original);
@@ -119,8 +117,7 @@ public class ProcessInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final ProcessInstanceDbModel instance =
         ProcessInstanceFixtures.createRandomized(b -> b.tags(Set.of("foo", "bar")));
@@ -143,8 +140,7 @@ public class ProcessInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final Long processInstanceKey = nextKey();
     final Long processDefinitionKey = nextKey();
@@ -192,8 +188,7 @@ public class ProcessInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final String uniqueProcessDefinitionId = ProcessInstanceFixtures.nextStringId();
     final var processInstance =
@@ -219,8 +214,7 @@ public class ProcessInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final var processInstance = createAndSaveRandomProcessInstance(rdbmsWriters, b -> b);
     createAndSaveRandomProcessInstances(rdbmsWriters);
@@ -241,8 +235,7 @@ public class ProcessInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final Long processDefinitionKey = nextKey();
     createAndSaveRandomProcessInstances(
@@ -275,8 +268,7 @@ public class ProcessInstanceIT {
   public void shouldFindAllProcessInstancePaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final String processDefinitionId = ProcessInstanceFixtures.nextStringId();
     createAndSaveRandomProcessInstances(
@@ -300,8 +292,7 @@ public class ProcessInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final String processDefinitionId = ProcessInstanceFixtures.nextStringId();
     createAndSaveRandomProcessInstances(
@@ -326,8 +317,7 @@ public class ProcessInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final Long processInstanceKey = nextKey();
     createAndSaveRandomProcessInstances(rdbmsWriters);
@@ -374,8 +364,7 @@ public class ProcessInstanceIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final var processDefinition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -427,8 +416,7 @@ public class ProcessInstanceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final var cleanupDate = NOW.minusDays(1);
 
@@ -479,8 +467,7 @@ public class ProcessInstanceIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final var processDefinition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -572,7 +559,7 @@ public class ProcessInstanceIT {
     // Select expired process instances
     final var expiredPIs =
         rdbmsService
-            .getProcessInstanceReader("default")
+            .getProcessInstanceReader()
             .selectExpiredRootProcessInstances(partitionId, cleanupDate, 10);
 
     assertThat(expiredPIs).hasSize(2);
@@ -622,7 +609,7 @@ public class ProcessInstanceIT {
     // Select with limit of 3
     final var expiredPIs =
         rdbmsService
-            .getProcessInstanceReader("default")
+            .getProcessInstanceReader()
             .selectExpiredRootProcessInstances(partitionId, cleanupDate, 3);
 
     assertThat(expiredPIs).hasSize(3);
@@ -662,7 +649,7 @@ public class ProcessInstanceIT {
     // Select expired process instances for partitionId only
     final var expiredPIs =
         rdbmsService
-            .getProcessInstanceReader("default")
+            .getProcessInstanceReader()
             .selectExpiredRootProcessInstances(partitionId, cleanupDate, 10);
 
     assertThat(expiredPIs).hasSize(1);
@@ -694,7 +681,7 @@ public class ProcessInstanceIT {
     // Select expired process instances
     final var expiredPIs =
         rdbmsService
-            .getProcessInstanceReader("default")
+            .getProcessInstanceReader()
             .selectExpiredRootProcessInstances(partitionId, cleanupDate, 10);
 
     assertThat(expiredPIs).hasSize(1);
@@ -724,7 +711,7 @@ public class ProcessInstanceIT {
     // Select expired process instances
     final var expiredPIs =
         rdbmsService
-            .getProcessInstanceReader("default")
+            .getProcessInstanceReader()
             .selectExpiredRootProcessInstances(partitionId, cleanupDate, 10);
 
     assertThat(expiredPIs).hasSize(0);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
@@ -154,7 +154,7 @@ public class ProcessInstanceSortIT {
       final Function<Builder, ObjectBuilder<ProcessInstanceSort>> sortBuilder,
       final Comparator<ProcessInstanceEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader reader = rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader reader = rdbmsService.getProcessInstanceReader();
 
     final var version = new Random().nextInt(32767);
     for (int i = 0; i < 20; i++) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.it.rdbms.db.processinstance;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
 import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstance;
 import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveRandomProcessInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
@@ -44,7 +46,8 @@ public class ProcessInstanceSpecificFilterIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private ProcessInstanceDbReader processInstanceReader;
 
@@ -52,8 +55,9 @@ public class ProcessInstanceSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    processInstanceReader = rdbmsService.getProcessInstanceReader("default");
+    processInstanceReader = rdbmsService.getProcessInstanceReader();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceTagIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceTagIT.java
@@ -37,8 +37,7 @@ public class ProcessInstanceTagIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final var processDefinitionId = "test-process-" + nextKey();
     createAndSaveProcessInstance(
@@ -67,8 +66,7 @@ public class ProcessInstanceTagIT {
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final ProcessInstanceDbReader processInstanceReader =
-        rdbmsService.getProcessInstanceReader("default");
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final var processDefinitionId = "test-process-" + nextKey();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -40,7 +40,7 @@ public class RoleIT {
   public void shouldSaveAndFindById(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final RoleDbReader roleReader = rdbmsService.getRoleReader("default");
+    final RoleDbReader roleReader = rdbmsService.getRoleReader();
 
     final var role = RoleFixtures.createRandomized(b -> b);
     createAndSaveRole(rdbmsWriters, role);
@@ -54,7 +54,7 @@ public class RoleIT {
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final RoleDbReader roleReader = rdbmsService.getRoleReader("default");
+    final RoleDbReader roleReader = rdbmsService.getRoleReader();
 
     final var role = RoleFixtures.createRandomized(b -> b);
     createAndSaveRole(rdbmsWriters, role);
@@ -73,7 +73,7 @@ public class RoleIT {
   public void shouldSaveAndDelete(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final RoleDbReader roleReader = rdbmsService.getRoleReader("default");
+    final RoleDbReader roleReader = rdbmsService.getRoleReader();
 
     final var role = RoleFixtures.createRandomized(b -> b);
     createAndSaveRole(rdbmsWriters, role);
@@ -91,7 +91,7 @@ public class RoleIT {
   public void shouldFindByName(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final RoleDbReader roleReader = rdbmsService.getRoleReader("default");
+    final RoleDbReader roleReader = rdbmsService.getRoleReader();
 
     final var role = RoleFixtures.createRandomized(b -> b);
     createAndSaveRole(rdbmsWriters, role);
@@ -118,7 +118,7 @@ public class RoleIT {
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final RoleDbReader roleReader = rdbmsService.getRoleReader("default");
+    final RoleDbReader roleReader = rdbmsService.getRoleReader();
 
     createAndSaveRandomRolesWithMembers(rdbmsWriters, b -> b.name("John Doe"));
 
@@ -138,7 +138,7 @@ public class RoleIT {
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final RoleDbReader roleReader = rdbmsService.getRoleReader("default");
+    final RoleDbReader roleReader = rdbmsService.getRoleReader();
 
     createAndSaveRandomRolesWithMembers(rdbmsWriters, 120, b -> b.name("Jane More"));
 
@@ -159,7 +159,7 @@ public class RoleIT {
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final RoleDbReader roleReader = rdbmsService.getRoleReader("default");
+    final RoleDbReader roleReader = rdbmsService.getRoleReader();
 
     final var role = RoleFixtures.createRandomized(b -> b);
     createAndSaveRandomRoles(rdbmsWriters);
@@ -181,7 +181,7 @@ public class RoleIT {
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final RoleDbReader roleReader = rdbmsService.getRoleReader("default");
+    final RoleDbReader roleReader = rdbmsService.getRoleReader();
 
     createAndSaveRandomRoles(rdbmsWriters, b -> b.name("Alice Doe"));
     final var sort = RoleSort.of(s -> s.name().asc());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleMemberIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleMemberIT.java
@@ -39,7 +39,7 @@ public class RoleMemberIT {
   public void shouldFindRoleMember(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final RoleMemberDbReader reader = rdbmsService.getRoleMemberReader("default");
+    final RoleMemberDbReader reader = rdbmsService.getRoleMemberReader();
 
     RoleFixtures.createAndSaveRandomRoles(rdbmsWriters, b -> b);
     final var role = RoleFixtures.createAndSaveRole(rdbmsWriters, b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSortIT.java
@@ -56,7 +56,7 @@ public class RoleSortIT {
       final Function<Builder, ObjectBuilder<RoleSort>> sortBuilder,
       final Comparator<RoleEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final RoleDbReader reader = rdbmsService.getRoleReader("default");
+    final RoleDbReader reader = rdbmsService.getRoleReader();
 
     final var name = nextStringId();
     createAndSaveRandomRoles(rdbmsWriters, b -> b.name(name));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.rdbms.db.role;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
 import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveGroup;
 import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRandomRolesWithMembers;
@@ -17,6 +18,7 @@ import static io.camunda.security.api.model.authz.EntityType.ROLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.RoleDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.RoleMemberDbModel;
@@ -61,7 +63,8 @@ public class RoleSpecificFilterIT {
   public static final String ENTITY_ID = "entityId";
   public static final EntityType ENTITY_TYPE = EntityType.USER;
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private RoleDbReader roleReader;
 
@@ -69,8 +72,9 @@ public class RoleSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    roleReader = rdbmsService.getRoleReader("default");
+    roleReader = rdbmsService.getRoleReader();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/sequenceflow/SequenceFlowIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/sequenceflow/SequenceFlowIT.java
@@ -39,7 +39,7 @@ public class SequenceFlowIT {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader("default");
+    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader();
 
     // when
     final var sequenceFlow = createAndSaveRandomSequenceFlow(rdbmsWriter, b -> b);
@@ -69,7 +69,7 @@ public class SequenceFlowIT {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader("default");
+    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader();
 
     final var sequenceFlow = createAndSaveRandomSequenceFlow(rdbmsWriter, b -> b);
     createAndSaveRandomSequenceFlows(rdbmsWriter);
@@ -102,7 +102,7 @@ public class SequenceFlowIT {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader("default");
+    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader();
 
     final var sequenceFlow =
         createAndSaveRandomSequenceFlow(rdbmsWriter, b -> b.processInstanceKey(42L));
@@ -127,7 +127,7 @@ public class SequenceFlowIT {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader("default");
+    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader();
 
     final var sequenceFlow =
         createAndSaveRandomSequenceFlow(rdbmsWriter, b -> b.processInstanceKey(42L));
@@ -151,7 +151,7 @@ public class SequenceFlowIT {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader("default");
+    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader();
     final var sequenceFlowWriter = rdbmsWriter.getSequenceFlowWriter();
 
     final var sequenceFlow = createRandomized(b -> b);
@@ -175,7 +175,7 @@ public class SequenceFlowIT {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader("default");
+    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader();
     final var sequenceFlowWriter = rdbmsWriter.getSequenceFlowWriter();
     final var dbModel = createRandomized(b -> b);
     sequenceFlowWriter.create(dbModel);
@@ -200,7 +200,7 @@ public class SequenceFlowIT {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
     final var rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader("default");
+    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader();
     final var sequenceFlowWriter = rdbmsWriter.getSequenceFlowWriter();
 
     final var dbModel = createRandomized(b -> b);
@@ -235,7 +235,7 @@ public class SequenceFlowIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader("default");
+    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader();
     final var sequenceFlowWriter = rdbmsWriters.getSequenceFlowWriter();
 
     final var item1 = createRandomized(b -> b);
@@ -268,7 +268,7 @@ public class SequenceFlowIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader("default");
+    final var sequenceFlowReader = rdbmsService.getSequenceFlowReader();
     final var sequenceFlowWriter = rdbmsWriters.getSequenceFlowWriter();
 
     final var item1 = createRandomized(b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
@@ -47,7 +47,7 @@ public class TenantIT {
   public void shouldSaveAndFindTenantByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader reader = rdbmsService.getTenantReader("default");
+    final TenantDbReader reader = rdbmsService.getTenantReader();
 
     final var tenant = createAndSaveTenant(rdbmsWriters);
 
@@ -59,7 +59,7 @@ public class TenantIT {
   public void shouldFindByTenantId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader reader = rdbmsService.getTenantReader("default");
+    final TenantDbReader reader = rdbmsService.getTenantReader();
 
     final var tenant = createAndSaveTenant(rdbmsWriters);
 
@@ -81,7 +81,7 @@ public class TenantIT {
   public void shouldFindByAuthorizedResourceId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader reader = rdbmsService.getTenantReader("default");
+    final TenantDbReader reader = rdbmsService.getTenantReader();
 
     final var tenant = createAndSaveTenant(rdbmsWriters);
     createAndSaveRandomTenants(rdbmsWriters);
@@ -103,7 +103,7 @@ public class TenantIT {
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader tenantReader = rdbmsService.getTenantReader("default");
+    final TenantDbReader tenantReader = rdbmsService.getTenantReader();
 
     final var tenantId = nextStringId();
     final var tenant = TenantFixtures.createRandomized(b -> b.tenantId(tenantId));
@@ -122,7 +122,7 @@ public class TenantIT {
   public void shouldSaveAndDelete(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader tenantReader = rdbmsService.getTenantReader("default");
+    final TenantDbReader tenantReader = rdbmsService.getTenantReader();
 
     final var tenant = TenantFixtures.createRandomized(b -> b);
     createAndSaveTenant(rdbmsWriters, tenant);
@@ -140,7 +140,7 @@ public class TenantIT {
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader reader = rdbmsService.getTenantReader("default");
+    final TenantDbReader reader = rdbmsService.getTenantReader();
 
     final var tenantName = "tenant-" + nextStringId();
     createAndSaveRandomTenants(rdbmsWriters, b -> b.name(tenantName));
@@ -160,7 +160,7 @@ public class TenantIT {
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader reader = rdbmsService.getTenantReader("default");
+    final TenantDbReader reader = rdbmsService.getTenantReader();
 
     final var tenantName = "tenant-more-" + nextStringId();
     createAndSaveRandomTenants(rdbmsWriters, 120, b -> b.name(tenantName));
@@ -182,7 +182,7 @@ public class TenantIT {
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader reader = rdbmsService.getTenantReader("default");
+    final TenantDbReader reader = rdbmsService.getTenantReader();
 
     createAndSaveRandomTenants(rdbmsWriters, b -> b.name("test"));
     final var instance = createAndSaveTenant(rdbmsWriters);
@@ -206,7 +206,7 @@ public class TenantIT {
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader tenantReader = rdbmsService.getTenantReader("default");
+    final TenantDbReader tenantReader = rdbmsService.getTenantReader();
 
     final var tenantName = nextStringId();
     createAndSaveRandomTenants(rdbmsWriters, b -> b.name(tenantName));
@@ -239,7 +239,7 @@ public class TenantIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
     final var tenant = TenantFixtures.createRandomized(b -> b);
     createAndSaveTenant(rdbmsWriters, tenant);
     final var user = UserFixtures.createRandomized(b -> b);
@@ -265,7 +265,7 @@ public class TenantIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
     final var tenant = TenantFixtures.createRandomized(b -> b);
     createAndSaveTenant(rdbmsWriters, tenant);
     final var user = UserFixtures.createRandomized(b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantMemberIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantMemberIT.java
@@ -40,7 +40,7 @@ public class TenantMemberIT {
   public void shouldFindTenantMember(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantMemberDbReader reader = rdbmsService.getTenantMemberReader("default");
+    final TenantMemberDbReader reader = rdbmsService.getTenantMemberReader();
 
     createAndSaveRandomTenants(rdbmsWriters, b -> b);
     final var tenant = createAndSaveTenant(rdbmsWriters, b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
@@ -83,7 +83,7 @@ public class TenantSortIT {
   public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader reader = rdbmsService.getTenantReader("default");
+    final TenantDbReader reader = rdbmsService.getTenantReader();
 
     // create 20 tenants with unique, ordered names and collect their IDs for isolated filtering
     // (aggregator approach can't be used as name is the sort field and must vary)
@@ -116,7 +116,7 @@ public class TenantSortIT {
       final Function<TenantDbModel.Builder, TenantDbModel.Builder> aggregatorBuilderFunction,
       final Function<TenantFilter.Builder, TenantFilter.Builder> aggregatorFilterFunction) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final TenantDbReader reader = rdbmsService.getTenantReader("default");
+    final TenantDbReader reader = rdbmsService.getTenantReader();
 
     aggregatorBuilderFunction.apply(new TenantDbModel.Builder().name("test"));
     createAndSaveRandomTenants(rdbmsWriters, aggregatorBuilderFunction);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.it.rdbms.db.tenant;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveRandomTenants;
 import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.TenantDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.TenantMemberDbModel;
@@ -40,7 +42,8 @@ public class TenantSpecificFilterIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private TenantDbReader tenantReader;
 
@@ -48,8 +51,9 @@ public class TenantSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    tenantReader = rdbmsService.getTenantReader("default");
+    tenantReader = rdbmsService.getTenantReader();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetric/UsageMetricIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetric/UsageMetricIT.java
@@ -104,8 +104,8 @@ public class UsageMetricIT {
   void setUp() {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    usageMetricReader = rdbmsService.getUsageMetricReader("default");
-    usageMetricTUDbReader = rdbmsService.getUsageMetricTUReader("default");
+    usageMetricReader = rdbmsService.getUsageMetricReader();
+    usageMetricTUDbReader = rdbmsService.getUsageMetricTUReader();
     usageMetricWriter = rdbmsWriters.getUsageMetricWriter();
     usageMetricTUWriter = rdbmsWriters.getUsageMetricTUWriter();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -41,7 +41,7 @@ public class UserIT {
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
 
     final var user = UserFixtures.createRandomized(b -> b);
     createAndSaveUser(rdbmsWriters, user);
@@ -60,7 +60,7 @@ public class UserIT {
   public void shouldSaveAndDelete(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
 
     final var user = UserFixtures.createRandomized(b -> b);
     createAndSaveUser(rdbmsWriters, user);
@@ -78,7 +78,7 @@ public class UserIT {
   public void shouldFindByUsername(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
 
     final var user = UserFixtures.createRandomized(b -> b);
     createAndSaveUser(rdbmsWriters, user);
@@ -107,7 +107,7 @@ public class UserIT {
   public void shouldFindByNameUTF8(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
 
     final var username = "カムンダ ユーザー";
     final var user = UserFixtures.createRandomized(b -> b.name(username));
@@ -127,7 +127,7 @@ public class UserIT {
   public void shouldFindAuthorization(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
 
     final var user = UserFixtures.createRandomized(b -> b);
     createAndSaveUser(rdbmsWriters, user);
@@ -156,7 +156,7 @@ public class UserIT {
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
 
     final String userId = UserFixtures.nextStringId();
     createAndSaveRandomUsers(rdbmsWriters, b -> b.name("John Doe"));
@@ -177,7 +177,7 @@ public class UserIT {
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
 
     createAndSaveRandomUsers(rdbmsWriters, 120, b -> b.name("Jane More"));
 
@@ -198,7 +198,7 @@ public class UserIT {
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
 
     final var user = UserFixtures.createRandomized(b -> b);
     createAndSaveRandomUsers(rdbmsWriters);
@@ -224,7 +224,7 @@ public class UserIT {
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader("default");
+    final UserDbReader userReader = rdbmsService.getUserReader();
 
     createAndSaveRandomUsers(rdbmsWriters, b -> b.name("Alice Doe"));
     final var sort = UserSort.of(s -> s.name().asc().username().asc().email().desc());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSortIT.java
@@ -80,7 +80,7 @@ public class UserSortIT {
       final Function<Builder, ObjectBuilder<UserSort>> sortBuilder,
       final Comparator<UserEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader reader = rdbmsService.getUserReader("default");
+    final UserDbReader reader = rdbmsService.getUserReader();
 
     final var email = nextStringId();
     createAndSaveRandomUsers(rdbmsWriters, b -> b.email(email));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.rdbms.db.user;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveGroup;
 import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRole;
 import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveTenant;
@@ -15,6 +16,7 @@ import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.service.UserDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.GroupMemberDbModel;
@@ -43,7 +45,8 @@ import org.springframework.test.context.TestPropertySource;
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class UserSpecificFilterIT {
 
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
 
   private UserDbReader userReader;
 
@@ -51,8 +54,9 @@ public class UserSpecificFilterIT {
 
   @BeforeEach
   public void beforeAll() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     rdbmsWriters = rdbmsService.createWriter(0L);
-    userReader = rdbmsService.getUserReader("default");
+    userReader = rdbmsService.getUserReader();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -66,8 +66,7 @@ public class UserTaskIT {
     final UserTaskDbModel userTask = UserTaskFixtures.createRandomized();
     createAndSaveUserTask(rdbmsService, userTask);
 
-    final var instance =
-        rdbmsService.getUserTaskReader("default").findOne(userTask.userTaskKey()).get();
+    final var instance = rdbmsService.getUserTaskReader().findOne(userTask.userTaskKey()).get();
     assertUserTaskEntity(instance, userTask);
   }
 
@@ -80,8 +79,7 @@ public class UserTaskIT {
         UserTaskFixtures.createRandomized(b -> b.customHeaders(Map.of("headerKey", "headerValue")));
     createAndSaveUserTask(rdbmsService, userTask);
 
-    final var instance =
-        rdbmsService.getUserTaskReader("default").findOne(userTask.userTaskKey()).get();
+    final var instance = rdbmsService.getUserTaskReader().findOne(userTask.userTaskKey()).get();
     assertUserTaskEntity(instance, userTask);
     assertThat(instance.customHeaders()).containsExactly(entry("headerKey", "headerValue"));
   }
@@ -95,8 +93,7 @@ public class UserTaskIT {
         UserTaskFixtures.createRandomized(b -> b.candidateGroups(null).candidateUsers(null));
     createAndSaveUserTask(rdbmsService, userTask);
 
-    final var instance =
-        rdbmsService.getUserTaskReader("default").findOne(userTask.userTaskKey()).get();
+    final var instance = rdbmsService.getUserTaskReader().findOne(userTask.userTaskKey()).get();
     assertUserTaskEntity(instance, userTask);
   }
 
@@ -113,8 +110,7 @@ public class UserTaskIT {
     writer.getUserTaskWriter().update(updatedModel);
     writer.flush();
 
-    final var instance =
-        rdbmsService.getUserTaskReader("default").findOne(userTask.userTaskKey()).get();
+    final var instance = rdbmsService.getUserTaskReader().findOne(userTask.userTaskKey()).get();
     assertUserTaskEntity(instance, updatedModel);
   }
 
@@ -140,8 +136,7 @@ public class UserTaskIT {
     writer.getUserTaskWriter().update(updatedModel);
     writer.flush();
 
-    final var instance =
-        rdbmsService.getUserTaskReader("default").findOne(userTask.userTaskKey()).get();
+    final var instance = rdbmsService.getUserTaskReader().findOne(userTask.userTaskKey()).get();
     assertUserTaskEntity(instance, updatedModel);
   }
 
@@ -158,8 +153,7 @@ public class UserTaskIT {
     writer.getUserTaskWriter().update(updatedModel);
     writer.flush();
 
-    final var instance =
-        rdbmsService.getUserTaskReader("default").findOne(userTask.userTaskKey()).get();
+    final var instance = rdbmsService.getUserTaskReader().findOne(userTask.userTaskKey()).get();
     assertUserTaskEntity(instance, updatedModel);
   }
 
@@ -180,8 +174,7 @@ public class UserTaskIT {
     rdbmsWriters.getUserTaskWriter().update(updatedModel);
     rdbmsWriters.flush();
 
-    final var instance =
-        rdbmsService.getUserTaskReader("default").findOne(userTask.userTaskKey()).get();
+    final var instance = rdbmsService.getUserTaskReader().findOne(userTask.userTaskKey()).get();
     assertUserTaskEntity(instance, updatedModel);
   }
 
@@ -196,7 +189,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder().processDefinitionIds(processDefinitionId).build(),
@@ -219,7 +212,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -247,7 +240,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -282,7 +275,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -311,7 +304,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -338,7 +331,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -366,7 +359,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -395,7 +388,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -427,7 +420,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -460,7 +453,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -492,7 +485,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -521,7 +514,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 resourceAccessChecksFromResourceIds(
@@ -544,7 +537,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b), resourceAccessChecksFromTenantIds(userTask.tenantId()));
 
@@ -567,7 +560,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -596,7 +589,7 @@ public class UserTaskIT {
     // when - authenticate as the first candidate user
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -627,7 +620,7 @@ public class UserTaskIT {
     // when - authenticate with the first candidate group
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -664,7 +657,7 @@ public class UserTaskIT {
     final var userGroups = List.of(group, generateRandomString("unrelatedGroup"));
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -703,7 +696,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -751,7 +744,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -794,7 +787,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -835,7 +828,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -872,7 +865,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -915,7 +908,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -964,7 +957,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -1011,7 +1004,7 @@ public class UserTaskIT {
     // when - combining ID-based and property-based, but only ID matches
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -1052,7 +1045,7 @@ public class UserTaskIT {
     // when - combining ID-based and property-based, but only property matches
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -1097,7 +1090,7 @@ public class UserTaskIT {
     // when
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 UserTaskQuery.of(b -> b),
                 ResourceAccessChecks.of(
@@ -1150,7 +1143,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1194,7 +1187,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1232,7 +1225,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1280,7 +1273,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1324,7 +1317,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1370,7 +1363,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1401,7 +1394,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder().processDefinitionIds(processDefinitionId).build(),
@@ -1423,7 +1416,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder().processDefinitionIds(processDefinitionId).build(),
@@ -1448,7 +1441,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1475,7 +1468,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1502,7 +1495,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1529,7 +1522,7 @@ public class UserTaskIT {
 
     final var searchResultGte =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1554,7 +1547,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1579,7 +1572,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder().dueDateOperations(Operation.lte(dueDate)).build(),
@@ -1604,7 +1597,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1631,7 +1624,7 @@ public class UserTaskIT {
 
     final var searchResult =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1658,7 +1651,7 @@ public class UserTaskIT {
 
     final var searchResultGte =
         rdbmsService
-            .getUserTaskReader("default")
+            .getUserTaskReader()
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
@@ -1675,7 +1668,7 @@ public class UserTaskIT {
   @TestTemplate
   public void shouldFindUserTaskWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final UserTaskDbReader processInstanceReader = rdbmsService.getUserTaskReader("default");
+    final UserTaskDbReader processInstanceReader = rdbmsService.getUserTaskReader();
 
     createAndSaveRandomUserTasks(rdbmsService);
     final UserTaskDbModel userTask = UserTaskFixtures.createRandomized(b -> b);
@@ -1711,7 +1704,7 @@ public class UserTaskIT {
   @TestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final UserTaskDbReader reader = rdbmsService.getUserTaskReader("default");
+    final UserTaskDbReader reader = rdbmsService.getUserTaskReader();
 
     createAndSaveRandomUserTasks(rdbmsService, b -> b.tenantId("tenant-1337"));
     final var sort = UserTaskSort.of(s -> s.priority().asc().completionDate().asc().desc());
@@ -1804,7 +1797,7 @@ public class UserTaskIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserTaskDbReader reader = rdbmsService.getUserTaskReader("default");
+    final UserTaskDbReader reader = rdbmsService.getUserTaskReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
@@ -1846,7 +1839,7 @@ public class UserTaskIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserTaskDbReader reader = rdbmsService.getUserTaskReader("default");
+    final UserTaskDbReader reader = rdbmsService.getUserTaskReader();
 
     final var definition =
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
@@ -134,7 +134,7 @@ public class UserTaskSortIT {
       final RdbmsService rdbmsService,
       final Function<Builder, ObjectBuilder<UserTaskSort>> sortBuilder,
       final Comparator<UserTaskEntity> comparator) {
-    final UserTaskDbReader reader = rdbmsService.getUserTaskReader("default");
+    final UserTaskDbReader reader = rdbmsService.getUserTaskReader();
 
     final var processDefinitionId = nextStringId();
     createAndSaveRandomUserTasks(rdbmsService, b -> b.processDefinitionId(processDefinitionId));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskTagIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskTagIT.java
@@ -121,7 +121,7 @@ public class UserTaskTagIT {
   }
 
   private static UserTaskDbReader setupReader(final CamundaRdbmsTestApplication testApplication) {
-    return testApplication.getRdbmsService().getUserTaskReader("default");
+    return testApplication.getRdbmsService().getUserTaskReader();
   }
 
   private static RdbmsWriters setupWriter(final CamundaRdbmsTestApplication testApplication) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.it.rdbms.db.util;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
@@ -134,7 +137,7 @@ public final class CamundaRdbmsTestApplication
     if (!isStarted()) {
       throw new IllegalStateException("Application is not started");
     }
-    return super.bean(RdbmsService.class);
+    return super.bean(RdbmsServiceFactory.class).createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   private void setSecondaryStorageToRdbms() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/ProcessDefinitionVariableNameLookupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/ProcessDefinitionVariableNameLookupIT.java
@@ -43,7 +43,7 @@ public class ProcessDefinitionVariableNameLookupIT {
     assertThat(
             testApplication
                 .getRdbmsService()
-                .getVariableReader("default")
+                .getVariableReader()
                 .findLookupVariableNames(procDefKey))
         .containsExactly(varName);
   }
@@ -65,7 +65,7 @@ public class ProcessDefinitionVariableNameLookupIT {
     assertThat(
             testApplication
                 .getRdbmsService()
-                .getVariableReader("default")
+                .getVariableReader()
                 .findLookupVariableNames(procDefKey))
         .containsExactlyInAnyOrder(varNameA, varNameB);
   }
@@ -111,7 +111,7 @@ public class ProcessDefinitionVariableNameLookupIT {
     assertThat(
             testApplication
                 .getRdbmsService()
-                .getVariableReader("default")
+                .getVariableReader()
                 .findLookupVariableNames(procDefKey))
         .containsExactly(varName);
   }
@@ -139,7 +139,7 @@ public class ProcessDefinitionVariableNameLookupIT {
     assertThat(
             testApplication
                 .getRdbmsService()
-                .getVariableReader("default")
+                .getVariableReader()
                 .findLookupVariableNames(procDefKey))
         .isEmpty();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
@@ -49,7 +49,7 @@ public class VariableIT {
     final var instance =
         testApplication
             .getRdbmsService()
-            .getVariableReader("default")
+            .getVariableReader()
             .findOne(randomizedVariable.variableKey());
 
     assertThat(instance).isNotNull();
@@ -71,8 +71,7 @@ public class VariableIT {
     rdbmsWriters.getVariableWriter().update(updatedVariable);
     rdbmsWriters.flush();
 
-    final var instance =
-        rdbmsService.getVariableReader("default").findOne(randomizedVariable.variableKey());
+    final var instance = rdbmsService.getVariableReader().findOne(randomizedVariable.variableKey());
 
     assertThat(instance).isNotNull();
     assertVariableDbModelEqualToEntity(updatedVariable, instance);
@@ -87,8 +86,7 @@ public class VariableIT {
         VariableFixtures.createRandomized(b -> b.value(bigValue));
     createAndSaveVariable(rdbmsService, randomizedVariable);
 
-    final var instance =
-        rdbmsService.getVariableReader("default").findOne(randomizedVariable.variableKey());
+    final var instance = rdbmsService.getVariableReader().findOne(randomizedVariable.variableKey());
 
     assertThat(instance).isNotNull();
     assertThat(instance.isPreview()).isTrue();
@@ -106,8 +104,7 @@ public class VariableIT {
         VariableFixtures.createRandomized(b -> b.value(bigValue));
     createAndSaveVariable(rdbmsService, randomizedVariable);
 
-    final var instance =
-        rdbmsService.getVariableReader("default").findOne(randomizedVariable.variableKey());
+    final var instance = rdbmsService.getVariableReader().findOne(randomizedVariable.variableKey());
 
     assertThat(instance).as("variable is not null").isNotNull();
     assertThat(instance.isPreview()).as("variable is preview").isTrue();
@@ -127,7 +124,7 @@ public class VariableIT {
 
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 new VariableQuery(
                     new VariableFilter.Builder()
@@ -157,7 +154,7 @@ public class VariableIT {
 
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 VariableQuery.of(b -> b),
                 CommonFixtures.resourceAccessChecksFromResourceIds(
@@ -185,7 +182,7 @@ public class VariableIT {
 
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 VariableQuery.of(b -> b),
                 CommonFixtures.resourceAccessChecksFromTenantIds(randomizedVariable.tenantId()));
@@ -209,7 +206,7 @@ public class VariableIT {
 
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 new VariableQuery(
                     new VariableFilter.Builder().names(varName).build(),
@@ -231,7 +228,7 @@ public class VariableIT {
 
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 new VariableQuery(
                     new VariableFilter.Builder().names(varName).build(),
@@ -254,7 +251,7 @@ public class VariableIT {
 
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 new VariableQuery(
                     new VariableFilter.Builder().names(varName).build(),
@@ -269,7 +266,7 @@ public class VariableIT {
   @TestTemplate
   public void shouldFindVariableWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final VariableDbReader variableReader = rdbmsService.getVariableReader("default");
+    final VariableDbReader variableReader = rdbmsService.getVariableReader();
 
     final String varName =
         VariableFixtures.createAndSaveRandomVariablesWithFixedName(rdbmsService).getLast().name();
@@ -298,7 +295,7 @@ public class VariableIT {
   @TestTemplate
   public void shouldFindVariableWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final VariableDbReader variableReader = rdbmsService.getVariableReader("default");
+    final VariableDbReader variableReader = rdbmsService.getVariableReader();
 
     final String varName =
         VariableFixtures.createAndSaveRandomVariablesWithFixedName(rdbmsService).getLast().name();
@@ -334,7 +331,7 @@ public class VariableIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final VariableDbReader reader = rdbmsService.getVariableReader("default");
+    final VariableDbReader reader = rdbmsService.getVariableReader();
 
     final var tenantId = nextStringId();
     final var item1 = createAndSaveVariable(rdbmsService, b -> b.tenantId(tenantId));
@@ -369,7 +366,7 @@ public class VariableIT {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final VariableDbReader reader = rdbmsService.getVariableReader("default");
+    final VariableDbReader reader = rdbmsService.getVariableReader();
 
     final var tenantId = nextStringId();
     final var item1 = createAndSaveVariable(rdbmsService, b -> b.tenantId(tenantId));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableSortIT.java
@@ -107,7 +107,7 @@ public class VariableSortIT {
 
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 new VariableQuery(
                     new VariableFilter.Builder().processInstanceKeys(processInstanceKey).build(),
@@ -129,7 +129,7 @@ public class VariableSortIT {
 
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 new VariableQuery(
                     new VariableFilter.Builder().processInstanceKeys(processInstanceKey).build(),
@@ -153,7 +153,7 @@ public class VariableSortIT {
 
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 new VariableQuery(
                     new VariableFilter.Builder().scopeKeys(scopeKey).build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableValueFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableValueFilterIT.java
@@ -236,7 +236,7 @@ public class VariableValueFilterIT {
     // when we search for it, we should find one
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 new VariableQuery(
                     variableFilter,
@@ -270,7 +270,7 @@ public class VariableValueFilterIT {
     // when we search for it, we should find one
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 new VariableQuery(
                     variableFilter,
@@ -296,7 +296,7 @@ public class VariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 VariableQuery.of(
                     b -> b.filter(f -> f.valueOperations(Operation.like(variableValue + "*")))));
@@ -322,7 +322,7 @@ public class VariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 VariableQuery.of(
                     b -> b.filter(f -> f.valueOperations(Operation.like(variableValue + "?")))));
@@ -348,7 +348,7 @@ public class VariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 VariableQuery.of(
                     b -> b.filter(f -> f.valueOperations(Operation.like("ignoreAnyValue\\%X")))));
@@ -373,7 +373,7 @@ public class VariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 VariableQuery.of(
                     b ->
@@ -397,7 +397,7 @@ public class VariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 VariableQuery.of(
                     b -> b.filter(f -> f.valueOperations(Operation.like("value\\*any\\%*")))));
@@ -422,7 +422,7 @@ public class VariableValueFilterIT {
     // when
     final var actual =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 VariableQuery.of(
                     b ->
@@ -461,7 +461,7 @@ public class VariableValueFilterIT {
 
     final var searchResult =
         rdbmsService
-            .getVariableReader("default")
+            .getVariableReader()
             .search(
                 new VariableQuery(
                     builder.build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateIT.java
@@ -39,8 +39,7 @@ public class WaitStateIT {
     rdbmsWriters.flush();
 
     // then
-    final var found =
-        rdbmsService.getWaitStateReader("default").findOne(model.waitStateKey()).orElse(null);
+    final var found = rdbmsService.getWaitStateReader().findOne(model.waitStateKey()).orElse(null);
     assertThat(found).isNotNull();
     assertThat(found.waitStateKey()).isEqualTo(model.waitStateKey());
     assertThat(found.rootProcessInstanceKey()).isEqualTo(model.rootProcessInstanceKey());
@@ -62,15 +61,14 @@ public class WaitStateIT {
     final var model = createRandomized(nextKey());
     rdbmsWriters.getWaitStateWriter().create(model);
     rdbmsWriters.flush();
-    assertThat(rdbmsService.getWaitStateReader("default").findOne(model.waitStateKey()))
-        .isPresent();
+    assertThat(rdbmsService.getWaitStateReader().findOne(model.waitStateKey())).isPresent();
 
     // when
     rdbmsWriters.getWaitStateWriter().delete(model.waitStateKey());
     rdbmsWriters.flush();
 
     // then
-    assertThat(rdbmsService.getWaitStateReader("default").findOne(model.waitStateKey())).isEmpty();
+    assertThat(rdbmsService.getWaitStateReader().findOne(model.waitStateKey())).isEmpty();
   }
 
   private static WaitStateDbModel createRandomized(final long waitStateKey) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateSortIT.java
@@ -109,7 +109,7 @@ public class WaitStateSortIT {
       final Function<Builder, ObjectBuilder<WaitStateSort>> sortBuilder,
       final Comparator<WaitStateEntity> comparator) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final WaitStateDbReader reader = rdbmsService.getWaitStateReader("default");
+    final WaitStateDbReader reader = rdbmsService.getWaitStateReader();
 
     final var processInstanceKey = nextKey();
     createAndSaveRandomWaitStates(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.exporter.rdbms.RdbmsExporterWrapper;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
@@ -47,7 +48,8 @@ class RdbmsExporterBatchOperationsIT {
   private static final RecordFixtures FIXTURES = new RecordFixtures();
   private final ExporterTestController controller = new ExporterTestController();
   @Autowired private RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry;
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  private RdbmsService rdbmsService;
   private RdbmsExporterWrapper exporter;
 
   @BeforeEach
@@ -56,7 +58,9 @@ class RdbmsExporterBatchOperationsIT {
   }
 
   private void setup(final boolean exportPendingItems) {
-    exporter = new RdbmsExporterWrapper(rdbmsService, rdbmsSchemaManagerRegistry);
+    rdbmsService =
+        rdbmsServiceFactory.createRdbmsService(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    exporter = new RdbmsExporterWrapper(rdbmsServiceFactory, rdbmsSchemaManagerRegistry);
     exporter.configure(
         new ExporterContext(
             null,
@@ -83,7 +87,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader("default").findOne(String.valueOf(batchOperationKey));
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey));
     assertThat(batchOperation)
         .hasValueSatisfying(
             entity -> {
@@ -108,7 +112,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader("default").findOne(String.valueOf(batchOperationKey));
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey));
     assertThat(batchOperation)
         .hasValueSatisfying(
             entity -> {
@@ -130,10 +134,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.COMPLETED);
   }
 
@@ -149,10 +150,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.PARTIALLY_COMPLETED);
     assertThat(batchOperation.errors()).isNotEmpty();
   }
@@ -169,10 +167,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.FAILED);
     assertThat(batchOperation.errors()).isNotEmpty();
   }
@@ -189,10 +184,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.CANCELED);
 
     // and the items should be canceled
@@ -216,10 +208,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.SUSPENDED);
   }
 
@@ -238,10 +227,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then it should be canceled
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
   }
 
@@ -265,10 +251,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
@@ -297,10 +280,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
@@ -333,10 +313,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
@@ -365,10 +342,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
@@ -402,10 +376,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
@@ -434,10 +405,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
@@ -466,10 +434,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
@@ -499,10 +464,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
@@ -532,10 +494,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
@@ -565,10 +524,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
@@ -587,10 +543,7 @@ class RdbmsExporterBatchOperationsIT {
     exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     final var batchOperation =
-        rdbmsService
-            .getBatchOperationReader("default")
-            .findOne(String.valueOf(batchOperationKey))
-            .get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
 
     assumeThat(batchOperation).isNotNull();
     assumeThat(batchOperation.operationsTotalCount()).isEqualTo(3);
@@ -600,7 +553,7 @@ class RdbmsExporterBatchOperationsIT {
 
   private List<BatchOperationItemEntity> getItems(final long batchOperationKey) {
     return rdbmsService
-        .getBatchOperationItemReader("default")
+        .getBatchOperationItemReader()
         .search(
             SearchQueryBuilders.batchOperationItemQuery(
                 q -> q.filter(f -> f.batchOperationKeys(Long.toString(batchOperationKey)))))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
@@ -140,16 +141,18 @@ class RdbmsExporterIT {
   private static final RecordFixtures FIXTURES = new RecordFixtures();
   private final ExporterTestController controller = new ExporterTestController();
   @Autowired private RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry;
-  @Autowired private RdbmsService rdbmsService;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
   @Autowired private Map<String, RdbmsMapperBundle> rdbmsMapperBundles;
+  private RdbmsService rdbmsService;
   private ExporterPositionMapper exporterPositionMapper;
   private RdbmsExporterWrapper exporter;
 
   @BeforeEach
   void setUp() {
+    rdbmsService = rdbmsServiceFactory.createRdbmsService(DEFAULT_PHYSICAL_TENANT_ID);
     exporterPositionMapper =
         rdbmsMapperBundles.get(DEFAULT_PHYSICAL_TENANT_ID).exporterPositionMapper();
-    exporter = new RdbmsExporterWrapper(rdbmsService, rdbmsSchemaManagerRegistry);
+    exporter = new RdbmsExporterWrapper(rdbmsServiceFactory, rdbmsSchemaManagerRegistry);
     exporter.configure(
         new ExporterContext(
             null,
@@ -187,7 +190,7 @@ class RdbmsExporterIT {
     // then
     final var key =
         ((ProcessInstanceRecordValue) processInstanceRecord.getValue()).getProcessInstanceKey();
-    final var processInstance = rdbmsService.getProcessInstanceReader("default").findOne(key);
+    final var processInstance = rdbmsService.getProcessInstanceReader().findOne(key);
     assertThat(processInstance).isNotEmpty();
     verifyRootProcessInstanceKey(processInstance.get(), processInstanceRecord);
 
@@ -198,8 +201,7 @@ class RdbmsExporterIT {
     exporter.export(processInstanceCompletedRecord);
 
     // then
-    final var completedProcessInstance =
-        rdbmsService.getProcessInstanceReader("default").findOne(key);
+    final var completedProcessInstance = rdbmsService.getProcessInstanceReader().findOne(key);
     assertThat(completedProcessInstance).isNotEmpty();
     assertThat(completedProcessInstance.get().state()).isEqualTo(ProcessInstanceState.COMPLETED);
     verifyRootProcessInstanceKey(completedProcessInstance.get(), processInstanceRecord);
@@ -217,7 +219,7 @@ class RdbmsExporterIT {
     // then
     final var key =
         ((ProcessInstanceRecordValue) rootProcessInstanceRecord.getValue()).getProcessInstanceKey();
-    final var processInstance = rdbmsService.getProcessInstanceReader("default").findOne(key);
+    final var processInstance = rdbmsService.getProcessInstanceReader().findOne(key);
     assertThat(processInstance).isNotEmpty();
     verifyRootProcessInstanceKey(processInstance.get(), rootProcessInstanceRecord);
 
@@ -229,8 +231,7 @@ class RdbmsExporterIT {
     exporter.export(rootProcessInstanceCompletedRecord);
 
     // then
-    final var rootCompletedProcessInstance =
-        rdbmsService.getProcessInstanceReader("default").findOne(key);
+    final var rootCompletedProcessInstance = rdbmsService.getProcessInstanceReader().findOne(key);
     assertThat(rootCompletedProcessInstance).isNotEmpty();
     assertThat(rootCompletedProcessInstance.get().state())
         .isEqualTo(ProcessInstanceState.COMPLETED);
@@ -249,7 +250,7 @@ class RdbmsExporterIT {
 
     // then
     final var key = ((Process) processDefinitionRecord.getValue()).getProcessDefinitionKey();
-    final var processDefinition = rdbmsService.getProcessDefinitionReader("default").findOne(key);
+    final var processDefinition = rdbmsService.getProcessDefinitionReader().findOne(key);
     assertThat(processDefinition).isNotEmpty();
     assertThat(processDefinition).map(ProcessDefinitionEntity::bpmnXml).isPresent();
     assertThat(processDefinition).map(ProcessDefinitionEntity::formId).contains("test");
@@ -270,8 +271,7 @@ class RdbmsExporterIT {
     exporter.export(variableCreatedRecord);
 
     // then
-    final var variable =
-        rdbmsService.getVariableReader("default").findOne(variableCreatedRecord.getKey());
+    final var variable = rdbmsService.getVariableReader().findOne(variableCreatedRecord.getKey());
     final VariableRecordValue variableRecordValue =
         (VariableRecordValue) variableCreatedRecord.getValue();
     assertThat(variable).isNotNull();
@@ -297,7 +297,7 @@ class RdbmsExporterIT {
     // then
     final var variable =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .getGloballyScopedClusterVariable(
                 clusterVariableRecordValue.getName(),
                 ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
@@ -324,7 +324,7 @@ class RdbmsExporterIT {
     // then
     final var variable =
         rdbmsService
-            .getClusterVariableReader("default")
+            .getClusterVariableReader()
             .getTenantScopedClusterVariable(
                 clusterVariableRecordValue.getName(),
                 clusterVariableRecordValue.getTenantId(),
@@ -351,12 +351,11 @@ class RdbmsExporterIT {
     // then
     final var key =
         ((ProcessInstanceRecordValue) processInstanceRecord.getValue()).getProcessInstanceKey();
-    final var processInstance = rdbmsService.getProcessInstanceReader("default").findOne(key);
+    final var processInstance = rdbmsService.getProcessInstanceReader().findOne(key);
     assertThat(processInstance).isNotEmpty();
     verifyRootProcessInstanceKey(processInstance.get(), processInstanceRecord);
 
-    final var variable =
-        rdbmsService.getVariableReader("default").findOne(variableCreated.getKey());
+    final var variable = rdbmsService.getVariableReader().findOne(variableCreated.getKey());
     final VariableRecordValue variableRecordValue =
         (VariableRecordValue) variableCreated.getValue();
     assertThat(variable).isNotNull();
@@ -373,7 +372,7 @@ class RdbmsExporterIT {
 
     // then
     final var key = elementRecord.getKey();
-    final var element = rdbmsService.getFlowNodeInstanceReader("default").findOne(key);
+    final var element = rdbmsService.getFlowNodeInstanceReader().findOne(key);
     assertThat(element).isNotEmpty();
     verifyRootProcessInstanceKey(element.get(), elementRecord);
 
@@ -384,7 +383,7 @@ class RdbmsExporterIT {
     exporter.export(elementCompleteRecord);
 
     // then
-    final var completedElement = rdbmsService.getFlowNodeInstanceReader("default").findOne(key);
+    final var completedElement = rdbmsService.getFlowNodeInstanceReader().findOne(key);
     assertThat(completedElement).isNotEmpty();
     assertThat(completedElement.get().state()).isEqualTo(FlowNodeState.COMPLETED);
     // Default tree path
@@ -404,8 +403,7 @@ class RdbmsExporterIT {
     final var key = flowTakenRecord.getKey();
     final var sequenceFlowQuery =
         SequenceFlowQuery.of(b -> b.filter(f -> f.processInstanceKey(key)));
-    final var sequenceFlows =
-        rdbmsService.getSequenceFlowReader("default").search(sequenceFlowQuery);
+    final var sequenceFlows = rdbmsService.getSequenceFlowReader().search(sequenceFlowQuery);
     assertThat(sequenceFlows.total()).isEqualTo(1L);
     final var sequenceFlow = sequenceFlows.items().getFirst();
     verifyRootProcessInstanceKey(sequenceFlow, flowTakenRecord);
@@ -418,8 +416,7 @@ class RdbmsExporterIT {
     exporter.export(flowDeletedRecord);
 
     // then
-    final var deletedSequenceFlows =
-        rdbmsService.getSequenceFlowReader("default").search(sequenceFlowQuery);
+    final var deletedSequenceFlows = rdbmsService.getSequenceFlowReader().search(sequenceFlowQuery);
     assertThat(deletedSequenceFlows.total()).isEqualTo(0L);
     assertThat(deletedSequenceFlows.items()).isEmpty();
   }
@@ -435,7 +432,7 @@ class RdbmsExporterIT {
     // then
     final UserTaskRecordValue recordValue = (UserTaskRecordValue) userTaskRecord.getValue();
     final var key = recordValue.getUserTaskKey();
-    final var userTask = rdbmsService.getUserTaskReader("default").findOne(key);
+    final var userTask = rdbmsService.getUserTaskReader().findOne(key);
     assertThat(userTask).isNotEmpty();
     assertThat(userTask.get().processInstanceKey()).isEqualTo(recordValue.getProcessInstanceKey());
     assertThat(userTask.get().rootProcessInstanceKey())
@@ -453,7 +450,7 @@ class RdbmsExporterIT {
     // then
     final var key =
         ((DecisionRequirementsRecordValue) record.getValue()).getDecisionRequirementsKey();
-    final var entity = rdbmsService.getDecisionRequirementsReader("default").findOne(key);
+    final var entity = rdbmsService.getDecisionRequirementsReader().findOne(key);
     assertThat(entity).isNotEmpty();
   }
 
@@ -467,7 +464,7 @@ class RdbmsExporterIT {
 
     // then
     final var key = ((DecisionRecordValue) decisionDefinitionRecord.getValue()).getDecisionKey();
-    final var definition = rdbmsService.getDecisionDefinitionReader("default").findOne(key);
+    final var definition = rdbmsService.getDecisionDefinitionReader().findOne(key);
     assertThat(definition).isNotEmpty();
   }
 
@@ -489,7 +486,7 @@ class RdbmsExporterIT {
 
     // then
     final var key = evaluatedDecisionValue.getDecisionEvaluationInstanceKey();
-    final var decisionInstance = rdbmsService.getDecisionInstanceReader("default").findOne(key);
+    final var decisionInstance = rdbmsService.getDecisionInstanceReader().findOne(key);
     assertThat(decisionInstance).isNotEmpty();
     final var recordValue = (DecisionEvaluationRecordValue) decisionEvaluationRecord.getValue();
     assertThat(decisionInstance.get().processInstanceKey())
@@ -508,8 +505,7 @@ class RdbmsExporterIT {
     exporter.export(userRecord);
 
     // then
-    final var user =
-        rdbmsService.getUserReader("default").findOneByUsername(userRecordValue.getUsername());
+    final var user = rdbmsService.getUserReader().findOneByUsername(userRecordValue.getUsername());
     assertThat(user).isNotEmpty();
     assertThat(user.get().userKey()).isEqualTo(userRecordValue.getUserKey());
     assertThat(user.get().username()).isEqualTo(userRecordValue.getUsername());
@@ -526,9 +522,7 @@ class RdbmsExporterIT {
 
     // then
     final var updatedUser =
-        rdbmsService
-            .getUserReader("default")
-            .findOneByUsername(updateUserRecordValue.getUsername());
+        rdbmsService.getUserReader().findOneByUsername(updateUserRecordValue.getUsername());
     assertThat(updatedUser).isNotEmpty();
     assertThat(updatedUser.get().userKey()).isEqualTo(updateUserRecordValue.getUserKey());
     assertThat(updatedUser.get().username()).isEqualTo(updateUserRecordValue.getUsername());
@@ -541,7 +535,7 @@ class RdbmsExporterIT {
 
     // then
     final var deletedUser =
-        rdbmsService.getUserReader("default").findOneByUsername(userRecordValue.getUsername());
+        rdbmsService.getUserReader().findOneByUsername(userRecordValue.getUsername());
     assertThat(deletedUser).isEmpty();
   }
 
@@ -558,7 +552,7 @@ class RdbmsExporterIT {
     // then
     final var tenant =
         rdbmsService
-            .getTenantReader("default")
+            .getTenantReader()
             .findOne(((TenantRecordValue) tenantRecord.getValue()).getTenantId());
     assertThat(tenant).isNotEmpty();
     assertThat(tenant.get().key()).isEqualTo(tenantRecord.getKey());
@@ -576,7 +570,7 @@ class RdbmsExporterIT {
     // then
     final var updatedTenant =
         rdbmsService
-            .getTenantReader("default")
+            .getTenantReader()
             .findOne(((TenantRecordValue) tenantRecord.getValue()).getTenantId());
     assertThat(updatedTenant).isNotEmpty();
     assertThat(updatedTenant.get().key()).isEqualTo(updateTenantRecordValue.getTenantKey());
@@ -595,7 +589,7 @@ class RdbmsExporterIT {
     exporter.export(roleRecord);
 
     // then
-    final var role = rdbmsService.getRoleReader("default").findOne(recordValue.getRoleId());
+    final var role = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(role).isNotEmpty();
     assertThat(role.get().roleKey()).isEqualTo(recordValue.getRoleKey());
     assertThat(role.get().roleId()).isEqualTo(recordValue.getRoleId());
@@ -610,7 +604,7 @@ class RdbmsExporterIT {
     exporter.export(updateRoleRecord);
 
     // then
-    final var updatedRole = rdbmsService.getRoleReader("default").findOne(recordValue.getRoleId());
+    final var updatedRole = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(updatedRole).isNotEmpty();
     assertThat(updatedRole.get().roleKey()).isEqualTo(updateRoleRecordValue.getRoleKey());
     assertThat(updatedRole.get().roleId()).isEqualTo(updateRoleRecordValue.getRoleId());
@@ -621,7 +615,7 @@ class RdbmsExporterIT {
     exporter.export(FIXTURES.getRoleRecord(roleId, RoleIntent.DELETED));
 
     // then
-    final var deletedRole = rdbmsService.getRoleReader("default").findOne(recordValue.getRoleId());
+    final var deletedRole = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(deletedRole).isEmpty();
   }
 
@@ -639,7 +633,7 @@ class RdbmsExporterIT {
     exporter.export(roleRecord);
 
     // then
-    final var role = rdbmsService.getRoleReader("default").findOne(recordValue.getRoleId());
+    final var role = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(role).isNotEmpty();
     assertThat(role.get().roleKey()).isEqualTo(recordValue.getRoleKey());
     assertThat(role.get().roleId()).isEqualTo(recordValue.getRoleId());
@@ -650,10 +644,10 @@ class RdbmsExporterIT {
     exporter.export(FIXTURES.getRoleRecord(roleId, RoleIntent.ENTITY_ADDED, username));
 
     // then
-    assertThat(rdbmsService.getRoleReader("default").findOne(recordValue.getRoleId())).isPresent();
+    assertThat(rdbmsService.getRoleReader().findOne(recordValue.getRoleId())).isPresent();
     final var usersWithRole =
         rdbmsService
-            .getUserReader("default")
+            .getUserReader()
             .search(
                 UserQuery.of(q -> q.filter(new Builder().roleId(recordValue.getRoleId()).build())))
             .items();
@@ -663,10 +657,10 @@ class RdbmsExporterIT {
     exporter.export(FIXTURES.getRoleRecord(roleId, RoleIntent.ENTITY_REMOVED, username));
 
     // then
-    assertThat(rdbmsService.getRoleReader("default").findOne(recordValue.getRoleId())).isPresent();
+    assertThat(rdbmsService.getRoleReader().findOne(recordValue.getRoleId())).isPresent();
     final var usersWithRoleAfterDeletion =
         rdbmsService
-            .getUserReader("default")
+            .getUserReader()
             .search(
                 UserQuery.of(q -> q.filter(new Builder().roleId(recordValue.getRoleId()).build())))
             .items();
@@ -686,7 +680,7 @@ class RdbmsExporterIT {
     // then
     final var group =
         rdbmsService
-            .getGroupReader("default")
+            .getGroupReader()
             .findOne(((GroupRecordValue) groupRecord.getValue()).getGroupId());
     assertThat(group).isNotEmpty();
     assertThat(group.get().groupKey()).isEqualTo(groupRecordValue.getGroupKey());
@@ -704,7 +698,7 @@ class RdbmsExporterIT {
     // then
     final var updatedGroup =
         rdbmsService
-            .getGroupReader("default")
+            .getGroupReader()
             .findOne(((GroupRecordValue) groupRecord.getValue()).getGroupId());
     assertThat(updatedGroup).isNotEmpty();
     assertThat(updatedGroup.get().groupKey()).isEqualTo(updateGroupRecordValue.getGroupKey());
@@ -718,7 +712,7 @@ class RdbmsExporterIT {
     // then
     final var deletedGroup =
         rdbmsService
-            .getGroupReader("default")
+            .getGroupReader()
             .findOne(((GroupRecordValue) groupRecord.getValue()).getGroupId());
     assertThat(deletedGroup).isEmpty();
   }
@@ -748,18 +742,16 @@ class RdbmsExporterIT {
     exporter.export(incidentRecord);
 
     // then
-    final var element =
-        rdbmsService.getFlowNodeInstanceReader("default").findOne(elementInstanceKey);
+    final var element = rdbmsService.getFlowNodeInstanceReader().findOne(elementInstanceKey);
     assertThat(element).isNotEmpty();
     assertThat(element.get().incidentKey()).isEqualTo(incidentKey);
     assertThat(element.get().hasIncident()).isTrue();
 
-    final var processInstance =
-        rdbmsService.getProcessInstanceReader("default").findOne(processInstanceKey);
+    final var processInstance = rdbmsService.getProcessInstanceReader().findOne(processInstanceKey);
     assertThat(processInstance).isNotEmpty();
     assertThat(processInstance.get().hasIncident()).isTrue();
 
-    final var incident = rdbmsService.getIncidentReader("default").findOne(incidentKey);
+    final var incident = rdbmsService.getIncidentReader().findOne(incidentKey);
     assertThat(incident).isNotEmpty();
     assertThat(incident.get().incidentKey()).isEqualTo(incidentKey);
     assertThat(incident.get().state()).isEqualTo(IncidentState.ACTIVE);
@@ -779,19 +771,17 @@ class RdbmsExporterIT {
     exporter.export(incidentResolvedRecord);
 
     // then
-    final var element2 =
-        rdbmsService.getFlowNodeInstanceReader("default").findOne(elementInstanceKey);
+    final var element2 = rdbmsService.getFlowNodeInstanceReader().findOne(elementInstanceKey);
     assertThat(element2).isNotEmpty();
     assertThat(element2.get().incidentKey()).isNull();
     assertThat(element2.get().hasIncident()).isFalse();
 
     final var processInstance2 =
-        rdbmsService.getProcessInstanceReader("default").findOne(processInstanceKey);
+        rdbmsService.getProcessInstanceReader().findOne(processInstanceKey);
     assertThat(processInstance2).isNotEmpty();
     assertThat(processInstance2.get().hasIncident()).isFalse();
 
-    final var incident2 =
-        rdbmsService.getIncidentReader("default").findOne(incidentKey).orElseThrow();
+    final var incident2 = rdbmsService.getIncidentReader().findOne(incidentKey).orElseThrow();
     assertThat(incident2.state()).isEqualTo(IncidentState.RESOLVED);
     assertThat(incident2.processInstanceKey()).isEqualTo(processInstanceKey);
     assertThat(incident2.rootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
@@ -887,7 +877,7 @@ class RdbmsExporterIT {
       final OffsetDateTime lastCompletedAt) {
     final var jobBatchMetrics =
         rdbmsService
-            .getJobMetricsBatchDbReader("default")
+            .getJobMetricsBatchDbReader()
             .getGlobalJobStatistics(
                 GlobalJobStatisticsQuery.of(
                     b ->
@@ -917,7 +907,7 @@ class RdbmsExporterIT {
 
     // then
     final var formKey = ((Form) formCreatedRecord.getValue()).getFormKey();
-    final var formEntity = rdbmsService.getFormReader("default").findOne(formKey);
+    final var formEntity = rdbmsService.getFormReader().findOne(formKey);
     assertThat(formEntity).isNotEmpty();
   }
 
@@ -937,9 +927,7 @@ class RdbmsExporterIT {
 
     // then
     final var messageSubscription =
-        rdbmsService
-            .getMessageSubscriptionReader("default")
-            .findOne(messageSubscriptionRecord.getKey());
+        rdbmsService.getMessageSubscriptionReader().findOne(messageSubscriptionRecord.getKey());
     assertThat(messageSubscription).isNotEmpty();
     final var recordValue = messageSubscriptionRecord.getValue();
     assertThat(messageSubscription.get().processInstanceKey())
@@ -972,9 +960,7 @@ class RdbmsExporterIT {
 
     // then
     final var messageSubscription =
-        rdbmsService
-            .getMessageSubscriptionReader("default")
-            .findOne(messageSubscriptionRecord.getKey());
+        rdbmsService.getMessageSubscriptionReader().findOne(messageSubscriptionRecord.getKey());
     assertThat(messageSubscription).isPresent();
     assertThat(messageSubscription.get().messageSubscriptionState())
         .isEqualTo(MessageSubscriptionState.DELETED);
@@ -998,7 +984,7 @@ class RdbmsExporterIT {
     final var recordValue = correlatedMessageSubscriptionRecord.getValue();
     final var correlatedMessageSubscription =
         rdbmsService
-            .getCorrelatedMessageSubscriptionReader("default")
+            .getCorrelatedMessageSubscriptionReader()
             .findOne(recordValue.getMessageKey(), correlatedMessageSubscriptionRecord.getKey());
     assertThat(correlatedMessageSubscription).isNotEmpty();
     assertThat(correlatedMessageSubscription.get().processInstanceKey())
@@ -1027,7 +1013,7 @@ class RdbmsExporterIT {
     final var recordValue = messageStartEventSubRecord.getValue();
     final var correlatedMessageSubscription =
         rdbmsService
-            .getCorrelatedMessageSubscriptionReader("default")
+            .getCorrelatedMessageSubscriptionReader()
             .findOne(recordValue.getMessageKey(), messageStartEventSubRecord.getKey());
     assertThat(correlatedMessageSubscription).isNotEmpty();
     final var processInstanceKey = recordValue.getProcessInstanceKey();
@@ -1050,7 +1036,7 @@ class RdbmsExporterIT {
     // then
     final var mappingRuleId =
         ((MappingRuleRecordValue) mappingRuleCreatedRecord.getValue()).getMappingRuleId();
-    final var mappingRule = rdbmsService.getMappingRuleReader("default").findOne(mappingRuleId);
+    final var mappingRule = rdbmsService.getMappingRuleReader().findOne(mappingRuleId);
     assertThat(mappingRule).isNotEmpty();
 
     // given
@@ -1063,7 +1049,7 @@ class RdbmsExporterIT {
     exporter.export(mappingDeletedRecord);
 
     // then
-    final var deletedMapping = rdbmsService.getMappingRuleReader("default").findOne(mappingRuleId);
+    final var deletedMapping = rdbmsService.getMappingRuleReader().findOne(mappingRuleId);
     assertThat(deletedMapping).isEmpty();
   }
 
@@ -1087,7 +1073,7 @@ class RdbmsExporterIT {
     final var recordValue = (AuthorizationRecordValue) authorizationRecord.getValue();
     final var authorization =
         rdbmsService
-            .getAuthorizationReader("default")
+            .getAuthorizationReader()
             .findOne(
                 recordValue.getOwnerId(),
                 recordValue.getOwnerType().name(),
@@ -1112,7 +1098,7 @@ class RdbmsExporterIT {
     // then
     final var updatedAuthorization =
         rdbmsService
-            .getAuthorizationReader("default")
+            .getAuthorizationReader()
             .findOne(
                 recordValue.getOwnerId(),
                 recordValue.getOwnerType().name(),
@@ -1145,7 +1131,7 @@ class RdbmsExporterIT {
     final var recordValue = (AuthorizationRecordValue) authorizationRecord.getValue();
     final var authorization =
         rdbmsService
-            .getAuthorizationReader("default")
+            .getAuthorizationReader()
             .findOne(
                 recordValue.getOwnerId(),
                 recordValue.getOwnerType().name(),
@@ -1170,7 +1156,7 @@ class RdbmsExporterIT {
     // then
     final var deletedAuthorization =
         rdbmsService
-            .getAuthorizationReader("default")
+            .getAuthorizationReader()
             .findOne(
                 recordValue.getOwnerId(),
                 recordValue.getOwnerType().name(),
@@ -1208,7 +1194,7 @@ class RdbmsExporterIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader("default").findOne(String.valueOf(batchOperationKey));
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey));
     assertThat(batchOperation)
         .hasValueSatisfying(
             entity -> {
@@ -1228,7 +1214,7 @@ class RdbmsExporterIT {
             io.camunda.zeebe.protocol.record.value.BatchOperationType.MIGRATE_PROCESS_INSTANCE);
 
     final var batchOperation =
-        rdbmsService.getBatchOperationReader("default").findOne(String.valueOf(batchOperationKey));
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey));
     assertThat(batchOperation)
         .hasValueSatisfying(
             entity -> {
@@ -1279,7 +1265,7 @@ class RdbmsExporterIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader("default").findOne(String.valueOf(batchOperationKey));
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey));
     assertThat(batchOperation).isNotEmpty();
     assertThat(batchOperation.get().operationType())
         .isEqualTo(BatchOperationType.MODIFY_PROCESS_INSTANCE);
@@ -1435,7 +1421,7 @@ class RdbmsExporterIT {
     exporter.export(jobCreatedRecord);
 
     // then
-    final var job = rdbmsService.getJobReader("default").findOne(jobCreatedRecord.getKey());
+    final var job = rdbmsService.getJobReader().findOne(jobCreatedRecord.getKey());
     assertThat(job).isNotNull();
     assertThat(job.get().rootProcessInstanceKey())
         .isEqualTo(((JobRecordValue) jobCreatedRecord.getValue()).getRootProcessInstanceKey());
@@ -1462,7 +1448,7 @@ class RdbmsExporterIT {
     final var recordValue = processInstanceCreationRecord.getValue();
     final var results =
         rdbmsService
-            .getAuditLogReader("default")
+            .getAuditLogReader()
             .search(
                 AuditLogQuery.of(
                     b ->
@@ -1484,7 +1470,8 @@ class RdbmsExporterIT {
     // given - create a separate exporter with interval-based flush (queueSize > 0, not per-record)
     // Use partitionId=2 to avoid interfering with other tests that use partitionId=1
     final var intervalController = new ExporterTestController();
-    final var intervalExporter = new RdbmsExporterWrapper(rdbmsService, rdbmsSchemaManagerRegistry);
+    final var intervalExporter =
+        new RdbmsExporterWrapper(rdbmsServiceFactory, rdbmsSchemaManagerRegistry);
     intervalExporter.configure(
         new ExporterContext(
             null,
@@ -1625,7 +1612,7 @@ class RdbmsExporterIT {
   private SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
       final long itemKey) {
     return rdbmsService
-        .getBatchOperationItemReader("default")
+        .getBatchOperationItemReader()
         .search(BatchOperationItemQuery.of(b -> b.filter(f -> f.itemKeys(itemKey))));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterFactory.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterFactory.java
@@ -8,20 +8,20 @@
 package io.camunda.exporter.rdbms;
 
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
-import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.zeebe.broker.exporter.repo.ExporterFactory;
 import io.camunda.zeebe.broker.exporter.repo.ExporterInstantiationException;
 import io.camunda.zeebe.exporter.api.Exporter;
 
 public class RdbmsExporterFactory implements ExporterFactory {
 
-  private final RdbmsService rdbmsService;
+  private final RdbmsServiceFactory rdbmsServiceFactory;
   private final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry;
 
   public RdbmsExporterFactory(
-      final RdbmsService rdbmsService,
+      final RdbmsServiceFactory rdbmsServiceFactory,
       final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry) {
-    this.rdbmsService = rdbmsService;
+    this.rdbmsServiceFactory = rdbmsServiceFactory;
     this.rdbmsSchemaManagerRegistry = rdbmsSchemaManagerRegistry;
   }
 
@@ -32,7 +32,7 @@ public class RdbmsExporterFactory implements ExporterFactory {
 
   @Override
   public Exporter newInstance() throws ExporterInstantiationException {
-    return new RdbmsExporterWrapper(rdbmsService, rdbmsSchemaManagerRegistry);
+    return new RdbmsExporterWrapper(rdbmsServiceFactory, rdbmsSchemaManagerRegistry);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.rdbms;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
-import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
@@ -82,16 +82,16 @@ public class RdbmsExporterWrapper implements Exporter {
   /** The partition on which all process deployments are published */
   public static final long PROCESS_DEFINITION_PARTITION = 1L;
 
-  private final RdbmsService rdbmsService;
+  private final RdbmsServiceFactory rdbmsServiceFactory;
   private final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry;
 
   private RdbmsExporter exporter;
   private RdbmsCacheRegistry cacheRegistry;
 
   public RdbmsExporterWrapper(
-      final RdbmsService rdbmsService,
+      final RdbmsServiceFactory rdbmsServiceFactory,
       final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry) {
-    this.rdbmsService = rdbmsService;
+    this.rdbmsServiceFactory = rdbmsServiceFactory;
     this.rdbmsSchemaManagerRegistry = rdbmsSchemaManagerRegistry;
   }
 
@@ -104,6 +104,7 @@ public class RdbmsExporterWrapper implements Exporter {
     final var physicalTenantId = context.getPhysicalTenantId();
     final var rdbmsWriterConfig =
         config.createRdbmsWriterConfig(partitionId, physicalTenantId, context.clock());
+    final var rdbmsService = rdbmsServiceFactory.createRdbmsService(physicalTenantId);
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(rdbmsWriterConfig);
 
     final var builder =
@@ -114,21 +115,18 @@ public class RdbmsExporterWrapper implements Exporter {
             .queueSize(config.getQueueSize())
             .rdbmsWriter(rdbmsWriters);
 
-    cacheRegistry =
-        new RdbmsCacheRegistry(config, rdbmsService, physicalTenantId, context.getMeterRegistry());
+    cacheRegistry = new RdbmsCacheRegistry(config, rdbmsService, context.getMeterRegistry());
 
     final var historyCleanupService =
         new HistoryCleanupService(
-            rdbmsWriterConfig,
-            rdbmsWriters,
-            rdbmsService.getProcessInstanceReader(physicalTenantId));
+            rdbmsWriterConfig, rdbmsWriters, rdbmsService.getProcessInstanceReader());
     builder.historyCleanupService(historyCleanupService);
     final var historyDeletionService =
         new HistoryDeletionService(
             rdbmsWriters,
-            rdbmsService.getHistoryDeletionDbReader(physicalTenantId),
-            rdbmsService.getProcessInstanceReader(physicalTenantId),
-            rdbmsService.getDecisionInstanceReader(physicalTenantId),
+            rdbmsService.getHistoryDeletionDbReader(),
+            rdbmsService.getProcessInstanceReader(),
+            rdbmsService.getDecisionInstanceReader(),
             new HistoryDeletionConfig(
                 config.getHistoryDeletion().getDelayBetweenRuns(),
                 config.getHistoryDeletion().getMaxDelayBetweenRuns(),

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsCacheRegistry.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsCacheRegistry.java
@@ -48,25 +48,24 @@ public final class RdbmsCacheRegistry {
   public RdbmsCacheRegistry(
       final ExporterConfiguration config,
       final RdbmsService rdbmsService,
-      final String physicalTenantId,
       final MeterRegistry meterRegistry) {
     processCache =
         createCache(
             config.getProcessCache().getMaxSize(),
             "process",
-            processLoader(rdbmsService, physicalTenantId, config.getExtensionProperties()),
+            processLoader(rdbmsService, config.getExtensionProperties()),
             meterRegistry);
     decisionRequirementsCache =
         createCache(
             config.getDecisionRequirementsCache().getMaxSize(),
             "decisionRequirements",
-            decisionRequirementsLoader(rdbmsService, physicalTenantId),
+            decisionRequirementsLoader(rdbmsService),
             meterRegistry);
     batchOperationCache =
         createCache(
             config.getBatchOperationCache().getMaxSize(),
             "batchOperation",
-            batchOperationLoader(rdbmsService, physicalTenantId),
+            batchOperationLoader(rdbmsService),
             meterRegistry);
   }
 
@@ -98,10 +97,8 @@ public final class RdbmsCacheRegistry {
 
   private BulkExporterEntityCacheLoader<Long, CachedProcessEntity> processLoader(
       final RdbmsService rdbmsService,
-      final String physicalTenantId,
       final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
-    final ProcessDefinitionDbReader reader =
-        rdbmsService.getProcessDefinitionReader(physicalTenantId);
+    final ProcessDefinitionDbReader reader = rdbmsService.getProcessDefinitionReader();
     return new RdbmsEntityCacheLoader<>(
         "Process",
         reader::findOne,
@@ -116,9 +113,8 @@ public final class RdbmsCacheRegistry {
   }
 
   private BulkExporterEntityCacheLoader<Long, CachedDecisionRequirementsEntity>
-      decisionRequirementsLoader(final RdbmsService rdbmsService, final String physicalTenantId) {
-    final DecisionRequirementsDbReader reader =
-        rdbmsService.getDecisionRequirementsReader(physicalTenantId);
+      decisionRequirementsLoader(final RdbmsService rdbmsService) {
+    final DecisionRequirementsDbReader reader = rdbmsService.getDecisionRequirementsReader();
     return new RdbmsEntityCacheLoader<>(
         "DecisionRequirements",
         reader::findOne,
@@ -133,8 +129,8 @@ public final class RdbmsCacheRegistry {
   }
 
   private CacheLoader<String, CachedBatchOperationEntity> batchOperationLoader(
-      final RdbmsService rdbmsService, final String physicalTenantId) {
-    final BatchOperationDbReader reader = rdbmsService.getBatchOperationReader(physicalTenantId);
+      final RdbmsService rdbmsService) {
+    final BatchOperationDbReader reader = rdbmsService.getBatchOperationReader();
     return new RdbmsEntityCacheLoader<>(
         "BatchOperation",
         reader::findOne,

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.exporter.rdbms.handlers.AuditLogExportHandler;
@@ -67,7 +68,8 @@ class RdbmsExporterWrapperTest {
         .thenReturn(configuration);
 
     final RdbmsExporterWrapper exporterWrapper =
-        new RdbmsExporterWrapper(mock(RdbmsService.class), mock(RdbmsSchemaManagerRegistry.class));
+        new RdbmsExporterWrapper(
+            mock(RdbmsServiceFactory.class), mock(RdbmsSchemaManagerRegistry.class));
 
     // when
     assertThatThrownBy(() -> exporterWrapper.configure(context))
@@ -79,8 +81,10 @@ class RdbmsExporterWrapperTest {
     // given
     final var configuration = new ExporterConfiguration();
     final Context context = mock(Context.class, Mockito.RETURNS_DEEP_STUBS);
+    final RdbmsServiceFactory rdbmsServiceFactory = mock(RdbmsServiceFactory.class);
     final RdbmsService rdbmsService = mock(RdbmsService.class, Mockito.RETURNS_DEEP_STUBS);
     final RdbmsWriters rdbmsWriters = mock(RdbmsWriters.class, Mockito.RETURNS_DEEP_STUBS);
+    when(rdbmsServiceFactory.createRdbmsService(Mockito.anyString())).thenReturn(rdbmsService);
 
     when(context.getConfiguration().instantiate(Mockito.eq(ExporterConfiguration.class)))
         .thenReturn(configuration);
@@ -89,7 +93,7 @@ class RdbmsExporterWrapperTest {
     when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriters);
 
     final RdbmsExporterWrapper exporterWrapper =
-        new RdbmsExporterWrapper(rdbmsService, mock(RdbmsSchemaManagerRegistry.class));
+        new RdbmsExporterWrapper(rdbmsServiceFactory, mock(RdbmsSchemaManagerRegistry.class));
 
     // when
     exporterWrapper.configure(context);
@@ -158,8 +162,10 @@ class RdbmsExporterWrapperTest {
     // given
     final var configuration = new ExporterConfiguration();
     final Context context = mock(Context.class, Mockito.RETURNS_DEEP_STUBS);
+    final RdbmsServiceFactory rdbmsServiceFactory = mock(RdbmsServiceFactory.class);
     final RdbmsService rdbmsService = mock(RdbmsService.class, Mockito.RETURNS_DEEP_STUBS);
     final RdbmsWriters rdbmsWriters = mock(RdbmsWriters.class, Mockito.RETURNS_DEEP_STUBS);
+    when(rdbmsServiceFactory.createRdbmsService(Mockito.anyString())).thenReturn(rdbmsService);
 
     when(context.getConfiguration().instantiate(Mockito.eq(ExporterConfiguration.class)))
         .thenReturn(configuration);
@@ -168,7 +174,7 @@ class RdbmsExporterWrapperTest {
     when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriters);
 
     final RdbmsExporterWrapper exporterWrapper =
-        new RdbmsExporterWrapper(rdbmsService, mock(RdbmsSchemaManagerRegistry.class));
+        new RdbmsExporterWrapper(rdbmsServiceFactory, mock(RdbmsSchemaManagerRegistry.class));
 
     // when
     exporterWrapper.configure(context);
@@ -222,8 +228,10 @@ class RdbmsExporterWrapperTest {
     // given
     final var configuration = new ExporterConfiguration();
     final Context context = mock(Context.class, Mockito.RETURNS_DEEP_STUBS);
+    final RdbmsServiceFactory rdbmsServiceFactory = mock(RdbmsServiceFactory.class);
     final RdbmsService rdbmsService = mock(RdbmsService.class, Mockito.RETURNS_DEEP_STUBS);
     final RdbmsWriters rdbmsWriters = mock(RdbmsWriters.class, Mockito.RETURNS_DEEP_STUBS);
+    when(rdbmsServiceFactory.createRdbmsService(Mockito.anyString())).thenReturn(rdbmsService);
 
     when(context.getConfiguration().instantiate(Mockito.eq(ExporterConfiguration.class)))
         .thenReturn(configuration);
@@ -232,7 +240,7 @@ class RdbmsExporterWrapperTest {
     when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriters);
 
     final RdbmsExporterWrapper exporterWrapper =
-        new RdbmsExporterWrapper(rdbmsService, mock(RdbmsSchemaManagerRegistry.class));
+        new RdbmsExporterWrapper(rdbmsServiceFactory, mock(RdbmsSchemaManagerRegistry.class));
 
     // when
     exporterWrapper.configure(context);
@@ -286,8 +294,10 @@ class RdbmsExporterWrapperTest {
     // given
     final var configuration = new ExporterConfiguration();
     final Context context = mock(Context.class, Mockito.RETURNS_DEEP_STUBS);
+    final RdbmsServiceFactory rdbmsServiceFactory = mock(RdbmsServiceFactory.class);
     final RdbmsService rdbmsService = mock(RdbmsService.class, Mockito.RETURNS_DEEP_STUBS);
     final RdbmsWriters rdbmsWriters = mock(RdbmsWriters.class, Mockito.RETURNS_DEEP_STUBS);
+    when(rdbmsServiceFactory.createRdbmsService(Mockito.anyString())).thenReturn(rdbmsService);
 
     when(context.getConfiguration().instantiate(Mockito.eq(ExporterConfiguration.class)))
         .thenReturn(configuration);
@@ -296,7 +306,7 @@ class RdbmsExporterWrapperTest {
     when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriters);
 
     final RdbmsExporterWrapper exporterWrapper =
-        new RdbmsExporterWrapper(rdbmsService, mock(RdbmsSchemaManagerRegistry.class));
+        new RdbmsExporterWrapper(rdbmsServiceFactory, mock(RdbmsSchemaManagerRegistry.class));
 
     // when
     exporterWrapper.configure(context);


### PR DESCRIPTION
## Description

Scopes `RdbmsService` to a single physical tenant. Instead of a multi-tenant holder whose ~40 reader accessors each took a `physicalTenantId`, a new `RdbmsServiceFactory` (the Spring bean) mints a tenant-scoped `RdbmsService` on demand — at the last moment, once the physical tenant is known (e.g. from the exporter `Context`). Each physical tenant connects to its own RDBMS, so its readers, writers and replication status provider are all bound to that tenant's datasource.

This also delivers the goal of #55780 (per-tenant async-replication backpressure) as a consequence: `getReplicationLogStatusProvider()` is now backed by the tenant's own bundle, and the dead singleton `replicationStatusMapper()` bean / default-tenant hardcode on the replication path are removed.

### Key changes
- `RdbmsServiceFactory.createRdbmsService(tenantId)` resolves the tenant's mapper bundle + readers and fails fast (`IllegalArgumentException`) on unknown ids.
- Dropped `physicalTenantId` from all `RdbmsService` getters, `RdbmsWriterFactory` (now bound to one bundle) and `RdbmsCacheRegistry`.
- Adapted the exporter wrapper and all RDBMS tests to obtain the service via the factory.

Closes #55780

🤖 Generated with [Claude Code](https://claude.com/claude-code)
