### PR TITLE
feat: add MCP inbound channel fields to audit log schema

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
-		"@camunda/camunda-api-zod-schemas": "0.0.76",
+		"@camunda/camunda-api-zod-schemas": "0.0.77",
 		"@camunda/camunda-composite-components": "0.24.0",
 		"@carbon/react": "1.109.0",
 		"@carbon/type": "11.61.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -28,7 +28,7 @@
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
-				"@camunda/camunda-api-zod-schemas": "0.0.76",
+				"@camunda/camunda-api-zod-schemas": "0.0.77",
 				"@camunda/camunda-composite-components": "0.24.0",
 				"@carbon/react": "1.109.0",
 				"@carbon/type": "11.61.0",
@@ -11039,13 +11039,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.76",
+				"@camunda/camunda-api-zod-schemas": "0.0.77",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.76",
+			"version": "0.0.77",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.9.3",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.76",
+		"@camunda/camunda-api-zod-schemas": "0.0.77",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.77
+
+### 🚀 Enhancements
+
+- Add MCP inbound channel fields to the 8.10 audit log schema ([#53594](https://github.com/camunda/camunda/issues/53594))
+
+### ❤️ Contributors
+
+- Daniel Kelemen ([@danielkelemen](https://github.com/danielkelemen))
+
 ## v0.0.76
 
 ### 🩹 Fixes

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/audit-log.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/audit-log.ts
@@ -108,6 +108,8 @@ const auditLogSchema = z.object({
 	relatedEntityType: auditLogEntityTypeSchema.nullable(),
 	entityDescription: z.string().nullable(),
 	agentElementId: z.string().nullable(),
+	inboundChannelType: z.string().nullable(),
+	inboundChannelToolName: z.string().nullable(),
 });
 type AuditLog = z.infer<typeof auditLogSchema>;
 
@@ -132,6 +134,8 @@ const auditLogFilterSchema = z
 		relatedEntityType: getEnumFilterSchema(auditLogEntityTypeSchema).optional(),
 		relatedEntityKey: advancedStringFilterSchema.optional(),
 		entityDescription: advancedStringFilterSchema.optional(),
+		inboundChannelType: advancedStringFilterSchema.optional(),
+		inboundChannelToolName: advancedStringFilterSchema.optional(),
 	})
 	.partial();
 
@@ -155,6 +159,8 @@ const auditLogSortFieldEnum = z.enum([
 	'processDefinitionId',
 	'processDefinitionKey',
 	'processInstanceKey',
+	'inboundChannelType',
+	'inboundChannelToolName',
 	'result',
 	'tenantId',
 	'timestamp',

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.76",
+	"version": "0.0.77",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

Adds MCP inbound channel fields to 8.10 audit log zod schema. New nullable `inboundChannelType` + `inboundChannelToolName` on result, filter, and sort — matching `audit-logs.yaml`. Bumps package to v0.0.77, updates workspace consumers + lockfile, adds changelog entry.

## Related issues

related to https://github.com/camunda/camunda/issues/53594
