### PR TITLE
feat: expose retry attempt counts

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableRetryStrategy.java
@@ -11,14 +11,15 @@ import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.retry.ActorRetryMechanism.Control;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 
 public final class AbortableRetryStrategy implements RetryStrategy {
 
   private final ActorControl actor;
   private final ActorRetryMechanism retryMechanism;
+  private final AtomicInteger retryCount = new AtomicInteger();
   private CompletableActorFuture<Boolean> currentFuture;
-  private volatile int retryCount;
 
   public AbortableRetryStrategy(final ActorControl actor) {
     this.actor = actor;
@@ -34,7 +35,7 @@ public final class AbortableRetryStrategy implements RetryStrategy {
   public ActorFuture<Boolean> runWithRetry(
       final OperationToRetry callable, final BooleanSupplier condition) {
     currentFuture = new CompletableActorFuture<>();
-    retryCount = 0;
+    retryCount.set(0);
     retryMechanism.wrap(callable, condition, currentFuture);
 
     actor.run(this::run);
@@ -44,14 +45,14 @@ public final class AbortableRetryStrategy implements RetryStrategy {
 
   @Override
   public int getRetryCount() {
-    return retryCount;
+    return retryCount.get();
   }
 
   private void run() {
     try {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
-        retryCount++;
+        retryCount.incrementAndGet();
         actor.run(this::run);
         actor.yieldThread();
       }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableRetryStrategy.java
@@ -18,6 +18,7 @@ public final class AbortableRetryStrategy implements RetryStrategy {
   private final ActorControl actor;
   private final ActorRetryMechanism retryMechanism;
   private CompletableActorFuture<Boolean> currentFuture;
+  private volatile int retryCount;
 
   public AbortableRetryStrategy(final ActorControl actor) {
     this.actor = actor;
@@ -33,6 +34,7 @@ public final class AbortableRetryStrategy implements RetryStrategy {
   public ActorFuture<Boolean> runWithRetry(
       final OperationToRetry callable, final BooleanSupplier condition) {
     currentFuture = new CompletableActorFuture<>();
+    retryCount = 0;
     retryMechanism.wrap(callable, condition, currentFuture);
 
     actor.run(this::run);
@@ -40,10 +42,16 @@ public final class AbortableRetryStrategy implements RetryStrategy {
     return currentFuture;
   }
 
+  @Override
+  public int getRetryCount() {
+    return retryCount;
+  }
+
   private void run() {
     try {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
+        retryCount++;
         actor.run(this::run);
         actor.yieldThread();
       }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/BackOffRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/BackOffRetryStrategy.java
@@ -23,6 +23,7 @@ public final class BackOffRetryStrategy implements RetryStrategy {
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier currentTerminateCondition;
   private OperationToRetry currentCallable;
+  private volatile int retryCount;
 
   public BackOffRetryStrategy(final ActorControl actor, final Duration maxBackOff) {
     this(actor, maxBackOff, Duration.ofSeconds(1));
@@ -47,10 +48,16 @@ public final class BackOffRetryStrategy implements RetryStrategy {
     currentTerminateCondition = terminateCondition;
     currentCallable = callable;
     backOffDuration = initialBackOff;
+    retryCount = 0;
 
     actor.run(this::run);
 
     return currentFuture;
+  }
+
+  @Override
+  public int getRetryCount() {
+    return retryCount;
   }
 
   private void run() {
@@ -72,6 +79,7 @@ public final class BackOffRetryStrategy implements RetryStrategy {
   }
 
   private void backOff() {
+    retryCount++;
     final boolean notReachedMaxBackOff = !backOffDuration.equals(maxBackOff);
     if (notReachedMaxBackOff) {
       final Duration nextBackOff = backOffDuration.multipliedBy(2);

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/BackOffRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/BackOffRetryStrategy.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 
 public final class BackOffRetryStrategy implements RetryStrategy {
@@ -18,12 +19,12 @@ public final class BackOffRetryStrategy implements RetryStrategy {
   private final ActorControl actor;
   private final Duration maxBackOff;
   private final Duration initialBackOff;
+  private final AtomicInteger retryCount = new AtomicInteger();
 
   private Duration backOffDuration;
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier currentTerminateCondition;
   private OperationToRetry currentCallable;
-  private volatile int retryCount;
 
   public BackOffRetryStrategy(final ActorControl actor, final Duration maxBackOff) {
     this(actor, maxBackOff, Duration.ofSeconds(1));
@@ -48,7 +49,7 @@ public final class BackOffRetryStrategy implements RetryStrategy {
     currentTerminateCondition = terminateCondition;
     currentCallable = callable;
     backOffDuration = initialBackOff;
-    retryCount = 0;
+    retryCount.set(0);
 
     actor.run(this::run);
 
@@ -57,7 +58,7 @@ public final class BackOffRetryStrategy implements RetryStrategy {
 
   @Override
   public int getRetryCount() {
-    return retryCount;
+    return retryCount.get();
   }
 
   private void run() {
@@ -79,7 +80,7 @@ public final class BackOffRetryStrategy implements RetryStrategy {
   }
 
   private void backOff() {
-    retryCount++;
+    retryCount.incrementAndGet();
     final boolean notReachedMaxBackOff = !backOffDuration.equals(maxBackOff);
     if (notReachedMaxBackOff) {
       final Duration nextBackOff = backOffDuration.multipliedBy(2);

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.retry.ActorRetryMechanism.Control;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,9 +26,9 @@ public final class EndlessRetryStrategy implements RetryStrategy {
   private final ActorRetryMechanism retryMechanism;
   private final int maxRetries;
   private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
+  private final AtomicInteger retryCount = new AtomicInteger();
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier terminateCondition;
-  private volatile int retryCount;
 
   public EndlessRetryStrategy(final ActorControl actor) {
     this(actor, Integer.MAX_VALUE);
@@ -49,7 +50,7 @@ public final class EndlessRetryStrategy implements RetryStrategy {
       final OperationToRetry callable, final BooleanSupplier condition) {
     currentFuture = new CompletableActorFuture<>();
     terminateCondition = condition;
-    retryCount = 0;
+    retryCount.set(0);
     retryMechanism.wrap(callable, terminateCondition, currentFuture);
 
     actor.run(this::run);
@@ -59,14 +60,15 @@ public final class EndlessRetryStrategy implements RetryStrategy {
 
   @Override
   public int getRetryCount() {
-    return retryCount;
+    return retryCount.get();
   }
 
   private void run() {
     try {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
-        if (!retryLimitExceeded(++retryCount, maxRetries, null, LOG, currentFuture)) {
+        if (!retryLimitExceeded(
+            retryCount.incrementAndGet(), maxRetries, null, LOG, currentFuture)) {
           actor.run(this::run);
           actor.yieldThread();
         }
@@ -74,15 +76,18 @@ public final class EndlessRetryStrategy implements RetryStrategy {
     } catch (final Exception exception) {
       if (terminateCondition.getAsBoolean()) {
         currentFuture.complete(false);
-      } else if (!retryLimitExceeded(++retryCount, maxRetries, exception, LOG, currentFuture)) {
-        throttledLog.warn(
-            "Caught recoverable exception (retry {}/{}), will retry: {}",
-            retryCount,
-            maxRetries,
-            exception.getMessage(),
-            exception);
-        actor.run(this::run);
-        actor.yieldThread();
+      } else {
+        final int retries = retryCount.incrementAndGet();
+        if (!retryLimitExceeded(retries, maxRetries, exception, LOG, currentFuture)) {
+          throttledLog.warn(
+              "Caught recoverable exception (retry {}/{}), will retry: {}",
+              retries,
+              maxRetries,
+              exception.getMessage(),
+              exception);
+          actor.run(this::run);
+          actor.yieldThread();
+        }
       }
     }
   }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
@@ -27,7 +27,7 @@ public final class EndlessRetryStrategy implements RetryStrategy {
   private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier terminateCondition;
-  private int retryCount;
+  private volatile int retryCount;
 
   public EndlessRetryStrategy(final ActorControl actor) {
     this(actor, Integer.MAX_VALUE);
@@ -55,6 +55,11 @@ public final class EndlessRetryStrategy implements RetryStrategy {
     actor.run(this::run);
 
     return currentFuture;
+  }
+
+  @Override
+  public int getRetryCount() {
+    return retryCount;
   }
 
   private void run() {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.scheduler.retry.ActorRetryMechanism.Control;
 import io.camunda.zeebe.util.exception.RecoverableException;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,9 +27,9 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
   private final ActorRetryMechanism retryMechanism;
   private final int maxRetries;
   private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
+  private final AtomicInteger retryCount = new AtomicInteger();
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier terminateCondition;
-  private volatile int retryCount;
 
   public RecoverableRetryStrategy(final ActorControl actor) {
     this(actor, Integer.MAX_VALUE);
@@ -50,7 +51,7 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
       final OperationToRetry callable, final BooleanSupplier condition) {
     currentFuture = new CompletableActorFuture<>();
     terminateCondition = condition;
-    retryCount = 0;
+    retryCount.set(0);
     retryMechanism.wrap(callable, terminateCondition, currentFuture);
 
     actor.run(this::run);
@@ -60,24 +61,26 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
 
   @Override
   public int getRetryCount() {
-    return retryCount;
+    return retryCount.get();
   }
 
   private void run() {
     try {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
-        if (!retryLimitExceeded(++retryCount, maxRetries, null, LOG, currentFuture)) {
+        if (!retryLimitExceeded(
+            retryCount.incrementAndGet(), maxRetries, null, LOG, currentFuture)) {
           actor.run(this::run);
           actor.yieldThread();
         }
       }
     } catch (final RecoverableException ex) {
       if (!terminateCondition.getAsBoolean()) {
-        if (!retryLimitExceeded(++retryCount, maxRetries, ex, LOG, currentFuture)) {
+        final int retries = retryCount.incrementAndGet();
+        if (!retryLimitExceeded(retries, maxRetries, ex, LOG, currentFuture)) {
           throttledLog.warn(
               "Caught recoverable exception (retry {}/{}), will retry: {}",
-              retryCount,
+              retries,
               maxRetries,
               ex.getMessage(),
               ex);

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
@@ -28,7 +28,7 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
   private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier terminateCondition;
-  private int retryCount;
+  private volatile int retryCount;
 
   public RecoverableRetryStrategy(final ActorControl actor) {
     this(actor, Integer.MAX_VALUE);
@@ -56,6 +56,11 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
     actor.run(this::run);
 
     return currentFuture;
+  }
+
+  @Override
+  public int getRetryCount() {
+    return retryCount;
   }
 
   private void run() {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RetryStrategy.java
@@ -39,6 +39,16 @@ public interface RetryStrategy {
   ActorFuture<Boolean> runWithRetry(OperationToRetry callable, BooleanSupplier terminateCondition);
 
   /**
+   * Returns how many retry attempts have been scheduled for the current operation.
+   *
+   * <p>The initial execution is not counted as a retry. Implementations reset the counter when a
+   * new operation is passed to {@link #runWithRetry(OperationToRetry, BooleanSupplier)}.
+   *
+   * @return the number of retry attempts for the current operation
+   */
+  int getRetryCount();
+
+  /**
    * Checks whether the retry limit has been exceeded. If the limit is exceeded, logs an error and
    * completes the given future exceptionally with a {@link RetryLimitExceededException}.
    *

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
@@ -57,6 +57,44 @@ final class RetryStrategyTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"endless", "recoverable", "abortable", "backoff"})
+  void shouldExposeRetryCount(final TestCase<?> test) {
+    // given
+    final var count = new AtomicInteger(0);
+    schedulerRule.submitActor(test.actor);
+
+    // when
+    test.actor.run(
+        () -> resultFuture = test.strategy.runWithRetry(() -> count.incrementAndGet() == 4));
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(count.get()).isEqualTo(4);
+    assertThat(resultFuture).succeedsWithin(Duration.ZERO).isEqualTo(true);
+    assertThat(test.strategy.getRetryCount()).isEqualTo(3);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"endless", "recoverable", "abortable", "backoff"})
+  void shouldResetExposedRetryCountOnNewRunWithRetry(final TestCase<?> test) {
+    // given
+    final var count = new AtomicInteger(0);
+    schedulerRule.submitActor(test.actor);
+    test.actor.run(
+        () -> resultFuture = test.strategy.runWithRetry(() -> count.incrementAndGet() == 4));
+    schedulerRule.workUntilDone();
+    assertThat(test.strategy.getRetryCount()).isEqualTo(3);
+
+    // when
+    test.actor.run(() -> resultFuture = test.strategy.runWithRetry(() -> true));
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(resultFuture).succeedsWithin(Duration.ZERO).isEqualTo(true);
+    assertThat(test.strategy.getRetryCount()).isZero();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"endless", "recoverable", "abortable", "backoff"})
   void shouldStopWhenAbortConditionReturnsTrue(final TestCase<?> test) {
     // given
     final AtomicInteger count = new AtomicInteger(0);


### PR DESCRIPTION
## Description

Retry strategies already know when an operation is being retried, but callers cannot inspect how many retries have been scheduled for the current operation. That makes retry loops harder to diagnose when investigating scheduler or processor behavior.

This adds `RetryStrategy#getRetryCount()` and wires the scheduler retry strategies to expose the current operation's retry-attempt count. The initial execution is not counted as a retry, counts reset on each new `runWithRetry(...)`, and the counters are `volatile` so diagnostic readers can observe actor-thread updates.

Validation:
- `gh run list --branch main --limit 5 --repo camunda/camunda`
- `.\mvnw.cmd install -Dquickly -T1C`
- `.\mvnw.cmd license:format spotless:apply -T1C`
- `.\mvnw.cmd -pl zeebe\scheduler "-Dtest=RetryStrategyTest" -DskipTests=false -DskipITs -Dquickly test`
- `.\mvnw.cmd -pl zeebe\scheduler clean verify -DskipTests=false -Dquickly -T1`
- `git diff --check`

## Checklist

- [x] No backport is required for this internal observability API change.
- [x] This PR does not modify the C8 Orchestration Cluster E2E Test Suite.

## Related issues

Closes #50990
