### PR TITLE
Add businessId filter and sort to decision instances search API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionInstanceFilter.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.DecisionInstanceStateProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import io.camunda.client.api.search.response.DecisionDefinitionType;
 import io.camunda.client.api.search.response.DecisionInstanceState;
@@ -56,6 +57,26 @@ public interface DecisionInstanceFilter extends SearchRequestFilter {
 
   /** Filter by processInstanceKey */
   DecisionInstanceFilter processInstanceKey(long processInstanceKey);
+
+  /**
+   * Filters decision instances by the business ID of their owning process instance. This only works
+   * for decision instances created with 8.10 and onwards. Decision instances from prior versions
+   * and standalone evaluations don't contain this data.
+   *
+   * @param businessId the business ID of the owning process instance
+   * @return the updated filter
+   */
+  DecisionInstanceFilter businessId(final String businessId);
+
+  /**
+   * Filters decision instances by the business ID of their owning process instance using {@link
+   * StringProperty} consumer. This only works for decision instances created with 8.10 and onwards.
+   * Decision instances from prior versions and standalone evaluations don't contain this data.
+   *
+   * @param fn the business ID {@link StringProperty} consumer
+   * @return the updated filter
+   */
+  DecisionInstanceFilter businessId(final Consumer<StringProperty> fn);
 
   /** Filter by elementInstanceKey */
   DecisionInstanceFilter elementInstanceKey(long elementInstanceKey);

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/DecisionInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/DecisionInstanceSort.java
@@ -40,6 +40,9 @@ public interface DecisionInstanceSort extends SearchRequestSort<DecisionInstance
   /** Sort by processInstanceKey */
   DecisionInstanceSort processInstanceKey();
 
+  /** Sort by businessId */
+  DecisionInstanceSort businessId();
+
   /** Sort by elementInstanceKey */
   DecisionInstanceSort elementInstanceKey();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionInstanceFilterImpl.java
@@ -20,12 +20,14 @@ import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.DecisionInstanceStateProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.response.DecisionDefinitionType;
 import io.camunda.client.api.search.response.DecisionInstanceState;
 import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.DecisionInstanceStatePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DecisionDefinitionTypeEnum;
@@ -103,6 +105,19 @@ public class DecisionInstanceFilterImpl
   @Override
   public DecisionInstanceFilter processInstanceKey(final long processInstanceKey) {
     filter.setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
+    return this;
+  }
+
+  @Override
+  public DecisionInstanceFilter businessId(final String businessId) {
+    return businessId(b -> b.eq(businessId));
+  }
+
+  @Override
+  public DecisionInstanceFilter businessId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setBusinessId(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/DecisionInstanceSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/DecisionInstanceSortImpl.java
@@ -62,6 +62,11 @@ public class DecisionInstanceSortImpl extends SearchRequestSortBase<DecisionInst
   }
 
   @Override
+  public DecisionInstanceSort businessId() {
+    return field("businessId");
+  }
+
+  @Override
   public DecisionInstanceSort elementInstanceKey() {
     return field("elementInstanceKey");
   }

--- a/clients/java/src/test/java/io/camunda/client/decision/GetDecisionInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/GetDecisionInstanceTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.protocol.rest.DecisionInstanceResult;
 import io.camunda.client.util.ClientRestTest;
 import java.time.OffsetDateTime;
@@ -50,5 +51,30 @@ public final class GetDecisionInstanceTest extends ClientRestTest {
     final LoggedRequest request = gatewayService.getLastRequest();
     assertThat(request.getUrl()).isEqualTo("/v2/decision-instances/" + decisionInstanceId);
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+
+  @Test
+  void shouldGetDecisionInstanceWithBusinessId() {
+    // given
+    final String decisionInstanceId = "1-1";
+    gatewayService.onDecisionInstanceRequest(
+        decisionInstanceId,
+        Instancio.create(DecisionInstanceResult.class)
+            .decisionEvaluationKey("1")
+            .decisionDefinitionKey("2")
+            .elementInstanceKey("3")
+            .processDefinitionKey("4")
+            .processInstanceKey("5")
+            .rootDecisionDefinitionKey("6")
+            .rootProcessInstanceKey("7")
+            .businessId("order-42")
+            .evaluationDate(OffsetDateTime.now().toString()));
+
+    // when
+    final DecisionInstance decisionInstance =
+        client.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
+
+    // then
+    assertThat(decisionInstance.getBusinessId()).isEqualTo("order-42");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/decision/SearchDecisionInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/SearchDecisionInstanceTest.java
@@ -236,14 +236,16 @@ class SearchDecisionInstanceTest extends ClientRestTest {
                     .decisionDefinitionType()
                     .asc()
                     .tenantId()
-                    .asc())
+                    .asc()
+                    .businessId()
+                    .desc())
         .send()
         .join();
 
     // then
     final DecisionInstanceSearchQuery request =
         gatewayService.getLastRequest(DecisionInstanceSearchQuery.class);
-    assertThat(request.getSort().size()).isEqualTo(12);
+    assertThat(request.getSort().size()).isEqualTo(13);
     assertThat(request.getSort().get(0).getField())
         .isEqualTo(DecisionInstanceSearchQuerySortRequest.FieldEnum.DECISION_DEFINITION_KEY);
     assertThat(request.getSort().get(0).getOrder()).isEqualTo(SortOrderEnum.ASC);
@@ -280,5 +282,8 @@ class SearchDecisionInstanceTest extends ClientRestTest {
     assertThat(request.getSort().get(11).getField())
         .isEqualTo(DecisionInstanceSearchQuerySortRequest.FieldEnum.TENANT_ID);
     assertThat(request.getSort().get(11).getOrder()).isEqualTo(SortOrderEnum.ASC);
+    assertThat(request.getSort().get(12).getField())
+        .isEqualTo(DecisionInstanceSearchQuerySortRequest.FieldEnum.BUSINESS_ID);
+    assertThat(request.getSort().get(12).getOrder()).isEqualTo(SortOrderEnum.DESC);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/decision/SearchDecisionInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/SearchDecisionInstanceTest.java
@@ -51,6 +51,7 @@ class SearchDecisionInstanceTest extends ClientRestTest {
                     .decisionDefinitionType(DecisionDefinitionType.DECISION_TABLE)
                     .processDefinitionKey(2L)
                     .processInstanceKey(3L)
+                    .businessId("biz")
                     .decisionDefinitionKey(4L)
                     .elementInstanceKey(5L)
                     .decisionDefinitionId("ddi")
@@ -70,12 +71,39 @@ class SearchDecisionInstanceTest extends ClientRestTest {
         .isEqualTo(DecisionDefinitionTypeEnum.DECISION_TABLE);
     assertThat(request.getFilter().getProcessDefinitionKey()).isEqualTo("2");
     assertThat(request.getFilter().getProcessInstanceKey()).isEqualTo("3");
+    assertThat(request.getFilter().getBusinessId().get$Eq()).isEqualTo("biz");
     assertThat(request.getFilter().getDecisionDefinitionKey().get$Eq()).isEqualTo("4");
     assertThat(request.getFilter().getElementInstanceKey().get$Eq()).isEqualTo("5");
     assertThat(request.getFilter().getDecisionDefinitionId()).isEqualTo("ddi");
     assertThat(request.getFilter().getDecisionDefinitionName()).isEqualTo("ddm");
     assertThat(request.getFilter().getDecisionDefinitionVersion()).isEqualTo(5);
     assertThat(request.getFilter().getTenantId()).isEqualTo("t");
+  }
+
+  @Test
+  void shouldSearchDecisionInstanceByBusinessId() {
+    // when
+    client.newDecisionInstanceSearchRequest().filter(f -> f.businessId("order-42")).send().join();
+
+    // then
+    final DecisionInstanceSearchQuery request =
+        gatewayService.getLastRequest(DecisionInstanceSearchQuery.class);
+    assertThat(request.getFilter().getBusinessId().get$Eq()).isEqualTo("order-42");
+  }
+
+  @Test
+  void shouldSearchDecisionInstanceByBusinessIdStringFilter() {
+    // when
+    client
+        .newDecisionInstanceSearchRequest()
+        .filter(f -> f.businessId(b -> b.like("order-*")))
+        .send()
+        .join();
+
+    // then
+    final DecisionInstanceSearchQuery request =
+        gatewayService.getLastRequest(DecisionInstanceSearchQuery.class);
+    assertThat(request.getFilter().getBusinessId().get$Like()).isEqualTo("order-*");
   }
 
   @Test

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/DecisionInstanceSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/DecisionInstanceSearchColumn.java
@@ -14,6 +14,7 @@ public enum DecisionInstanceSearchColumn implements SearchColumn<DecisionInstanc
   DECISION_INSTANCE_KEY("decisionInstanceKey"),
   PROCESS_DEFINITION_KEY("processDefinitionKey"),
   PROCESS_INSTANCE_KEY("processInstanceKey"),
+  BUSINESS_ID("businessId"),
   FLOW_NODE_INSTANCE_KEY("flowNodeInstanceKey"),
   DECISION_DEFINITION_NAME("decisionDefinitionName"),
   DECISION_DEFINITION_ID("decisionDefinitionId"),

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -189,6 +189,12 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
+      <if test="filter.businessIdOperations != null and !filter.businessIdOperations.isEmpty()">
+        <foreach collection="filter.businessIdOperations" item="operation">
+          AND di.BUSINESS_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
       <if test="filter.partitionId != null">
         AND di.PARTITION_ID = #{filter.partitionId}
       </if>

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -297,6 +297,9 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getProcessInstanceKey())
           .map(mapKeyToLong("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeys);
+      ofNullable(filter.getBusinessId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::businessIdOperations);
       ofNullable(filter.getElementInstanceKey())
           .map(mapToKeyOperations("elementInstanceKey", validationErrors))
           .ifPresent(builder::flowNodeInstanceKeyOperations);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -366,6 +366,7 @@ public class SearchQuerySortRequestMapper {
         case DECISION_DEFINITION_TYPE -> builder.decisionDefinitionType();
         case ROOT_DECISION_DEFINITION_KEY -> builder.rootDecisionDefinitionKey();
         case TENANT_ID -> builder.tenantId();
+        case BUSINESS_ID -> builder.businessId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
@@ -565,6 +565,33 @@ class DecisionInstanceSearchIT {
   }
 
   @Test
+  public void shouldSortDecisionInstancesByBusinessId(final CamundaClient camundaClient) {
+    // when - filter to the in-process decisions (the standalone evaluations carry a null
+    // businessId, which sorts inconsistently across backends) and order by businessId
+    final var resultAsc =
+        camundaClient
+            .newDecisionInstanceSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("order-*")))
+            .sort(s -> s.businessId().asc())
+            .send()
+            .join();
+    final var resultDesc =
+        camundaClient
+            .newDecisionInstanceSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("order-*")))
+            .sort(s -> s.businessId().desc())
+            .send()
+            .join();
+
+    // then - the businessId sort is accepted and applied end-to-end on both backends; both
+    // in-process decision instances share the owning instance's businessId
+    assertThat(resultAsc.items()).hasSize(2);
+    assertThat(resultDesc.items()).hasSize(2);
+    assertThat(resultAsc.items()).extracting("businessId").containsOnly(BUSINESS_ID);
+    assertThat(resultDesc.items()).extracting("businessId").containsOnly(BUSINESS_ID);
+  }
+
+  @Test
   public void shouldRetrieveDecisionInstanceByStateAndType() {
     // when
     final DecisionInstanceState state = DecisionInstanceState.EVALUATED;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
@@ -103,7 +103,7 @@ class DecisionInstanceSearchIT {
     final var result = camundaClient.newDecisionInstanceSearchRequest().send().join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(5);
+    assertThat(result.items()).hasSize(5);
   }
 
   @Test
@@ -113,7 +113,7 @@ class DecisionInstanceSearchIT {
 
     final var resultWithLimit =
         camundaClient.newDecisionInstanceSearchRequest().page(p -> p.limit(2)).send().join();
-    assertThat(resultWithLimit.items().size()).isEqualTo(2);
+    assertThat(resultWithLimit.items()).hasSize(2);
 
     final var thirdKey = resultAll.items().get(2).getDecisionInstanceKey();
 
@@ -136,7 +136,7 @@ class DecisionInstanceSearchIT {
 
     final var resultWithLimit =
         camundaClient.newDecisionInstanceSearchRequest().page(p -> p.limit(2)).send().join();
-    assertThat(resultWithLimit.items().size()).isEqualTo(2);
+    assertThat(resultWithLimit.items()).hasSize(2);
 
     final var firstTwoKeys =
         resultAll.items().subList(0, 2).stream()
@@ -175,7 +175,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items()).hasSize(1);
     final var decisionInstance = result.singleItem();
 
     assertThat(decisionInstance.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
@@ -220,7 +220,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items()).hasSize(1);
     final var decisionInstance = result.singleItem();
 
     assertThat(decisionInstance.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
@@ -265,7 +265,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items()).hasSize(1);
     final var decisionInstance = result.singleItem();
 
     assertThat(decisionInstance.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
@@ -310,7 +310,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(4);
+    assertThat(result.items()).hasSize(4);
   }
 
   @Test
@@ -327,7 +327,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items()).hasSize(1);
     assertThat(result.items().getFirst().getDecisionDefinitionKey())
         .isEqualTo(decisionDefinitionKey);
     assertThat(result.items().getFirst().getDecisionInstanceKey())
@@ -349,7 +349,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(4);
+    assertThat(result.items()).hasSize(4);
     assertThat(result.items())
         .extracting(DecisionInstance::getDecisionDefinitionId)
         .containsExactlyInAnyOrder(
@@ -381,7 +381,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items()).hasSize(1);
     final var decisionInstance = result.singleItem();
 
     assertThat(decisionInstance.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
@@ -424,7 +424,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items()).hasSize(1);
     assertThat(result.items().getFirst().getRootDecisionDefinitionKey())
         .isEqualTo(rootDecisionDefinitionKey);
     assertThat(result.items().getFirst().getDecisionInstanceKey())
@@ -448,7 +448,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(4);
+    assertThat(result.items()).hasSize(4);
     assertThat(result.items())
         .extracting(DecisionInstance::getDecisionDefinitionId)
         .containsExactlyInAnyOrder(
@@ -472,7 +472,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items()).hasSize(2);
     assertThat(result.items().getFirst().getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
     assertThat(result.items().getLast().getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
   }
@@ -498,7 +498,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items()).hasSize(2);
     assertThat(result.items())
         .extracting("elementInstanceKey", "decisionDefinitionId")
         .containsExactlyInAnyOrder(
@@ -518,7 +518,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items()).hasSize(2);
     assertThat(result.items())
         .extracting("processInstanceKey", "rootProcessInstanceKey", "decisionDefinitionId")
         .containsExactlyInAnyOrder(
@@ -538,7 +538,7 @@ class DecisionInstanceSearchIT {
 
     // then - only the two in-process decision instances carry the owning instance's businessId;
     // the standalone evaluations stay null
-    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items()).hasSize(2);
     assertThat(result.items())
         .extracting("businessId", "processInstanceKey", "decisionDefinitionId")
         .containsExactlyInAnyOrder(
@@ -558,7 +558,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items()).hasSize(2);
     assertThat(result.items())
         .extracting("businessId")
         .containsExactlyInAnyOrder(BUSINESS_ID, BUSINESS_ID);
@@ -604,7 +604,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(5);
+    assertThat(result.items()).hasSize(5);
   }
 
   @Test
@@ -619,7 +619,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(5);
+    assertThat(result.items()).hasSize(5);
   }
 
   @Test
@@ -634,7 +634,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(5);
+    assertThat(result.items()).hasSize(5);
   }
 
   @Test
@@ -740,7 +740,7 @@ class DecisionInstanceSearchIT {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items()).hasSize(1);
     assertThat(result.singleItem().getDecisionInstanceKey())
         .isEqualTo(EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionEvaluationKey());
   }
