### PR TITLE
fix: resolve default physical tenant for off-request session store access

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SessionStoreAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SessionStoreAdapter.java
@@ -34,9 +34,10 @@ import org.slf4j.LoggerFactory;
  * save path. This resilience policy lives here (rather than in the library) because it inspects the
  * search-specific {@link CamundaSearchException} reasons to decide what is transient.
  *
- * <p>Read and write operations ({@link #get}, {@link #upsert}, and in-request {@link #delete}) are
- * routed to the physical tenant resolved from the current request context. Background operations
- * ({@link #getAll} and off-request {@link #delete}) fan out across all known physical tenants.
+ * <p>Read and write operations ({@link #get} and {@link #upsert}) are routed to the physical tenant
+ * resolved from the current request context; when no request scope is bound (e.g. Spring Session's
+ * commit phase, which runs after the request scope is torn down), they fall back to the default
+ * physical tenant, matching the behaviour of {@link #delete} and {@link #getAll}.
  */
 public class SessionStoreAdapter implements SessionStorePort {
 
@@ -73,17 +74,22 @@ public class SessionStoreAdapter implements SessionStorePort {
     return throwable instanceof RuntimeException;
   }
 
+  private String currentPhysicalTenantOrDefault() {
+    final String currentTenant = PhysicalTenantContext.currentOrNull();
+    return currentTenant != null ? currentTenant : PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+  }
+
   @Override
   public PersistentSession get(final String sessionId) {
     return toPersistentSession(
         sessionClients
-            .withPhysicalTenant(PhysicalTenantContext.current())
+            .withPhysicalTenant(currentPhysicalTenantOrDefault())
             .getPersistentWebSession(sessionId));
   }
 
   @Override
   public void upsert(final PersistentSession session) {
-    final var client = sessionClients.withPhysicalTenant(PhysicalTenantContext.current());
+    final var client = sessionClients.withPhysicalTenant(currentPhysicalTenantOrDefault());
     final var entity = toEntity(session);
     try {
       Retry.decorateRunnable(UPSERT_RETRY, () -> client.upsertPersistentWebSession(entity)).run();

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SessionStoreAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SessionStoreAdapterTest.java
@@ -333,6 +333,37 @@ class SessionStoreAdapterTest {
     assertThat(sessions).extracting(PersistentSession::id).containsExactlyInAnyOrder("s1", "s2");
   }
 
+  @Test
+  void shouldFallBackToDefaultTenantOnGetWhenOffRequest() {
+    // given — a session stored under the default physical tenant
+    final var client = new PersistentWebSessionClientStub();
+    final var adapter = adapterWith(client);
+    client.upsertPersistentWebSession(
+        new PersistentWebSessionEntity("s1", 100L, 200L, 1800L, Map.of()));
+
+    // when — no request scope bound (Spring Session commits after the request scope is torn down)
+    RequestContextHolder.resetRequestAttributes();
+
+    // then — resolves to the default physical tenant instead of throwing
+    assertThat(adapter.get("s1")).isNotNull();
+    assertThat(adapter.get("s1").id()).isEqualTo("s1");
+  }
+
+  @Test
+  void shouldFallBackToDefaultTenantOnUpsertWhenOffRequest() {
+    // given
+    final var client = new PersistentWebSessionClientStub();
+    final var adapter = adapterWith(client);
+    final var session = new PersistentSession("s1", 100L, 200L, 1800L, Map.of());
+
+    // when — no request scope bound
+    RequestContextHolder.resetRequestAttributes();
+    adapter.upsert(session);
+
+    // then — stored under the default physical tenant
+    assertThat(client.getPersistentWebSession("s1")).isNotNull();
+  }
+
   private static void setRequestContext(final String physicalTenantId) {
     final var req = new MockHttpServletRequest();
     PhysicalTenantContext.setPhysicalTenantId(req, physicalTenantId);

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SessionStoreAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SessionStoreAdapterTest.java
@@ -345,8 +345,9 @@ class SessionStoreAdapterTest {
     RequestContextHolder.resetRequestAttributes();
 
     // then — resolves to the default physical tenant instead of throwing
-    assertThat(adapter.get("s1")).isNotNull();
-    assertThat(adapter.get("s1").id()).isEqualTo("s1");
+    final var stored = adapter.get("s1");
+    assertThat(stored).isNotNull();
+    assertThat(stored.id()).isEqualTo("s1");
   }
 
   @Test


### PR DESCRIPTION
## Description

Non-PT / SaaS deployments returned **HTTP 500** on every session-backed webapp request when persistent web sessions are enabled:

```
PhysicalTenantContext.current() called outside a request scope; the physical
tenant must be resolved on the request thread (or propagated onto this thread).
```

### Root cause

`SessionStoreAdapter.get`/`upsert` resolved the per-PT session client via the **throwing** `PhysicalTenantContext.current()`. Spring Session's `SessionRepositoryFilter.commitSession` runs in a `finally` block **after** the request scope has been torn down (the session filter is outermost, so the request scope binds/unbinds inside it). At commit time no scope is bound → `currentOrNull()` returns `null` → `current()` throws → 500. The sibling methods `delete`/`getAll` already tolerated the absent scope.

Introduced by `e2bf83ab008`.

### Fix

`get`/`upsert` now fall back to the default physical tenant when no request scope is bound (via a small `currentPhysicalTenantOrDefault()` helper), matching the existing tolerance in `delete`/`getAll`. For the non-PT / SaaS path — the issue's entire scope — the default tenant is exactly the correct target, so the non-prefixed path behaves identically to `/physical-tenants/default`.

`PhysicalTenantContext.current()`'s global throw-on-no-scope semantics are **left intact** — an async authz read that lost its context still fails loudly rather than silently using the wrong tenant (ADR-0006 constraint).

The alternative of stamping the default in `PhysicalTenantFilter` was rejected: the failure is the *absence* of a bound request scope at commit, not a missing stamp, so a filter stamp never reaches the commit phase without invasive filter reordering.

### Known limitation (multi-PT) — tracked in #55852

This fix is correct for the non-PT / SaaS path. For **multi-PT** deployments it is not complete: a non-default PT's session **write** also happens at commit (scope torn down), so it falls back to the **default** store rather than the PT's store. Reads during dispatch route correctly, so the session is silently written to the wrong store. This is **not a regression** (commits threw 500 before this change) and multi-PT persistent web sessions are not a shipped working path yet. Correct per-PT commit routing (carrying the PT into the commit phase + full e2e ITs through the real filter chain) is tracked as a follow-up under epic #51949: **#55852**.

### Tests

Two new unit tests reproduce the off-request commit scenario (request scope reset before `get`/`upsert`) — they fail with `IllegalStateException` before the fix and pass after. Full `SessionStoreAdapterTest` (16 tests) green.

> Note: end-to-end coverage through the real Spring Session filter chain (the commit phase) is intentionally deferred to #55852, where the proper per-PT routing change lands.

Closes #55849

🤖 Generated with [Claude Code](https://claude.com/claude-code)