### PR TITLE
fix: map ES/OS runtime exceptions to TasklistRuntimeException

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/DraftVariablesStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/DraftVariablesStoreElasticSearch.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.store.elasticsearch;
 import static io.camunda.tasklist.util.ElasticsearchUtil.UPDATE_RETRY_COUNT;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
@@ -60,7 +61,7 @@ public class DraftVariablesStoreElasticSearch implements DraftVariableStore {
     try {
       final var bulkOperations = draftVariables.stream().map(this::createUpsertOperation).toList();
       ElasticsearchUtil.executeBulkRequest(esClient, bulkOperations, Refresh.WaitFor);
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       throw new TasklistRuntimeException("Error persisting draft variables", e);
     }
   }
@@ -75,7 +76,7 @@ public class DraftVariablesStoreElasticSearch implements DraftVariableStore {
     try {
       final var response = esClient.deleteByQuery(request);
       return response.deleted(); // Return the count of deleted documents
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       throw new TasklistRuntimeException(
           String.format(
               "Error preparing the query to delete draft task variable instances for task [%s]",
@@ -140,8 +141,8 @@ public class DraftVariablesStoreElasticSearch implements DraftVariableStore {
       }
 
       return Optional.ofNullable(response.hits().hits().get(0).source());
-    } catch (final IOException e) {
-      LOGGER.error(
+    } catch (final IOException | ElasticsearchException e) {
+      LOGGER.warn(
           String.format("Error retrieving draft task variable instance with ID [%s]", variableId),
           e);
       return Optional.empty();

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.store.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.GetRequest;
@@ -122,7 +123,7 @@ public class FormStoreElasticSearch implements FormStore {
                 (String) sourceAsMap.get(FormIndex.BPMN_ID),
                 ((Number) sourceAsMap.get(FormIndex.VERSION)).longValue()));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       throw new TasklistRuntimeException(
           String.format("Error retrieving the last version for the formKey: %s", formKey), e);
     }
@@ -148,7 +149,7 @@ public class FormStoreElasticSearch implements FormStore {
       if (response.hits().total().value() == 1) {
         return response.hits().hits().get(0).source();
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
     return null;
@@ -198,10 +199,10 @@ public class FormStoreElasticSearch implements FormStore {
         formEntity.setIsDeleted((Boolean) sourceAsMap.get(FormIndex.IS_DELETED));
         return formEntity;
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final var formIdNotFoundMessage =
           String.format("Error retrieving the version for the formId: [%s]", formId);
-      throw new TasklistRuntimeException(formIdNotFoundMessage);
+      throw new TasklistRuntimeException(formIdNotFoundMessage, e);
     }
     return null;
   }
@@ -245,10 +246,10 @@ public class FormStoreElasticSearch implements FormStore {
       } else {
         return Optional.empty();
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final var formIdNotFoundMessage =
           String.format("Error retrieving the version for the formId: [%s]", formId);
-      throw new TasklistRuntimeException(formIdNotFoundMessage);
+      throw new TasklistRuntimeException(formIdNotFoundMessage, e);
     }
   }
 
@@ -276,10 +277,10 @@ public class FormStoreElasticSearch implements FormStore {
       } else {
         return Optional.empty();
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final var formIdNotFoundMessage =
           String.format("Error retrieving the version for the formId: [%s]", formId);
-      throw new TasklistRuntimeException(formIdNotFoundMessage);
+      throw new TasklistRuntimeException(formIdNotFoundMessage, e);
     }
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.store.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
@@ -80,7 +81,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
         throw new NotFoundException(
             String.format("Process with key %s not found", processDefinitionKey));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       throw new TasklistRuntimeException(e);
     }
   }
@@ -124,7 +125,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
         throw new NotFoundException(
             String.format("Could not find process with id '%s'.", bpmnProcessId));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -150,7 +151,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
         throw new NotFoundException(
             String.format("Could not find process with id '%s'.", processId));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -437,7 +438,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
         return getAggregateSearchHits(bpmnProcessIdBuckets);
       }
 
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
@@ -13,6 +13,7 @@ import static io.camunda.webapps.schema.descriptors.template.UsageMetricTUTempla
 import static io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate.TENANT_ID;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.ExpandWildcard;
 import co.elastic.clients.elasticsearch._types.Result;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