@@ -893,7 +893,7 @@ class DecisionInstanceSearchIT {
         .untilAsserted(
             () -> {
               final var result = camundaClient.newDecisionInstanceSearchRequest().send().join();
-              assertThat(result.items().size()).isEqualTo(expectedCount);
+              assertThat(result.items()).hasSize(expectedCount);
             });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
@@ -8,7 +8,6 @@
 package io.camunda.it.client;
 
 import static io.camunda.it.util.TestHelper.deployResource;
-import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
 import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceIsEnded;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
@@ -44,6 +43,7 @@ class DecisionInstanceSearchIT {
   private static final String DECISION_DEFINITION_ID_3 = "invoiceClassification";
   private static final String PROCESS_DEFINITION_ID = "myProcessWithDMN";
   private static final String ELEMENT_ID_DMN_CALL = "dmnCall";
+  private static final String BUSINESS_ID = "order-42";
 
   private static CamundaClient camundaClient;
   private static long processInstanceKey;
@@ -83,10 +83,13 @@ class DecisionInstanceSearchIT {
         "myProcessWithDMN.bpmn");
     processInstanceKey =
         // creates two decision instances
-        startProcessInstance(
-                camundaClient,
-                PROCESS_DEFINITION_ID,
-                "{\"amount\": 100, \"invoiceCategory\": \"Misc\"}")
+        camundaClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_DEFINITION_ID)
+            .latestVersion()
+            .businessId(BUSINESS_ID)
+            .variables("{\"amount\": 100, \"invoiceCategory\": \"Misc\"}")
+            .execute()
             .getProcessInstanceKey();
 
     waitUntilProcessInstanceIsEnded(camundaClient, processInstanceKey);
@@ -521,6 +524,44 @@ class DecisionInstanceSearchIT {
         .containsExactlyInAnyOrder(
             tuple(processInstanceKey, processInstanceKey, DECISION_DEFINITION_ID_2),
             tuple(processInstanceKey, processInstanceKey, DECISION_DEFINITION_ID_3));
+  }
+
+  @Test
+  public void shouldRetrieveDecisionInstanceByBusinessIdFilter(final CamundaClient camundaClient) {
+    // when
+    final var result =
+        camundaClient
+            .newDecisionInstanceSearchRequest()
+            .filter(f -> f.businessId(BUSINESS_ID))
+            .send()
+            .join();
+
+    // then - only the two in-process decision instances carry the owning instance's businessId;
+    // the standalone evaluations stay null
+    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items())
+        .extracting("businessId", "processInstanceKey", "decisionDefinitionId")
+        .containsExactlyInAnyOrder(
+            tuple(BUSINESS_ID, processInstanceKey, DECISION_DEFINITION_ID_2),
+            tuple(BUSINESS_ID, processInstanceKey, DECISION_DEFINITION_ID_3));
+  }
+
+  @Test
+  public void shouldRetrieveDecisionInstanceByBusinessIdLikeFilter(
+      final CamundaClient camundaClient) {
+    // when
+    final var result =
+        camundaClient
+            .newDecisionInstanceSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("order-*")))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items())
+        .extracting("businessId")
+        .containsExactlyInAnyOrder(BUSINESS_ID, BUSINESS_ID);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
@@ -11,6 +11,7 @@ import static io.camunda.it.util.TestHelper.assertSorted;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.startProcessInstanceWithBusinessId;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static io.camunda.search.schema.config.IndexConfiguration.DEFAULT_VARIABLE_SIZE_THRESHOLD;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +52,12 @@ class UserTaskSearchIT {
   private static OffsetDateTime defaultProcessTaskDate;
   private static final String LARGE_VAR_NAME = "largeVariable";
   private static final String LARGE_VALUE = "b".repeat(DEFAULT_VARIABLE_SIZE_THRESHOLD + 10);
+  // the two plain "process" instances carry distinct businessIds so the filter/sort can be
+  // asserted deterministically; the parent process carries a non-"order-*" businessId that the
+  // child user task inherits (mirroring the rootProcessInstanceKey child-inheritance test)
+  private static final String BUSINESS_ID_1 = "order-001";
+  private static final String BUSINESS_ID_2 = "order-002";
+  private static final String CHILD_PARENT_BUSINESS_ID = "biz-parent-001";
 
   private static CamundaClient camundaClient;
 
@@ -76,9 +83,9 @@ class UserTaskSearchIT {
     deployProcessFromResourcePath(
         "/process/parent_with_child_usertask.bpmn", "parent_with_child_usertask.bpmn");
 
-    startProcessInstance(camundaClient, "process");
+    startProcessInstanceWithBusinessId(camundaClient, "process", BUSINESS_ID_1);
     startProcessInstance(camundaClient, "process-2");
-    startProcessInstance(camundaClient, "process");
+    startProcessInstanceWithBusinessId(camundaClient, "process", BUSINESS_ID_2);
     startProcessInstance(camundaClient, "process-3");
     startProcessInstance(camundaClient, "bpmProcessVariable");
     startProcessInstance(camundaClient, "processWithForm");
@@ -91,7 +98,9 @@ class UserTaskSearchIT {
 
     // Start parent process that calls child process with user task
     parentProcessInstanceKey =
-        startProcessInstance(camundaClient, "parentWithChildUserTask").getProcessInstanceKey();
+        startProcessInstanceWithBusinessId(
+                camundaClient, "parentWithChildUserTask", CHILD_PARENT_BUSINESS_ID)
+            .getProcessInstanceKey();
 
     startProcessInstance(camundaClient, "processWithOverlappingVars");
 
@@ -870,6 +879,78 @@ class UserTaskSearchIT {
                       variable.getName())
                   .isEqualTo(childProcessInstanceKey);
             });
+  }
+
+  @Test
+  void shouldReturnUserTaskBusinessIdInheritedFromOwningInstance() {
+    // when - get the child user task from a call activity whose parent was started with a
+    // businessId
+    final var childUserTask = camundaClient.newUserTaskGetRequest(childUserTaskKey).send().join();
+
+    // then - the child instance inherits the owning (parent) instance's businessId, and the user
+    // task is stamped from its owning instance (mirroring rootProcessInstanceKey inheritance)
+    assertThat(childUserTask.getBusinessId()).isEqualTo(CHILD_PARENT_BUSINESS_ID);
+  }
+
+  @Test
+  void shouldRetrieveUserTaskByBusinessId() {
+    // when
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.businessId(BUSINESS_ID_1))
+            .send()
+            .join();
+
+    // then - only the "process" instance started with that businessId matches
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getBusinessId()).isEqualTo(BUSINESS_ID_1);
+    assertThat(result.items().getFirst().getBpmnProcessId()).isEqualTo("process");
+  }
+
+  @Test
+  void shouldRetrieveUserTaskByBusinessIdLike() {
+    // when
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("order-*")))
+            .send()
+            .join();
+
+    // then - both "process" instances carry an "order-*" businessId
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items())
+        .extracting(UserTask::getBusinessId)
+        .containsExactlyInAnyOrder(BUSINESS_ID_1, BUSINESS_ID_2);
+  }
+
+  @Test
+  void shouldSortUserTasksByBusinessId() {
+    // when - filter to the in-process tasks carrying an "order-*" businessId (the rest are null,
+    // which sorts inconsistently across backends) and order by businessId
+    final var resultAsc =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("order-*")))
+            .sort(s -> s.businessId().asc())
+            .send()
+            .join();
+    final var resultDesc =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("order-*")))
+            .sort(s -> s.businessId().desc())
+            .send()
+            .join();
+
+    // then
+    assertThat(resultAsc.items()).hasSize(2);
+    assertThat(resultDesc.items()).hasSize(2);
+    assertThat(resultAsc.items().getFirst().getBusinessId()).isEqualTo(BUSINESS_ID_1);
+    assertThat(resultAsc.items().getLast().getBusinessId()).isEqualTo(BUSINESS_ID_2);
+    assertThat(resultDesc.items().getFirst().getBusinessId()).isEqualTo(BUSINESS_ID_2);
+    assertThat(resultDesc.items().getLast().getBusinessId()).isEqualTo(BUSINESS_ID_1);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.rdbms.db.decisioninstance;
 
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.generateRandomString;
 import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveDecisionInstance;
 import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstance;
 import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
