### PR TITLE
feat: strip unused zstd-jni native libs from packaged c8run archive

### DIFF
--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -350,6 +350,103 @@ func stripRocksDbNativeLibs(camundaVersion, osType, arch string) error {
 	return nil
 }
 
+// zstdNativePrefix returns the directory prefix used by zstd-jni to store
+// native libs for the given platform. zstd-jni uses "<os>/<arch>/" paths where
+// os is "darwin", "linux", or "win" and arch may differ from c8run's convention
+// (e.g., "amd64" instead of "x86_64").
+func zstdNativePrefix(osType, arch string) (string, error) {
+	switch osType {
+	case "linux":
+		switch arch {
+		case "x86_64":
+			return "linux/amd64/", nil
+		case "aarch64":
+			return "linux/aarch64/", nil
+		}
+	case "darwin":
+		switch arch {
+		case "x86_64":
+			return "darwin/x86_64/", nil
+		case "aarch64":
+			return "darwin/aarch64/", nil
+		}
+	case "windows":
+		switch arch {
+		case "x86_64":
+			return "win/amd64/", nil
+		}
+	}
+	return "", fmt.Errorf("no zstd-jni native prefix for os=%s arch=%s", osType, arch)
+}
+
+// zstdNativeOsPrefixes lists all top-level OS directory prefixes used by zstd-jni.
+// Entries starting with any of these (but not matching the target prefix) are foreign.
+var zstdNativeOsPrefixes = []string{
+	"linux/", "darwin/", "win/", "aix/", "freebsd/",
+}
+
+// isZstdNativeEntry reports whether a ZIP entry name is a zstd-jni native lib.
+// These live under <os>/<arch>/ directories and end with a native extension.
+func isZstdNativeEntry(name string) bool {
+	for _, prefix := range zstdNativeOsPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// stripZstdJniNativeLibs strips unused platform native libs from zstd-jni JAR(s).
+func stripZstdJniNativeLibs(camundaVersion, osType, arch string) error {
+	keepPrefix, err := zstdNativePrefix(osType, arch)
+	if err != nil {
+		return fmt.Errorf("stripZstdJniNativeLibs: %w", err)
+	}
+
+	pattern := filepath.Join("camunda-zeebe-"+camundaVersion, "lib", "zstd-jni-*.jar")
+	jars, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("stripZstdJniNativeLibs: failed to glob %s: %w", pattern, err)
+	}
+	if len(jars) == 0 {
+		log.Warn().Str("pattern", pattern).Msg("no zstd-jni jar found; skipping native lib stripping")
+		return nil
+	}
+	if len(jars) > 1 {
+		log.Warn().Strs("jars", jars).Msg("multiple zstd-jni jars found; stripping only the first")
+	}
+
+	// Pre-scan: count entries to drop and verify idempotency.
+	r, err := zip.OpenReader(jars[0])
+	if err != nil {
+		return fmt.Errorf("stripZstdJniNativeLibs: open %s: %w", jars[0], err)
+	}
+	var toDrop int
+	for _, f := range r.File {
+		if isZstdNativeEntry(f.Name) && !strings.HasPrefix(f.Name, keepPrefix) {
+			toDrop++
+		}
+	}
+	if err := r.Close(); err != nil {
+		return fmt.Errorf("stripZstdJniNativeLibs: close %s: %w", jars[0], err)
+	}
+
+	if toDrop == 0 {
+		log.Info().Str("jar", jars[0]).Str("keeping", keepPrefix).Msg("no unused zstd-jni native libs to strip (already stripped?)")
+		return nil
+	}
+
+	log.Info().Str("jar", jars[0]).Str("keeping", keepPrefix).Int("dropping", toDrop).Msg("stripping unused zstd-jni native libs")
+
+	shouldDrop := func(name string) bool {
+		return isZstdNativeEntry(name) && !strings.HasPrefix(name, keepPrefix)
+	}
+	if _, err := rewriteJarDroppingEntries(jars[0], shouldDrop); err != nil {
+		return err
+	}
+	return nil
+}
+
 func getJavaArtifactsToken() (string, error) {
 	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
 	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")
@@ -783,6 +880,10 @@ func New(camundaVersion, connectorsVersion string) error {
 
 	if err := stripRocksDbNativeLibs(camundaVersion, osType, architecture); err != nil {
 		return fmt.Errorf("package %s: failed to strip RocksDB native libs: %w", osType, err)
+	}
+
+	if err := stripZstdJniNativeLibs(camundaVersion, osType, architecture); err != nil {
+		return fmt.Errorf("package %s: failed to strip zstd-jni native libs: %w", osType, err)
 	}
 
 	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, ".", javaArtifactsToken, func(_, _ string) error { return nil })

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -416,19 +416,29 @@ func stripZstdJniNativeLibs(camundaVersion, osType, arch string) error {
 		log.Warn().Strs("jars", jars).Msg("multiple zstd-jni jars found; stripping only the first")
 	}
 
-	// Pre-scan: count entries to drop and verify idempotency.
+	// Pre-scan: count entries to drop, verify idempotency, and confirm the
+	// target platform's prefix is actually present — guards against a wrong
+	// mapping silently producing a JAR with no usable native lib.
 	r, err := zip.OpenReader(jars[0])
 	if err != nil {
 		return fmt.Errorf("stripZstdJniNativeLibs: open %s: %w", jars[0], err)
 	}
 	var toDrop int
+	var keepFound bool
 	for _, f := range r.File {
+		if strings.HasPrefix(f.Name, keepPrefix) {
+			keepFound = true
+		}
 		if isZstdNativeEntry(f.Name) && !strings.HasPrefix(f.Name, keepPrefix) {
 			toDrop++
 		}
 	}
 	if err := r.Close(); err != nil {
 		return fmt.Errorf("stripZstdJniNativeLibs: close %s: %w", jars[0], err)
+	}
+
+	if toDrop > 0 && !keepFound {
+		return fmt.Errorf("stripZstdJniNativeLibs: no entries matching prefix %q found in %s: verify zstdNativePrefix mapping", keepPrefix, jars[0])
 	}
 
 	if toDrop == 0 {

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -385,8 +385,8 @@ var zstdNativeOsPrefixes = []string{
 	"linux/", "darwin/", "win/", "aix/", "freebsd/",
 }
 
-// isZstdNativeEntry reports whether a ZIP entry name is a zstd-jni native lib.
-// These live under <os>/<arch>/ directories and end with a native extension.
+// isZstdNativeEntry reports whether a ZIP entry belongs to zstd-jni's
+// platform-specific native directory trees (e.g. linux/amd64/, darwin/x86_64/, win/amd64/).
 func isZstdNativeEntry(name string) bool {
 	for _, prefix := range zstdNativeOsPrefixes {
 		if strings.HasPrefix(name, prefix) {

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -801,6 +801,57 @@ func TestStripZstdJniNativeLibsSkipsWhenJarMissing(t *testing.T) {
 	}
 }
 
+func TestStripZstdJniNativeLibsErrorsWhenKeepPrefixAbsent(t *testing.T) {
+	// given: JAR contains only foreign-platform native libs — the target prefix is absent.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "zstd-jni-1.5.7-9.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	// Only linux/aarch64 — no linux/amd64/ entry for the target linux/x86_64.
+	fw, err := w.Create("linux/aarch64/libzstd-jni-1.5.7-9.so")
+	if err != nil {
+		t.Fatalf("failed to create zip entry: %v", err)
+	}
+	if _, err := fw.Write([]byte("binary")); err != nil {
+		t.Fatalf("failed to write zip entry: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for linux/x86_64 — keepPrefix "linux/amd64/" is absent.
+	err = stripZstdJniNativeLibs(version, "linux", "x86_64")
+
+	// then: should return an error, not silently strip all native libs.
+	if err == nil {
+		t.Fatal("expected error when target prefix is absent in JAR, got nil")
+	}
+}
+
 func TestVerifyClassFileVersionAcceptsJava21Class(t *testing.T) {
 	// given — minimal class file header with major version matching helperJavaRelease
 	dir := t.TempDir()

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -555,6 +555,252 @@ func TestStripRocksDbNativeLibsIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestZstdNativePrefix(t *testing.T) {
+	tests := []struct {
+		osType   string
+		arch     string
+		expected string
+	}{
+		{"linux", "x86_64", "linux/amd64/"},
+		{"linux", "aarch64", "linux/aarch64/"},
+		{"darwin", "x86_64", "darwin/x86_64/"},
+		{"darwin", "aarch64", "darwin/aarch64/"},
+		{"windows", "x86_64", "win/amd64/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.osType+"/"+tt.arch, func(t *testing.T) {
+			got, err := zstdNativePrefix(tt.osType, tt.arch)
+			if err != nil {
+				t.Fatalf("zstdNativePrefix(%q, %q) error: %v", tt.osType, tt.arch, err)
+			}
+			if got != tt.expected {
+				t.Fatalf("zstdNativePrefix(%q, %q) = %q, want %q", tt.osType, tt.arch, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestZstdNativePrefixUnknownPlatformErrors(t *testing.T) {
+	tests := []struct {
+		osType string
+		arch   string
+	}{
+		{"freebsd", "x86_64"},
+		{"windows", "aarch64"},
+		{"linux", "i386"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.osType+"/"+tt.arch, func(t *testing.T) {
+			_, err := zstdNativePrefix(tt.osType, tt.arch)
+			if err == nil {
+				t.Fatalf("expected error for unsupported os/arch %s/%s, got nil", tt.osType, tt.arch)
+			}
+		})
+	}
+}
+
+func TestIsZstdNativeEntry(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		{"linux/amd64/libzstd-jni-1.5.7-9.so", true},
+		{"darwin/aarch64/libzstd-jni-1.5.7-9.dylib", true},
+		{"win/amd64/libzstd-jni-1.5.7-9.dll", true},
+		{"aix/ppc64/libzstd-jni-1.5.7-9.so", true},
+		{"freebsd/amd64/libzstd-jni-1.5.7-9.so", true},
+		{"META-INF/MANIFEST.MF", false},
+		{"com/github/luben/zstd/Zstd.class", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isZstdNativeEntry(tt.name)
+			if got != tt.expected {
+				t.Fatalf("isZstdNativeEntry(%q) = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStripZstdJniNativeLibsStripsJar(t *testing.T) {
+	// given
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "zstd-jni-1.5.7-9.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	entries := []string{
+		"META-INF/MANIFEST.MF",
+		"com/github/luben/zstd/Zstd.class",
+		"linux/amd64/libzstd-jni-1.5.7-9.so",
+		"linux/aarch64/libzstd-jni-1.5.7-9.so",
+		"darwin/x86_64/libzstd-jni-1.5.7-9.dylib",
+		"darwin/aarch64/libzstd-jni-1.5.7-9.dylib",
+		"win/amd64/libzstd-jni-1.5.7-9.dll",
+		"aix/ppc64/libzstd-jni-1.5.7-9.so",
+		"freebsd/amd64/libzstd-jni-1.5.7-9.so",
+	}
+	for _, name := range entries {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", name, err)
+		}
+		if _, err := fw.Write([]byte("binary-" + name)); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for linux/x86_64 (keeps linux/amd64/)
+	err = stripZstdJniNativeLibs(version, "linux", "x86_64")
+
+	// then
+	if err != nil {
+		t.Fatalf("stripZstdJniNativeLibs returned error: %v", err)
+	}
+
+	r, err := zip.OpenReader(jarPath)
+	if err != nil {
+		t.Fatalf("failed to open stripped jar: %v", err)
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("failed to close stripped jar: %v", err)
+		}
+	}()
+
+	kept := make(map[string]bool)
+	for _, entry := range r.File {
+		kept[entry.Name] = true
+	}
+
+	// Should keep: non-native entries + linux/amd64/
+	for _, mustKeep := range []string{
+		"META-INF/MANIFEST.MF",
+		"com/github/luben/zstd/Zstd.class",
+		"linux/amd64/libzstd-jni-1.5.7-9.so",
+	} {
+		if !kept[mustKeep] {
+			t.Fatalf("expected entry %q to be preserved, got entries: %v", mustKeep, kept)
+		}
+	}
+
+	// Should drop: all other native entries
+	for _, mustDrop := range []string{
+		"linux/aarch64/libzstd-jni-1.5.7-9.so",
+		"darwin/x86_64/libzstd-jni-1.5.7-9.dylib",
+		"darwin/aarch64/libzstd-jni-1.5.7-9.dylib",
+		"win/amd64/libzstd-jni-1.5.7-9.dll",
+		"aix/ppc64/libzstd-jni-1.5.7-9.so",
+		"freebsd/amd64/libzstd-jni-1.5.7-9.so",
+	} {
+		if kept[mustDrop] {
+			t.Fatalf("expected entry %q to be dropped, but it was kept", mustDrop)
+		}
+	}
+}
+
+func TestStripZstdJniNativeLibsIsIdempotent(t *testing.T) {
+	// given: JAR already stripped — only the target platform remains
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "zstd-jni-1.5.7-9.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	fw, err := w.Create("darwin/aarch64/libzstd-jni-1.5.7-9.dylib")
+	if err != nil {
+		t.Fatalf("failed to create zip entry: %v", err)
+	}
+	if _, err := fw.Write([]byte("binary")); err != nil {
+		t.Fatalf("failed to write zip entry: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: first call
+	if err := stripZstdJniNativeLibs(version, "darwin", "aarch64"); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+	// when: second call on already-stripped JAR
+	if err := stripZstdJniNativeLibs(version, "darwin", "aarch64"); err != nil {
+		t.Fatalf("second call (idempotency) failed: %v", err)
+	}
+}
+
+func TestStripZstdJniNativeLibsSkipsWhenJarMissing(t *testing.T) {
+	// given: empty temp dir — no zstd-jni jar
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	// when: no jar exists — should warn and return nil (not error)
+	err = stripZstdJniNativeLibs("8.10.0-test", "linux", "x86_64")
+
+	// then
+	if err != nil {
+		t.Fatalf("expected nil error when jar is missing (graceful skip), got: %v", err)
+	}
+}
+
 func TestVerifyClassFileVersionAcceptsJava21Class(t *testing.T) {
 	// given — minimal class file header with major version matching helperJavaRelease
 	dir := t.TempDir()


### PR DESCRIPTION
## What

Strips unused platform-specific native libraries from `zstd-jni-*.jar` during c8run packaging. The JAR bundles native libs for 18 platforms under `<os>/<arch>/` directories — only one is needed per target.

## Why

PR 2 of the implementation plan in #54950. Saves ~6.5MB per platform archive.

## How

- `zstdNativePrefix(osType, arch)` maps c8run's platform to zstd-jni's directory convention:
  | c8run target | zstd-jni prefix |
  |---|---|
  | linux/x86_64 | `linux/amd64/` |
  | linux/aarch64 | `linux/aarch64/` |
  | darwin/x86_64 | `darwin/x86_64/` |
  | darwin/aarch64 | `darwin/aarch64/` |
  | windows/x86_64 | `win/amd64/` |

- `isZstdNativeEntry()` identifies entries under known OS prefixes (`linux/`, `darwin/`, `win/`, `aix/`, `freebsd/`)
- `stripZstdJniNativeLibs()` orchestrates: pre-scan for idempotency, then rewrite via `rewriteJarDroppingEntries()`
- Graceful skip if zstd-jni JAR is not present (warn, no error)
- Idempotent: already-stripped JARs return early without modification

## Testing

- Unit tests with synthetic JARs covering: happy path, idempotency, missing JAR (graceful skip)
- Platform mapping tests for all supported targets + error cases
- `go test ./...` passes from `c8run/`

## Verification

```bash
cd c8run && go test ./internal/packages/... -v -run TestZstd
cd c8run && go test ./internal/packages/... -v -run TestStripZstd
```