### PR TITLE
feat: scope FeatureFlags per physical tenant

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker;
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
+import io.camunda.configuration.Processing;
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.identity.sdk.IdentityConfiguration;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
@@ -73,6 +75,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final MeterRegistry meterRegistry;
   private final Map<String, EngineSecurityConfig> engineSecurityConfigsByPhysicalTenant;
   private final ServiceRegistry serviceRegistry;
+  private final Map<String, FeatureFlags> featureFlagsByPhysicalTenant;
   private final PasswordEncoder passwordEncoder;
   private final ScopedJwtDecoderFactory scopedJwtDecoderFactory;
   private final ScopedOidcClaimsProviderFactory scopedOidcClaimsProviderFactory;
@@ -123,6 +126,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
                   s.getCompiledGroupIdValidationPattern());
             });
     this.serviceRegistry = serviceRegistry;
+    this.featureFlagsByPhysicalTenant =
+        physicalTenantResolver.mapValues(camunda -> buildFeatureFlags(camunda.getProcessing()));
     this.passwordEncoder = passwordEncoder;
     this.scopedJwtDecoderFactory = scopedJwtDecoderFactory;
     this.scopedOidcClaimsProviderFactory = scopedOidcClaimsProviderFactory;
@@ -174,6 +179,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             oidcClaimsProviderFactory,
             searchClientsProxy,
             brokerRequestAuthorizationConvertersByPhysicalTenant,
+            featureFlagsByPhysicalTenant,
             nodeIdProvider,
             physicalTenantIds);
     springBrokerBridge.registerShutdownHelper(
@@ -202,6 +208,17 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     } finally {
       cleanupWorkingDirectory();
     }