@@ -219,6 +220,7 @@ public class DecisionInstanceIT {
                                     .states(instance.state())
                                     .decisionTypes(instance.decisionType())
                                     .processInstanceKeys(instance.processInstanceKey())
+                                    .businessIds(instance.businessId())
                                     .evaluationFailures(instance.evaluationFailure())
                                     .evaluationDateOperations(
                                         List.of(
@@ -226,6 +228,58 @@ public class DecisionInstanceIT {
                                                 instance.evaluationDate().minusSeconds(1)))))
                         .sort(s -> s)
                         .page(p -> p.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().decisionInstanceId())
+        .isEqualTo(instance.decisionInstanceId());
+  }
+
+  @TestTemplate
+  public void shouldFindDecisionInstanceByBusinessIdEq(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionInstanceDbReader decisionInstanceReader =
+        rdbmsService.getDecisionInstanceReader();
+
+    final String businessId = generateRandomString("businessId");
+    final var instance =
+        createAndSaveRandomDecisionInstance(rdbmsWriters, b -> b.businessId(businessId));
+    createAndSaveRandomDecisionInstances(rdbmsWriters);
+
+    final var searchResult =
+        decisionInstanceReader.search(
+            DecisionInstanceQuery.of(
+                b ->
+                    b.filter(f -> f.businessIdOperations(Operation.eq(businessId)))
+                        .page(p -> p.from(0).size(10))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().decisionInstanceId())
+        .isEqualTo(instance.decisionInstanceId());
+  }
+
+  @TestTemplate
+  public void shouldFindDecisionInstanceByBusinessIdLike(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionInstanceDbReader decisionInstanceReader =
+        rdbmsService.getDecisionInstanceReader();
+
+    final String prefix = generateRandomString("business-transaction");
+    final var instance =
+        createAndSaveRandomDecisionInstance(rdbmsWriters, b -> b.businessId(prefix + "-v1"));
+    createAndSaveRandomDecisionInstances(rdbmsWriters);
+
+    final var searchResult =
+        decisionInstanceReader.search(
+            DecisionInstanceQuery.of(
+                b ->
+                    b.filter(f -> f.businessIdOperations(Operation.like(prefix + "*")))
+                        .page(p -> p.from(0).size(10))));
 
     assertThat(searchResult.total()).isEqualTo(1);
     assertThat(searchResult.items()).hasSize(1);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
@@ -89,6 +89,22 @@ public class DecisionInstanceSortIT {
   }
 
   @TestTemplate
+  public void shouldSortByBusinessIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.businessId().asc(),
+        Comparator.comparing(DecisionInstanceEntity::businessId));
+  }
+
+  @TestTemplate
+  public void shouldSortByBusinessIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.businessId().desc(),
+        Comparator.comparing(DecisionInstanceEntity::businessId).reversed());
+  }
+
+  @TestTemplate
   public void shouldSortByFlowNodeInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionInstanceFixtures.java
