### PR TITLE
ci: automate C8Run release with build-once promote workflows

### DIFF
--- a/.github/workflows/c8run-release-public.yaml
+++ b/.github/workflows/c8run-release-public.yaml
@@ -1,0 +1,213 @@
+# type: Release
+# owner: @camunda/distribution
+---
+name: "C8Run: Public Release"
+run-name: c8run-public-${{ inputs.camundaVersion }}
+
+# Promotes a previously staged RC (build-once → promote): pulls the exact notarized bytes from Harbor
+# and publishes them to the consumer-facing targets. No rebuild, no signing, no packager.
+
+on:
+  workflow_dispatch:
+    inputs:
+      camundaVersion:
+        description: "Full Camunda release version to promote (e.g., 8.8.29, 8.8.0-alpha4.1). Pulls c8run:<camundaVersion>-rc from Harbor. The minor (e.g. 8.8) is derived from it."
+        type: string
+        required: true
+        default: ""
+      dryRun:
+        description: "Dry run: pull the isolated <version>-rc-dryrun tag, verify byte-identity, and LOG (not execute) the GitHub release + Download Center publishes. Nothing public is written."
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  HARBOR_REGISTRY_HOST: registry.camunda.cloud
+  HARBOR_REGISTRY_PROJECT: team-distribution
+  RC_REPOSITORY: c8run
+
+jobs:
+  promote:
+    name: Promote staged RC to public targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout observe-build-status action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/observe-build-status
+          sparse-checkout-cone-mode: false
+
+      - name: ℹ️ Print workflow inputs ℹ️
+        env:
+          WORKFLOW_INPUTS: ${{ toJson(inputs) }}
+        run: |
+          echo "Action Inputs:"
+          echo "${WORKFLOW_INPUTS}"
+
+      - name: Derive minor version
+        id: vars
+        env:
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+        run: |
+          minor="$(echo "${CAMUNDA_VERSION}" | cut -d. -f1,2)"
+          echo "minor=${minor}" >> "$GITHUB_OUTPUT"
+          echo "Full version: ${CAMUNDA_VERSION}; minor: ${minor}"
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci HARBOR_REGISTRY_USER;
+            secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD;
+            secret/data/common/jenkins/downloads-camunda-cloud_google_sa_key DOWNLOAD_CENTER_GCLOUD_KEY_BYTES | GCP_CREDENTIALS_NAME;
+
+      - name: Setup oras
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
+      - name: Guard - Camunda apps release must exist
+        if: ${{ !inputs.dryRun }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+          REPO: ${{ github.repository }}
+        run: |
+          if ! gh release view "${CAMUNDA_VERSION}" --repo "${REPO}" >/dev/null 2>&1; then
+            echo "::error::Camunda apps GitHub release '${CAMUNDA_VERSION}' does not exist yet. The monorepo release must create it before C8Run is published."
+            exit 1
+          fi
+
+      - name: Pull RC artifacts from Harbor
+        env:
+          HARBOR_REGISTRY_USER: ${{ steps.secrets.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.HARBOR_REGISTRY_PASSWORD }}
+          RC_REF: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
+        run: |
+          mkdir -p artifacts
+          echo "${HARBOR_REGISTRY_PASSWORD}" | \
+            oras login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --password-stdin
+          oras pull "${RC_REF}" --output artifacts
+          echo "Pulled RC artifacts (notarized bytes, unchanged):"
+          ls -la artifacts
+          echo "Artifact checksums (post-pull; must match the RC build's pre-push checksums):"
+          sha256sum artifacts/* || true
+
+      # The minor-named copies feed the Download Center "own release" path; the pulled (patch-named)
+      # files are byte-identical and used as-is for the GitHub release and the apps-version DC path.
+      - name: Prepare minor-named copies
+        id: prepare
+        env:
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+          MINOR: ${{ steps.vars.outputs.minor }}
+        run: |
+          cd artifacts
+          for f in camunda8-run-"${CAMUNDA_VERSION}"-*; do
+            [ -e "$f" ] || { echo "::error::No pulled artifact matching camunda8-run-${CAMUNDA_VERSION}-*"; exit 1; }
+            suffix="${f#camunda8-run-"${CAMUNDA_VERSION}"-}"
+            cp -a "$f" "camunda8-run-${MINOR}-${suffix}"
+          done
+          echo "Artifacts after preparing minor-named copies:"
+          ls -la
+
+      - name: GitHub - Upload artifacts to Camunda apps release
+        if: ${{ !inputs.dryRun }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+        run: |
+          cd artifacts
+          gh release upload "${CAMUNDA_VERSION}" camunda8-run-"${CAMUNDA_VERSION}"-* \
+            --repo "${{ github.repository }}" --clobber
+
+      - name: Camunda Download Center - Upload artifacts in own (minor) release
+        if: ${{ !inputs.dryRun }}
+        uses: camunda/infra-global-github-actions/download-center-upload@1c317c29f01f213c82f601e971ac4d6d449071d2 # main
+        with:
+          gcp_credentials: ${{ steps.secrets.outputs.GCP_CREDENTIALS_NAME }}
+          version: ${{ steps.vars.outputs.minor }}
+          artifact_subpath: c8run
+          artifact_file: artifacts/camunda8-run-${{ steps.vars.outputs.minor }}-*
+
+      - name: Camunda Download Center - Upload artifacts in Camunda apps version
+        if: ${{ !inputs.dryRun }}
+        uses: camunda/infra-global-github-actions/download-center-upload@1c317c29f01f213c82f601e971ac4d6d449071d2 # main
+        with:
+          gcp_credentials: ${{ steps.secrets.outputs.GCP_CREDENTIALS_NAME }}
+          version: ${{ inputs.camundaVersion }}
+          artifact_subpath: c8run
+          artifact_file: artifacts/camunda8-run-${{ inputs.camundaVersion }}-*
+
+      # Dry run prints the publish plan without touching any public target. The byte-identity proof
+      # (checksums in the pull step above) is the point of the run; the publishes are unchanged from
+      # the proven legacy workflow, so logging them is sufficient coverage.
+      - name: Dry run - log skipped public publishes
+        if: ${{ inputs.dryRun }}
+        env:
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+          MINOR: ${{ steps.vars.outputs.minor }}
+        run: |
+          echo "::notice::[dry run] Public publishes were skipped. Plan:"
+          echo "GitHub release '${CAMUNDA_VERSION}' would receive:"
+          ls -la artifacts/camunda8-run-"${CAMUNDA_VERSION}"-* || true
+          echo "Download Center own (minor):  c8run/${MINOR}/  <- artifacts/camunda8-run-${MINOR}-*"
+          echo "Download Center apps version: c8run/${CAMUNDA_VERSION}/  <- artifacts/camunda8-run-${CAMUNDA_VERSION}-*"
+
+      # On a dry run ARCHIVE_TAG carries a -dryrun suffix, so this retags the isolated dryrun artifact
+      # rather than a public version — it intentionally runs in both modes and needs no dryRun guard.
+      - name: Harbor - Tag promoted version (archival)
+        env:
+          HARBOR_REGISTRY_USER: ${{ steps.secrets.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.HARBOR_REGISTRY_PASSWORD }}
+          RC_REF: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
+          ARCHIVE_TAG: ${{ inputs.camundaVersion }}${{ inputs.dryRun && '-dryrun' || '' }}
+        run: |
+          echo "${HARBOR_REGISTRY_PASSWORD}" | \
+            oras login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --password-stdin
+          oras tag "${RC_REF}" "${ARCHIVE_TAG}"
+
+      - name: Release summary
+        env:
+          MINOR: ${{ steps.vars.outputs.minor }}
+          DRY_RUN: ${{ inputs.dryRun }}
+          ARCHIVE_TAG: ${{ inputs.camundaVersion }}${{ inputs.dryRun && '-dryrun' || '' }}
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+          REPO: ${{ github.repository }}
+        run: |
+          {
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "🧪 C8Run public promote (DRY RUN) 🧪"
+              echo "- Version: \`${CAMUNDA_VERSION}\` (minor \`${MINOR}\`)"
+              echo "- Pulled & re-hashed the isolated \`${CAMUNDA_VERSION}-rc-dryrun\` tag — see the pull step for checksums."
+              echo "- Public publishes (GitHub release + Download Center) were logged, not executed."
+              echo "- Delete the dryrun tags when done: \`oras manifest delete .../${RC_REPOSITORY}:${ARCHIVE_TAG}\` and \`...:${CAMUNDA_VERSION}-rc-dryrun\`"
+            else
+              echo "⭐ C8Run public release complete ⭐"
+              echo "- Version: \`${CAMUNDA_VERSION}\` (minor \`${MINOR}\`)"
+              echo "- GitHub release: https://github.com/${REPO}/releases/tag/${CAMUNDA_VERSION}"
+              echo "- Download Center (own): https://downloads.camunda.cloud/release/camunda/c8run/${MINOR}/"
+              echo "- Download Center (apps): https://downloads.camunda.cloud/release/camunda/c8run/${CAMUNDA_VERSION}/"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8run-release-rc.yaml
+++ b/.github/workflows/c8run-release-rc.yaml
@@ -1,0 +1,469 @@
+# type: Release
+# owner: @camunda/distribution
+---
+name: "C8Run: Release Candidate"
+# run-name carries the full version so the release-train BPMN can find this run by name
+# (GET /actions/workflows/{id}/runs then match `name == c8run-rc-<camundaVersion>`). The version
+# is released exactly once, so it is a unique key without a separate correlation id.
+run-name: c8run-rc-${{ inputs.camundaVersion }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Release branch to build from (e.g., main, stable/8.7, stable/8.8)"
+        type: string
+        required: true
+        default: ""
+      camundaVersion:
+        description: "Full Camunda release version = the C8Run version (e.g., 8.8.29, 8.8.0-alpha4.1). The minor (e.g. 8.8) is derived from it."
+        type: string
+        required: true
+        default: ""
+      connectorsVersion:
+        description: "Full Connectors bundle version (e.g., 8.8.15)"
+        type: string
+        required: true
+        default: ""
+      dryRun:
+        description: "Dry run: build for real but stage to an isolated <version>-rc-dryrun Harbor tag and skip the .env bump PR. Nothing public is written; the dryrun tag is deletable residue."
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  HARBOR_REGISTRY_HOST: registry.camunda.cloud
+  HARBOR_REGISTRY_PROJECT: team-distribution
+  RC_REPOSITORY: c8run
+
+jobs:
+  # Gate: for docker-reliant branches (those whose c8run/.env pins COMPOSE_TAG), the bundled rolling
+  # docker-compose-<minor> release must already pin the target version. This is the automated form of
+  # the manual "ensure the Docker Compose versions were released" precursor in c8run/docs/release.md,
+  # and the same readiness primitive as the release train's check-versions.bpmn. Java-only branches
+  # (main, stable/8.9) have no COMPOSE_TAG and skip the gate.
+  verify-compose:
+    name: Verify Docker Compose is at target
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: ℹ️ Print workflow inputs ℹ️
+        env:
+          WORKFLOW_INPUTS: ${{ toJson(inputs) }}
+        run: |
+          echo "Action Inputs:"
+          echo "${WORKFLOW_INPUTS}"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Verify rolling docker-compose pins the target version
+        env:
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+        run: |
+          compose_tag="$(grep -E '^COMPOSE_TAG=' c8run/.env | head -1 | cut -d= -f2- || true)"
+          if [ -z "${compose_tag}" ]; then
+            echo "Java-only branch (no COMPOSE_TAG in c8run/.env) — no Docker Compose dependency. Skipping gate."
+            exit 0
+          fi
+
+          url="https://github.com/camunda/camunda-distributions/releases/download/docker-compose-${compose_tag}/docker-compose-${compose_tag}.zip"
+          echo "Fetching released compose bundle: ${url}"
+          if ! curl -fsSL -o docker-compose.zip "${url}"; then
+            echo "::error::Could not download docker-compose-${compose_tag}.zip from camunda-distributions. The minor compose release is missing."
+            exit 1
+          fi
+          unzip -o -q docker-compose.zip -d dc
+          dc_camunda="$(grep -E '^CAMUNDA_VERSION=' dc/.env | head -1 | cut -d= -f2-)"
+          echo "docker-compose-${compose_tag} pins CAMUNDA_VERSION=${dc_camunda}; target is ${CAMUNDA_VERSION}"
+          if [ "${dc_camunda}" != "${CAMUNDA_VERSION}" ]; then
+            echo "::error::Rolling docker-compose-${compose_tag} pins ${dc_camunda} but the target is ${CAMUNDA_VERSION}. Compose is not ready — refresh it upstream (Renovate / release train) before building C8Run."
+            exit 1
+          fi
+          echo "Docker Compose is at target. Proceeding."
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  build:
+    name: C8Run - ${{ matrix.os.name }}
+    needs: verify-compose
+    runs-on: ${{ matrix.os.id }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos-latest is ARM, macos-15-intel will execute on x86 runner.
+        os:
+          - name: Ubuntu (AMD64)
+            id: ubuntu-latest
+            artifactFileSuffix: linux-x86_64.tar.gz
+            workingDir: ./c8run
+            c8runArtifactName: c8run
+            packagerArtifactName: packager
+            command: ./c8run
+            packagingCmd: ./packager
+          - name: MacOS (ARM64)
+            id: macos-latest
+            artifactFileSuffix: darwin-aarch64.zip
+            workingDir: ./c8run
+            c8runArtifactName: c8run
+            packagerArtifactName: packager
+            command: ./c8run
+            packagingCmd: ./packager
+          - name: MacOS (AMD64)
+            id: macos-15-intel
+            artifactFileSuffix: darwin-x86_64.zip
+            workingDir: ./c8run
+            c8runArtifactName: c8run
+            packagerArtifactName: packager
+            command: ./c8run
+            packagingCmd: ./packager
+          - name: Windows (AMD64)
+            id: windows-latest
+            artifactFileSuffix: windows-x86_64.zip
+            workingDir: ./c8run
+            c8runArtifactName: c8run.exe
+            packagerArtifactName: packager.exe
+            command: ./c8run.exe
+            packagingCmd: ./packager.exe
+    env:
+      # Final artifact name; matches the packager output (camunda8-run-<CAMUNDA_VERSION>-<suffix>).
+      C8RUN_NAME_ARTIFACT: >-
+        camunda8-run-${{ inputs.camundaVersion }}-${{ matrix.os.artifactFileSuffix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci/nexus USER | NEXUS_USERNAME;
+            secret/data/products/distribution/ci/nexus PASSWORD | NEXUS_PASSWORD;
+            secret/data/products/distribution/ci APPLE_CERTIFICATE;
+            secret/data/products/distribution/ci APPLE_CERTIFICATE_PASSWORD;
+            secret/data/products/distribution/ci APPLE_DEVELOPER_ID;
+            secret/data/products/distribution/ci APPLE_DEVELOPER_PASSWORD;
+            secret/data/products/distribution/ci APPLE_TEAM_ID;
+            secret/data/products/distribution/ci APPLE_COMMON_NAME;
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ">=1.23.1"
+          cache: false # disabling since not working anyways without a cache-dependency-path specified
+
+      - name: Setup Java 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: "temurin"
+          java-version: "25"
+
+      # Inject the build versions into c8run/.env in place, preserving every other key and comment
+      # (ELASTICSEARCH_VERSION, CAMUNDA_DOCKER_VERSION, COMPOSE_TAG, COMPOSE_EXTRACTED_FOLDER, etc.).
+      # This replaces the manual pre-merged ".env bump PR" runbook step and works on every branch
+      # regardless of whether the packager has a syncEnvFile (8.7/8.8 do not).
+      - name: Update c8run/.env with build versions
+        working-directory: ${{ matrix.os.workingDir }}
+        env:
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+          CONNECTORS_VERSION: ${{ inputs.connectorsVersion }}
+        run: |
+          awk -v cv="${CAMUNDA_VERSION}" -v cnv="${CONNECTORS_VERSION}" '
+            /^CAMUNDA_VERSION=/    { print "CAMUNDA_VERSION=" cv; seen_cv=1; next }
+            /^CONNECTORS_VERSION=/ { print "CONNECTORS_VERSION=" cnv; seen_cnv=1; next }
+            { print }
+            END {
+              if (!seen_cv)  print "CAMUNDA_VERSION=" cv
+              if (!seen_cnv) print "CONNECTORS_VERSION=" cnv
+            }
+          ' .env > .env.tmp && mv .env.tmp .env
+
+      - name: ℹ️ Print resolved c8run/.env ℹ️
+        working-directory: ${{ matrix.os.workingDir }}
+        run: |
+          echo "Resolved c8run/.env to be bundled:"
+          cat .env
+
+      - name: Build artifact runtime distro
+        working-directory: ${{ matrix.os.workingDir }}
+        run: go build -o ${{ matrix.os.c8runArtifactName }} ./cmd/c8run
+
+      - name: Build artifact packaging distro
+        working-directory: ${{ matrix.os.workingDir }}
+        run: go build -o ${{ matrix.os.packagerArtifactName }} ./cmd/packager
+
+      - name: Create artifact package
+        working-directory: ${{ matrix.os.workingDir }}
+        run: ${{ matrix.os.packagingCmd }} package
+        env:
+          JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
+          JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
+
+      - name: MacOS - Extract package
+        id: macos-extract
+        if: startsWith(matrix.os.name, 'MacOS')
+        run: |
+          mkdir -p tmp
+          mv "$C8RUN_NAME_ARTIFACT" tmp
+          cd tmp
+          unzip "$C8RUN_NAME_ARTIFACT"
+          extracted_dir="$(find . -mindepth 1 -maxdepth 1 -type d ! -name '__MACOSX' -print -quit)"
+          if [ -z "$extracted_dir" ]; then
+            echo "Unable to locate extracted directory"
+            exit 1
+          fi
+          extracted_dir="${extracted_dir#./}"
+          echo "Extracted directory: $extracted_dir"
+          echo "extracted_dir=./c8run/tmp/$extracted_dir" >> "$GITHUB_OUTPUT"
+        shell: bash
+        working-directory: ./c8run
+
+      - name: MacOS - Sign and notarize
+        if: startsWith(matrix.os.name, 'MacOS')
+        uses: ./.github/actions/sign-and-notarize
+        with:
+          p12-base64: ${{ steps.secrets.outputs.APPLE_CERTIFICATE }}
+          p12-password: ${{ steps.secrets.outputs.APPLE_CERTIFICATE_PASSWORD }}
+          developer-id-cert-name: ${{ steps.secrets.outputs.APPLE_DEVELOPER_ID }}
+          apple-id: ${{ steps.secrets.outputs.APPLE_DEVELOPER_ID }}
+          app-password: ${{ steps.secrets.outputs.APPLE_DEVELOPER_PASSWORD }}
+          team-id: ${{ steps.secrets.outputs.APPLE_TEAM_ID }}
+          path: ${{ steps.macos-extract.outputs.extracted_dir }}
+
+      - name: MacOS - Replace old artifact with codesigned artifact
+        if: startsWith(matrix.os.name, 'MacOS')
+        run: |
+          mv ./c8run/tmp/c8run_complete.zip ./c8run/"$C8RUN_NAME_ARTIFACT"
+
+      - name: Upload RC artifact for staging
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.os.id }}
+          path: ${{ matrix.os.workingDir }}/${{ env.C8RUN_NAME_ARTIFACT }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "c8run-rc-build/${{ matrix.os.name }}"
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  stage-rc:
+    name: Stage RC to Harbor
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout observe-build-status action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/observe-build-status
+          sparse-checkout-cone-mode: false
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci HARBOR_REGISTRY_USER;
+            secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD;
+
+      - name: Setup oras
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
+      - name: Download built RC artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: rc-artifacts
+          merge-multiple: true
+
+      - name: Push RC artifacts to Harbor
+        working-directory: rc-artifacts
+        env:
+          HARBOR_REGISTRY_USER: ${{ steps.secrets.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.HARBOR_REGISTRY_PASSWORD }}
+          RC_REF: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
+        run: |
+          echo "Staging artifacts:"
+          ls -la
+          echo "Artifact checksums (pre-push; compare against the public promote):"
+          sha256sum ./* || true
+          mapfile -t files < <(find . -maxdepth 1 -type f -printf '%P\n')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::No RC artifacts found to push."
+            exit 1
+          fi
+
+          echo "${HARBOR_REGISTRY_PASSWORD}" | \
+            oras login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --password-stdin
+
+          # Retry oras push for transient Harbor 401s.
+          attempt=1
+          until oras push "${RC_REF}" "${files[@]}"; do
+            if [ "${attempt}" -ge 3 ]; then
+              echo "::error::oras push failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "::warning::oras push failed (attempt ${attempt}); re-authenticating and retrying..."
+            echo "${HARBOR_REGISTRY_PASSWORD}" | \
+              oras login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --password-stdin || true
+            attempt=$((attempt + 1))
+            sleep 30
+          done
+
+      - name: Release summary
+        env:
+          RC_REF: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
+          DRY_RUN: ${{ inputs.dryRun }}
+          BRANCH: ${{ inputs.branch }}
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+          CONNECTORS_VERSION: ${{ inputs.connectorsVersion }}
+        run: |
+          {
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "🧪 C8Run RC staged to Harbor (DRY RUN) 🧪"
+              echo "- The .env bump PR was skipped."
+              echo "- Delete this tag when done: \`oras manifest delete ${RC_REF}\`"
+            else
+              echo "⭐ C8Run RC staged to Harbor ⭐"
+            fi
+            echo "- Branch: \`${BRANCH}\`"
+            echo "- Version: \`${CAMUNDA_VERSION}\`"
+            echo "- Connectors: \`${CONNECTORS_VERSION}\`"
+            echo "- RC artifact: \`${RC_REF}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  # Persist exactly what was built: open (do not merge) a c8run/.env bump PR against the release
+  # branch. This replaces the manual "Version Bump" runbook step. The PR is merged after QA sign-off
+  # by the release train (this workflow only opens it), so a QA-rejected RC rebuilt with other
+  # versions never leaves a wrong .env merged. Uses the Monorepo DevOps Automation app token (same as
+  # backport.yml) so the PR triggers CI and can clear the main ruleset + merge queue.
+  open-env-pr:
+    name: Open c8run/.env bump PR
+    needs: stage-rc
+    if: ${{ !inputs.dryRun }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: {}
+    steps:
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@1c317c29f01f213c82f601e971ac4d6d449071d2 # main
+        with:
+          github-app-id-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ steps.github-token.outputs.token }}
+
+      - name: Open .env bump PR
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+          CONNECTORS_VERSION: ${{ inputs.connectorsVersion }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          pr_branch="c8run-release-${CAMUNDA_VERSION}"
+          git config user.name "monorepo-devops-automation[bot]"
+          git config user.email "248077375+monorepo-devops-automation[bot]@users.noreply.github.com"
+          git checkout -b "${pr_branch}"
+
+          awk -v cv="${CAMUNDA_VERSION}" -v cnv="${CONNECTORS_VERSION}" '
+            /^CAMUNDA_VERSION=/    { print "CAMUNDA_VERSION=" cv; seen_cv=1; next }
+            /^CONNECTORS_VERSION=/ { print "CONNECTORS_VERSION=" cnv; seen_cnv=1; next }
+            { print }
+            END {
+              if (!seen_cv)  print "CAMUNDA_VERSION=" cv
+              if (!seen_cnv) print "CONNECTORS_VERSION=" cnv
+            }
+          ' c8run/.env > c8run/.env.tmp && mv c8run/.env.tmp c8run/.env
+
+          if git diff --quiet -- c8run/.env; then
+            echo "c8run/.env already at target versions; nothing to persist."
+            exit 0
+          fi
+
+          git add c8run/.env
+          git commit -m "deps: update c8run versions to ${CAMUNDA_VERSION}"
+          git push --force-with-lease origin "${pr_branch}"
+
+          if gh pr view "${pr_branch}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "PR for ${pr_branch} already exists; updated its branch."
+            exit 0
+          fi
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --base "${BRANCH}" \
+            --head "${pr_branch}" \
+            --title "deps: update c8run versions to ${CAMUNDA_VERSION}" \
+            --body "Persists the versions built for the C8Run \`${CAMUNDA_VERSION}\` release candidate (CAMUNDA_VERSION=\`${CAMUNDA_VERSION}\`, CONNECTORS_VERSION=\`${CONNECTORS_VERSION}\`). Merged after QA sign-off by the release train."
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/c8run/cmd/packager/main.go
+++ b/c8run/cmd/packager/main.go
@@ -62,12 +62,67 @@ func GetJavaHome(javaBinary string) (string, error) {
 	return javaHomeOutput, nil
 }
 
-// syncEnvFile writes the resolved camundaVersion and connectorsVersion to path so that
+// syncEnvFile updates CAMUNDA_VERSION and CONNECTORS_VERSION in place at path so that
 // the .env bundled in the distribution archive is consistent with the artifact being packaged.
 // CAMUNDA_VERSION may be overridden via the process environment (e.g. 8.10.0-SNAPSHOT on a branch)
-// while the committed .env still contains a stale released version.
+// while the committed .env still contains a stale released version. Every other line — comments and
+// any additional keys present on a branch (ELASTICSEARCH_VERSION, CAMUNDA_DOCKER_VERSION, COMPOSE_TAG,
+// COMPOSE_EXTRACTED_FOLDER, CAMUNDA_RELEASE_TAG) — is preserved verbatim. A key not already present is
+// appended. A missing file is treated as empty so the two keys are created.
 func syncEnvFile(path, camundaVersion, connectorsVersion string) error {
-	content := "# this is the version of camunda/ zeebe\nCAMUNDA_VERSION=" + camundaVersion + "\n# Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/\nCONNECTORS_VERSION=" + connectorsVersion + "\n"
+	keys := []string{"CAMUNDA_VERSION", "CONNECTORS_VERSION"}
+	updates := map[string]string{
+		"CAMUNDA_VERSION":    camundaVersion,
+		"CONNECTORS_VERSION": connectorsVersion,
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	hadTrailingNewline := strings.HasSuffix(string(data), "\n")
+	body := strings.TrimSuffix(string(data), "\n")
+	var lines []string
+	if body != "" {
+		lines = strings.Split(body, "\n")
+	}
+
+	// Preserve the file's line endings: on a CRLF .env each split line keeps a trailing \r, so
+	// rewritten and appended keys must carry the same ending instead of silently downgrading to LF.
+	lineEnd := ""
+	if strings.Contains(string(data), "\r\n") {
+		lineEnd = "\r"
+	}
+
+	seen := map[string]bool{}
+	for i, line := range lines {
+		raw := strings.TrimSuffix(line, "\r")
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		name, _, found := strings.Cut(raw, "=")
+		if !found {
+			continue
+		}
+		name = strings.TrimSpace(name)
+		if value, ok := updates[name]; ok {
+			lines[i] = name + "=" + value + lineEnd
+			seen[name] = true
+		}
+	}
+
+	for _, key := range keys {
+		if !seen[key] {
+			lines = append(lines, key+"="+updates[key]+lineEnd)
+		}
+	}
+
+	content := strings.Join(lines, "\n")
+	if hadTrailingNewline || len(data) == 0 {
+		content += "\n"
+	}
 	return os.WriteFile(path, []byte(content), 0644)
 }
 

--- a/c8run/cmd/packager/main_test.go
+++ b/c8run/cmd/packager/main_test.go
@@ -57,3 +57,84 @@ func TestSyncEnvFileReturnsErrorOnUnwritablePath(t *testing.T) {
 	// then
 	assert.Error(t, err)
 }
+
+func TestSyncEnvFilePreservesOtherKeysAndComments(t *testing.T) {
+	// given - an 8.8-style .env carrying compose/elasticsearch keys and comments
+	path := filepath.Join(t.TempDir(), ".env")
+	original := "ELASTICSEARCH_VERSION=8.17.3\n" +
+		"# this is the version of camunda/ zeebe\n" +
+		"CAMUNDA_VERSION=8.8.28\n" +
+		"# docker images moved to a shortened tag, override compose with this value when using --docker\n" +
+		"CAMUNDA_DOCKER_VERSION=8.8.28\n" +
+		"CONNECTORS_VERSION=8.8.14\n" +
+		"# version of docker compose artifact (used for --docker option)\n" +
+		"COMPOSE_TAG=8.8\n" +
+		"COMPOSE_EXTRACTED_FOLDER=docker-compose-8.8\n"
+	require.NoError(t, os.WriteFile(path, []byte(original), 0644))
+
+	// when
+	err := syncEnvFile(path, "8.8.29", "8.8.15")
+
+	// then
+	require.NoError(t, err)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	got := string(content)
+	// the two supplied keys are updated in place; the old version line is gone
+	assert.Contains(t, got, "CAMUNDA_VERSION=8.8.29")
+	assert.Contains(t, got, "CONNECTORS_VERSION=8.8.15")
+	assert.NotContains(t, got, "CAMUNDA_VERSION=8.8.28")
+	assert.NotContains(t, got, "CONNECTORS_VERSION=8.8.14")
+	// every other key survives untouched — including CAMUNDA_DOCKER_VERSION, whose name shares the
+	// CAMUNDA_VERSION prefix and whose value matches the old CAMUNDA_VERSION (guards a prefix-match bug)
+	assert.Contains(t, got, "CAMUNDA_DOCKER_VERSION=8.8.28")
+	assert.Contains(t, got, "ELASTICSEARCH_VERSION=8.17.3")
+	assert.Contains(t, got, "COMPOSE_TAG=8.8")
+	assert.Contains(t, got, "COMPOSE_EXTRACTED_FOLDER=docker-compose-8.8")
+	// comments survive
+	assert.Contains(t, got, "# version of docker compose artifact (used for --docker option)")
+	// updated keys stay in their original positions (not moved/appended) and nothing else shifts
+	expected := "ELASTICSEARCH_VERSION=8.17.3\n" +
+		"# this is the version of camunda/ zeebe\n" +
+		"CAMUNDA_VERSION=8.8.29\n" +
+		"# docker images moved to a shortened tag, override compose with this value when using --docker\n" +
+		"CAMUNDA_DOCKER_VERSION=8.8.28\n" +
+		"CONNECTORS_VERSION=8.8.15\n" +
+		"# version of docker compose artifact (used for --docker option)\n" +
+		"COMPOSE_TAG=8.8\n" +
+		"COMPOSE_EXTRACTED_FOLDER=docker-compose-8.8\n"
+	assert.Equal(t, expected, got)
+}
+
+func TestSyncEnvFilePreservesCRLFLineEndings(t *testing.T) {
+	// given - a CRLF .env
+	path := filepath.Join(t.TempDir(), ".env")
+	require.NoError(t, os.WriteFile(path, []byte("CAMUNDA_VERSION=8.9.0\r\nCONNECTORS_VERSION=8.9.0\r\nELASTICSEARCH_VERSION=8.17.3\r\n"), 0644))
+
+	// when
+	err := syncEnvFile(path, "8.9.1", "8.9.1")
+
+	// then - updated keys keep CRLF; no line is silently downgraded to bare LF
+	require.NoError(t, err)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	expected := "CAMUNDA_VERSION=8.9.1\r\nCONNECTORS_VERSION=8.9.1\r\nELASTICSEARCH_VERSION=8.17.3\r\n"
+	assert.Equal(t, expected, string(content))
+}
+
+func TestSyncEnvFileAppendsMissingKey(t *testing.T) {
+	// given - a .env that only pins CAMUNDA_VERSION
+	path := filepath.Join(t.TempDir(), ".env")
+	require.NoError(t, os.WriteFile(path, []byte("CAMUNDA_VERSION=8.9.0\n"), 0644))
+
+	// when
+	err := syncEnvFile(path, "8.9.1", "8.9.1")
+
+	// then
+	require.NoError(t, err)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	got := string(content)
+	assert.Contains(t, got, "CAMUNDA_VERSION=8.9.1")
+	assert.Contains(t, got, "CONNECTORS_VERSION=8.9.1")
+}

--- a/c8run/docs/release.md
+++ b/c8run/docs/release.md
@@ -1,7 +1,17 @@
 # Release Process
 
-Releases are owned by `@camunda/distribution` and triggered manually via the
-[C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml).
+Releases are owned by `@camunda/distribution` and follow a **build-once → promote** model:
+
+- [`c8run-release-rc.yaml`](https://github.com/camunda/camunda/actions/workflows/c8run-release-rc.yaml)
+  builds, signs, and notarizes the four OS artifacts **once** and stages them in Harbor as the release
+  candidate (RC).
+- [`c8run-release-public.yaml`](https://github.com/camunda/camunda/actions/workflows/c8run-release-public.yaml)
+  promotes the **exact same bytes** from Harbor to the public targets — no rebuild, no re-signing.
+
+The release train drives both workflows via BPMN; the `gh`/UI invocations below are for ad-hoc or
+hotfix runs. The legacy single-stage
+[`c8run-release.yaml`](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml)
+remains available during the transition.
 
 ---
 
@@ -61,33 +71,29 @@ fails the release before upload.
 
 ## Before You Start
 
-### 1. Check Docker Compose is released
+### Determine the versions to release
 
-> [!WARNING]
-> Ensure the Docker Compose versions were released correctly prior to the C8Run release.
+The easiest place to look up all updated component versions at once is the Renovate PR in
+[camunda/camunda-distributions](https://github.com/camunda/camunda-distributions/pulls) labelled
+`deps/docker-compose` and `version/8.x`. The table at the top of the PR body lists every version
+change. The two versions the release workflows take as inputs are:
 
-The easiest place to verify this — and to look up all updated component versions at once — is the
-Renovate PR in [camunda/camunda-distributions](https://github.com/camunda/camunda-distributions/pulls)
-labelled `deps/docker-compose` and `version/8.x`. That PR shows the full version delta for
-Camunda, Connectors, and Docker Compose in one place. Wait for it to be merged before proceeding.
+|        Input        |               Where to read it from                |
+|---------------------|----------------------------------------------------|
+| `camundaVersion`    | `camunda/camunda` row in the Renovate PR           |
+| `connectorsVersion` | `camunda/connectors-bundle` row in the Renovate PR |
 
-### 2. Determine the versions to release
+`camundaVersion` is the **full** version (e.g. `8.8.29`, `8.8.0-alpha4.1`) — it is the C8Run version.
+The minor (e.g. `8.8`) is derived from it automatically; you do not enter it separately.
 
-Open the Renovate PR described above. The table at the top of the PR body lists every version
-change. Record:
+> **Docker Compose readiness (8.7/8.8 only).** For branches whose `c8run/.env` pins `COMPOSE_TAG`,
+> the RC workflow **verifies** that the rolling `docker-compose-<minor>` release already pins the
+> target `CAMUNDA_VERSION` and fails the build if it is behind. Make sure the Renovate PR above is
+> merged (or the release train has refreshed the compose) before triggering the RC. C8Run cannot
+> refresh the compose itself — it pins only 2 of Docker Compose's component versions. `main`/`stable/8.9`
+> have no Docker Compose dependency and skip this check.
 
-These two variables are the ones you will update in `./c8run/.env`:
-
-| `./c8run/.env` variable |               Where to read it from                |
-|-------------------------|----------------------------------------------------|
-| `CAMUNDA_VERSION`       | `camunda/camunda` row in the Renovate PR           |
-| `CONNECTORS_VERSION`    | `camunda/connectors-bundle` row in the Renovate PR |
-
-> **Note:** `CAMUNDA_DOCKER_VERSION` and `ELASTICSEARCH_VERSION` are **not** part of `./c8run/.env`
-> — they belong to the Docker Compose distribution and are managed separately in
-> `camunda/camunda-distributions`.
-
-You can also cross-check that no c8run artifacts have been published yet for the target release:
+You can cross-check that no c8run artifacts have been published yet for the target release:
 
 ```bash
 gh release view <version> --repo camunda/camunda --json assets --jq '.assets[].name' 2>/dev/null \
@@ -98,94 +104,74 @@ If there is no output, the c8run release has not been done yet.
 
 ---
 
-## Release Candidates
+## Release Candidate
 
-### 1. Version Bump
+Build once, sign + notarize once, and stage the artifacts in Harbor. QA validates this exact RC; the
+public release later promotes the **same bytes** without rebuilding.
 
-For each version:
+There is **no manual `.env` version bump** — the workflow updates `c8run/.env` in place (preserving the
+compose/Elasticsearch keys) and opens the `deps: update c8run versions to <version>` PR itself.
 
-1. Clone [camunda/camunda](https://github.com/camunda/camunda).
-2. Create a new branch from the version base branch:
-   - `main` for the latest alpha.
-   - `stable/8.8` for 8.8, etc.
-   - Branch name convention: `c8run-release-<version>` (e.g. `c8run-release-8.8.24`)
-3. Update `./c8run/.env` with the correct versions determined above.
-4. Commit with `deps: update c8run versions to <version>` and open a PR targeting the version
-   base branch (e.g. `stable/8.8`). Get it merged before triggering the workflow.
-
-### 2. Artifact
-
-For each version, trigger the
-[C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml)
+Trigger
+[`c8run-release-rc.yaml`](https://github.com/camunda/camunda/actions/workflows/c8run-release-rc.yaml)
 via the UI or the `gh` CLI:
 
 ```bash
-gh workflow run c8run-release.yaml \
+gh workflow run c8run-release-rc.yaml \
   --repo camunda/camunda \
   --ref main \
   --field branch=stable/8.8 \
-  --field camundaVersion=8.8 \
-  --field camundaAppsRelease=8.8.24 \
-  --field publishToCamundaAppsRelease=true \
-  --field publishToCamundaDownloadCenter=false \
-  --field typePrerelease=false \
-  --field artifactVersionSuffix="-rc"
+  --field camundaVersion=8.8.29 \
+  --field connectorsVersion=8.8.15
 ```
 
-If using the UI instead:
+|        Input        |                              Value                              |
+|---------------------|-----------------------------------------------------------------|
+| Run workflow from   | `Branch: main` (always)                                         |
+| `branch`            | release branch, e.g. `stable/8.8` (`main` for the latest alpha) |
+| `camundaVersion`    | full version, e.g. `8.8.29` or `8.8.0-alpha4.1`                 |
+| `connectorsVersion` | full connectors version, e.g. `8.8.15`                          |
 
-|                    Input                    |                            Value                            |
-|---------------------------------------------|-------------------------------------------------------------|
-| Run workflow from                           | `Branch: main` (always)                                     |
-| Release branch                              | e.g. `stable/8.7` for 8.7                                   |
-| Camunda minor version                       | e.g. `8.7`                                                  |
-| Camunda app GH release                      | e.g. `8.7.4`                                                |
-| Publish to Camunda apps GitHub release page | **Ticked**                                                  |
-| Publish to Camunda Download Center          | **Unticked** (RCs are not published to the Download Center) |
-| Artifact version suffix                     | `-rc` (include the dash)                                    |
+The workflow then:
 
-Then:
+1. (8.7/8.8) verifies the rolling `docker-compose-<minor>` is at the target version;
+2. updates `c8run/.env` in place and builds + signs + notarizes the four OS artifacts;
+3. pushes them to Harbor as `registry.camunda.cloud/team-distribution/c8run:<camundaVersion>-rc`;
+4. opens the `c8run/.env` bump PR (merged after QA sign-off by the release train).
 
-1. Monitor the GitHub Action logs.
-2. Confirm `*-rc` artifacts are published in [Camunda repo GitHub releases](https://github.com/camunda/camunda/releases) under the correct Camunda tag version.
-3. Report back each version in the release train form in the Slack release thread that the RC artifacts for C8Run are created.
+The RC lives **only in Harbor** — nothing is published to GitHub releases or the Download Center yet.
+QA validates the artifact at the RC tag.
 
 ---
 
 ## Public Release
 
-For each version, trigger the workflow via the `gh` CLI:
+Promotes the staged RC — pulls the exact notarized bytes from Harbor and publishes them. **No rebuild,
+no re-signing.** The Camunda apps GitHub release (tag `<camundaVersion>`) must already exist; it is
+created by the monorepo release.
+
+Trigger
+[`c8run-release-public.yaml`](https://github.com/camunda/camunda/actions/workflows/c8run-release-public.yaml):
 
 ```bash
-gh workflow run c8run-release.yaml \
+gh workflow run c8run-release-public.yaml \
   --repo camunda/camunda \
   --ref main \
-  --field branch=stable/8.8 \
-  --field camundaVersion=8.8 \
-  --field camundaAppsRelease=8.8.24 \
-  --field publishToCamundaAppsRelease=true \
-  --field publishToCamundaDownloadCenter=true \
-  --field typePrerelease=false \
-  --field artifactVersionSuffix=""
+  --field camundaVersion=8.8.29
 ```
 
-If using the UI instead:
+|       Input       |                 Value                  |
+|-------------------|----------------------------------------|
+| Run workflow from | `Branch: main` (always)                |
+| `camundaVersion`  | full version to promote, e.g. `8.8.29` |
 
-|                    Input                    |                    Value                     |
-|---------------------------------------------|----------------------------------------------|
-| Run workflow from                           | `Branch: main` (always)                      |
-| Release branch                              | e.g. `stable/8.8` for 8.8, `main` for latest |
-| Camunda minor version                       | e.g. `8.6`, `8.7`, `8.8`                     |
-| Camunda app GH release                      | e.g. `8.7.1`, `8.8-alpha4.1`                 |
-| Publish to Camunda apps GitHub release page | **Ticked**                                   |
-| Publish to Camunda Download Center          | **Ticked**                                   |
-| Artifact version suffix                     | *(leave empty)*                              |
+The workflow pulls `c8run:<camundaVersion>-rc` from Harbor and:
 
-Then:
+1. uploads the artifacts to the Camunda apps GitHub release (tag `<camundaVersion>`);
+2. uploads to the Download Center (own minor release + apps version);
+3. tags Harbor `<camundaVersion>` for archival.
 
-1. Monitor the GitHub Action logs.
-2. Confirm artifacts are added to the [Camunda repo GitHub release](https://github.com/camunda/camunda/releases).
-3. Delete any prior C8Run releases tagged with `-pending-removal`.
-4. Delete the RC artifacts from the Camunda GitHub release (the version specified in the release inputs).
-5. Report back each version in the release train form in the Slack release thread that the C8Run release is complete.
+No `-rc` / `-pending-removal` cleanup is needed — the RC never lands on the GitHub release or the
+Download Center, so there is nothing to delete. Report back in the release train Slack thread that the
+C8Run release is complete.
 


### PR DESCRIPTION
## Description

Replaces the manual, rebuild-twice C8Run release with a build-once → promote model. Two new
`workflow_dispatch` workflows:

- `c8run-release-rc.yaml` — builds, signs, and notarizes the four OS artifacts once and `oras push`es
  them to Harbor as the RC; verifies the rolling `docker-compose-<minor>` is at-target for
  docker-reliant branches; opens the `c8run/.env` bump PR.
- `c8run-release-public.yaml` — `oras pull`s the same notarized bytes and publishes them to the GitHub
  release + Download Center. No rebuild, no re-signing.

Both take a `dryRun` input that stages to an isolated `-rc-dryrun` tag and logs (does not execute) the
public publishes, so the pipeline can be validated without touching a public target.

Also: `packager`'s `syncEnvFile` updates the version keys in place, preserving every other `c8run/.env`
key and comment; `c8run/docs/release.md` rewritten to the build-once → promote runbook.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes camunda/camunda-distributions#319
