### PR TITLE
55734 optimize cleanup OOM fix

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractBrokerlessZeebeCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractBrokerlessZeebeCCSMIT.java
@@ -112,6 +112,13 @@ public abstract class AbstractBrokerlessZeebeCCSMIT extends AbstractIT {
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
   }
 
+  protected void persistProcessDefinitions(final List<ProcessDefinitionOptimizeDto> definitions) {
+    embeddedOptimizeExtension
+        .getBean(ProcessDefinitionWriter.class)
+        .importProcessDefinitions(definitions);
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+  }
+
   /**
    * Persists the given process instances directly into the Optimize process-instance index, then
    * refreshes all indices so subsequent reads in the same test see the data immediately. Use this

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
@@ -36,7 +36,8 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
       new RandomStringGenerator.Builder().withinRange('a', 'z').get();
 
   @RegisterExtension
-  LogCapturer cleanupServiceLogs = LogCapturer.create().captureForType(CleanupService.class);
+  LogCapturer engineDataProcessCleanupServiceLogs =
+      LogCapturer.create().captureForType(EngineDataProcessCleanupService.class);
 
   @BeforeEach
   public void enableProcessCleanup() {
@@ -328,7 +329,7 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
 
     assertProcessInstanceDataExists(List.of(unaffectedProcessInstanceForSameDefinition));
     // and the misconfigured process is logged
-    cleanupServiceLogs.assertContains(
+    engineDataProcessCleanupServiceLogs.assertContains(
         String.format(
             "History Cleanup Configuration contains definition keys for which there is no "
                 + "definition imported yet. The keys without a match in the database are: [%s]",

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/ProcessDefinitionReaderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/ProcessDefinitionReaderIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.reader;
+
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.commons.text.RandomStringGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ProcessDefinitionReaderIT extends AbstractBrokerlessZeebeCCSMIT {
+  private static final RandomStringGenerator KEY_GENERATOR =
+      new RandomStringGenerator.Builder().withinRange('a', 'z').get();
+  private ProcessDefinitionReader processDefinitionReader;
+
+  @BeforeEach
+  void setup() {
+    processDefinitionReader = embeddedOptimizeExtension.getBean(ProcessDefinitionReader.class);
+  }
+
+  @Test
+  void shouldFindNoProcessDefinitions() {
+    final var it = processDefinitionReader.getAllProcessDefinitions();
+    assertThat(it).isExhausted();
+  }
+
+  @Test
+  void shouldFindProcessDefinition() {
+    final var key = KEY_GENERATOR.generate(8);
+    final List<ProcessDefinitionOptimizeDto> definitions =
+        List.of(
+            ProcessDefinitionOptimizeDto.builder()
+                .id(key)
+                .key(key)
+                .version("1")
+                .name(key)
+                .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+                .bpmn20Xml("<definitions/>")
+                .build());
+    persistProcessDefinitions(definitions);
+
+    final var it = processDefinitionReader.getAllProcessDefinitions();
+    assertThat(it).hasNext();
+
+    final var def = it.next();
+    assertThat(def.getKey()).isEqualTo(key);
+    assertThat(def.getVersion()).isEqualTo("1");
+
+    assertThat(it).isExhausted();
+  }
+
+  @Test
+  void shouldFindLargeNumberOfProcessDefinitions() {
+    final var prefix = KEY_GENERATOR.generate(8);
+    final List<ProcessDefinitionOptimizeDto> definitions =
+        IntStream.range(1, 2000)
+            .mapToObj(i -> prefix + "-" + i)
+            .map(
+                key ->
+                    ProcessDefinitionOptimizeDto.builder()
+                        .id(key)
+                        .key(key)
+                        .version("1")
+                        .name(key)
+                        .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+                        .bpmn20Xml("<definitions/>")
+                        .build())
+            .toList();
+    persistProcessDefinitions(definitions);
+
+    final var it = processDefinitionReader.getAllProcessDefinitions();
+    assertThat(it).hasNext();
+
+    final var keys = new ArrayList<>();
+    while (it.hasNext()) {
+      final var def = it.next();
+      keys.add(def.getKey());
+    }
+    assertThat(it).isExhausted();
+
+    final var expectedKeys =
+        definitions.stream().map(ProcessDefinitionOptimizeDto::getKey).toList();
+    assertThat(keys).containsExactlyInAnyOrderElementsOf(expectedKeys);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/cleanup/CleanupService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/cleanup/CleanupService.java
@@ -8,8 +8,6 @@
 package io.camunda.optimize.service.cleanup;
 
 import java.time.OffsetDateTime;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 public abstract class CleanupService {
@@ -19,19 +17,4 @@ public abstract class CleanupService {
   public abstract boolean isEnabled();
 
   public abstract void doCleanup(final OffsetDateTime startTime);
-
-  public void verifyConfiguredKeysAreKnownDefinitionKeys(
-      final Set<String> knownDefinitionKeys, final Set<String> specificDefinitionConfigKeys) {
-    final Set<String> knownConfiguredKeys =
-        specificDefinitionConfigKeys.stream()
-            .filter(knownDefinitionKeys::contains)
-            .collect(Collectors.toSet());
-    specificDefinitionConfigKeys.removeAll(knownConfiguredKeys);
-    if (!specificDefinitionConfigKeys.isEmpty()) {
-      LOG.warn(
-          "History Cleanup Configuration contains definition keys for which there is no "
-              + "definition imported yet. The keys without a match in the database are: "
-              + specificDefinitionConfigKeys);
-    }
-  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupService.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.optimize.service.cleanup;
 
-import static java.util.stream.Collectors.toSet;
-
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.query.PageResultDto;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
@@ -19,8 +17,10 @@ import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.cleanup.CleanupConfiguration;
 import io.camunda.optimize.service.util.configuration.cleanup.ProcessDefinitionCleanupConfiguration;
 import java.time.OffsetDateTime;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.SequencedSet;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -55,18 +55,33 @@ public class EngineDataProcessCleanupService extends CleanupService {
 
   @Override
   public void doCleanup(final OffsetDateTime startTime) {
-    final Set<String> allOptimizeProcessDefinitionKeys = getAllCamundaEngineProcessDefinitionKeys();
+    final Iterator<ProcessDefinitionOptimizeDto> processDefinitions =
+        processDefinitionReader.getAllProcessDefinitions();
 
-    verifyConfiguredKeysAreKnownDefinitionKeys(
-        allOptimizeProcessDefinitionKeys,
+    final var specificDefinitionConfigKeys =
         getCleanupConfiguration()
             .getProcessDataCleanupConfiguration()
-            .getAllProcessSpecificConfigurationKeys());
+            .getAllProcessSpecificConfigurationKeys();
+
+    final var seen = new RecentlySeen();
     int i = 1;
-    for (final String currentProcessDefinitionKey : allOptimizeProcessDefinitionKeys) {
-      LOG.info("Process History Cleanup step {}/{}", i, allOptimizeProcessDefinitionKeys.size());
+    while (processDefinitions.hasNext()) {
+      final ProcessDefinitionOptimizeDto processDefinition = processDefinitions.next();
+      final String currentProcessDefinitionKey = processDefinition.getKey();
+      if (seen.recentlySeen(currentProcessDefinitionKey)) {
+        continue;
+      }
+      specificDefinitionConfigKeys.remove(currentProcessDefinitionKey);
+      LOG.info("Process History Cleanup step {}", i);
       performCleanupForProcessKey(startTime, currentProcessDefinitionKey);
       i++;
+    }
+
+    if (!specificDefinitionConfigKeys.isEmpty()) {
+      LOG.warn(
+          "History Cleanup Configuration contains definition keys for which there is no "
+              + "definition imported yet. The keys without a match in the database are: "
+              + specificDefinitionConfigKeys);
     }
   }
 
@@ -132,17 +147,29 @@ public class EngineDataProcessCleanupService extends CleanupService {
     }
   }
 
-  private Set<String> getAllCamundaEngineProcessDefinitionKeys() {
-    return processDefinitionReader.getAllProcessDefinitions().stream()
-        .map(ProcessDefinitionOptimizeDto::getKey)
-        .collect(toSet());
-  }
-
   private CleanupConfiguration getCleanupConfiguration() {
     return configurationService.getCleanupServiceConfiguration();
   }
 
   private int getBatchSize() {
     return getCleanupConfiguration().getProcessDataCleanupConfiguration().getBatchSize();
+  }
+
+  // relying on the fact we're getting keys in sorted sequence, so we don't need to
+  // record everything (in case we have a large number of process definitions)
+  static class RecentlySeen {
+    private static final int MAX_SIZE = 1000;
+    private final SequencedSet<String> seen = new LinkedHashSet<>(MAX_SIZE);
+
+    boolean recentlySeen(final String key) {
+      if (seen.contains(key)) {
+        return true;
+      }
+      seen.add(key);
+      if (seen.size() > MAX_SIZE) {
+        seen.removeFirst();
+      }
+      return false;
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/DecisionDefinitionReaderImpl.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/DecisionDefinitionReaderImpl.java
@@ -37,11 +37,6 @@ public class DecisionDefinitionReaderImpl implements DecisionDefinitionReader {
   }
 
   @Override
-  public List<DecisionDefinitionOptimizeDto> getAllDecisionDefinitions() {
-    return definitionReader.getDefinitions(DefinitionType.DECISION, false, false, true);
-  }
-
-  @Override
   public String getLatestVersionToKey(final String key) {
     return definitionReader.getLatestVersionToKey(DefinitionType.DECISION, key);
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DefinitionReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DefinitionReaderES.java
@@ -26,8 +26,8 @@ import static io.camunda.optimize.service.util.DefinitionVersionHandlingUtil.con
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Script;
 import co.elastic.clients.elasticsearch._types.ScriptSortType;
+import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
-import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregation;
@@ -40,6 +40,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
 import co.elastic.clients.elasticsearch._types.aggregations.TermsAggregation;
 import co.elastic.clients.elasticsearch._types.aggregations.TopHitsAggregate;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery.Builder;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
@@ -74,6 +75,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -483,6 +485,16 @@ public class DefinitionReaderES implements DefinitionReader {
   }
 
   @Override
+  public <T extends DefinitionOptimizeResponseDto> Iterator<List<T>> getDefinitionsIterator(
+      final DefinitionType type,
+      final boolean fullyImported,
+      final boolean withXml,
+      final boolean includeDeleted) {
+    return getDefinitionsIterator(
+        type, Collections.emptySet(), fullyImported, withXml, includeDeleted);
+  }
+
+  @Override
   public <T extends DefinitionOptimizeResponseDto> List<T> getDefinitions(
       final DefinitionType type,
       final boolean fullyImported,
@@ -498,8 +510,29 @@ public class DefinitionReaderES implements DefinitionReader {
       final boolean fullyImported,
       final boolean withXml,
       final boolean includeDeleted) {
+    final Builder rootQuery =
+        createDefinitionsRootQuery(type, definitionKeys, fullyImported, includeDeleted);
+    return getDefinitions(type, rootQuery, withXml);
+  }
+
+  public <T extends DefinitionOptimizeResponseDto> Iterator<List<T>> getDefinitionsIterator(
+      final DefinitionType type,
+      final Set<String> definitionKeys,
+      final boolean fullyImported,
+      final boolean withXml,
+      final boolean includeDeleted) {
+    final Builder rootQuery =
+        createDefinitionsRootQuery(type, definitionKeys, fullyImported, includeDeleted);
+    return getDefinitionsIterator(type, rootQuery, withXml);
+  }
+
+  private Builder createDefinitionsRootQuery(
+      final DefinitionType type,
+      final Set<String> definitionKeys,
+      final boolean fullyImported,
+      final boolean includeDeleted) {
     final String xmlField = resolveXmlFieldFromType(type);
-    final BoolQuery.Builder rootQuery = new BoolQuery.Builder();
+    final Builder rootQuery = new Builder();
     rootQuery.must(
         m -> {
           if (fullyImported) {
@@ -523,10 +556,10 @@ public class DefinitionReaderES implements DefinitionReader {
                               tt ->
                                   tt.value(definitionKeys.stream().map(FieldValue::of).toList()))));
     }
-    return getDefinitions(type, rootQuery, withXml);
+    return rootQuery;
   }
 
-  public <T extends DefinitionOptimizeResponseDto> List<T> getDefinitions(
+  public <T extends DefinitionOptimizeResponseDto> Iterator<List<T>> getDefinitionsIterator(
       final DefinitionType type, final BoolQuery.Builder filteredQuery, final boolean withXml) {
     final String xmlField = resolveXmlFieldFromType(type);
     final List<String> fieldsToExclude = withXml ? null : List.of(xmlField);
@@ -536,14 +569,12 @@ public class DefinitionReaderES implements DefinitionReader {
               s.optimizeIndex(esClient, resolveIndexNameForType(type))
                   .query(Query.of(q -> q.bool(filteredQuery.build())))
                   .size(LIST_FETCH_LIMIT)
-                  .scroll(
-                      Time.of(
-                          t ->
-                              t.time(
-                                  configurationService
-                                          .getElasticSearchConfiguration()
-                                          .getScrollTimeoutInSeconds()
-                                      + "s")));
+                  .sort(
+                      SortOptions.of(
+                          sort -> sort.field(f -> f.field(DEFINITION_KEY).order(SortOrder.Asc))),
+                      SortOptions.of(
+                          sort -> sort.field(f -> f.field("_doc").order(SortOrder.Asc))));
+
               if (fieldsToExclude != null) {
                 s.source(so -> so.filter(f -> f.excludes(fieldsToExclude)));
               }
@@ -551,22 +582,18 @@ public class DefinitionReaderES implements DefinitionReader {
             });
 
     final Class<T> typeClass = resolveDefinitionClassFromType(type);
-    final SearchResponse<T> scrollResp;
-    try {
-      scrollResp = esClient.search(searchRequest, typeClass);
-    } catch (final IOException e) {
-      final String errorMsg =
-          String.format("Was not able to retrieve definitions of type %s", type);
-      LOG.error(errorMsg, e);
-      throw new OptimizeRuntimeException(errorMsg, e);
-    }
+    return ElasticsearchReaderUtil.searchIterator(esClient, searchRequest, typeClass);
+  }
 
-    return ElasticsearchReaderUtil.retrieveAllScrollResults(
-        scrollResp,
-        typeClass,
-        createMappingFunctionForDefinitionType(typeClass),
-        esClient,
-        configurationService.getElasticSearchConfiguration().getScrollTimeoutInSeconds());
+  public <T extends DefinitionOptimizeResponseDto> List<T> getDefinitions(
+      final DefinitionType type, final BoolQuery.Builder filteredQuery, final boolean withXml) {
+    final Iterator<List<T>> definitionsIterator =
+        getDefinitionsIterator(type, filteredQuery, withXml);
+    final List<T> definitions = new ArrayList<>();
+    while (definitionsIterator.hasNext()) {
+      definitions.addAll(definitionsIterator.next());
+    }
+    return definitions;
   }
 
   private void addVersionFilterToQuery(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DefinitionReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DefinitionReaderES.java
@@ -8,9 +8,7 @@
 package io.camunda.optimize.service.db.es.reader;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
-import static io.camunda.optimize.service.db.DatabaseConstants.DECISION_DEFINITION_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
-import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.VERSION_FOR_SORTING_AGGREGATION;
 import static io.camunda.optimize.service.db.es.writer.ElasticsearchWriterUtil.createDefaultScript;
 import static io.camunda.optimize.service.db.schema.index.AbstractDefinitionIndex.DATA_SOURCE;
@@ -31,7 +29,6 @@ import co.elastic.clients.elasticsearch._types.ScriptSortType;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
-import co.elastic.clients.elasticsearch._types.aggregations.Buckets;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregation;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregationSource;
@@ -206,62 +203,6 @@ public class DefinitionReaderES implements DefinitionReader {
     }
 
     return getLatestFullyImportedDefinitionPerTenant(type, definitionKey);
-  }
-
-  @Override
-  public Set<String> getDefinitionEngines(final DefinitionType type, final String definitionKey) {
-    final TermsAggregation termsAggregation =
-        TermsAggregation.of(
-            t -> t.field(DATA_SOURCE + "." + DataSourceDto.Fields.name).size(LIST_FETCH_LIMIT));
-    final SearchRequest searchRequest =
-        OptimizeSearchRequestBuilderES.of(
-            s ->
-                s.optimizeIndex(
-                        esClient,
-                        DefinitionType.PROCESS.equals(type)
-                            ? PROCESS_DEFINITION_INDEX_NAME
-                            : DECISION_DEFINITION_INDEX_NAME)
-                    .query(
-                        q ->
-                            q.bool(
-                                b ->
-                                    b.must(
-                                            m ->
-                                                m.term(
-                                                    t ->
-                                                        t.field(
-                                                                resolveDefinitionKeyFieldFromType(
-                                                                    type))
-                                                            .value(definitionKey)))
-                                        .must(
-                                            m ->
-                                                m.term(
-                                                    t ->
-                                                        t.field(DEFINITION_DELETED).value(false)))))
-                    // no search results needed, we only need the aggregation
-                    .size(0)
-                    .aggregations(
-                        ENGINE_AGGREGATION, Aggregation.of(a -> a.terms(termsAggregation))));
-
-    final SearchResponse<?> searchResponse;
-    try {
-      searchResponse = esClient.search(searchRequest, Object.class);
-    } catch (final IOException e) {
-      final String reason =
-          String.format(
-              "Was not able to fetch engines for definition key [%s] and type [%s]",
-              definitionKey, type);
-      LOG.error(reason, e);
-      throw new OptimizeRuntimeException(reason, e);
-    }
-
-    final Buckets<StringTermsBucket> buckets =
-        searchResponse.aggregations().get(ENGINE_AGGREGATION).sterms().buckets();
-    if (buckets.isArray()) {
-      return buckets.array().stream().map(b -> b.key().stringValue()).collect(Collectors.toSet());
-    } else {
-      return buckets.keyed().keySet();
-    }
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/ElasticsearchReaderUtil.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/ElasticsearchReaderUtil.java
@@ -12,6 +12,7 @@ import co.elastic.clients.elasticsearch.core.ClearScrollResponse;
 import co.elastic.clients.elasticsearch.core.MgetResponse;
 import co.elastic.clients.elasticsearch.core.ScrollRequest;
 import co.elastic.clients.elasticsearch.core.ScrollResponse;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
@@ -23,6 +24,7 @@ import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -44,21 +46,6 @@ public final class ElasticsearchReaderUtil {
         initialScrollResponse,
         itemClass,
         objectMapper,
-        esClient,
-        scrollingTimeoutInSeconds,
-        Integer.MAX_VALUE);
-  }
-
-  public static <T> List<T> retrieveAllScrollResults(
-      final SearchResponse<?> initialScrollResponse,
-      final Class<T> itemClass,
-      final Function<Hit<?>, T> mappingFunction,
-      final OptimizeElasticsearchClient esClient,
-      final Integer scrollingTimeoutInSeconds) {
-    return retrieveScrollResultsTillLimit(
-        initialScrollResponse,
-        itemClass,
-        mappingFunction,
         esClient,
         scrollingTimeoutInSeconds,
         Integer.MAX_VALUE);
@@ -221,6 +208,18 @@ public final class ElasticsearchReaderUtil {
               itemClass.getSimpleName());
       LOG.error(reason);
     }
+  }
+
+  /*
+   Returns an iterator to extract all results from a given search (using search_after instead of scrolls).
+
+   This is done in a lazy fashion so we do not read everything into memory at once.
+  */
+  public static <T> Iterator<List<T>> searchIterator(
+      final OptimizeElasticsearchClient esClient,
+      final SearchRequest searchRequest,
+      final Class<T> itemClass) {
+    return new SearchAfterIterator<>(esClient, searchRequest, itemClass);
   }
 
   public static <T> List<T> mapHits(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/SearchAfterIterator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/SearchAfterIterator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.reader;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.List;
+
+class SearchAfterIterator<T> implements Iterator<List<T>> {
+  private final OptimizeElasticsearchClient esClient;
+  private final SearchRequest searchRequest;
+  private final Class<T> itemClass;
+
+  private List<T> current;
+  private List<FieldValue> lastSortValues;
+  private boolean finished = false;
+
+  SearchAfterIterator(
+      final OptimizeElasticsearchClient esClient,
+      final SearchRequest searchRequest,
+      final Class<T> itemClass) {
+    this.esClient = esClient;
+    this.searchRequest = searchRequest;
+    this.itemClass = itemClass;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (finished) {
+      return false;
+    }
+    SearchRequest nextSearch = searchRequest;
+    if (lastSortValues != null) {
+      nextSearch = searchRequest.rebuild().searchAfter(lastSortValues).build();
+    }
+    try {
+      final SearchResponse<T> response = esClient.search(nextSearch, itemClass);
+      final List<Hit<T>> hits = response.hits().hits();
+      if (!hits.isEmpty()) {
+        current = hits.stream().map(Hit::source).filter(java.util.Objects::nonNull).toList();
+        lastSortValues = hits.getLast().sort();
+      } else {
+        finished = true;
+        return false;
+      }
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return true;
+  }
+
+  @Override
+  public List<T> next() {
+    return current;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/SearchAfterIterator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/SearchAfterIterator.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 class SearchAfterIterator<T> implements Iterator<List<T>> {
   private final OptimizeElasticsearchClient esClient;
@@ -40,6 +41,9 @@ class SearchAfterIterator<T> implements Iterator<List<T>> {
     if (finished) {
       return false;
     }
+    if (current != null) {
+      return true;
+    }
     SearchRequest nextSearch = searchRequest;
     if (lastSortValues != null) {
       nextSearch = searchRequest.rebuild().searchAfter(lastSortValues).build();
@@ -62,6 +66,11 @@ class SearchAfterIterator<T> implements Iterator<List<T>> {
 
   @Override
   public List<T> next() {
-    return current;
+    if (!hasNext()) {
+      throw new NoSuchElementException("SearchAfterIterator has no more elements");
+    }
+    final var next = current;
+    current = null;
+    return next;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionReaderOS.java
@@ -37,8 +37,6 @@ import io.camunda.optimize.service.db.os.OpenSearchCompositeAggregationScroller;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.client.dsl.AggregationDSL;
 import io.camunda.optimize.service.db.os.client.dsl.QueryDSL;
-import io.camunda.optimize.service.db.os.client.dsl.RequestDSL;
-import io.camunda.optimize.service.db.os.client.sync.OpenSearchDocumentOperations;
 import io.camunda.optimize.service.db.os.schema.index.DecisionDefinitionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ProcessDefinitionIndexOS;
 import io.camunda.optimize.service.db.reader.DefinitionReader;
@@ -47,11 +45,11 @@ import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.DefinitionVersionHandlingUtil;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -428,6 +426,16 @@ public class DefinitionReaderOS implements DefinitionReader {
   }
 
   @Override
+  public <T extends DefinitionOptimizeResponseDto> Iterator<List<T>> getDefinitionsIterator(
+      final DefinitionType type,
+      final boolean fullyImported,
+      final boolean withXml,
+      final boolean includeDeleted) {
+    return getDefinitionsIterator(
+        type, Collections.emptySet(), fullyImported, withXml, includeDeleted);
+  }
+
+  @Override
   public <T extends DefinitionOptimizeResponseDto> List<T> getDefinitions(
       final DefinitionType type,
       final boolean fullyImported,
@@ -443,22 +451,23 @@ public class DefinitionReaderOS implements DefinitionReader {
       final boolean fullyImported,
       final boolean withXml,
       final boolean includeDeleted) {
-    final String xmlField = resolveXmlFieldFromType(type);
-    final BoolQuery.Builder rootQuery =
-        new BoolQuery.Builder()
-            .must(fullyImported ? QueryDSL.exists(xmlField) : QueryDSL.matchAll());
-    final BoolQuery.Builder filteredQuery = rootQuery.must(QueryDSL.matchAll());
-    if (!includeDeleted) {
-      filteredQuery.must(QueryDSL.term(DEFINITION_DELETED, false));
-    }
-    if (!definitionKeys.isEmpty()) {
-      filteredQuery.must(
-          QueryDSL.terms(resolveDefinitionKeyFieldFromType(type), definitionKeys, FieldValue::of));
-    }
+    final BoolQuery.Builder filteredQuery =
+        createDefinitionsRootQuery(type, definitionKeys, fullyImported, includeDeleted);
     return getDefinitions(type, filteredQuery.build(), withXml);
   }
 
-  public <T extends DefinitionOptimizeResponseDto> List<T> getDefinitions(
+  public <T extends DefinitionOptimizeResponseDto> Iterator<List<T>> getDefinitionsIterator(
+      final DefinitionType type,
+      final Set<String> definitionKeys,
+      final boolean fullyImported,
+      final boolean withXml,
+      final boolean includeDeleted) {
+    final BoolQuery.Builder filteredQuery =
+        createDefinitionsRootQuery(type, definitionKeys, fullyImported, includeDeleted);
+    return getDefinitionsIterator(type, filteredQuery.build(), withXml);
+  }
+
+  public <T extends DefinitionOptimizeResponseDto> Iterator<List<T>> getDefinitionsIterator(
       final DefinitionType type, final BoolQuery filterQuery, final boolean withXml) {
     final String xmlField = resolveXmlFieldFromType(type);
     final List<String> fieldsToExclude = withXml ? Collections.emptyList() : List.of(xmlField);
@@ -473,25 +482,48 @@ public class DefinitionReaderOS implements DefinitionReader {
             .query(filterQuery.toQuery())
             .source(searchSourceBuilder)
             .size(LIST_FETCH_LIMIT)
-            .scroll(
-                RequestDSL.time(
-                    String.valueOf(
-                        configurationService
-                            .getOpenSearchConfiguration()
-                            .getScrollTimeoutInSeconds())));
+            .sort(
+                SortOptions.of(
+                    sort -> sort.field(f -> f.field(DEFINITION_KEY).order(SortOrder.Asc))),
+                SortOptions.of(sort -> sort.field(f -> f.field("_doc").order(SortOrder.Asc))));
 
     final Class<T> typeClass = resolveDefinitionClassFromType(type);
-    final OpenSearchDocumentOperations.AggregatedResult<Hit<T>> scrollResp;
-    try {
-      scrollResp = osClient.retrieveAllScrollResults(searchBuilder, typeClass);
-    } catch (final IOException e) {
-      final String errorMsg =
-          String.format("Was not able to retrieve definitions of type %s", type);
-      LOG.error(errorMsg, e);
-      throw new OptimizeRuntimeException(errorMsg, e);
+
+    final String errorMsg = String.format("Was not able to retrieve definitions of type %s", type);
+
+    return OpensearchReaderUtil.searchIterator(
+        osClient, searchBuilder.build(), typeClass, errorMsg);
+  }
+
+  private BoolQuery.Builder createDefinitionsRootQuery(
+      final DefinitionType type,
+      final Set<String> definitionKeys,
+      final boolean fullyImported,
+      final boolean includeDeleted) {
+    final String xmlField = resolveXmlFieldFromType(type);
+    final BoolQuery.Builder rootQuery =
+        new BoolQuery.Builder()
+            .must(fullyImported ? QueryDSL.exists(xmlField) : QueryDSL.matchAll());
+    final BoolQuery.Builder filteredQuery = rootQuery.must(QueryDSL.matchAll());
+    if (!includeDeleted) {
+      filteredQuery.must(QueryDSL.term(DEFINITION_DELETED, false));
     }
-    return OpensearchReaderUtil.extractAggregatedResponseValues(
-        scrollResp, createMappingFunctionForDefinitionType(typeClass));
+    if (!definitionKeys.isEmpty()) {
+      filteredQuery.must(
+          QueryDSL.terms(resolveDefinitionKeyFieldFromType(type), definitionKeys, FieldValue::of));
+    }
+    return filteredQuery;
+  }
+
+  public <T extends DefinitionOptimizeResponseDto> List<T> getDefinitions(
+      final DefinitionType type, final BoolQuery filterQuery, final boolean withXml) {
+    final Iterator<List<T>> definitionsIterator =
+        getDefinitionsIterator(type, filterQuery, withXml);
+    final List<T> definitions = new ArrayList<>();
+    while (definitionsIterator.hasNext()) {
+      definitions.addAll(definitionsIterator.next());
+    }
+    return definitions;
   }
 
   private void addVersionFilterToQuery(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionReaderOS.java
@@ -8,9 +8,7 @@
 package io.camunda.optimize.service.db.os.reader;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
-import static io.camunda.optimize.service.db.DatabaseConstants.DECISION_DEFINITION_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
-import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.VERSION_FOR_SORTING_AGGREGATION;
 import static io.camunda.optimize.service.db.os.writer.OpenSearchWriterUtil.createDefaultScript;
 import static io.camunda.optimize.service.db.schema.index.AbstractDefinitionIndex.DATA_SOURCE;
@@ -200,42 +198,6 @@ public class DefinitionReaderOS implements DefinitionReader {
       return Collections.emptyList();
     }
     return getLatestFullyImportedDefinitionPerTenant(type, definitionKey);
-  }
-
-  @Override
-  public Set<String> getDefinitionEngines(final DefinitionType type, final String definitionKey) {
-    final TermsAggregation enginesAggregation =
-        AggregationDSL.termAggregation(
-            DATA_SOURCE + "." + DataSourceDto.Fields.name, LIST_FETCH_LIMIT);
-
-    final SearchRequest.Builder searchRequest =
-        new SearchRequest.Builder()
-            .index(
-                DefinitionType.PROCESS.equals(type)
-                    ? PROCESS_DEFINITION_INDEX_NAME
-                    : DECISION_DEFINITION_INDEX_NAME)
-            .query(
-                new BoolQuery.Builder()
-                    .must(QueryDSL.term(resolveDefinitionKeyFieldFromType(type), definitionKey))
-                    .must(QueryDSL.term(DEFINITION_DELETED, false))
-                    .build()
-                    .toQuery())
-            .size(0)
-            .aggregations(
-                Collections.singletonMap(ENGINE_AGGREGATION, enginesAggregation.toAggregation()));
-
-    final String errorMessage =
-        String.format(
-            "Was not able to fetch engines for definition key [%s] and type [%s]",
-            definitionKey, type);
-    final SearchResponse<String> searchResponse =
-        osClient.search(searchRequest, String.class, errorMessage);
-
-    return Stream.of(searchResponse.aggregations().get(ENGINE_AGGREGATION).sterms())
-        .map(MultiBucketAggregateBase::buckets)
-        .flatMap(bucket -> bucket.array().stream())
-        .map(StringTermsBucket::key)
-        .collect(Collectors.toSet());
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/OpensearchReaderUtil.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/OpensearchReaderUtil.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.optimize.service.db.os.reader;
 
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.client.sync.OpenSearchDocumentOperations;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -21,6 +23,7 @@ import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.Buckets;
 import org.opensearch.client.opensearch._types.aggregations.MultiBucketAggregateBase;
 import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.get.GetResult;
 import org.opensearch.client.opensearch.core.search.Hit;
@@ -100,6 +103,19 @@ public class OpensearchReaderUtil {
 
   public static <T> Optional<T> processGetResponse(final GetResult<T> getResponse) {
     return Optional.ofNullable(getResponse).filter(GetResult::found).map(GetResult::source);
+  }
+
+  /*
+   Returns an iterator to extract all results from a given search (using search_after instead of scrolls).
+
+   This is done in a lazy fashion so we do not read everything into memory at once.
+  */
+  public static <T> Iterator<List<T>> searchIterator(
+      final OptimizeOpenSearchClient osClient,
+      final SearchRequest searchRequest,
+      final Class<T> itemClass,
+      final String errorMessage) {
+    return new SearchAfterIterator<>(osClient, searchRequest, itemClass, errorMessage);
   }
 
   public static <T> Collection<? extends T> mapHits(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/SearchAfterIterator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/SearchAfterIterator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.reader;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import java.util.Iterator;
+import java.util.List;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+class SearchAfterIterator<T> implements Iterator<List<T>> {
+  private final OptimizeOpenSearchClient osClient;
+  private final SearchRequest searchRequest;
+  private final Class<T> itemClass;
+  private final String errorMessage;
+
+  private List<T> current;
+  private List<FieldValue> lastSortValues;
+  private boolean finished = false;
+
+  SearchAfterIterator(
+      final OptimizeOpenSearchClient osClient,
+      final SearchRequest searchRequest,
+      final Class<T> itemClass,
+      final String errorMessage) {
+    this.osClient = osClient;
+    this.searchRequest = searchRequest;
+    this.itemClass = itemClass;
+    this.errorMessage = errorMessage;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (finished) {
+      return false;
+    }
+    SearchRequest.Builder nextSearch = searchRequest.toBuilder();
+    if (lastSortValues != null) {
+      nextSearch = nextSearch.searchAfter(lastSortValues);
+    }
+    final SearchResponse<T> response = osClient.search(nextSearch, itemClass, errorMessage);
+    final List<Hit<T>> hits = response.hits().hits();
+    if (!hits.isEmpty()) {
+      current = hits.stream().map(Hit::source).filter(java.util.Objects::nonNull).toList();
+      lastSortValues = hits.getLast().sort();
+    } else {
+      finished = true;
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public List<T> next() {
+    return current;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/SearchAfterIterator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/SearchAfterIterator.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.db.os.reader;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -41,6 +42,9 @@ class SearchAfterIterator<T> implements Iterator<List<T>> {
     if (finished) {
       return false;
     }
+    if (current != null) {
+      return true;
+    }
     SearchRequest.Builder nextSearch = searchRequest.toBuilder();
     if (lastSortValues != null) {
       nextSearch = nextSearch.searchAfter(lastSortValues);
@@ -59,6 +63,11 @@ class SearchAfterIterator<T> implements Iterator<List<T>> {
 
   @Override
   public List<T> next() {
-    return current;
+    if (!hasNext()) {
+      throw new NoSuchElementException("SearchAfterIterator has no more elements");
+    }
+    final var next = current;
+    current = null;
+    return next;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/DecisionDefinitionReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/DecisionDefinitionReader.java
@@ -18,7 +18,5 @@ public interface DecisionDefinitionReader {
       final List<String> decisionDefinitionVersions,
       final List<String> tenantIds);
 
-  List<DecisionDefinitionOptimizeDto> getAllDecisionDefinitions();
-
   String getLatestVersionToKey(String key);
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/DefinitionReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/DefinitionReader.java
@@ -25,6 +25,7 @@ import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIds
 import io.camunda.optimize.dto.optimize.query.definition.TenantIdWithDefinitionsDto;
 import io.camunda.optimize.dto.optimize.rest.DefinitionVersionResponseDto;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -79,6 +80,14 @@ public interface DefinitionReader {
 
   List<DefinitionVersionResponseDto> getDefinitionVersions(
       final DefinitionType type, final String key, final Set<String> tenantIds);
+
+  default <T extends DefinitionOptimizeResponseDto> Iterator<List<T>> getDefinitionsIterator(
+      final DefinitionType type,
+      final boolean fullyImported,
+      final boolean withXml,
+      final boolean includeDeleted) {
+    throw new UnsupportedOperationException("getDefinitionsIterator is not implemented");
+  }
 
   <T extends DefinitionOptimizeResponseDto> List<T> getDefinitions(
       final DefinitionType type,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/DefinitionReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/DefinitionReader.java
@@ -73,8 +73,6 @@ public interface DefinitionReader {
       List<T> getLatestFullyImportedDefinitionsFromTenantsIfAvailable(
           final DefinitionType type, final String definitionKey);
 
-  Set<String> getDefinitionEngines(final DefinitionType type, final String definitionKey);
-
   Map<String, TenantIdWithDefinitionsDto> getDefinitionsGroupedByTenant();
 
   String getLatestVersionToKey(final DefinitionType type, final String key);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/DefinitionReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/DefinitionReader.java
@@ -81,13 +81,11 @@ public interface DefinitionReader {
   List<DefinitionVersionResponseDto> getDefinitionVersions(
       final DefinitionType type, final String key, final Set<String> tenantIds);
 
-  default <T extends DefinitionOptimizeResponseDto> Iterator<List<T>> getDefinitionsIterator(
+  <T extends DefinitionOptimizeResponseDto> Iterator<List<T>> getDefinitionsIterator(
       final DefinitionType type,
       final boolean fullyImported,
       final boolean withXml,
-      final boolean includeDeleted) {
-    throw new UnsupportedOperationException("getDefinitionsIterator is not implemented");
-  }
+      final boolean includeDeleted);
 
   <T extends DefinitionOptimizeResponseDto> List<T> getDefinitions(
       final DefinitionType type,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/ProcessDefinitionReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/ProcessDefinitionReader.java
@@ -7,16 +7,22 @@
  */
 package io.camunda.optimize.service.db.reader;
 
+import com.google.common.collect.Iterators;
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 public interface ProcessDefinitionReader {
 
-  default List<ProcessDefinitionOptimizeDto> getAllProcessDefinitions() {
-    return getDefinitionReader().getDefinitions(DefinitionType.PROCESS, false, false, true);
+  default Iterator<ProcessDefinitionOptimizeDto> getAllProcessDefinitions() {
+    final Iterator<List<ProcessDefinitionOptimizeDto>> definitionsPageIterator =
+        getDefinitionReader().getDefinitionsIterator(DefinitionType.PROCESS, false, false, true);
+    final Iterator<Iterator<ProcessDefinitionOptimizeDto>> nestedIterator =
+        Iterators.transform(definitionsPageIterator, List::iterator);
+    return Iterators.concat(nestedIterator);
   }
 
   default String getLatestVersionToKey(final String key) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/cleanup/OptimizeProcessCleanupServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/cleanup/OptimizeProcessCleanupServiceTest.java
@@ -59,7 +59,8 @@ public class OptimizeProcessCleanupServiceTest {
       new PageResultDto<>("1", 1, INSTANCE_IDS.subList(1, 2));
 
   @RegisterExtension
-  LogCapturer logCapturer = LogCapturer.create().captureForType(CleanupService.class);
+  LogCapturer logCapturer =
+      LogCapturer.create().captureForType(EngineDataProcessCleanupService.class);
 
   @Mock private ProcessDefinitionReader processDefinitionReader;
   @Mock private ProcessInstanceReader processInstanceReader;
@@ -370,7 +371,7 @@ public class OptimizeProcessCleanupServiceTest {
             .map(this::createProcessDefinitionDto)
             .collect(Collectors.toList());
     when(processDefinitionReader.getAllProcessDefinitions())
-        .thenReturn(processDefinitionOptimizeDtos);
+        .thenReturn(processDefinitionOptimizeDtos.iterator());
   }
 
   private List<String> generateRandomDefinitionsKeys(final Integer amount) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/reader/SearchAfterIteratorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/reader/SearchAfterIteratorTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SearchAfterIteratorTest {
+
+  @Mock private OptimizeElasticsearchClient esClient;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private SearchResponse<String> emptyResponse;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private SearchResponse<String> firstPageResponse;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private SearchResponse<String> secondPageResponse;
+
+  @Test
+  void shouldReturnFalseWhenFirstPageIsEmpty() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+    when(esClient.search(any(SearchRequest.class), eq(String.class))).thenReturn(emptyResponse);
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(esClient, request, String.class);
+
+    // when / then
+    assertThat(iterator).isExhausted();
+  }
+
+  @Test
+  void shouldThrowNoSuchElementExceptionWhenFirstPageIsEmpty() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+    when(esClient.search(any(SearchRequest.class), eq(String.class))).thenReturn(emptyResponse);
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(esClient, request, String.class);
+
+    // when / then
+    assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class);
+  }
+
+  @Test
+  void shouldReturnSinglePageOfResults() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    final Hit<String> hit = buildHit("item-1", List.of(FieldValue.of("sort-1")));
+    when(firstPageResponse.hits().hits()).thenReturn(List.of(hit)).thenReturn(List.of());
+
+    when(esClient.search(any(SearchRequest.class), eq(String.class)))
+        .thenReturn(firstPageResponse)
+        .thenReturn(emptyResponse);
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(esClient, request, String.class);
+
+    // when / then
+    assertThat(iterator).hasNext();
+    final List<String> page = iterator.next();
+    assertThat(page).containsExactly("item-1");
+    assertThat(iterator).isExhausted();
+  }
+
+  @Test
+  void shouldOnlyPerformSearchOnceForRepeatedHasNextCalls() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    final Hit<String> hit = buildHit("item-1", List.of(FieldValue.of("sort-1")));
+    when(firstPageResponse.hits().hits()).thenReturn(List.of(hit)).thenReturn(List.of());
+
+    when(esClient.search(any(SearchRequest.class), eq(String.class)))
+        .thenReturn(firstPageResponse)
+        .thenReturn(emptyResponse);
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(esClient, request, String.class);
+
+    // when
+    assertThat(iterator).hasNext();
+
+    // then
+    verify(esClient).search(any(SearchRequest.class), eq(String.class));
+
+    assertThat(iterator).hasNext();
+
+    verify(esClient).search(any(SearchRequest.class), eq(String.class));
+  }
+
+  @Test
+  void shouldIterateOverMultiplePages() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+
+    final Hit<String> firstHit = buildHit("item-1", List.of(FieldValue.of("sort-1")));
+    final Hit<String> secondHit = buildHit("item-2", List.of(FieldValue.of("sort-2")));
+
+    when(firstPageResponse.hits().hits()).thenReturn(List.of(firstHit));
+    when(secondPageResponse.hits().hits()).thenReturn(List.of(secondHit));
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+
+    when(esClient.search(any(SearchRequest.class), eq(String.class)))
+        .thenReturn(firstPageResponse)
+        .thenReturn(secondPageResponse)
+        .thenReturn(emptyResponse);
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(esClient, request, String.class);
+
+    // when
+    final List<List<String>> pages = new ArrayList<>();
+    while (iterator.hasNext()) {
+      pages.add(iterator.next());
+    }
+
+    // then
+    assertThat(pages).hasSize(2);
+    assertThat(pages.get(0)).containsExactly("item-1");
+    assertThat(pages.get(1)).containsExactly("item-2");
+  }
+
+  @Test
+  void shouldExcludeNullSourcesFromPage() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    final Hit<String> hitWithSource = buildHit("item-1", List.of(FieldValue.of("sort-1")));
+    final Hit<String> hitWithNullSource = buildHit(null, List.of(FieldValue.of("sort-2")));
+
+    when(firstPageResponse.hits().hits()).thenReturn(List.of(hitWithSource, hitWithNullSource));
+    when(esClient.search(any(SearchRequest.class), eq(String.class))).thenReturn(firstPageResponse);
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(esClient, request, String.class);
+
+    // when
+    assertThat(iterator.hasNext()).isTrue();
+    final List<String> page = iterator.next();
+
+    // then
+    assertThat(page).containsExactly("item-1");
+  }
+
+  @Test
+  void shouldReturnFalseOnSubsequentCallsOnceFinished() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+    when(esClient.search(any(SearchRequest.class), eq(String.class))).thenReturn(emptyResponse);
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(esClient, request, String.class);
+
+    // when
+    assertThat(iterator).isExhausted();
+
+    // then — no further ES calls needed, finished flag is set
+    assertThat(iterator).isExhausted();
+  }
+
+  @Test
+  void shouldWrapIOExceptionAsUncheckedIOException() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    when(esClient.search(any(SearchRequest.class), eq(String.class)))
+        .thenThrow(new IOException("ES unavailable"));
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(esClient, request, String.class);
+
+    // when / then
+    assertThatThrownBy(iterator::hasNext)
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessageContaining("ES unavailable");
+  }
+
+  @SuppressWarnings("unchecked")
+  private Hit<String> buildHit(final String source, final List<FieldValue> sortValues) {
+    final Hit<String> hit = (Hit<String>) mock(Hit.class);
+    when(hit.source()).thenReturn(source);
+    // lenient: sort() is only called on the last hit in each page, not every hit
+    lenient().when(hit.sort()).thenReturn(sortValues);
+    return hit;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/reader/SearchAfterIteratorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/reader/SearchAfterIteratorTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+@ExtendWith(MockitoExtension.class)
+class SearchAfterIteratorTest {
+  private static final String ERROR_MESSAGE = "ERROR MESSAGE";
+
+  @Mock private OptimizeOpenSearchClient osClient;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private SearchResponse<String> emptyResponse;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private SearchResponse<String> firstPageResponse;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private SearchResponse<String> secondPageResponse;
+
+  @Test
+  void shouldReturnFalseWhenFirstPageIsEmpty() {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+    when(osClient.search(any(SearchRequest.Builder.class), eq(String.class), eq(ERROR_MESSAGE)))
+        .thenReturn(emptyResponse);
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(osClient, request, String.class, ERROR_MESSAGE);
+
+    // when / then
+    assertThat(iterator).isExhausted();
+  }
+
+  @Test
+  void shouldThrowNoSuchElementExceptionWhenFirstPageIsEmpty() {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+    when(osClient.search(any(SearchRequest.Builder.class), eq(String.class), eq(ERROR_MESSAGE)))
+        .thenReturn(emptyResponse);
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(osClient, request, String.class, ERROR_MESSAGE);
+
+    // when / then
+    assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class);
+  }
+
+  @Test
+  void shouldReturnSinglePageOfResults() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    final Hit<String> hit = buildHit("item-1", List.of(FieldValue.of("sort-1")));
+    when(firstPageResponse.hits().hits()).thenReturn(List.of(hit)).thenReturn(List.of());
+
+    when(osClient.search(any(SearchRequest.Builder.class), eq(String.class), eq(ERROR_MESSAGE)))
+        .thenReturn(firstPageResponse)
+        .thenReturn(emptyResponse);
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(osClient, request, String.class, ERROR_MESSAGE);
+
+    // when / then
+    assertThat(iterator).hasNext();
+    final List<String> page = iterator.next();
+    assertThat(page).containsExactly("item-1");
+    assertThat(iterator).isExhausted();
+  }
+
+  @Test
+  void shouldOnlyPerformSearchOnceForRepeatedHasNextCalls() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    final Hit<String> hit = buildHit("item-1", List.of(FieldValue.of("sort-1")));
+    when(firstPageResponse.hits().hits()).thenReturn(List.of(hit)).thenReturn(List.of());
+
+    when(osClient.search(any(SearchRequest.Builder.class), eq(String.class), eq(ERROR_MESSAGE)))
+        .thenReturn(firstPageResponse)
+        .thenReturn(emptyResponse);
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(osClient, request, String.class, ERROR_MESSAGE);
+
+    // when
+    assertThat(iterator).hasNext();
+
+    // then
+    verify(osClient).search(any(SearchRequest.Builder.class), eq(String.class), eq(ERROR_MESSAGE));
+
+    assertThat(iterator).hasNext();
+
+    verify(osClient).search(any(SearchRequest.Builder.class), eq(String.class), eq(ERROR_MESSAGE));
+  }
+
+  @Test
+  void shouldIterateOverMultiplePages() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+
+    final Hit<String> firstHit = buildHit("item-1", List.of(FieldValue.of("sort-1")));
+    final Hit<String> secondHit = buildHit("item-2", List.of(FieldValue.of("sort-2")));
+
+    when(firstPageResponse.hits().hits()).thenReturn(List.of(firstHit));
+    when(secondPageResponse.hits().hits()).thenReturn(List.of(secondHit));
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+
+    when(osClient.search(any(SearchRequest.Builder.class), eq(String.class), eq(ERROR_MESSAGE)))
+        .thenReturn(firstPageResponse)
+        .thenReturn(secondPageResponse)
+        .thenReturn(emptyResponse);
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(osClient, request, String.class, ERROR_MESSAGE);
+
+    // when
+    final List<List<String>> pages = new ArrayList<>();
+    while (iterator.hasNext()) {
+      pages.add(iterator.next());
+    }
+
+    // then
+    assertThat(pages).hasSize(2);
+    assertThat(pages.get(0)).containsExactly("item-1");
+    assertThat(pages.get(1)).containsExactly("item-2");
+  }
+
+  @Test
+  void shouldExcludeNullSourcesFromPage() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    final Hit<String> hitWithSource = buildHit("item-1", List.of(FieldValue.of("sort-1")));
+    final Hit<String> hitWithNullSource = buildHit(null, List.of(FieldValue.of("sort-2")));
+
+    when(firstPageResponse.hits().hits()).thenReturn(List.of(hitWithSource, hitWithNullSource));
+    when(osClient.search(any(SearchRequest.Builder.class), eq(String.class), eq(ERROR_MESSAGE)))
+        .thenReturn(firstPageResponse);
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(osClient, request, String.class, ERROR_MESSAGE);
+
+    // when
+    assertThat(iterator.hasNext()).isTrue();
+    final List<String> page = iterator.next();
+
+    // then
+    assertThat(page).containsExactly("item-1");
+  }
+
+  @Test
+  void shouldReturnFalseOnSubsequentCallsOnceFinished() throws IOException {
+    // given
+    final SearchRequest request = SearchRequest.of(r -> r.index("test-index"));
+    when(emptyResponse.hits().hits()).thenReturn(List.of());
+    when(osClient.search(any(SearchRequest.Builder.class), eq(String.class), eq(ERROR_MESSAGE)))
+        .thenReturn(emptyResponse);
+
+    final SearchAfterIterator<String> iterator =
+        new SearchAfterIterator<>(osClient, request, String.class, ERROR_MESSAGE);
+
+    // when
+    assertThat(iterator).isExhausted();
+
+    // then — no further ES calls needed, finished flag is set
+    assertThat(iterator).isExhausted();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Hit<String> buildHit(final String source, final List<FieldValue> sortValues) {
+    final Hit<String> hit = (Hit<String>) mock(Hit.class);
+    when(hit.source()).thenReturn(source);
+    // lenient: sort() is only called on the last hit in each page, not every hit
+    lenient().when(hit.sort()).thenReturn(sortValues);
+    return hit;
+  }
+}


### PR DESCRIPTION
The Optimize process instance cleanup job (`EngineDataProcessCleanupService`) was reading _all_ (all versions + deleted etc) process definitions into memory at once - purely to get a list of `key`s to then use for the actual cleanup logic.

We have a client with 60K process definitions and this was causing the importer to failed with an out of memory exception (and never running the actual deletes).

This PR changes things so we read a page of process definitions at a time (using `search_after`), so we limit how much memory we consume at once.

In theory we could also make it request less data per request (e.g. just the `key` fields), but I wanted to avoid too many changes at once - particularly as this is my first foray into Optimize.

## Related issues

closes #55734