@@ -114,11 +115,10 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
       final List<LongTermsBucket> buckets = termsResult.buckets().array();
 
       return buckets.stream().map(LongTermsBucket::key).collect(Collectors.toSet());
-    } catch (final IOException e) {
-      LOGGER.error(
-          "Error while retrieving assigned users between dates from index: " + template, e);
+    } catch (final IOException | ElasticsearchException e) {
+      LOGGER.warn("Error while retrieving assigned users between dates from index: " + template, e);
       final String message = "Error while retrieving assigned users between dates";
-      throw new TasklistRuntimeException(message);
+      throw new TasklistRuntimeException(message, e);
     }
   }
 
@@ -132,9 +132,9 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
       final var result = response.result();
 
       return Result.Created.equals(result) || Result.Updated.equals(result);
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       LOGGER.error(e.getMessage(), e);
-      throw new TasklistRuntimeException("Error while trying to upsert entity: " + entity);
+      throw new TasklistRuntimeException("Error while trying to upsert entity: " + entity, e);
     }
   }
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -12,6 +12,7 @@ import static io.camunda.tasklist.util.CollectionUtil.getOrDefaultFromMap;
 import static java.util.stream.Collectors.toList;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.ScriptSortType;
@@ -115,7 +116,7 @@ public class TaskStoreElasticSearch implements TaskStore {
         throw new NotFoundException(
             String.format("%s with id %s was not found", taskTemplate.getIndexName(), userTaskKey));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
@@ -308,8 +309,8 @@ public class TaskStoreElasticSearch implements TaskStore {
       } else {
         throw new NotFoundException(String.format("No tasks were found for ids %s", ids));
       }
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
+    } catch (final IOException | ElasticsearchException e) {
+      throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
 
@@ -471,7 +472,7 @@ public class TaskStoreElasticSearch implements TaskStore {
         }
       }
       return tasks;
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining tasks: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
@@ -168,7 +169,7 @@ public class VariableStoreElasticSearch implements VariableStore {
     try {
       final var bulkOperations = finalVariables.stream().map(this::createUpsertRequest).toList();
       ElasticsearchUtil.executeBulkRequest(esClient, bulkOperations, Refresh.WaitFor);
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       throw new TasklistRuntimeException("Error persisting task variables", e);
     }
   }
