### PR TITLE
feat: add RocksDB adapters for MembershipPort and AuthorizationScopeRepositoryPort (Inc 3)

### DIFF
--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -62,6 +62,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.identity.adapter;
 
-import io.camunda.security.api.model.authz.AuthorizationResourceMatcher;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.authz.EntityType;
@@ -15,6 +14,7 @@ import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
 import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
+import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -37,11 +37,8 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
       final Map<EntityType, Set<String>> ownerIds,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType) {
-    final var zeebeResourceType =
-        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.valueOf(
-            resourceType.name());
-    final var zeebePermissionType =
-        io.camunda.zeebe.protocol.record.value.PermissionType.valueOf(permissionType.name());
+    final var zeebeResourceType = AuthzModelMapper.toProtocol(resourceType);
+    final var zeebePermissionType = AuthzModelMapper.toProtocol(permissionType);
     final var result = new HashSet<AuthorizationScope>();
     for (final var entry : ownerIds.entrySet()) {
       final var ownerType = toAuthorizationOwnerType(entry.getKey());
@@ -71,9 +68,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
       final Map<EntityType, Set<String>> ownerIds,
       final AuthorizationResourceType resourceType,
       final List<String> resourceIds) {
-    final var zeebeResourceType =
-        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.valueOf(
-            resourceType.name());
+    final var zeebeResourceType = AuthzModelMapper.toProtocol(resourceType);
     final var result = new HashSet<PermissionType>();
     for (final var entry : ownerIds.entrySet()) {
       final var ownerType = toAuthorizationOwnerType(entry.getKey());
@@ -85,7 +80,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
             .filter(auth -> auth.getResourceType() == zeebeResourceType)
             .filter(auth -> matchesPersistedAuthByResourceId(auth, resourceIds))
             .flatMap(auth -> auth.getPermissionTypes().stream())
-            .map(pt -> PermissionType.valueOf(pt.name()))
+            .map(AuthzModelMapper::fromProtocol)
             .forEach(result::add);
       }
     }
@@ -105,9 +100,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
 
   private AuthorizationScope toCslScope(
       final io.camunda.zeebe.protocol.record.value.AuthorizationScope zeebeScope) {
-    final var cslMatcher = AuthorizationResourceMatcher.valueOf(zeebeScope.getMatcher().name());
-    return new AuthorizationScope(
-        cslMatcher, zeebeScope.getResourceId(), zeebeScope.getResourcePropertyName());
+    return AuthzModelMapper.fromProtocol(zeebeScope);
   }
 
   private boolean matchesCslScopeByResourceId(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
@@ -46,12 +46,6 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
             .build(new ScopeCacheLoader(authorizationState));
   }
 
-  private record ScopeCacheKey(
-      AuthorizationOwnerType ownerType,
-      String ownerId,
-      io.camunda.zeebe.protocol.record.value.AuthorizationResourceType resourceType,
-      io.camunda.zeebe.protocol.record.value.PermissionType permissionType) {}
-
   /** Returns all authorized scopes for the given owners, resource type, and permission type. */
   @Override
   public List<AuthorizationScope> findAuthorizedScopes(
@@ -178,6 +172,12 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
       case PROPERTY, UNSPECIFIED -> false;
     };
   }
