### PR TITLE
docs: document golden file tests in load-tests instructions

### DIFF
--- a/.github/instructions/load-tests.instructions.md
+++ b/.github/instructions/load-tests.instructions.md
@@ -13,7 +13,16 @@ When reviewing changes to load tests, workflows, or load test infrastructure:
    other secondary storage types (e.g. OpenSearch) or that may have long-running
    impact, a manual load test run is required in addition to smoke CI.
 
-2. **Versioned setup folders**: For changes to `load-tests/setup/`, do **not**
+2. **Golden file snapshot tests**: Changes under `load-tests/setup/**` that alter
+   the rendered Kubernetes manifests fail the golden file tests in CI. Regenerate
+   and commit the golden files in the same PR:
+   ```sh
+   cd load-tests/setup/test && make update-golden
+   ```
+   then review `git diff golden/`. See `load-tests/setup/test/README.md` for the
+   suite, layout, and how to add a stable version.
+
+3. **Versioned setup folders**: For changes to `load-tests/setup/`, do **not**
    propose backports to stable branches. Instead, update the relevant versioned
    subfolder(s) on `main`. To find current folders:
    ```sh
@@ -42,6 +51,7 @@ if related documentation needs updating:
 
 - `load-tests/README.md` — main entry point and workflow overview
 - `load-tests/setup/README.md` — version-dispatcher pattern, folder layout, values reference
+- `load-tests/setup/test/README.md` — golden file snapshot tests; run `make update-golden` after setup changes
 - Workflow YAML header comments (`.github/workflows/*load-test*`, etc.) — per-workflow reference
 - `docs/testing/reliability-testing.md` — goals, test variants, observability, chaos engineering
 - This file (`.github/instructions/load-tests.instructions.md`) — AI-facing guidance


### PR DESCRIPTION
## Description

Follow-up to #55807 (golden file snapshot tests for the load test setup).

That PR added the golden file tests but left a documentation gap: `.github/instructions/load-tests.instructions.md` — the file AI assistants and reviewers read when touching `load-tests/` — had no mention of them. A contributor editing a values file or chart would hit a failing golden test in CI with no pointer to what to do.

This adds:
- A **Required Review Checks** item explaining that changes under `load-tests/setup/**` are snapshot-tested and how to regenerate (`cd load-tests/setup/test && make update-golden`), pointing to the test README.
- The test README in the **Documentation** list alongside the other load-test docs.

Docs-only; no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)