### PR TITLE
feat: add job priority update command to Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -101,6 +101,7 @@ import io.camunda.client.api.command.UpdateAuthorizationCommandStep1;
 import io.camunda.client.api.command.UpdateGlobalTaskListenerCommandStep1;
 import io.camunda.client.api.command.UpdateGroupCommandStep1;
 import io.camunda.client.api.command.UpdateJobCommandStep1;
+import io.camunda.client.api.command.UpdateJobPriorityCommandStep1;
 import io.camunda.client.api.command.UpdateMappingRuleCommandStep1;
 import io.camunda.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.client.api.command.UpdateRoleCommandStep1;
@@ -638,6 +639,40 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   UpdateTimeoutJobCommandStep1 newUpdateTimeoutCommand(ActivatedJob job);
+
+  /**
+   * Command to update the priority of a job.
+   *
+   * <pre>
+   * long jobKey = ..;
+   *
+   * camundaClient
+   *  .newUpdateJobPriorityCommand(jobKey)
+   *  .priority(5)
+   *  .send();
+   * </pre>
+   *
+   * @param jobKey the key of the job to update
+   * @return a builder for the command
+   */
+  UpdateJobPriorityCommandStep1 newUpdateJobPriorityCommand(long jobKey);
+
+  /**
+   * Command to update the priority of a job.
+   *
+   * <pre>
+   * ActivatedJob job= ..;
+   *
+   * camundaClient
+   *  .newUpdateJobPriorityCommand(job)
+   *  .priority(5)
+   *  .send();
+   * </pre>
+   *
+   * @param job the activated job
+   * @return a builder for the command
+   */
+  UpdateJobPriorityCommandStep1 newUpdateJobPriorityCommand(ActivatedJob job);
 
   /**
    * Registers a new job worker for jobs of a given type.

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateJobCommandStep1.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 public interface UpdateJobCommandStep1 {
 
   /**
-   * Update the retries and/or the timeout of this job.
+   * Update the retries, timeout, and/or priority of this job.
    *
    * <p>If the given retries are greater than zero then this job will be picked up again by a job
    * subscription and a related incident will be marked as resolved.
@@ -37,7 +37,7 @@ public interface UpdateJobCommandStep1 {
   UpdateJobCommandStep2 update(JobChangeset jobChangeset);
 
   /**
-   * Update the retries and/or the timeout of this job.
+   * Update the retries, timeout, and/or priority of this job.
    *
    * <p>If the given retries are greater than zero then this job will be picked up again by a job
    * subscription and a related incident will be marked as resolved.

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateJobCommandStep1.java
@@ -88,6 +88,15 @@ public interface UpdateJobCommandStep1 {
    */
   UpdateJobCommandStep2 updateTimeout(Duration timeout);
 
