### PR TITLE
fix: ensure that persisted exporting state is correctly overwritten

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
@@ -126,7 +126,8 @@ public class PartitionProcessingState {
         state.name(),
         StandardCharsets.UTF_8,
         StandardOpenOption.DSYNC,
-        StandardOpenOption.CREATE);
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING);
   }
 
   private void initExportingState() {
@@ -138,7 +139,7 @@ public class PartitionProcessingState {
         final var state =
             Files.readString(
                 getPersistedPauseState(PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toPath());
-        if (state == null || state.isEmpty() || state.isBlank()) {
+        if (state.isBlank()) {
           // Backwards compatibility. If the file exists, it is paused.
           exporterPhase = ExporterPhase.PAUSED;
           return;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
@@ -142,4 +142,18 @@ class PartitionProcessingStateTest {
         .describedAs("Exporting must be paused.")
         .isEqualTo(ExporterPhase.PAUSED);
   }
+
+  @Test
+  void shouldSupportSoftThenHardPause() {
+    // given
+    final var partitionProcessingState = new PartitionProcessingState(MOCK_RAFT_PARTITION);
+    partitionProcessingState.softPauseExporting();
+
+    // when
+    partitionProcessingState.pauseExporting();
+
+    // then
+    final var newState = new PartitionProcessingState(MOCK_RAFT_PARTITION);
+    assertThat(newState.getExporterPhase()).isEqualTo(ExporterPhase.PAUSED);
+  }
 }


### PR DESCRIPTION
When soft-pausing and then hard-pausing, the exporter state would not get fully overwritten, instead the shorter "PAUSED" and the longer "SOFT_PAUSED" merge into one and can't be deserialized back.

Use `TRUNCATE_EXISTING` to ensure that every write fully overwrites the previous state.

closes #55838
