### PR TITLE
feat: add available tools section to agent details

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {AvailableTools} from './index';
+import type {AgentTool} from '@camunda/camunda-api-zod-schemas/8.10';
+
+describe('<AvailableTools />', () => {
+  it('should render a list with tool name and description for each tool', () => {
+    const tools: AgentTool[] = [
+      {
+        name: 'get_weather',
+        description: 'Returns current weather for a location.',
+        elementId: null,
+      },
+      {
+        name: 'send_email',
+        description: 'Sends an email to a recipient.',
+        elementId: 'Activity_2',
+      },
+    ];
+
+    render(<AvailableTools tools={tools} />);
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    const firstTool = screen.getByRole('listitem', {name: 'get_weather'});
+    expect(firstTool).toBeVisible();
+    expect(firstTool).toHaveTextContent(
+      'Returns current weather for a location.',
+    );
+
+    const secondTool = screen.getByRole('listitem', {name: 'send_email'});
+    expect(secondTool).toBeVisible();
+    expect(secondTool).toHaveTextContent('Sends an email to a recipient.');
+  });
+
+  it('should render an empty hint when no tools are configured', () => {
+    render(<AvailableTools tools={[]} />);
+
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('No tools available for the AI agent.'),
+    ).toBeVisible();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.tsx
@@ -21,8 +21,13 @@ const AvailableTools: React.FC<AvailableToolsProps> = ({tools}) => {
   return (
     <ToolList>
       {tools.map((tool, i) => (
-        <li key={i} aria-labelledby={`agent-instance-tool-${i}`}>
-          <ToolName id={`agent-instance-tool-${i}`}>{tool.name}</ToolName>
+        <li
+          key={`${tool.name}-${i}`}
+          aria-labelledby={`agent-instance-tool-${tool.name}-${i}`}
+        >
+          <ToolName id={`agent-instance-tool-${tool.name}-${i}`}>
+            {tool.name}
+          </ToolName>
           {tool.description !== null && (
             <ToolDescription>{tool.description}</ToolDescription>
           )}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {AgentTool} from '@camunda/camunda-api-zod-schemas/8.10';
+import {ToolList, ToolName, ToolDescription, EmptyHint} from './styled';
+
+type AvailableToolsProps = {
+  tools: AgentTool[];
+};
+
+const AvailableTools: React.FC<AvailableToolsProps> = ({tools}) => {
+  if (tools.length === 0) {
+    return <EmptyHint>No tools available for the AI agent.</EmptyHint>;
+  }
+
+  return (
+    <ToolList>
+      {tools.map((tool, i) => (
+        <li key={i} aria-labelledby={`agent-instance-tool-${i}`}>
+          <ToolName id={`agent-instance-tool-${i}`}>{tool.name}</ToolName>
+          {tool.description !== null && (
+            <ToolDescription>{tool.description}</ToolDescription>
+          )}
+        </li>
+      ))}
+    </ToolList>
+  );
+};
+
+export {AvailableTools};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/styled.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const ToolList = styled.ul`
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-04);
+`;
+
+const ToolName = styled.span`
+  font-size: var(--cds-label-01-font-size);
+  line-height: var(--cds-label-01-line-height);
+  letter-spacing: var(--cds-label-01-letter-spacing);
+  font-weight: var(--cds-heading-compact-01-font-weight);
+  color: var(--cds-text-primary);
+`;
+
+const ToolDescription = styled.p`
+  font-size: var(--cds-body-compact-01-font-size);
+  line-height: var(--cds-body-compact-01-line-height);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing);
+  color: var(--cds-text-secondary);
+`;
+
+const EmptyHint = styled.span`
+  font-size: var(--cds-body-compact-01-font-size);
+  line-height: var(--cds-body-compact-01-line-height);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing);
+  font-weight: var(--cds-body-compact-01-font-weight);
+  color: var(--cds-text-primary);
+`;
+
+export {ToolList, ToolName, ToolDescription, EmptyHint};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
@@ -20,7 +20,7 @@ const StatusHint = styled.span`
   font-weight: var(--cds-body-compact-01-font-weight);
   line-height: var(--cds-body-compact-01-line-height);
   letter-spacing: var(--cds-body-compact-01-letter-spacing);
-  color: var(--cds-text-primary);
+  color: var(--cds-text-secondary);
 `;
 
 const ShowMoreButton = styled(Button)`

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -251,6 +251,31 @@ describe('<AgentDetails />', () => {
     expect(within(section).getByText('gpt-4')).toBeInTheDocument();
   });
 
+  it('should render tools available for the agent instance', () => {
+    render(
+      <AgentDetails
+        agentInstance={mockAgentInstance({
+          tools: [
+            {name: 'get_weather', description: null, elementId: null},
+            {name: 'tell_joke', description: null, elementId: null},
+          ],
+        })}
+        isLoading={false}
+        isError={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    const section = screen.getByTestId('agent-available-tools-section');
+    expect(section).toBeInTheDocument();
+    expect(
+      within(section).getByRole('listitem', {name: 'get_weather'}),
+    ).toBeInTheDocument();
+    expect(
+      within(section).getByRole('listitem', {name: 'tell_joke'}),
+    ).toBeInTheDocument();
+  });
+
   it('should render the system prompt with copy and expand options', () => {
     render(
       <AgentDetails

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -21,6 +21,7 @@ import {
   Chip,
   DocumentBlank,
   Chat,
+  Tools,
 } from '@carbon/react/icons';
 import {
   AgentDetailsContainer,
@@ -37,6 +38,7 @@ import {SectionTitle} from './SectionTitle';
 import {ConversationMessage} from './ConversationMessage';
 import {ConversationHistory} from './ConversationHistory';
 import {LatestAgentMessage} from './ConversationHistory/LatestAgentMessage';
+import {AvailableTools} from './AvailableTools';
 import {isAgentInstanceActive} from 'modules/queries/agentInstances/agentInstanceStatus';
 
 const STATUS_LABELS: Record<AgentInstanceStatus, string> = {
@@ -185,6 +187,16 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
             actor="SYSTEM"
             content={[{contentType: 'TEXT', text: definition.systemPrompt}]}
           />
+        </AccordionItem>
+        <AccordionItem
+          data-testid="agent-available-tools-section"
+          title={
+            <SectionTitle icon={<Tools size={16} />}>
+              Available tools
+            </SectionTitle>
+          }
+        >
+          <AvailableTools tools={agentInstance.tools} />
         </AccordionItem>
         <AccordionItem
           data-testid="agent-model-section"

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/styled.ts
@@ -26,7 +26,7 @@ const ErrorHint = styled.span`
   font-size: var(--cds-body-compact-01-font-size);
   line-height: var(--cds-body-compact-01-line-height);
   letter-spacing: var(--cds-body-compact-01-letter-spacing);
-  color: var(--cds-text-primary);
+  color: var(--cds-text-secondary);
 `;
 
 const AgentHeading = styled.h5`


### PR DESCRIPTION
## Description

This PR adds a new "Available tools" section to the agent details. It displays the name and description of `tools` on an `agentInstance` as an unordered list.

Furthermore, I adjusted the color of status hints in other parts of the agent details from `primary` to `secondary`. This aligns better with the main text color used throughout Operate.

> [!NOTE]
> The agentic-ai connector currently does not publish available tools. For testing this PR locally, they have to be mocked. https://github.com/camunda/connectors/issues/7640

## Related issues

closes #55711
