### PR TITLE
ci: run RDBMS test-template invocations in parallel to speed up rdbms-integration-tests

### DIFF
--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -787,6 +787,20 @@
             <configuration>
               <groups>rdbms</groups>
               <excludedGroups>rdbms-aurora, multi-db-test, compatibility-test, history</excludedGroups>
+              <properties>
+                <configurationParameters>
+                  <!-- Run the 6 DB-backend invocations of each @RdbmsTestTemplate method in
+                       parallel. Each invocation targets its own isolated container (H2, PG,
+                       MariaDB, MySQL, Oracle, MSSQL), so concurrent execution is safe. Classes
+                       and methods within a class remain sequential to avoid sharing the same
+                       container across concurrent writes. -->
+                  junit.jupiter.execution.parallel.enabled = true
+                  junit.jupiter.execution.parallel.config.strategy = fixed
+                  junit.jupiter.execution.parallel.config.fixed.parallelism = 6
+                  junit.jupiter.execution.parallel.mode.default = same_thread
+                  junit.jupiter.execution.parallel.mode.classes.default = same_thread
+                </configurationParameters>
+              </properties>
             </configuration>
           </plugin>
         </plugins>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/ManualUserDatabaseIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/ManualUserDatabaseIT.java
@@ -15,9 +15,9 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +45,7 @@ public class ManualUserDatabaseIT {
   private static final Logger LOGGER = LoggerFactory.getLogger(ManualUserDatabaseIT.class);
   private static final int PARTITION_ID = 0;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldWorkWithManualUser(final CamundaRdbmsTestApplication testApplication) {
     LOGGER.info("Testing with manual user...");
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
@@ -14,12 +14,12 @@ import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import java.time.OffsetDateTime;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -29,7 +29,7 @@ public class PurgerIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindProcessInstanceByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
@@ -382,7 +382,7 @@ public class RdbmsFlushRollbackIT {
    * duplicate row in the batch INSERT. The {@code BatchInsertMerger} must absorb the second insert
    * so the flush succeeds with a single row instead of failing with a primary-key violation.
    */
-  @TestTemplate
+  @RdbmsTestTemplate
   void shouldDropDuplicateInsertWithinSameFlush(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
@@ -20,11 +20,11 @@ import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -51,7 +51,7 @@ public class RdbmsFlushRollbackIT {
   private static final int PARTITION_ID_FULL_SCENARIO = 10_005;
   private static final int PARTITION_ID_DUPLICATE_INSERT = 10_006;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   void shouldRollbackAllStatementsWhenSecondStatementFails(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -86,7 +86,7 @@ public class RdbmsFlushRollbackIT {
    * listener — if it survived a failed flush, the DB position would advance without
    * lastFlushedPosition being updated, causing a permanent "position mismatch" on the next flush.
    */
-  @TestTemplate
+  @RdbmsTestTemplate
   void shouldRollbackPreFlushListenerItemsWhenFlushFails(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -151,7 +151,7 @@ public class RdbmsFlushRollbackIT {
    * in-memory state (e.g. lastFlushedPosition) is not advanced when the DB transaction was rolled
    * back.
    */
-  @TestTemplate
+  @RdbmsTestTemplate
   void shouldNotCallPostFlushListenerWhenFlushFails(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -191,7 +191,7 @@ public class RdbmsFlushRollbackIT {
    * queued items are rolled back. This mirrors the production scenario where
    * registerLockPositionHook detects divergence and prevents a double-write.
    */
-  @TestTemplate
+  @RdbmsTestTemplate
   void shouldRollbackAllItemsWhenInTransactionHookFails(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -247,7 +247,7 @@ public class RdbmsFlushRollbackIT {
    *   <li>A retry flush succeeds: all queued items are committed and the position advances.
    * </ol>
    */
-  @TestTemplate
+  @RdbmsTestTemplate
   void shouldNotAdvanceExporterPositionAfterFailedFlush(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/TableMetricsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/TableMetricsIT.java
@@ -10,15 +10,15 @@ package io.camunda.it.rdbms.db;
 import io.camunda.db.rdbms.sql.TableMetricsMapper;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class TableMetricsIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCountTableRows(final CamundaRdbmsTestApplication testApplication) {
     final var tableMetricsMapper = testApplication.bean(TableMetricsMapper.class);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
 import io.camunda.search.filter.AgentInstanceFilter;
@@ -24,14 +25,13 @@ import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class AgentInstanceFilterIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByAgentInstanceKey(final CamundaRdbmsTestApplication testApplication) {
     final var model = createAndSaveRandomAgentInstance(testApplication, b -> b);
     createAndSaveRandomAgentInstance(testApplication, b -> b);
@@ -45,7 +45,7 @@ public class AgentInstanceFilterIT {
     assertThat(result.items().getFirst().agentInstanceKey()).isEqualTo(model.agentInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByProcessInstanceKey(final CamundaRdbmsTestApplication testApplication) {
     final long piKey = nextKey();
     final var model =
@@ -60,7 +60,7 @@ public class AgentInstanceFilterIT {
     assertThat(result.items().getFirst().processInstanceKey()).isEqualTo(piKey);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByProcessDefinitionId(final CamundaRdbmsTestApplication testApplication) {
     final String procDefId = "myProcess-" + nextStringId();
     createAndSaveRandomAgentInstance(testApplication, b -> b.processDefinitionId(procDefId));
@@ -76,7 +76,7 @@ public class AgentInstanceFilterIT {
     assertThat(result.items()).allMatch(e -> procDefId.equals(e.processDefinitionId()));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByStatus(final CamundaRdbmsTestApplication testApplication) {
     final String procDefId = "proc-status-" + nextStringId();
     createAndSaveRandomAgentInstance(
@@ -99,7 +99,7 @@ public class AgentInstanceFilterIT {
     assertThat(result.items()).allMatch(e -> e.status() == AgentInstanceStatus.IDLE);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByTenantId(final CamundaRdbmsTestApplication testApplication) {
     final String tenantId = "tenant-" + nextStringId();
     createAndSaveRandomAgentInstance(testApplication, b -> b.tenantId(tenantId));
@@ -113,7 +113,7 @@ public class AgentInstanceFilterIT {
     assertThat(result.items()).allMatch(e -> tenantId.equals(e.tenantId()));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByElementId(final CamundaRdbmsTestApplication testApplication) {
     final String elementId = "Task_specificElement";
     final var model =
@@ -127,7 +127,7 @@ public class AgentInstanceFilterIT {
     assertThat(result.items().getFirst().elementId()).isEqualTo(elementId);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByRootProcessInstanceKey(
       final CamundaRdbmsTestApplication testApplication) {
     final long rootKey = nextKey();
@@ -145,7 +145,7 @@ public class AgentInstanceFilterIT {
     assertThat(result.items().getFirst().rootProcessInstanceKey()).isEqualTo(rootKey);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByElementInstanceKey(final CamundaRdbmsTestApplication testApplication) {
     final long elementInstanceKey = nextKey();
     final var model =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
 import io.camunda.search.filter.AgentInstanceFilter;
@@ -23,14 +24,13 @@ import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class AgentInstanceIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCreateAndGetAgentInstanceByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final AgentInstanceDbModel model = createAndSaveRandomAgentInstance(testApplication, b -> b);
@@ -46,7 +46,7 @@ public class AgentInstanceIT {
     assertFieldsMatch(model, entity);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnNullForUnknownKey(final CamundaRdbmsTestApplication testApplication) {
     final var entity =
         testApplication
@@ -57,7 +57,7 @@ public class AgentInstanceIT {
     assertThat(entity).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllAgentInstancesPaged(final CamundaRdbmsTestApplication testApplication) {
     final String processId = "process-paged-" + nextStringId();
     createAndSaveRandomAgentInstances(testApplication, 20, b -> b.processDefinitionId(processId));
@@ -78,7 +78,7 @@ public class AgentInstanceIT {
     assertThat(result.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyResultForPageSizeZero(
       final CamundaRdbmsTestApplication testApplication) {
     final String processId = "process-zero-" + nextStringId();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
 import io.camunda.search.filter.AgentInstanceFilter;
@@ -26,14 +27,13 @@ import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class AgentInstanceSortIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByCreationDateAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -41,7 +41,7 @@ public class AgentInstanceSortIT {
         Comparator.comparing(AgentInstanceEntity::creationDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByCreationDateDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -49,7 +49,7 @@ public class AgentInstanceSortIT {
         Comparator.comparing(AgentInstanceEntity::creationDate).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByLastUpdatedDateAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -57,7 +57,7 @@ public class AgentInstanceSortIT {
         Comparator.comparing(AgentInstanceEntity::lastUpdatedDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByLastUpdatedDateDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -65,13 +65,13 @@ public class AgentInstanceSortIT {
         Comparator.comparing(AgentInstanceEntity::lastUpdatedDate).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByStatusAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication, b -> b.status().asc(), Comparator.comparing(e -> e.status().name()));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByStatusDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -79,7 +79,7 @@ public class AgentInstanceSortIT {
         Comparator.comparing((AgentInstanceEntity e) -> e.status().name()).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByAgentInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -87,7 +87,7 @@ public class AgentInstanceSortIT {
         Comparator.comparingLong(AgentInstanceEntity::agentInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByAgentInstanceKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -95,7 +95,7 @@ public class AgentInstanceSortIT {
         Comparator.comparingLong(AgentInstanceEntity::agentInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -103,7 +103,7 @@ public class AgentInstanceSortIT {
         Comparator.comparingLong(AgentInstanceEntity::processInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -112,7 +112,7 @@ public class AgentInstanceSortIT {
         Comparator.comparingLong(AgentInstanceEntity::processInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -121,7 +121,7 @@ public class AgentInstanceSortIT {
         Comparator.comparingLong(AgentInstanceEntity::processDefinitionKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -130,7 +130,7 @@ public class AgentInstanceSortIT {
         Comparator.comparingLong(AgentInstanceEntity::processDefinitionKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByElementIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -138,7 +138,7 @@ public class AgentInstanceSortIT {
         Comparator.comparing(AgentInstanceEntity::elementId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByElementIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -146,7 +146,7 @@ public class AgentInstanceSortIT {
         Comparator.comparing(AgentInstanceEntity::elementId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -154,7 +154,7 @@ public class AgentInstanceSortIT {
         Comparator.comparing(AgentInstanceEntity::tenantId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -162,7 +162,7 @@ public class AgentInstanceSortIT {
         Comparator.comparing(AgentInstanceEntity::tenantId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRootProcessInstanceKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -171,7 +171,7 @@ public class AgentInstanceSortIT {
         Comparator.comparingLong(AgentInstanceEntity::rootProcessInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRootProcessInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/ReplicationStatusLogIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/ReplicationStatusLogIT.java
@@ -12,10 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 @Tag("rdbms")
@@ -26,7 +26,7 @@ public class ReplicationStatusLogIT {
       new CamundaRdbmsInvocationContextProviderExtension(
           "camundaWithPostgresReplicationCluster", "camundaWithMssqlReplicationCluster");
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldQueryReplicationStatus(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final var replicationStatusProvider = rdbmsService.getReplicationLogStatusProvider();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogHistoryCleanupIT.java
@@ -15,18 +15,18 @@ import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.it.rdbms.db.fixtures.AuditLogFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class AuditLogHistoryCleanupIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCleanupAuditLogOperations(final CamundaRdbmsTestApplication testApplication) {
     // GIVEN
     final var rdbmsService = testApplication.getRdbmsService();
@@ -52,7 +52,7 @@ public class AuditLogHistoryCleanupIT {
         .isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotCleanupAuditLogOperations(
       final CamundaRdbmsTestApplication testApplication) {
     // GIVEN

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogHistoryCleanupIT.java
@@ -15,18 +15,18 @@ import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.it.rdbms.db.fixtures.AuditLogFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
-import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class AuditLogHistoryCleanupIT {
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldCleanupAuditLogOperations(final CamundaRdbmsTestApplication testApplication) {
     // GIVEN
     final var rdbmsService = testApplication.getRdbmsService();
@@ -52,7 +52,7 @@ public class AuditLogHistoryCleanupIT {
         .isNull();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldNotCleanupAuditLogOperations(
       final CamundaRdbmsTestApplication testApplication) {
     // GIVEN

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
@@ -27,6 +27,7 @@ import io.camunda.db.rdbms.write.service.AuditLogWriter;
 import io.camunda.it.rdbms.db.fixtures.AuditLogFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
 import io.camunda.search.query.AuditLogQuery;
@@ -40,7 +41,6 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -50,7 +50,7 @@ public class AuditLogIT {
   public static final int PARTITION_ID = 0;
   private static final int LIMIT = 10000;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldGetAuditLogById(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -66,7 +66,7 @@ public class AuditLogIT {
     compareAuditLog(instance, original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAuditLogByEntityType(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -90,7 +90,7 @@ public class AuditLogIT {
         .contains(original.auditLogKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAuditLogByProcessInstanceKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -117,7 +117,7 @@ public class AuditLogIT {
     compareAuditLog(instance, original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllAuditLogsPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -139,7 +139,7 @@ public class AuditLogIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllAuditLogsPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -163,7 +163,7 @@ public class AuditLogIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAuditLogWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -198,7 +198,7 @@ public class AuditLogIT {
     assertThat(searchResult.items().getFirst().entityKey()).isEqualTo(original.entityKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAuditLogWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -236,7 +236,7 @@ public class AuditLogIT {
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByAuthorizedCategories(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -277,7 +277,7 @@ public class AuditLogIT {
         .doesNotContain(deployedResourcesLog.auditLogKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByProcessDefinitionWithReadProcessInstance(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -323,7 +323,7 @@ public class AuditLogIT {
         .doesNotContain(log3.auditLogKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByProcessDefinitionWithReadProcessInstanceWildcard(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -376,7 +376,7 @@ public class AuditLogIT {
         .doesNotContain(logWithoutProcessDefId.auditLogKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByProcessDefinitionWithReadUserTask(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -428,7 +428,7 @@ public class AuditLogIT {
         .doesNotContain(log3.auditLogKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByProcessDefinitionWithReadUserTaskWildcard(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -478,7 +478,7 @@ public class AuditLogIT {
         .doesNotContain(adminLog.auditLogKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByCompositeAuthorization(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -539,7 +539,7 @@ public class AuditLogIT {
         .doesNotContain(log4.auditLogKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyResultWhenNoAuthorizationMatch(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -568,7 +568,7 @@ public class AuditLogIT {
     assertThat(searchResult.items()).isEmpty();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnAllWhenAuthorizationDisabled(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -588,7 +588,7 @@ public class AuditLogIT {
     assertThat(searchResult.items()).hasSize(20);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCombineAuthorizationWithOtherFilters(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -655,7 +655,7 @@ public class AuditLogIT {
     assertThat(instance.entityType()).isEqualTo(original.entityType());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessDefinitionRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -704,7 +704,7 @@ public class AuditLogIT {
     assertThat(searchResult.items()).isEmpty();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -744,7 +744,7 @@ public class AuditLogIT {
         .containsOnly(processInstanceKey2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -812,7 +812,7 @@ public class AuditLogIT {
         .containsOnly(processInstanceKey1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSetCleanupDateForProcessInstances(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -852,7 +852,7 @@ public class AuditLogIT {
         .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNotNull());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSetCleanupDateForProcessDefinitions(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -892,7 +892,7 @@ public class AuditLogIT {
         .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNotNull());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSetCleanupDateForDecisionInstances(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -932,7 +932,7 @@ public class AuditLogIT {
         .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNotNull());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSetCleanupDateForDecisionRequirements(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -972,7 +972,7 @@ public class AuditLogIT {
         .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNotNull());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotOverwriteNonNullCleanupDates(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.AuditLogDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.filter.AuditLogFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class AuditLogSortIT {
 
   public static final long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByAuditLogKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -43,7 +43,7 @@ public class AuditLogSortIT {
         Comparator.comparing(AuditLogEntity::auditLogKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByAuditLogKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -51,7 +51,7 @@ public class AuditLogSortIT {
         Comparator.comparing(AuditLogEntity::auditLogKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTimestampAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -59,7 +59,7 @@ public class AuditLogSortIT {
         Comparator.comparing(AuditLogEntity::timestamp));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTimestampDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -67,7 +67,7 @@ public class AuditLogSortIT {
         Comparator.comparing(AuditLogEntity::timestamp).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByActorIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -75,7 +75,7 @@ public class AuditLogSortIT {
         Comparator.comparing(AuditLogEntity::actorId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByActorIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -83,7 +83,7 @@ public class AuditLogSortIT {
         Comparator.comparing(AuditLogEntity::actorId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -91,7 +91,7 @@ public class AuditLogSortIT {
         Comparator.comparing(AuditLogEntity::tenantId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -99,7 +99,7 @@ public class AuditLogSortIT {
         Comparator.comparing(AuditLogEntity::tenantId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByEntityTypeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -107,7 +107,7 @@ public class AuditLogSortIT {
         Comparator.comparing(e -> e.entityType().name()));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByEntityTypeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
@@ -19,6 +19,7 @@ import io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -28,7 +29,6 @@ import io.camunda.security.api.model.authz.AuthorizationResourceMatcher;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -38,7 +38,7 @@ public class AuthorizationIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -56,7 +56,7 @@ public class AuthorizationIT {
     compareAuthorizations(instance, authorization);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -91,7 +91,7 @@ public class AuthorizationIT {
     assertThat(instance.resourceId()).isEqualTo("bar");
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndDelete(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -113,7 +113,7 @@ public class AuthorizationIT {
     assertThat(deletedInstance).isEmpty();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByResourceId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -139,7 +139,7 @@ public class AuthorizationIT {
     compareAuthorizations(instance, authorization);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByAuthorizedResourceId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -165,7 +165,7 @@ public class AuthorizationIT {
     compareAuthorizations(instance, authorization);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -185,7 +185,7 @@ public class AuthorizationIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -206,7 +206,7 @@ public class AuthorizationIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -235,7 +235,7 @@ public class AuthorizationIT {
     compareAuthorizations(searchResult.items().getFirst(), authorization);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class AuthorizationSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByOwnerKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -43,7 +43,7 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::ownerId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByOwnerKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -51,7 +51,7 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::ownerId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByOwnerTypeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -59,7 +59,7 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::ownerType));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByOwnerTypeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -67,7 +67,7 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::ownerType).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourceTypeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -75,7 +75,7 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::resourceType));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourceTypeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -83,7 +83,7 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::resourceType).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourceIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -91,7 +91,7 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::resourceId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourceIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -99,7 +99,7 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::resourceId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourcePropertyNameAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -108,7 +108,7 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::resourcePropertyName));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourcePropertyNameDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationHistoryCleanupIT.java
@@ -15,20 +15,20 @@ import io.camunda.it.rdbms.db.fixtures.AuditLogFixtures;
 import io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class BatchOperationHistoryCleanupIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCleanupBatchOperations(final CamundaRdbmsTestApplication testApplication) {
     // GIVEN
     final var rdbmsService = testApplication.getRdbmsService();
@@ -72,7 +72,7 @@ public class BatchOperationHistoryCleanupIT {
         .isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNOTCleanupBatchOperations(final CamundaRdbmsTestApplication testApplication) {
     // GIVEN
     final var rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationHistoryCleanupIT.java
@@ -15,20 +15,20 @@ import io.camunda.it.rdbms.db.fixtures.AuditLogFixtures;
 import io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
-import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class BatchOperationHistoryCleanupIT {
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldCleanupBatchOperations(final CamundaRdbmsTestApplication testApplication) {
     // GIVEN
     final var rdbmsService = testApplication.getRdbmsService();
@@ -72,7 +72,7 @@ public class BatchOperationHistoryCleanupIT {
         .isNull();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldNOTCleanupBatchOperations(final CamundaRdbmsTestApplication testApplication) {
     // GIVEN
     final var rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -27,6 +27,7 @@ import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
@@ -48,14 +49,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class BatchOperationIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotFailOnSecondCreate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(0);
@@ -73,7 +73,7 @@ public class BatchOperationIT {
     assertThat(updatedBatchOperation).isNotNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldInsertBatchItems(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -109,7 +109,7 @@ public class BatchOperationIT {
     assertThat(updatedItems.items().getFirst().rootProcessInstanceKey()).isNotNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateCompletedBatchItem(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -178,7 +178,7 @@ public class BatchOperationIT {
     assertThat(lastItem.state()).isEqualTo(BatchOperationItemState.ACTIVE);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateCompletedBatchItemWithLargeErrorMessage(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -238,7 +238,7 @@ public class BatchOperationIT {
     assertThat(updatedItem.errorMessage().length()).isEqualTo(4000);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateCompletedBatchItemWithoutInitialExport(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -291,7 +291,7 @@ public class BatchOperationIT {
     assertThat(firstItem.errorMessage()).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateFailedBatchItem(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -359,7 +359,7 @@ public class BatchOperationIT {
     assertThat(lastItem.state()).isEqualTo(BatchOperationItemState.ACTIVE);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateSkippedBatchItem(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -427,7 +427,7 @@ public class BatchOperationIT {
     assertThat(lastItem.state()).isEqualTo(BatchOperationItemState.ACTIVE);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCancelBatchOperationAndActiveItems(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -468,7 +468,7 @@ public class BatchOperationIT {
         .isEqualTo(BatchOperationState.CANCELED);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSuspendBatchOperation(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -492,7 +492,7 @@ public class BatchOperationIT {
         .isEqualTo(BatchOperationState.SUSPENDED);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldResumeBatchOperation(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -519,7 +519,7 @@ public class BatchOperationIT {
         .isEqualTo(BatchOperationState.ACTIVE);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFinishBatchOperation(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -545,7 +545,7 @@ public class BatchOperationIT {
         .isEqualTo(BatchOperationState.COMPLETED);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFinishBatchOperationWithErrors(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -599,7 +599,7 @@ public class BatchOperationIT {
     assertThat(error2.message()).isEqualTo("error message 2");
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFinishBatchOperationWithErrorWithLargeMessage(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -640,7 +640,7 @@ public class BatchOperationIT {
     assertThat(error.message().length()).isEqualTo(4000);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldActivateBatchOperation(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -670,7 +670,7 @@ public class BatchOperationIT {
             });
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindBatchOperationByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -694,7 +694,7 @@ public class BatchOperationIT {
     assertBatchOperationEntity(searchResult.items().getFirst(), batchOperation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindBatchOperationByOperationType(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -723,7 +723,7 @@ public class BatchOperationIT {
     assertThat(operationTypes).containsOnly(batchOperation.operationType());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindBatchOperationByState(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -751,7 +751,7 @@ public class BatchOperationIT {
     assertThat(searchResult.items()).anySatisfy(i -> assertBatchOperationEntity(i, batchOperation));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindBatchOperationWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -782,7 +782,7 @@ public class BatchOperationIT {
     assertThat(searchResult.items()).anySatisfy(i -> assertBatchOperationEntity(i, batchOperation));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllBatchOperationsPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -804,7 +804,7 @@ public class BatchOperationIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllBatchOperationItemsPaged(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -831,7 +831,7 @@ public class BatchOperationIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllBatchOperationsPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -855,7 +855,7 @@ public class BatchOperationIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllBatchOperationItemsPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -881,7 +881,7 @@ public class BatchOperationIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindBatchOperationItemsWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationItemSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationItemSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.BatchOperationItemDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.filter.BatchOperationItemFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -25,7 +26,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -34,7 +34,7 @@ public class BatchOperationItemSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByBatchOperationKey(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -42,7 +42,7 @@ public class BatchOperationItemSortIT {
         Comparator.comparing(BatchOperationItemEntity::batchOperationKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByItemKey(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -50,7 +50,7 @@ public class BatchOperationItemSortIT {
         Comparator.comparing(BatchOperationItemEntity::itemKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKey(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -58,7 +58,7 @@ public class BatchOperationItemSortIT {
         Comparator.comparing(BatchOperationItemEntity::processInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByState(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationSortIT.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
 import io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.filter.BatchOperationFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -21,14 +22,13 @@ import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.sort.BatchOperationSort;
 import java.util.Comparator;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class BatchOperationSortIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortIdAsc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final BatchOperationDbReader batchOperationReader = rdbmsService.getBatchOperationReader();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -22,6 +22,7 @@ import io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.filter.ClusterVariableFilter;
@@ -31,7 +32,6 @@ import io.camunda.search.sort.ClusterVariableSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -41,7 +41,7 @@ public class ClusterVariableIT {
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindTenantClusterVariableByNameAndResource(
       final CamundaRdbmsTestApplication testApplication) {
     final ClusterVariableDbModel randomizedVariable =
@@ -63,7 +63,7 @@ public class ClusterVariableIT {
     assertThat(instance.isPreview()).isFalse();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindGlobalClusterVariableByNameAndResource(
       final CamundaRdbmsTestApplication testApplication) {
     final ClusterVariableDbModel randomizedVariable =
@@ -84,7 +84,7 @@ public class ClusterVariableIT {
     assertThat(instance.isPreview()).isFalse();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindBigTenantClusterVariableByNameAndResource(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -109,7 +109,7 @@ public class ClusterVariableIT {
     assertThat(instance.value()).hasSizeLessThan(instance.fullValue().length());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindBigGlobalClusterVariableByNameAndResource(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -133,7 +133,7 @@ public class ClusterVariableIT {
     assertThat(instance.value()).hasSizeLessThan(instance.fullValue().length());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllTenantClusterVariablesPaged(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -159,7 +159,7 @@ public class ClusterVariableIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllGlobalClusterVariablesPaged(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -181,7 +181,7 @@ public class ClusterVariableIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllTenantClusterVariablesPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -208,7 +208,7 @@ public class ClusterVariableIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllTenantClusterVariablesPageValuesAreNull(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -234,7 +234,7 @@ public class ClusterVariableIT {
     assertThat(searchResult.items()).hasSize(20);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -270,7 +270,7 @@ public class ClusterVariableIT {
     assertThat(searchResult.items().getFirst().tenantId()).isEqualTo(tenantId);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithSearchAfter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -310,7 +310,7 @@ public class ClusterVariableIT {
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateTenantClusterVariable(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -341,7 +341,7 @@ public class ClusterVariableIT {
     assertVariableDbModelEqualToEntity(updatedClusterVariable, instance);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateGlobalClusterVariable(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -371,7 +371,7 @@ public class ClusterVariableIT {
     assertVariableDbModelEqualToEntity(updatedClusterVariable, instance);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteTenantClusterVariable(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -407,7 +407,7 @@ public class ClusterVariableIT {
     assertThat(deletedInstance).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteGlobalClusterVariable(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableSortIT.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.filter.ClusterVariableFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -24,14 +25,13 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class ClusterVariableSortIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByValueAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -39,7 +39,7 @@ public class ClusterVariableSortIT {
         Comparator.comparing(ClusterVariableEntity::value));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByValueDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -47,7 +47,7 @@ public class ClusterVariableSortIT {
         Comparator.comparing(ClusterVariableEntity::value).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -55,7 +55,7 @@ public class ClusterVariableSortIT {
         Comparator.comparing(ClusterVariableEntity::name));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByNameDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -63,7 +63,7 @@ public class ClusterVariableSortIT {
         Comparator.comparing(ClusterVariableEntity::name).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByScopeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -71,7 +71,7 @@ public class ClusterVariableSortIT {
         Comparator.comparing(ClusterVariableEntity::scope));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByScopeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -79,7 +79,7 @@ public class ClusterVariableSortIT {
         Comparator.comparing(ClusterVariableEntity::scope).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -87,7 +87,7 @@ public class ClusterVariableSortIT {
         Comparator.comparing(ClusterVariableEntity::tenantId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableValueFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableValueFilterIT.java
@@ -19,6 +19,7 @@ import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel.ClusterVariableDb
 import io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.filter.ClusterVariableFilter;
@@ -28,14 +29,13 @@ import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.search.sort.ClusterVariableSort;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class ClusterVariableValueFilterIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given 20 random tenant variables
@@ -61,7 +61,7 @@ public class ClusterVariableValueFilterIT {
         testApplication.getRdbmsService(), variableWithFixedName, varName, tenantId, null);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameAndEqValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -88,7 +88,7 @@ public class ClusterVariableValueFilterIT {
         rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameAndLikeValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -115,7 +115,7 @@ public class ClusterVariableValueFilterIT {
         rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameAndEqNumberValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -142,7 +142,7 @@ public class ClusterVariableValueFilterIT {
         rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameAndEqBooleanValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -168,7 +168,7 @@ public class ClusterVariableValueFilterIT {
         rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameAndNeqValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 20 random variables
@@ -197,7 +197,7 @@ public class ClusterVariableValueFilterIT {
         rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameAndGtValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -223,7 +223,7 @@ public class ClusterVariableValueFilterIT {
         rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameAndGteValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -249,7 +249,7 @@ public class ClusterVariableValueFilterIT {
         rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameAndLtValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -275,7 +275,7 @@ public class ClusterVariableValueFilterIT {
         rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameAndLteValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -301,7 +301,7 @@ public class ClusterVariableValueFilterIT {
         rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithNameAndLtValueDouble(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -328,7 +328,7 @@ public class ClusterVariableValueFilterIT {
         rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithMultipleNamesFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -369,7 +369,7 @@ public class ClusterVariableValueFilterIT {
     assertThat(searchResult.items().getFirst().name()).isEqualTo(varName);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindClusterVariableWithMultipleNamesAndValuesFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -412,7 +412,7 @@ public class ClusterVariableValueFilterIT {
     assertThat(searchResult.items().getFirst().value()).isEqualTo(varValue);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldTransformAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -459,7 +459,7 @@ public class ClusterVariableValueFilterIT {
     }
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldTransformSingleWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -504,7 +504,7 @@ public class ClusterVariableValueFilterIT {
     }
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldIgnoreEscapedSQLAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -547,7 +547,7 @@ public class ClusterVariableValueFilterIT {
     assertThat(actual.items().getFirst().value()).isEqualTo(variableValue);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldIgnoreEscapedSQLSingleWildcard(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -591,7 +591,7 @@ public class ClusterVariableValueFilterIT {
     assertThat(actual.items().getFirst().value()).isEqualTo(variableValue);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUnescapeESAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -635,7 +635,7 @@ public class ClusterVariableValueFilterIT {
     assertThat(actual.items()).extracting("value").containsExactlyInAnyOrder(varValue, varValue2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUnescapeESSingleWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
@@ -18,6 +18,7 @@ import io.camunda.it.rdbms.db.fixtures.CorrelatedMessageSubscriptionFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.query.CorrelatedMessageSubscriptionQuery;
 import io.camunda.search.sort.CorrelatedMessageSubscriptionSort;
@@ -28,7 +29,6 @@ import java.util.Comparator;
 import java.util.List;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -38,7 +38,7 @@ public class CorrelatedMessageSubscriptionIT {
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindCorrelatedMessageSubscriptionByCompositeKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -57,7 +57,7 @@ public class CorrelatedMessageSubscriptionIT {
     compareCorrelatedMessageSubscription(instance, original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindCorrelatedMessageSubscriptionByProcessDefinitionId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -81,7 +81,7 @@ public class CorrelatedMessageSubscriptionIT {
         .contains(original.processDefinitionId());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindCorrelatedMessageSubscriptionByBusinessId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -106,7 +106,7 @@ public class CorrelatedMessageSubscriptionIT {
     assertThat(searchResult.items().getFirst().businessId()).isEqualTo(original.businessId());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindCorrelatedMessageSubscriptionByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -130,7 +130,7 @@ public class CorrelatedMessageSubscriptionIT {
     compareCorrelatedMessageSubscription(searchResult.items().getFirst(), original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindCorrelatedMessageSubscriptionByAuthorizedTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -153,7 +153,7 @@ public class CorrelatedMessageSubscriptionIT {
     compareCorrelatedMessageSubscription(searchResult.items().getFirst(), original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllCorrelatedMessageSubscriptionsPaged(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -178,7 +178,7 @@ public class CorrelatedMessageSubscriptionIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllCorrelatedMessageSubscriptionsPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -204,7 +204,7 @@ public class CorrelatedMessageSubscriptionIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindCorrelatedMessageSubscriptionWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -244,7 +244,7 @@ public class CorrelatedMessageSubscriptionIT {
         .isEqualTo(original.subscriptionKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindCorrelatedMessageSubscriptionWithSearchAfter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -285,7 +285,7 @@ public class CorrelatedMessageSubscriptionIT {
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindCorrelatedMessageSubscriptionWithSearchAfterByNullableBusinessId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -340,7 +340,7 @@ public class CorrelatedMessageSubscriptionIT {
     assertThat(nextPage.items()).isEqualTo(allItems.items().subList(15, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByBusinessId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -375,7 +375,7 @@ public class CorrelatedMessageSubscriptionIT {
         .isSortedAccordingTo(Comparator.reverseOrder());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -418,7 +418,7 @@ public class CorrelatedMessageSubscriptionIT {
         .containsExactlyInAnyOrder(item1.messageKey(), item3.messageKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
@@ -18,6 +18,7 @@ import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.DecisionDefinitionQuery;
@@ -25,7 +26,6 @@ import io.camunda.search.sort.DecisionDefinitionSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class DecisionDefinitionIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -64,7 +64,7 @@ public class DecisionDefinitionIT {
         .isEqualTo(decisionDefinition.decisionRequirementsVersion());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByBpmnProcessId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -107,7 +107,7 @@ public class DecisionDefinitionIT {
         .isEqualTo(decisionDefinition.decisionRequirementsVersion());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByAuthorizedResourceId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -134,7 +134,7 @@ public class DecisionDefinitionIT {
         .isEqualTo(decisionDefinition.decisionDefinitionKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByAuthorizedTenantId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -159,7 +159,7 @@ public class DecisionDefinitionIT {
         .isEqualTo(decisionDefinition.decisionDefinitionKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -184,7 +184,7 @@ public class DecisionDefinitionIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -210,7 +210,7 @@ public class DecisionDefinitionIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPageValuesAreNull(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -231,7 +231,7 @@ public class DecisionDefinitionIT {
     assertThat(searchResult.items()).hasSizeGreaterThanOrEqualTo(20);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -265,7 +265,7 @@ public class DecisionDefinitionIT {
         .isEqualTo(decisionDefinition.decisionDefinitionKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class DecisionDefinitionSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionDefinitionIdAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -44,7 +44,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::decisionDefinitionId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionDefinitionIdDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -53,7 +53,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::decisionDefinitionId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionDefinitionKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -62,7 +62,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::decisionDefinitionKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionDefinitionKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -71,7 +71,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::decisionDefinitionKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -79,7 +79,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::name));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByNameDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -87,7 +87,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::name).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRequirementsIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -95,7 +95,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRequirementsIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -103,7 +103,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVersionAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -111,7 +111,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::version));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVersionDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -119,7 +119,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::version).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRequirementsNameAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -127,7 +127,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsName));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRequirementsNameDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -135,7 +135,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsName).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRequirementsVersionAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -144,7 +144,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsVersion));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRequirementsVersionDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -153,7 +153,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsVersion).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -161,7 +161,7 @@ public class DecisionDefinitionSortIT {
         Comparator.comparing(DecisionDefinitionEntity::tenantId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
@@ -23,6 +23,7 @@ import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceInputEntity;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceOutputEntity;
@@ -38,7 +39,6 @@ import java.util.List;
 import javax.sql.DataSource;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -47,7 +47,7 @@ public class DecisionInstanceIT {
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindDecisionInstanceById(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -77,7 +77,7 @@ public class DecisionInstanceIT {
     assertThat(actual.evaluatedOutputs()).hasSize(original.evaluatedOutputs().size());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -103,7 +103,7 @@ public class DecisionInstanceIT {
     assertThat(instance.decisionInstanceKey()).isEqualTo(original.decisionInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindByAuthorizedTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -128,7 +128,7 @@ public class DecisionInstanceIT {
     assertThat(instance.decisionInstanceKey()).isEqualTo(original.decisionInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllDecisionInstancePaged(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -157,7 +157,7 @@ public class DecisionInstanceIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllDecisionInstancePagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -189,7 +189,7 @@ public class DecisionInstanceIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDecisionInstanceWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -233,7 +233,7 @@ public class DecisionInstanceIT {
         .isEqualTo(instance.decisionInstanceId());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDecisionInstanceWithSearchAfter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -288,7 +288,7 @@ public class DecisionInstanceIT {
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindDecisionInstanceWithLargeFailureMessage(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -306,7 +306,7 @@ public class DecisionInstanceIT {
     assertThat(actual.evaluationFailureMessage().length()).isEqualTo(4000);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -348,7 +348,7 @@ public class DecisionInstanceIT {
         .containsExactlyInAnyOrder(item1.decisionInstanceKey(), item3.decisionInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -390,7 +390,7 @@ public class DecisionInstanceIT {
         .containsExactlyInAnyOrder(item1.decisionInstanceKey(), item3.decisionInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveDecisionInstancesWithLargeInputOutputsAndResultsAndFindDecisionInstanceById(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -443,7 +443,7 @@ public class DecisionInstanceIT {
             List.of(new DecisionInstanceInputEntity(evaluatedInputId, "inputName", largeInput)));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFallbackToOldColumnsWhenFindingDecisionInstanceById(
       final CamundaRdbmsTestApplication testApplication) throws SQLException {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
@@ -17,6 +17,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.filter.DecisionInstanceFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -27,7 +28,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -36,7 +36,7 @@ public class DecisionInstanceSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionInstanceIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -44,7 +44,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::decisionInstanceId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionInstanceIdDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -53,7 +53,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::decisionInstanceId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionInstanceKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -62,7 +62,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::decisionInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -71,7 +71,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::decisionInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -80,7 +80,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::processInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -88,7 +88,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::processInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByFlowNodeInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -97,7 +97,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::flowNodeInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByElementInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -105,7 +105,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::flowNodeInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionDefinitionKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     // TODO this makes no sense since builder.decisionDefinitionKey sets the field to "decisionId"
@@ -115,7 +115,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::decisionDefinitionId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionDefinitionKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -124,7 +124,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::decisionDefinitionKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionDefinitionName(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -133,7 +133,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::decisionDefinitionName));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionDefinitionVersion(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -142,7 +142,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::decisionDefinitionVersion));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByEvaluationDate(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -150,7 +150,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::evaluationDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByEvaluationDateDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -158,7 +158,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::evaluationDate).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByState(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -166,7 +166,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::state));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRootDecisionDefinitionKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -175,7 +175,7 @@ public class DecisionInstanceSortIT {
         Comparator.comparing(DecisionInstanceEntity::rootDecisionDefinitionKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRootDecisionDefinitionKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
@@ -19,6 +19,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.filter.DecisionRequirementsFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.DecisionRequirementsQuery;
@@ -27,7 +28,6 @@ import io.camunda.search.sort.DecisionRequirementsSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -37,7 +37,7 @@ public class DecisionRequirementsIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -63,7 +63,7 @@ public class DecisionRequirementsIT {
     assertThat(instance.xml()).isEqualTo(decisionRequirements.xml());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindById(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -101,7 +101,7 @@ public class DecisionRequirementsIT {
     assertThat(instance.xml()).isEqualTo(decisionRequirements.xml());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByAuthorizedResourceId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -128,7 +128,7 @@ public class DecisionRequirementsIT {
         .isEqualTo(decisionRequirements.decisionRequirementsKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByAuthorizedTenantId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -153,7 +153,7 @@ public class DecisionRequirementsIT {
         .isEqualTo(decisionRequirements.decisionRequirementsKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -186,7 +186,7 @@ public class DecisionRequirementsIT {
             });
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -213,7 +213,7 @@ public class DecisionRequirementsIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -246,7 +246,7 @@ public class DecisionRequirementsIT {
         .isEqualTo(decisionRequirements.decisionRequirementsKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.filter.DecisionRequirementsFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class DecisionRequirementsSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionRequirementsIdAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -44,7 +44,7 @@ public class DecisionRequirementsSortIT {
         Comparator.comparing(DecisionRequirementsEntity::decisionRequirementsId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionRequirementsIdDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -53,7 +53,7 @@ public class DecisionRequirementsSortIT {
         Comparator.comparing(DecisionRequirementsEntity::decisionRequirementsId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionRequirementsKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -62,7 +62,7 @@ public class DecisionRequirementsSortIT {
         Comparator.comparing(DecisionRequirementsEntity::decisionRequirementsKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDecisionRequirementsKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -71,7 +71,7 @@ public class DecisionRequirementsSortIT {
         Comparator.comparing(DecisionRequirementsEntity::decisionRequirementsKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -79,7 +79,7 @@ public class DecisionRequirementsSortIT {
         Comparator.comparing(DecisionRequirementsEntity::name));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByNameDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -87,7 +87,7 @@ public class DecisionRequirementsSortIT {
         Comparator.comparing(DecisionRequirementsEntity::name).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVersionAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -95,7 +95,7 @@ public class DecisionRequirementsSortIT {
         Comparator.comparing(DecisionRequirementsEntity::version));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVersionDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceIT.java
@@ -21,6 +21,7 @@ import io.camunda.db.rdbms.write.domain.DeployedResourceDbModel;
 import io.camunda.it.rdbms.db.fixtures.DeployedResourceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.DeployedResourceEntity;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.DeployedResourceQuery;
@@ -28,7 +29,6 @@ import io.camunda.search.sort.DeployedResourceSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -37,7 +37,7 @@ public class DeployedResourceIT {
 
   public static final int PARTITION_ID = 0;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindDeployedResourceByKey(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -64,7 +64,7 @@ public class DeployedResourceIT {
     assertThat(entity.resourceContent()).isEqualTo(resource.resourceContent());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindDeployedResourceMetadataByKey(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -92,7 +92,7 @@ public class DeployedResourceIT {
     assertThat(entity.resourceContent()).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDeployedResourceByResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -120,7 +120,7 @@ public class DeployedResourceIT {
     assertThat(searchResult.items().getFirst().resourceId()).isEqualTo(resource.resourceId());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDeployedResourceByResourceType(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -148,7 +148,7 @@ public class DeployedResourceIT {
     assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDeployedResourceByDeploymentKey(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -176,7 +176,7 @@ public class DeployedResourceIT {
     assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDeployedResourceByVersion(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -208,7 +208,7 @@ public class DeployedResourceIT {
     assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDeployedResourceByVersionTag(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -236,7 +236,7 @@ public class DeployedResourceIT {
     assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDeployedResourceByTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -264,7 +264,7 @@ public class DeployedResourceIT {
     assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDeployedResourceWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -300,7 +300,7 @@ public class DeployedResourceIT {
     assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllDeployedResourcesPaged(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -326,7 +326,7 @@ public class DeployedResourceIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllDeployedResourcesPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -353,7 +353,7 @@ public class DeployedResourceIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDeployedResourceWithSearchAfter(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -397,7 +397,7 @@ public class DeployedResourceIT {
     assertThat(nextPage.items()).isEqualTo(fullResult.items().subList(10, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteDeployedResource(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -431,7 +431,7 @@ public class DeployedResourceIT {
         .containsExactlyInAnyOrder(resource1.resourceKey(), resource3.resourceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDeployedResourceByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -455,7 +455,7 @@ public class DeployedResourceIT {
     assertThat(searchResult.items().getFirst().resourceKey()).isEqualTo(resource.resourceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindDeployedResourceByAuthorizedTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/deployedresource/DeployedResourceSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.DeployedResourceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.DeployedResourceEntity;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.DeployedResourceQuery;
@@ -25,14 +26,13 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class DeployedResourceSortIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -40,7 +40,7 @@ public class DeployedResourceSortIT {
         Comparator.comparing(DeployedResourceEntity::resourceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourceKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -48,7 +48,7 @@ public class DeployedResourceSortIT {
         Comparator.comparing(DeployedResourceEntity::resourceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourceIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -56,7 +56,7 @@ public class DeployedResourceSortIT {
         Comparator.comparing(DeployedResourceEntity::resourceId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourceNameAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -64,7 +64,7 @@ public class DeployedResourceSortIT {
         Comparator.comparing(DeployedResourceEntity::resourceName));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVersionAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -72,7 +72,7 @@ public class DeployedResourceSortIT {
         Comparator.comparing(DeployedResourceEntity::version));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVersionDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -80,7 +80,7 @@ public class DeployedResourceSortIT {
         Comparator.comparing(DeployedResourceEntity::version).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVersionTagAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -89,7 +89,7 @@ public class DeployedResourceSortIT {
             DeployedResourceEntity::versionTag, Comparator.nullsFirst(Comparator.naturalOrder())));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDeploymentKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -97,7 +97,7 @@ public class DeployedResourceSortIT {
         Comparator.comparing(DeployedResourceEntity::deploymentKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/exporterposition/ExporterPositionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/exporterposition/ExporterPositionIT.java
@@ -15,9 +15,9 @@ import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
 import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -28,7 +28,7 @@ public class ExporterPositionIT {
   public static final int OTHER_PARTITION_ID = 1001;
   private static final LocalDateTime NOW = LocalDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindExporterPositionByPartitionId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -48,7 +48,7 @@ public class ExporterPositionIT {
     assertThat(position.lastExportedPosition()).isEqualTo(readPosition.lastExportedPosition());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSelectForUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(OTHER_PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
@@ -21,6 +21,7 @@ import io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -32,7 +33,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -42,7 +42,7 @@ public class FlowNodeInstanceIT {
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindFlowNodeInstanceByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -56,7 +56,7 @@ public class FlowNodeInstanceIT {
     compareFlowNodeInstance(actual, flowNodeInstance);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveLogAndResolveIncident(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -84,7 +84,7 @@ public class FlowNodeInstanceIT {
     assertThat(resolvedInstance.incidentKey()).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindElementInstanceByProcessDefinitionId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -110,7 +110,7 @@ public class FlowNodeInstanceIT {
     compareFlowNodeInstance(searchResult.items().getFirst(), flowNodeInstance);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindElementInstanceByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -135,7 +135,7 @@ public class FlowNodeInstanceIT {
     compareFlowNodeInstance(searchResult.items().getFirst(), flowNodeInstance);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindElementInstanceByAuthorizedTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -158,7 +158,7 @@ public class FlowNodeInstanceIT {
     compareFlowNodeInstance(searchResult.items().getFirst(), flowNodeInstance);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllElementInstancePaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -181,7 +181,7 @@ public class FlowNodeInstanceIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllElementInstancePagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -207,7 +207,7 @@ public class FlowNodeInstanceIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllElementInstancePageValuesAreNull(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -232,7 +232,7 @@ public class FlowNodeInstanceIT {
     assertThat(searchResult.items()).hasSize(20);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindElementInstanceWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -292,7 +292,7 @@ public class FlowNodeInstanceIT {
         .isCloseTo(expected.endDate(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindElementInstanceWithSearchAfter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -337,7 +337,7 @@ public class FlowNodeInstanceIT {
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -379,7 +379,7 @@ public class FlowNodeInstanceIT {
         .containsExactlyInAnyOrder(item1.flowNodeInstanceKey(), item3.flowNodeInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class FlowNodeInstanceSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByFlowNodeInstanceKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -44,7 +44,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::flowNodeInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByFlowNodeInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -53,7 +53,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::flowNodeInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByFlowNodeIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -61,7 +61,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::flowNodeId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByFlowNodeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -69,7 +69,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::flowNodeId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKey(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -77,7 +77,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::processInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionKey(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -85,7 +85,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::processDefinitionKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByStartDateAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -93,7 +93,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::startDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByStartDateDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -101,7 +101,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::startDate).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByEndDate(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -109,7 +109,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::endDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByState(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -117,7 +117,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::state));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantId(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -125,7 +125,7 @@ public class FlowNodeInstanceSortIT {
         Comparator.comparing(FlowNodeInstanceEntity::tenantId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByIncidentKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -136,7 +136,7 @@ public class FlowNodeInstanceSortIT {
                 Comparator.nullsLast(Comparator.naturalOrder()))));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByIncidentKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -148,7 +148,7 @@ public class FlowNodeInstanceSortIT {
                 .reversed()));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByType(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/form/FormIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/form/FormIT.java
@@ -18,20 +18,20 @@ import io.camunda.db.rdbms.write.domain.FormDbModel.FormDbModelBuilder;
 import io.camunda.it.rdbms.db.fixtures.FormFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.filter.FormFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.sort.FormSort;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class FormIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindFormByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -42,7 +42,7 @@ public class FormIT {
     assertFormEntity(form, randomizedForm);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateAndFindFormByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -57,7 +57,7 @@ public class FormIT {
     assertFormEntity(form, updatedModel);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindFormByFormId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -79,7 +79,7 @@ public class FormIT {
     assertFormEntity(searchResult.items().getFirst(), randomizedForm);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindFormByTenantId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -101,7 +101,7 @@ public class FormIT {
     assertFormEntity(searchResult.items().getFirst(), randomizedForm);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllFormsPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -122,7 +122,7 @@ public class FormIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllFormsPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -145,7 +145,7 @@ public class FormIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindFormWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final FormDbReader formReader = rdbmsService.getFormReader();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/form/FormSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/form/FormSortIT.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.read.service.FormDbReader;
 import io.camunda.it.rdbms.db.fixtures.FormFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.filter.FormFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -22,14 +23,13 @@ import io.camunda.search.query.FormQuery;
 import io.camunda.search.sort.FormSort;
 import java.util.Comparator;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class FormSortIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortFormsByVersionAsc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final FormDbReader formReader = rdbmsService.getFormReader();
@@ -48,7 +48,7 @@ public class FormSortIT {
     assertThat(searchResult.items()).isSortedAccordingTo(Comparator.comparing(FormEntity::version));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortFormsByVersionDesc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final FormDbReader formReader = rdbmsService.getFormReader();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerFilterIT.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.GlobalListenerEntity;
 import io.camunda.search.filter.GlobalListenerFilter;
 import io.camunda.search.filter.Operation;
@@ -26,13 +27,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class GlobalListenerFilterIT {
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithEqListenerIdFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given multiple listeners but only one with "expectedEq" listenerId
@@ -63,7 +63,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithLikeListenerIdFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given multiple listeners but only two with listenerId matching "expectedLike*"
@@ -96,7 +96,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithInListenerIdFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given multiple listeners but only two with listenerId either "expectedIn1" or "expectedIn2"
@@ -129,7 +129,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithEqTypeFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given multiple listeners but only one with "expectedEq" type
@@ -157,7 +157,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithLikeTypeFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given multiple listeners but only two with type matching "expectedLike*"
@@ -187,7 +187,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithInTypeFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given multiple listeners but only two with type either "expectedIn1" or "expectedIn2"
@@ -217,7 +217,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithEqRetriesFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -250,7 +250,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithGtRetriesFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -285,7 +285,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithGteRetriesFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -320,7 +320,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithLtRetriesFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -355,7 +355,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithLteRetriesFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -390,7 +390,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithInRetriesFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -425,7 +425,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithAfterNonGlobalFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given multiple listeners but only one with afterNonGlobal=true
@@ -451,7 +451,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithEqPriorityFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -484,7 +484,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithGtPriorityFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -519,7 +519,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithGtePriorityFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -554,7 +554,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithLtPriorityFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -589,7 +589,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithLtePriorityFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -624,7 +624,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithInPriorityFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -659,7 +659,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithEqEventTypeFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -698,7 +698,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithLikeEventTypeFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
@@ -737,7 +737,7 @@ public class GlobalListenerFilterIT {
     assertExpectedResult(searchResult, expectedListener1, expectedListener2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGlobalListenerWithInEventTypeFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
@@ -17,6 +17,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.GlobalListenerEntity;
 import io.camunda.search.filter.GlobalListenerFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -24,14 +25,13 @@ import io.camunda.search.query.GlobalListenerQuery;
 import io.camunda.search.sort.GlobalListenerSort;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class GlobalListenerIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCreateAndGetGlobalListenerByListenerIdAndListenerType(
       final CamundaRdbmsTestApplication testApplication) {
     // given a randomized listener
@@ -55,7 +55,7 @@ public class GlobalListenerIT {
     assertDbModelEqualToEntity(globalListener, entity);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllGlobalListenersPaged(final CamundaRdbmsTestApplication testApplication) {
     // This value is set in the "type" of all listeners and used in the search query in order to
     // ensure that only the listeners created in this specific test are returned
@@ -82,7 +82,7 @@ public class GlobalListenerIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllGlobalListenersPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final String testIdentifier = nextStringId();
@@ -109,7 +109,7 @@ public class GlobalListenerIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateGlobalListener(final CamundaRdbmsTestApplication testApplication) {
     // given an existing global listener
     final GlobalListenerDbModel globalListener =
@@ -139,7 +139,7 @@ public class GlobalListenerIT {
     assertDbModelEqualToEntity(updatedGlobalListener, instance);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteGlobalListener(final CamundaRdbmsTestApplication testApplication) {
     // given an existing global listener
     final GlobalListenerDbModel globalListener =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerSortIT.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.GlobalListenerEntity;
 import io.camunda.search.filter.GlobalListenerFilter;
 import io.camunda.search.filter.Operation;
@@ -25,19 +26,18 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class GlobalListenerSortIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(testApplication, b -> b.id().asc(), Comparator.comparing(GlobalListenerEntity::id));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -45,7 +45,7 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::id).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByListenerIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -53,7 +53,7 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::listenerId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByListenerIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -61,13 +61,13 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::listenerId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTypeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication, b -> b.type().asc(), Comparator.comparing(GlobalListenerEntity::type));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTypeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -75,7 +75,7 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::type).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByAfterNonGlobalAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -83,7 +83,7 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::afterNonGlobal));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByAfterNonGlobalDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -91,7 +91,7 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::afterNonGlobal).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByPriorityAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -99,7 +99,7 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::priority));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByPriorityDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -107,13 +107,13 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::priority).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortBySourceAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication, b -> b.source().asc(), Comparator.comparing(GlobalListenerEntity::source));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortBySourceDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -121,7 +121,7 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::source).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByListenerTypeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -129,7 +129,7 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::listenerType));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByListenerTypeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication,
@@ -137,7 +137,7 @@ public class GlobalListenerSortIT {
         Comparator.comparing(GlobalListenerEntity::listenerType).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortWhenCombiningWithDefaultSorting(
       final CamundaRdbmsTestApplication testApplication) {
     // When searching global listeners through API, a default sorting is applied:

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
@@ -23,6 +23,7 @@ import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.fixtures.UserFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.UserFilter;
@@ -33,7 +34,6 @@ import io.camunda.search.sort.GroupSort;
 import io.camunda.search.sort.UserSort;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -43,7 +43,7 @@ public class GroupIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -57,7 +57,7 @@ public class GroupIT {
     compareGroups(instance, group);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindById(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -71,7 +71,7 @@ public class GroupIT {
     compareGroups(instance, group);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -90,7 +90,7 @@ public class GroupIT {
     compareGroups(instance, groupUpdate);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndDelete(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -108,7 +108,7 @@ public class GroupIT {
     assertThat(deletedInstance).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByName(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -135,7 +135,7 @@ public class GroupIT {
     assertThat(instance.name()).isEqualTo(group.name());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByGroupIds(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -160,7 +160,7 @@ public class GroupIT {
         .containsExactlyInAnyOrder(group1.groupId(), group2.groupId());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -180,7 +180,7 @@ public class GroupIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -201,7 +201,7 @@ public class GroupIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -223,7 +223,7 @@ public class GroupIT {
     assertThat(searchResult.items().getFirst().groupKey()).isEqualTo(group.groupKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -254,7 +254,7 @@ public class GroupIT {
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAddMemberToGroup(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -280,7 +280,7 @@ public class GroupIT {
     assertThat(users.total()).isEqualTo(1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldRemoveMemberFromGroup(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupMemberIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupMemberIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.write.domain.GroupMemberDbModel;
 import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.filter.GroupMemberFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -36,7 +36,7 @@ public class GroupMemberIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindGroupMember(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.GroupDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class GroupSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByGroupKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -43,7 +43,7 @@ public class GroupSortIT {
         Comparator.comparing(GroupEntity::groupKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByGroupKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -51,7 +51,7 @@ public class GroupSortIT {
         Comparator.comparing(GroupEntity::groupKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByGroupIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -59,7 +59,7 @@ public class GroupSortIT {
         Comparator.comparing(GroupEntity::groupId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByGroupIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historycleanup/HistoryCleanupIT.java
@@ -16,17 +16,17 @@ import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.history.ProcessInstanceHistory;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class HistoryCleanupIT extends ProcessInstanceHistory {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldExecuteHistoryCleanupSuccessfully(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -66,7 +66,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     processInstanceAndRelatedRecordsExist(rdbmsService, otherRootProcessInstanceKey);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldExitEarlyIfDependentChildrenNotFullyDeleted(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -105,7 +105,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     assertThat(auditLogCount(rdbmsService, rootProcessInstanceKey)).isEqualTo(10L);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteDependentProcesses(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -141,7 +141,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     processInstanceAndRelatedRecordsHaveBeenDeleted(rdbmsService, dependentProcessInstanceKey);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldExitEarlyIfDependentProcessesNotFullyDeleted(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -184,7 +184,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     assertThat(processInstanceCount(rdbmsService, dependentProcessInstanceIds)).isEqualTo(0L);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldIgnoreNonRootProcessInstancesWithCleanupDateSet(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historycleanup/HistoryCleanupIT.java
@@ -16,17 +16,17 @@ import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.history.ProcessInstanceHistory;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
-import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class HistoryCleanupIT extends ProcessInstanceHistory {
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldExecuteHistoryCleanupSuccessfully(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -66,7 +66,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     processInstanceAndRelatedRecordsExist(rdbmsService, otherRootProcessInstanceKey);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldExitEarlyIfDependentChildrenNotFullyDeleted(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -105,7 +105,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     assertThat(auditLogCount(rdbmsService, rootProcessInstanceKey)).isEqualTo(10L);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldDeleteDependentProcesses(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -141,7 +141,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     processInstanceAndRelatedRecordsHaveBeenDeleted(rdbmsService, dependentProcessInstanceKey);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldExitEarlyIfDependentProcessesNotFullyDeleted(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -184,7 +184,7 @@ public class HistoryCleanupIT extends ProcessInstanceHistory {
     assertThat(processInstanceCount(rdbmsService, dependentProcessInstanceIds)).isEqualTo(0L);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldIgnoreNonRootProcessInstancesWithCleanupDateSet(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionIT.java
@@ -17,10 +17,10 @@ import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
 import io.camunda.db.rdbms.write.service.HistoryDeletionWriter;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -49,7 +49,7 @@ public class HistoryDeletionIT {
     rdbmsWriters.getRdbmsPurger().purgeRdbms();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldInsertHistoryDeletion() {
     // given
     final var model =
@@ -65,7 +65,7 @@ public class HistoryDeletionIT {
     assertThat(actual.historyDeletionModels()).containsExactly(model);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldBeEmpty() {
     // when
     final var actual = historyDeletionReader.getNextBatch(PARTITION_ID, 1);
@@ -74,7 +74,7 @@ public class HistoryDeletionIT {
     assertThat(actual.historyDeletionModels()).isEmpty();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldInsertAndRetrieveMultipleModels() {
     // given
     final var model1 =
@@ -102,7 +102,7 @@ public class HistoryDeletionIT {
     assertThat(actual.historyDeletionModels()).containsExactlyInAnyOrder(model1, model2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByPartition() {
     // given
     final var modelPartition0 =
@@ -132,7 +132,7 @@ public class HistoryDeletionIT {
     assertThat(actualPartition1.historyDeletionModels()).containsExactly(modelPartition1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByBatchOperationKeyAndResourceKey() {
     // given
     final var modelA =
@@ -173,7 +173,7 @@ public class HistoryDeletionIT {
             );
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotFailOnDuplicateInsert() {
     // given
     final var model =
@@ -191,7 +191,7 @@ public class HistoryDeletionIT {
     assertThat(actual.historyDeletionModels()).containsExactly(model);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteHistoryDeletion() {
     // given
     final var model =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionIT.java
@@ -17,10 +17,10 @@ import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
 import io.camunda.db.rdbms.write.service.HistoryDeletionWriter;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
-import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -49,7 +49,7 @@ public class HistoryDeletionIT {
     rdbmsWriters.getRdbmsPurger().purgeRdbms();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldInsertHistoryDeletion() {
     // given
     final var model =
@@ -65,7 +65,7 @@ public class HistoryDeletionIT {
     assertThat(actual.historyDeletionModels()).containsExactly(model);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldBeEmpty() {
     // when
     final var actual = historyDeletionReader.getNextBatch(PARTITION_ID, 1);
@@ -74,7 +74,7 @@ public class HistoryDeletionIT {
     assertThat(actual.historyDeletionModels()).isEmpty();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldInsertAndRetrieveMultipleModels() {
     // given
     final var model1 =
@@ -102,7 +102,7 @@ public class HistoryDeletionIT {
     assertThat(actual.historyDeletionModels()).containsExactlyInAnyOrder(model1, model2);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterByPartition() {
     // given
     final var modelPartition0 =
@@ -132,7 +132,7 @@ public class HistoryDeletionIT {
     assertThat(actualPartition1.historyDeletionModels()).containsExactly(modelPartition1);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldSortByBatchOperationKeyAndResourceKey() {
     // given
     final var modelA =
@@ -173,7 +173,7 @@ public class HistoryDeletionIT {
             );
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldNotFailOnDuplicateInsert() {
     // given
     final var model =
@@ -191,7 +191,7 @@ public class HistoryDeletionIT {
     assertThat(actual.historyDeletionModels()).containsExactly(model);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldDeleteHistoryDeletion() {
     // given
     final var model =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
@@ -20,16 +20,16 @@ import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.history.ProcessInstanceHistory;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import java.time.Duration;
 import java.time.InstantSource;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldExecuteHistoryDeletionForProcessInstanceSuccessfully(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -75,7 +75,7 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
     processInstanceAndRelatedRecordsExist(rdbmsService, otherProcessInstanceKey);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldExitEarlyIfProcessInstanceDependentChildrenNotFullyDeleted(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -120,7 +120,7 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
     auditLogsNotDeleted(rdbmsService, processInstanceKey);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteVariableNameLookupWhenDeletingProcessDefinition(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -24,7 +24,6 @@ import io.camunda.it.rdbms.db.fixtures.IncidentFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
-import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
@@ -43,6 +42,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -52,7 +52,7 @@ public class IncidentIT {
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldSaveAndFindIncidentByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -66,7 +66,7 @@ public class IncidentIT {
     compareIncident(instance, original);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldSaveAndFindIncidentWithLargeErrorMessageByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -82,7 +82,7 @@ public class IncidentIT {
     assertThat(instance.errorMessage().length()).isLessThan(original.errorMessage().length());
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldSaveAndResolveIncident(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -100,7 +100,7 @@ public class IncidentIT {
     assertThat(instance.errorMessage()).isEqualTo(original.errorMessage());
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldSaveAndResolveIncidentInSingleFlush(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -119,7 +119,7 @@ public class IncidentIT {
     assertThat(instance.errorMessage()).isEqualTo(original.errorMessage());
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindIncidentByBpmnProcessId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -145,7 +145,7 @@ public class IncidentIT {
     compareIncident(instance, original);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindIncidentByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -169,7 +169,7 @@ public class IncidentIT {
     compareIncident(searchResult.items().getFirst(), original);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindIncidentByAuthorizedTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -191,7 +191,7 @@ public class IncidentIT {
     compareIncident(searchResult.items().getFirst(), original);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindAllIncidentPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -213,7 +213,7 @@ public class IncidentIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindAllIncidentPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -238,7 +238,7 @@ public class IncidentIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindIncidentWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -277,7 +277,7 @@ public class IncidentIT {
     assertThat(searchResult.items().getFirst().incidentKey()).isEqualTo(original.incidentKey());
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindIncidentWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -327,7 +327,7 @@ public class IncidentIT {
         .isCloseTo(original.creationDate(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -369,7 +369,7 @@ public class IncidentIT {
         .containsExactlyInAnyOrder(item1.incidentKey(), item3.incidentKey());
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -411,7 +411,7 @@ public class IncidentIT {
         .containsExactlyInAnyOrder(item1.incidentKey(), item3.incidentKey());
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindIncidentProcessInstanceStatisticsByError(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -489,7 +489,7 @@ public class IncidentIT {
             org.assertj.core.api.Assertions.tuple(error2Hash, error2, 2L));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindIncidentProcessInstanceStatisticsByErrorWithSortAndPagination(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -640,7 +640,7 @@ public class IncidentIT {
                 .errorMessageHash(hash));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindIncidentProcessInstanceStatisticsByDefinition(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -720,7 +720,7 @@ public class IncidentIT {
                 1L));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFindIncidentProcessInstanceStatisticsByDefinitionWithSortAndPagination(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -24,6 +24,7 @@ import io.camunda.it.rdbms.db.fixtures.IncidentFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
@@ -42,7 +43,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -52,7 +52,7 @@ public class IncidentIT {
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindIncidentByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -66,7 +66,7 @@ public class IncidentIT {
     compareIncident(instance, original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindIncidentWithLargeErrorMessageByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -82,7 +82,7 @@ public class IncidentIT {
     assertThat(instance.errorMessage().length()).isLessThan(original.errorMessage().length());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndResolveIncident(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -100,7 +100,7 @@ public class IncidentIT {
     assertThat(instance.errorMessage()).isEqualTo(original.errorMessage());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndResolveIncidentInSingleFlush(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -119,7 +119,7 @@ public class IncidentIT {
     assertThat(instance.errorMessage()).isEqualTo(original.errorMessage());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindIncidentByBpmnProcessId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -145,7 +145,7 @@ public class IncidentIT {
     compareIncident(instance, original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindIncidentByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -169,7 +169,7 @@ public class IncidentIT {
     compareIncident(searchResult.items().getFirst(), original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindIncidentByAuthorizedTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -191,7 +191,7 @@ public class IncidentIT {
     compareIncident(searchResult.items().getFirst(), original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllIncidentPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -213,7 +213,7 @@ public class IncidentIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllIncidentPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -238,7 +238,7 @@ public class IncidentIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindIncidentWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -277,7 +277,7 @@ public class IncidentIT {
     assertThat(searchResult.items().getFirst().incidentKey()).isEqualTo(original.incidentKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindIncidentWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -327,7 +327,7 @@ public class IncidentIT {
         .isCloseTo(original.creationDate(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -369,7 +369,7 @@ public class IncidentIT {
         .containsExactlyInAnyOrder(item1.incidentKey(), item3.incidentKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -411,7 +411,7 @@ public class IncidentIT {
         .containsExactlyInAnyOrder(item1.incidentKey(), item3.incidentKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindIncidentProcessInstanceStatisticsByError(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -489,7 +489,7 @@ public class IncidentIT {
             org.assertj.core.api.Assertions.tuple(error2Hash, error2, 2L));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindIncidentProcessInstanceStatisticsByErrorWithSortAndPagination(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -640,7 +640,7 @@ public class IncidentIT {
                 .errorMessageHash(hash));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindIncidentProcessInstanceStatisticsByDefinition(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -720,7 +720,7 @@ public class IncidentIT {
                 1L));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindIncidentProcessInstanceStatisticsByDefinitionWithSortAndPagination(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.IncidentDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class IncidentSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByIncidentKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -43,7 +43,7 @@ public class IncidentSortIT {
         Comparator.comparing(IncidentEntity::incidentKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByIncidentKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -51,7 +51,7 @@ public class IncidentSortIT {
         Comparator.comparing(IncidentEntity::incidentKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByElementIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -59,7 +59,7 @@ public class IncidentSortIT {
         Comparator.comparing(IncidentEntity::flowNodeId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionIdDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -68,7 +68,7 @@ public class IncidentSortIT {
         Comparator.comparing(IncidentEntity::processDefinitionId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -77,7 +77,7 @@ public class IncidentSortIT {
         Comparator.comparing(IncidentEntity::processDefinitionKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -86,7 +86,7 @@ public class IncidentSortIT {
         Comparator.comparing(IncidentEntity::processInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByErrorTypeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -94,7 +94,7 @@ public class IncidentSortIT {
         Comparator.comparing(it -> it.errorType().name()));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByStateAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -102,7 +102,7 @@ public class IncidentSortIT {
         Comparator.comparing(it -> it.state().name()));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByJobKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -110,7 +110,7 @@ public class IncidentSortIT {
         Comparator.comparing(IncidentEntity::jobKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -118,7 +118,7 @@ public class IncidentSortIT {
         Comparator.comparing(IncidentEntity::tenantId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByCreationTimeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -126,7 +126,7 @@ public class IncidentSortIT {
         Comparator.comparing(IncidentEntity::creationTime));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByCreationTimeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
@@ -22,6 +22,7 @@ import io.camunda.it.rdbms.db.fixtures.JobFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.JobQuery;
@@ -33,7 +34,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -43,7 +43,7 @@ public class JobIT {
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindJobByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -63,7 +63,7 @@ public class JobIT {
     assertThat(instance.isDenied()).isFalse();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindJobWithLargeErrorMessageByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -79,7 +79,7 @@ public class JobIT {
     assertThat(instance.errorMessage().length()).isLessThan(original.errorMessage().length());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveUpdateAndFindJobWithLargeErrorMessageByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -100,7 +100,7 @@ public class JobIT {
     assertThat(instance.errorMessage().length()).isLessThan(errorMessage.length());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindJobByProcessDefinitionId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -127,7 +127,7 @@ public class JobIT {
     compareJob(instance, original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindJobByPartitionId(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -162,7 +162,7 @@ public class JobIT {
     assertThat(searchResult.items()).hasSize(3);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindJobByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -186,7 +186,7 @@ public class JobIT {
     compareJob(searchResult.items().getFirst(), original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindJobByAuthorizedTenantId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -207,7 +207,7 @@ public class JobIT {
     compareJob(searchResult.items().getFirst(), original);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllJobPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -229,7 +229,7 @@ public class JobIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllJobPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -253,7 +253,7 @@ public class JobIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindJobWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -287,7 +287,7 @@ public class JobIT {
     assertThat(searchResult.items().getFirst().jobKey()).isEqualTo(original.jobKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindJobWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -340,7 +340,7 @@ public class JobIT {
         .isCloseTo(original.deadline(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateJobWithoutOverwritingNullableFieldsWithNull(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -398,7 +398,7 @@ public class JobIT {
     assertThat(stored.priority()).isEqualTo(original.priority());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -440,7 +440,7 @@ public class JobIT {
         .containsExactlyInAnyOrder(item1.jobKey(), item3.jobKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -482,7 +482,7 @@ public class JobIT {
         .containsExactlyInAnyOrder(item1.jobKey(), item3.jobKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindJobByPriorityFilter(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -509,7 +509,7 @@ public class JobIT {
     assertThat(rangeResult.items().getFirst().jobKey()).isEqualTo(target.jobKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindJobSortedByPriority(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -539,7 +539,7 @@ public class JobIT {
         .containsExactly(low.jobKey(), mid.jobKey(), high.jobKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldExcludeNullPriorityJobsFromPriorityFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given — a job with NULL priority (pre-8.10) and a job with explicit priority

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.JobDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.filter.JobFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class JobSortIT {
 
   public static final long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByJobKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -43,7 +43,7 @@ public class JobSortIT {
         Comparator.comparing(JobEntity::jobKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByJobKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -51,7 +51,7 @@ public class JobSortIT {
         Comparator.comparing(JobEntity::jobKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTypeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -59,7 +59,7 @@ public class JobSortIT {
         Comparator.comparing(JobEntity::type));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTypeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -67,7 +67,7 @@ public class JobSortIT {
         Comparator.comparing(JobEntity::type).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByWorkerAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -75,7 +75,7 @@ public class JobSortIT {
         Comparator.comparing(JobEntity::worker));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByWorkerDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -83,7 +83,7 @@ public class JobSortIT {
         Comparator.comparing(JobEntity::worker).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -91,7 +91,7 @@ public class JobSortIT {
         Comparator.comparing(JobEntity::tenantId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -99,7 +99,7 @@ public class JobSortIT {
         Comparator.comparing(JobEntity::tenantId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -107,7 +107,7 @@ public class JobSortIT {
         Comparator.comparing(JobEntity::processInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
@@ -24,7 +24,6 @@ import io.camunda.it.rdbms.db.fixtures.JobFixtures;
 import io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
-import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
 import io.camunda.search.entities.JobEntity.JobState;
@@ -47,6 +46,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -101,7 +101,7 @@ public class JobMetricsBatchIT {
     jobMetricsBatchWriter.cleanupMetrics(PARTITION_ID, NOW.plusDays(100), Integer.MAX_VALUE);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateGlobalJobStatistics() {
     // given
     final var metric1 =
@@ -128,7 +128,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateMetricsAcrossMultipleTenants() {
     // given
     final var metricTenant1 = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1));
@@ -153,7 +153,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateMetricsAcrossMultipleJobTypes() {
     // given
     final var metricJobTypeA = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
@@ -178,7 +178,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateMetricsAcrossMultipleWorkers() {
     // given
     final var metricWorker1 =
@@ -205,7 +205,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterMetricsByTimeRange() {
     // given
     final var metricOld =
@@ -236,7 +236,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metricMiddle);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterMetricsByJobType() {
     // given
     final var metricJobTypeA =
@@ -264,7 +264,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metricJobTypeA);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnMaxLastUpdatedAtTimestamp() {
     // given
     final var metric1 = JobMetricsBatchFixtures.createRandomized(b -> b);
@@ -288,7 +288,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnIncompleteWhenAnyBatchIsIncomplete() {
     // given
     final var metricComplete =
@@ -315,7 +315,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.isIncomplete()).isTrue();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnEmptyResultWhenNoMetricsExist() {
     // when
     final var actual =
@@ -334,7 +334,7 @@ public class JobMetricsBatchIT {
                 false));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnEmptyResultWhenNoMetricsMatchFilter() {
     // given
     final var metric = JobMetricsBatchFixtures.createRandomized(b -> b);
@@ -361,7 +361,7 @@ public class JobMetricsBatchIT {
                 false));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterByAuthorizedTenants() {
     // given
     final var metricTenant1 = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1));
@@ -387,7 +387,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metricTenant1);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnEmptyResultWhenNoAuthorizedTenants() {
     // given
     final var metric = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1));
@@ -415,7 +415,7 @@ public class JobMetricsBatchIT {
                 false));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldHandleMetricsWithNullTimestamps() {
     // given - metrics with some zero counts (null timestamps)
     final var metric =
@@ -449,7 +449,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.failed().lastUpdatedAt()).isNull();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAsyncWriteAndReadMetrics() {
     // given
     final var metric = JobMetricsBatchFixtures.createRandomized(b -> b);
@@ -472,7 +472,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metric);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldInsertJobMetricsBatch() {
     // given
     final var metric = JobMetricsBatchFixtures.createRandomized(b -> b);
@@ -494,7 +494,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metric);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldInsertMultipleJobMetricsBatches() {
     // given
     final var metric1 =
@@ -515,7 +515,7 @@ public class JobMetricsBatchIT {
     assertThat(rdbmsWriters).isNotNull();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldInsertJobMetricsBatchWithDifferentTenants() {
     // given
     final var metricTenant1 =
@@ -540,7 +540,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldInsertJobMetricsBatchWithIncompleteBatch() {
     // given
     final var metric = JobMetricsBatchFixtures.createRandomized(b -> b.incompleteBatch(true));
@@ -561,7 +561,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metric);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldInsertJobMetricsBatchWithNullLastUpdatedTimes() {
     // given - create a batch with zero counts, so no lastUpdatedAt times
     final var model =
@@ -589,7 +589,7 @@ public class JobMetricsBatchIT {
     assertThat(model.lastCreatedAt()).isNull();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldCleanupJobMetricsBatchesProperly() {
     // given
     final var recentA =
@@ -656,7 +656,7 @@ public class JobMetricsBatchIT {
     assertThat(deletedCount).isEqualTo(2);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldCleanupJobMetricsBatchesWithLimit() {
     // given - create 5 old records
     final var oldTimestamp = NOW.minusYears(3);
@@ -679,7 +679,7 @@ public class JobMetricsBatchIT {
     assertThat(deletedCount).isEqualTo(3);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldNotCleanupRecentJobMetricsBatches() {
     // given - create only recent records
     final var startTime1 = NOW.minusMinutes(3);
@@ -706,7 +706,7 @@ public class JobMetricsBatchIT {
   // Job Type Statistics Tests
   // ==========================================================================
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateJobStatisticsByJobType() {
     // given
     final var metricJobTypeA = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
@@ -741,7 +741,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertJobTypeStats(actual.items().get(1), metricJobTypeB);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateJobTypeStatsAcrossMultipleBatches() {
     // given - multiple batches for same job type
     final var metric1 = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
@@ -771,7 +771,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertJobTypeStats(actual.items().get(0), metrics);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldCountDistinctWorkersPerJobType() {
     // given - multiple workers for same job type
     final var metricWorker1 =
@@ -802,7 +802,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.items().get(0).workers()).isEqualTo(2); // WORKER_1 and WORKER_2
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterJobTypeStatsByTimeRange() {
     // given
     final var metricOld =
@@ -832,7 +832,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.items().get(0).jobType()).isEqualTo(metricMiddle.jobType());
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterJobTypeStatsByJobTypeExactMatch() {
     // given
     final var metricJobTypeA =
@@ -864,7 +864,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertJobTypeStats(actual.items().getFirst(), metricJobTypeA);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterJobTypeStatsByJobTypeLike() {
     // given
     final var metricFetchOrders =
@@ -898,7 +898,7 @@ public class JobMetricsBatchIT {
     assertThat(jobTypes).containsExactly("fetch-customers", "fetch-orders");
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterJobTypeStatsByJobTypeIn() {
     // given
     final var metricA =
@@ -938,7 +938,7 @@ public class JobMetricsBatchIT {
   // Job Worker Statistics Tests
   // ==========================================================================
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateJobStatisticsByWorker() {
     // given
     final var metricWorker1 =
@@ -981,7 +981,7 @@ public class JobMetricsBatchIT {
         metricWorker2);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateWorkerStatsAcrossMultipleBatches() {
     // given - multiple batches for same worker
     final var metric1 =
@@ -1015,7 +1015,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metrics);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterWorkerStatsByJobType() {
     // given - workers for different job types
     final var metricWorkerA =
@@ -1047,7 +1047,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metricWorkerA);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterWorkerStatsByTimeRange() {
     // given
     final var metricOld =
@@ -1086,7 +1086,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.items().getFirst().worker()).isEqualTo(WORKER_2);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterWorkerStatsByAuthorizedTenants() {
     // given
     final var metricTenant1 =
@@ -1119,7 +1119,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metricTenant1);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnEmptyWorkerStatsWhenNoMetricsMatchFilter() {
     // given
     final var metric =
@@ -1143,7 +1143,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.total()).isZero();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnEmptyWorkerStatsWhenJobTypeDoesNotMatch() {
     // given
     final var metric =
@@ -1167,7 +1167,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.total()).isZero();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnEmptyWorkerStatsWhenNoAuthorizedTenants() {
     // given
     final var metric =
@@ -1192,7 +1192,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.total()).isZero();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnMaxLastUpdatedAtForWorkerStats() {
     // given - multiple batches for the same worker
     final var metric1 =
@@ -1221,7 +1221,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metrics);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateWorkerStatsAcrossMultipleTenants() {
     // given - same worker, same job type, different tenants
     final var metricTenant1 =
@@ -1257,7 +1257,7 @@ public class JobMetricsBatchIT {
   // Time-series statistics
   // -----------------------------------------------------------------------
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnSingleTimeBucketForSingleMetric() {
     // given — one row with a resolution larger than the window so everything lands in one bucket
     final var metric =
@@ -1283,7 +1283,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().getFirst(), metric);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateTwoBatchesIntoSameBucket() {
     // given — two rows with the same start-hour, same jobType → both collapse into one bucket
     final var base = NOW.truncatedTo(ChronoUnit.HOURS);
@@ -1327,7 +1327,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().getFirst(), metrics);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnTwoBucketsWhenMetricsSpanTwoHours() {
     // given — two rows in different hours
     final var base = NOW.truncatedTo(ChronoUnit.HOURS);
@@ -1372,7 +1372,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().get(1), metric2);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateTwoBatchesIntoFirstBucketAndKeepThirdBucketSeparate() {
     // given — metric1 and metric2 start within the same minute → same bucket
     //         metric3 starts in a different minute → separate bucket
@@ -1433,7 +1433,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().get(1), metric3);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldRespectJobTypeFilterForTimeSeries() {
     // given — two different job types in the same time range
     final var metric1 =
@@ -1463,7 +1463,7 @@ public class JobMetricsBatchIT {
     assertTimeSeriesStats(actual.items().get(0), metric1);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnEmptyTimeSeriesWhenNoDataInRange() {
     // given — data outside the query window
     final var metric =
@@ -1489,7 +1489,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.items()).isEmpty();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnFirstPageOfTimeSeries() {
     // given — 3 batches each in a distinct minute bucket
     final var base = NOW.truncatedTo(ChronoUnit.MINUTES);
@@ -1543,7 +1543,7 @@ public class JobMetricsBatchIT {
     assertTimeSeriesStats(firstPage.items().get(1), metric2);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnSecondPageOfTimeSeriesUsingCursor() {
     // given — 3 batches each in a distinct minute bucket
     final var base = NOW.truncatedTo(ChronoUnit.MINUTES);
@@ -1611,7 +1611,7 @@ public class JobMetricsBatchIT {
     assertTimeSeriesStats(secondPage.items().getFirst(), metric3);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnEmptyTimeSeriesWhenTenantNotAuthorized() {
     // given
     final var metric =
@@ -1641,7 +1641,7 @@ public class JobMetricsBatchIT {
   // getJobErrorStatistics
   // -----------------------------------------------------------------------
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnErrorStatisticsGroupedByErrorCodeAndMessage() {
     // given — two jobs with the same error, one job with a different error
     final var uniqueTenant = "error-tenant-" + CommonFixtures.generateRandomString(8);
@@ -1707,7 +1707,7 @@ public class JobMetricsBatchIT {
     assertErrorStats(timeout, "TIMEOUT", "Connection timed out", 1);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterErrorStatisticsByErrorCodePrefix() {
     // given
     final var uniqueTenant = "error-tenant-" + CommonFixtures.generateRandomString(8);
@@ -1754,7 +1754,7 @@ public class JobMetricsBatchIT {
     assertErrorStats(result.items().getFirst(), "IO_ERROR", "Disk full", 1);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnEmptyErrorStatisticsWhenTenantNotAuthorized() {
     // given
     final var now = NOW;
@@ -1785,7 +1785,7 @@ public class JobMetricsBatchIT {
     assertThat(result.items()).isEmpty();
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldOnlyCountJobsFromAuthorizedTenants() {
     // given — one job on TENANT1 (authorized), one on TENANT2 (not authorized), same error
     final var now = NOW;
@@ -1827,7 +1827,7 @@ public class JobMetricsBatchIT {
     assertErrorStats(result.items().getFirst(), "IO_ERROR", "Disk full", 1);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldIncludeFailedStateAndExcludeCompletedState() {
     // given — one ERROR_THROWN job (with errorCode), one FAILED job (no errorCode),
     //         one COMPLETED job (must be excluded by the state filter)
@@ -1896,7 +1896,7 @@ public class JobMetricsBatchIT {
     assertThat(failed.workers()).isEqualTo(1);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldReturnPagesOfErrorStatisticsUsingCursor() throws InterruptedException {
     // given — 5 jobs: two FAILED with empty errorCode and three ERROR_THROWN with distinct codes.
     // Sort order is errorCode ASC NULLS FIRST, then errorMessage ASC, so:

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
@@ -24,6 +24,7 @@ import io.camunda.it.rdbms.db.fixtures.JobFixtures;
 import io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
 import io.camunda.search.entities.JobEntity.JobState;
@@ -46,7 +47,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -101,7 +101,7 @@ public class JobMetricsBatchIT {
     jobMetricsBatchWriter.cleanupMetrics(PARTITION_ID, NOW.plusDays(100), Integer.MAX_VALUE);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateGlobalJobStatistics() {
     // given
     final var metric1 =
@@ -128,7 +128,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateMetricsAcrossMultipleTenants() {
     // given
     final var metricTenant1 = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1));
@@ -153,7 +153,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateMetricsAcrossMultipleJobTypes() {
     // given
     final var metricJobTypeA = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
@@ -178,7 +178,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateMetricsAcrossMultipleWorkers() {
     // given
     final var metricWorker1 =
@@ -205,7 +205,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterMetricsByTimeRange() {
     // given
     final var metricOld =
@@ -236,7 +236,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metricMiddle);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterMetricsByJobType() {
     // given
     final var metricJobTypeA =
@@ -264,7 +264,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metricJobTypeA);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnMaxLastUpdatedAtTimestamp() {
     // given
     final var metric1 = JobMetricsBatchFixtures.createRandomized(b -> b);
@@ -288,7 +288,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnIncompleteWhenAnyBatchIsIncomplete() {
     // given
     final var metricComplete =
@@ -315,7 +315,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.isIncomplete()).isTrue();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyResultWhenNoMetricsExist() {
     // when
     final var actual =
@@ -334,7 +334,7 @@ public class JobMetricsBatchIT {
                 false));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyResultWhenNoMetricsMatchFilter() {
     // given
     final var metric = JobMetricsBatchFixtures.createRandomized(b -> b);
@@ -361,7 +361,7 @@ public class JobMetricsBatchIT {
                 false));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterByAuthorizedTenants() {
     // given
     final var metricTenant1 = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1));
@@ -387,7 +387,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metricTenant1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyResultWhenNoAuthorizedTenants() {
     // given
     final var metric = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1));
@@ -415,7 +415,7 @@ public class JobMetricsBatchIT {
                 false));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldHandleMetricsWithNullTimestamps() {
     // given - metrics with some zero counts (null timestamps)
     final var metric =
@@ -449,7 +449,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.failed().lastUpdatedAt()).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAsyncWriteAndReadMetrics() {
     // given
     final var metric = JobMetricsBatchFixtures.createRandomized(b -> b);
@@ -472,7 +472,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metric);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldInsertJobMetricsBatch() {
     // given
     final var metric = JobMetricsBatchFixtures.createRandomized(b -> b);
@@ -494,7 +494,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metric);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldInsertMultipleJobMetricsBatches() {
     // given
     final var metric1 =
@@ -515,7 +515,7 @@ public class JobMetricsBatchIT {
     assertThat(rdbmsWriters).isNotNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldInsertJobMetricsBatchWithDifferentTenants() {
     // given
     final var metricTenant1 =
@@ -540,7 +540,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldInsertJobMetricsBatchWithIncompleteBatch() {
     // given
     final var metric = JobMetricsBatchFixtures.createRandomized(b -> b.incompleteBatch(true));
@@ -561,7 +561,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertGlobalStats(actual, metric);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldInsertJobMetricsBatchWithNullLastUpdatedTimes() {
     // given - create a batch with zero counts, so no lastUpdatedAt times
     final var model =
@@ -589,7 +589,7 @@ public class JobMetricsBatchIT {
     assertThat(model.lastCreatedAt()).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCleanupJobMetricsBatchesProperly() {
     // given
     final var recentA =
@@ -656,7 +656,7 @@ public class JobMetricsBatchIT {
     assertThat(deletedCount).isEqualTo(2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCleanupJobMetricsBatchesWithLimit() {
     // given - create 5 old records
     final var oldTimestamp = NOW.minusYears(3);
@@ -679,7 +679,7 @@ public class JobMetricsBatchIT {
     assertThat(deletedCount).isEqualTo(3);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotCleanupRecentJobMetricsBatches() {
     // given - create only recent records
     final var startTime1 = NOW.minusMinutes(3);
@@ -706,7 +706,7 @@ public class JobMetricsBatchIT {
   // Job Type Statistics Tests
   // ==========================================================================
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateJobStatisticsByJobType() {
     // given
     final var metricJobTypeA = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
@@ -741,7 +741,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertJobTypeStats(actual.items().get(1), metricJobTypeB);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateJobTypeStatsAcrossMultipleBatches() {
     // given - multiple batches for same job type
     final var metric1 = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
@@ -771,7 +771,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertJobTypeStats(actual.items().get(0), metrics);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCountDistinctWorkersPerJobType() {
     // given - multiple workers for same job type
     final var metricWorker1 =
@@ -802,7 +802,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.items().get(0).workers()).isEqualTo(2); // WORKER_1 and WORKER_2
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterJobTypeStatsByTimeRange() {
     // given
     final var metricOld =
@@ -832,7 +832,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.items().get(0).jobType()).isEqualTo(metricMiddle.jobType());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterJobTypeStatsByJobTypeExactMatch() {
     // given
     final var metricJobTypeA =
@@ -864,7 +864,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertJobTypeStats(actual.items().getFirst(), metricJobTypeA);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterJobTypeStatsByJobTypeLike() {
     // given
     final var metricFetchOrders =
@@ -898,7 +898,7 @@ public class JobMetricsBatchIT {
     assertThat(jobTypes).containsExactly("fetch-customers", "fetch-orders");
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterJobTypeStatsByJobTypeIn() {
     // given
     final var metricA =
@@ -938,7 +938,7 @@ public class JobMetricsBatchIT {
   // Job Worker Statistics Tests
   // ==========================================================================
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateJobStatisticsByWorker() {
     // given
     final var metricWorker1 =
@@ -981,7 +981,7 @@ public class JobMetricsBatchIT {
         metricWorker2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateWorkerStatsAcrossMultipleBatches() {
     // given - multiple batches for same worker
     final var metric1 =
@@ -1015,7 +1015,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metrics);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterWorkerStatsByJobType() {
     // given - workers for different job types
     final var metricWorkerA =
@@ -1047,7 +1047,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metricWorkerA);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterWorkerStatsByTimeRange() {
     // given
     final var metricOld =
@@ -1086,7 +1086,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.items().getFirst().worker()).isEqualTo(WORKER_2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterWorkerStatsByAuthorizedTenants() {
     // given
     final var metricTenant1 =
@@ -1119,7 +1119,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metricTenant1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyWorkerStatsWhenNoMetricsMatchFilter() {
     // given
     final var metric =
@@ -1143,7 +1143,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.total()).isZero();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyWorkerStatsWhenJobTypeDoesNotMatch() {
     // given
     final var metric =
@@ -1167,7 +1167,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.total()).isZero();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyWorkerStatsWhenNoAuthorizedTenants() {
     // given
     final var metric =
@@ -1192,7 +1192,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.total()).isZero();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnMaxLastUpdatedAtForWorkerStats() {
     // given - multiple batches for the same worker
     final var metric1 =
@@ -1221,7 +1221,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metrics);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateWorkerStatsAcrossMultipleTenants() {
     // given - same worker, same job type, different tenants
     final var metricTenant1 =
@@ -1257,7 +1257,7 @@ public class JobMetricsBatchIT {
   // Time-series statistics
   // -----------------------------------------------------------------------
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnSingleTimeBucketForSingleMetric() {
     // given — one row with a resolution larger than the window so everything lands in one bucket
     final var metric =
@@ -1283,7 +1283,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().getFirst(), metric);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateTwoBatchesIntoSameBucket() {
     // given — two rows with the same start-hour, same jobType → both collapse into one bucket
     final var base = NOW.truncatedTo(ChronoUnit.HOURS);
@@ -1327,7 +1327,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().getFirst(), metrics);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnTwoBucketsWhenMetricsSpanTwoHours() {
     // given — two rows in different hours
     final var base = NOW.truncatedTo(ChronoUnit.HOURS);
@@ -1372,7 +1372,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().get(1), metric2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateTwoBatchesIntoFirstBucketAndKeepThirdBucketSeparate() {
     // given — metric1 and metric2 start within the same minute → same bucket
     //         metric3 starts in a different minute → separate bucket
@@ -1433,7 +1433,7 @@ public class JobMetricsBatchIT {
     JobMetricsBatchFixtures.assertTimeSeriesStats(actual.items().get(1), metric3);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldRespectJobTypeFilterForTimeSeries() {
     // given — two different job types in the same time range
     final var metric1 =
@@ -1463,7 +1463,7 @@ public class JobMetricsBatchIT {
     assertTimeSeriesStats(actual.items().get(0), metric1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyTimeSeriesWhenNoDataInRange() {
     // given — data outside the query window
     final var metric =
@@ -1489,7 +1489,7 @@ public class JobMetricsBatchIT {
     assertThat(actual.items()).isEmpty();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnFirstPageOfTimeSeries() {
     // given — 3 batches each in a distinct minute bucket
     final var base = NOW.truncatedTo(ChronoUnit.MINUTES);
@@ -1543,7 +1543,7 @@ public class JobMetricsBatchIT {
     assertTimeSeriesStats(firstPage.items().get(1), metric2);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnSecondPageOfTimeSeriesUsingCursor() {
     // given — 3 batches each in a distinct minute bucket
     final var base = NOW.truncatedTo(ChronoUnit.MINUTES);
@@ -1611,7 +1611,7 @@ public class JobMetricsBatchIT {
     assertTimeSeriesStats(secondPage.items().getFirst(), metric3);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyTimeSeriesWhenTenantNotAuthorized() {
     // given
     final var metric =
@@ -1641,7 +1641,7 @@ public class JobMetricsBatchIT {
   // getJobErrorStatistics
   // -----------------------------------------------------------------------
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnErrorStatisticsGroupedByErrorCodeAndMessage() {
     // given — two jobs with the same error, one job with a different error
     final var uniqueTenant = "error-tenant-" + CommonFixtures.generateRandomString(8);
@@ -1707,7 +1707,7 @@ public class JobMetricsBatchIT {
     assertErrorStats(timeout, "TIMEOUT", "Connection timed out", 1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterErrorStatisticsByErrorCodePrefix() {
     // given
     final var uniqueTenant = "error-tenant-" + CommonFixtures.generateRandomString(8);
@@ -1754,7 +1754,7 @@ public class JobMetricsBatchIT {
     assertErrorStats(result.items().getFirst(), "IO_ERROR", "Disk full", 1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyErrorStatisticsWhenTenantNotAuthorized() {
     // given
     final var now = NOW;
@@ -1785,7 +1785,7 @@ public class JobMetricsBatchIT {
     assertThat(result.items()).isEmpty();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldOnlyCountJobsFromAuthorizedTenants() {
     // given — one job on TENANT1 (authorized), one on TENANT2 (not authorized), same error
     final var now = NOW;
@@ -1827,7 +1827,7 @@ public class JobMetricsBatchIT {
     assertErrorStats(result.items().getFirst(), "IO_ERROR", "Disk full", 1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldIncludeFailedStateAndExcludeCompletedState() {
     // given — one ERROR_THROWN job (with errorCode), one FAILED job (no errorCode),
     //         one COMPLETED job (must be excluded by the state filter)
@@ -1896,7 +1896,7 @@ public class JobMetricsBatchIT {
     assertThat(failed.workers()).isEqualTo(1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnPagesOfErrorStatisticsUsingCursor() throws InterruptedException {
     // given — 5 jobs: two FAILED with empty errorCode and three ERROR_THROWN with distinct codes.
     // Sort order is errorCode ASC NULLS FIRST, then errorMessage ASC, so:

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleIT.java
@@ -20,6 +20,7 @@ import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.fixtures.MappingRuleFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.filter.MappingRuleFilter;
 import io.camunda.search.filter.MappingRuleFilter.Claim;
@@ -29,7 +30,6 @@ import io.camunda.search.sort.MappingRuleSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class MappingRuleIT {
   private static final long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindMappingRuleByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -54,7 +54,7 @@ public class MappingRuleIT {
     assertThat(mappingRule).usingRecursiveComparison().isEqualTo(randomizedMappingRule);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteMappingRule(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -79,7 +79,7 @@ public class MappingRuleIT {
     assertThat(deletedMappingRuleResult).isEmpty();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindMappingRuleByClaimName(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -109,7 +109,7 @@ public class MappingRuleIT {
     assertThat(instance).usingRecursiveComparison().isEqualTo(randomizedMappingRule);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindMappingRuleByClaimValue(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -139,7 +139,7 @@ public class MappingRuleIT {
     assertThat(instance).usingRecursiveComparison().isEqualTo(randomizedMappingRule);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindMappingRuleByClaims(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -173,7 +173,7 @@ public class MappingRuleIT {
         .containsExactly(mappingRule1.mappingRuleId(), mappingRule2.mappingRuleId());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindMappingRuleByAuthorizationResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -202,7 +202,7 @@ public class MappingRuleIT {
     assertThat(instance).usingRecursiveComparison().isEqualTo(randomizedMappingRule);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllMappingRulesPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -224,7 +224,7 @@ public class MappingRuleIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllMappingRulesPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -248,7 +248,7 @@ public class MappingRuleIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindMappingRuleWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -279,7 +279,7 @@ public class MappingRuleIT {
         .isEqualTo(randomizedMappingRule.mappingRuleId());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateMappingRule(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSortIT.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.MappingRuleFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.filter.MappingRuleFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -22,7 +23,6 @@ import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.sort.MappingRuleSort;
 import java.util.Comparator;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -31,7 +31,7 @@ public class MappingRuleSortIT {
 
   public static final long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortMappingsByClaimNameAsc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -53,7 +53,7 @@ public class MappingRuleSortIT {
         .isSortedAccordingTo(Comparator.comparing(MappingRuleEntity::claimName));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortMappingsByClaimNameDesc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -75,7 +75,7 @@ public class MappingRuleSortIT {
         .isSortedAccordingTo(Comparator.comparing(MappingRuleEntity::claimName).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortMappingsByClaimValueAsc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -97,7 +97,7 @@ public class MappingRuleSortIT {
         .isSortedAccordingTo(Comparator.comparing(MappingRuleEntity::claimName));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortMappingsByClaimValueDesc(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -120,7 +120,7 @@ public class MappingRuleSortIT {
         .isSortedAccordingTo(Comparator.comparing(MappingRuleEntity::claimName).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortMappingsByNameValueDesc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionIT.java
@@ -17,6 +17,7 @@ import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.it.rdbms.db.fixtures.MessageSubscriptionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionMessageSubscriptionStatisticsEntity;
 import io.camunda.search.filter.MessageSubscriptionFilter;
@@ -29,7 +30,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -39,7 +39,7 @@ public class MessageSubscriptionIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindById(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -57,7 +57,7 @@ public class MessageSubscriptionIT {
     compareMessageSubscriptions(instance, subscriptionDbModel);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -81,7 +81,7 @@ public class MessageSubscriptionIT {
     compareMessageSubscriptions(instance, roleUpdate);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -105,7 +105,7 @@ public class MessageSubscriptionIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -129,7 +129,7 @@ public class MessageSubscriptionIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessDefinitionMessageSubscriptionStatisticsWithPagination(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -229,7 +229,7 @@ public class MessageSubscriptionIT {
     assertThat(nextPage.items()).isEqualTo(allResults.items().subList(2, 3));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -283,7 +283,7 @@ public class MessageSubscriptionIT {
             subscription1.processInstanceKey(), subscription3.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.MessageSubscriptionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.filter.MessageSubscriptionFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -25,7 +26,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -34,7 +34,7 @@ public class MessageSubscriptionSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByMessageNameAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -42,7 +42,7 @@ public class MessageSubscriptionSortIT {
         Comparator.comparing(MessageSubscriptionEntity::messageName));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByMessageNameDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
@@ -26,6 +26,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
@@ -38,7 +39,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -48,7 +48,7 @@ public class ProcessDefinitionIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindProcessDefinitionByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -69,7 +69,7 @@ public class ProcessDefinitionIT {
     assertThat(instance.resourceName()).isEqualTo(processDefinition.resourceName());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessInstanceByBpmnProcessId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -103,7 +103,7 @@ public class ProcessDefinitionIT {
     assertThat(instance.resourceName()).isEqualTo(processDefinition.resourceName());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldStoreLongProcessDefinitionId(
       final CamundaRdbmsTestApplication testApplication) {
     final var rdbmsService = testApplication.getRdbmsService();
@@ -133,7 +133,7 @@ public class ProcessDefinitionIT {
         .isEqualTo(processDefinition.processDefinitionKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldStoreAndFindUTF8ProcessDefinitionName(
       final CamundaRdbmsTestApplication testApplication) {
     final var rdbmsService = testApplication.getRdbmsService();
@@ -155,7 +155,7 @@ public class ProcessDefinitionIT {
         .containsExactly(name);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldStoreLongUTF8ProcessDefinitionName(
       final CamundaRdbmsTestApplication testApplication) {
     final var rdbmsService = testApplication.getRdbmsService();
@@ -177,7 +177,7 @@ public class ProcessDefinitionIT {
         .containsExactly(name);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessInstanceByAuthorizationResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -202,7 +202,7 @@ public class ProcessDefinitionIT {
         .isEqualTo(processDefinition.processDefinitionKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessInstanceByAuthorizationTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -225,7 +225,7 @@ public class ProcessDefinitionIT {
         .isEqualTo(processDefinition.processDefinitionKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllProcessDefinitionPaged(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -250,7 +250,7 @@ public class ProcessDefinitionIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllProcessDefinitionPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -276,7 +276,7 @@ public class ProcessDefinitionIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllProcessInstancePageValuesAreNull(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -296,7 +296,7 @@ public class ProcessDefinitionIT {
     assertThat(searchResult.items()).hasSizeGreaterThanOrEqualTo(20);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessInstanceWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -330,7 +330,7 @@ public class ProcessDefinitionIT {
         .isEqualTo(processDefinition.processDefinitionKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessDefinitionsWithSearchAfter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -370,7 +370,7 @@ public class ProcessDefinitionIT {
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessDefinitionInstanceStatistics(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -421,7 +421,7 @@ public class ProcessDefinitionIT {
     assertThat(statistics.activeInstancesWithoutIncidentCount()).isEqualTo(1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessDefinitionInstanceVersionStatistics(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -494,7 +494,7 @@ public class ProcessDefinitionIT {
                 1L));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessDefinitionsByKey(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.sort.ProcessDefinitionSort;
@@ -24,7 +25,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -33,7 +33,7 @@ public class ProcessDefinitionSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionIdAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -42,7 +42,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::processDefinitionId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionIdDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -51,7 +51,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::processDefinitionId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -60,7 +60,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::processDefinitionKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -69,7 +69,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::processDefinitionKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -77,7 +77,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::name));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByNameDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -85,7 +85,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::name).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourceNameAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -93,7 +93,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::resourceName));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByResourceNameDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -101,7 +101,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::resourceName).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVersionAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -109,7 +109,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::version));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVersionDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -117,7 +117,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::version).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -125,7 +125,7 @@ public class ProcessDefinitionSortIT {
         Comparator.comparing(ProcessDefinitionEntity::tenantId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -24,6 +24,7 @@ import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.query.ProcessInstanceQuery;
@@ -35,7 +36,6 @@ import java.util.List;
 import java.util.Set;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -45,7 +45,7 @@ public class ProcessInstanceIT {
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindProcessInstanceByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -86,7 +86,7 @@ public class ProcessInstanceIT {
     assertThat(instance.businessId()).isEqualTo("test-business-id");
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveLogAndResolveIncident(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -112,7 +112,7 @@ public class ProcessInstanceIT {
     assertThat(resolvedInstance.hasIncident()).isFalse();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveTagsAndCompleteInSameFlush(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -135,7 +135,7 @@ public class ProcessInstanceIT {
     assertThat(readInstance.tags()).containsExactlyInAnyOrder("foo", "bar");
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessInstanceByBpmnProcessId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -183,7 +183,7 @@ public class ProcessInstanceIT {
     assertThat(instance.processDefinitionVersion()).isEqualTo(1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessInstanceByAuthorizationResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -209,7 +209,7 @@ public class ProcessInstanceIT {
         .isEqualTo(processInstance.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessInstanceByAuthorizationTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -230,7 +230,7 @@ public class ProcessInstanceIT {
         .isEqualTo(processInstance.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessInstanceWithIncidents(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -264,7 +264,7 @@ public class ProcessInstanceIT {
             incidentPI1.processInstanceKey(), incidentPI2.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllProcessInstancePaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -287,7 +287,7 @@ public class ProcessInstanceIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllProcessInstancePagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -312,7 +312,7 @@ public class ProcessInstanceIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessInstanceWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -359,7 +359,7 @@ public class ProcessInstanceIT {
     assertThat(searchResult.items().getFirst().processInstanceKey()).isEqualTo(processInstanceKey);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindProcessInstanceWithSearchAfter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -411,7 +411,7 @@ public class ProcessInstanceIT {
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(10, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessByKey(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -461,7 +461,7 @@ public class ProcessInstanceIT {
         .containsExactlyInAnyOrder(pi1.processInstanceKey(), pi3.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteChildrenByRootProcessInstances(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -524,7 +524,7 @@ public class ProcessInstanceIT {
         .containsExactlyInAnyOrder(rootProcessInstanceKey, pi3.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSelectRootExpiredRootProcessInstances(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -567,7 +567,7 @@ public class ProcessInstanceIT {
         .containsExactlyInAnyOrder(pi1.processInstanceKey(), pi3.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSelectExpiredRootProcessInstancesWithLimit(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -622,7 +622,7 @@ public class ProcessInstanceIT {
             pi5.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotSelectExpiredRootProcessInstancesFromDifferentPartition(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -656,7 +656,7 @@ public class ProcessInstanceIT {
     assertThat(expiredPIs).containsExactly(pi1.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotSelectRootProcessInstancesWithoutCleanupDate(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -688,7 +688,7 @@ public class ProcessInstanceIT {
     assertThat(expiredPIs).containsExactly(pi1.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotScheduleNonRootProcessInstancesForCleanupByThemselves(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -28,7 +29,6 @@ import java.util.Comparator;
 import java.util.Random;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -37,7 +37,7 @@ public class ProcessInstanceSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -45,7 +45,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(ProcessInstanceEntity::processInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -54,7 +54,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(ProcessInstanceEntity::processInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -63,7 +63,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(ProcessInstanceEntity::processDefinitionKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessDefinitionIdAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -72,7 +72,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(ProcessInstanceEntity::processDefinitionId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByStartDateAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -80,7 +80,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(ProcessInstanceEntity::startDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByEndDateAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -88,7 +88,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(ProcessInstanceEntity::endDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -96,7 +96,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(ProcessInstanceEntity::tenantId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByHasIncidentAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -104,7 +104,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(ProcessInstanceEntity::hasIncident));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByParentProcessInstanceKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -113,7 +113,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(ProcessInstanceEntity::parentProcessInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByParentElementInstanceKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -122,7 +122,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(ProcessInstanceEntity::parentFlowNodeInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByStateAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -130,7 +130,7 @@ public class ProcessInstanceSortIT {
         Comparator.comparing(p -> p.state().name()));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByBusinessIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -139,7 +139,7 @@ public class ProcessInstanceSortIT {
             ProcessInstanceEntity::businessId, Comparator.nullsFirst(Comparator.naturalOrder())));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByBusinessIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceTagIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceTagIT.java
@@ -17,11 +17,11 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.query.ProcessInstanceQuery;
 import java.util.Set;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -32,7 +32,7 @@ public class ProcessInstanceTagIT {
   public static final String TAG_VALUE_FOO = "foo_tag";
   public static final String TAG_VALUE_BAR = "bar_tag";
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindProcessInstanceByTag(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -61,7 +61,7 @@ public class ProcessInstanceTagIT {
     assertThat(searchResult.items().getFirst().tags()).containsOnly(TAG_VALUE_FOO);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindProcessInstanceWithMultipleTags(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -19,6 +19,7 @@ import io.camunda.db.rdbms.write.domain.RoleDbModel;
 import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.search.query.RoleQuery;
 import io.camunda.search.sort.RoleSort;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -36,7 +36,7 @@ public class RoleIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindById(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -50,7 +50,7 @@ public class RoleIT {
     compareRoles(instance, role);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -69,7 +69,7 @@ public class RoleIT {
     compareRoles(instance, roleUpdate);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndDelete(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -87,7 +87,7 @@ public class RoleIT {
     assertThat(deletedInstance).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByName(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -114,7 +114,7 @@ public class RoleIT {
     assertThat(instance.name()).isEqualTo(role.name());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -134,7 +134,7 @@ public class RoleIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -155,7 +155,7 @@ public class RoleIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -177,7 +177,7 @@ public class RoleIT {
     assertThat(searchResult.items().getFirst().roleId()).isEqualTo(role.roleId());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleMemberIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleMemberIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.write.domain.RoleMemberDbModel;
 import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.RoleMemberEntity;
 import io.camunda.search.filter.RoleMemberFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -25,7 +26,6 @@ import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class RoleMemberIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindRoleMember(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.RoleDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class RoleSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRoleIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -43,7 +43,7 @@ public class RoleSortIT {
         Comparator.comparing(RoleEntity::roleId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRoleIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/sequenceflow/SequenceFlowIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/sequenceflow/SequenceFlowIT.java
@@ -18,13 +18,13 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.query.SequenceFlowQuery;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -34,7 +34,7 @@ public class SequenceFlowIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCreateSequenceFlow(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -64,7 +64,7 @@ public class SequenceFlowIT {
                 .build());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSearchSequenceFlow(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -96,7 +96,7 @@ public class SequenceFlowIT {
                 .build());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindSequenceFlowByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -121,7 +121,7 @@ public class SequenceFlowIT {
         .isEqualTo(sequenceFlow.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindSequenceFlowByAuthorizedTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -145,7 +145,7 @@ public class SequenceFlowIT {
         .isEqualTo(sequenceFlow.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCreateSequenceFlowIfNotExists(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -169,7 +169,7 @@ public class SequenceFlowIT {
     assertThat(items.getFirst().processInstanceKey()).isEqualTo(sequenceFlow.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotCreateSequenceFlowIfExists(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -195,7 +195,7 @@ public class SequenceFlowIT {
     assertThat(items.getFirst().processInstanceKey()).isEqualTo(dbModel.processInstanceKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteSequenceFlow(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -229,7 +229,7 @@ public class SequenceFlowIT {
     assertThat(itemsAfterDelete).isEmpty();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -262,7 +262,7 @@ public class SequenceFlowIT {
     assertThat(findByProcessInstanceKey(sequenceFlowReader, item3.processInstanceKey())).hasSize(1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
@@ -24,6 +24,7 @@ import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.fixtures.UserFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.filter.UserFilter;
@@ -34,7 +35,6 @@ import io.camunda.search.sort.TenantSort;
 import io.camunda.search.sort.UserSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -43,7 +43,7 @@ public class TenantIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindTenantByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -55,7 +55,7 @@ public class TenantIT {
     compareTenant(actual, tenant);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByTenantId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -77,7 +77,7 @@ public class TenantIT {
     compareTenant(searchResult.items().getFirst(), tenant);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByAuthorizedResourceId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -99,7 +99,7 @@ public class TenantIT {
     compareTenant(searchResult.items().getFirst(), tenant);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -118,7 +118,7 @@ public class TenantIT {
     compareTenant(instance, tenantUpdate);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndDelete(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -136,7 +136,7 @@ public class TenantIT {
     assertThat(deletedInstance).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -156,7 +156,7 @@ public class TenantIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -178,7 +178,7 @@ public class TenantIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -202,7 +202,7 @@ public class TenantIT {
     assertThat(searchResult.items().getFirst().key()).isEqualTo(instance.tenantKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -234,7 +234,7 @@ public class TenantIT {
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAddMemberToTenant(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -260,7 +260,7 @@ public class TenantIT {
     assertThat(users.total()).isEqualTo(1);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldRemoveMemberFromTenant(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantMemberIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantMemberIT.java
@@ -17,6 +17,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.TenantMemberDbModel;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.filter.TenantMemberFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -36,7 +36,7 @@ public class TenantMemberIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindTenantMember(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
@@ -19,6 +19,7 @@ import io.camunda.db.rdbms.write.domain.TenantDbModel;
 import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -31,7 +32,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -40,7 +40,7 @@ public class TenantSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     final var aggregator =
         "AggregatorSortByKeyAsc " + nextStringId(); // Will be used to have isolated test data
@@ -53,7 +53,7 @@ public class TenantSortIT {
         b -> b.name(aggregator));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     final var aggregator =
         "AggregatorSortByKeyDesc " + nextStringId(); // Will be used to have isolated test data
@@ -66,7 +66,7 @@ public class TenantSortIT {
         b -> b.name(aggregator));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     final var aggregator =
         "AggregatorSortByKeyAsc " + nextStringId(); // Will be used to have isolated test data
@@ -79,7 +79,7 @@ public class TenantSortIT {
         b -> b.name(aggregator));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetric/UsageMetricIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetric/UsageMetricIT.java
@@ -24,7 +24,6 @@ import io.camunda.db.rdbms.write.service.UsageMetricWriter;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
-import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
 import io.camunda.search.entities.UsageMetricStatisticsEntity.UsageMetricStatisticsEntityTenant;
 import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
@@ -42,6 +41,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -116,7 +116,7 @@ public class UsageMetricIT {
     usageMetricTUWriter.cleanupMetrics(PARTITION_ID.intValue(), NOW.plusDays(1), Integer.MAX_VALUE);
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateMetricsWithTenant() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 11L);
@@ -148,7 +148,7 @@ public class UsageMetricIT {
                     new UsageMetricStatisticsEntityTenant(6L, 6L))));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateTUMetricsWithTenant() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW, TENANT1, ASSIGNEE_HASH_1);
@@ -175,7 +175,7 @@ public class UsageMetricIT {
                     new UsageMetricTUStatisticsEntityTenant(3L))));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateMetricsWithoutTenant() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 11L);
@@ -194,7 +194,7 @@ public class UsageMetricIT {
     assertThat(actual).isEqualTo(new UsageMetricStatisticsEntity(16, 14, 2, null));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldAggregateTUMetricsWithoutTenant() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW, TENANT1, ASSIGNEE_HASH_1);
@@ -213,7 +213,7 @@ public class UsageMetricIT {
     assertThat(actualTU).isEqualTo(new UsageMetricTUStatisticsEntity(3, null));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterMetricsByDate() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 1L);
@@ -232,7 +232,7 @@ public class UsageMetricIT {
     assertThat(actual).isEqualTo(new UsageMetricStatisticsEntity(1, 1, 1, null));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterTUMetricsByDate() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT1, ASSIGNEE_HASH_1);
@@ -255,7 +255,7 @@ public class UsageMetricIT {
     assertThat(actualTU).isEqualTo(new UsageMetricTUStatisticsEntity(2, null));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterMetricsWithTenantByDate() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 1L);
@@ -287,7 +287,7 @@ public class UsageMetricIT {
                     TENANT2, new UsageMetricStatisticsEntityTenant(1L, 1L))));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterTUMetricsWithTenantByDate() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT2, ASSIGNEE_HASH_1);
@@ -312,7 +312,7 @@ public class UsageMetricIT {
                 1, Map.of(TENANT2, new UsageMetricTUStatisticsEntityTenant(1L))));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterMetricsWithTenantByTenantId() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 1L);
@@ -332,7 +332,7 @@ public class UsageMetricIT {
                 1, 0, 1, Map.of(TENANT1, new UsageMetricStatisticsEntityTenant(1L, 0L))));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldFilterTUMetricsWithTenantByTenantId() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW_MINUS_10M, TENANT1, ASSIGNEE_HASH_1);
@@ -354,7 +354,7 @@ public class UsageMetricIT {
                 2, Map.of(TENANT1, new UsageMetricTUStatisticsEntityTenant(2L))));
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldCleanupUsageMetricsProperly() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 11L);
@@ -390,7 +390,7 @@ public class UsageMetricIT {
             });
   }
 
-  @RdbmsTestTemplate
+  @TestTemplate
   public void shouldCleanupUsageMetricsTUProperly() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW, TENANT1, ASSIGNEE_HASH_1);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetric/UsageMetricIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetric/UsageMetricIT.java
@@ -24,6 +24,7 @@ import io.camunda.db.rdbms.write.service.UsageMetricWriter;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.UsageMetricStatisticsEntity;
 import io.camunda.search.entities.UsageMetricStatisticsEntity.UsageMetricStatisticsEntityTenant;
 import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
@@ -41,7 +42,6 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -116,7 +116,7 @@ public class UsageMetricIT {
     usageMetricTUWriter.cleanupMetrics(PARTITION_ID.intValue(), NOW.plusDays(1), Integer.MAX_VALUE);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateMetricsWithTenant() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 11L);
@@ -148,7 +148,7 @@ public class UsageMetricIT {
                     new UsageMetricStatisticsEntityTenant(6L, 6L))));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateTUMetricsWithTenant() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW, TENANT1, ASSIGNEE_HASH_1);
@@ -175,7 +175,7 @@ public class UsageMetricIT {
                     new UsageMetricTUStatisticsEntityTenant(3L))));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateMetricsWithoutTenant() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 11L);
@@ -194,7 +194,7 @@ public class UsageMetricIT {
     assertThat(actual).isEqualTo(new UsageMetricStatisticsEntity(16, 14, 2, null));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldAggregateTUMetricsWithoutTenant() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW, TENANT1, ASSIGNEE_HASH_1);
@@ -213,7 +213,7 @@ public class UsageMetricIT {
     assertThat(actualTU).isEqualTo(new UsageMetricTUStatisticsEntity(3, null));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterMetricsByDate() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 1L);
@@ -232,7 +232,7 @@ public class UsageMetricIT {
     assertThat(actual).isEqualTo(new UsageMetricStatisticsEntity(1, 1, 1, null));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterTUMetricsByDate() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT1, ASSIGNEE_HASH_1);
@@ -255,7 +255,7 @@ public class UsageMetricIT {
     assertThat(actualTU).isEqualTo(new UsageMetricTUStatisticsEntity(2, null));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterMetricsWithTenantByDate() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 1L);
@@ -287,7 +287,7 @@ public class UsageMetricIT {
                     TENANT2, new UsageMetricStatisticsEntityTenant(1L, 1L))));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterTUMetricsWithTenantByDate() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW_MINUS_5M, TENANT2, ASSIGNEE_HASH_1);
@@ -312,7 +312,7 @@ public class UsageMetricIT {
                 1, Map.of(TENANT2, new UsageMetricTUStatisticsEntityTenant(1L))));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterMetricsWithTenantByTenantId() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 1L);
@@ -332,7 +332,7 @@ public class UsageMetricIT {
                 1, 0, 1, Map.of(TENANT1, new UsageMetricStatisticsEntityTenant(1L, 0L))));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFilterTUMetricsWithTenantByTenantId() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW_MINUS_10M, TENANT1, ASSIGNEE_HASH_1);
@@ -354,7 +354,7 @@ public class UsageMetricIT {
                 2, Map.of(TENANT1, new UsageMetricTUStatisticsEntityTenant(2L))));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCleanupUsageMetricsProperly() {
     // given
     writeMetric(usageMetricWriter, RPI, NOW, TENANT1, 11L);
@@ -390,7 +390,7 @@ public class UsageMetricIT {
             });
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCleanupUsageMetricsTUProperly() {
     // given
     writeTUMetric(usageMetricTUWriter, NOW, TENANT1, ASSIGNEE_HASH_1);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -19,6 +19,7 @@ import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.fixtures.UserFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -27,7 +28,6 @@ import io.camunda.search.sort.UserSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -37,7 +37,7 @@ public class UserIT {
   public static final Long PARTITION_ID = 0L;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -56,7 +56,7 @@ public class UserIT {
     compareUsers(instance, userUpdate);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndDelete(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -74,7 +74,7 @@ public class UserIT {
     assertThat(deletedInstance).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByUsername(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -103,7 +103,7 @@ public class UserIT {
     assertThat(instance.email()).isEqualTo(user.email());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindByNameUTF8(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -123,7 +123,7 @@ public class UserIT {
     assertThat(searchResult.items()).extracting(UserEntity::name).containsExactly(username);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAuthorization(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -152,7 +152,7 @@ public class UserIT {
     assertThat(instance.email()).isEqualTo(user.email());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -173,7 +173,7 @@ public class UserIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -194,7 +194,7 @@ public class UserIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -220,7 +220,7 @@ public class UserIT {
     assertThat(searchResult.items().getFirst().userKey()).isEqualTo(user.userKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.UserDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -26,7 +27,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -35,7 +35,7 @@ public class UserSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByUsernameAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -43,7 +43,7 @@ public class UserSortIT {
         Comparator.comparing(UserEntity::username));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByUsernameDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -51,7 +51,7 @@ public class UserSortIT {
         Comparator.comparing(UserEntity::username).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByUserKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -59,7 +59,7 @@ public class UserSortIT {
         Comparator.comparing(UserEntity::userKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -67,7 +67,7 @@ public class UserSortIT {
         Comparator.comparing(UserEntity::name));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByEmailAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -26,6 +26,7 @@ import io.camunda.it.rdbms.db.fixtures.UserTaskFixtures;
 import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.UntypedOperation;
@@ -49,7 +50,6 @@ import java.util.Map;
 import java.util.UUID;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -59,7 +59,7 @@ public class UserTaskIT {
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCreateAndFindUserTaskByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -70,7 +70,7 @@ public class UserTaskIT {
     assertUserTaskEntity(instance, userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCreateAndFindUserTaskByKeyWithCustomHeader(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -84,7 +84,7 @@ public class UserTaskIT {
     assertThat(instance.customHeaders()).containsExactly(entry("headerKey", "headerValue"));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldCreateAndFindUserTaskWithoutCandidatesByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -97,7 +97,7 @@ public class UserTaskIT {
     assertUserTaskEntity(instance, userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateAndFindUserTaskByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -114,7 +114,7 @@ public class UserTaskIT {
     assertUserTaskEntity(instance, updatedModel);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateAndFindUserTaskWithoutCandidatesByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -140,7 +140,7 @@ public class UserTaskIT {
     assertUserTaskEntity(instance, updatedModel);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeletingExistingCandidates(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -157,7 +157,7 @@ public class UserTaskIT {
     assertUserTaskEntity(instance, updatedModel);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateCandidateUserAndGroupAndFindByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -178,7 +178,7 @@ public class UserTaskIT {
     assertUserTaskEntity(instance, updatedModel);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllUserTasksPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -202,7 +202,7 @@ public class UserTaskIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByProcessInstanceKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -227,7 +227,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByProcessDefinitionIdEq(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -255,7 +255,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByProcessDefinitionIdNeq(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -291,7 +291,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), taskB);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByProcessDefinitionIdLike(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -319,7 +319,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByBusinessIdEq(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -346,7 +346,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByBusinessIdLike(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -374,7 +374,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByProcessDefinitionKeyNeq(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -404,7 +404,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), taskB);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByProcessDefinitionKeyIn(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -439,7 +439,7 @@ public class UserTaskIT {
         .containsExactlyInAnyOrder(taskA.userTaskKey(), taskB.userTaskKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByProcessInstanceKeyNeq(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -469,7 +469,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), taskB);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByProcessInstanceKeyIn(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -503,7 +503,7 @@ public class UserTaskIT {
         .containsExactlyInAnyOrder(taskA.userTaskKey(), taskB.userTaskKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -526,7 +526,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByAuthorizedTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -547,7 +547,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByPropertyBasedAuthorizationWithAssignee(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -576,7 +576,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByPropertyBasedAuthorizationWithCandidateUser(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -607,7 +607,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByPropertyBasedAuthorizationWithCandidateGroup(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -639,7 +639,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindSeveralUserTaskByPropertyBasedAuthorizationWithCandidateGroups(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -676,7 +676,7 @@ public class UserTaskIT {
         .containsExactlyInAnyOrder(task1.userTaskKey(), task2.userTaskKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByPropertyBasedAuthorizationCombiningMultipleProperties(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -728,7 +728,7 @@ public class UserTaskIT {
         .containsExactlyInAnyOrder(task1.userTaskKey(), task2.userTaskKey(), task3.userTaskKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCompositeAuthorizationWhenBothBranchesMatch(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -769,7 +769,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCompositeAuthorizationWhenOnlyProcessDefinitionMatches(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -812,7 +812,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCompositeAuthorizationWhenOnlyUserTaskMatches(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -851,7 +851,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldReturnEmptyResultWhenNeitherCompositeAuthorizationBranchMatches(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -887,7 +887,7 @@ public class UserTaskIT {
     assertThat(searchResult.items()).isEmpty();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindMultipleUserTasksByCompositeAuthorizationWithPartialMatches(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -933,7 +933,7 @@ public class UserTaskIT {
         .containsExactlyInAnyOrder(userTask1.userTaskKey(), userTask2.userTaskKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCompositeAuthorizationWithMultipleResourceIdsPerType(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -991,7 +991,7 @@ public class UserTaskIT {
             userTask4.userTaskKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCompositeAuthorizationWhenOnlyIdBranchMatches(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -1030,7 +1030,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCompositeAuthorizationWhenOnlyPropertyBranchMatches(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -1070,7 +1070,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void
       shouldFindMultipleUserTasksByCompositeAuthorizationWithIdAndPropertyBasedPartialMatches(
           final CamundaRdbmsTestApplication testApplication) {
@@ -1124,7 +1124,7 @@ public class UserTaskIT {
         .containsExactlyInAnyOrder(task1.userTaskKey(), task2.userTaskKey(), task3.userTaskKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByProcessInstanceVariableName(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1162,7 +1162,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByTwoProcessInstanceVariableNames(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1209,7 +1209,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByProcessInstanceVariableNameAndValue(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1247,7 +1247,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByTwoProcessInstanceVariableNamesAndValues(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1301,7 +1301,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByLocalVariableName(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1336,7 +1336,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByTwoLocalVariableNames(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1385,7 +1385,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllUserTasksPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -1406,7 +1406,7 @@ public class UserTaskIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllUserTasksPageValuesAreNull(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1428,7 +1428,7 @@ public class UserTaskIT {
     assertThat(searchResult.items()).hasSize(20);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCreationDateGt(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1455,7 +1455,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCompletionDateGte(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1482,7 +1482,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCreationDateLte(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1509,7 +1509,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCompletionDateLt(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1536,7 +1536,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResultGte.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByDueDateGt(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -1561,7 +1561,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByDueDateLte(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -1584,7 +1584,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByFollowUpDateGt(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1611,7 +1611,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByFollowUpDateLte(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1638,7 +1638,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResult.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskByCompletionDateEquals(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -1665,7 +1665,7 @@ public class UserTaskIT {
     assertUserTaskEntity(searchResultGte.items().getFirst(), userTask);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final UserTaskDbReader processInstanceReader = rdbmsService.getUserTaskReader();
@@ -1701,7 +1701,7 @@ public class UserTaskIT {
     assertThat(searchResult.items().getFirst().userTaskKey()).isEqualTo(userTask.userTaskKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final UserTaskDbReader reader = rdbmsService.getUserTaskReader();
@@ -1791,7 +1791,7 @@ public class UserTaskIT {
     }
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -1833,7 +1833,7 @@ public class UserTaskIT {
         .containsExactlyInAnyOrder(item1.userTaskKey(), item3.userTaskKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.UserTaskDbReader;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -25,7 +26,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -34,7 +34,7 @@ public class UserTaskSortIT {
 
   public static final Long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByCreationTimeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -42,7 +42,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::creationDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByCreationTimeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -50,7 +50,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::creationDate).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByCompletionTimeAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -58,7 +58,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::creationDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByCompletionTimeDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -66,7 +66,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::creationDate).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByPriorityAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -74,7 +74,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::priority));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByPriorityDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -82,7 +82,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::priority).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDueDateAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -90,7 +90,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::dueDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByDueDateDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -98,7 +98,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::dueDate).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByFollowUpDateAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -106,7 +106,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::followUpDate));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByFollowUpDateDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
@@ -114,7 +114,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::followUpDate).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByBusinessIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -122,7 +122,7 @@ public class UserTaskSortIT {
         Comparator.comparing(UserTaskEntity::businessId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByBusinessIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskTagIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskTagIT.java
@@ -16,10 +16,10 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.UserTaskFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.query.UserTaskQuery;
 import java.util.Set;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -30,7 +30,7 @@ public class UserTaskTagIT {
   private static final String TAG_FOO = "foo";
   private static final String TAG_BAR = "bar";
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindUserTaskWithSingleTag(final CamundaRdbmsTestApplication testApplication) {
     final var reader = setupReader(testApplication);
     final var writer = setupWriter(testApplication);
@@ -52,7 +52,7 @@ public class UserTaskTagIT {
     assertThat(searchResult.items().getFirst().tags()).containsOnly(TAG_FOO);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindOnlyUserTasksWithAllRequestedTags(
       final CamundaRdbmsTestApplication testApplication) {
     final var reader = setupReader(testApplication);
@@ -90,7 +90,7 @@ public class UserTaskTagIT {
     assertThat(searchResult.items().getFirst().tags()).containsExactlyInAnyOrder(TAG_FOO, TAG_BAR);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotFindUserTasksWithoutTags(final CamundaRdbmsTestApplication testApplication) {
     final var reader = setupReader(testApplication);
     final var writer = setupWriter(testApplication);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsTestTemplate.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsTestTemplate.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+/**
+ * Composed annotation that marks a method as a {@link TestTemplate} whose invocations (one per DB
+ * backend provided by {@link CamundaRdbmsInvocationContextProviderExtension}) run concurrently.
+ * Since each invocation targets a completely separate database container, running them in parallel
+ * is safe. Methods within a test class still execute sequentially, preventing data contamination
+ * across methods that share the same container.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@Execution(ExecutionMode.CONCURRENT)
+public @interface RdbmsTestTemplate {}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/ProcessDefinitionVariableNameLookupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/ProcessDefinitionVariableNameLookupIT.java
@@ -18,16 +18,16 @@ import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class ProcessDefinitionVariableNameLookupIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldRecordVariableNameForProcessDefinition(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -48,7 +48,7 @@ public class ProcessDefinitionVariableNameLookupIT {
         .containsExactly(varName);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldRecordDistinctVariableNamesForProcessDefinition(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -70,7 +70,7 @@ public class ProcessDefinitionVariableNameLookupIT {
         .containsExactlyInAnyOrder(varNameA, varNameB);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldNotInsertDuplicateLookupEntryWithinSameWriterSession(
       final CamundaRdbmsTestApplication testApplication) {
     // given: a single writer instance whose in-memory cache tracks seen (procDefKey, varName) pairs
@@ -116,7 +116,7 @@ public class ProcessDefinitionVariableNameLookupIT {
         .containsExactly(varName);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteAllLookupEntriesWhenProcessDefinitionDeleted(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
@@ -23,6 +23,7 @@ import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -32,7 +33,6 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -42,7 +42,7 @@ public class VariableIT {
   public static final int PARTITION_ID = 0;
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindVariableByKey(final CamundaRdbmsTestApplication testApplication) {
     final VariableDbModel randomizedVariable = prepareRandomVariablesAndReturnOne(testApplication);
 
@@ -58,7 +58,7 @@ public class VariableIT {
     assertThat(instance.isPreview()).isFalse();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateAndFindVariableByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final VariableDbModel randomizedVariable = prepareRandomVariablesAndReturnOne(testApplication);
@@ -77,7 +77,7 @@ public class VariableIT {
     assertVariableDbModelEqualToEntity(updatedVariable, instance);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindBigVariableByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -94,7 +94,7 @@ public class VariableIT {
     assertThat(instance.value()).hasSizeLessThan(instance.fullValue().length());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindLargeByteVariableByKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -114,7 +114,7 @@ public class VariableIT {
         .hasSizeLessThan(instance.fullValue().length());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableByProcessInstanceKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -143,7 +143,7 @@ public class VariableIT {
     assertVariableDbModelEqualToEntity(randomizedVariable, instance);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -171,7 +171,7 @@ public class VariableIT {
         .isEqualTo(randomizedVariable.variableKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableByAuthorizedTenantId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -197,7 +197,7 @@ public class VariableIT {
         .isEqualTo(randomizedVariable.variableKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllVariablesPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -218,7 +218,7 @@ public class VariableIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllVariablesPagedWithHasMoreHits(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -241,7 +241,7 @@ public class VariableIT {
     assertThat(searchResult.items()).hasSize(5);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllVariablesPageValuesAreNull(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -263,7 +263,7 @@ public class VariableIT {
     assertThat(searchResult.items()).hasSize(20);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final VariableDbReader variableReader = rdbmsService.getVariableReader();
@@ -292,7 +292,7 @@ public class VariableIT {
         .isEqualTo(randomizedVariable.variableKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final VariableDbReader variableReader = rdbmsService.getVariableReader();
@@ -325,7 +325,7 @@ public class VariableIT {
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -360,7 +360,7 @@ public class VariableIT {
         .containsExactlyInAnyOrder(item1.variableKey(), item3.variableKey());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableSortIT.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -25,14 +26,13 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class VariableSortIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVariableKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -40,7 +40,7 @@ public class VariableSortIT {
         Comparator.comparing(VariableEntity::variableKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByVariableKeyDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -48,7 +48,7 @@ public class VariableSortIT {
         Comparator.comparing(VariableEntity::variableKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByValueAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -56,7 +56,7 @@ public class VariableSortIT {
         Comparator.comparing(VariableEntity::value));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByValueDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -64,7 +64,7 @@ public class VariableSortIT {
         Comparator.comparing(VariableEntity::value).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -72,7 +72,7 @@ public class VariableSortIT {
         Comparator.comparing(VariableEntity::processInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -81,7 +81,7 @@ public class VariableSortIT {
         Comparator.comparing(VariableEntity::processInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -89,7 +89,7 @@ public class VariableSortIT {
         Comparator.comparing(VariableEntity::tenantId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -97,7 +97,7 @@ public class VariableSortIT {
         Comparator.comparing(VariableEntity::tenantId).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByScopeKeyAsc(final CamundaRdbmsTestApplication testApplication) {
 
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -119,7 +119,7 @@ public class VariableSortIT {
     assertThat(searchResult).isSortedAccordingTo(Comparator.comparing(VariableEntity::scopeKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByScopeKeyDesc(final CamundaRdbmsTestApplication testApplication) {
 
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableValueFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableValueFilterIT.java
@@ -19,6 +19,7 @@ import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.VariableFilter;
@@ -27,14 +28,13 @@ import io.camunda.search.query.VariableQuery;
 import io.camunda.search.sort.VariableSort;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class VariableValueFilterIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameFilter(final CamundaRdbmsTestApplication testApplication) {
     // given 20 random variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -51,7 +51,7 @@ public class VariableValueFilterIT {
         testApplication.getRdbmsService(), randomizedVariable, varName, null);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameAndEqValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -69,7 +69,7 @@ public class VariableValueFilterIT {
         rdbmsService, randomizedVariable, randomizedVariable.name(), operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameAndLikeValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -85,7 +85,7 @@ public class VariableValueFilterIT {
         rdbmsService, randomizedVariable, randomizedVariable.name(), operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameAndEqNumberValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -102,7 +102,7 @@ public class VariableValueFilterIT {
         rdbmsService, randomizedVariable, randomizedVariable.name(), operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameAndEqBooleanValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -119,7 +119,7 @@ public class VariableValueFilterIT {
         rdbmsService, randomizedVariable, randomizedVariable.name(), operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameAndNeqValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 20 random variables
@@ -139,7 +139,7 @@ public class VariableValueFilterIT {
     searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameAndGtValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -155,7 +155,7 @@ public class VariableValueFilterIT {
     searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameAndGteValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -171,7 +171,7 @@ public class VariableValueFilterIT {
     searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameAndLtValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -187,7 +187,7 @@ public class VariableValueFilterIT {
     searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameAndLteValue(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -203,7 +203,7 @@ public class VariableValueFilterIT {
     searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithNameAndLtValueDouble(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -219,7 +219,7 @@ public class VariableValueFilterIT {
     searchAndAssertVariableValueFilter(rdbmsService, randomizedVariable, varName, operation);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithMultipleNamesFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -250,7 +250,7 @@ public class VariableValueFilterIT {
     assertThat(searchResult.items().getFirst().name()).isEqualTo(randomizedVariable.name());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindVariableWithMultipleNamesAndValuesFilter(
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
@@ -284,7 +284,7 @@ public class VariableValueFilterIT {
     assertThat(searchResult.items().getFirst().name()).isEqualTo(randomizedVariable.name());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldTransformAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -310,7 +310,7 @@ public class VariableValueFilterIT {
     }
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldTransformSingleWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -336,7 +336,7 @@ public class VariableValueFilterIT {
     }
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldIgnoreEscapedSQLAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
@@ -360,7 +360,7 @@ public class VariableValueFilterIT {
     assertThat(actual.items().getFirst().value()).isEqualTo(variableValue);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldIgnoreEscapedSQLSingleWildcard(
       final CamundaRdbmsTestApplication testApplication) {
     // given
@@ -386,7 +386,7 @@ public class VariableValueFilterIT {
     assertThat(actual.items().getFirst().value()).isEqualTo(variableValue);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUnescapeESAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -411,7 +411,7 @@ public class VariableValueFilterIT {
         .containsExactly("value*any%wildcards1", "value*any%wildcards2");
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUnescapeESSingleWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateIT.java
@@ -15,10 +15,10 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -27,7 +27,7 @@ public class WaitStateIT {
 
   public static final int PARTITION_ID = 0;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldInsertAndFindWaitStateByKey(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -53,7 +53,7 @@ public class WaitStateIT {
     assertThat(found.partitionId()).isEqualTo(PARTITION_ID);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteWaitStateByKey(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateSortIT.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.read.service.WaitStateDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.filter.ElementInstanceWaitStateFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -27,7 +28,6 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
@@ -36,7 +36,7 @@ public class WaitStateSortIT {
 
   public static final long PARTITION_ID = 0L;
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByElementInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -44,7 +44,7 @@ public class WaitStateSortIT {
         Comparator.comparing(WaitStateEntity::elementInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByElementInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -53,7 +53,7 @@ public class WaitStateSortIT {
         Comparator.comparing(WaitStateEntity::elementInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -61,7 +61,7 @@ public class WaitStateSortIT {
         Comparator.comparing(WaitStateEntity::processInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByProcessInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -70,7 +70,7 @@ public class WaitStateSortIT {
         Comparator.comparing(WaitStateEntity::processInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRootProcessInstanceKeyAsc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -79,7 +79,7 @@ public class WaitStateSortIT {
         Comparator.comparing(WaitStateEntity::rootProcessInstanceKey));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByRootProcessInstanceKeyDesc(
       final CamundaRdbmsTestApplication testApplication) {
     testSorting(
@@ -88,7 +88,7 @@ public class WaitStateSortIT {
         Comparator.comparing(WaitStateEntity::rootProcessInstanceKey).reversed());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByElementIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
@@ -96,7 +96,7 @@ public class WaitStateSortIT {
         Comparator.comparing(WaitStateEntity::elementId));
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSortByElementIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PersistentWebSessionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PersistentWebSessionIT.java
@@ -13,19 +13,19 @@ import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
 import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestTemplate;
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class PersistentWebSessionIT {
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldSaveAndFindWebSessionById(final CamundaRdbmsTestApplication testApplication) {
     final PersistentWebSessionDbReader reader =
         testApplication.bean(PersistentWebSessionDbReader.class);
@@ -61,7 +61,7 @@ public class PersistentWebSessionIT {
     assertThat(foundSession.attributes().get("role")).isEqualTo("admin".getBytes());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldUpdateExistingWebSession(final CamundaRdbmsTestApplication testApplication) {
     final PersistentWebSessionDbReader reader =
         testApplication.bean(PersistentWebSessionDbReader.class);
@@ -105,7 +105,7 @@ public class PersistentWebSessionIT {
     assertThat(foundSession.attributes().get("newAttribute")).isEqualTo("value".getBytes());
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldDeleteWebSession(final CamundaRdbmsTestApplication testApplication) {
     final PersistentWebSessionDbReader reader =
         testApplication.bean(PersistentWebSessionDbReader.class);
@@ -133,7 +133,7 @@ public class PersistentWebSessionIT {
     assertThat(reader.findById(sessionId)).isNull();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldFindAllWebSessions(final CamundaRdbmsTestApplication testApplication) {
     final PersistentWebSessionDbReader reader =
         testApplication.bean(PersistentWebSessionDbReader.class);
@@ -165,7 +165,7 @@ public class PersistentWebSessionIT {
         .contains(sessionId1, sessionId2, sessionId3);
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldHandleEmptyAttributes(final CamundaRdbmsTestApplication testApplication) {
     final PersistentWebSessionDbReader reader =
         testApplication.bean(PersistentWebSessionDbReader.class);
@@ -194,7 +194,7 @@ public class PersistentWebSessionIT {
     assertThat(foundSession.attributes()).isEmpty();
   }
 
-  @TestTemplate
+  @RdbmsTestTemplate
   public void shouldHandleLargeAttributes(final CamundaRdbmsTestApplication testApplication) {
     final PersistentWebSessionDbReader reader =
         testApplication.bean(PersistentWebSessionDbReader.class);


### PR DESCRIPTION
## Summary

- Introduces `@RdbmsTestTemplate`, a composed JUnit 5 annotation (`@TestTemplate` + `@Execution(CONCURRENT)`), so each `@TestTemplate` method's 6 database-backend invocations run concurrently within a single JVM fork.
- Enables JUnit 5 parallel execution (parallelism=6, `mode.default=same_thread`) in the `rdbms` Maven profile in `qa/acceptance-tests/pom.xml`.
- Mechanically replaces `@TestTemplate` with `@RdbmsTestTemplate` across all ~100 RDBMS integration-test classes.

## Why

The `rdbms-integration-tests` CI job runs each `@TestTemplate` method against 6 database backends (H2, PostgreSQL, MariaDB, MySQL, Oracle, MSSQL) sequentially, resulting in ~600+ invocations running one-at-a-time on an 8-core runner. The job regularly takes close to its 30-minute timeout.

Simply increasing `forkCount` was tried but hits Docker resource limits quickly: each JVM fork starts its own 6 containers, so `forkCount=4` → 24 containers.

## Approach

Each invocation uses a completely separate Docker container (different DB engine, different host/port), so concurrent execution of a single method's 6 invocations is safe — they share no state. Methods within a class remain sequential (`mode.default=same_thread`), preventing data contamination between methods that reuse the same container.

- Containers: still 6 (started once at JVM startup, shared across all test classes)
- Expected speedup: ~6× — from ~25 min to ~4–5 min

## Notes for reviewers

- `CamundaRdbmsInvocationContextProviderExtension.SUPPORTED_TEST_APPLICATIONS` is a `Map.copyOf()` (read-only after init), and each invocation gets its own `CamundaDatabaseTestApplicationResolver` — no thread-safety concerns in the extension itself.
- The `NoSuchMethodError` seen in local test runs (`CamundaRdbmsTestApplication.withUnifiedConfig`) is a stale-JAR issue from a local Maven cache mismatch after rebasing; it is unrelated to this change and does not occur in CI where all modules are built fresh.

## Test plan

- [ ] `rdbms-integration-tests` CI job passes and completes faster than baseline
- [ ] All 6 database backends appear in the test report for each test method
- [ ] No data-contamination test failures (tests should remain green)