@@ -211,7 +212,7 @@ public class VariableStoreElasticSearch implements VariableStore {
       } else {
         throw new NotFoundException(String.format("Variable with id %s was not found", variableId));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining variable: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -241,7 +242,7 @@ public class VariableStoreElasticSearch implements VariableStore {
         throw new NotFoundException(
             String.format("Task variable with id %s was not found", variableId));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining task variable: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/DraftVariablesStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/DraftVariablesStoreOpenSearch.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch.core.BulkRequest;
@@ -86,7 +87,7 @@ public class DraftVariablesStoreOpenSearch implements DraftVariableStore {
     try {
       final DeleteByQueryResponse response = osClient.deleteByQuery(request.build());
       return response.deleted(); // Return the count of deleted documents
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(
           String.format(
               "Error preparing the query to delete draft task variable instances for task [%s]",
@@ -131,7 +132,7 @@ public class DraftVariablesStoreOpenSearch implements DraftVariableStore {
               .query(q -> q.bool(queryBuilder.build()));
 
       return OpenSearchUtil.scroll(searchRequestBuilder, DraftTaskVariableEntity.class, osClient);
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(
           String.format(
               "Error executing the query to get draft task variable instances for task [%s] with variable names %s",
@@ -161,8 +162,8 @@ public class DraftVariablesStoreOpenSearch implements DraftVariableStore {
 
       final Hit<DraftTaskVariableEntity> hit = hits.get(0);
       return Optional.of(hit.source());
-    } catch (final IOException e) {
-      LOGGER.error(
+    } catch (final IOException | OpenSearchException e) {
+      LOGGER.warn(
           String.format("Error retrieving draft task variable instance with ID [%s]", variableId),
           e);
       return Optional.empty();
@@ -190,7 +191,7 @@ public class DraftVariablesStoreOpenSearch implements DraftVariableStore {
 
     try {
       return OpenSearchUtil.scrollIdsToList(searchRequest, osClient);
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
@@ -94,7 +94,7 @@ public class FormStoreOpenSearch implements FormStore {
             .fields(f -> f.field(FormIndex.ID));
     try {
       return OpenSearchUtil.scrollIdsToList(searchRequest, osClient);
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
@@ -167,12 +167,12 @@ public class FormStoreOpenSearch implements FormStore {
       } else {
         return Optional.empty();
       }
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String formIdNotFoundMessage =
           String.format(
               "Error retrieving the association for the formId: [%s] and processDefinitionId: [%s]",
               formId, processDefinitionId);
-      throw new TasklistRuntimeException(formIdNotFoundMessage);
+      throw new TasklistRuntimeException(formIdNotFoundMessage, e);
     }
   }
 
@@ -207,12 +207,12 @@ public class FormStoreOpenSearch implements FormStore {
       } else {
         return Optional.empty();
       }
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String formIdNotFoundMessage =
           String.format(
               "Error retrieving the association for the formId: [%s] and processDefinitionId: [%s]",
               formId, processDefinitionId);
-      throw new TasklistRuntimeException(formIdNotFoundMessage);
+      throw new TasklistRuntimeException(formIdNotFoundMessage, e);
     }
   }
 
@@ -285,10 +285,10 @@ public class FormStoreOpenSearch implements FormStore {
       } else {
         return null;
       }
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String formIdNotFoundMessage =
           String.format("Error retrieving the version for the formId: [%s]", formId);
-      throw new TasklistRuntimeException(formIdNotFoundMessage);
+      throw new TasklistRuntimeException(formIdNotFoundMessage, e);
     }
   }
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
@@ -159,7 +159,7 @@ public class ProcessStoreOpenSearch implements ProcessStore {
         throw new NotFoundException(
             String.format("Could not find process with id '%s'.", bpmnProcessId));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -187,7 +187,7 @@ public class ProcessStoreOpenSearch implements ProcessStore {
         throw new NotFoundException(
             String.format("Could not find process with id '%s'.", processId));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -430,7 +430,7 @@ public class ProcessStoreOpenSearch implements ProcessStore {
 
       return OpenSearchUtil.mapSearchHits(hits, objectMapper, ProcessEntity.class);
 
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
@@ -131,8 +131,7 @@ public class TaskMetricsStoreOpenSearch implements TaskMetricsStore {
       final List<LongTermsBucket> buckets = aggregate.lterms().buckets().array();
       return buckets.stream().map(l -> l.key().signed()).collect(Collectors.toSet());
     } catch (final IOException | OpenSearchException e) {
-      LOGGER.error(
-          "Error while retrieving assigned users between dates from index: " + template, e);
+      LOGGER.warn("Error while retrieving assigned users between dates from index: " + template, e);
       final String message = "Error while retrieving assigned users between dates";
       throw new TasklistRuntimeException(message);
     }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -55,6 +55,7 @@ import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldSort;
 import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.opensearch._types.ScriptSortType;
@@ -112,7 +113,7 @@ public class TaskStoreOpenSearch implements TaskStore {
     try {
       final var rawTask = getTaskRawResponse(id);
       return rawTask.source();
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
@@ -134,7 +135,7 @@ public class TaskStoreOpenSearch implements TaskStore {
 
     try {
       return OpenSearchUtil.scrollUserTaskKeysToList(searchRequest, osClient);
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
@@ -155,7 +156,7 @@ public class TaskStoreOpenSearch implements TaskStore {
             .fields(f -> f.field(TaskTemplate.KEY));
     try {
       return OpenSearchUtil.scrollIdsWithIndexToMap(searchRequest, osClient);
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
@@ -186,7 +187,7 @@ public class TaskStoreOpenSearch implements TaskStore {
     final Hit taskBeforeSearchHit;
     try {
       taskBeforeSearchHit = getTaskRawResponse(String.valueOf(taskBefore.getKey()));
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
 
@@ -226,7 +227,7 @@ public class TaskStoreOpenSearch implements TaskStore {
     final Hit taskBeforeSearchHit;
     try {
       taskBeforeSearchHit = getTaskRawResponse(String.valueOf(taskBefore.getKey()));
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
 
@@ -277,8 +278,8 @@ public class TaskStoreOpenSearch implements TaskStore {
     try {
       final List<Hit<TaskEntity>> response = getTasksRawResponse(ids);
       return response.stream().map(Hit::source).collect(Collectors.toList());
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
+    } catch (final IOException | OpenSearchException e) {
+      throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
 
@@ -300,7 +301,7 @@ public class TaskStoreOpenSearch implements TaskStore {
           this::buildSearchCreatedTasksByProcessInstanceIdsRequest,
           TaskEntity.class,
           osClient);
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
@@ -434,7 +435,7 @@ public class TaskStoreOpenSearch implements TaskStore {
         }
       }
       return tasks;
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining tasks: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -988,7 +989,7 @@ public class TaskStoreOpenSearch implements TaskStore {
 
         listOfTaskIdsSets.add(taskIdsForCurrentVar);
 
-      } catch (final IOException e) {
+      } catch (final IOException | OpenSearchException e) {
         final String message =
             String.format("Exception occurred while obtaining taskIds: %s", e.getMessage());
         throw new TasklistRuntimeException(message, e);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -50,6 +50,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.ConstantScoreQuery;
@@ -99,7 +100,7 @@ public class VariableStoreOpenSearch implements VariableStore {
           chunk -> buildSearchVariablesByScopeFNIsAndVarNamesRequest(chunk, varNames, fieldNames),
           VariableEntity.class,
           osClient);
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining all variables: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -156,7 +157,7 @@ public class VariableStoreOpenSearch implements VariableStore {
           .collect(
               groupingBy(
                   SnapshotTaskVariableEntity::getTaskId, mapping(Function.identity(), toList())));
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining all variables: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -183,7 +184,7 @@ public class VariableStoreOpenSearch implements VariableStore {
 
     try {
       return OpenSearchUtil.scrollIdsWithIndexToMap(searchRequest, osClient);
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
@@ -213,7 +214,7 @@ public class VariableStoreOpenSearch implements VariableStore {
           this::buildSearchFNIByProcessInstanceKeysRequest,
           FlowNodeInstanceEntity.class,
           osClient);
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining all flow nodes: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -240,7 +241,7 @@ public class VariableStoreOpenSearch implements VariableStore {
       } else {
         throw new NotFoundException(String.format("Variable with id %s was not found", variableId));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining variable: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -266,7 +267,7 @@ public class VariableStoreOpenSearch implements VariableStore {
         throw new NotFoundException(
             String.format("Task variable with id %s was not found", variableId));
       }
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final String message =
           String.format("Exception occurred, while obtaining task variable: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -310,7 +311,7 @@ public class VariableStoreOpenSearch implements VariableStore {
             new HashSet<>(
                 OpenSearchUtil.scrollFieldToList(
                     searchRequestBuilder, PROCESS_INSTANCE_KEY, osClient));
-      } catch (final IOException e) {
+      } catch (final IOException | OpenSearchException e) {
         final String message =
             String.format(
                 "Exception occurred while obtaining flowNodeInstanceIds for variable %s: %s",

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
@@ -192,7 +192,7 @@ public abstract class OpenSearchUtil {
           }
         }
         LOGGER.debug("************* FLUSH BULK FINISH *************");
-      } catch (final IOException ex) {
+      } catch (final IOException | OpenSearchException ex) {
         throw new PersistenceException(
             "Error when processing bulk request against OpenSearch: " + ex.getMessage(), ex);
       }

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearchTest.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.store.elasticsearch;
 
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -17,6 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
@@ -24,6 +26,7 @@ import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.CommonUtils;
+import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.queries.TaskQuery;
 import io.camunda.tasklist.util.ElasticsearchTenantHelper;
 import io.camunda.tasklist.views.TaskSearchView;
@@ -117,6 +120,20 @@ class TaskStoreElasticSearchTest {
     // Then
     verify(tenantHelper).makeQueryTenantAware(any(Query.class), eq(Set.of("tenant_a", "tenant_b")));
     assertThat(result).hasSize(1);
+  }
+
+  @Test
+  void getTaskShouldWrapElasticsearchExceptionInTasklistRuntimeException() throws IOException {
+    // Given a server-side ES failure (e.g. "all shards failed") surfaces as an
+    // ElasticsearchException, which is a RuntimeException rather than an IOException.
+    when(tenantHelper.makeQueryTenantAware(any(Query.class))).thenAnswer(i -> i.getArgument(0));
+    when(esClient.search(any(SearchRequest.class), eq(TaskEntity.class)))
+        .thenThrow(mock(ElasticsearchException.class));
+
+    // When / Then it must be mapped to a TasklistRuntimeException (handled at WARN) instead of
+    // leaking to the generic exception handler (logged at ERROR). See issue #35823.
+    assertThatThrownBy(() -> instance.getTask("123456789"))
+        .isInstanceOf(TasklistRuntimeException.class);
   }
 
   @SuppressWarnings("unchecked")

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearchTest.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.store.opensearch;
 
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -17,6 +18,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.queries.TaskQuery;
 import io.camunda.tasklist.tenant.TenantAwareOpenSearchClient;
 import io.camunda.tasklist.views.TaskSearchView;
@@ -38,6 +40,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
@@ -120,6 +123,19 @@ public class TaskStoreOpenSearchTest {
     // Then
     verify(tenantAwareClient, never()).search(any(), any(Class.class));
     assertThat(result).hasSize(1);
+  }
+
+  @Test
+  void getTaskShouldWrapOpenSearchExceptionInTasklistRuntimeException() throws IOException {
+    // Given a server-side OS failure (e.g. "all shards failed") surfaces as an
+    // OpenSearchException, which is a RuntimeException rather than an IOException.
+    when(tenantAwareClient.search(any(), eq(TaskEntity.class)))
+        .thenThrow(mock(OpenSearchException.class));
+
+    // When / Then it must be mapped to a TasklistRuntimeException (handled at WARN) instead of
+    // leaking to the generic exception handler (logged at ERROR). See issue #35823.
+    assertThatThrownBy(() -> instance.getTask("123456789"))
+        .isInstanceOf(TasklistRuntimeException.class);
   }
 
   private static TaskEntity getTaskEntity(final TaskState taskState) {


### PR DESCRIPTION
## Description

Server-side Elasticsearch/OpenSearch failures (e.g. *"all shards failed"*, node-not-connected) surface as `ElasticsearchException`/`OpenSearchException` — both **`RuntimeException`s**, not `IOException`. Tasklist store methods only caught `IOException`, so these exceptions leaked **past** the `TasklistRuntimeException` handler (logs WARN, returns 500) straight to the generic `Exception` handler in `ApiErrorController`, which logs them at **ERROR** as *"Unexpected exception happened"*.

This is the cause of the stacktrace reported in [#35823 (comment)](https://github.com/camunda/camunda/issues/35823#issuecomment-4305980592): a `getTaskById` REST call hit `TaskStoreElasticSearch.getRawTaskByUserTaskKey`, which threw `ElasticsearchException` during an ES connectivity blip and got logged as an unexpected ERROR rather than a handled WARN.

## Fix

Widen the `catch (IOException e)` clauses to `catch (IOException | ElasticsearchException e)` / `catch (IOException | OpenSearchException e)` across **every** Tasklist store method that issues an ES/OS client call, wrapping into `TasklistRuntimeException`. This matches the convention already present in `FormStoreOpenSearch`.

- `NotFoundException` (a `TasklistRuntimeException` subtype, unrelated to the client exception types) still propagates untouched, so 404 mapping is preserved.
- Two raw `throw new RuntimeException(e)` (ES & OS `getTasksById`) are upgraded to `TasklistRuntimeException` so they too land at WARN.

Beyond the reported call site, the same anti-pattern was swept and fixed across all Tasklist store classes (30 sites / 12 files):

| Layer | Files |
|---|---|
| ES stores | `TaskStore`, `FormStore`, `ProcessStore`, `VariableStore`, `DraftVariablesStore`, `TaskMetricsStore` |
| OS stores | `TaskStore`, `FormStore`, `ProcessStore`, `VariableStore`, `DraftVariablesStore` + `OpenSearchUtil.processBulkRequest` |

**Verified not affected:** webapp service/util `IOException` catches that only do JSON deserialization or file I/O (no client call); `FormStore*.getFormByKey` which already had a dedicated `OpenSearchException` catch; and the `scrollAllStream` util whose store callers already catch broad `Exception`.

## Tests

Added `getTaskShouldWrap{Elasticsearch,OpenSearch}ExceptionInTasklistRuntimeException` to the ES/OS `TaskStore` test classes, asserting a client-thrown `*Exception` is mapped to `TasklistRuntimeException` rather than leaking. 

closes #35823

🤖 Generated with [Claude Code](https://claude.com/claude-code)
