### PR TITLE
feat: strip unused conscrypt native libs from packaged c8run archive

### DIFF
--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -512,20 +512,29 @@ func stripConscryptNativeLibs(camundaVersion, osType, arch string) error {
 	}
 
 	// Pre-scan: count entries to drop and verify idempotency.
+	// When suffix is non-empty, also verify at least one entry matches —
+	// prevents silently dropping all native libs if the suffix mapping is wrong.
 	r, err := zip.OpenReader(jars[0])
 	if err != nil {
 		return fmt.Errorf("stripConscryptNativeLibs: open %s: %w", jars[0], err)
 	}
 	var toDrop int
+	var kept int
 	for _, f := range r.File {
 		if isConscryptNativeEntry(f.Name) {
 			if suffix == "" || !strings.Contains(f.Name, suffix) {
 				toDrop++
+			} else {
+				kept++
 			}
 		}
 	}
 	if err := r.Close(); err != nil {
 		return fmt.Errorf("stripConscryptNativeLibs: close %s: %w", jars[0], err)
+	}
+
+	if suffix != "" && toDrop > 0 && kept == 0 {
+		return fmt.Errorf("stripConscryptNativeLibs: native entries exist in %s but none match suffix %q: verify conscryptNativeSuffix mapping", jars[0], suffix)
 	}
 
 	if toDrop == 0 {

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -457,6 +457,105 @@ func stripZstdJniNativeLibs(camundaVersion, osType, arch string) error {
 	return nil
 }
 
+// conscryptNativeSuffix returns the platform suffix used by conscrypt-openjdk-uber
+// to identify native library entries under META-INF/native/. Returns empty string
+// when the JAR has no native lib for the target platform (e.g., aarch64 builds),
+// in which case all native entries should be dropped.
+func conscryptNativeSuffix(osType, arch string) string {
+	switch osType {
+	case "linux":
+		switch arch {
+		case "x86_64":
+			return "-linux-x86_64."
+		}
+	case "darwin":
+		switch arch {
+		case "x86_64":
+			return "-osx-x86_64."
+		}
+	case "windows":
+		switch arch {
+		case "x86_64":
+			return "-windows-x86_64."
+		}
+	}
+	// No native lib exists for this platform (e.g., aarch64).
+	return ""
+}
+
+// isConscryptNativeEntry reports whether a ZIP entry is a conscrypt native lib.
+// These live under META-INF/native/ and end with a native extension.
+func isConscryptNativeEntry(name string) bool {
+	if !strings.HasPrefix(name, "META-INF/native/") {
+		return false
+	}
+	return strings.HasSuffix(name, ".so") || strings.HasSuffix(name, ".dylib") || strings.HasSuffix(name, ".dll")
+}
+
+// stripConscryptNativeLibs strips unused platform native libs from conscrypt JARs.
+// When no native lib exists for the target platform (aarch64), all native entries
+// are dropped — conscrypt falls back to JCA providers at runtime.
+func stripConscryptNativeLibs(camundaVersion, osType, arch string) error {
+	suffix := conscryptNativeSuffix(osType, arch)
+
+	pattern := filepath.Join("camunda-zeebe-"+camundaVersion, "lib", "conscrypt-openjdk-uber-*.jar")
+	jars, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("stripConscryptNativeLibs: failed to glob %s: %w", pattern, err)
+	}
+	if len(jars) == 0 {
+		log.Warn().Str("pattern", pattern).Msg("no conscrypt jar found; skipping native lib stripping")
+		return nil
+	}
+	if len(jars) > 1 {
+		log.Warn().Strs("jars", jars).Msg("multiple conscrypt jars found; stripping only the first")
+	}
+
+	// Pre-scan: count entries to drop and verify idempotency.
+	r, err := zip.OpenReader(jars[0])
+	if err != nil {
+		return fmt.Errorf("stripConscryptNativeLibs: open %s: %w", jars[0], err)
+	}
+	var toDrop int
+	for _, f := range r.File {
+		if isConscryptNativeEntry(f.Name) {
+			if suffix == "" || !strings.Contains(f.Name, suffix) {
+				toDrop++
+			}
+		}
+	}
+	if err := r.Close(); err != nil {
+		return fmt.Errorf("stripConscryptNativeLibs: close %s: %w", jars[0], err)
+	}
+
+	if toDrop == 0 {
+		log.Info().Str("jar", jars[0]).Msg("no unused conscrypt native libs to strip (already stripped?)")
+		return nil
+	}
+
+	keepDesc := suffix
+	if keepDesc == "" {
+		keepDesc = "(none — no native lib for this platform)"
+	}
+	log.Info().Str("jar", jars[0]).Str("keeping", keepDesc).Int("dropping", toDrop).Msg("stripping unused conscrypt native libs")
+
+	shouldDrop := func(name string) bool {
+		if !isConscryptNativeEntry(name) {
+			return false
+		}
+		// No native lib for this platform: drop all native entries.
+		if suffix == "" {
+			return true
+		}
+		// Keep only the entry matching our platform suffix.
+		return !strings.Contains(name, suffix)
+	}
+	if _, err := rewriteJarDroppingEntries(jars[0], shouldDrop); err != nil {
+		return err
+	}
+	return nil
+}
+
 func getJavaArtifactsToken() (string, error) {
 	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
 	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")
@@ -894,6 +993,10 @@ func New(camundaVersion, connectorsVersion string) error {
 
 	if err := stripZstdJniNativeLibs(camundaVersion, osType, architecture); err != nil {
 		return fmt.Errorf("package %s: failed to strip zstd-jni native libs: %w", osType, err)
+	}
+
+	if err := stripConscryptNativeLibs(camundaVersion, osType, architecture); err != nil {
+		return fmt.Errorf("package %s: failed to strip conscrypt native libs: %w", osType, err)
 	}
 
 	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, ".", javaArtifactsToken, func(_, _ string) error { return nil })

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -1141,6 +1141,64 @@ func TestStripConscryptNativeLibsIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestStripConscryptNativeLibsErrorsWhenSuffixMismatch(t *testing.T) {
+	// given: JAR has native entries but none match the expected suffix.
+	// This catches suffix mapping errors that would silently drop all native libs.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "conscrypt-openjdk-uber-2.5.2.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	// Only entries that do NOT match linux-x86_64 suffix
+	for _, name := range []string{
+		"META-INF/MANIFEST.MF",
+		"META-INF/native/conscrypt_openjdk_jni-windows-x86_64.dll",
+		"META-INF/native/libconscrypt_openjdk_jni-osx-x86_64.dylib",
+	} {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", name, err)
+		}
+		if _, err := fw.Write([]byte("binary")); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for linux/x86_64 — suffix is "-linux-x86_64." but no entry matches
+	err = stripConscryptNativeLibs(version, "linux", "x86_64")
+
+	// then: should error, not silently drop all native entries
+	if err == nil {
+		t.Fatal("expected error when native entries exist but none match suffix, got nil")
+	}
+}
+
 func TestStripConscryptNativeLibsSkipsWhenJarMissing(t *testing.T) {
 	// given: empty temp dir
 	cwd, err := os.Getwd()

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -852,6 +852,320 @@ func TestStripZstdJniNativeLibsErrorsWhenKeepPrefixAbsent(t *testing.T) {
 	}
 }
 
+func TestConscryptNativeSuffix(t *testing.T) {
+	tests := []struct {
+		osType   string
+		arch     string
+		expected string
+	}{
+		{"linux", "x86_64", "-linux-x86_64."},
+		{"darwin", "x86_64", "-osx-x86_64."},
+		{"windows", "x86_64", "-windows-x86_64."},
+		// No native lib for aarch64 — empty suffix means "drop all".
+		{"linux", "aarch64", ""},
+		{"darwin", "aarch64", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.osType+"/"+tt.arch, func(t *testing.T) {
+			got := conscryptNativeSuffix(tt.osType, tt.arch)
+			if got != tt.expected {
+				t.Fatalf("conscryptNativeSuffix(%q, %q) = %q, want %q", tt.osType, tt.arch, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsConscryptNativeEntry(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		{"META-INF/native/libconscrypt_openjdk_jni-linux-x86_64.so", true},
+		{"META-INF/native/libconscrypt_openjdk_jni-osx-x86_64.dylib", true},
+		{"META-INF/native/conscrypt_openjdk_jni-windows-x86_64.dll", true},
+		{"META-INF/native/conscrypt_openjdk_jni-windows-x86.dll", true},
+		{"META-INF/MANIFEST.MF", false},
+		{"META-INF/native/", false}, // directory entry
+		{"org/conscrypt/Conscrypt.class", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isConscryptNativeEntry(tt.name)
+			if got != tt.expected {
+				t.Fatalf("isConscryptNativeEntry(%q) = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStripConscryptNativeLibsStripsJar(t *testing.T) {
+	// given
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "conscrypt-openjdk-uber-2.5.2.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	entries := []string{
+		"META-INF/MANIFEST.MF",
+		"org/conscrypt/Conscrypt.class",
+		"META-INF/native/conscrypt_openjdk_jni-windows-x86.dll",
+		"META-INF/native/conscrypt_openjdk_jni-windows-x86_64.dll",
+		"META-INF/native/libconscrypt_openjdk_jni-linux-x86_64.so",
+		"META-INF/native/libconscrypt_openjdk_jni-osx-x86_64.dylib",
+	}
+	for _, name := range entries {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", name, err)
+		}
+		if _, err := fw.Write([]byte("binary-" + name)); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for linux/x86_64
+	err = stripConscryptNativeLibs(version, "linux", "x86_64")
+
+	// then
+	if err != nil {
+		t.Fatalf("stripConscryptNativeLibs returned error: %v", err)
+	}
+
+	r, err := zip.OpenReader(jarPath)
+	if err != nil {
+		t.Fatalf("failed to open stripped jar: %v", err)
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("failed to close stripped jar: %v", err)
+		}
+	}()
+
+	kept := make(map[string]bool)
+	for _, entry := range r.File {
+		kept[entry.Name] = true
+	}
+
+	// Should keep: non-native entries + linux-x86_64
+	for _, mustKeep := range []string{
+		"META-INF/MANIFEST.MF",
+		"org/conscrypt/Conscrypt.class",
+		"META-INF/native/libconscrypt_openjdk_jni-linux-x86_64.so",
+	} {
+		if !kept[mustKeep] {
+			t.Fatalf("expected entry %q to be preserved, got entries: %v", mustKeep, kept)
+		}
+	}
+
+	// Should drop: all other native entries
+	for _, mustDrop := range []string{
+		"META-INF/native/conscrypt_openjdk_jni-windows-x86.dll",
+		"META-INF/native/conscrypt_openjdk_jni-windows-x86_64.dll",
+		"META-INF/native/libconscrypt_openjdk_jni-osx-x86_64.dylib",
+	} {
+		if kept[mustDrop] {
+			t.Fatalf("expected entry %q to be dropped, but it was kept", mustDrop)
+		}
+	}
+}
+
+func TestStripConscryptNativeLibsDropsAllOnAarch64(t *testing.T) {
+	// given: conscrypt has no aarch64 native libs — all should be dropped
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "conscrypt-openjdk-uber-2.5.2.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	entries := []string{
+		"META-INF/MANIFEST.MF",
+		"org/conscrypt/Conscrypt.class",
+		"META-INF/native/conscrypt_openjdk_jni-windows-x86_64.dll",
+		"META-INF/native/libconscrypt_openjdk_jni-linux-x86_64.so",
+		"META-INF/native/libconscrypt_openjdk_jni-osx-x86_64.dylib",
+	}
+	for _, name := range entries {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", name, err)
+		}
+		if _, err := fw.Write([]byte("binary-" + name)); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for darwin/aarch64 — no matching lib exists
+	err = stripConscryptNativeLibs(version, "darwin", "aarch64")
+
+	// then
+	if err != nil {
+		t.Fatalf("stripConscryptNativeLibs returned error: %v", err)
+	}
+
+	r, err := zip.OpenReader(jarPath)
+	if err != nil {
+		t.Fatalf("failed to open stripped jar: %v", err)
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("failed to close stripped jar: %v", err)
+		}
+	}()
+
+	kept := make(map[string]bool)
+	for _, entry := range r.File {
+		kept[entry.Name] = true
+	}
+
+	// Should keep: non-native entries only
+	for _, mustKeep := range []string{
+		"META-INF/MANIFEST.MF",
+		"org/conscrypt/Conscrypt.class",
+	} {
+		if !kept[mustKeep] {
+			t.Fatalf("expected entry %q to be preserved, got entries: %v", mustKeep, kept)
+		}
+	}
+
+	// Should drop: ALL native entries (none match aarch64)
+	for _, mustDrop := range []string{
+		"META-INF/native/conscrypt_openjdk_jni-windows-x86_64.dll",
+		"META-INF/native/libconscrypt_openjdk_jni-linux-x86_64.so",
+		"META-INF/native/libconscrypt_openjdk_jni-osx-x86_64.dylib",
+	} {
+		if kept[mustDrop] {
+			t.Fatalf("expected entry %q to be dropped on aarch64, but it was kept", mustDrop)
+		}
+	}
+}
+
+func TestStripConscryptNativeLibsIsIdempotent(t *testing.T) {
+	// given: JAR already stripped
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "conscrypt-openjdk-uber-2.5.2.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	// Only the kept lib — simulates already stripped.
+	fw, err := w.Create("META-INF/native/libconscrypt_openjdk_jni-linux-x86_64.so")
+	if err != nil {
+		t.Fatalf("failed to create zip entry: %v", err)
+	}
+	if _, err := fw.Write([]byte("binary")); err != nil {
+		t.Fatalf("failed to write zip entry: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: first and second call
+	if err := stripConscryptNativeLibs(version, "linux", "x86_64"); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+	if err := stripConscryptNativeLibs(version, "linux", "x86_64"); err != nil {
+		t.Fatalf("second call (idempotency) failed: %v", err)
+	}
+}
+
+func TestStripConscryptNativeLibsSkipsWhenJarMissing(t *testing.T) {
+	// given: empty temp dir
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	// when: no jar exists — should warn and return nil
+	err = stripConscryptNativeLibs("8.10.0-test", "linux", "x86_64")
+
+	// then
+	if err != nil {
+		t.Fatalf("expected nil error when jar is missing (graceful skip), got: %v", err)
+	}
+}
+
 func TestVerifyClassFileVersionAcceptsJava21Class(t *testing.T) {
 	// given — minimal class file header with major version matching helperJavaRelease
 	dir := t.TempDir()


### PR DESCRIPTION
## What

Strips unused platform-specific native libraries from `conscrypt-openjdk-uber-*.jar` during c8run packaging.

## Why

PR 3 of the implementation plan in #54950. Saves ~3MB on x86_64 targets.

## How

- `conscryptNativeSuffix(osType, arch)` maps c8run's platform to conscrypt's filename convention:
  | c8run target | conscrypt suffix | Action |
  |---|---|---|
  | linux/x86_64 | `-linux-x86_64.` | Keep matching, drop rest |
  | darwin/x86_64 | `-osx-x86_64.` | Keep matching, drop rest |
  | windows/x86_64 | `-windows-x86_64.` | Keep matching, drop rest |
  | linux/aarch64 | (empty) | Drop ALL native entries |
  | darwin/aarch64 | (empty) | Drop ALL native entries |

- `isConscryptNativeEntry()` identifies entries under `META-INF/native/` with native extensions
- `stripConscryptNativeLibs()` orchestrates: pre-scan for idempotency, then rewrite

**Key design decision:** conscrypt-openjdk-uber 2.5.2 has **no aarch64 native libs**. On aarch64 targets, all native entries are dropped — Conscrypt falls back to JCA providers at runtime (still works, just uses a different TLS provider).

## Independent of PR 2

This PR branches from `main` and is independent of #55867 (zstd-jni stripping). They can be reviewed and merged in any order.

## Testing

- Suffix mapping tests for all 5 platforms (including aarch64 empty-suffix cases)
- Entry detection tests (positive + negative)
- Integration: happy path (linux/x86_64), aarch64 drop-all, idempotency, missing JAR (graceful skip)
- `go test ./...` passes from `c8run/`

## Verification

```bash
cd c8run && go test ./internal/packages/... -v -run TestConscrypt
cd c8run && go test ./internal/packages/... -v -run TestStripConscrypt
```