@@ -32,6 +32,7 @@ public final class DecisionInstanceFixtures extends CommonFixtures {
             .decisionInstanceKey(decisionInstanceKey)
             .processInstanceKey(nextKey())
             .rootProcessInstanceKey(nextKey())
+            .businessId(generateRandomString("businessId"))
             .processDefinitionKey(nextKey())
             .processDefinitionId("process-" + decisionInstanceKey)
             .flowNodeInstanceKey(nextKey())

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
@@ -17,6 +17,7 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperatio
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.PARTITION_ID;
+import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.BUSINESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_DEFINITION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_NAME;
@@ -64,6 +65,7 @@ public final class DecisionInstanceFilterTransformer
     ofNullable(getProcessDefinitionKeysQuery(filter.processDefinitionKeys()))
         .ifPresent(queries::add);
     ofNullable(getProcessInstanceKeysQuery(filter.processInstanceKeys())).ifPresent(queries::add);
+    queries.addAll(getBusinessIdQuery(filter.businessIdOperations()));
     queries.addAll(getDecisionDefinitionKeysQuery(filter.decisionDefinitionKeyOperations()));
     queries.addAll(getFlowNodeInstanceKeysQuery(filter.flowNodeInstanceKeyOperations()));
     ofNullable(getDecisionDefinitionIdsQuery(filter.decisionDefinitionIds()))
@@ -120,6 +122,10 @@ public final class DecisionInstanceFilterTransformer
 
   private SearchQuery getProcessInstanceKeysQuery(final List<Long> processInstanceKeys) {
     return longTerms(PROCESS_INSTANCE_KEY, processInstanceKeys);
+  }
+
+  private List<SearchQuery> getBusinessIdQuery(final List<Operation<String>> businessIdOperations) {
+    return stringOperations(BUSINESS_ID, businessIdOperations);
   }
 
   private List<SearchQuery> getDecisionDefinitionKeysQuery(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionInstanceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionInstanceFieldSortingTransformer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients.transformers.sort;
 
+import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.BUSINESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_DEFINITION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_NAME;
@@ -37,6 +38,7 @@ public class DecisionInstanceFieldSortingTransformer implements FieldSortingTran
       case "evaluationFailureMessage" -> EVALUATION_FAILURE_MESSAGE;
       case "processDefinitionKey" -> PROCESS_DEFINITION_KEY;
       case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
+      case "businessId" -> BUSINESS_ID;
       case "flowNodeInstanceKey" -> ELEMENT_INSTANCE_KEY;
       case "decisionDefinitionKey" -> DECISION_DEFINITION_ID; // yes, this is correct
       case "decisionDefinitionId" -> DECISION_ID;

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DecisionInstanceQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DecisionInstanceQueryTransformerTest.java
@@ -267,6 +267,26 @@ class DecisionInstanceQueryTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
+  void shouldQueryByBusinessId() {
+    // given
+    final var decisionInstanceFilter =
+        FilterBuilders.decisionInstance(f -> f.businessIds("businessId1"));
+
+    // when
+    final var searchRequest = transformQuery(decisionInstanceFilter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("businessId");
+              assertThat(t.value().stringValue()).isEqualTo("businessId1");
+            });
+  }
+
+  @Test
   void shouldQueryByPartitionId() {
     // given
     final var decisionInstanceFilter = FilterBuilders.decisionInstance(f -> f.partitionId(3));

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
@@ -38,6 +38,7 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
         new TestArguments(
             "processDefinitionKey", SortOrder.ASC, s -> s.processDefinitionKey().asc()),
         new TestArguments("processInstanceKey", SortOrder.ASC, s -> s.processInstanceKey().asc()),
+        new TestArguments("businessId", SortOrder.ASC, s -> s.businessId().asc()),
         new TestArguments(
             "elementInstanceKey", SortOrder.DESC, s -> s.flowNodeInstanceKey().desc()));
   }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DecisionInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DecisionInstanceFilter.java