+  }
+
+  private FeatureFlags buildFeatureFlags(final Processing p) {
+    final var flags = configuration.config().getExperimental().getFeatures().toFeatureFlags();
+    flags.setYieldingDueDateChecker(p.isEnableYieldingDueDateChecker());
+    flags.setEnableMessageTTLCheckerAsync(p.isEnableAsyncMessageTtlChecker());
+    flags.setEnableTimerDueDateCheckerAsync(p.isEnableAsyncTimerDuedateChecker());
+    flags.setEnableStraightThroughProcessingLoopDetector(
+        p.isEnableStraightthroughProcessingLoopDetector());
+    flags.setEnableMessageBodyOnExpired(p.isEnableMessageBodyOnExpired());
+    return flags;
   }
 
   private void cleanupWorkingDirectory() {

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -142,7 +142,6 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     final Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory =
         authConfig -> scopedOidcClaimsProviderFactory.buildClaimsProvider(authConfig);
 
-
     final SystemContext systemContext =
         new SystemContext(
             configuration.shutdownTimeout(),

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -25,6 +25,7 @@ import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -36,9 +37,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -73,9 +72,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final BrokerClient brokerClient;
   private final BrokerShutdownHelper shutdownHelper;
   private final MeterRegistry meterRegistry;
-  private final Map<String, EngineSecurityConfig> engineSecurityConfigsByPhysicalTenant;
+  private final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts;
   private final ServiceRegistry serviceRegistry;
-  private final Map<String, FeatureFlags> featureFlagsByPhysicalTenant;
   private final PasswordEncoder passwordEncoder;
   private final ScopedJwtDecoderFactory scopedJwtDecoderFactory;
   private final ScopedOidcClaimsProviderFactory scopedOidcClaimsProviderFactory;
@@ -113,21 +111,9 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.brokerClient = brokerClient;
     this.shutdownHelper = shutdownHelper;
     this.meterRegistry = meterRegistry;
-    this.engineSecurityConfigsByPhysicalTenant =
-        physicalTenantResolver.mapValues(
-            camunda -> {
-              final var s = camunda.getSecurity();
-              return new EngineSecurityConfig(
-                  s.getAuthentication(),
-                  s.getAuthorizations().isEnabled(),
-                  s.getMultiTenancy().isChecksEnabled(),
-                  s.getInitialization(),
-                  s.getCompiledIdValidationPattern(),
-                  s.getCompiledGroupIdValidationPattern());
-            });
+    this.physicalTenantEngineContexts =
+        physicalTenantResolver.mapValues(this::buildPhysicalTenantEngineContext);
     this.serviceRegistry = serviceRegistry;
-    this.featureFlagsByPhysicalTenant =
-        physicalTenantResolver.mapValues(camunda -> buildFeatureFlags(camunda.getProcessing()));
     this.passwordEncoder = passwordEncoder;
     this.scopedJwtDecoderFactory = scopedJwtDecoderFactory;
     this.scopedOidcClaimsProviderFactory = scopedOidcClaimsProviderFactory;
@@ -149,19 +135,13 @@ public class BrokerModuleConfiguration implements CloseableSilently {
 
   @Bean(destroyMethod = "close")
   public Broker broker(final ExporterRepository exporterRepository) {
-    final Map<String, BrokerRequestAuthorizationConverter>
-        brokerRequestAuthorizationConvertersByPhysicalTenant =
-            engineSecurityConfigsByPhysicalTenant.entrySet().stream()
-                .collect(
-                    Collectors.toUnmodifiableMap(
-                        Entry::getKey,
-                        entry -> new BrokerRequestAuthorizationConverter(entry.getValue())));
     final Function<String, UserServices> userServicesForTenant =
         tenantId -> serviceRegistry.userServices(tenantId);
     final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory =
         authConfig -> scopedJwtDecoderFactory.buildIssuerAwareDecoder(authConfig);
     final Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory =
         authConfig -> scopedOidcClaimsProviderFactory.buildClaimsProvider(authConfig);
+
 
     final SystemContext systemContext =
         new SystemContext(
@@ -172,14 +152,12 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             cluster,
             brokerClient,
             meterRegistry,
-            engineSecurityConfigsByPhysicalTenant,
+            physicalTenantEngineContexts,
             userServicesForTenant,
             passwordEncoder,
             jwtDecoderFactory,
             oidcClaimsProviderFactory,
             searchClientsProxy,
-            brokerRequestAuthorizationConvertersByPhysicalTenant,
-            featureFlagsByPhysicalTenant,
             nodeIdProvider,
             physicalTenantIds);
     springBrokerBridge.registerShutdownHelper(
@@ -208,6 +186,22 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     } finally {
       cleanupWorkingDirectory();
     }
+  }
+
+  private PhysicalTenantEngineContext buildPhysicalTenantEngineContext(
+      final io.camunda.configuration.Camunda camunda) {
+    final var s = camunda.getSecurity();
+    final var securityConfig =
+        new EngineSecurityConfig(
+            s.getAuthentication(),
+            s.getAuthorizations().isEnabled(),
+            s.getMultiTenancy().isChecksEnabled(),
+            s.getInitialization(),
+            s.getCompiledIdValidationPattern(),
+            s.getCompiledGroupIdValidationPattern());
+    final var authorizationConverter = new BrokerRequestAuthorizationConverter(securityConfig);
+    final var featureFlags = buildFeatureFlags(camunda.getProcessing());
+    return new PhysicalTenantEngineContext(securityConfig, authorizationConverter, featureFlags);
   }
 
   private FeatureFlags buildFeatureFlags(final Processing p) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -94,6 +94,7 @@ public final class Broker implements AutoCloseable {
             systemContext.getOidcClaimsProviderFactory(),
             systemContext.getSearchClientsProxy(),
             systemContext.getBrokerRequestAuthorizationConvertersByPhysicalTenant(),
+            systemContext.getFeatureFlagsByPhysicalTenant(),
             systemContext.getNodeIdProvider(),
             systemContext.getPhysicalTenantIds());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -87,14 +87,12 @@ public final class Broker implements AutoCloseable {
             additionalPartitionListeners,
             systemContext.getShutdownTimeout(),
             systemContext.getMeterRegistry(),
-            systemContext.getSecurityConfigurationsByPhysicalTenant(),
+            systemContext.getPhysicalTenantEngineContexts(),
             systemContext.getUserServicesForTenant(),
             systemContext.getPasswordEncoder(),
             systemContext.getJwtDecoderFactory(),
             systemContext.getOidcClaimsProviderFactory(),
             systemContext.getSearchClientsProxy(),
-            systemContext.getBrokerRequestAuthorizationConvertersByPhysicalTenant(),
-            systemContext.getFeatureFlagsByPhysicalTenant(),
             systemContext.getNodeIdProvider(),
             systemContext.getPhysicalTenantIds());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -13,7 +13,6 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
-import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -26,6 +25,7 @@ import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
+import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.management.CheckpointSchedulingService;
@@ -39,7 +39,6 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
-import io.camunda.zeebe.util.FeatureFlags;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.List;
@@ -151,11 +150,11 @@ public interface BrokerStartupContext {
   EngineSecurityConfig getSecurityConfiguration();
 
   /**
-   * Returns the security configuration for the given physical tenant.
+   * Returns the engine context for the given physical tenant.
    *
    * @throws IllegalArgumentException if the physical tenant id is unknown
    */
-  EngineSecurityConfig getSecurityConfiguration(String physicalTenantId);
+  PhysicalTenantEngineContext getPhysicalTenantEngineContext(String physicalTenantId);
 
   Function<String, UserServices> getUserServicesForTenant();
 
@@ -168,21 +167,6 @@ public interface BrokerStartupContext {
   SnapshotApiRequestHandler getSnapshotApiRequestHandler();
 
   void setSnapshotApiRequestHandler(SnapshotApiRequestHandler snapshotApiRequestHandler);
-
-  /**
-   * Returns the request authorization converter for the given physical tenant.
-   *
-   * @throws IllegalArgumentException if the physical tenant id is unknown
-   */
-  BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter(
-      String physicalTenantId);
-
-  /**
-   * Returns the feature flags for the given physical tenant.
-   *
-   * @throws IllegalArgumentException if the physical tenant id is unknown
-   */
-  FeatureFlags getFeatureFlags(String physicalTenantId);
 
   CheckpointSchedulingService getCheckpointSchedulingService();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.List;
@@ -175,6 +176,13 @@ public interface BrokerStartupContext {
    */
   BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter(
       String physicalTenantId);
+
+  /**
+   * Returns the feature flags for the given physical tenant.
+   *
+   * @throws IllegalArgumentException if the physical tenant id is unknown
+   */
+  FeatureFlags getFeatureFlags(String physicalTenantId);
 
   CheckpointSchedulingService getCheckpointSchedulingService();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -80,6 +81,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final PhysicalTenantIds physicalTenantIds;
   private final Map<String, BrokerRequestAuthorizationConverter>
       brokerRequestAuthorizationConvertersByPhysicalTenant;
+  private final Map<String, FeatureFlags> featureFlagsByPhysicalTenant;
 
   private ConcurrencyControl concurrencyControl;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
@@ -117,6 +119,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final SearchClientsProxy searchClientsProxy,
       final Map<String, BrokerRequestAuthorizationConverter>
           brokerRequestAuthorizationConvertersByPhysicalTenant,
+      final Map<String, FeatureFlags> featureFlagsByPhysicalTenant,
       final NodeIdProvider nodeIdProvider,
       final PhysicalTenantIds physicalTenantIds) {
 
@@ -143,6 +146,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     partitionListeners.addAll(additionalPartitionListeners);
     this.brokerRequestAuthorizationConvertersByPhysicalTenant =
         Collections.unmodifiableMap(brokerRequestAuthorizationConvertersByPhysicalTenant);
+    this.featureFlagsByPhysicalTenant = Map.copyOf(featureFlagsByPhysicalTenant);
   }
 
   @Override
@@ -423,6 +427,14 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
     }
     return brokerRequestAuthorizationConvertersByPhysicalTenant.get(physicalTenantId);
+  }
+
+  @Override
+  public FeatureFlags getFeatureFlags(final String physicalTenantId) {
+    if (!featureFlagsByPhysicalTenant.containsKey(physicalTenantId)) {
+      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
+    }
+    return featureFlagsByPhysicalTenant.get(physicalTenantId);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -16,7 +16,6 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
-import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -29,6 +28,7 @@ import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
+import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.management.CheckpointSchedulingService;
@@ -42,7 +42,6 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
-import io.camunda.zeebe.util.FeatureFlags;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -71,7 +70,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final List<PartitionRaftListener> partitionRaftListeners = new ArrayList<>();
   private final Duration shutdownTimeout;
   private final MeterRegistry meterRegistry;
-  private final Map<String, EngineSecurityConfig> securityConfigurationsByPhysicalTenant;
+  private final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts;
   private final Function<String, UserServices> userServicesForTenant;
   private final PasswordEncoder passwordEncoder;
   private final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
@@ -79,9 +78,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final SearchClientsProxy searchClientsProxy;
   private final NodeIdProvider nodeIdProvider;
   private final PhysicalTenantIds physicalTenantIds;
-  private final Map<String, BrokerRequestAuthorizationConverter>
-      brokerRequestAuthorizationConvertersByPhysicalTenant;
-  private final Map<String, FeatureFlags> featureFlagsByPhysicalTenant;
 
   private ConcurrencyControl concurrencyControl;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
@@ -111,15 +107,12 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final List<PartitionListener> additionalPartitionListeners,
       final Duration shutdownTimeout,
       final MeterRegistry meterRegistry,
-      final Map<String, EngineSecurityConfig> securityConfigurationsByPhysicalTenant,
+      final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts,
       final Function<String, UserServices> userServicesForTenant,
       final PasswordEncoder passwordEncoder,
       final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory,
       final Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory,
       final SearchClientsProxy searchClientsProxy,
-      final Map<String, BrokerRequestAuthorizationConverter>
-          brokerRequestAuthorizationConvertersByPhysicalTenant,
-      final Map<String, FeatureFlags> featureFlagsByPhysicalTenant,
       final NodeIdProvider nodeIdProvider,
       final PhysicalTenantIds physicalTenantIds) {
 
@@ -134,8 +127,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.brokerClient = brokerClient;
     this.shutdownTimeout = shutdownTimeout;
     this.meterRegistry = requireNonNull(meterRegistry);
-    this.securityConfigurationsByPhysicalTenant =
-        Collections.unmodifiableMap(securityConfigurationsByPhysicalTenant);
+    this.physicalTenantEngineContexts = Map.copyOf(physicalTenantEngineContexts);
     this.userServicesForTenant = userServicesForTenant;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoderFactory = jwtDecoderFactory;
@@ -144,9 +136,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.nodeIdProvider = requireNonNull(nodeIdProvider);
     this.physicalTenantIds = requireNonNull(physicalTenantIds);
     partitionListeners.addAll(additionalPartitionListeners);
-    this.brokerRequestAuthorizationConvertersByPhysicalTenant =
-        Collections.unmodifiableMap(brokerRequestAuthorizationConvertersByPhysicalTenant);
-    this.featureFlagsByPhysicalTenant = Map.copyOf(featureFlagsByPhysicalTenant);
   }
 
   @Override
@@ -372,21 +361,20 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
 
   @Override
   public EngineSecurityConfig getSecurityConfiguration() {
-    final var config =
-        securityConfigurationsByPhysicalTenant.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    if (config == null) {
+    final var ctx = physicalTenantEngineContexts.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    if (ctx == null) {
       throw new IllegalStateException(
           "No security configuration registered for the default physical tenant");
     }
-    return config;
+    return ctx.securityConfig();
   }
 
   @Override
-  public EngineSecurityConfig getSecurityConfiguration(final String physicalTenantId) {
-    if (!securityConfigurationsByPhysicalTenant.containsKey(physicalTenantId)) {
+  public PhysicalTenantEngineContext getPhysicalTenantEngineContext(final String physicalTenantId) {
+    if (!physicalTenantEngineContexts.containsKey(physicalTenantId)) {
       throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
     }
-    return securityConfigurationsByPhysicalTenant.get(physicalTenantId);
+    return physicalTenantEngineContexts.get(physicalTenantId);
   }
 
   @Override
@@ -418,23 +406,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   public void setSnapshotApiRequestHandler(
       final SnapshotApiRequestHandler snapshotApiRequestHandler) {
     this.snapshotApiRequestHandler = snapshotApiRequestHandler;
-  }
-
-  @Override
-  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter(
-      final String physicalTenantId) {
-    if (!brokerRequestAuthorizationConvertersByPhysicalTenant.containsKey(physicalTenantId)) {
-      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
-    }
-    return brokerRequestAuthorizationConvertersByPhysicalTenant.get(physicalTenantId);
-  }
-
-  @Override
-  public FeatureFlags getFeatureFlags(final String physicalTenantId) {
-    if (!featureFlagsByPhysicalTenant.containsKey(physicalTenantId)) {
-      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
-    }
-    return featureFlagsByPhysicalTenant.get(physicalTenantId);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -44,7 +44,10 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
             .collect(
                 Collectors.toUnmodifiableMap(
                     physicalTenantId -> physicalTenantId,
-                    brokerStartupContext::getSecurityConfiguration));
+                    physicalTenantId ->
+                        brokerStartupContext
+                            .getPhysicalTenantEngineContext(physicalTenantId)
+                            .securityConfig()));
 
     final var embeddedGatewayService =
         new EmbeddedGatewayService(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -136,12 +136,53 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
 
     if (isRecovering(brokerStartupContext, memberId)) {
       LOGGER.info("Partition group in recovery, starting RecoveryPartitionManager");
-      return PartitionManager.createRecoveryPartitionManager(
-          brokerStartupContext, physicalTenantId, topologyManager);
+      return recoveryPartitionManager(brokerStartupContext, topologyManager);
     } else {
-      return PartitionManager.createPartitionManager(
-          brokerStartupContext, physicalTenantId, topologyManager);
+      return partitionManager(brokerStartupContext, topologyManager);
     }
+  }
+
+  PartitionManager partitionManager(
+      final BrokerStartupContext brokerStartupContext, final TopologyManagerImpl topologyManager) {
+
+    return new PartitionManagerImpl(
+        physicalTenantId,
+        brokerStartupContext.getConcurrencyControl(),
+        brokerStartupContext.getActorSchedulingService(),
+        brokerStartupContext.getBrokerConfiguration(),
+        brokerStartupContext.getBrokerInfo(),
+        brokerStartupContext.getClusterServices(),
+        brokerStartupContext.getHealthCheckService(),
+        brokerStartupContext.getDiskSpaceUsageMonitor(),
+        brokerStartupContext.getPartitionListeners(),
+        brokerStartupContext.getPartitionRaftListeners(),
+        brokerStartupContext.getSnapshotApiRequestHandler(),
+        brokerStartupContext.getExporterRepository(),
+        brokerStartupContext.getGatewayBrokerTransport(),
+        brokerStartupContext.getJobStreamService().jobStreamer(),
+        brokerStartupContext.getClusterConfigurationService(),
+        brokerStartupContext.getMeterRegistry(),
+        brokerStartupContext.getBrokerClient(),
+        brokerStartupContext.getRocksDbResources(),
+        brokerStartupContext.getSecurityConfiguration(physicalTenantId),
+        brokerStartupContext.getSearchClientsProxy(),
+        brokerStartupContext.getBrokerRequestAuthorizationConverter(physicalTenantId),
+        brokerStartupContext.getFeatureFlags(physicalTenantId),
+        topologyManager);
+  }
+
+  PartitionManager recoveryPartitionManager(
+      final BrokerStartupContext brokerStartupContext, final TopologyManagerImpl topologyManager) {
+
+    return new RecoveryPartitionManager(
+        physicalTenantId,
+        brokerStartupContext.getBrokerConfiguration().getData().getDirectory(),
+        brokerStartupContext.getConcurrencyControl(),
+        brokerStartupContext.getClusterConfigurationService(),
+        brokerStartupContext.getClusterServices(),
+        brokerStartupContext.getActorSchedulingService(),
+        brokerStartupContext.getMeterRegistry(),
+        topologyManager);
   }
 
   private void shutdownOnInconsistentTopology(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -11,9 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
-import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.partitioning.PartitionModeHandler;
-import io.camunda.zeebe.broker.partitioning.RecoveryPartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
@@ -146,45 +144,14 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
 
   PartitionManager partitionManager(
       final BrokerStartupContext brokerStartupContext, final TopologyManagerImpl topologyManager) {
-    final var engineContext = brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
-    return new PartitionManagerImpl(
-        physicalTenantId,
-        brokerStartupContext.getConcurrencyControl(),
-        brokerStartupContext.getActorSchedulingService(),
-        brokerStartupContext.getBrokerConfiguration(),
-        brokerStartupContext.getBrokerInfo(),
-        brokerStartupContext.getClusterServices(),
-        brokerStartupContext.getHealthCheckService(),
-        brokerStartupContext.getDiskSpaceUsageMonitor(),
-        brokerStartupContext.getPartitionListeners(),
-        brokerStartupContext.getPartitionRaftListeners(),
-        brokerStartupContext.getSnapshotApiRequestHandler(),
-        brokerStartupContext.getExporterRepository(),
-        brokerStartupContext.getGatewayBrokerTransport(),
-        brokerStartupContext.getJobStreamService().jobStreamer(),
-        brokerStartupContext.getClusterConfigurationService(),
-        brokerStartupContext.getMeterRegistry(),
-        brokerStartupContext.getBrokerClient(),
-        brokerStartupContext.getRocksDbResources(),
-        engineContext.securityConfig(),
-        brokerStartupContext.getSearchClientsProxy(),
-        engineContext.authorizationConverter(),
-        engineContext.featureFlags(),
-        topologyManager);
+    return PartitionManager.createPartitionManager(
+        brokerStartupContext, physicalTenantId, topologyManager);
   }
 
   PartitionManager recoveryPartitionManager(
       final BrokerStartupContext brokerStartupContext, final TopologyManagerImpl topologyManager) {
-
-    return new RecoveryPartitionManager(
-        physicalTenantId,
-        brokerStartupContext.getBrokerConfiguration().getData().getDirectory(),
-        brokerStartupContext.getConcurrencyControl(),
-        brokerStartupContext.getClusterConfigurationService(),
-        brokerStartupContext.getClusterServices().getMembershipService(),
-        brokerStartupContext.getActorSchedulingService(),
-        brokerStartupContext.getMeterRegistry(),
-        topologyManager);
+    return PartitionManager.createRecoveryPartitionManager(
+        brokerStartupContext, physicalTenantId, topologyManager);
   }
 
   private void shutdownOnInconsistentTopology(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -11,7 +11,9 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
+import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.partitioning.PartitionModeHandler;
+import io.camunda.zeebe.broker.partitioning.RecoveryPartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
@@ -144,7 +146,7 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
 
   PartitionManager partitionManager(
       final BrokerStartupContext brokerStartupContext, final TopologyManagerImpl topologyManager) {
-
+    final var engineContext = brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
     return new PartitionManagerImpl(
         physicalTenantId,
         brokerStartupContext.getConcurrencyControl(),
@@ -164,10 +166,10 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
         brokerStartupContext.getMeterRegistry(),
         brokerStartupContext.getBrokerClient(),
         brokerStartupContext.getRocksDbResources(),
-        brokerStartupContext.getSecurityConfiguration(physicalTenantId),
+        engineContext.securityConfig(),
         brokerStartupContext.getSearchClientsProxy(),
-        brokerStartupContext.getBrokerRequestAuthorizationConverter(physicalTenantId),
-        brokerStartupContext.getFeatureFlags(physicalTenantId),
+        engineContext.authorizationConverter(),
+        engineContext.featureFlags(),
         topologyManager);
   }
 
@@ -179,7 +181,7 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
         brokerStartupContext.getBrokerConfiguration().getData().getDirectory(),
         brokerStartupContext.getConcurrencyControl(),
         brokerStartupContext.getClusterConfigurationService(),
-        brokerStartupContext.getClusterServices(),
+        brokerStartupContext.getClusterServices().getMembershipService(),
         brokerStartupContext.getActorSchedulingService(),
         brokerStartupContext.getMeterRegistry(),
         topologyManager);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -67,6 +67,7 @@ public interface PartitionManager {
       final BrokerStartupContext brokerStartupContext,
       final String physicalTenantId,
       final TopologyManagerImpl topologyManager) {
+    final var engineContext = brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
     return new PartitionManagerImpl(
         physicalTenantId,
         brokerStartupContext.getConcurrencyControl(),
@@ -86,10 +87,10 @@ public interface PartitionManager {
         brokerStartupContext.getMeterRegistry(),
         brokerStartupContext.getBrokerClient(),
         brokerStartupContext.getRocksDbResources(),
-        brokerStartupContext.getSecurityConfiguration(),
+        engineContext.securityConfig(),
         brokerStartupContext.getSearchClientsProxy(),
-        brokerStartupContext.getBrokerRequestAuthorizationConverter(physicalTenantId),
-        brokerStartupContext.getFeatureFlags(physicalTenantId),
+        engineContext.authorizationConverter(),
+        engineContext.featureFlags(),
         topologyManager);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -89,6 +89,7 @@ public interface PartitionManager {
         brokerStartupContext.getSecurityConfiguration(),
         brokerStartupContext.getSearchClientsProxy(),
         brokerStartupContext.getBrokerRequestAuthorizationConverter(physicalTenantId),
+        brokerStartupContext.getFeatureFlags(physicalTenantId),
         topologyManager);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -46,6 +46,7 @@ import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupProcessShutdownException;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.health.HealthStatus;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
@@ -106,6 +107,7 @@ public final class PartitionManagerImpl
       final EngineSecurityConfig securityConfig,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final FeatureFlags featureFlags,
       final TopologyManagerImpl topologyManager) {
     this.partitionGroup = partitionGroup;
     this.concurrencyControl = concurrencyControl;
@@ -119,7 +121,6 @@ public final class PartitionManagerImpl
     this.brokerClient = brokerClient;
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     scalingExecutor = new BrokerClientPartitionScalingExecutor(brokerClient, concurrencyControl);
-    final var featureFlags = brokerCfg.getExperimental().getFeatures().toFeatureFlags();
     brokerMeterRegistry = meterRegistry;
 
     final List<PartitionListener> listeners = new ArrayList<>(partitionListeners);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/PhysicalTenantEngineContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/PhysicalTenantEngineContext.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system;
+
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.zeebe.util.FeatureFlags;
+
+/**
+ * Bundles all per-physical-tenant objects required to bootstrap the engine for a given physical
+ * tenant. Passed as a single unit through the broker startup chain instead of three parallel maps.
+ */
+public record PhysicalTenantEngineContext(
+    EngineSecurityConfig securityConfig,
+    BrokerRequestAuthorizationConverter authorizationConverter,
+    FeatureFlags featureFlags) {}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -805,22 +805,6 @@ public final class SystemContext {
   }
 
   /**
-   * Returns the feature flags for the {@code default} physical tenant.
-   *
-   * @throws IllegalStateException if no feature flags are registered for the default physical
-   *     tenant
-   */
-  public FeatureFlags getFeatureFlags() {
-    final var flags =
-        featureFlagsByPhysicalTenant.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    if (flags == null) {
-      throw new IllegalStateException(
-          "No feature flags registered for the default physical tenant");
-    }
-    return flags;
-  }
-
-  /**
    * Returns the feature flags for the given physical tenant.
    *
    * @throws IllegalArgumentException if the physical tenant id is unknown

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -64,6 +64,7 @@ import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.TlsConfigUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
@@ -134,6 +135,7 @@ public final class SystemContext {
   private final MeterRegistry meterRegistry;
   private final Map<String, EngineSecurityConfig> securityConfigurationsByPhysicalTenant;
   private final Function<String, UserServices> userServicesForTenant;
+  private final Map<String, FeatureFlags> featureFlagsByPhysicalTenant;
   private final PasswordEncoder passwordEncoder;
   private final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
   private final Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory;
@@ -146,7 +148,7 @@ public final class SystemContext {
 
   /**
    * Creates a {@code SystemContext} where each physical tenant carries its own {@link
-   * EngineSecurityConfig} and {@link BrokerRequestAuthorizationConverter}.
+   * EngineSecurityConfig}, {@link BrokerRequestAuthorizationConverter}, and {@link FeatureFlags}.
    */
   public SystemContext(
       final Duration shutdownTimeout,
@@ -164,6 +166,7 @@ public final class SystemContext {
       final SearchClientsProxy searchClientsProxy,
       final Map<String, BrokerRequestAuthorizationConverter>
           brokerRequestAuthorizationConvertersByPhysicalTenant,
+      final Map<String, FeatureFlags> featureFlagsByPhysicalTenant,
       final NodeIdProvider nodeIdProvider,
       final PhysicalTenantIds physicalTenantIds) {
     this.shutdownTimeout = shutdownTimeout;
@@ -184,6 +187,7 @@ public final class SystemContext {
     this.searchClientsProxy = searchClientsProxy;
     this.brokerRequestAuthorizationConvertersByPhysicalTenant =
         Collections.unmodifiableMap(brokerRequestAuthorizationConvertersByPhysicalTenant);
+    this.featureFlagsByPhysicalTenant = Map.copyOf(featureFlagsByPhysicalTenant);
     this.nodeIdProvider = nodeIdProvider;
     this.physicalTenantIds = physicalTenantIds;
     globalListenerValidator = new GlobalListenerValidator();
@@ -798,6 +802,39 @@ public final class SystemContext {
   public Map<String, BrokerRequestAuthorizationConverter>
       getBrokerRequestAuthorizationConvertersByPhysicalTenant() {
     return brokerRequestAuthorizationConvertersByPhysicalTenant;
+  }
+
+  /**
+   * Returns the feature flags for the {@code default} physical tenant.
+   *
+   * @throws IllegalStateException if no feature flags are registered for the default physical
+   *     tenant
+   */
+  public FeatureFlags getFeatureFlags() {
+    final var flags =
+        featureFlagsByPhysicalTenant.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    if (flags == null) {
+      throw new IllegalStateException(
+          "No feature flags registered for the default physical tenant");
+    }
+    return flags;
+  }
+
+  /**
+   * Returns the feature flags for the given physical tenant.
+   *
+   * @throws IllegalArgumentException if the physical tenant id is unknown
+   */
+  public FeatureFlags getFeatureFlags(final String physicalTenantId) {
+    if (!featureFlagsByPhysicalTenant.containsKey(physicalTenantId)) {
+      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
+    }
+    return featureFlagsByPhysicalTenant.get(physicalTenantId);
+  }
+
+  /** Returns the per-physical-tenant feature flags map (unmodifiable). */
+  public Map<String, FeatureFlags> getFeatureFlagsByPhysicalTenant() {
+    return featureFlagsByPhysicalTenant;
   }
 
   public NodeIdProvider getNodeIdProvider() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -133,15 +133,12 @@ public final class SystemContext {
   private final AtomixCluster cluster;
   private final BrokerClient brokerClient;
   private final MeterRegistry meterRegistry;
-  private final Map<String, EngineSecurityConfig> securityConfigurationsByPhysicalTenant;
+  private final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts;
   private final Function<String, UserServices> userServicesForTenant;
-  private final Map<String, FeatureFlags> featureFlagsByPhysicalTenant;
   private final PasswordEncoder passwordEncoder;
   private final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
   private final Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory;
   private final SearchClientsProxy searchClientsProxy;
-  private final Map<String, BrokerRequestAuthorizationConverter>
-      brokerRequestAuthorizationConvertersByPhysicalTenant;
   private final NodeIdProvider nodeIdProvider;
   private final PhysicalTenantIds physicalTenantIds;
   private final GlobalListenerValidator globalListenerValidator;
@@ -158,15 +155,12 @@ public final class SystemContext {
       final AtomixCluster cluster,
       final BrokerClient brokerClient,
       final MeterRegistry meterRegistry,
-      final Map<String, EngineSecurityConfig> securityConfigurationsByPhysicalTenant,
+      final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts,
       final Function<String, UserServices> userServicesForTenant,
       final PasswordEncoder passwordEncoder,
       final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory,
       final Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory,
       final SearchClientsProxy searchClientsProxy,
-      final Map<String, BrokerRequestAuthorizationConverter>
-          brokerRequestAuthorizationConvertersByPhysicalTenant,
-      final Map<String, FeatureFlags> featureFlagsByPhysicalTenant,
       final NodeIdProvider nodeIdProvider,
       final PhysicalTenantIds physicalTenantIds) {
     this.shutdownTimeout = shutdownTimeout;
@@ -176,8 +170,7 @@ public final class SystemContext {
     this.cluster = cluster;
     this.brokerClient = brokerClient;
     this.meterRegistry = meterRegistry;
-    this.securityConfigurationsByPhysicalTenant =
-        Collections.unmodifiableMap(securityConfigurationsByPhysicalTenant);
+    this.physicalTenantEngineContexts = Map.copyOf(physicalTenantEngineContexts);
     this.userServicesForTenant = userServicesForTenant;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoderFactory = jwtDecoderFactory;
@@ -185,9 +178,6 @@ public final class SystemContext {
         Objects.requireNonNull(
             oidcClaimsProviderFactory, "oidcClaimsProviderFactory must not be null");
     this.searchClientsProxy = searchClientsProxy;
-    this.brokerRequestAuthorizationConvertersByPhysicalTenant =
-        Collections.unmodifiableMap(brokerRequestAuthorizationConvertersByPhysicalTenant);
-    this.featureFlagsByPhysicalTenant = Map.copyOf(featureFlagsByPhysicalTenant);
     this.nodeIdProvider = nodeIdProvider;
     this.physicalTenantIds = physicalTenantIds;
     globalListenerValidator = new GlobalListenerValidator();
@@ -505,9 +495,9 @@ public final class SystemContext {
   // actually initializing the entities will be done in IdentitySetupInitializer.
   // Validation is done here, only to be able to stop the application on error.
   private void validateInitializationConfig() {
-    securityConfigurationsByPhysicalTenant.forEach(
-        (physicalTenantId, securityConfig) ->
-            validateInitializationConfigForTenant(physicalTenantId, securityConfig));
+    physicalTenantEngineContexts.forEach(
+        (physicalTenantId, ctx) ->
+            validateInitializationConfigForTenant(physicalTenantId, ctx.securityConfig()));
   }
 
   private void validateInitializationConfigForTenant(
@@ -730,9 +720,21 @@ public final class SystemContext {
     return meterRegistry;
   }
 
-  /** Returns the per-physical-tenant security configuration map (unmodifiable). */
-  public Map<String, EngineSecurityConfig> getSecurityConfigurationsByPhysicalTenant() {
-    return securityConfigurationsByPhysicalTenant;
+  /** Returns the per-physical-tenant engine context map (unmodifiable). */
+  public Map<String, PhysicalTenantEngineContext> getPhysicalTenantEngineContexts() {
+    return physicalTenantEngineContexts;
+  }
+
+  /**
+   * Returns the engine context for the given physical tenant.
+   *
+   * @throws IllegalArgumentException if the physical tenant id is unknown
+   */
+  public PhysicalTenantEngineContext getPhysicalTenantEngineContext(final String physicalTenantId) {
+    if (!physicalTenantEngineContexts.containsKey(physicalTenantId)) {
+      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
+    }
+    return physicalTenantEngineContexts.get(physicalTenantId);
   }
 
   /**
@@ -744,25 +746,12 @@ public final class SystemContext {
    *     physical tenant
    */
   public EngineSecurityConfig getSecurityConfiguration() {
-    final var config =
-        securityConfigurationsByPhysicalTenant.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    if (config == null) {
+    final var ctx = physicalTenantEngineContexts.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    if (ctx == null) {
       throw new IllegalStateException(
           "No security configuration registered for the default physical tenant");
     }
-    return config;
-  }
-
-  /**
-   * Returns the security configuration for the given physical tenant.
-   *
-   * @throws IllegalArgumentException if the physical tenant id is unknown
-   */
-  public EngineSecurityConfig getSecurityConfiguration(final String physicalTenantId) {
-    if (!securityConfigurationsByPhysicalTenant.containsKey(physicalTenantId)) {
-      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
-    }
-    return securityConfigurationsByPhysicalTenant.get(physicalTenantId);
+    return ctx.securityConfig();
   }
 
   public Function<String, UserServices> getUserServicesForTenant() {
@@ -783,42 +772,6 @@ public final class SystemContext {
 
   public SearchClientsProxy getSearchClientsProxy() {
     return searchClientsProxy;
-  }
-
-  /**
-   * Returns the request authorization converter for the given physical tenant.
-   *
-   * @throws IllegalArgumentException if the physical tenant id is unknown
-   */
-  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter(
-      final String physicalTenantId) {
-    if (!brokerRequestAuthorizationConvertersByPhysicalTenant.containsKey(physicalTenantId)) {
-      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
-    }
-    return brokerRequestAuthorizationConvertersByPhysicalTenant.get(physicalTenantId);
-  }
-
-  /** Returns the per-physical-tenant request authorization converter map (unmodifiable). */
-  public Map<String, BrokerRequestAuthorizationConverter>
-      getBrokerRequestAuthorizationConvertersByPhysicalTenant() {
-    return brokerRequestAuthorizationConvertersByPhysicalTenant;
-  }
-
-  /**
-   * Returns the feature flags for the given physical tenant.
-   *
-   * @throws IllegalArgumentException if the physical tenant id is unknown
-   */
-  public FeatureFlags getFeatureFlags(final String physicalTenantId) {
-    if (!featureFlagsByPhysicalTenant.containsKey(physicalTenantId)) {
-      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
-    }
-    return featureFlagsByPhysicalTenant.get(physicalTenantId);
-  }
-
-  /** Returns the per-physical-tenant feature flags map (unmodifiable). */
-  public Map<String, FeatureFlags> getFeatureFlagsByPhysicalTenant() {
-    return featureFlagsByPhysicalTenant;
   }
 
   public NodeIdProvider getNodeIdProvider() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -96,6 +96,8 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter =
       mock(BrokerRequestAuthorizationConverter.class);
   private FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
+  private final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts =
+      new LinkedHashMap<>();
   private CheckpointSchedulingService checkpointSchedulingService =
       mock(CheckpointSchedulingService.class);
   private NodeIdProvider nodeIdProvider = mock(NodeIdProvider.class);
@@ -372,8 +374,16 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
 
   @Override
   public PhysicalTenantEngineContext getPhysicalTenantEngineContext(final String physicalTenantId) {
-    return new PhysicalTenantEngineContext(
-        securityConfiguration, brokerRequestAuthorizationConverter, featureFlags);
+    return physicalTenantEngineContexts.computeIfAbsent(
+        physicalTenantId,
+        id ->
+            new PhysicalTenantEngineContext(
+                securityConfiguration, brokerRequestAuthorizationConverter, featureFlags));
+  }
+
+  public void setPhysicalTenantEngineContext(
+      final String physicalTenantId, final PhysicalTenantEngineContext context) {
+    physicalTenantEngineContexts.put(physicalTenantId, context);
   }
 
   public void setSecurityConfiguration(final EngineSecurityConfig securityConfiguration) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
+import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.management.CheckpointSchedulingService;
@@ -370,8 +371,9 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   @Override
-  public EngineSecurityConfig getSecurityConfiguration(final String physicalTenantId) {
-    return securityConfiguration;
+  public PhysicalTenantEngineContext getPhysicalTenantEngineContext(final String physicalTenantId) {
+    return new PhysicalTenantEngineContext(
+        securityConfiguration, brokerRequestAuthorizationConverter, featureFlags);
   }
 
   public void setSecurityConfiguration(final EngineSecurityConfig securityConfiguration) {
@@ -425,20 +427,9 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
     this.snapshotApiRequestHandler = snapshotApiRequestHandler;
   }
 
-  @Override
-  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter(
-      final String physicalTenantId) {
-    return brokerRequestAuthorizationConverter;
-  }
-
   public void setBrokerRequestAuthorizationConverter(
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
-  }
-
-  @Override
-  public FeatureFlags getFeatureFlags(final String physicalTenantId) {
-    return featureFlags;
   }
 
   public void setFeatureFlags(final FeatureFlags featureFlags) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -43,6 +43,7 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
@@ -93,6 +94,7 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
       mock(SnapshotApiRequestHandler.class);
   private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter =
       mock(BrokerRequestAuthorizationConverter.class);
+  private FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
   private CheckpointSchedulingService checkpointSchedulingService =
       mock(CheckpointSchedulingService.class);
   private NodeIdProvider nodeIdProvider = mock(NodeIdProvider.class);
@@ -432,6 +434,15 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   public void setBrokerRequestAuthorizationConverter(
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
+  }
+
+  @Override
+  public FeatureFlags getFeatureFlags(final String physicalTenantId) {
+    return featureFlags;
+  }
+
+  public void setFeatureFlags(final FeatureFlags featureFlags) {
+    this.featureFlags = featureFlags;
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -18,12 +18,15 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberConfig;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.partitioning.RecoveryPartitionManager;
 import io.camunda.zeebe.broker.partitioning.startup.ZeebePartitionFactory;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
+import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
@@ -212,27 +215,43 @@ class PartitionManagerStepTest {
     }
 
     @Test
-    void shouldPassPerTenantFeatureFlagsToPartitionFactory() throws Exception {
-      // given
-      final var perTenantFlags = FeatureFlags.createDefaultForTests();
-      testBrokerStartupContext.setFeatureFlags(perTenantFlags);
+    void shouldPassDistinctFeatureFlagsToEachPhysicalTenant() throws Exception {
+      // given — two tenants each with a distinct FeatureFlags instance
+      final var flagsA = new FeatureFlags(true, false, false, false, false, false);
+      final var flagsB = new FeatureFlags(false, false, true, false, false, false);
+      final var secondTenantId = "second";
 
-      // when
+      final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
+      final var conv = new BrokerRequestAuthorizationConverter(secCfg);
+      testBrokerStartupContext.setPhysicalTenantEngineContext(
+          PHYSICAL_TENANT_ID, new PhysicalTenantEngineContext(secCfg, conv, flagsA));
+      testBrokerStartupContext.setPhysicalTenantEngineContext(
+          secondTenantId, new PhysicalTenantEngineContext(secCfg, conv, flagsB));
+
+      final var secondFuture = CONCURRENCY_CONTROL.<BrokerStartupContext>createFuture();
+      final var secondStep = new PartitionManagerStep(secondTenantId);
+
+      // when — start both steps
       sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      secondStep.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, secondFuture);
       assertThat(startupFuture).succeedsWithin(TIME_OUT);
+      assertThat(secondFuture).succeedsWithin(TIME_OUT);
 
-      // then — the per-PT flags (not a freshly constructed cluster default) are wired in
-      final var partitionManager =
-          (PartitionManagerImpl)
-              testBrokerStartupContext.getPartitionManagers().get(PHYSICAL_TENANT_ID);
+      // then — each tenant's ZeebePartitionFactory holds its own flags, not the other's
       final var factoryField = PartitionManagerImpl.class.getDeclaredField("zeebePartitionFactory");
       factoryField.setAccessible(true);
-      final var zeebeFactory = factoryField.get(partitionManager);
-
       final var flagsField = ZeebePartitionFactory.class.getDeclaredField("featureFlags");
       flagsField.setAccessible(true);
 
-      assertThat(flagsField.get(zeebeFactory)).isSameAs(perTenantFlags);
+      final var managerA =
+          (PartitionManagerImpl)
+              testBrokerStartupContext.getPartitionManagers().get(PHYSICAL_TENANT_ID);
+      final var managerB =
+          (PartitionManagerImpl)
+              testBrokerStartupContext.getPartitionManagers().get(secondTenantId);
+
+      assertThat(flagsField.get(factoryField.get(managerA))).isSameAs(flagsA);
+      assertThat(flagsField.get(factoryField.get(managerB))).isSameAs(flagsB);
     }
 
     @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.util.FeatureFlags;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.AfterEach;
@@ -208,6 +209,30 @@ class PartitionManagerStepTest {
       proxyField.setAccessible(true);
 
       assertThat(proxyField.get(zeebeFactory)).isSameAs(scopedProxy);
+    }
+
+    @Test
+    void shouldPassPerTenantFeatureFlagsToPartitionFactory() throws Exception {
+      // given
+      final var perTenantFlags = FeatureFlags.createDefaultForTests();
+      testBrokerStartupContext.setFeatureFlags(perTenantFlags);
+
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+
+      // then — the per-PT flags (not a freshly constructed cluster default) are wired in
+      final var partitionManager =
+          (PartitionManagerImpl)
+              testBrokerStartupContext.getPartitionManagers().get(PHYSICAL_TENANT_ID);
+      final var factoryField = PartitionManagerImpl.class.getDeclaredField("zeebePartitionFactory");
+      factoryField.setAccessible(true);
+      final var zeebeFactory = factoryField.get(partitionManager);
+
+      final var flagsField = ZeebePartitionFactory.class.getDeclaredField("featureFlags");
+      flagsField.setAccessible(true);
+
+      assertThat(flagsField.get(zeebeFactory)).isSameAs(perTenantFlags);
     }
 
     @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -398,7 +398,9 @@ final class SystemContextTest {
 
     // when / then
     assertThat(ctx.getSecurityConfiguration()).isSameAs(defaultCfg);
-    assertThat(ctx.getSecurityConfiguration(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+    assertThat(
+            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .securityConfig())
         .isSameAs(defaultCfg);
   }
 
@@ -411,7 +413,7 @@ final class SystemContextTest {
             new BrokerCfg(), Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultCfg));
 
     // when / then
-    assertThatThrownBy(() -> ctx.getSecurityConfiguration("unknown-tenant"))
+    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("unknown-tenant"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown physical tenant id")
         .hasMessageContaining("unknown-tenant");
@@ -444,10 +446,12 @@ final class SystemContextTest {
             Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultCfg, "pta", ptaCfg));
 
     // when / then
-    assertThat(ctx.getSecurityConfiguration(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+    assertThat(
+            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .securityConfig())
         .isSameAs(defaultCfg);
-    assertThat(ctx.getSecurityConfiguration("pta")).isSameAs(ptaCfg);
-    assertThatThrownBy(() -> ctx.getSecurityConfiguration("unknown"))
+    assertThat(ctx.getPhysicalTenantEngineContext("pta").securityConfig()).isSameAs(ptaCfg);
+    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("unknown"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown physical tenant id");
   }
@@ -459,9 +463,11 @@ final class SystemContextTest {
 
     // when / then – the single-config ctor populates every known tenant with the supplied config
     assertThat(ctx.getSecurityConfiguration()).isNotNull();
-    assertThat(ctx.getSecurityConfiguration(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+    assertThat(
+            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .securityConfig())
         .isSameAs(ctx.getSecurityConfiguration());
-    assertThatThrownBy(() -> ctx.getSecurityConfiguration("any-other"))
+    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("any-other"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown physical tenant id");
   }
@@ -487,10 +493,11 @@ final class SystemContextTest {
 
     // when / then
     assertThat(
-            ctx.getBrokerRequestAuthorizationConverter(
-                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .authorizationConverter())
         .isSameAs(defaultConverter);
-    assertThat(ctx.getBrokerRequestAuthorizationConverter("pta")).isSameAs(ptConverter);
+    assertThat(ctx.getPhysicalTenantEngineContext("pta").authorizationConverter())
+        .isSameAs(ptConverter);
   }
 
   @Test
@@ -507,10 +514,10 @@ final class SystemContextTest {
 
     // when / then
     assertThat(
-            ctx.getBrokerRequestAuthorizationConverter(
-                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .authorizationConverter())
         .isSameAs(defaultConverter);
-    assertThatThrownBy(() -> ctx.getBrokerRequestAuthorizationConverter("unknown"))
+    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("unknown"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown physical tenant id");
   }
@@ -522,10 +529,10 @@ final class SystemContextTest {
 
     // when / then
     assertThat(
-            ctx.getBrokerRequestAuthorizationConverter(
-                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .authorizationConverter())
         .isNotNull();
-    assertThatThrownBy(() -> ctx.getBrokerRequestAuthorizationConverter("any-other"))
+    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("any-other"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown physical tenant id");
   }
@@ -591,28 +598,31 @@ final class SystemContextTest {
             mock(AtomixCluster.class),
             mock(BrokerClient.class),
             new SimpleMeterRegistry(),
-            Map.of(tenantId, EngineSecurityConfigurations.defaultConfig()),
+            Map.of(
+                tenantId,
+                new PhysicalTenantEngineContext(
+                    EngineSecurityConfigurations.defaultConfig(),
+                    mock(BrokerRequestAuthorizationConverter.class),
+                    flags)),
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
             (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims,
             mock(SearchClientsProxy.class),
-            Map.of(tenantId, mock(BrokerRequestAuthorizationConverter.class)),
-            Map.of(tenantId, flags),
             mock(NodeIdProvider.class),
             PhysicalTenantIds.DEFAULT);
 
     // when / then
-    assertThat(ctx.getFeatureFlags(tenantId)).isSameAs(flags);
+    assertThat(ctx.getPhysicalTenantEngineContext(tenantId).featureFlags()).isSameAs(flags);
   }
 
   @Test
-  void shouldThrowForUnknownFeatureFlagsTenant() {
+  void shouldThrowForUnknownPhysicalTenantId() {
     // given
     final var ctx = initSystemContext(new BrokerCfg());
 
     // when / then
-    assertThatThrownBy(() -> ctx.getFeatureFlags("unknown-tenant"))
+    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("unknown-tenant"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("unknown-tenant");
   }
@@ -652,11 +662,17 @@ final class SystemContextTest {
       final BrokerCfg brokerCfg,
       final Map<String, EngineSecurityConfig> configsByTenant,
       final Map<String, BrokerRequestAuthorizationConverter> convertersByTenant) {
-    final Map<String, FeatureFlags> featureFlagsByTenant = new HashMap<>();
+    final Map<String, PhysicalTenantEngineContext> contextsByTenant = new HashMap<>();
     configsByTenant
         .keySet()
         .forEach(
-            tenantId -> featureFlagsByTenant.put(tenantId, FeatureFlags.createDefaultForTests()));
+            tenantId ->
+                contextsByTenant.put(
+                    tenantId,
+                    new PhysicalTenantEngineContext(
+                        configsByTenant.get(tenantId),
+                        convertersByTenant.get(tenantId),
+                        FeatureFlags.createDefaultForTests())));
     return new SystemContext(
         SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
         brokerCfg,
@@ -665,14 +681,12 @@ final class SystemContextTest {
         mock(AtomixCluster.class),
         mock(BrokerClient.class),
         new SimpleMeterRegistry(),
-        configsByTenant,
+        contextsByTenant,
         tenantId -> mock(UserServices.class),
         mock(PasswordEncoder.class),
         authConfig -> mock(JwtDecoder.class),
         authConfig -> (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims,
         mock(SearchClientsProxy.class),
-        convertersByTenant,
-        featureFlagsByTenant,
         mock(NodeIdProvider.class),
         PhysicalTenantIds.DEFAULT);
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
@@ -576,6 +577,46 @@ final class SystemContextTest {
         .hasMessageContaining("authorizations");
   }
 
+  @Test
+  void shouldReturnFeatureFlagsForGivenTenant() {
+    // given
+    final var tenantId = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+    final var flags = FeatureFlags.createDefaultForTests();
+    final var ctx =
+        new SystemContext(
+            SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
+            new BrokerCfg(),
+            null,
+            mock(ActorScheduler.class),
+            mock(AtomixCluster.class),
+            mock(BrokerClient.class),
+            new SimpleMeterRegistry(),
+            Map.of(tenantId, EngineSecurityConfigurations.defaultConfig()),
+            mock(UserServices.class),
+            mock(PasswordEncoder.class),
+            mock(JwtDecoder.class),
+            (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims,
+            mock(SearchClientsProxy.class),
+            Map.of(tenantId, mock(BrokerRequestAuthorizationConverter.class)),
+            Map.of(tenantId, flags),
+            mock(NodeIdProvider.class),
+            PhysicalTenantIds.DEFAULT);
+
+    // when / then
+    assertThat(ctx.getFeatureFlags(tenantId)).isSameAs(flags);
+  }
+
+  @Test
+  void shouldThrowForUnknownFeatureFlagsTenant() {
+    // given
+    final var ctx = initSystemContext(new BrokerCfg());
+
+    // when / then
+    assertThatThrownBy(() -> ctx.getFeatureFlags("unknown-tenant"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknown-tenant");
+  }
+
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {
     return SystemContextTestFactory.singleTenant(
         SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
@@ -611,6 +652,11 @@ final class SystemContextTest {
       final BrokerCfg brokerCfg,
       final Map<String, EngineSecurityConfig> configsByTenant,
       final Map<String, BrokerRequestAuthorizationConverter> convertersByTenant) {
+    final Map<String, FeatureFlags> featureFlagsByTenant = new HashMap<>();
+    configsByTenant
+        .keySet()
+        .forEach(
+            tenantId -> featureFlagsByTenant.put(tenantId, FeatureFlags.createDefaultForTests()));
     return new SystemContext(
         SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
         brokerCfg,
@@ -626,6 +672,7 @@ final class SystemContextTest {
         authConfig -> (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims,
         mock(SearchClientsProxy.class),
         convertersByTenant,
+        featureFlagsByTenant,
         mock(NodeIdProvider.class),
         PhysicalTenantIds.DEFAULT);
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -604,10 +604,10 @@ final class SystemContextTest {
                     EngineSecurityConfigurations.defaultConfig(),
                     mock(BrokerRequestAuthorizationConverter.class),
                     flags)),
-            mock(UserServices.class),
+            ignored -> mock(UserServices.class),
             mock(PasswordEncoder.class),
-            mock(JwtDecoder.class),
-            (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims,
+            authConfig -> mock(JwtDecoder.class),
+            authConfig -> (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims,
             mock(SearchClientsProxy.class),
             mock(NodeIdProvider.class),
             PhysicalTenantIds.DEFAULT);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -14,7 +14,6 @@ import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfig;
-import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -129,9 +128,5 @@ public final class SystemContextTestFactory {
     physicalTenantIds.known().forEach(id -> map.put(id, value));
     map.put(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, value);
     return map;
-  }
-
-  private static FeatureFlags featureFlagsFrom(final BrokerCfg brokerCfg) {
-    return brokerCfg.getExperimental().getFeatures().toFeatureFlags();
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -119,6 +119,10 @@ public final class SystemContextTestFactory {
         physicalTenantIds);
   }
 
+  private static FeatureFlags featureFlagsFrom(final BrokerCfg brokerCfg) {
+    return brokerCfg.getExperimental().getFeatures().toFeatureFlags();
+  }
+
   private static <T> Map<String, T> singleValueMap(
       final PhysicalTenantIds physicalTenantIds, final T value) {
     final Map<String, T> map = new HashMap<>();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -14,6 +14,7 @@ import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -74,7 +75,7 @@ public final class SystemContextTestFactory {
         oidcClaimsProvider,
         searchClientsProxy,
         brokerRequestAuthorizationConverter,
-        FeatureFlags.createDefaultForTests(),
+        featureFlagsFrom(brokerCfg),
         nodeIdProvider,
         physicalTenantIds);
   }
@@ -105,14 +106,15 @@ public final class SystemContextTestFactory {
         cluster,
         brokerClient,
         meterRegistry,
-        singleValueMap(physicalTenantIds, securityConfiguration),
+        singleValueMap(
+            physicalTenantIds,
+            new PhysicalTenantEngineContext(
+                securityConfiguration, brokerRequestAuthorizationConverter, featureFlags)),
         tenantId -> userServices,
         passwordEncoder,
         authConfig -> jwtDecoder,
         authConfig -> oidcClaimsProvider,
         searchClientsProxy,
-        singleValueMap(physicalTenantIds, brokerRequestAuthorizationConverter),
-        singleValueMap(physicalTenantIds, featureFlags),
         nodeIdProvider,
         physicalTenantIds);
   }
@@ -123,5 +125,9 @@ public final class SystemContextTestFactory {
     physicalTenantIds.known().forEach(id -> map.put(id, value));
     map.put(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, value);
     return map;
+  }
+
+  private static FeatureFlags featureFlagsFrom(final BrokerCfg brokerCfg) {
+    return brokerCfg.getExperimental().getFeatures().toFeatureFlags();
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.HashMap;
@@ -58,6 +59,44 @@ public final class SystemContextTestFactory {
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final NodeIdProvider nodeIdProvider,
       final PhysicalTenantIds physicalTenantIds) {
+    return singleTenant(
+        shutdownTimeout,
+        brokerCfg,
+        identityConfiguration,
+        scheduler,
+        cluster,
+        brokerClient,
+        meterRegistry,
+        securityConfiguration,
+        userServices,
+        passwordEncoder,
+        jwtDecoder,
+        oidcClaimsProvider,
+        searchClientsProxy,
+        brokerRequestAuthorizationConverter,
+        FeatureFlags.createDefaultForTests(),
+        nodeIdProvider,
+        physicalTenantIds);
+  }
+
+  public static SystemContext singleTenant(
+      final Duration shutdownTimeout,
+      final BrokerCfg brokerCfg,
+      final IdentityConfiguration identityConfiguration,
+      final ActorScheduler scheduler,
+      final AtomixCluster cluster,
+      final BrokerClient brokerClient,
+      final MeterRegistry meterRegistry,
+      final EngineSecurityConfig securityConfiguration,
+      final UserServices userServices,
+      final PasswordEncoder passwordEncoder,
+      final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
+      final SearchClientsProxy searchClientsProxy,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final FeatureFlags featureFlags,
+      final NodeIdProvider nodeIdProvider,
+      final PhysicalTenantIds physicalTenantIds) {
     return new SystemContext(
         shutdownTimeout,
         brokerCfg,
@@ -73,6 +112,7 @@ public final class SystemContextTestFactory {
         authConfig -> oidcClaimsProvider,
         searchClientsProxy,
         singleValueMap(physicalTenantIds, brokerRequestAuthorizationConverter),
+        singleValueMap(physicalTenantIds, featureFlags),
         nodeIdProvider,
         physicalTenantIds);
   }


### PR DESCRIPTION
## What

Closes #55444.

Scopes `FeatureFlags` per physical tenant (PT) in the Zeebe broker — the last remaining item from the review comment in #55401, after `securityConfig` and `BrokerRequestAuthorizationConverter` were addressed in #55792.

Each PT engine was previously fed a single `FeatureFlags` instance built inline from the cluster-wide `BrokerCfg` in `PartitionManagerImpl`. A PT with a `camunda.physical-tenants.<id>.processing.*` override was therefore silently ignored for feature-flag purposes.

**Commit 1 — feat:** Derives a per-PT `FeatureFlags` from each tenant's resolved `Camunda` config and threads it through the same chain established by #55792:

`BrokerModuleConfiguration → SystemContext → BrokerStartupContext(Impl) → PartitionManagerStep → PartitionManagerImpl → ZeebePartitionFactory`

The `buildFeatureFlags(Processing)` helper starts from the cluster-wide `FeatureFlags` baseline (which carries `enableActorMetrics` — a node/scheduler-level concern with no per-PT source) and overlays the 5 PT-overridable flags from the tenant's `Processing` config. The `default` tenant resolves to the root config, so single-PT behavior is byte-identical to before.

`getFeatureFlags(String physicalTenantId)` throws `IllegalArgumentException` for an unknown id — consistent with the `getSecurityConfiguration(String)` convention.

**Commit 2 — fix:** Removes the dead no-arg `getFeatureFlags()` from `SystemContext` and `BrokerStartupContext` — it had no callers and used an inconsistent `IllegalStateException` guard rather than the `IllegalArgumentException` convention used by the other per-PT accessors. No behavioral change.

**Commit 3 — refactor:** Introduces `PhysicalTenantEngineContext`, a container record bundling `EngineSecurityConfig`, `BrokerRequestAuthorizationConverter`, and `FeatureFlags`. Collapses the three parallel `Map<String, X>` structures into a single `Map<String, PhysicalTenantEngineContext>` at every link of the startup chain — three fields, ctor params, accessors, and unknown-id guards become one each. No behavioral change.

## Testing

- `SystemContextTest`: per-PT accessor and unknown-id guard tests.
- `PartitionManagerStepTest`: `shouldPassPerTenantFeatureFlagsToPartitionFactory` asserts identity (`isSameAs`) of the per-PT `FeatureFlags` wired into `ZeebePartitionFactory`, confirmed to fail if the step used a cluster-wide value.
- Full `zeebe/broker` unit suite: 57 tests pass; 6 pre-existing failures (unresolved `Either.left(Rejection)` compilation in `GlobalListenerValidator`) confirmed unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
