### PR TITLE
feat: add OIDC redirect diagnostics and Entra token-version guard

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -22,6 +22,7 @@ import io.camunda.authentication.csrf.CsrfProtectionRequestMatcher;
 import io.camunda.authentication.exception.BasicAuthenticationNotSupportedException;
 import io.camunda.authentication.filters.AdminUserCheckFilter;
 import io.camunda.authentication.filters.OAuth2RefreshTokenFilter;
+import io.camunda.authentication.filters.OidcRedirectDiagnosticsFilter;
 import io.camunda.authentication.filters.WebComponentAuthorizationCheckFilter;
 import io.camunda.authentication.handler.AuthFailureHandler;
 import io.camunda.authentication.handler.LoggingAuthenticationFailureHandler;
@@ -115,6 +116,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter;
@@ -1175,9 +1177,25 @@ public class WebSecurityConfig {
 
       applyOauth2RefreshTokenFilter(
           httpSecurity, authorizedClientRepository, authorizedClientManager);
+      applyOidcRedirectDiagnosticsFilter(httpSecurity, securityConfiguration);
       applyCsrfConfiguration(httpSecurity, securityConfiguration, csrfTokenRepository);
 
       return filterChainBuilder.build();
+    }
+
+    private void applyOidcRedirectDiagnosticsFilter(
+        final HttpSecurity httpSecurity, final SecurityConfiguration securityConfiguration) {
+      if (securityConfiguration.getAuthentication().getOidc().getDiagnostics().isEnabled()) {
+        // Positioned before the redirect filter so the diagnostics filter wraps the redirect
+        // generation and can inspect the resulting Location header on the way back out.
+        httpSecurity.addFilterBefore(
+            new OidcRedirectDiagnosticsFilter(REDIRECT_URI),
+            OAuth2AuthorizationRequestRedirectFilter.class);
+        LOG.info(
+            "OIDC redirect diagnostics filter enabled (camunda.security.authentication.oidc.diagnostics.enabled=true). "
+                + "Enable DEBUG logging for {} to see full redirect diagnostics.",
+            OidcRedirectDiagnosticsFilter.class.getName());
+      }
     }
 
     private Customizer<ProtectedResourceMetadataConfigurer>

--- a/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
@@ -13,11 +13,23 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.OidcPrincipalLoader;
 import io.camunda.security.configuration.SecurityConfiguration;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 
 public class TokenClaimsConverter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TokenClaimsConverter.class);
+
+  // Microsoft identity platform issuer hosts. v2.0 tokens are issued by login.microsoftonline.com
+  // (issuer ends in /v2.0); v1.0 tokens are issued by sts.windows.net.
+  private static final String MS_ISSUER_V2_HOST = "login.microsoftonline.com";
+  private static final String MS_ISSUER_V1_HOST = "sts.windows.net";
+  private static final String ISSUER_CLAIM = "iss";
+  private static final String TOKEN_VERSION_CLAIM = "ver";
+  private static final String REQUIRED_ENTRA_TOKEN_VERSION = "2.0";
 
   private final OidcPrincipalLoader oidcPrincipalLoader;
   private final String usernameClaim;