@@ -29,6 +29,7 @@ public record DecisionInstanceFilter(
     List<String> evaluationFailures,
     List<Long> processDefinitionKeys,
     List<Long> processInstanceKeys,
+    List<Operation<String>> businessIdOperations,
     List<Operation<Long>> flowNodeInstanceKeyOperations,
     List<Operation<Long>> decisionDefinitionKeyOperations,
     List<String> decisionDefinitionIds,
@@ -55,6 +56,7 @@ public record DecisionInstanceFilter(
         .evaluationFailures(evaluationFailures)
         .processDefinitionKeys(processDefinitionKeys)
         .processInstanceKeys(processInstanceKeys)
+        .businessIdOperations(businessIdOperations)
         .flowNodeInstanceKeyOperations(flowNodeInstanceKeyOperations)
         .decisionDefinitionKeyOperations(decisionDefinitionKeyOperations)
         .decisionDefinitionIds(decisionDefinitionIds)
@@ -76,6 +78,7 @@ public record DecisionInstanceFilter(
     private List<String> evaluationFailures;
     private List<Long> processDefinitionKeys;
     private List<Long> processInstanceKeys;
+    private List<Operation<String>> businessIdOperations;
     private List<Operation<Long>> flowNodeInstanceKeyOperations;
     private List<Operation<Long>> decisionDefinitionKeyOperations;
     private List<String> decisionDefinitionIds;
@@ -163,6 +166,21 @@ public record DecisionInstanceFilter(
 
     public Builder processInstanceKeys(final Long... values) {
       return processInstanceKeys(collectValuesAsList(values));
+    }
+
+    public Builder businessIdOperations(final List<Operation<String>> operations) {
+      businessIdOperations = addValuesToList(businessIdOperations, operations);
+      return this;
+    }
+
+    public Builder businessIds(final String value, final String... values) {
+      return businessIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder businessIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return businessIdOperations(collectValues(operation, operations));
     }
 
     public Builder flowNodeInstanceKeyOperations(final List<Operation<Long>> operations) {
@@ -289,6 +307,7 @@ public record DecisionInstanceFilter(
           Objects.requireNonNullElse(evaluationFailures, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(businessIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(flowNodeInstanceKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(decisionDefinitionKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(decisionDefinitionIds, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/sort/DecisionInstanceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/DecisionInstanceSort.java
@@ -61,6 +61,11 @@ public record DecisionInstanceSort(List<FieldSorting> orderings) implements Sort
       return this;
     }
 
+    public Builder businessId() {
+      currentOrdering = new FieldSorting("businessId", null);
+      return this;
+    }
+
     public Builder flowNodeInstanceKey() {
       currentOrdering = new FieldSorting("flowNodeInstanceKey", null);
       return this;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/DecisionInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/DecisionInstanceTemplate.java
@@ -44,6 +44,7 @@ public class DecisionInstanceTemplate extends AbstractTemplateDescriptor
   public static final String EVALUATED_INPUTS = "evaluatedInputs";
   public static final String EVALUATED_OUTPUTS = "evaluatedOutputs";
   public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
+  public static final String BUSINESS_ID = "businessId";
 
   public DecisionInstanceTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -261,6 +261,13 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance.
+        businessId:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: >
+            The business ID of the owning process instance the decision instance belongs to. This
+            only works for decision instances created with 8.10 and onwards. Decision instances from
+            prior versions and standalone evaluations don't contain this data and cannot be found.
         decisionDefinitionKey:
           description: The key of the decision.
           allOf:
@@ -310,6 +317,8 @@ components:
           addedInVersion: "8.9"
         - propertyName: decisionRequirementsKey
           addedInVersion: "8.9"
+        - propertyName: businessId
+          addedInVersion: "8.10"
 
     DeleteDecisionInstanceRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -174,6 +174,7 @@ components:
           description: The field to sort by.
           type: string
           enum:
+            - businessId
             - decisionDefinitionId
             - decisionDefinitionKey
             - decisionDefinitionName

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -201,7 +201,18 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                 }
           ]
       }""",
-            q -> q.sort(s -> s.rootDecisionDefinitionKey().asc())));
+            q -> q.sort(s -> s.rootDecisionDefinitionKey().asc())),
+        new TestArguments(
+            """
+      {
+          "sort": [
+                {
+                    "field": "businessId",
+                    "order": "DESC"
+                }
+          ]
+      }""",
+            q -> q.sort(s -> s.businessId().desc())));
   }
 
   @ParameterizedTest

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -497,6 +497,10 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         streamBuilder,
         "decisionEvaluationInstanceKey",
         ops -> new DecisionInstanceFilter.Builder().decisionInstanceIdOperations(ops).build());
+    stringOperationTestCases(
+        streamBuilder,
+        "businessId",
+        ops -> new DecisionInstanceFilter.Builder().businessIdOperations(ops).build());
     dateTimeOperationTestCases(
         streamBuilder,
         "evaluationDate",


### PR DESCRIPTION
## Description

Adds `businessId` as a filterable and sortable field on the Decision Instance Search API. This is the search/query counterpart to https://github.com/camunda/camunda/pull/55830, which introduced the businessId field on decision instances.

`businessId` represents the business ID of the owning process instance for a decision instance. It is only available for decision instances created with Camunda **8.10 and onwards** — prior versions and standalone evaluations will not have this value populated.

### Changes

**API / OpenAPI**
- Added `businessId` to the `DecisionInstanceFilterRequest` schema with full `StringFilterProperty` support (`$eq`, `$like`, etc.)
- Added `businessId` to the `DecisionInstanceSearchQuerySortRequest` enum

**Search Domain & Transformers**
- Extended `DecisionInstanceFilter` with `businessIdOperations` (`List<Operation<String>>`)
- Extended `DecisionInstanceSort` with a `businessId()` sort builder method
- Added filter transformer logic in `DecisionInstanceFilterTransformer` and sort mapping in `DecisionInstanceFieldSortingTransformer`

**Java Client**
- Added `businessId(String)` and `businessId(Consumer<StringProperty>)` overloads to `DecisionInstanceFilter`
- Added `businessId()` to `DecisionInstanceSort`

**RDBMS**
- Added `BUSINESS_ID` to `DecisionInstanceSearchColumn` enum
- Added the corresponding `AND di.BUSINESS_ID` condition to `DecisionInstanceMapper.xml`
- Gateway HTTP mapping wired up in `SearchQueryFilterMapper` and `SearchQuerySortRequestMapper`

**Tests**
- Unit tests: `DecisionInstanceQueryTransformerTest`, `DecisionInstanceSortTest`, `DecisionInstanceQueryControllerTest`, `SearchDecisionInstanceTest`
- RDBMS integration tests: `DecisionInstanceIT` (eq + like filter), `DecisionInstanceSortIT` (asc + desc)
- Acceptance/E2E tests: `DecisionInstanceSearchIT` (filter by exact businessId, like pattern, sort asc/desc), `UserTaskSearchIT` (businessId inheritance from parent process instance, filter, like, sort)

### Notes

- Decision instances from process instances started before 8.10, and standalone DMN evaluations, will have a `null` `businessId` and cannot be found via this filter.
- Child process instances inherit the `businessId` of their owning (root) process instance, consistent with `rootProcessInstanceKey` inheritance.

## Related issues

closes #51685