### PR TITLE
fix: sort decision instance ids by numeric segments

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionInstanceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionInstanceFieldSortingTransformer.java
@@ -16,6 +16,7 @@ import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTem
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.EVALUATION_DATE;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.EVALUATION_FAILURE;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.EVALUATION_FAILURE_MESSAGE;
+import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.EXECUTION_INDEX;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.KEY;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.PROCESS_DEFINITION_KEY;
@@ -23,6 +24,8 @@ import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTem
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.ROOT_DECISION_DEFINITION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.STATE;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.TENANT_ID;
+
+import java.util.List;
 
 public class DecisionInstanceFieldSortingTransformer implements FieldSortingTransformer {
 
@@ -46,6 +49,14 @@ public class DecisionInstanceFieldSortingTransformer implements FieldSortingTran
       case "rootDecisionDefinitionKey" -> ROOT_DECISION_DEFINITION_ID;
       case "tenantId" -> TENANT_ID;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+
+  @Override
+  public List<String> applyAll(final String domainField) {
+    return switch (domainField) {
+      case "decisionInstanceId" -> List.of(KEY, EXECUTION_INDEX);
+      default -> FieldSortingTransformer.super.applyAll(domainField);
     };
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/FieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/FieldSortingTransformer.java
@@ -8,11 +8,16 @@
 package io.camunda.search.clients.transformers.sort;
 
 import io.camunda.search.clients.transformers.ServiceTransformer;
+import java.util.List;
 
 public interface FieldSortingTransformer extends ServiceTransformer<String, String> {
 
   @Override
   String apply(final String domainField);
+
+  default List<String> applyAll(final String domainField) {
+    return List.of(apply(domainField));
+  }
 
   default String defaultSortField() {
     return "key";

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/SortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/SortingTransformer.java
@@ -43,7 +43,7 @@ public final class SortingTransformer
     if (orderings != null && !orderings.isEmpty()) {
       sorting =
           orderings.stream()
-              .map((f) -> toSearchSortOption(f, reverse))
+              .flatMap((f) -> toSearchSortOptions(f, reverse).stream())
               .collect(Collectors.toList());
     } else {
       sorting = new ArrayList<>();
@@ -51,14 +51,19 @@ public final class SortingTransformer
     return sorting;
   }
 
-  private SearchSortOptions toSearchSortOption(final FieldSorting value, final boolean reverse) {
-    final var field = fieldSortingTransformer.apply(value.field());
+  private List<SearchSortOptions> toSearchSortOptions(
+      final FieldSorting value, final boolean reverse) {
     final var order = value.order();
-    if (!reverse) {
-      return sortOptions(field, order, "_last");
-    } else {
-      return sortOptions(field, reverseOrder(order), "_first");
-    }
+    return fieldSortingTransformer.applyAll(value.field()).stream()
+        .map(field -> toSearchSortOption(field, order, reverse))
+        .toList();
+  }
+
+  private SearchSortOptions toSearchSortOption(
+      final String field, final SortOrder order, final boolean reverse) {
+    return !reverse
+        ? sortOptions(field, order, "_last")
+        : sortOptions(field, reverseOrder(order), "_first");
   }
 
   private SearchSortOptions getDefaultSearchSortOption(final boolean reverse) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
@@ -16,6 +16,7 @@ import io.camunda.search.sort.SortOrder;
 import io.camunda.util.ObjectBuilder;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,7 +26,6 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
   private static Stream<Arguments> provideSortParameters() {
     return Stream.of(
         new TestArguments("key", SortOrder.ASC, s -> s.decisionInstanceKey().asc()),
-        new TestArguments("id", SortOrder.ASC, s -> s.decisionInstanceId().asc()),
         new TestArguments("decisionId", SortOrder.ASC, s -> s.decisionDefinitionId().asc()),
         new TestArguments(
             "decisionDefinitionId", SortOrder.DESC, s -> s.decisionDefinitionKey().desc()),
@@ -68,6 +68,23 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
               assertThat(t.field().field()).isEqualTo("id");
               assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
             });
+  }
+
+  @Test
+  void shouldSortDecisionInstanceIdByKeyAndExecutionIndex() {
+    // when
+    final var request =
+        SearchQueryBuilders.decisionInstanceSearchQuery(
+            q -> q.sort(s -> s.decisionInstanceId().desc()));
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort)
+        .extracting(searchSort -> searchSort.field().field())
+        .containsExactly("key", "executionIndex", "id");
+    assertThat(sort)
+        .extracting(searchSort -> searchSort.field().order())
+        .containsExactly(SortOrder.DESC, SortOrder.DESC, SortOrder.ASC);
   }
 
   private record TestArguments(


### PR DESCRIPTION
## Description

Decision instance IDs are stored as `<key>-<executionIndex>`. Sorting by the stored ID string can order suffixes lexicographically, so a descending sort may place `...-2` before `...-10`.

This keeps the public `decisionInstanceId` sort option unchanged, but expands it to the stored numeric `key` and `executionIndex` fields before applying the existing stable `id` tie-breaker.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Verification

- `.\mvnw.cmd -pl search\search-client-query-transformer -am -Dtest=DecisionInstanceSortTest -DskipTests=false -DskipITs -Dquickly "-Dsurefire.failIfNoSpecifiedTests=false" test`
- `.\mvnw.cmd -pl search\search-client-query-transformer spotless:check -DskipTests -DskipITs`
- `git diff --check`

## Related issues

closes #32993