+  /**
+   * Set the priority of this job.
+   *
+   * @param priority the priority of this job
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateJobCommandStep2 updatePriority(int priority);
+
   interface UpdateJobCommandStep2 extends FinalCommandStep<UpdateJobResponse> {
     // the place for new optional parameters
   }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateJobPriorityCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateJobPriorityCommandStep1.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.UpdateJobPriorityResponse;
+
+public interface UpdateJobPriorityCommandStep1
+    extends CommandWithCommunicationApiStep<UpdateJobPriorityCommandStep1> {
+
+  /**
+   * Set the priority of this job.
+   *
+   * @param priority the priority of this job
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateJobPriorityCommandStep2 priority(int priority);
+
+  interface UpdateJobPriorityCommandStep2
+      extends CommandWithOperationReferenceStep<UpdateJobPriorityCommandStep2>,
+          FinalCommandStep<UpdateJobPriorityResponse> {
+    // the place for new optional parameters
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateJobPriorityResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateJobPriorityResponse.java
@@ -13,38 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.command;
+package io.camunda.client.api.response;
 
-public class JobChangeset {
-
-  private Integer retries;
-  private Long timeout;
-  private Integer priority;
-
-  public Integer getRetries() {
-    return retries;
-  }
-
-  public JobChangeset setRetries(Integer retries) {
-    this.retries = retries;
-    return this;
-  }
-
-  public Long getTimeout() {
-    return timeout;
-  }
-
-  public JobChangeset setTimeout(Long timeout) {
-    this.timeout = timeout;
-    return this;
-  }
-
-  public Integer getPriority() {
-    return priority;
-  }
-
-  public JobChangeset setPriority(Integer priority) {
-    this.priority = priority;
-    return this;
-  }
-}
+public interface UpdateJobPriorityResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -112,6 +112,7 @@ import io.camunda.client.api.command.UpdateAuthorizationCommandStep1;
 import io.camunda.client.api.command.UpdateGlobalTaskListenerCommandStep1;
 import io.camunda.client.api.command.UpdateGroupCommandStep1;
 import io.camunda.client.api.command.UpdateJobCommandStep1;
+import io.camunda.client.api.command.UpdateJobPriorityCommandStep1;
 import io.camunda.client.api.command.UpdateMappingRuleCommandStep1;
 import io.camunda.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.client.api.command.UpdateRoleCommandStep1;
@@ -264,6 +265,7 @@ import io.camunda.client.impl.command.EvaluateExpressionCommandImpl;
 import io.camunda.client.impl.command.GloballyScopedCreateClusterVariableImpl;
 import io.camunda.client.impl.command.GloballyScopedDeleteClusterVariableImpl;
 import io.camunda.client.impl.command.GloballyScopedUpdateClusterVariableImpl;
+import io.camunda.client.impl.command.JobUpdatePriorityCommandImpl;
 import io.camunda.client.impl.command.JobUpdateRetriesCommandImpl;
 import io.camunda.client.impl.command.JobUpdateTimeoutCommandImpl;
 import io.camunda.client.impl.command.MigrateProcessInstanceCommandImpl;
@@ -856,6 +858,23 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public UpdateTimeoutJobCommandStep1 newUpdateTimeoutCommand(final ActivatedJob job) {
     return newUpdateTimeoutCommand(job.getKey());
+  }
+
+  @Override
+  public UpdateJobPriorityCommandStep1 newUpdateJobPriorityCommand(final long jobKey) {
+    return new JobUpdatePriorityCommandImpl(
+        asyncStub,
+        jobKey,
+        config.getDefaultRequestTimeout(),
+        credentialsProvider::shouldRetryRequest,
+        httpClient,
+        config.preferRestOverGrpc(),
+        jsonMapper);
+  }
+
+  @Override
+  public UpdateJobPriorityCommandStep1 newUpdateJobPriorityCommand(final ActivatedJob job) {
+    return newUpdateJobPriorityCommand(job.getKey());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdatePriorityCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdatePriorityCommandImpl.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.CredentialsProvider.StatusCode;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.UpdateJobPriorityCommandStep1;
+import io.camunda.client.api.command.UpdateJobPriorityCommandStep1.UpdateJobPriorityCommandStep2;
+import io.camunda.client.api.response.UpdateJobPriorityResponse;
+import io.camunda.client.impl.RetriableClientFutureImpl;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UpdateJobPriorityResponseImpl;
+import io.camunda.client.protocol.rest.JobChangeset;
+import io.camunda.client.protocol.rest.JobUpdateRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobPriorityRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobPriorityRequest.Builder;
+import io.grpc.stub.StreamObserver;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class JobUpdatePriorityCommandImpl
+    implements UpdateJobPriorityCommandStep1, UpdateJobPriorityCommandStep2 {
+
+  private final GatewayStub asyncStub;
+  private final Builder grpcRequestObjectBuilder;
+  private final Predicate<StatusCode> retryPredicate;
+  private Duration requestTimeout;
+  private boolean useRest;
+  private final JobUpdateRequest httpRequestObject;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long jobKey;
+  private final JsonMapper jsonMapper;
+
+  public JobUpdatePriorityCommandImpl(
+      final GatewayStub asyncStub,
+      final long jobKey,
+      final Duration requestTimeout,
+      final Predicate<StatusCode> retryPredicate,
+      final HttpClient httpClient,
+      final boolean preferRestOverGrpc,
+      final JsonMapper jsonMapper) {
+    this.asyncStub = asyncStub;
+    this.requestTimeout = requestTimeout;
+    this.retryPredicate = retryPredicate;
+    grpcRequestObjectBuilder = UpdateJobPriorityRequest.newBuilder();
+    grpcRequestObjectBuilder.setJobKey(jobKey);
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    httpRequestObject = new JobUpdateRequest();
+    useRest = preferRestOverGrpc;
+    this.jobKey = jobKey;
+    this.jsonMapper = jsonMapper;
+  }
+
+  @Override
+  public UpdateJobPriorityCommandStep2 priority(final int priority) {
+    grpcRequestObjectBuilder.setPriority(priority);
+    getChangesetEnsureInitialized().priority(priority);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<UpdateJobPriorityResponse> requestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<UpdateJobPriorityResponse> send() {
+    if (useRest) {
+      return sendRestRequest();
+    } else {
+      return sendGrpcRequest();
+    }
+  }
+
+  private CamundaFuture<UpdateJobPriorityResponse> sendRestRequest() {
+    final HttpCamundaFuture<UpdateJobPriorityResponse> result = new HttpCamundaFuture<>();
+    httpClient.patch(
+        "/jobs/" + jobKey,
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        UpdateJobPriorityResponseImpl::new,
+        result);
+    return result;
+  }
+
+  private CamundaFuture<UpdateJobPriorityResponse> sendGrpcRequest() {
+    final UpdateJobPriorityRequest request = grpcRequestObjectBuilder.build();
+
+    final RetriableClientFutureImpl<
+            UpdateJobPriorityResponse, GatewayOuterClass.UpdateJobPriorityResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                UpdateJobPriorityResponseImpl::new,
+                retryPredicate,
+                streamObserver -> sendGrpcRequest(request, streamObserver));
+
+    sendGrpcRequest(request, future);
+    return future;
+  }
+
+  private void sendGrpcRequest(
+      final UpdateJobPriorityRequest request,
+      final StreamObserver<GatewayOuterClass.UpdateJobPriorityResponse> streamObserver) {
+    asyncStub
+        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+        .updateJobPriority(request, streamObserver);
+  }
+
+  @Override
+  public UpdateJobPriorityCommandStep2 operationReference(final long operationReference) {
+    grpcRequestObjectBuilder.setOperationReference(operationReference);
+    httpRequestObject.setOperationReference(operationReference);
+    return this;
+  }
+
+  @Override
+  public UpdateJobPriorityCommandStep1 useRest() {
+    useRest = true;
+    return this;
+  }
+
+  @Override
+  public UpdateJobPriorityCommandStep1 useGrpc() {
+    useRest = false;
+    return this;
+  }
+
+  private JobChangeset getChangesetEnsureInitialized() {
+    JobChangeset changeset = httpRequestObject.getChangeset();
+    if (changeset == null) {
+      changeset = new JobChangeset();
+      httpRequestObject.setChangeset(changeset);
+    }
+    return changeset;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdatePriorityCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdatePriorityCommandImpl.java
@@ -76,7 +76,7 @@ public final class JobUpdatePriorityCommandImpl
   @Override
   public UpdateJobPriorityCommandStep2 priority(final int priority) {
     grpcRequestObjectBuilder.setPriority(priority);
-    getChangesetEnsureInitialized().priority(priority);
+    getChangesetEnsureInitialized().setPriority(priority);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateJobCommandImpl.java
@@ -70,7 +70,10 @@ public class UpdateJobCommandImpl implements UpdateJobCommandStep1, UpdateJobCom
     final io.camunda.client.protocol.rest.JobChangeset changeset =
         new io.camunda.client.protocol.rest.JobChangeset();
     if (jobChangeset != null) {
-      changeset.retries(jobChangeset.getRetries()).timeout(jobChangeset.getTimeout());
+      changeset
+          .retries(jobChangeset.getRetries())
+          .timeout(jobChangeset.getTimeout())
+          .priority(jobChangeset.getPriority());
     }
     httpRequestObject.setChangeset(changeset);
     return this;
@@ -97,6 +100,12 @@ public class UpdateJobCommandImpl implements UpdateJobCommandStep1, UpdateJobCom
   @Override
   public UpdateJobCommandStep2 updateTimeout(final Duration timeout) {
     return updateTimeout(timeout.toMillis());
+  }
+
+  @Override
+  public UpdateJobCommandStep2 updatePriority(final int priority) {
+    getChangesetEnsureInitialized().priority(priority);
+    return this;
   }
 
   private io.camunda.client.protocol.rest.JobChangeset getChangesetEnsureInitialized() {

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateJobPriorityResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateJobPriorityResponseImpl.java
@@ -13,38 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.command;
+package io.camunda.client.impl.response;
 
-public class JobChangeset {
+import io.camunda.client.api.response.UpdateJobPriorityResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 
-  private Integer retries;
-  private Long timeout;
-  private Integer priority;
+public class UpdateJobPriorityResponseImpl implements UpdateJobPriorityResponse {
 
-  public Integer getRetries() {
-    return retries;
-  }
+  public UpdateJobPriorityResponseImpl(
+      final GatewayOuterClass.UpdateJobPriorityResponse response) {}
 
-  public JobChangeset setRetries(Integer retries) {
-    this.retries = retries;
-    return this;
-  }
-
-  public Long getTimeout() {
-    return timeout;
-  }
-
-  public JobChangeset setTimeout(Long timeout) {
-    this.timeout = timeout;
-    return this;
-  }
-
-  public Integer getPriority() {
-    return priority;
-  }
-
-  public JobChangeset setPriority(Integer priority) {
-    this.priority = priority;
-    return this;
-  }
+  public UpdateJobPriorityResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/test/java/io/camunda/client/job/JobUpdatePriorityTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/JobUpdatePriorityTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.api.command.UpdateJobPriorityCommandStep1;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.UpdateJobPriorityResponse;
+import io.camunda.client.util.ClientTest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobPriorityRequest;
+import java.time.Duration;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public final class JobUpdatePriorityTest extends ClientTest {
+
+  @Test
+  public void shouldUpdatePriorityByKey() {
+    // given
+    final long jobKey = 12;
+    final int newPriority = 5;
+
+    // when
+    client.newUpdateJobPriorityCommand(jobKey).priority(newPriority).send().join();
+
+    // then
+    final UpdateJobPriorityRequest request = gatewayService.getLastRequest();
+    assertThat(request.getJobKey()).isEqualTo(jobKey);
+    assertThat(request.getPriority()).isEqualTo(newPriority);
+
+    rule.verifyDefaultRequestTimeout();
+  }
+
+  @Test
+  public void shouldUpdatePriority() {
+    // given
+    final int newPriority = 5;
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+
+    // when
+    client.newUpdateJobPriorityCommand(job).priority(newPriority).send().join();
+
+    // then
+    final UpdateJobPriorityRequest request = gatewayService.getLastRequest();
+    assertThat(request.getJobKey()).isEqualTo(job.getKey());
+    assertThat(request.getPriority()).isEqualTo(newPriority);
+
+    rule.verifyDefaultRequestTimeout();
+  }
+
+  @Test
+  public void shouldSetRequestTimeout() {
+    // given
+    final Duration requestTimeout = Duration.ofHours(124);
+
+    // when
+    client
+        .newUpdateJobPriorityCommand(123)
+        .priority(5)
+        .requestTimeout(requestTimeout)
+        .send()
+        .join();
+
+    // then
+    rule.verifyRequestTimeout(requestTimeout);
+  }
+
+  @Test
+  public void shouldSetOperationReference() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client
+        .newUpdateJobPriorityCommand(123)
+        .priority(5)
+        .operationReference(operationReference)
+        .execute();
+
+    // then
+    final UpdateJobPriorityRequest request = gatewayService.getLastRequest();
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
+  public void shouldTransmitPriorityZero() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newUpdateJobPriorityCommand(jobKey).priority(0).send().join();
+
+    // then
+    final UpdateJobPriorityRequest request = gatewayService.getLastRequest();
+    assertThat(request.getPriority()).isEqualTo(0);
+    assertThat(request.hasPriority()).isTrue();
+  }
+
+  @Test
+  public void shouldNotHaveNullResponse() {
+    // given
+    final UpdateJobPriorityCommandStep1 command = client.newUpdateJobPriorityCommand(12);
+
+    // when
+    final UpdateJobPriorityResponse response = command.priority(5).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
@@ -364,4 +364,96 @@ public class JobUpdateRestTest extends ClientRestTest {
     assertThat(request.getChangeset().getRetries()).isNull();
     assertThat(request.getChangeset().getTimeout()).isNull();
   }
+
+  @Test
+  public void shouldUpdatePriorityByKey() {
+    // given
+    final long jobKey = 12;
+    final int newPriority = 5;
+
+    // when
+    client.newUpdateJobPriorityCommand(jobKey).priority(newPriority).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getChangeset().getPriority()).isEqualTo(newPriority);
+  }
+
+  @Test
+  public void shouldUpdatePriority() {
+    // given
+    final int newPriority = 5;
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+
+    // when
+    client.newUpdateJobPriorityCommand(job).priority(newPriority).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getChangeset().getPriority()).isEqualTo(newPriority);
+  }
+
+  @Test
+  public void shouldSetOperationReferenceForUpdatePriorityCommand() {
+    // given
+    final long operationReference = 456;
+
+    // when
+    client
+        .newUpdateJobPriorityCommand(123)
+        .priority(5)
+        .operationReference(operationReference)
+        .execute();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+
+  @Test
+  public void shouldUpdatePriorityZero() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newUpdateJobPriorityCommand(jobKey).priority(0).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getChangeset().getPriority()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldUpdateJobCommandWithPriority() {
+    // given
+    final long jobKey = 12;
+    final int newPriority = 7;
+
+    // when
+    client.newUpdateJobCommand(jobKey).updatePriority(newPriority).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getChangeset().getPriority()).isEqualTo(newPriority);
+    assertThat(request.getChangeset().getRetries()).isNull();
+    assertThat(request.getChangeset().getTimeout()).isNull();
+  }
+
+  @Test
+  public void shouldUpdateJobChangesetWithPriority() {
+    // given
+    final long jobKey = 12;
+    final int newPriority = 3;
+    final JobChangeset changeset = new JobChangeset().setPriority(newPriority);
+
+    // when
+    client.newUpdateJobCommand(jobKey).update(changeset).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getChangeset().getPriority()).isEqualTo(newPriority);
+    assertThat(request.getChangeset().getRetries()).isNull();
+    assertThat(request.getChangeset().getTimeout()).isNull();
+  }
 }

--- a/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
@@ -425,7 +425,7 @@ public class JobUpdateRestTest extends ClientRestTest {
   }
 
   @Test
-  public void shouldSetRequestTimeoutForUpdatePriorityCommand() {
+  public void shouldSendUpdatePriorityRequestWhenRequestTimeoutIsConfigured() {
     // given
     final long jobKey = 12;
     final Duration requestTimeout = Duration.ofHours(124);

--- a/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
@@ -441,6 +441,8 @@ public class JobUpdateRestTest extends ClientRestTest {
     // then
     final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
     assertThat(request.getChangeset().getPriority()).isEqualTo(5);
+    assertThat(request.getChangeset().getTimeout()).isNull();
+    assertThat(request.getChangeset().getRetries()).isNull();
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
@@ -421,7 +421,26 @@ public class JobUpdateRestTest extends ClientRestTest {
 
     // then
     final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
-    assertThat(request.getChangeset().getPriority()).isEqualTo(0);
+    assertThat(request.getChangeset().getPriority()).isNotNull().isEqualTo(0);
+  }
+
+  @Test
+  public void shouldSetRequestTimeoutForUpdatePriorityCommand() {
+    // given
+    final long jobKey = 12;
+    final Duration requestTimeout = Duration.ofHours(124);
+
+    // when
+    client
+        .newUpdateJobPriorityCommand(jobKey)
+        .priority(5)
+        .requestTimeout(requestTimeout)
+        .send()
+        .join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getChangeset().getPriority()).isEqualTo(5);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
@@ -69,6 +69,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobPriorityRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobPriorityResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
@@ -119,6 +121,8 @@ public final class RecordingGatewayService extends GatewayImplBase {
         UpdateJobRetriesRequest.class, r -> UpdateJobRetriesResponse.getDefaultInstance());
     addRequestHandler(
         UpdateJobTimeoutRequest.class, r -> UpdateJobTimeoutResponse.getDefaultInstance());
+    addRequestHandler(
+        UpdateJobPriorityRequest.class, r -> UpdateJobPriorityResponse.getDefaultInstance());
     addRequestHandler(FailJobRequest.class, r -> FailJobResponse.getDefaultInstance());
     addRequestHandler(ThrowErrorRequest.class, r -> ThrowErrorResponse.getDefaultInstance());
     addRequestHandler(CompleteJobRequest.class, r -> CompleteJobResponse.getDefaultInstance());
@@ -431,6 +435,13 @@ public final class RecordingGatewayService extends GatewayImplBase {
   public void updateJobTimeout(
       final UpdateJobTimeoutRequest request,
       final StreamObserver<UpdateJobTimeoutResponse> responseObserver) {
+    handle(request, responseObserver);
+  }
+
+  @Override
+  public void updateJobPriority(
+      final UpdateJobPriorityRequest request,
+      final StreamObserver<UpdateJobPriorityResponse> responseObserver) {
     handle(request, responseObserver);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/JobPriorityUpdateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/JobPriorityUpdateIT.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForJobs;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.UpdateJobPriorityResponse;
+import io.camunda.client.api.search.response.Job;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class JobPriorityUpdateIT {
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withUnauthenticatedAccess();
+
+  private static CamundaClient client;
+  private static CamundaClient grpcClient;
+
+  @BeforeAll
+  static void setUp() {
+    grpcClient = BROKER.newClientBuilder().preferRestOverGrpc(false).build();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (grpcClient != null) {
+      grpcClient.close();
+    }
+  }
+
+  @Test
+  void shouldUpdateJobPriorityViaRest() {
+    // given
+    final int newPriority = 7;
+    final long processInstanceKey = deployAndStartProcess(client, "prio-upd-rest-process");
+    final Job job = waitForJobAvailable(client, processInstanceKey);
+
+    // when
+    final UpdateJobPriorityResponse response =
+        client
+            .newUpdateJobPriorityCommand(job.getJobKey())
+            .useRest()
+            .priority(newPriority)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertPriorityUpdated(client, processInstanceKey, newPriority);
+  }
+
+  @Test
+  void shouldUpdateJobPriorityViaGrpc() {
+    // given
+    final int newPriority = 5;
+    final long processInstanceKey = deployAndStartProcess(grpcClient, "prio-upd-grpc-process");
+    final Job job = waitForJobAvailable(grpcClient, processInstanceKey);
+
+    // when
+    final UpdateJobPriorityResponse response =
+        grpcClient.newUpdateJobPriorityCommand(job.getJobKey()).priority(newPriority).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertPriorityUpdated(grpcClient, processInstanceKey, newPriority);
+  }
+
+  @Test
+  void shouldUpdateJobPriorityViaUpdateJobCommand() {
+    // given
+    final int newPriority = 3;
+    final long processInstanceKey = deployAndStartProcess(client, "prio-upd-cmd-process");
+    final Job job = waitForJobAvailable(client, processInstanceKey);
+
+    // when
+    client.newUpdateJobCommand(job.getJobKey()).updatePriority(newPriority).send().join();
+
+    // then
+    assertPriorityUpdated(client, processInstanceKey, newPriority);
+  }
+
+  @Test
+  void shouldUpdateActivatedJobPriority() {
+    // given
+    final int newPriority = 9;
+    final String jobType = "prio-upd-activated-job";
+    final long processInstanceKey =
+        deployAndStartProcess(client, "prio-upd-activated-process", jobType);
+    waitForJobAvailable(client, processInstanceKey);
+
+    final ActivatedJob activatedJob = activateJob(client, jobType);
+
+    // when
+    client.newUpdateJobCommand(activatedJob).updatePriority(newPriority).send().join();
+
+    // then
+    assertPriorityUpdated(client, processInstanceKey, newPriority);
+  }
+
+  private static long deployAndStartProcess(final CamundaClient c, final String processId) {
+    return deployAndStartProcess(c, processId, "priority-update-job");
+  }
+
+  private static long deployAndStartProcess(
+      final CamundaClient c, final String processId, final String jobType) {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(c, process, processId + ".bpmn");
+    return startProcessInstance(c, processId).getProcessInstanceKey();
+  }
+
+  private static Job waitForJobAvailable(final CamundaClient c, final long processInstanceKey) {
+    return waitForJobs(c, List.of(processInstanceKey)).getFirst();
+  }
+
+  private static ActivatedJob activateJob(final CamundaClient c, final String jobType) {
+    return c.newActivateJobsCommand()
+        .jobType(jobType)
+        .maxJobsToActivate(1)
+        .send()
+        .join()
+        .getJobs()
+        .getFirst();
+  }
+
+  private static void assertPriorityUpdated(
+      final CamundaClient c, final long processInstanceKey, final int expectedPriority) {
+    Awaitility.await("job priority should be updated in search index")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        c.newJobSearchRequest()
+                            .filter(f -> f.processInstanceKey(processInstanceKey))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(job -> assertThat(job.getPriority()).isEqualTo(expectedPriority)));
+  }
+}


### PR DESCRIPTION
## Description

Add `newUpdateJobPriorityCommand(long jobKey)` to the Java client, implementing the same dual-transport (gRPC + REST) pattern used by retries and timeout. Also extend the combined `UpdateJobCommand` with `updatePriority(int)` and wire `priority` through `update(JobChangeset)`. This closes the gap for job priority updates, enabling callers to change a job's priority via either `newUpdateJobPriorityCommand(key).priority(n).send()` (transport-agnostic) or the combined `newUpdateJobCommand(key).updatePriority(n).send()` (REST only). Integration tests cover round-trip updates via both gRPC and REST transports.

## Checklist

<!--- Please delete options that are not relevant. -->

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53857
