### PR TITLE
fix: keep scheduler latency timestamps monotonic

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
@@ -60,14 +60,22 @@ public final class ActorJob {
       final var now = System.nanoTime();
       if (subscription instanceof final ActorFutureSubscription s
           && s.getFuture() instanceof final CompletableActorFuture<?> f) {
-        final var subscriptionCompleted = f.getCompletedAt();
-        metrics.observeJobSchedulingLatency(now - subscriptionCompleted, SubscriptionType.FUTURE);
+        observeSchedulingLatency(metrics, now, f.getCompletedAt(), SubscriptionType.FUTURE);
       } else if (subscription instanceof final TimerSubscription s) {
-        final var timerExpired = s.getTimerExpiredAt();
-        metrics.observeJobSchedulingLatency(now - timerExpired, SubscriptionType.TIMER);
+        observeSchedulingLatency(metrics, now, s.getTimerExpiredAt(), SubscriptionType.TIMER);
       } else if (subscription == null && scheduledAt != -1) {
-        metrics.observeJobSchedulingLatency(now - scheduledAt, SubscriptionType.NONE);
+        observeSchedulingLatency(metrics, now, scheduledAt, SubscriptionType.NONE);
       }
+    }
+  }
+
+  private static void observeSchedulingLatency(
+      final ActorMetrics metrics,
+      final long now,
+      final long referenceTimeNs,
+      final SubscriptionType subscriptionType) {
+    if (referenceTimeNs > 0 && now >= referenceTimeNs) {
+      metrics.observeJobSchedulingLatency(now - referenceTimeNs, subscriptionType);
     }
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/DelayedTimerSubscription.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/DelayedTimerSubscription.java
@@ -99,7 +99,7 @@ public final class DelayedTimerSubscription implements TimerSubscription {
   public void onTimerExpired(final TimeUnit timeUnit, final long now) {
     if (!isCanceled) {
       isDone = true;
-      timerExpiredAt = timeUnit.toNanos(now);
+      timerExpiredAt = System.nanoTime();
       task.tryWakeup();
     }
   }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/StampedTimerSubscription.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/StampedTimerSubscription.java
@@ -86,7 +86,7 @@ public final class StampedTimerSubscription implements TimerSubscription {
   public void onTimerExpired(final TimeUnit timeUnit, final long now) {
     if (!isCanceled) {
       isDone = true;
-      timerExpiredAt = timeUnit.toNanos(now);
+      timerExpiredAt = System.nanoTime();
       task.tryWakeup();
     }
   }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -70,6 +70,7 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
 
   private CompletableActorFuture(final V value) {
     this.value = value;
+    completedAt = System.nanoTime();
     state = COMPLETED;
   }
 
@@ -77,6 +78,7 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
     ensureValidThrowable(throwable);
     failure = throwable.getMessage();
     failureCause = throwable;
+    completedAt = System.nanoTime();
     state = COMPLETED_EXCEPTIONALLY;
   }
 
@@ -87,6 +89,7 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   public void setAwaitingResult() {
+    completedAt = 0;
     state = AWAITING_RESULT;
     isDoneCondition = completionLock.newCondition();
   }
@@ -192,8 +195,8 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   public void complete(final V value) {
     if (UnsafeApi.compareAndSetInt(this, STATE_OFFSET, AWAITING_RESULT, COMPLETING)) {
       this.value = value;
-      state = COMPLETED;
       completedAt = System.nanoTime();
+      state = COMPLETED;
       notifyAllBlocked();
     } else {
       final String err =
@@ -214,6 +217,7 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
     if (UnsafeApi.compareAndSetInt(this, STATE_OFFSET, AWAITING_RESULT, COMPLETING)) {
       this.failure = failure;
       failureCause = throwable;
+      completedAt = System.nanoTime();
       state = COMPLETED_EXCEPTIONALLY;
       notifyAllBlocked();
     } else {

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/TimerSubscriptionTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/TimerSubscriptionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+final class TimerSubscriptionTest {
+
+  @Test
+  void shouldRecordDelayedTimerExpirationWithMonotonicClock() {
+    // given
+    final var timer = newDelayedTimer();
+    final var before = System.nanoTime();
+
+    // when
+    timer.onTimerExpired(TimeUnit.MILLISECONDS, Long.MAX_VALUE);
+    final var after = System.nanoTime();
+
+    // then
+    assertThat(timer.getTimerExpiredAt()).isBetween(before, after);
+  }
+
+  @Test
+  void shouldRecordStampedTimerExpirationWithMonotonicClock() {
+    // given
+    final var timer = newStampedTimer();
+    final var before = System.nanoTime();
+
+    // when
+    timer.onTimerExpired(TimeUnit.MILLISECONDS, Long.MAX_VALUE);
+    final var after = System.nanoTime();
+
+    // then
+    assertThat(timer.getTimerExpiredAt()).isBetween(before, after);
+  }
+
+  @Test
+  void shouldWakeTaskWhenDelayedTimerExpires() {
+    // given
+    final var task = mock(ActorTask.class);
+    final var timer = new DelayedTimerSubscription(newJob(task), 1, TimeUnit.MILLISECONDS, false);
+
+    // when
+    timer.onTimerExpired(TimeUnit.MILLISECONDS, 1);
+
+    // then
+    verify(task).tryWakeup();
+  }
+
+  @Test
+  void shouldWakeTaskWhenStampedTimerExpires() {
+    // given
+    final var task = mock(ActorTask.class);
+    final var timer = new StampedTimerSubscription(newJob(task), 1);
+
+    // when
+    timer.onTimerExpired(TimeUnit.MILLISECONDS, 1);
+
+    // then
+    verify(task).tryWakeup();
+  }
+
+  private static DelayedTimerSubscription newDelayedTimer() {
+    return new DelayedTimerSubscription(
+        newJob(mock(ActorTask.class)), 1, TimeUnit.MILLISECONDS, false);
+  }
+
+  private static StampedTimerSubscription newStampedTimer() {
+    return new StampedTimerSubscription(newJob(mock(ActorTask.class)), 1);
+  }
+
+  private static ActorJob newJob(final ActorTask task) {
+    final var job = mock(ActorJob.class);
+    when(job.getTask()).thenReturn(task);
+    return job;
+  }
+}

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/future/CompletableActorFutureTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/future/CompletableActorFutureTest.java
@@ -27,6 +27,64 @@ public class CompletableActorFutureTest {
   @AutoClose private static final ExecutorService EXECUTOR = Executors.newWorkStealingPool();
 
   @Nested
+  class CompletionTimestamps {
+    @Test
+    public void shouldRecordCompletionTimestampForSuccessfulStaticFuture() {
+      // given
+      final var before = System.nanoTime();
+
+      // when
+      final var future = CompletableActorFuture.completed("value");
+      final var after = System.nanoTime();
+
+      // then
+      assertThat(future.getCompletedAt()).isBetween(before, after);
+    }
+
+    @Test
+    public void shouldRecordCompletionTimestampForFailedStaticFuture() {
+      // given
+      final var before = System.nanoTime();
+
+      // when
+      final var future =
+          CompletableActorFuture.completedExceptionally(new RuntimeException("Expected"));
+      final var after = System.nanoTime();
+
+      // then
+      assertThat(future.getCompletedAt()).isBetween(before, after);
+    }
+
+    @Test
+    public void shouldRecordCompletionTimestampBeforeSuccessfulFutureIsDone() {
+      // given
+      final var future = new CompletableActorFuture<String>();
+      final var before = System.nanoTime();
+
+      // when
+      future.complete("value");
+      final var after = System.nanoTime();
+
+      // then
+      assertThat(future.getCompletedAt()).isBetween(before, after);
+    }
+
+    @Test
+    public void shouldRecordCompletionTimestampBeforeFailedFutureIsDone() {
+      // given
+      final var future = new CompletableActorFuture<String>();
+      final var before = System.nanoTime();
+
+      // when
+      future.completeExceptionally(new RuntimeException("Expected"));
+      final var after = System.nanoTime();
+
+      // then
+      assertThat(future.getCompletedAt()).isBetween(before, after);
+    }
+  }
+
+  @Nested
   class VoidContinuations {
     @Test
     public void shouldConsumeFutureResult() {


### PR DESCRIPTION
## Description

Fixes #46139.

Scheduler latency metrics are recorded against `System.nanoTime()`, but timer subscriptions stored the actor clock value converted to nanoseconds. That mixed two different time origins and could produce negative scheduling latency values. Completed futures also had gaps where `completedAt` was unset or written after the future was visible as done.

This change:
- records timer expiration timestamps with the monotonic clock
- records future completion timestamps before publishing completed states, including static completed futures and exceptional completions
- skips invalid latency source timestamps defensively before recording scheduler latency metrics
- adds regression coverage for timer and future completion timestamps

Validation:
- `.\mvnw.cmd -pl zeebe/scheduler "-Dtest=CompletableActorFutureTest,TimerSubscriptionTest" -DskipTests=false -DskipITs -Dquickly test`
- `.\mvnw.cmd -pl zeebe/scheduler spotless:check -DskipTests -DskipITs`
- `git diff --check`

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46139