@@ -37,6 +49,8 @@ public class TokenClaimsConverter {
   }
 
   public CamundaAuthentication convert(final Map<String, Object> tokenClaims) {
+    validateEntraTokenVersion(tokenClaims);
+
     final var principals = oidcPrincipalLoader.load(tokenClaims);
     final var username = principals.username();
     final var clientId = principals.clientId();
@@ -60,5 +74,42 @@ public class TokenClaimsConverter {
     }
 
     return membershipService.resolveMemberships(tokenClaims, principalName, principalType);
+  }
+
+  /**
+   * Fails authentication hard when a Microsoft Entra (Azure AD) access token is not a v2.0 token.
+   *
+   * <p>Entra app registrations that leave {@code api.requestedAccessTokenVersion} unset emit v1.0
+   * access tokens (issuer {@code sts.windows.net}, {@code ver=1.0}). These fail downstream
+   * validation and typically manifest as a silent redirect loop back to Entra. Detecting the
+   * mismatch here turns that into a clear, actionable failure for operators.
+   */
+  private void validateEntraTokenVersion(final Map<String, Object> tokenClaims) {
+    final Object issuer = tokenClaims.get(ISSUER_CLAIM);
+    if (!(issuer instanceof final String issuerUri) || !isMicrosoftIssuer(issuerUri)) {
+      return;
+    }
+
+    final Object version = tokenClaims.get(TOKEN_VERSION_CLAIM);
+    if (REQUIRED_ENTRA_TOKEN_VERSION.equals(version)) {
+      return;
+    }
+
+    LOG.error(
+        "Rejected a Microsoft Entra access token from issuer '{}' with an unsupported access token version (ver='{}'). "
+            + "Camunda requires v2.0 access tokens. Set 'api.requestedAccessTokenVersion' to 2 in the Entra app registration "
+            + "manifest (Azure portal: App registrations > your app > Manifest) so the identity platform issues v2.0 tokens, "
+            + "then retry. v1.0 tokens otherwise fail validation and cause a redirect loop back to Entra.",
+        issuerUri,
+        version);
+
+    throw new OAuth2AuthenticationException(
+        new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN),
+        "Microsoft Entra access token version '%s' is not supported; v2.0 is required. Set api.requestedAccessTokenVersion = 2 in the Entra app registration manifest."
+            .formatted(version));
+  }
+
+  private static boolean isMicrosoftIssuer(final String issuerUri) {
+    return issuerUri.contains(MS_ISSUER_V2_HOST) || issuerUri.contains(MS_ISSUER_V1_HOST);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
@@ -110,6 +110,11 @@ public class TokenClaimsConverter {
   }
 
   private static boolean isMicrosoftIssuer(final String issuerUri) {
-    return issuerUri.contains(MS_ISSUER_V2_HOST) || issuerUri.contains(MS_ISSUER_V1_HOST);
+    try {
+      final String host = java.net.URI.create(issuerUri).getHost();
+      return MS_ISSUER_V2_HOST.equalsIgnoreCase(host) || MS_ISSUER_V1_HOST.equalsIgnoreCase(host);
+    } catch (final RuntimeException e) {
+      return false;
+    }
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
@@ -95,7 +95,17 @@ public class TokenClaimsConverter {
       return;
     }
 
-    LOG.error(
+    // Logged at WARN, not ERROR: this is a client/configuration fault (a bad incoming token) that
+    // is per-request and fully caller-controllable, so a client replaying a v1 token must not be
+    // able to flood ERROR logs or trip alerting. No stacktrace is logged for the same reason.
+    //
+    // This log mainly serves the bearer/API flow, whose entry point
+    // (AuthenticationEntryPointFailureHandler + BearerTokenAuthenticationEntryPoint) returns 401
+    // silently, leaving the actionable guidance otherwise invisible. On the webapp/login chain it
+    // is somewhat redundant with the container log of the bubbled OAuth2AuthenticationException;
+    // the
+    // guidance also lives in the exception message below.
+    LOG.warn(
         "Rejected a Microsoft Entra access token from issuer '{}' with an unsupported access token version (ver='{}'). "
             + "Camunda requires v2.0 access tokens. Set 'api.requestedAccessTokenVersion' to 2 in the Entra app registration "
             + "manifest (Azure portal: App registrations > your app > Manifest) so the identity platform issues v2.0 tokens, "

--- a/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
@@ -77,12 +77,15 @@ public class TokenClaimsConverter {
   }
 
   /**
-   * Fails authentication hard when a Microsoft Entra (Azure AD) access token is not a v2.0 token.
+   * Fails authentication hard when a Microsoft Entra (Azure AD) token is not a v2.0 token.
    *
-   * <p>Entra app registrations that leave {@code api.requestedAccessTokenVersion} unset emit v1.0
-   * access tokens (issuer {@code sts.windows.net}, {@code ver=1.0}). These fail downstream
-   * validation and typically manifest as a silent redirect loop back to Entra. Detecting the
-   * mismatch here turns that into a clear, actionable failure for operators.
+   * <p>{@code convert()} runs on both access-token claims (API/bearer flow) and ID-token claims
+   * (webapp login flow), so two distinct misconfigurations land here. Access tokens are emitted as
+   * v1.0 when the app registration leaves {@code api.requestedAccessTokenVersion} unset; ID tokens
+   * are v1.0 when the v1.0 authority is used instead of a {@code /v2.0} issuer endpoint. Both
+   * surface as {@code iss=sts.windows.net}, {@code ver=1.0}, fail downstream validation, and
+   * typically manifest as a silent redirect loop back to Entra. Detecting the mismatch here turns
+   * that into a clear, actionable failure for operators.
    */
   private void validateEntraTokenVersion(final Map<String, Object> tokenClaims) {
     final Object issuer = tokenClaims.get(ISSUER_CLAIM);
@@ -106,16 +109,17 @@ public class TokenClaimsConverter {
     // the
     // guidance also lives in the exception message below.
     LOG.warn(
-        "Rejected a Microsoft Entra access token from issuer '{}' with an unsupported access token version (ver='{}'). "
-            + "Camunda requires v2.0 access tokens. Set 'api.requestedAccessTokenVersion' to 2 in the Entra app registration "
-            + "manifest (Azure portal: App registrations > your app > Manifest) so the identity platform issues v2.0 tokens, "
-            + "then retry. v1.0 tokens otherwise fail validation and cause a redirect loop back to Entra.",
+        "Rejected a Microsoft Entra token from issuer '{}' with an unsupported token version (ver='{}'). "
+            + "Camunda requires v2.0 tokens. For access tokens (API/bearer flow), set 'api.requestedAccessTokenVersion' to 2 "
+            + "in the Entra app registration manifest (Azure portal: App registrations > your app > Manifest). For ID tokens "
+            + "(webapp login flow), configure the v2.0 authority by using an issuer-uri that ends in '/v2.0'. Then retry; "
+            + "v1.0 tokens otherwise fail validation and cause a redirect loop back to Entra.",
         issuerUri,
         version);
 
     throw new OAuth2AuthenticationException(
         new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN),
-        "Microsoft Entra access token version '%s' is not supported; v2.0 is required. Set api.requestedAccessTokenVersion = 2 in the Entra app registration manifest."
+        "Microsoft Entra token version '%s' is not supported; v2.0 is required. For access tokens, set api.requestedAccessTokenVersion = 2 in the Entra app registration manifest; for ID tokens (login flow), use a v2.0 issuer-uri ending in /v2.0."
             .formatted(version));
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilter.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Diagnostic filter that makes OIDC redirect issues visible in the application logs instead of
+ * requiring browser dev-tools. It is purely observational: it only reads the request/response and
+ * never mutates the response or short-circuits the chain, so it is safe to leave enabled.
+ *
+ * <p>It is registered only when {@code camunda.security.authentication.oidc.diagnostics.enabled} is
+ * {@code true} (see {@code WebSecurityConfig#applyOidcRedirectDiagnosticsFilter}).
+ *
+ * <p>Before the chain runs it logs (at DEBUG) the inputs that drive the redirect computation:
+ * forwarded headers, the computed external base URL, the configured callback path, the expected
+ * {@code redirect_uri}, the (secret-redacted) query parameters, and the HTTP session state.
+ *
+ * <p>After the chain runs it logs (at WARN) the two classic redirect-loop signatures:
+ *
+ * <ul>
+ *   <li>an authorization request ({@code /oauth2/authorization/*}) whose generated {@code Location}
+ *       carries a {@code redirect_uri} that does not match the expected one;
+ *   <li>a callback that received an authorization {@code code} but has no valid HTTP session.
+ * </ul>
+ */
+public class OidcRedirectDiagnosticsFilter extends OncePerRequestFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OidcRedirectDiagnosticsFilter.class);
+
+  private static final String AUTHORIZATION_REQUEST_PREFIX = "/oauth2/authorization/";
+  private static final Set<String> REDACTED_PARAMS =
+      Set.of("code", "client_secret", "id_token", "access_token", "token", "state", "credential");
+  private static final String REDACTED = "***";
+
+  private final String callbackPath;
+
+  public OidcRedirectDiagnosticsFilter(final String callbackPath) {
+    this.callbackPath = callbackPath;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final FilterChain filterChain)
+      throws ServletException, IOException {
+
+    final String externalBaseUrl = computeExternalBaseUrl(request);
+    final String expectedRedirectUri = externalBaseUrl + callbackPath;
+
+    logRequestDiagnostics(request, externalBaseUrl, expectedRedirectUri);
+
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      inspectResponse(request, response, expectedRedirectUri);
+    }
+  }
+
+  private void logRequestDiagnostics(
+      final HttpServletRequest request,
+      final String externalBaseUrl,
+      final String expectedRedirectUri) {
+    if (!LOG.isDebugEnabled()) {
+      return;
+    }
+    final HttpSession session = request.getSession(false);
+    LOG.debug(
+        "OIDC redirect diagnostics for {} {}: forwardedHeaders={}, externalBaseUrl={}, callbackPath={}, expectedRedirectUri={}, queryParams={}, session={}",
+        request.getMethod(),
+        request.getRequestURI(),
+        forwardedHeaders(request),
+        externalBaseUrl,
+        callbackPath,
+        expectedRedirectUri,
+        redactedQueryParams(request),
+        session == null ? "none" : "id=present,new=%s".formatted(session.isNew()));
+  }
+
+  private void inspectResponse(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final String expectedRedirectUri) {
+    final String requestUri = request.getRequestURI();
+
+    if (isAuthorizationRequest(requestUri)) {
+      final String location = response.getHeader(HttpHeaders.LOCATION);
+      final String actualRedirectUri = extractRedirectUri(location);
+      if (actualRedirectUri != null && !actualRedirectUri.equals(expectedRedirectUri)) {
+        LOG.warn(
+            "OIDC redirect_uri mismatch on {}: the authorization request sends redirect_uri={} but the server expected {} (derived from the external base URL + callback path). "
+                + "This is a classic cause of redirect loops; verify the IdP redirect URI registration and any reverse-proxy X-Forwarded-* headers.",
+            requestUri,
+            actualRedirectUri,
+            expectedRedirectUri);
+      }
+    }
+
+    if (isCallback(requestUri)
+        && request.getParameter("code") != null
+        && request.getSession(false) == null) {
+      LOG.warn(
+          "OIDC callback {} received an authorization code but there is no valid HTTP session. "
+              + "The session created at the start of the login was lost before the callback (likely a redirect/login loop); "
+              + "check session cookie attributes (SameSite/Secure/domain) and that the external base URL matches across the login and callback requests.",
+          requestUri);
+    }
+  }
+
+  private boolean isAuthorizationRequest(final String requestUri) {
+    return requestUri != null && requestUri.contains(AUTHORIZATION_REQUEST_PREFIX);
+  }
+
+  private boolean isCallback(final String requestUri) {
+    return requestUri != null && callbackPath != null && requestUri.startsWith(callbackPath);
+  }
+
+  private static String extractRedirectUri(final String location) {
+    if (location == null || location.isBlank()) {
+      return null;
+    }
+    try {
+      final var params = UriComponentsBuilder.fromUriString(location).build().getQueryParams();
+      final String value = params.getFirst("redirect_uri");
+      return value == null ? null : URI.create(value).toString();
+    } catch (final RuntimeException e) {
+      LOG.debug("Could not parse redirect_uri from Location header '{}'", location, e);
+      return null;
+    }
+  }
+
+  private static Map<String, String> forwardedHeaders(final HttpServletRequest request) {
+    final Map<String, String> headers = new LinkedHashMap<>();
+    for (final String name :
+        new String[] {
+          "X-Forwarded-Proto",
+          "X-Forwarded-Host",
+          "X-Forwarded-Port",
+          "X-Forwarded-Prefix",
+          "Forwarded"
+        }) {
+      final String value = request.getHeader(name);
+      if (value != null) {
+        headers.put(name, value);
+      }
+    }
+    return headers;
+  }
+
+  private static Map<String, String> redactedQueryParams(final HttpServletRequest request) {
+    final Map<String, String> params = new LinkedHashMap<>();
+    request
+        .getParameterMap()
+        .forEach(
+            (key, values) ->
+                params.put(
+                    key, REDACTED_PARAMS.contains(key) ? REDACTED : String.join(",", values)));
+    return params;
+  }
+
+  /**
+   * Computes the externally-visible base URL ({@code scheme://host[:port][prefix]}), honouring
+   * reverse-proxy forwarded headers when present and falling back to the servlet request otherwise.
+   */
+  private static String computeExternalBaseUrl(final HttpServletRequest request) {
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromUriString(request.getRequestURL().toString())
+            .replacePath(null)
+            .replaceQuery(null);
+
+    final String forwardedProto = request.getHeader("X-Forwarded-Proto");
+    if (forwardedProto != null && !forwardedProto.isBlank()) {
+      builder.scheme(firstToken(forwardedProto));
+    }
+
+    final String forwardedHost = request.getHeader("X-Forwarded-Host");
+    if (forwardedHost != null && !forwardedHost.isBlank()) {
+      final String host = firstToken(forwardedHost);
+      final int colon = host.indexOf(':');
+      if (colon >= 0) {
+        builder.host(host.substring(0, colon)).port(host.substring(colon + 1));
+      } else {
+        builder.host(host).port(null);
+      }
+    }
+
+    final String forwardedPort = request.getHeader("X-Forwarded-Port");
+    if (forwardedPort != null && !forwardedPort.isBlank()) {
+      builder.port(firstToken(forwardedPort));
+    }
+
+    final String forwardedPrefix = request.getHeader("X-Forwarded-Prefix");
+    final String prefix =
+        forwardedPrefix != null && !forwardedPrefix.isBlank()
+            ? stripTrailingSlash(firstToken(forwardedPrefix))
+            : stripTrailingSlash(request.getContextPath());
+
+    return builder.build().toUriString() + prefix;
+  }
+
+  private static String firstToken(final String headerValue) {
+    final int comma = headerValue.indexOf(',');
+    return (comma >= 0 ? headerValue.substring(0, comma) : headerValue).trim();
+  }
+
+  private static String stripTrailingSlash(final String value) {
+    if (value == null || value.isBlank() || "/".equals(value)) {
+      return "";
+    }
+    return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilter.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -195,13 +196,7 @@ public class OidcRedirectDiagnosticsFilter extends OncePerRequestFilter {
 
     final String forwardedHost = request.getHeader("X-Forwarded-Host");
     if (forwardedHost != null && !forwardedHost.isBlank()) {
-      final String host = firstToken(forwardedHost);
-      final int colon = host.indexOf(':');
-      if (colon >= 0) {
-        builder.host(host.substring(0, colon)).port(host.substring(colon + 1));
-      } else {
-        builder.host(host).port(null);
-      }
+      applyForwardedHost(builder, firstToken(forwardedHost));
     }
 
     final String forwardedPort = request.getHeader("X-Forwarded-Port");
@@ -216,6 +211,27 @@ public class OidcRedirectDiagnosticsFilter extends OncePerRequestFilter {
             : stripTrailingSlash(request.getContextPath());
 
     return builder.build().toUriString() + prefix;
+  }
+
+  /**
+   * Applies the {@code X-Forwarded-Host} value (host plus optional port) to the builder. Authority
+   * parsing is delegated to {@link UriComponentsBuilder} so bracketed IPv6 literals (e.g. {@code
+   * [2001:db8::1]:443}) are handled correctly; a naive {@code indexOf(':')} split would mangle
+   * them.
+   */
+  private static void applyForwardedHost(
+      final UriComponentsBuilder builder, final String hostHeader) {
+    try {
+      final UriComponents authority =
+          UriComponentsBuilder.fromUriString("x://" + hostHeader).build();
+      if (authority.getHost() != null && !authority.getHost().isBlank()) {
+        builder.host(authority.getHost());
+        // getPort() returns -1 when no port is present, which clears any port on the builder.
+        builder.port(authority.getPort());
+      }
+    } catch (final RuntimeException e) {
+      LOG.debug("Could not parse X-Forwarded-Host '{}'", hostHeader, e);
+    }
   }
 
   private static String firstToken(final String headerValue) {

--- a/authentication/src/main/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilter.java
@@ -132,7 +132,7 @@ public class OidcRedirectDiagnosticsFilter extends OncePerRequestFilter {
   }
 
   private boolean isCallback(final String requestUri) {
-    return requestUri != null && callbackPath != null && requestUri.startsWith(callbackPath);
+    return requestUri != null && callbackPath != null && requestUri.contains(callbackPath);
   }
 
   private static String extractRedirectUri(final String location) {

--- a/authentication/src/main/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilter.java
@@ -105,8 +105,7 @@ public class OidcRedirectDiagnosticsFilter extends OncePerRequestFilter {
     final String requestUri = request.getRequestURI();
 
     if (isAuthorizationRequest(requestUri)) {
-      final String location = response.getHeader(HttpHeaders.LOCATION);
-      final String actualRedirectUri = extractRedirectUri(location);
+      final String actualRedirectUri = extractRedirectUri(response.getHeader(HttpHeaders.LOCATION));
       if (actualRedirectUri != null && !actualRedirectUri.equals(expectedRedirectUri)) {
         LOG.warn(
             "OIDC redirect_uri mismatch on {}: the authorization request sends redirect_uri={} but the server expected {} (derived from the external base URL + callback path). "
@@ -117,9 +116,7 @@ public class OidcRedirectDiagnosticsFilter extends OncePerRequestFilter {
       }
     }
 
-    if (isCallback(requestUri)
-        && request.getParameter("code") != null
-        && request.getSession(false) == null) {
+    if (indicatesLostSession(request, callbackPath)) {
       LOG.warn(
           "OIDC callback {} received an authorization code but there is no valid HTTP session. "
               + "The session created at the start of the login was lost before the callback (likely a redirect/login loop); "
@@ -128,15 +125,25 @@ public class OidcRedirectDiagnosticsFilter extends OncePerRequestFilter {
     }
   }
 
-  private boolean isAuthorizationRequest(final String requestUri) {
+  static boolean isAuthorizationRequest(final String requestUri) {
     return requestUri != null && requestUri.contains(AUTHORIZATION_REQUEST_PREFIX);
   }
 
-  private boolean isCallback(final String requestUri) {
+  static boolean isCallback(final String requestUri, final String callbackPath) {
     return requestUri != null && callbackPath != null && requestUri.contains(callbackPath);
   }
 
-  private static String extractRedirectUri(final String location) {
+  /**
+   * Returns {@code true} when a callback request carries an authorization {@code code} but has no
+   * valid HTTP session — the classic signature of a session lost mid-login (a redirect/login loop).
+   */
+  static boolean indicatesLostSession(final HttpServletRequest request, final String callbackPath) {
+    return isCallback(request.getRequestURI(), callbackPath)
+        && request.getParameter("code") != null
+        && request.getSession(false) == null;
+  }
+
+  static String extractRedirectUri(final String location) {
     if (location == null || location.isBlank()) {
       return null;
     }
@@ -183,7 +190,7 @@ public class OidcRedirectDiagnosticsFilter extends OncePerRequestFilter {
    * Computes the externally-visible base URL ({@code scheme://host[:port][prefix]}), honouring
    * reverse-proxy forwarded headers when present and falling back to the servlet request otherwise.
    */
-  private static String computeExternalBaseUrl(final HttpServletRequest request) {
+  static String computeExternalBaseUrl(final HttpServletRequest request) {
     final UriComponentsBuilder builder =
         UriComponentsBuilder.fromUriString(request.getRequestURL().toString())
             .replacePath(null)

--- a/authentication/src/main/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilter.java
@@ -13,7 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
-import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -23,6 +23,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
 /**
  * Diagnostic filter that makes OIDC redirect issues visible in the application logs instead of
@@ -150,7 +151,10 @@ public class OidcRedirectDiagnosticsFilter extends OncePerRequestFilter {
     try {
       final var params = UriComponentsBuilder.fromUriString(location).build().getQueryParams();
       final String value = params.getFirst("redirect_uri");
-      return value == null ? null : URI.create(value).toString();
+      // getQueryParams() returns the raw, still percent-encoded value (real authorization redirects
+      // encode redirect_uri per the OAuth2 spec). Decode it so it can be compared against — and
+      // logged alongside — the plain expected redirect URI.
+      return value == null ? null : UriUtils.decode(value, StandardCharsets.UTF_8);
     } catch (final RuntimeException e) {
       LOG.debug("Could not parse redirect_uri from Location header '{}'", location, e);
       return null;

--- a/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterNoDbTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterNoDbTest.java
@@ -127,6 +127,75 @@ public class TokenClaimsConverterNoDbTest {
   }
 
   @Test
+  void shouldRejectEntraV1AccessToken() {
+    // given - a Microsoft Entra v1.0 access token (issuer sts.windows.net, ver=1.0)
+    final Map<String, Object> claims =
+        Map.of(
+            "preferred_username",
+            "testuser",
+            "iss",
+            "https://sts.windows.net/9188040d-6c67-4c5b-b112-36a304b66dad/",
+            "ver",
+            "1.0");
+
+    // when & then
+    assertThatThrownBy(() -> tokenClaimsConverter.convert(claims))
+        .isInstanceOf(OAuth2AuthenticationException.class)
+        .hasMessageContaining("requestedAccessTokenVersion");
+  }
+
+  @Test
+  void shouldAcceptEntraV2AccessToken() {
+    // given - a Microsoft Entra v2.0 access token
+    final Map<String, Object> claims =
+        Map.of(
+            "preferred_username",
+            "testuser",
+            "iss",
+            "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+            "ver",
+            "2.0");
+
+    // when
+    final var result = tokenClaimsConverter.convert(claims);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.authenticatedUsername()).isEqualTo("testuser");
+  }
+
+  @Test
+  void shouldRejectEntraTokenWithoutVersionClaim() {
+    // given - a Microsoft issuer but no ver claim (treated as non-v2)
+    final Map<String, Object> claims =
+        Map.of(
+            "preferred_username",
+            "testuser",
+            "iss",
+            "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0");
+
+    // when & then
+    assertThatThrownBy(() -> tokenClaimsConverter.convert(claims))
+        .isInstanceOf(OAuth2AuthenticationException.class)
+        .hasMessageContaining("requestedAccessTokenVersion");
+  }
+
+  @Test
+  void shouldNotApplyEntraGuardToNonMicrosoftIssuer() {
+    // given - a non-Microsoft issuer (e.g. Keycloak) with no ver claim
+    final Map<String, Object> claims =
+        Map.of(
+            "preferred_username", "testuser", "iss", "https://keycloak.example.com/realms/camunda");
+
+    // when
+    final var result = tokenClaimsConverter.convert(claims);
+
+    // then - unaffected by the Entra guard
+    assertThat(result).isNotNull();
+    assertThat(result.authenticatedUsername()).isEqualTo("testuser");
+  }
+
+  @Test
   void shouldHandleNoGroupsClaimConfiguration() {
     // given - service with no groups claim configured
     final var oidcConfig = new OidcAuthenticationConfiguration();

--- a/authentication/src/test/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilterTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.FilterChain;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class OidcRedirectDiagnosticsFilterTest {
+
+  private static final String CALLBACK_PATH = "/sso-callback";
+
+  private final OidcRedirectDiagnosticsFilter filter =
+      new OidcRedirectDiagnosticsFilter(CALLBACK_PATH);
+
+  private Logger filterLogger;
+  private Level originalLevel;
+  private CapturingAppender appender;
+
+  @BeforeEach
+  void setUp() {
+    final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+    filterLogger = ctx.getLogger(OidcRedirectDiagnosticsFilter.class.getName());
+    originalLevel = filterLogger.getLevel();
+    appender = new CapturingAppender();
+    appender.start();
+    filterLogger.addAppender(appender);
+    // ensure WARN events are not filtered out by the default root level
+    filterLogger.setLevel(Level.WARN);
+  }
+
+  @AfterEach
+  void tearDown() {
+    filterLogger.removeAppender(appender);
+    filterLogger.setLevel(originalLevel);
+  }
+
+  @Test
+  void shouldWarnWhenAuthorizationRedirectUriDoesNotMatch() throws Exception {
+    // given - an authorization request whose generated redirect_uri points at a different host
+    final MockHttpServletRequest request =
+        new MockHttpServletRequest("GET", "/oauth2/authorization/oidc");
+    request.setServerName("localhost");
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    final FilterChain chain =
+        (req, res) ->
+            ((MockHttpServletResponse) res)
+                .setHeader(
+                    HttpHeaders.LOCATION,
+                    "https://idp.example.com/authorize?client_id=x&redirect_uri=https://wrong-host/sso-callback");
+
+    // when
+    filter.doFilter(request, response, chain);
+
+    // then
+    assertThat(warnMessages())
+        .anySatisfy(
+            message ->
+                assertThat(message)
+                    .contains("redirect_uri mismatch")
+                    .contains("https://wrong-host/sso-callback"));
+  }
+
+  @Test
+  void shouldNotWarnWhenAuthorizationRedirectUriMatches() throws Exception {
+    // given - redirect_uri matches the expected externalBaseUrl + callback path
+    final MockHttpServletRequest request =
+        new MockHttpServletRequest("GET", "/oauth2/authorization/oidc");
+    request.setServerName("localhost");
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    final FilterChain chain =
+        (req, res) ->
+            ((MockHttpServletResponse) res)
+                .setHeader(
+                    HttpHeaders.LOCATION,
+                    "https://idp.example.com/authorize?client_id=x&redirect_uri=http://localhost/sso-callback");
+
+    // when
+    filter.doFilter(request, response, chain);
+
+    // then
+    assertThat(warnMessages()).noneMatch(message -> message.contains("redirect_uri mismatch"));
+  }
+
+  @Test
+  void shouldWarnWhenCallbackReceivesCodeWithoutSession() throws Exception {
+    // given - a callback carrying an authorization code but no HTTP session
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", CALLBACK_PATH);
+    request.setServerName("localhost");
+    request.setParameter("code", "auth-code-123");
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    // when
+    filter.doFilter(request, response, new MockFilterChain());
+
+    // then
+    assertThat(warnMessages()).anyMatch(message -> message.contains("no valid HTTP session"));
+  }
+
+  @Test
+  void shouldNotWarnWhenCallbackHasSession() throws Exception {
+    // given - a callback carrying a code and a valid session
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", CALLBACK_PATH);
+    request.setServerName("localhost");
+    request.setParameter("code", "auth-code-123");
+    request.getSession(true);
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    // when
+    filter.doFilter(request, response, new MockFilterChain());
+
+    // then
+    assertThat(warnMessages()).noneMatch(message -> message.contains("no valid HTTP session"));
+  }
+
+  private List<String> warnMessages() {
+    return appender.events.stream()
+        .filter(event -> event.getLevel() == Level.WARN)
+        .map(event -> event.getMessage().getFormattedMessage())
+        .toList();
+  }
+
+  /** Minimal in-memory Log4j2 appender that records the events it receives. */
+  private static final class CapturingAppender extends AbstractAppender {
+
+    private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+
+    private CapturingAppender() {
+      super("capturing", null, null, false, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(final LogEvent event) {
+      events.add(event.toImmutable());
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilterTest.java
@@ -104,6 +104,36 @@ public class OidcRedirectDiagnosticsFilterTest {
   }
 
   @Test
+  void shouldComputeExpectedRedirectUriFromBracketedIpv6ForwardedHost() throws Exception {
+    // given - the request comes through a reverse proxy reporting a bracketed IPv6 host + port.
+    // A naive ':' split would corrupt the IPv6 literal; the expected redirect_uri in the mismatch
+    // warning must preserve the full bracketed authority and its port.
+    final MockHttpServletRequest request =
+        new MockHttpServletRequest("GET", "/oauth2/authorization/oidc");
+    request.setServerName("internal-host");
+    request.addHeader("X-Forwarded-Proto", "https");
+    request.addHeader("X-Forwarded-Host", "[2001:db8::1]:8443");
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    final FilterChain chain =
+        (req, res) ->
+            ((MockHttpServletResponse) res)
+                .setHeader(
+                    HttpHeaders.LOCATION,
+                    "https://idp.example.com/authorize?client_id=x&redirect_uri=https://wrong-host/sso-callback");
+
+    // when
+    filter.doFilter(request, response, chain);
+
+    // then - the expected URI is derived correctly from the bracketed IPv6 authority + port
+    assertThat(warnMessages())
+        .anySatisfy(
+            message ->
+                assertThat(message)
+                    .contains("redirect_uri mismatch")
+                    .contains("https://[2001:db8::1]:8443/sso-callback"));
+  }
+
+  @Test
   void shouldWarnWhenCallbackReceivesCodeWithoutSession() throws Exception {
     // given - a callback carrying an authorization code but no HTTP session
     final MockHttpServletRequest request = new MockHttpServletRequest("GET", CALLBACK_PATH);

--- a/authentication/src/test/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilterTest.java
@@ -9,180 +9,124 @@ package io.camunda.authentication.filters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.servlet.FilterChain;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
-import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 
 public class OidcRedirectDiagnosticsFilterTest {
 
   private static final String CALLBACK_PATH = "/sso-callback";
 
-  private final OidcRedirectDiagnosticsFilter filter =
-      new OidcRedirectDiagnosticsFilter(CALLBACK_PATH);
-
-  private Logger filterLogger;
-  private Level originalLevel;
-  private CapturingAppender appender;
-
-  @BeforeEach
-  void setUp() {
-    final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-    filterLogger = ctx.getLogger(OidcRedirectDiagnosticsFilter.class.getName());
-    originalLevel = filterLogger.getLevel();
-    appender = new CapturingAppender();
-    appender.start();
-    filterLogger.addAppender(appender);
-    // ensure WARN events are not filtered out by the default root level
-    filterLogger.setLevel(Level.WARN);
-  }
-
-  @AfterEach
-  void tearDown() {
-    filterLogger.removeAppender(appender);
-    filterLogger.setLevel(originalLevel);
-  }
-
   @Test
-  void shouldWarnWhenAuthorizationRedirectUriDoesNotMatch() throws Exception {
-    // given - an authorization request whose generated redirect_uri points at a different host
+  void shouldComputeExternalBaseUrlFromForwardedHeaders() {
+    // given - a request behind a reverse proxy terminating TLS on a non-default port
     final MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/oauth2/authorization/oidc");
-    request.setServerName("localhost");
-    final MockHttpServletResponse response = new MockHttpServletResponse();
-    final FilterChain chain =
-        (req, res) ->
-            ((MockHttpServletResponse) res)
-                .setHeader(
-                    HttpHeaders.LOCATION,
-                    "https://idp.example.com/authorize?client_id=x&redirect_uri=https://wrong-host/sso-callback");
+    request.setServerName("internal-host");
+    request.addHeader("X-Forwarded-Proto", "https");
+    request.addHeader("X-Forwarded-Host", "auth.example.com:8443");
 
     // when
-    filter.doFilter(request, response, chain);
+    final String baseUrl = OidcRedirectDiagnosticsFilter.computeExternalBaseUrl(request);
 
     // then
-    assertThat(warnMessages())
-        .anySatisfy(
-            message ->
-                assertThat(message)
-                    .contains("redirect_uri mismatch")
-                    .contains("https://wrong-host/sso-callback"));
+    assertThat(baseUrl).isEqualTo("https://auth.example.com:8443");
   }
 
   @Test
-  void shouldNotWarnWhenAuthorizationRedirectUriMatches() throws Exception {
-    // given - redirect_uri matches the expected externalBaseUrl + callback path
-    final MockHttpServletRequest request =
-        new MockHttpServletRequest("GET", "/oauth2/authorization/oidc");
-    request.setServerName("localhost");
-    final MockHttpServletResponse response = new MockHttpServletResponse();
-    final FilterChain chain =
-        (req, res) ->
-            ((MockHttpServletResponse) res)
-                .setHeader(
-                    HttpHeaders.LOCATION,
-                    "https://idp.example.com/authorize?client_id=x&redirect_uri=http://localhost/sso-callback");
-
-    // when
-    filter.doFilter(request, response, chain);
-
-    // then
-    assertThat(warnMessages()).noneMatch(message -> message.contains("redirect_uri mismatch"));
-  }
-
-  @Test
-  void shouldComputeExpectedRedirectUriFromBracketedIpv6ForwardedHost() throws Exception {
-    // given - the request comes through a reverse proxy reporting a bracketed IPv6 host + port.
-    // A naive ':' split would corrupt the IPv6 literal; the expected redirect_uri in the mismatch
-    // warning must preserve the full bracketed authority and its port.
+  void shouldComputeExternalBaseUrlFromBracketedIpv6ForwardedHost() {
+    // given - the reverse proxy reports a bracketed IPv6 host + port. A naive ':' split would
+    // corrupt the IPv6 literal; the authority must be preserved verbatim.
     final MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/oauth2/authorization/oidc");
     request.setServerName("internal-host");
     request.addHeader("X-Forwarded-Proto", "https");
     request.addHeader("X-Forwarded-Host", "[2001:db8::1]:8443");
-    final MockHttpServletResponse response = new MockHttpServletResponse();
-    final FilterChain chain =
-        (req, res) ->
-            ((MockHttpServletResponse) res)
-                .setHeader(
-                    HttpHeaders.LOCATION,
-                    "https://idp.example.com/authorize?client_id=x&redirect_uri=https://wrong-host/sso-callback");
 
     // when
-    filter.doFilter(request, response, chain);
+    final String baseUrl = OidcRedirectDiagnosticsFilter.computeExternalBaseUrl(request);
 
-    // then - the expected URI is derived correctly from the bracketed IPv6 authority + port
-    assertThat(warnMessages())
-        .anySatisfy(
-            message ->
-                assertThat(message)
-                    .contains("redirect_uri mismatch")
-                    .contains("https://[2001:db8::1]:8443/sso-callback"));
+    // then
+    assertThat(baseUrl).isEqualTo("https://[2001:db8::1]:8443");
   }
 
   @Test
-  void shouldWarnWhenCallbackReceivesCodeWithoutSession() throws Exception {
+  void shouldHonourForwardedPrefixInExternalBaseUrl() {
+    // given - the app is served under a path prefix by the proxy
+    final MockHttpServletRequest request =
+        new MockHttpServletRequest("GET", "/oauth2/authorization/oidc");
+    request.setServerName("internal-host");
+    request.addHeader("X-Forwarded-Proto", "https");
+    request.addHeader("X-Forwarded-Host", "auth.example.com");
+    request.addHeader("X-Forwarded-Prefix", "/camunda/");
+
+    // when
+    final String baseUrl = OidcRedirectDiagnosticsFilter.computeExternalBaseUrl(request);
+
+    // then - trailing slash on the prefix is stripped
+    assertThat(baseUrl).isEqualTo("https://auth.example.com/camunda");
+  }
+
+  @Test
+  void shouldExtractRedirectUriFromLocationHeader() {
+    // given
+    final String location =
+        "https://idp.example.com/authorize?client_id=x&redirect_uri=https://app.example.com/sso-callback";
+
+    // when
+    final String redirectUri = OidcRedirectDiagnosticsFilter.extractRedirectUri(location);
+
+    // then
+    assertThat(redirectUri).isEqualTo("https://app.example.com/sso-callback");
+  }
+
+  @Test
+  void shouldReturnNullRedirectUriWhenLocationHasNoRedirectUriParam() {
+    assertThat(
+            OidcRedirectDiagnosticsFilter.extractRedirectUri("https://idp.example.com/authorize"))
+        .isNull();
+    assertThat(OidcRedirectDiagnosticsFilter.extractRedirectUri(null)).isNull();
+    assertThat(OidcRedirectDiagnosticsFilter.extractRedirectUri("")).isNull();
+  }
+
+  @Test
+  void shouldDetectAuthorizationRequests() {
+    assertThat(OidcRedirectDiagnosticsFilter.isAuthorizationRequest("/oauth2/authorization/oidc"))
+        .isTrue();
+    assertThat(OidcRedirectDiagnosticsFilter.isAuthorizationRequest("/sso-callback")).isFalse();
+    assertThat(OidcRedirectDiagnosticsFilter.isAuthorizationRequest(null)).isFalse();
+  }
+
+  @Test
+  void shouldFlagCallbackWithCodeAndNoSessionAsLostSession() {
     // given - a callback carrying an authorization code but no HTTP session
     final MockHttpServletRequest request = new MockHttpServletRequest("GET", CALLBACK_PATH);
-    request.setServerName("localhost");
     request.setParameter("code", "auth-code-123");
-    final MockHttpServletResponse response = new MockHttpServletResponse();
 
-    // when
-    filter.doFilter(request, response, new MockFilterChain());
-
-    // then
-    assertThat(warnMessages()).anyMatch(message -> message.contains("no valid HTTP session"));
+    // when / then
+    assertThat(OidcRedirectDiagnosticsFilter.indicatesLostSession(request, CALLBACK_PATH)).isTrue();
   }
 
   @Test
-  void shouldNotWarnWhenCallbackHasSession() throws Exception {
+  void shouldNotFlagCallbackWhenSessionIsPresent() {
     // given - a callback carrying a code and a valid session
     final MockHttpServletRequest request = new MockHttpServletRequest("GET", CALLBACK_PATH);
-    request.setServerName("localhost");
     request.setParameter("code", "auth-code-123");
     request.getSession(true);
-    final MockHttpServletResponse response = new MockHttpServletResponse();
 
-    // when
-    filter.doFilter(request, response, new MockFilterChain());
-
-    // then
-    assertThat(warnMessages()).noneMatch(message -> message.contains("no valid HTTP session"));
+    // when / then
+    assertThat(OidcRedirectDiagnosticsFilter.indicatesLostSession(request, CALLBACK_PATH))
+        .isFalse();
   }
 
-  private List<String> warnMessages() {
-    return appender.events.stream()
-        .filter(event -> event.getLevel() == Level.WARN)
-        .map(event -> event.getMessage().getFormattedMessage())
-        .toList();
-  }
+  @Test
+  void shouldNotFlagNonCallbackRequestAsLostSession() {
+    // given - an authorization request (not the callback) with no session
+    final MockHttpServletRequest request =
+        new MockHttpServletRequest("GET", "/oauth2/authorization/oidc");
+    request.setParameter("code", "auth-code-123");
 
-  /** Minimal in-memory Log4j2 appender that records the events it receives. */
-  private static final class CapturingAppender extends AbstractAppender {
-
-    private final List<LogEvent> events = new CopyOnWriteArrayList<>();
-
-    private CapturingAppender() {
-      super("capturing", null, null, false, Property.EMPTY_ARRAY);
-    }
-
-    @Override
-    public void append(final LogEvent event) {
-      events.add(event.toImmutable());
-    }
+    // when / then
+    assertThat(OidcRedirectDiagnosticsFilter.indicatesLostSession(request, CALLBACK_PATH))
+        .isFalse();
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/OidcRedirectDiagnosticsFilterTest.java
@@ -67,16 +67,32 @@ public class OidcRedirectDiagnosticsFilterTest {
   }
 
   @Test
-  void shouldExtractRedirectUriFromLocationHeader() {
-    // given
+  void shouldExtractAndDecodeRedirectUriFromLocationHeader() {
+    // given - a real authorization redirect Location, where
+    // OAuth2AuthorizationRequestRedirectFilter
+    // percent-encodes the redirect_uri query value per the OAuth2 spec
     final String location =
-        "https://idp.example.com/authorize?client_id=x&redirect_uri=https://app.example.com/sso-callback";
+        "https://idp.example.com/authorize?client_id=x&redirect_uri=https%3A%2F%2Fapp.example.com%2Fsso-callback";
+
+    // when
+    final String redirectUri = OidcRedirectDiagnosticsFilter.extractRedirectUri(location);
+
+    // then - returned decoded so it compares equal to the (plain) expected redirect URI; if it were
+    // left encoded the mismatch WARN would fire on every login
+    assertThat(redirectUri).isEqualTo("https://app.example.com/sso-callback");
+  }
+
+  @Test
+  void shouldExtractAndDecodeRedirectUriWithEncodedPortAndPath() {
+    // given - encoded redirect_uri including a port, as a proxied deployment would produce
+    final String location =
+        "https://idp.example.com/authorize?redirect_uri=https%3A%2F%2Fapp.example.com%3A8443%2Fcamunda%2Fsso-callback&client_id=x";
 
     // when
     final String redirectUri = OidcRedirectDiagnosticsFilter.extractRedirectUri(location);
 
     // then
-    assertThat(redirectUri).isEqualTo("https://app.example.com/sso-callback");
+    assertThat(redirectUri).isEqualTo("https://app.example.com:8443/camunda/sso-callback");
   }
 
   @Test

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -303,7 +303,7 @@ public class OidcAuthenticationConfiguration {
   }
 
   public void setDiagnostics(final OidcDiagnosticsConfiguration diagnostics) {
-    this.diagnostics = diagnostics;
+    this.diagnostics = diagnostics != null ? diagnostics : new OidcDiagnosticsConfiguration();
   }
 
   public boolean isSet() {

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -60,6 +60,7 @@ public class OidcAuthenticationConfiguration {
   private boolean userInfoEnabled = true;
   private OidcUserInfoAugmentationConfiguration userInfoAugmentation =
       new OidcUserInfoAugmentationConfiguration();
+  private OidcDiagnosticsConfiguration diagnostics = new OidcDiagnosticsConfiguration();
 
   @PostConstruct
   public void validate() {
@@ -297,6 +298,14 @@ public class OidcAuthenticationConfiguration {
     this.userInfoAugmentation = userInfoAugmentation;
   }
 
+  public OidcDiagnosticsConfiguration getDiagnostics() {
+    return diagnostics;
+  }
+
+  public void setDiagnostics(final OidcDiagnosticsConfiguration diagnostics) {
+    this.diagnostics = diagnostics;
+  }
+
   public boolean isSet() {
     return issuerUri != null
         || clientId != null
@@ -329,7 +338,8 @@ public class OidcAuthenticationConfiguration {
         || assertionConfiguration.getKidDigestAlgorithm() != KidDigestAlgorithm.SHA256
         || assertionConfiguration.getKidEncoding() != KidEncoding.BASE64URL
         || assertionConfiguration.getKidCase() != null
-        || !DEFAULT_CLOCK_SKEW.equals(clockSkew);
+        || !DEFAULT_CLOCK_SKEW.equals(clockSkew)
+        || diagnostics.isEnabled();
   }
 
   public static Builder builder() {
@@ -366,6 +376,7 @@ public class OidcAuthenticationConfiguration {
     private boolean userInfoEnabled = true;
     private OidcUserInfoAugmentationConfiguration userInfoAugmentation =
         new OidcUserInfoAugmentationConfiguration();
+    private OidcDiagnosticsConfiguration diagnostics = new OidcDiagnosticsConfiguration();
 
     public Builder issuerUri(final String issuerUri) {
       this.issuerUri = issuerUri;
@@ -505,6 +516,11 @@ public class OidcAuthenticationConfiguration {
       return this;
     }
 
+    public Builder diagnostics(final OidcDiagnosticsConfiguration diagnostics) {
+      this.diagnostics = diagnostics;
+      return this;
+    }
+
     public OidcAuthenticationConfiguration build() {
       final OidcAuthenticationConfiguration config = new OidcAuthenticationConfiguration();
       config.setIssuerUri(issuerUri);
@@ -534,6 +550,7 @@ public class OidcAuthenticationConfiguration {
       config.setIdpLogoutEnabled(idpLogoutEnabled);
       config.setUserInfoEnabled(userInfoEnabled);
       config.setUserInfoAugmentation(userInfoAugmentation);
+      config.setDiagnostics(diagnostics);
       return config;
     }
   }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcDiagnosticsConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcDiagnosticsConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+/**
+ * Optional OIDC redirect diagnostics. When enabled, the auth stack logs the inputs that drive the
+ * OIDC redirect computation (forwarded headers, computed external base URL, configured callback
+ * path, expected vs. actual {@code redirect_uri}) and warns on the typical redirect-loop
+ * signatures. Purely diagnostic and off by default.
+ */
+public class OidcDiagnosticsConfiguration {
+
+  private boolean enabled = false;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+}


### PR DESCRIPTION
Adds two operator-facing diagnostics to the consolidated-auth stack to make OIDC redirect/login-loop issues visible in logs instead of relying on browser tools.

OidcRedirectDiagnosticsFilter (opt-in, default off via camunda.security.authentication.oidc.diagnostics.enabled): logs the inputs that drive the redirect computation (forwarded headers, computed external base URL, callback path, expected redirect_uri, secret-redacted query params, session state) and warns on the classic redirect-loop signatures - actual vs expected redirect_uri mismatch on /oauth2/authorization/*, and an authorization code arriving at /sso-callback with no HTTP session. Wired into the webapp security chain only.

Entra token-version guard (always-on) in TokenClaimsConverter: detects Microsoft identity platform issuers and fails authentication hard with a clear ERROR when the access token is not v2.0 (ver != "2.0"), instructing operators to set api.requestedAccessTokenVersion = 2 in the Entra app registration manifest instead of silently looping back to Entra.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to https://github.com/camunda/camunda/issues/52473
related to [#inc-support-32986-improve-oidc-logging](https://camunda.slack.com/archives/C0B7NKUFAQH)