+
+  private record ScopeCacheKey(
+      AuthorizationOwnerType ownerType,
+      String ownerId,
+      io.camunda.zeebe.protocol.record.value.AuthorizationResourceType resourceType,
+      io.camunda.zeebe.protocol.record.value.PermissionType permissionType) {}
 
   /** Loads authorization scopes from {@link AuthorizationState}, bypassing the cache. */
   private static final class ScopeCacheLoader

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.identity.adapter;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.authz.EntityType;
@@ -27,10 +30,35 @@ import org.jspecify.annotations.NullMarked;
 public final class AuthorizationScopeStateAdapter implements AuthorizationScopeRepositoryPort {
 
   private final AuthorizationState authorizationState;
+  private final LoadingCache<
+          ScopeCacheKey, Set<io.camunda.zeebe.protocol.record.value.AuthorizationScope>>
+      scopeCache;
 
   public AuthorizationScopeStateAdapter(final AuthorizationState authorizationState) {
     this.authorizationState = authorizationState;
+    scopeCache =
+        CacheBuilder.newBuilder()
+            .maximumSize(1_000)
+            .build(
+                new CacheLoader<>() {
+                  @Override
+                  public Set<io.camunda.zeebe.protocol.record.value.AuthorizationScope> load(
+                      final ScopeCacheKey key) {
+                    return AuthorizationScopeStateAdapter.this.authorizationState
+                        .getAuthorizationScopes(
+                            key.ownerType(),
+                            key.ownerId(),
+                            key.resourceType(),
+                            key.permissionType());
+                  }
+                });
   }
+
+  private record ScopeCacheKey(
+      AuthorizationOwnerType ownerType,
+      String ownerId,
+      io.camunda.zeebe.protocol.record.value.AuthorizationResourceType resourceType,
+      io.camunda.zeebe.protocol.record.value.PermissionType permissionType) {}
 
   @Override
   public List<AuthorizationScope> findAuthorizedScopes(
@@ -43,10 +71,8 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
     for (final var entry : ownerIds.entrySet()) {
       final var ownerType = toAuthorizationOwnerType(entry.getKey());
       for (final var ownerId : entry.getValue()) {
-        authorizationState
-            .getAuthorizationScopes(ownerType, ownerId, zeebeResourceType, zeebePermissionType)
-            .stream()
-            .map(this::toCslScope)
+        getAuthorizationScopes(ownerType, ownerId, zeebeResourceType, zeebePermissionType).stream()
+            .map(AuthzModelMapper::fromProtocol)
             .forEach(result::add);
       }
     }
@@ -59,8 +85,20 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
       final List<String> resourceIds) {
-    return findAuthorizedScopes(ownerIds, resourceType, permissionType).stream()
-        .anyMatch(scope -> matchesCslScopeByResourceId(scope, resourceIds));
+    final var zeebeResourceType = AuthzModelMapper.toProtocol(resourceType);
+    final var zeebePermissionType = AuthzModelMapper.toProtocol(permissionType);
+    for (final var entry : ownerIds.entrySet()) {
+      final var ownerType = toAuthorizationOwnerType(entry.getKey());
+      for (final var ownerId : entry.getValue()) {
+        for (final var scope :
+            getAuthorizationScopes(ownerType, ownerId, zeebeResourceType, zeebePermissionType)) {
+          if (matchesCslScopeByResourceId(AuthzModelMapper.fromProtocol(scope), resourceIds)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
   }
 
   @Override
@@ -87,6 +125,15 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
     return result;
   }
 
+  private Set<io.camunda.zeebe.protocol.record.value.AuthorizationScope> getAuthorizationScopes(
+      final AuthorizationOwnerType ownerType,
+      final String ownerId,
+      final io.camunda.zeebe.protocol.record.value.AuthorizationResourceType resourceType,
+      final io.camunda.zeebe.protocol.record.value.PermissionType permissionType) {
+    return scopeCache.getUnchecked(
+        new ScopeCacheKey(ownerType, ownerId, resourceType, permissionType));
+  }
+
   private AuthorizationOwnerType toAuthorizationOwnerType(final EntityType cslEntityType) {
     return switch (cslEntityType) {
       case USER -> AuthorizationOwnerType.USER;
@@ -96,11 +143,6 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
       case MAPPING_RULE -> AuthorizationOwnerType.MAPPING_RULE;
       case UNSPECIFIED -> AuthorizationOwnerType.UNSPECIFIED;
     };
-  }
-
-  private AuthorizationScope toCslScope(
-      final io.camunda.zeebe.protocol.record.value.AuthorizationScope zeebeScope) {
-    return AuthzModelMapper.fromProtocol(zeebeScope);
   }
 
   private boolean matchesCslScopeByResourceId(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
@@ -15,6 +15,7 @@ import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
@@ -25,9 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
 
 @NullMarked
 public final class AuthorizationScopeStateAdapter implements AuthorizationScopeRepositoryPort {
+
+  private static final Logger LOG = Loggers.ENGINE_PROCESSING_LOGGER;
 
   private final AuthorizationState authorizationState;
   private final LoadingCache<
@@ -39,19 +43,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
     scopeCache =
         CacheBuilder.newBuilder()
             .maximumSize(1_000)
-            .build(
-                new CacheLoader<>() {
-                  @Override
-                  public Set<io.camunda.zeebe.protocol.record.value.AuthorizationScope> load(
-                      final ScopeCacheKey key) {
-                    return AuthorizationScopeStateAdapter.this.authorizationState
-                        .getAuthorizationScopes(
-                            key.ownerType(),
-                            key.ownerId(),
-                            key.resourceType(),
-                            key.permissionType());
-                  }
-                });
+            .build(new ScopeCacheLoader(authorizationState));
   }
 
   private record ScopeCacheKey(
@@ -60,11 +52,17 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
       io.camunda.zeebe.protocol.record.value.AuthorizationResourceType resourceType,
       io.camunda.zeebe.protocol.record.value.PermissionType permissionType) {}
 
+  /** Returns all authorized scopes for the given owners, resource type, and permission type. */
   @Override
   public List<AuthorizationScope> findAuthorizedScopes(
       final Map<EntityType, Set<String>> ownerIds,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType) {
+    LOG.trace(
+        "Finding authorized scopes for {} owner group(s), resource {}, permission {}",
+        ownerIds.size(),
+        resourceType,
+        permissionType);
     final var zeebeResourceType = AuthzModelMapper.toProtocol(resourceType);
     final var zeebePermissionType = AuthzModelMapper.toProtocol(permissionType);
     final var result = new HashSet<AuthorizationScope>();
@@ -79,12 +77,19 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
     return new ArrayList<>(result);
   }
 
+  /** Returns {@code true} if any authorized scope matches one of the given resource IDs. */
   @Override
   public boolean hasAuthorizedScope(
       final Map<EntityType, Set<String>> ownerIds,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
       final List<String> resourceIds) {
+    LOG.trace(
+        "Checking authorized scope for {} owner group(s), resource {}, permission {}, {} resource ID(s)",
+        ownerIds.size(),
+        resourceType,
+        permissionType,
+        resourceIds.size());
     final var zeebeResourceType = AuthzModelMapper.toProtocol(resourceType);
     final var zeebePermissionType = AuthzModelMapper.toProtocol(permissionType);
     for (final var entry : ownerIds.entrySet()) {
@@ -93,6 +98,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
         for (final var scope :
             getAuthorizationScopes(ownerType, ownerId, zeebeResourceType, zeebePermissionType)) {
           if (matchesCslScopeByResourceId(AuthzModelMapper.fromProtocol(scope), resourceIds)) {
+            LOG.trace("Authorized scope found for owner {}/{}", ownerType, ownerId);
             return true;
           }
         }
@@ -101,11 +107,17 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
     return false;
   }
 
+  /** Returns all permission types granted to the given owners for the matching resource IDs. */
   @Override
   public Set<PermissionType> findPermissionTypes(
       final Map<EntityType, Set<String>> ownerIds,
       final AuthorizationResourceType resourceType,
       final List<String> resourceIds) {
+    LOG.trace(
+        "Finding permission types for {} owner group(s), resource {}, {} resource ID(s)",
+        ownerIds.size(),
+        resourceType,
+        resourceIds.size());
     final var zeebeResourceType = AuthzModelMapper.toProtocol(resourceType);
     final var result = new HashSet<PermissionType>();
     for (final var entry : ownerIds.entrySet()) {
@@ -125,6 +137,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
     return result;
   }
 
+  /** Returns cached authorization scopes, loading from state on cache miss. */
   private Set<io.camunda.zeebe.protocol.record.value.AuthorizationScope> getAuthorizationScopes(
       final AuthorizationOwnerType ownerType,
       final String ownerId,
@@ -134,6 +147,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
         new ScopeCacheKey(ownerType, ownerId, resourceType, permissionType));
   }
 
+  /** Converts a CSL {@link EntityType} to the Zeebe {@link AuthorizationOwnerType}. */
   private AuthorizationOwnerType toAuthorizationOwnerType(final EntityType cslEntityType) {
     return switch (cslEntityType) {
       case USER -> AuthorizationOwnerType.USER;
@@ -145,6 +159,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
     };
   }
 
+  /** Returns {@code true} if the CSL scope matches any of the given resource IDs. */
   private boolean matchesCslScopeByResourceId(
       final AuthorizationScope scope, final List<String> resourceIds) {
     return switch (scope.getMatcher()) {
@@ -154,6 +169,7 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
     };
   }
 
+  /** Returns {@code true} if the persisted authorization matches any of the given resource IDs. */
   private boolean matchesPersistedAuthByResourceId(
       final PersistedAuthorization auth, final List<String> resourceIds) {
     return switch (auth.getResourceMatcher()) {
@@ -161,5 +177,30 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
       case ID -> resourceIds.contains(auth.getResourceId());
       case PROPERTY, UNSPECIFIED -> false;
     };
+  }
+
+  /** Loads authorization scopes from {@link AuthorizationState}, bypassing the cache. */
+  private static final class ScopeCacheLoader
+      extends CacheLoader<
+          ScopeCacheKey, Set<io.camunda.zeebe.protocol.record.value.AuthorizationScope>> {
+
+    private final AuthorizationState authorizationState;
+
+    private ScopeCacheLoader(final AuthorizationState authorizationState) {
+      this.authorizationState = authorizationState;
+    }
+
+    @Override
+    public Set<io.camunda.zeebe.protocol.record.value.AuthorizationScope> load(
+        final ScopeCacheKey key) {
+      LOG.trace(
+          "Loading authorization scopes for owner {}/{}, resource {}, permission {}",
+          key.ownerType(),
+          key.ownerId(),
+          key.resourceType(),
+          key.permissionType());
+      return authorizationState.getAuthorizationScopes(
+          key.ownerType(), key.ownerId(), key.resourceType(), key.permissionType());
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
@@ -15,6 +15,7 @@ import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
@@ -38,11 +39,13 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
           ScopeCacheKey, Set<io.camunda.zeebe.protocol.record.value.AuthorizationScope>>
       scopeCache;
 
-  public AuthorizationScopeStateAdapter(final AuthorizationState authorizationState) {
+  public AuthorizationScopeStateAdapter(
+      final AuthorizationState authorizationState, final EngineConfiguration config) {
     this.authorizationState = authorizationState;
     scopeCache =
         CacheBuilder.newBuilder()
-            .maximumSize(1_000)
+            .expireAfterWrite(config.getAuthorizationsCacheTtl())
+            .maximumSize(config.getAuthorizationsCacheCapacity())
             .build(new ScopeCacheLoader(authorizationState));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.adapter;
+
+import io.camunda.security.api.model.authz.AuthorizationResourceMatcher;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
+import io.camunda.security.api.model.authz.AuthorizationScope;
+import io.camunda.security.api.model.authz.EntityType;
+import io.camunda.security.api.model.authz.PermissionType;
+import io.camunda.security.core.port.out.AuthorizationScopeRepositoryPort;
+import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
+import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public final class AuthorizationScopeStateAdapter implements AuthorizationScopeRepositoryPort {
+
+  private final AuthorizationState authorizationState;
+
+  public AuthorizationScopeStateAdapter(final AuthorizationState authorizationState) {
+    this.authorizationState = authorizationState;
+  }
+
+  @Override
+  public List<AuthorizationScope> findAuthorizedScopes(
+      final Map<EntityType, Set<String>> ownerIds,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType) {
+    final var zeebeResourceType =
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.valueOf(
+            resourceType.name());
+    final var zeebePermissionType =
+        io.camunda.zeebe.protocol.record.value.PermissionType.valueOf(permissionType.name());
+    final var result = new HashSet<AuthorizationScope>();
+    for (final var entry : ownerIds.entrySet()) {
+      final var ownerType = toAuthorizationOwnerType(entry.getKey());
+      for (final var ownerId : entry.getValue()) {
+        authorizationState
+            .getAuthorizationScopes(ownerType, ownerId, zeebeResourceType, zeebePermissionType)
+            .stream()
+            .map(this::toCslScope)
+            .forEach(result::add);
+      }
+    }
+    return new ArrayList<>(result);
+  }
+
+  @Override
+  public boolean hasAuthorizedScope(
+      final Map<EntityType, Set<String>> ownerIds,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final List<String> resourceIds) {
+    return findAuthorizedScopes(ownerIds, resourceType, permissionType).stream()
+        .anyMatch(scope -> matchesCslScopeByResourceId(scope, resourceIds));
+  }
+
+  @Override
+  public Set<PermissionType> findPermissionTypes(
+      final Map<EntityType, Set<String>> ownerIds,
+      final AuthorizationResourceType resourceType,
+      final List<String> resourceIds) {
+    final var zeebeResourceType =
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.valueOf(
+            resourceType.name());
+    final var result = new HashSet<PermissionType>();
+    for (final var entry : ownerIds.entrySet()) {
+      final var ownerType = toAuthorizationOwnerType(entry.getKey());
+      for (final var ownerId : entry.getValue()) {
+        authorizationState.getAuthorizationKeysForOwner(ownerType, ownerId).stream()
+            .map(authorizationState::get)
+            .filter(opt -> opt.isPresent())
+            .map(opt -> opt.get())
+            .filter(auth -> auth.getResourceType() == zeebeResourceType)
+            .filter(auth -> matchesPersistedAuthByResourceId(auth, resourceIds))
+            .flatMap(auth -> auth.getPermissionTypes().stream())
+            .map(pt -> PermissionType.valueOf(pt.name()))
+            .forEach(result::add);
+      }
+    }
+    return result;
+  }
+
+  private AuthorizationOwnerType toAuthorizationOwnerType(final EntityType cslEntityType) {
+    return switch (cslEntityType) {
+      case USER -> AuthorizationOwnerType.USER;
+      case CLIENT -> AuthorizationOwnerType.CLIENT;
+      case GROUP -> AuthorizationOwnerType.GROUP;
+      case ROLE -> AuthorizationOwnerType.ROLE;
+      case MAPPING_RULE -> AuthorizationOwnerType.MAPPING_RULE;
+      case UNSPECIFIED -> AuthorizationOwnerType.UNSPECIFIED;
+    };
+  }
+
+  private AuthorizationScope toCslScope(
+      final io.camunda.zeebe.protocol.record.value.AuthorizationScope zeebeScope) {
+    final var cslMatcher = AuthorizationResourceMatcher.valueOf(zeebeScope.getMatcher().name());
+    return new AuthorizationScope(
+        cslMatcher, zeebeScope.getResourceId(), zeebeScope.getResourcePropertyName());
+  }
+
+  private boolean matchesCslScopeByResourceId(
+      final AuthorizationScope scope, final List<String> resourceIds) {
+    return switch (scope.getMatcher()) {
+      case ANY -> true;
+      case ID -> resourceIds.contains(scope.getResourceId());
+      case PROPERTY, UNSPECIFIED -> false;
+    };
+  }
+
+  private boolean matchesPersistedAuthByResourceId(
+      final PersistedAuthorization auth, final List<String> resourceIds) {
+    return switch (auth.getResourceMatcher()) {
+      case ANY -> true;
+      case ID -> resourceIds.contains(auth.getResourceId());
+      case PROPERTY, UNSPECIFIED -> false;
+    };
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -46,9 +46,6 @@ public final class MembershipStateAdapter implements MembershipPort {
             .build(new MembershipCacheLoader(membershipState));
   }
 
-  private record MembershipCacheKey(
-      EntityType entityType, String entityId, RelationType relationType) {}
-
   /** Returns mapping rule IDs whose conditions match the token claims in the query. */
   @Override
   public List<String> mappingRuleIds(final MembershipQuery query) {
@@ -154,6 +151,9 @@ public final class MembershipStateAdapter implements MembershipPort {
       case CLIENT -> EntityType.CLIENT;
     };
   }
+
+  private record MembershipCacheKey(
+      EntityType entityType, String entityId, RelationType relationType) {}
 
   /** Loads memberships from {@link MembershipState}, bypassing the cache. */
   private static final class MembershipCacheLoader

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.identity.adapter;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import io.camunda.security.core.auth.MappingRuleMatcher;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.MembershipQuery;
@@ -27,12 +30,27 @@ public final class MembershipStateAdapter implements MembershipPort {
 
   private final MappingRuleState mappingRuleState;
   private final MembershipState membershipState;
+  private final LoadingCache<MembershipCacheKey, List<String>> membershipCache;
 
   public MembershipStateAdapter(
       final MappingRuleState mappingRuleState, final MembershipState membershipState) {
     this.mappingRuleState = mappingRuleState;
     this.membershipState = membershipState;
+    membershipCache =
+        CacheBuilder.newBuilder()
+            .maximumSize(1_000)
+            .build(
+                new CacheLoader<>() {
+                  @Override
+                  public List<String> load(final MembershipCacheKey key) {
+                    return MembershipStateAdapter.this.membershipState.getMemberships(
+                        key.entityType(), key.entityId(), key.relationType());
+                  }
+                });
   }
+
+  private record MembershipCacheKey(
+      EntityType entityType, String entityId, RelationType relationType) {}
 
   @Override
   public List<String> mappingRuleIds(final MembershipQuery query) {
@@ -48,30 +66,35 @@ public final class MembershipStateAdapter implements MembershipPort {
   @Override
   public List<String> groupIds(final MembershipQuery query) {
     final var rawGroups = query.tokenClaims().get(Authorization.USER_GROUPS_CLAIMS);
+    final var result = new LinkedHashSet<String>();
     if (rawGroups instanceof List<?> groupsClaims) {
-      return groupsClaims.stream()
+      groupsClaims.stream()
           .filter(String.class::isInstance)
           .map(String.class::cast)
-          .distinct()
-          .toList();
+          .forEach(result::add);
+    } else {
+      getMemberships(toEntityType(query.principalType()), query.principalId(), RelationType.GROUP)
+          .forEach(result::add);
     }
-    return membershipState.getMemberships(
-        toEntityType(query.principalType()), query.principalId(), RelationType.GROUP);
+    query
+        .resolvedMappingRuleIds()
+        .forEach(
+            ruleId ->
+                getMemberships(EntityType.MAPPING_RULE, ruleId, RelationType.GROUP)
+                    .forEach(result::add));
+    return new ArrayList<>(result);
   }
 
   @Override
   public List<String> roleIds(final MembershipQuery query) {
     final var result = new LinkedHashSet<String>();
-    membershipState
-        .getMemberships(toEntityType(query.principalType()), query.principalId(), RelationType.ROLE)
+    getMemberships(toEntityType(query.principalType()), query.principalId(), RelationType.ROLE)
         .forEach(result::add);
     query
         .resolvedGroupIds()
         .forEach(
             groupId ->
-                membershipState
-                    .getMemberships(EntityType.GROUP, groupId, RelationType.ROLE)
-                    .forEach(result::add));
+                getMemberships(EntityType.GROUP, groupId, RelationType.ROLE).forEach(result::add));
     return new ArrayList<>(result);
   }
 
@@ -79,32 +102,29 @@ public final class MembershipStateAdapter implements MembershipPort {
   public List<String> tenantIds(final MembershipQuery query) {
     final var result = new LinkedHashSet<String>();
     final var entityType = toEntityType(query.principalType());
-    membershipState
-        .getMemberships(entityType, query.principalId(), RelationType.TENANT)
-        .forEach(result::add);
+    getMemberships(entityType, query.principalId(), RelationType.TENANT).forEach(result::add);
     query
         .resolvedRoleIds()
         .forEach(
             roleId ->
-                membershipState
-                    .getMemberships(EntityType.ROLE, roleId, RelationType.TENANT)
-                    .forEach(result::add));
+                getMemberships(EntityType.ROLE, roleId, RelationType.TENANT).forEach(result::add));
     query
         .resolvedGroupIds()
         .forEach(
             groupId -> {
-              membershipState
-                  .getMemberships(EntityType.GROUP, groupId, RelationType.TENANT)
-                  .forEach(result::add);
-              membershipState.getMemberships(EntityType.GROUP, groupId, RelationType.ROLE).stream()
+              getMemberships(EntityType.GROUP, groupId, RelationType.TENANT).forEach(result::add);
+              getMemberships(EntityType.GROUP, groupId, RelationType.ROLE).stream()
                   .flatMap(
                       roleId ->
-                          membershipState
-                              .getMemberships(EntityType.ROLE, roleId, RelationType.TENANT)
-                              .stream())
+                          getMemberships(EntityType.ROLE, roleId, RelationType.TENANT).stream())
                   .forEach(result::add);
             });
     return new ArrayList<>(result);
+  }
+
+  private List<String> getMemberships(
+      final EntityType entityType, final String entityId, final RelationType relationType) {
+    return membershipCache.getUnchecked(new MembershipCacheKey(entityType, entityId, relationType));
   }
 
   private EntityType toEntityType(final PrincipalType principalType) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -14,6 +14,7 @@ import io.camunda.security.core.auth.MappingRuleMatcher;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.MembershipQuery;
 import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
 import io.camunda.zeebe.engine.state.authorization.PersistedMappingRule;
 import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
@@ -24,9 +25,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
 
 @NullMarked
 public final class MembershipStateAdapter implements MembershipPort {
+
+  private static final Logger LOG = Loggers.ENGINE_PROCESSING_LOGGER;
 
   private final MappingRuleState mappingRuleState;
   private final MembershipState membershipState;
@@ -39,21 +43,16 @@ public final class MembershipStateAdapter implements MembershipPort {
     membershipCache =
         CacheBuilder.newBuilder()
             .maximumSize(1_000)
-            .build(
-                new CacheLoader<>() {
-                  @Override
-                  public List<String> load(final MembershipCacheKey key) {
-                    return MembershipStateAdapter.this.membershipState.getMemberships(
-                        key.entityType(), key.entityId(), key.relationType());
-                  }
-                });
+            .build(new MembershipCacheLoader(membershipState));
   }
 
   private record MembershipCacheKey(
       EntityType entityType, String entityId, RelationType relationType) {}
 
+  /** Returns mapping rule IDs whose conditions match the token claims in the query. */
   @Override
   public List<String> mappingRuleIds(final MembershipQuery query) {
+    LOG.trace("Resolving mapping rule IDs for principal {}", query.principalId());
     final var rawClaims = query.tokenClaims().get(Authorization.USER_TOKEN_CLAIMS);
     @SuppressWarnings("unchecked")
     final Map<String, Object> tokenClaims =
@@ -63,8 +62,12 @@ public final class MembershipStateAdapter implements MembershipPort {
         .toList();
   }
 
+  /**
+   * Returns group IDs for the principal, from token claims or membership state plus mapping rules.
+   */
   @Override
   public List<String> groupIds(final MembershipQuery query) {
+    LOG.trace("Resolving group IDs for principal {}", query.principalId());
     final var rawGroups = query.tokenClaims().get(Authorization.USER_GROUPS_CLAIMS);
     final var result = new LinkedHashSet<String>();
     if (rawGroups instanceof List<?> groupsClaims) {
@@ -85,8 +88,10 @@ public final class MembershipStateAdapter implements MembershipPort {
     return new ArrayList<>(result);
   }
 
+  /** Returns role IDs for the principal and all resolved groups. */
   @Override
   public List<String> roleIds(final MembershipQuery query) {
+    LOG.trace("Resolving role IDs for principal {}", query.principalId());
     final var result = new LinkedHashSet<String>();
     getMemberships(toEntityType(query.principalType()), query.principalId(), RelationType.ROLE)
         .forEach(result::add);
@@ -98,8 +103,10 @@ public final class MembershipStateAdapter implements MembershipPort {
     return new ArrayList<>(result);
   }
 
+  /** Returns tenant IDs via all inheritance paths: direct, roles, groups, and group roles. */
   @Override
   public List<String> tenantIds(final MembershipQuery query) {
+    LOG.trace("Resolving tenant IDs for principal {}", query.principalId());
     final var result = new LinkedHashSet<String>();
     final var entityType = toEntityType(query.principalType());
     getMemberships(entityType, query.principalId(), RelationType.TENANT).forEach(result::add);
@@ -122,15 +129,38 @@ public final class MembershipStateAdapter implements MembershipPort {
     return new ArrayList<>(result);
   }
 
+  /** Returns cached memberships, loading from state on cache miss. */
   private List<String> getMemberships(
       final EntityType entityType, final String entityId, final RelationType relationType) {
     return membershipCache.getUnchecked(new MembershipCacheKey(entityType, entityId, relationType));
   }
 
+  /** Converts a {@link PrincipalType} to the Zeebe {@link EntityType}. */
   private EntityType toEntityType(final PrincipalType principalType) {
     return switch (principalType) {
       case USER -> EntityType.USER;
       case CLIENT -> EntityType.CLIENT;
     };
+  }
+
+  /** Loads memberships from {@link MembershipState}, bypassing the cache. */
+  private static final class MembershipCacheLoader
+      extends CacheLoader<MembershipCacheKey, List<String>> {
+
+    private final MembershipState membershipState;
+
+    private MembershipCacheLoader(final MembershipState membershipState) {
+      this.membershipState = membershipState;
+    }
+
+    @Override
+    public List<String> load(final MembershipCacheKey key) {
+      LOG.trace(
+          "Loading memberships for entity {}/{}, relation {}",
+          key.entityType(),
+          key.entityId(),
+          key.relationType());
+      return membershipState.getMemberships(key.entityType(), key.entityId(), key.relationType());
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -38,7 +38,7 @@ public final class MembershipStateAdapter implements MembershipPort {
   public List<String> mappingRuleIds(final MembershipQuery query) {
     final var rawClaims = query.tokenClaims().get(Authorization.USER_TOKEN_CLAIMS);
     @SuppressWarnings("unchecked")
-    final var tokenClaims =
+    final Map<String, Object> tokenClaims =
         rawClaims instanceof Map<?, ?> map ? (Map<String, Object>) map : Map.of();
     return MappingRuleMatcher.matchingRules(mappingRuleState.getAll().stream(), tokenClaims)
         .map(PersistedMappingRule::getMappingRuleId)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -14,6 +14,7 @@ import io.camunda.security.core.auth.MappingRuleMatcher;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.MembershipQuery;
 import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
 import io.camunda.zeebe.engine.state.authorization.PersistedMappingRule;
@@ -37,12 +38,15 @@ public final class MembershipStateAdapter implements MembershipPort {
   private final LoadingCache<MembershipCacheKey, List<String>> membershipCache;
 
   public MembershipStateAdapter(
-      final MappingRuleState mappingRuleState, final MembershipState membershipState) {
+      final MappingRuleState mappingRuleState,
+      final MembershipState membershipState,
+      final EngineConfiguration config) {
     this.mappingRuleState = mappingRuleState;
     this.membershipState = membershipState;
     membershipCache =
         CacheBuilder.newBuilder()
-            .maximumSize(1_000)
+            .expireAfterWrite(config.getAuthorizationsCacheTtl())
+            .maximumSize(config.getAuthorizationsCacheCapacity())
             .build(new MembershipCacheLoader(membershipState));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.adapter;
+
+import io.camunda.security.core.auth.MappingRuleMatcher;
+import io.camunda.security.core.port.out.MembershipPort;
+import io.camunda.security.core.port.out.MembershipQuery;
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
+import io.camunda.zeebe.engine.state.authorization.PersistedMappingRule;
+import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
+import io.camunda.zeebe.engine.state.immutable.MembershipState;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public final class MembershipStateAdapter implements MembershipPort {
+
+  private final MappingRuleState mappingRuleState;
+  private final MembershipState membershipState;
+
+  public MembershipStateAdapter(
+      final MappingRuleState mappingRuleState, final MembershipState membershipState) {
+    this.mappingRuleState = mappingRuleState;
+    this.membershipState = membershipState;
+  }
+
+  @Override
+  public List<String> mappingRuleIds(final MembershipQuery query) {
+    @SuppressWarnings("unchecked")
+    final var tokenClaims =
+        (Map<String, Object>)
+            query.tokenClaims().getOrDefault(Authorization.USER_TOKEN_CLAIMS, Map.of());
+    return MappingRuleMatcher.matchingRules(mappingRuleState.getAll().stream(), tokenClaims)
+        .map(PersistedMappingRule::getMappingRuleId)
+        .toList();
+  }
+
+  @Override
+  public List<String> groupIds(final MembershipQuery query) {
+    @SuppressWarnings("unchecked")
+    final var groupsClaims =
+        (List<String>) query.tokenClaims().get(Authorization.USER_GROUPS_CLAIMS);
+    if (groupsClaims != null) {
+      return groupsClaims;
+    }
+    return membershipState.getMemberships(
+        toEntityType(query.principalType()), query.principalId(), RelationType.GROUP);
+  }
+
+  @Override
+  public List<String> roleIds(final MembershipQuery query) {
+    final var result = new LinkedHashSet<String>();
+    membershipState
+        .getMemberships(toEntityType(query.principalType()), query.principalId(), RelationType.ROLE)
+        .forEach(result::add);
+    query
+        .resolvedGroupIds()
+        .forEach(
+            groupId ->
+                membershipState
+                    .getMemberships(EntityType.GROUP, groupId, RelationType.ROLE)
+                    .forEach(result::add));
+    return new ArrayList<>(result);
+  }
+
+  @Override
+  public List<String> tenantIds(final MembershipQuery query) {
+    final var result = new LinkedHashSet<String>();
+    final var entityType = toEntityType(query.principalType());
+    membershipState
+        .getMemberships(entityType, query.principalId(), RelationType.TENANT)
+        .forEach(result::add);
+    query
+        .resolvedRoleIds()
+        .forEach(
+            roleId ->
+                membershipState
+                    .getMemberships(EntityType.ROLE, roleId, RelationType.TENANT)
+                    .forEach(result::add));
+    query
+        .resolvedGroupIds()
+        .forEach(
+            groupId -> {
+              membershipState
+                  .getMemberships(EntityType.GROUP, groupId, RelationType.TENANT)
+                  .forEach(result::add);
+              membershipState.getMemberships(EntityType.GROUP, groupId, RelationType.ROLE).stream()
+                  .flatMap(
+                      roleId ->
+                          membershipState
+                              .getMemberships(EntityType.ROLE, roleId, RelationType.TENANT)
+                              .stream())
+                  .forEach(result::add);
+            });
+    return new ArrayList<>(result);
+  }
+
+  private EntityType toEntityType(final PrincipalType principalType) {
+    return switch (principalType) {
+      case USER -> EntityType.USER;
+      case CLIENT -> EntityType.CLIENT;
+    };
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -100,6 +100,12 @@ public final class MembershipStateAdapter implements MembershipPort {
         .forEach(
             groupId ->
                 getMemberships(EntityType.GROUP, groupId, RelationType.ROLE).forEach(result::add));
+    query
+        .resolvedMappingRuleIds()
+        .forEach(
+            ruleId ->
+                getMemberships(EntityType.MAPPING_RULE, ruleId, RelationType.ROLE)
+                    .forEach(result::add));
     return new ArrayList<>(result);
   }
 
@@ -126,6 +132,12 @@ public final class MembershipStateAdapter implements MembershipPort {
                           getMemberships(EntityType.ROLE, roleId, RelationType.TENANT).stream())
                   .forEach(result::add);
             });
+    query
+        .resolvedMappingRuleIds()
+        .forEach(
+            mrId ->
+                getMemberships(EntityType.MAPPING_RULE, mrId, RelationType.TENANT)
+                    .forEach(result::add));
     return new ArrayList<>(result);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -36,10 +36,10 @@ public final class MembershipStateAdapter implements MembershipPort {
 
   @Override
   public List<String> mappingRuleIds(final MembershipQuery query) {
+    final var rawClaims = query.tokenClaims().get(Authorization.USER_TOKEN_CLAIMS);
     @SuppressWarnings("unchecked")
     final var tokenClaims =
-        (Map<String, Object>)
-            query.tokenClaims().getOrDefault(Authorization.USER_TOKEN_CLAIMS, Map.of());
+        rawClaims instanceof Map<?, ?> map ? (Map<String, Object>) map : Map.of();
     return MappingRuleMatcher.matchingRules(mappingRuleState.getAll().stream(), tokenClaims)
         .map(PersistedMappingRule::getMappingRuleId)
         .toList();
@@ -47,11 +47,13 @@ public final class MembershipStateAdapter implements MembershipPort {
 
   @Override
   public List<String> groupIds(final MembershipQuery query) {
-    @SuppressWarnings("unchecked")
-    final var groupsClaims =
-        (List<String>) query.tokenClaims().get(Authorization.USER_GROUPS_CLAIMS);
-    if (groupsClaims != null) {
-      return groupsClaims;
+    final var rawGroups = query.tokenClaims().get(Authorization.USER_GROUPS_CLAIMS);
+    if (rawGroups instanceof List<?> groupsClaims) {
+      return groupsClaims.stream()
+          .filter(String.class::isInstance)
+          .map(String.class::cast)
+          .distinct()
+          .toList();
     }
     return membershipState.getMemberships(
         toEntityType(query.principalType()), query.principalId(), RelationType.GROUP);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapterTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapterTest.java
@@ -13,6 +13,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.security.api.model.authz.PermissionType;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.appliers.AuthorizationCreatedApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
@@ -40,7 +41,9 @@ final class AuthorizationScopeStateAdapterTest {
 
   @BeforeEach
   void setup() {
-    adapter = new AuthorizationScopeStateAdapter(processingState.getAuthorizationState());
+    adapter =
+        new AuthorizationScopeStateAdapter(
+            processingState.getAuthorizationState(), new EngineConfiguration());
     authorizationCreatedApplier =
         new AuthorizationCreatedApplier(processingState.getAuthorizationState());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapterTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapterTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
+import io.camunda.security.api.model.authz.AuthorizationScope;
+import io.camunda.security.api.model.authz.EntityType;
+import io.camunda.security.api.model.authz.PermissionType;
+import io.camunda.zeebe.engine.state.appliers.AuthorizationCreatedApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class AuthorizationScopeStateAdapterTest {
+
+  @SuppressWarnings("unused") // injected by the extension
+  private MutableProcessingState processingState;
+
+  private AuthorizationScopeStateAdapter adapter;
+  private AuthorizationCreatedApplier authorizationCreatedApplier;
+  private final Random random = new Random();
+
+  @BeforeEach
+  void setup() {
+    adapter = new AuthorizationScopeStateAdapter(processingState.getAuthorizationState());
+    authorizationCreatedApplier =
+        new AuthorizationCreatedApplier(processingState.getAuthorizationState());
+  }
+
+  @Test
+  void shouldReturnScopeForOwner() {
+    // given
+    final var userId = "user1";
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        userId,
+        AuthorizationOwnerType.USER,
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION,
+        io.camunda.zeebe.protocol.record.value.PermissionType.READ,
+        resourceId);
+
+    // when
+    final var scopes =
+        adapter.findAuthorizedScopes(
+            Map.of(EntityType.USER, Set.of(userId)),
+            AuthorizationResourceType.PROCESS_DEFINITION,
+            PermissionType.READ);
+
+    // then
+    assertThat(scopes).containsExactly(AuthorizationScope.id(resourceId));
+  }
+
+  @Test
+  void shouldReturnEmptyScopesWhenNoPermission() {
+    // when
+    final var scopes =
+        adapter.findAuthorizedScopes(
+            Map.of(EntityType.USER, Set.of("no-such-user")),
+            AuthorizationResourceType.PROCESS_DEFINITION,
+            PermissionType.READ);
+
+    // then
+    assertThat(scopes).isEmpty();
+  }
+
+  @Test
+  void shouldAggregateScopesAcrossMultipleOwners() {
+    // given
+    final var resourceId1 = UUID.randomUUID().toString();
+    final var resourceId2 = UUID.randomUUID().toString();
+    addPermission(
+        "user1",
+        AuthorizationOwnerType.USER,
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION,
+        io.camunda.zeebe.protocol.record.value.PermissionType.READ,
+        resourceId1);
+    addPermission(
+        "role1",
+        AuthorizationOwnerType.ROLE,
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION,
+        io.camunda.zeebe.protocol.record.value.PermissionType.READ,
+        resourceId2);
+
+    // when
+    final var scopes =
+        adapter.findAuthorizedScopes(
+            Map.of(EntityType.USER, Set.of("user1"), EntityType.ROLE, Set.of("role1")),
+            AuthorizationResourceType.PROCESS_DEFINITION,
+            PermissionType.READ);
+
+    // then
+    assertThat(scopes)
+        .containsExactlyInAnyOrder(
+            AuthorizationScope.id(resourceId1), AuthorizationScope.id(resourceId2));
+  }
+
+  @Test
+  void shouldReturnTrueForHasAuthorizedScopeWithMatchingId() {
+    // given
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        "user1",
+        AuthorizationOwnerType.USER,
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION,
+        io.camunda.zeebe.protocol.record.value.PermissionType.READ,
+        resourceId);
+
+    // when / then
+    assertThat(
+            adapter.hasAuthorizedScope(
+                Map.of(EntityType.USER, Set.of("user1")),
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.READ,
+                List.of(resourceId)))
+        .isTrue();
+  }
+
+  @Test
+  void shouldReturnFalseForHasAuthorizedScopeWithNonMatchingId() {
+    // given
+    addPermission(
+        "user1",
+        AuthorizationOwnerType.USER,
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION,
+        io.camunda.zeebe.protocol.record.value.PermissionType.READ,
+        UUID.randomUUID().toString());
+
+    // when / then
+    assertThat(
+            adapter.hasAuthorizedScope(
+                Map.of(EntityType.USER, Set.of("user1")),
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.READ,
+                List.of("different-resource-id")))
+        .isFalse();
+  }
+
+  @Test
+  void shouldReturnPermissionTypesForMatchingResource() {
+    // given
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        "user1",
+        AuthorizationOwnerType.USER,
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION,
+        io.camunda.zeebe.protocol.record.value.PermissionType.READ,
+        resourceId);
+    addPermission(
+        "user1",
+        AuthorizationOwnerType.USER,
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION,
+        io.camunda.zeebe.protocol.record.value.PermissionType.CREATE_PROCESS_INSTANCE,
+        resourceId);
+
+    // when
+    final var permTypes =
+        adapter.findPermissionTypes(
+            Map.of(EntityType.USER, Set.of("user1")),
+            AuthorizationResourceType.PROCESS_DEFINITION,
+            List.of(resourceId));
+
+    // then
+    assertThat(permTypes)
+        .containsExactlyInAnyOrder(PermissionType.READ, PermissionType.CREATE_PROCESS_INSTANCE);
+  }
+
+  @Test
+  void shouldReturnEmptyPermissionTypesWhenResourceIdDoesNotMatch() {
+    // given
+    addPermission(
+        "user1",
+        AuthorizationOwnerType.USER,
+        io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION,
+        io.camunda.zeebe.protocol.record.value.PermissionType.READ,
+        UUID.randomUUID().toString());
+
+    // when
+    final var permTypes =
+        adapter.findPermissionTypes(
+            Map.of(EntityType.USER, Set.of("user1")),
+            AuthorizationResourceType.PROCESS_DEFINITION,
+            List.of("different-resource-id"));
+
+    // then
+    assertThat(permTypes).isEmpty();
+  }
+
+  @Test
+  void shouldMatchWildcardScopeForAnyResourceId() {
+    // given — wildcard authorization
+    final var authKey = random.nextLong();
+    final var auth =
+        new AuthorizationRecord()
+            .setAuthorizationKey(authKey)
+            .setOwnerId("user1")
+            .setOwnerType(AuthorizationOwnerType.USER)
+            .setResourceMatcher(AuthorizationResourceMatcher.ANY)
+            .setResourceId("*")
+            .setResourcePropertyName("")
+            .setResourceType(
+                io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION)
+            .setPermissionTypes(Set.of(io.camunda.zeebe.protocol.record.value.PermissionType.READ));
+    authorizationCreatedApplier.applyState(authKey, auth);
+
+    // when / then
+    assertThat(
+            adapter.hasAuthorizedScope(
+                Map.of(EntityType.USER, Set.of("user1")),
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.READ,
+                List.of("any-process-id")))
+        .isTrue();
+  }
+
+  // --- helpers ---
+
+  private void addPermission(
+      final String ownerId,
+      final AuthorizationOwnerType ownerType,
+      final io.camunda.zeebe.protocol.record.value.AuthorizationResourceType resourceType,
+      final io.camunda.zeebe.protocol.record.value.PermissionType permissionType,
+      final String resourceId) {
+    final var authKey = random.nextLong();
+    final var auth =
+        new AuthorizationRecord()
+            .setAuthorizationKey(authKey)
+            .setOwnerId(ownerId)
+            .setOwnerType(ownerType)
+            .setResourceMatcher(AuthorizationResourceMatcher.ID)
+            .setResourceId(resourceId)
+            .setResourcePropertyName("")
+            .setResourceType(resourceType)
+            .setPermissionTypes(Set.of(permissionType));
+    authorizationCreatedApplier.applyState(authKey, auth);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
@@ -226,6 +226,39 @@ final class MembershipStateAdapterTest {
         .containsExactlyInAnyOrder(directTenantId, roleTenantId, groupTenantId, groupRoleTenantId);
   }
 
+  @Test
+  void shouldReturnRoleIdsFromMappingRuleDirectRoleMembership() {
+    // given — mapping rule assigned directly to a role
+    final var mappingRuleId = UUID.randomUUID().toString();
+    final var roleId =
+        createRoleAndAssignEntity(mappingRuleId, EntityType.MAPPING_RULE).getRoleId();
+    final var query =
+        new MembershipQuery(Map.of(), "userId", PrincipalType.USER)
+            .withMappingRuleIds(List.of(mappingRuleId));
+
+    // when
+    final var result = adapter.roleIds(query);
+
+    // then
+    assertThat(result).containsExactly(roleId);
+  }
+
+  @Test
+  void shouldReturnTenantIdsFromMappingRuleDirectTenantMembership() {
+    // given — mapping rule assigned directly to a tenant
+    final var mappingRuleId = UUID.randomUUID().toString();
+    final var tenantId = createAndAssignTenant(mappingRuleId, EntityType.MAPPING_RULE);
+    final var query =
+        new MembershipQuery(Map.of(), "userId", PrincipalType.USER)
+            .withMappingRuleIds(List.of(mappingRuleId));
+
+    // when
+    final var result = adapter.tenantIds(query);
+
+    // then
+    assertThat(result).containsExactly(tenantId);
+  }
+
   // --- helpers ---
 
   private GroupRecord createGroupAndAssignEntity(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.adapter;
+
+import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
+import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.core.port.out.MembershipPort.PrincipalType;
+import io.camunda.security.core.port.out.MembershipQuery;
+import io.camunda.zeebe.engine.state.appliers.GroupCreatedApplier;
+import io.camunda.zeebe.engine.state.appliers.GroupEntityAddedApplier;
+import io.camunda.zeebe.engine.state.appliers.MappingRuleCreatedApplier;
+import io.camunda.zeebe.engine.state.appliers.RoleCreatedApplier;
+import io.camunda.zeebe.engine.state.appliers.RoleEntityAddedApplier;
+import io.camunda.zeebe.engine.state.appliers.TenantCreatedApplier;
+import io.camunda.zeebe.engine.state.appliers.TenantEntityAddedApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRuleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class MembershipStateAdapterTest {
+
+  @SuppressWarnings("unused") // injected by the extension
+  private MutableProcessingState processingState;
+
+  private MembershipStateAdapter adapter;
+  private MappingRuleCreatedApplier mappingRuleCreatedApplier;
+  private GroupCreatedApplier groupCreatedApplier;
+  private GroupEntityAddedApplier groupEntityAddedApplier;
+  private RoleCreatedApplier roleCreatedApplier;
+  private RoleEntityAddedApplier roleEntityAddedApplier;
+  private TenantCreatedApplier tenantCreatedApplier;
+  private TenantEntityAddedApplier tenantEntityAddedApplier;
+  private final Random random = new Random();
+
+  @BeforeEach
+  void setup() {
+    adapter =
+        new MembershipStateAdapter(
+            processingState.getMappingRuleState(), processingState.getMembershipState());
+    mappingRuleCreatedApplier =
+        new MappingRuleCreatedApplier(processingState.getMappingRuleState());
+    groupCreatedApplier = new GroupCreatedApplier(processingState.getGroupState());
+    groupEntityAddedApplier = new GroupEntityAddedApplier(processingState);
+    roleCreatedApplier = new RoleCreatedApplier(processingState.getRoleState());
+    roleEntityAddedApplier = new RoleEntityAddedApplier(processingState);
+    tenantCreatedApplier = new TenantCreatedApplier(processingState.getTenantState());
+    tenantEntityAddedApplier = new TenantEntityAddedApplier(processingState);
+  }
+
+  @Test
+  void shouldReturnMappingRuleIdsForMatchingTokenClaims() {
+    // given
+    final var claimName = "role";
+    final var claimValue = "admin";
+    final var mappingRuleId = UUID.randomUUID().toString();
+    final var rule =
+        new MappingRuleRecord()
+            .setMappingRuleId(mappingRuleId)
+            .setName(Strings.newRandomValidIdentityId())
+            .setClaimName(claimName)
+            .setClaimValue(claimValue);
+    mappingRuleCreatedApplier.applyState(random.nextLong(), rule);
+    final var query =
+        new MembershipQuery(
+            Map.of(USER_TOKEN_CLAIMS, Map.of(claimName, claimValue)), "user1", PrincipalType.USER);
+
+    // when
+    final var result = adapter.mappingRuleIds(query);
+
+    // then
+    assertThat(result).containsExactly(mappingRuleId);
+  }
+
+  @Test
+  void shouldReturnEmptyMappingRuleIdsWhenTokenClaimsDoNotMatch() {
+    // given
+    final var rule =
+        new MappingRuleRecord()
+            .setMappingRuleId(UUID.randomUUID().toString())
+            .setName(Strings.newRandomValidIdentityId())
+            .setClaimName("role")
+            .setClaimValue("admin");
+    mappingRuleCreatedApplier.applyState(random.nextLong(), rule);
+    final var query = new MembershipQuery(Map.of(), "user1", PrincipalType.USER);
+
+    // when
+    final var result = adapter.mappingRuleIds(query);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnGroupIdsFromTokenClaims() {
+    // given — USER_GROUPS_CLAIMS present → skip DB lookup
+    final var query =
+        new MembershipQuery(
+            Map.of(USER_GROUPS_CLAIMS, List.of("group1", "group2")), "user1", PrincipalType.USER);
+
+    // when
+    final var result = adapter.groupIds(query);
+
+    // then
+    assertThat(result).containsExactly("group1", "group2");
+  }
+
+  @Test
+  void shouldFallBackToMembershipStateWhenNoGroupsClaims() {
+    // given — no USER_GROUPS_CLAIMS → DB lookup
+    final var userId = Strings.newRandomValidIdentityId();
+    final var groupId = createGroupAndAssignEntity(userId, EntityType.USER).getGroupId();
+    final var query = new MembershipQuery(Map.of(), userId, PrincipalType.USER);
+
+    // when
+    final var result = adapter.groupIds(query);
+
+    // then
+    assertThat(result).containsExactly(groupId);
+  }
+
+  @Test
+  void shouldReturnRoleIdsForPrincipalAndGroups() {
+    // given
+    final var userId = Strings.newRandomValidIdentityId();
+    final var directRoleId = createRoleAndAssignEntity(userId, EntityType.USER).getRoleId();
+    final var groupId = createGroupAndAssignEntity(userId, EntityType.USER).getGroupId();
+    final var groupRoleId = createRoleAndAssignEntity(groupId, EntityType.GROUP).getRoleId();
+    final var query =
+        new MembershipQuery(Map.of(), userId, PrincipalType.USER).withGroupIds(List.of(groupId));
+
+    // when
+    final var result = adapter.roleIds(query);
+
+    // then
+    assertThat(result).containsExactlyInAnyOrder(directRoleId, groupRoleId);
+  }
+
+  @Test
+  void shouldDeduplicateRoleIds() {
+    // given — two groups both assigned to the same role
+    final var userId = Strings.newRandomValidIdentityId();
+    final var group1Id = createGroupAndAssignEntity(userId, EntityType.USER).getGroupId();
+    final var group2Id = createGroupAndAssignEntity(userId, EntityType.USER).getGroupId();
+    final var sharedRoleKey = random.nextLong();
+    final var sharedRoleId = Strings.newRandomValidIdentityId();
+    final var sharedRole =
+        new RoleRecord()
+            .setRoleKey(sharedRoleKey)
+            .setRoleId(sharedRoleId)
+            .setName(UUID.randomUUID().toString())
+            .setDescription(UUID.randomUUID().toString());
+    roleCreatedApplier.applyState(sharedRoleKey, sharedRole);
+    roleEntityAddedApplier.applyState(
+        sharedRoleKey, sharedRole.setEntityId(group1Id).setEntityType(EntityType.GROUP));
+    roleEntityAddedApplier.applyState(
+        sharedRoleKey, sharedRole.setEntityId(group2Id).setEntityType(EntityType.GROUP));
+    final var query =
+        new MembershipQuery(Map.of(), userId, PrincipalType.USER)
+            .withGroupIds(List.of(group1Id, group2Id));
+
+    // when
+    final var result = adapter.roleIds(query);
+
+    // then
+    assertThat(result).containsOnlyOnce(sharedRoleId);
+  }
+
+  @Test
+  void shouldReturnTenantIdsViaAllInheritancePaths() {
+    // given
+    final var userId = Strings.newRandomValidIdentityId();
+    final var directTenantId = createAndAssignTenant(userId, EntityType.USER);
+    final var directRoleId = createRoleAndAssignEntity(userId, EntityType.USER).getRoleId();
+    final var roleTenantId = createAndAssignTenant(directRoleId, EntityType.ROLE);
+    final var groupId = createGroupAndAssignEntity(userId, EntityType.USER).getGroupId();
+    final var groupTenantId = createAndAssignTenant(groupId, EntityType.GROUP);
+    final var groupRoleId = createRoleAndAssignEntity(groupId, EntityType.GROUP).getRoleId();
+    final var groupRoleTenantId = createAndAssignTenant(groupRoleId, EntityType.ROLE);
+    final var query =
+        new MembershipQuery(Map.of(), userId, PrincipalType.USER)
+            .withGroupIds(List.of(groupId))
+            .withRoleIds(List.of(directRoleId, groupRoleId));
+
+    // when
+    final var result = adapter.tenantIds(query);
+
+    // then
+    assertThat(result)
+        .containsExactlyInAnyOrder(directTenantId, roleTenantId, groupTenantId, groupRoleTenantId);
+  }
+
+  // --- helpers ---
+
+  private GroupRecord createGroupAndAssignEntity(
+      final String entityId, final EntityType entityType) {
+    final var groupKey = random.nextLong();
+    final var groupId = Strings.newRandomValidIdentityId();
+    final var group =
+        new GroupRecord()
+            .setGroupKey(groupKey)
+            .setGroupId(groupId)
+            .setName(UUID.randomUUID().toString())
+            .setDescription(UUID.randomUUID().toString())
+            .setEntityId(entityId)
+            .setEntityType(entityType);
+    groupCreatedApplier.applyState(groupKey, group);
+    groupEntityAddedApplier.applyState(groupKey, group);
+    return group;
+  }
+
+  private RoleRecord createRoleAndAssignEntity(final String entityId, final EntityType entityType) {
+    final var roleKey = random.nextLong();
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var role =
+        new RoleRecord()
+            .setRoleKey(roleKey)
+            .setRoleId(roleId)
+            .setName(UUID.randomUUID().toString())
+            .setDescription(UUID.randomUUID().toString())
+            .setEntityId(entityId)
+            .setEntityType(entityType);
+    roleCreatedApplier.applyState(roleKey, role);
+    roleEntityAddedApplier.applyState(roleKey, role);
+    return role;
+  }
+
+  private String createAndAssignTenant(final String entityId, final EntityType entityType) {
+    final var tenantKey = random.nextLong();
+    final var tenant =
+        new TenantRecord()
+            .setTenantKey(tenantKey)
+            .setTenantId(Strings.newRandomValidIdentityId())
+            .setName(UUID.randomUUID().toString())
+            .setDescription(UUID.randomUUID().toString());
+    tenantCreatedApplier.applyState(tenantKey, tenant);
+    tenant.setEntityId(entityId).setEntityType(entityType);
+    tenantEntityAddedApplier.applyState(tenantKey, tenant);
+    return tenant.getTenantId();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
@@ -139,6 +139,23 @@ final class MembershipStateAdapterTest {
   }
 
   @Test
+  void shouldReturnGroupIdsFromMatchedMappingRules() {
+    // given — mapping rule assigned to a group; no USER_GROUPS_CLAIMS
+    final var mappingRuleId = UUID.randomUUID().toString();
+    final var groupId =
+        createGroupAndAssignEntity(mappingRuleId, EntityType.MAPPING_RULE).getGroupId();
+    final var query =
+        new MembershipQuery(Map.of(), "userId", PrincipalType.USER)
+            .withMappingRuleIds(List.of(mappingRuleId));
+
+    // when
+    final var result = adapter.groupIds(query);
+
+    // then
+    assertThat(result).containsExactly(groupId);
+  }
+
+  @Test
   void shouldReturnRoleIdsForPrincipalAndGroups() {
     // given
     final var userId = Strings.newRandomValidIdentityId();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.core.port.out.MembershipPort.PrincipalType;
 import io.camunda.security.core.port.out.MembershipQuery;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.appliers.GroupCreatedApplier;
 import io.camunda.zeebe.engine.state.appliers.GroupEntityAddedApplier;
 import io.camunda.zeebe.engine.state.appliers.MappingRuleCreatedApplier;
@@ -56,7 +57,9 @@ final class MembershipStateAdapterTest {
   void setup() {
     adapter =
         new MembershipStateAdapter(
-            processingState.getMappingRuleState(), processingState.getMembershipState());
+            processingState.getMappingRuleState(),
+            processingState.getMembershipState(),
+            new EngineConfiguration());
     mappingRuleCreatedApplier =
         new MappingRuleCreatedApplier(processingState.getMappingRuleState());
     groupCreatedApplier = new GroupCreatedApplier(processingState.getGroupState());


### PR DESCRIPTION
## Summary

- Adds `MembershipStateAdapter` implementing `MembershipPort` (CSL) via `MappingRuleState` and `MembershipState`
- Adds `AuthorizationScopeStateAdapter` implementing `AuthorizationScopeRepositoryPort` (CSL) via `AuthorizationState`
- Both adapters are purely additive — no existing code modified; designed as long-lived singletons
- Dual-path group resolution (OIDC claims → DB fallback) mirrors `ClaimsExtractor.getGroups()`
- Tenant inheritance chain mirrors `TenantResolver.getTenantIdsForEntity()`

Closes https://github.com/camunda/camunda-security-library/issues/401

## Open question

`query.tokenClaims()` is assumed to be the engine authorization-claims map carrying `USER_TOKEN_CLAIMS` and `USER_GROUPS_CLAIMS`. Please confirm when wiring in Inc 4.

## Test plan

- [x] Both adapter unit tests pass with real in-process RocksDB (`ProcessingStateExtension`)
- [x] Full `zeebe/engine` module build passes
- [ ] Full repo compiles: `./mvnw install -Dquickly -T1C` (running)