### PR TITLE
refactor: cleaner `PartitionId` type

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionId.java
@@ -16,74 +16,26 @@
  */
 package io.atomix.primitive.partition;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.base.Preconditions;
-import io.atomix.utils.AbstractIdentifier;
-import java.util.Objects;
+import java.util.Comparator;
+import org.jspecify.annotations.NonNull;
 
 /** {@link PartitionMetadata} identifier. */
-public class PartitionId extends AbstractIdentifier<Integer> implements Comparable<PartitionId> {
-  private final String group;
+public record PartitionId(String group, int number) implements Comparable<PartitionId> {
 
-  /**
-   * Creates a partition identifier from an integer.
-   *
-   * @param group the group identifier
-   * @param id input integer
-   */
-  public PartitionId(final String group, final int id) {
-    super(id);
-    this.group = checkNotNull(group, "group cannot be null");
-    Preconditions.checkArgument(id >= 0, "partition id must be non-negative");
-  }
+  private static final Comparator<PartitionId> COMPARATOR =
+      Comparator.comparing(PartitionId::group).thenComparingInt(PartitionId::number);
 
-  /**
-   * Creates a partition identifier from an integer.
-   *
-   * @param group the group identifier
-   * @param id input integer
-   * @return partition identification
-   */
-  public static PartitionId from(final String group, final int id) {
-    return new PartitionId(group, id);
-  }
-
-  @Override
-  public int compareTo(final PartitionId that) {
-    return Integer.compare(identifier, that.identifier);
-  }
-
-  /**
-   * Returns the partition group name.
-   *
-   * @return the partition group name
-   */
-  public String group() {
-    return group;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(id(), group());
-  }
-
-  @Override
-  public boolean equals(final Object object) {
-    if (object instanceof PartitionId) {
-      final PartitionId partitionId = (PartitionId) object;
-      return partitionId.id().equals(id()) && partitionId.group().equals(group());
+  public PartitionId {
+    if (group == null) {
+      throw new IllegalArgumentException("group cannot be null");
     }
-
-    if (object instanceof AbstractIdentifier) {
-      return object.equals(this);
+    if (number < 0) {
+      throw new IllegalArgumentException("partition number must be non-negative");
     }
-    return false;
   }
 
   @Override
-  public String toString() {
-    return toStringHelper(this).add("id", id()).add("group", group).toString();
+  public int compareTo(@NonNull final PartitionId o) {
+    return COMPARATOR.compare(this, o);
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -147,12 +147,12 @@ public final class RaftPartition implements Partition, HealthMonitorable {
    * @return the partition name
    */
   public String name() {
-    return String.format(PARTITION_NAME_FORMAT, partitionId.group(), partitionId.id());
+    return String.format(PARTITION_NAME_FORMAT, partitionId.group(), partitionId.number());
   }
 
   @Override
   public String componentName() {
-    return String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId.id());
+    return String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId.number());
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -166,7 +166,7 @@ public class RaftPartitionServer implements HealthMonitorable {
   }
 
   private RaftServer buildServer(final MeterRegistry meterRegistry) {
-    final var partitionId = partition.id().id();
+    final var partitionId = partition.id().number();
     final var electionConfig =
         config.isPriorityElectionEnabled()
             ? RaftElectionConfig.ofPriorityElection(
@@ -308,7 +308,7 @@ public class RaftPartitionServer implements HealthMonitorable {
     final RaftStorageConfig storageConfig = config.getStorageConfig();
     return RaftStorage.builder(meterRegistry)
         .withPrefix(partition.name())
-        .withPartitionId(partition.id().id())
+        .withPartitionId(partition.id().number())
         .withDirectory(partition.dataDirectory())
         .withMaxSegmentSize((int) storageConfig.getSegmentSize())
         .withFlusherFactory(storageConfig.flusherFactory())
@@ -320,7 +320,7 @@ public class RaftPartitionServer implements HealthMonitorable {
   }
 
   private RaftServerCommunicator createServerProtocol() {
-    final var partitionId = partition.id().id();
+    final var partitionId = partition.id().number();
     final var partitionGroup = partition.id().group();
 
     final var sendingSubject = PARTITION_NAME_FORMAT.formatted(partitionGroup, partitionId);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerReceiverSubjectsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerReceiverSubjectsTest.java
@@ -55,7 +55,7 @@ public class RaftServerReceiverSubjectsTest {
       final String group, final RaftPartitionConfig raftPartitionConfig, final Path tempDir) {
     final var metadata =
         new PartitionMetadata(
-            new PartitionId(group, PARTITION_ID.id()), Set.of(), Map.of(), 1, MEMBER_ID);
+            new PartitionId(group, PARTITION_ID.number()), Set.of(), Map.of(), 1, MEMBER_ID);
     final var raftPartition =
         new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
     return new RaftPartitionServer(
@@ -105,7 +105,8 @@ public class RaftServerReceiverSubjectsTest {
   }
 
   void assertSubjectsRegistered(final String prefix, final int expected) {
-    final var subjectPrefix = PARTITION_NAME_FORMAT.formatted(prefix, PARTITION_ID.id()) + "-%s";
+    final var subjectPrefix =
+        PARTITION_NAME_FORMAT.formatted(prefix, PARTITION_ID.number()) + "-%s";
     final var expectedNumberOfInvocations = expected > 0 ? times(expected) : never();
 
     verify(clusterCommunicationService, expectedNumberOfInvocations)
@@ -133,7 +134,8 @@ public class RaftServerReceiverSubjectsTest {
   }
 
   void assertSubjectsUnregistered(final String prefix, final int expected) {
-    final var partitionName = PARTITION_NAME_FORMAT.formatted(prefix, PARTITION_ID.id()) + "-%s";
+    final var partitionName =
+        PARTITION_NAME_FORMAT.formatted(prefix, PARTITION_ID.number()) + "-%s";
     final var expectedNumberOfInvocations = expected > 0 ? times(expected) : never();
 
     verify(clusterCommunicationService, expectedNumberOfInvocations)

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
@@ -65,7 +65,7 @@ public class ZeebeTestNode {
   }
 
   RaftPartition getPartition(final int id) {
-    return partitions.stream().filter(p -> p.id().id() == id).findFirst().orElse(null);
+    return partitions.stream().filter(p -> p.id().number() == id).findFirst().orElse(null);
   }
 
   public CompletableFuture<Void> start(final Collection<ZeebeTestNode> nodes) {
@@ -74,7 +74,7 @@ public class ZeebeTestNode {
         nodes.stream().map(ZeebeTestNode::getMember).map(Member::id).collect(Collectors.toSet());
     members.add(member.id());
 
-    final PartitionId partitionId = PartitionId.from("test", 1);
+    final PartitionId partitionId = new PartitionId("test", 1);
     final var priorityMap =
         members.stream()
             .collect(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
@@ -245,7 +245,7 @@ final class Partition {
     return new IllegalStateException(
         String.format(
             "Expected to %s partition %s, but raft partition is not available",
-            operation, context.partitionMetadata().id().id()));
+            operation, context.partitionMetadata().id().number()));
   }
 
   ZeebePartition zeebePartition() {
@@ -254,9 +254,5 @@ final class Partition {
 
   RaftPartition raftPartition() {
     return context.raftPartition();
-  }
-
-  int id() {
-    return context.partitionMetadata().id().id();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -31,7 +31,7 @@ public interface PartitionManager {
    * @return the partition with the given id or null if partition does not exist
    */
   default @Nullable RaftPartition getRaftPartition(final PartitionId partitionId) {
-    return getRaftPartition(partitionId.id());
+    return getRaftPartition(partitionId.number());
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -162,7 +162,7 @@ public final class PartitionManagerImpl
       final DynamicPartitionConfig initialPartitionConfig,
       final boolean initializeFromSnapshot) {
     final var result = concurrencyControl.<Void>createFuture();
-    final var id = partitionMetadata.id().id();
+    final var id = partitionMetadata.id().number();
     final var context =
         new PartitionStartupContext(
             actorSchedulingService,
@@ -183,7 +183,7 @@ public final class PartitionManagerImpl
     final var partition = Partition.bootstrapping(context);
     if (partitions.putIfAbsent(id, partition) != null) {
       result.completeExceptionally(
-          new PartitionAlreadyExistsException(partitionMetadata.id().id()));
+          new PartitionAlreadyExistsException(partitionMetadata.id().number()));
     } else {
       concurrencyControl.runOnCompletion(
           partition.start(), (started, error) -> completePartitionStart(id, error, result));
@@ -196,7 +196,7 @@ public final class PartitionManagerImpl
       final PartitionMetadata partitionMetadata,
       final DynamicPartitionConfig initialPartitionConfig) {
     final var result = concurrencyControl.<Void>createFuture();
-    final var id = partitionMetadata.id().id();
+    final var id = partitionMetadata.id().number();
     final var context =
         new PartitionStartupContext(
             actorSchedulingService,
@@ -313,7 +313,7 @@ public final class PartitionManagerImpl
                           .getInitialClusterConfiguration()
                           .members()
                           .get(localMemberId)
-                          .getPartition(partitionMetadata.id().id())
+                          .getPartition(partitionMetadata.id().number())
                           .config();
                   return bootstrapPartition(partitionMetadata, initialPartitionConfig, false);
                 })
@@ -376,7 +376,7 @@ public final class PartitionManagerImpl
 
     final var partitionMetadata =
         new PartitionMetadata(
-            PartitionId.from(partitionGroup, partitionId),
+            new PartitionId(partitionGroup, partitionId),
             members,
             membersWithPriority,
             targetPriority,
@@ -428,7 +428,7 @@ public final class PartitionManagerImpl
 
     final var partitionMetadata =
         new PartitionMetadata(
-            PartitionId.from(partitionGroup, partitionId),
+            new PartitionId(partitionGroup, partitionId),
             members,
             Map.of(localMember, targetPriority),
             targetPriority,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
@@ -151,7 +151,7 @@ public final class RecoveryPartitionManager
           recoveryPartitions.addAll(starting);
           final var deactivateFutures =
               localPartitions.stream()
-                  .map(p -> topologyManager.setInactive(p.id().id()))
+                  .map(p -> topologyManager.setInactive(p.id().number()))
                   .collect(new ActorFutureCollector<>(concurrencyControl));
           concurrencyControl.runOnCompletion(
               deactivateFutures,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
@@ -73,7 +73,7 @@ public final class FixedPartitionDistributor implements PartitionDistributor {
       throw new IllegalStateException(
           String.format(
               "Expected to distribute partition %d, but no members configured for it",
-              partitionId.id()));
+              partitionId.number()));
     }
 
     final var priorities =
@@ -113,7 +113,7 @@ public final class FixedPartitionDistributor implements PartitionDistributor {
           String.format(
               "Expected partition %d to be replicated across a cluster made of members %s, but the "
                   + "following configured members %s are not part of the cluster",
-              partitionId.id(), clusterMembers, unknownMembers));
+              partitionId.number(), clusterMembers, unknownMembers));
     }
   }
 
@@ -124,7 +124,7 @@ public final class FixedPartitionDistributor implements PartitionDistributor {
           String.format(
               "Expected each partition to be replicated across exactly %d members, but partition %d"
                   + " is replicated across members %s",
-              replicationFactor, partitionId.id(), members));
+              replicationFactor, partitionId.number(), members));
     }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorBuilder.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorBuilder.java
@@ -49,7 +49,7 @@ public final class FixedPartitionDistributorBuilder {
   public FixedPartitionDistributorBuilder assignMember(
       final int partitionId, final int nodeId, final int priority) {
     return assignMember(
-        PartitionId.from(partitionGroupName, partitionId),
+        new PartitionId(partitionGroupName, partitionId),
         MemberId.from(String.valueOf(nodeId)),
         priority);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
@@ -89,11 +89,11 @@ public class PartitionStartupContext {
 
   @Override
   public String toString() {
-    return "PartitionStartupContext{" + "partition=" + partitionMetadata.id().id() + '}';
+    return "PartitionStartupContext{" + "partition=" + partitionMetadata.id().number() + '}';
   }
 
   public Integer partitionId() {
-    return partitionMetadata.id().id();
+    return partitionMetadata.id().number();
   }
 
   public ActorSchedulingService schedulingService() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -62,7 +62,7 @@ public final class RaftPartitionFactory {
     return Paths.get(dataDirectory)
         .resolve(GROUP_NAME)
         .resolve("partitions")
-        .resolve(partitionId.id().toString());
+        .resolve(String.valueOf(partitionId.number()));
   }
 
   public RaftPartition createRaftPartition(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -161,7 +161,7 @@ public final class ZeebePartitionFactory {
 
     final var databaseCfg = brokerCfg.getExperimental().getRocksdb();
     final var consistencyChecks = brokerCfg.getExperimental().getConsistencyChecks();
-    final var partitionId = raftPartition.id().id();
+    final var partitionId = raftPartition.id().number();
     final var rocksDbConfiguration = databaseCfg.createRocksDbConfiguration();
 
     final var zeebeFactory =
@@ -237,7 +237,7 @@ public final class ZeebePartitionFactory {
       final ConstructableSnapshotStore snapshotStore,
       final ConcurrencyControl concurrencyControl) {
     final Path runtimeDirectory;
-    final var partitionId = raftPartition.id().id();
+    final var partitionId = raftPartition.id().number();
     if (brokerCfg.getData().useSeparateRuntimeDirectory()) {
       final Path rootRuntimeDirectory = Paths.get(brokerCfg.getData().getRuntimeDirectory());
       try {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
@@ -30,7 +30,7 @@ public class MetricsStep implements StartupStep<PartitionStartupContext> {
   @Override
   public ActorFuture<PartitionStartupContext> startup(final PartitionStartupContext context) {
     final var brokerRegistry = context.brokerMeterRegistry();
-    final var partitionId = context.partitionMetadata().id().id();
+    final var partitionId = context.partitionMetadata().id().number();
     final var partitionRegistry =
         MicrometerUtil.wrap(brokerRegistry, PartitionKeyNames.tags(partitionId));
     context.partitionMeterRegistry(partitionRegistry);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionDirectoryStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionDirectoryStep.java
@@ -36,7 +36,7 @@ public final class PartitionDirectoryStep implements StartupStep<PartitionStartu
         dataDirectory
             .resolve(partitionId.group())
             .resolve("partitions")
-            .resolve(partitionId.id().toString());
+            .resolve(String.valueOf(partitionId.number()));
 
     try {
       FileUtil.ensureDirectoryExists(partitionDirectory);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
@@ -28,7 +28,7 @@ public final class PartitionRegistrationStep implements StartupStep<PartitionSta
   @Override
   public ActorFuture<PartitionStartupContext> startup(final PartitionStartupContext context) {
     final var result = context.concurrencyControl().<PartitionStartupContext>createFuture();
-    final var partitionId = context.partitionMetadata().id().id();
+    final var partitionId = context.partitionMetadata().id().number();
     final var zeebePartition = context.zeebePartition();
     final var topologyManager = context.topologyManager();
     zeebePartition.addFailureListener(
@@ -43,7 +43,7 @@ public final class PartitionRegistrationStep implements StartupStep<PartitionSta
   public ActorFuture<PartitionStartupContext> shutdown(final PartitionStartupContext context) {
     final var result = context.concurrencyControl().<PartitionStartupContext>createFuture();
 
-    final var partitionId = context.partitionMetadata().id().id();
+    final var partitionId = context.partitionMetadata().id().number();
     context.diskSpaceUsageMonitor().removeDiskUsageListener(context.zeebePartition());
     context.brokerHealthCheckService().removeMonitoredPartition(context.zeebePartition());
     context.topologyManager().removePartition(partitionId);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/PartitionDistribution.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/PartitionDistribution.java
@@ -41,7 +41,7 @@ public record PartitionDistribution(Set<PartitionMetadata> partitions) {
     final Map<MemberId, Integer> priority =
         pm.members().stream().collect(Collectors.toMap(m -> m, pm::getPriority));
     return new PartitionMetadata(
-        PartitionId.from(newGroupName, pm.id().id()),
+        new PartitionId(newGroupName, pm.id().number()),
         new HashSet<>(pm.members()),
         priority,
         pm.getTargetPriority(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -129,7 +129,7 @@ public final class StaticConfigurationGenerator {
   private static List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     // partition ids start from 1
     return IntStream.rangeClosed(1, partitionCount)
-        .mapToObj(p -> PartitionId.from(PartitionManagerImpl.DEFAULT_GROUP_NAME, p))
+        .mapToObj(p -> new PartitionId(PartitionManagerImpl.DEFAULT_GROUP_NAME, p))
         .sorted()
         .toList();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -110,10 +110,11 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
 
   public void registerBootstrapPartitions(final Collection<PartitionMetadata> partitions) {
     partitionInstallStatus =
-        partitions.stream().collect(Collectors.toMap(metadata -> metadata.id().id(), p -> false));
+        partitions.stream()
+            .collect(Collectors.toMap(metadata -> metadata.id().number(), p -> false));
     partitions.forEach(
         metadata ->
-            healthMonitor.monitorComponent(ZeebePartition.componentName(metadata.id().id())));
+            healthMonitor.monitorComponent(ZeebePartition.componentName(metadata.id().number())));
   }
 
   public boolean isBrokerReady() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -186,7 +186,7 @@ public class PartitionStartupAndTransitionContextImpl
 
   @Override
   public int getPartitionId() {
-    return partitionId.id();
+    return partitionId.number();
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/InterPartitionCommandServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/InterPartitionCommandServiceStep.java
@@ -97,8 +97,8 @@ public final class InterPartitionCommandServiceStep implements PartitionTransiti
 
     final var config = context.getBrokerCfg().getExperimental();
     final var partitionId = context.partitionId();
-    final var legacyReceivingSubject = LEGACY_TOPIC_PREFIX + partitionId.id();
-    final var receivingSubject = TOPIC_PREFIX.formatted(partitionId.group()) + partitionId.id();
+    final var legacyReceivingSubject = LEGACY_TOPIC_PREFIX + partitionId.number();
+    final var receivingSubject = TOPIC_PREFIX.formatted(partitionId.group()) + partitionId.number();
 
     final var receivingSubjects =
         config.isReceiveOnLegacySubject()

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -79,7 +79,7 @@ public final class BackupApiRequestHandler
     this.checkpointMetadataState = checkpointMetadataState;
     this.backupRangeState = backupRangeState;
     this.partition = partition;
-    partitionId = partition.id();
+    partitionId = partition.number();
     this.backupFeatureEnabled = backupFeatureEnabled;
     transport.unsubscribe(partition, RequestType.BACKUP);
     transport.subscribe(partition, RequestType.BACKUP, this);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
@@ -55,7 +55,7 @@ public final class CommandApiServiceImpl extends Actor
 
   @Override
   protected void onActorClosing() {
-    unregisterHandlersActorless(partitionId.id());
+    unregisterHandlersActorless(partitionId.number());
     actor.runOnCompletion(
         commandHandler.closeAsync(),
         (ok, error) -> {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
@@ -50,13 +50,13 @@ public class SnapshotApiRequestHandler
   public void addTransferService(
       final PartitionId partitionId, final SnapshotSenderService transferService) {
     serverTransport.subscribe(partitionId, RequestType.SNAPSHOT, this);
-    transferServices.put(partitionId.id(), new Registration(partitionId, transferService));
+    transferServices.put(partitionId.number(), new Registration(partitionId, transferService));
     LOG.debug("Added SnapshotTransferService for partition {}.", partitionId);
   }
 
   public void removeTransferService(final PartitionId partitionId) {
     serverTransport.unsubscribe(partitionId, RequestType.SNAPSHOT);
-    final var registration = transferServices.remove(partitionId.id());
+    final var registration = transferServices.remove(partitionId.number());
     LOG.debug("Removed SnapshotTransferService for partition {}.", partitionId);
     if (registration != null) {
       AsyncClosable.closeHelper(registration.service());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -93,7 +93,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
 
     final var partitionMetadata =
         new PartitionMetadata(
-            PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
+            new PartitionId("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
     final var raftPartition =
         new RaftPartition(partitionMetadata, null, dataDirectory.toFile(), meterRegistry);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
@@ -232,7 +232,7 @@ public final class RaftPartitionFactoryTest {
     return new RaftPartitionFactory(brokerCfg)
         .createRaftPartition(
             new PartitionMetadata(
-                PartitionId.from("test", 1),
+                new PartitionId("test", 1),
                 Set.of(MemberId.from("1")),
                 Map.of(),
                 1,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
@@ -147,7 +147,7 @@ public final class RaftRolesTest {
 
     final List<PartitionId> partitionIds =
         IntStream.rangeClosed(1, partitionCount)
-            .mapToObj(id -> PartitionId.from("test", id))
+            .mapToObj(id -> new PartitionId("test", id))
             .sorted()
             .toList();
     final var partitionDistribution =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
@@ -97,7 +97,7 @@ final class RecoveryPartitionManagerTest {
 
   private PartitionMetadata localPartitionMetadata(final int partitionId) {
     return new PartitionMetadata(
-        PartitionId.from(GROUP, partitionId),
+        new PartitionId(GROUP, partitionId),
         Set.of(localMemberId),
         Map.of(localMemberId, 1),
         1,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
@@ -156,7 +156,7 @@ final class FixedPartitionDistributorTest {
   }
 
   private PartitionId partition(final int id) {
-    return PartitionId.from(PARTITION_GROUP_NAME, id);
+    return new PartitionId(PARTITION_GROUP_NAME, id);
   }
 
   private MemberId node(final int id) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/steps/CommandApiServicePartitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/steps/CommandApiServicePartitionStepTest.java
@@ -52,7 +52,7 @@ class CommandApiServicePartitionStepTest {
 
     final var partitionMetadata = mock(PartitionMetadata.class);
     when(partitionMetadata.id())
-        .thenReturn(PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, PARTITION_ID));
+        .thenReturn(new PartitionId(Protocol.DEFAULT_PARTITION_GROUP_NAME, PARTITION_ID));
 
     when(mockContext.concurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
     when(mockContext.schedulingService()).thenReturn(mockSchedulingService);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/PartitionDistributionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/PartitionDistributionTest.java
@@ -49,7 +49,7 @@ final class PartitionDistributionTest {
 
       final var originalPartition =
           original.partitions().stream()
-              .filter(p -> p.id().id().equals(renamedPartition.id().id()))
+              .filter(p -> p.id().number() == renamedPartition.id().number())
               .findFirst()
               .orElseThrow();
 
@@ -81,14 +81,14 @@ final class PartitionDistributionTest {
   private static PartitionDistribution distributionInGroup(final String group) {
     final var partition1 =
         new PartitionMetadata(
-            PartitionId.from(group, 1),
+            new PartitionId(group, 1),
             Set.of(MEMBER_0, MEMBER_1, MEMBER_2),
             Map.of(MEMBER_0, 3, MEMBER_1, 2, MEMBER_2, 1),
             3,
             MEMBER_0);
     final var partition2 =
         new PartitionMetadata(
-            PartitionId.from(group, 2),
+            new PartitionId(group, 2),
             Set.of(MEMBER_0, MEMBER_1),
             Map.of(MEMBER_0, 1, MEMBER_1, 2),
             2,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
@@ -73,7 +73,7 @@ class StaticConfigurationGeneratorTest {
     return partitionDistribution.stream()
         .collect(
             Collectors.toMap(
-                p -> p.id().id(),
+                p -> p.id().number(),
                 p ->
                     p.members().stream()
                         .map(m -> Integer.valueOf(m.id()))

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -109,7 +109,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   @Override
   public PartitionId partitionId() {
-    return PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, getPartitionId());
+    return new PartitionId(Protocol.DEFAULT_PARTITION_GROUP_NAME, getPartitionId());
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -104,7 +104,7 @@ class BackupApiRequestHandlerTest {
             checkpointState,
             checkpointMetadataState,
             backupRangeState,
-            PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, 1),
+            new PartitionId(Protocol.DEFAULT_PARTITION_GROUP_NAME, 1),
             true);
     scheduler.submitActor(handler);
     scheduler.workUntilDone();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
@@ -45,7 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class CommandApiServiceImplTest {
 
   private static final PartitionId PARTITION_ID =
-      PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, 1);
+      new PartitionId(Protocol.DEFAULT_PARTITION_GROUP_NAME, 1);
 
   @Mock private ServerTransport serverTransport;
   @Mock private QueryApiCfg queryApi;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -70,8 +70,7 @@ public class SnapshotApiRequestHandlerTest {
   @AutoClose MeterRegistry registry = new SimpleMeterRegistry();
   @TempDir Path temporaryFolder;
   final int partitionId = 1;
-  final PartitionId partition =
-      PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, partitionId);
+  final PartitionId partition = new PartitionId(Protocol.DEFAULT_PARTITION_GROUP_NAME, partitionId);
   FileBasedSnapshotStore senderSnapshotStore;
   FileBasedSnapshotStore receiverSnapshotStore;
   private AtomixClientTransportAdapter clientTransport;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -119,7 +119,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
             .map(
                 n ->
                     IntStream.rangeClosed(currentConfiguration.partitionCount() + 1, n)
-                        .mapToObj(i -> PartitionId.from("temp", i))
+                        .mapToObj(i -> new PartitionId("temp", i))
                         .sorted()
                         .toList())
             .orElse(List.of());
@@ -152,11 +152,11 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
               new AwaitRedistributionCompletion(
                   coordinatorNodeId,
                   newPartitionCount.get(),
-                  new TreeSet<>(newPartitions.stream().map(PartitionId::id).toList())),
+                  new TreeSet<>(newPartitions.stream().map(PartitionId::number).toList())),
               new AwaitRelocationCompletion(
                   coordinatorNodeId,
                   newPartitionCount.get(),
-                  new TreeSet<>(newPartitions.stream().map(PartitionId::id).toList()))));
+                  new TreeSet<>(newPartitions.stream().map(PartitionId::number).toList()))));
     }
 
     return Either.right(operations);
@@ -164,7 +164,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
 
   private List<ClusterConfigurationChangeOperation> addPartition(
       final PartitionMetadata newMetadata) {
-    final Integer partitionId = newMetadata.id().id();
+    final Integer partitionId = newMetadata.id().number();
     final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
 
     // Bootstrap the partition in the primary
@@ -187,7 +187,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
 
   private List<ClusterConfigurationChangeOperation> movePartition(
       final PartitionMetadata oldMetadata, final PartitionMetadata newMetadata) {
-    final Integer partitionId = newMetadata.id().id();
+    final Integer partitionId = newMetadata.id().number();
     final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
 
     final var membersToJoin =

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -34,7 +34,7 @@ public final class ConfigurationUtil {
       @Nullable final String clusterId) {
     final var partitionStatesByMember = new HashMap<MemberId, Map<Integer, PartitionState>>();
     for (final var partitionMetadata : partitionDistribution) {
-      final var partitionId = partitionMetadata.id().id();
+      final var partitionId = partitionMetadata.id().number();
       for (final var member : partitionMetadata.members()) {
         final var memberPriority = partitionMetadata.getPriority(member);
         partitionStatesByMember
@@ -97,14 +97,10 @@ public final class ConfigurationUtil {
       throw new IllegalStateException("Found partition with no members");
     }
     return new PartitionMetadata(
-        partitionId(e.getKey(), groupName),
+        new PartitionId(groupName, e.getKey()),
         memberPriorities.keySet(),
         memberPriorities,
         optionalPrimary.get().getValue(),
         optionalPrimary.get().getKey());
-  }
-
-  private static PartitionId partitionId(final Integer key, final String groupName) {
-    return PartitionId.from(groupName, key);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
@@ -91,7 +91,7 @@ public final class RoundRobinPartitionDistributor implements PartitionDistributo
     // priority (=3) for partition 1,4,7 and 10. For partition 1 and 7, node 1 gets priority 2. For
     // partition 4 and 10, node 2 gets priority 2. This is done so that if node 0 dies, the
     // leadership is evenly distributed on the rest of the followers.
-    if ((partitionId.id() - 1) / clusterSize % 2 == 0) {
+    if ((partitionId.number() - 1) / clusterSize % 2 == 0) {
       int nextPriority = replicationFactor - 1;
       for (final MemberId member : membersForPartition) {
         if (!member.equals(primary)) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -207,11 +207,11 @@ final class ClusterConfigurationInitializerTest {
 
   private StaticConfiguration getStaticConfiguration(
       final MemberId member, final Set<MemberId> members) {
-    final var partitionId = PartitionId.from("test", 1);
+    final var partitionId = new PartitionId("test", 1);
     final Set<PartitionMetadata> partitions =
         Set.of(
             new PartitionMetadata(
-                PartitionId.from("test", 1),
+                new PartitionId("test", 1),
                 members,
                 members.stream().collect(Collectors.toMap(Function.identity(), ignored -> 1)),
                 1,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -335,13 +335,13 @@ class ClusterConfigurationManagementIntegrationTest {
   private Set<PartitionMetadata> getExpectedPartitionDistribution() {
     return Set.of(
         new PartitionMetadata(
-            PartitionId.from("test", 1),
+            new PartitionId("test", 1),
             Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")),
             Map.of(MemberId.from("0"), 1, MemberId.from("1"), 2, MemberId.from("2"), 3),
             3,
             MemberId.from("2")),
         new PartitionMetadata(
-            PartitionId.from("test", 2),
+            new PartitionId("test", 2),
             Set.of(MemberId.from("2")),
             Map.of(MemberId.from("2"), 1),
             1,
@@ -351,7 +351,7 @@ class ClusterConfigurationManagementIntegrationTest {
   private Set<PartitionMetadata> getIncorrectPartitionDistribution() {
     return Set.of(
         new PartitionMetadata(
-            PartitionId.from("test", 1),
+            new PartitionId("test", 1),
             Set.of(MemberId.from("10"), MemberId.from("11"), MemberId.from("12")),
             Map.of(MemberId.from("10"), 1, MemberId.from("11"), 2, MemberId.from("12"), 3),
             3,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionDistributorInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionDistributorInitializerTest.java
@@ -28,7 +28,7 @@ final class PartitionDistributorInitializerTest {
         distributor,
         Set.of(MemberId.from("0")),
         MemberId.from("0"),
-        List.of(PartitionId.from("test", 1)),
+        List.of(new PartitionId("test", 1)),
         1,
         DynamicPartitionConfig.init(),
         null);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -276,7 +276,7 @@ final class ClusterPatchRequestTransformerTest {
 
   private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     return IntStream.rangeClosed(1, partitionCount)
-        .mapToObj(id -> PartitionId.from("temp", id))
+        .mapToObj(id -> new PartitionId("temp", id))
         .collect(Collectors.toList());
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -278,7 +278,7 @@ final class ClusterScaleRequestTransformerTest {
 
   private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     return IntStream.rangeClosed(1, partitionCount)
-        .mapToObj(id -> PartitionId.from("temp", id))
+        .mapToObj(id -> new PartitionId("temp", id))
         .collect(Collectors.toList());
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
@@ -216,7 +216,7 @@ class PartitionReassignRequestTransformerTest {
 
   private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     return IntStream.rangeClosed(1, partitionCount)
-        .mapToObj(id -> PartitionId.from("temp", id))
+        .mapToObj(id -> new PartitionId("temp", id))
         .collect(Collectors.toList());
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -262,7 +262,7 @@ class ScaleRequestTransformerTest {
 
   private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     return IntStream.rangeClosed(1, partitionCount)
-        .mapToObj(id -> PartitionId.from("temp", id))
+        .mapToObj(id -> new PartitionId("temp", id))
         .collect(Collectors.toList());
   }
 
@@ -286,7 +286,7 @@ class ScaleRequestTransformerTest {
                     .mapToObj(id -> MemberId.from(Integer.toString(id)))
                     .collect(Collectors.toSet()),
                 partitionsInRange(1, 1 + currentPartitionCount).stream()
-                    .map(i -> PartitionId.from("temp", i))
+                    .map(i -> new PartitionId("temp", i))
                     .toList(),
                 replicationFactor);
     final var config =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -47,7 +47,7 @@ class UpdatePartitionDistributionTransformerTest {
   private static final Set<MemberId> MEMBERS = Set.of(ZONE_A_0, ZONE_A_1, ZONE_B_0);
 
   private static final List<PartitionId> PARTITION_IDS =
-      IntStream.rangeClosed(1, 3).mapToObj(i -> PartitionId.from("temp", i)).toList();
+      IntStream.rangeClosed(1, 3).mapToObj(i -> new PartitionId("temp", i)).toList();
 
   /** Builds a topology whose partitions are placed by ZoneAwarePartitionDistributor. */
   private static ClusterConfiguration buildTopology(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -41,14 +41,14 @@ class ConfigurationUtilTest {
     // given
     final PartitionMetadata partitionOne =
         new PartitionMetadata(
-            PartitionId.from(GROUP_NAME, 1),
+            new PartitionId(GROUP_NAME, 1),
             Set.of(member(1), member(2), member(0)),
             Map.of(member(0), 1, member(1), 2, member(2), 3),
             3,
             member(2));
     final PartitionMetadata partitionTwo =
         new PartitionMetadata(
-            PartitionId.from(GROUP_NAME, 2),
+            new PartitionId(GROUP_NAME, 2),
             Set.of(member(1), member(2), member(0)),
             Map.of(member(2), 1, member(1), 2, member(0), 3),
             3,
@@ -123,14 +123,14 @@ class ConfigurationUtilTest {
     // given
     final PartitionMetadata partitionOne =
         new PartitionMetadata(
-            PartitionId.from(GROUP_NAME, 1),
+            new PartitionId(GROUP_NAME, 1),
             Set.of(member(1), member(2), member(0)),
             Map.of(member(0), 1, member(1), 2, member(2), 3),
             3,
             member(2));
     final PartitionMetadata partitionTwo =
         new PartitionMetadata(
-            PartitionId.from(GROUP_NAME, 2),
+            new PartitionId(GROUP_NAME, 2),
             Set.of(member(1), member(2), member(0)),
             Map.of(member(2), 1, member(1), 2, member(0), 3),
             3,
@@ -182,7 +182,7 @@ class ConfigurationUtilTest {
     // given
     final PartitionMetadata partitionOne =
         new PartitionMetadata(
-            PartitionId.from(GROUP_NAME, 1),
+            new PartitionId(GROUP_NAME, 1),
             Set.of(member(1), member(0)),
             Map.of(member(0), 1, member(1), 2),
             2,
@@ -190,7 +190,7 @@ class ConfigurationUtilTest {
 
     final PartitionMetadata partitionTwo =
         new PartitionMetadata(
-            PartitionId.from(GROUP_NAME, 2),
+            new PartitionId(GROUP_NAME, 2),
             Set.of(member(1), member(0)),
             Map.of(member(1), 2, member(0), 3),
             3,
@@ -231,14 +231,14 @@ class ConfigurationUtilTest {
     // given
     final PartitionMetadata partitionOne =
         new PartitionMetadata(
-            PartitionId.from(GROUP_NAME, 1),
+            new PartitionId(GROUP_NAME, 1),
             Set.of(member(1), member(2), member(0)),
             Map.of(member(0), 1, member(1), 2, member(2), 3),
             3,
             member(2));
     final PartitionMetadata partitionTwo =
         new PartitionMetadata(
-            PartitionId.from(GROUP_NAME, 2),
+            new PartitionId(GROUP_NAME, 2),
             Set.of(member(1), member(2), member(0)),
             Map.of(member(2), 1, member(1), 2, member(0), 3),
             3,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RandomizedRoundRobinDistribution2RegionTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RandomizedRoundRobinDistribution2RegionTest.java
@@ -60,7 +60,7 @@ public class RandomizedRoundRobinDistribution2RegionTest {
   private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     final List<PartitionId> partitionIds = new ArrayList<>(partitionCount);
     for (int i = 1; i <= partitionCount; i++) {
-      partitionIds.add(PartitionId.from("test", i));
+      partitionIds.add(new PartitionId("test", i));
     }
     return partitionIds;
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributorTest.java
@@ -40,7 +40,7 @@ final class RoundRobinPartitionDistributorTest {
     assertThat(partitionMetadata).isNotEmpty();
     partitionMetadata.forEach(
         metadata -> {
-          final int partitionId = metadata.id().id();
+          final int partitionId = metadata.id().number();
           metadata
               .members()
               .forEach(
@@ -124,7 +124,7 @@ final class RoundRobinPartitionDistributorTest {
                     assertThat(metadata.getPriority(member))
                         .describedAs(
                             "Priority should be set for nodeId %d in partition %d",
-                            nodeId, metadata.id().id())
+                            nodeId, metadata.id().number())
                         .isPositive();
                   });
         });
@@ -141,7 +141,7 @@ final class RoundRobinPartitionDistributorTest {
   private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     final List<PartitionId> partitionIds = new ArrayList<>(partitionCount);
     for (int i = 1; i <= partitionCount; i++) {
-      partitionIds.add(PartitionId.from("test", i));
+      partitionIds.add(new PartitionId("test", i));
     }
     return partitionIds;
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributorTest.java
@@ -66,7 +66,7 @@ final class ZoneAwarePartitionDistributorTest {
 
   private static List<PartitionId> partitions(final int count) {
     return IntStream.rangeClosed(1, count)
-        .mapToObj(i -> PartitionId.from(GROUP, i))
+        .mapToObj(i -> new PartitionId(GROUP, i))
         .sorted()
         .toList();
   }
@@ -74,7 +74,7 @@ final class ZoneAwarePartitionDistributorTest {
   private static PartitionMetadata partitionById(
       final Set<PartitionMetadata> result, final int id) {
     return result.stream()
-        .filter(p -> p.id().id() == id)
+        .filter(p -> p.id().number() == id)
         .findFirst()
         .orElseThrow(() -> new AssertionError("Partition " + id + " not found"));
   }
@@ -103,7 +103,7 @@ final class ZoneAwarePartitionDistributorTest {
             config.clusterMembers(), partitions(5), config.replicationFactor());
 
     // then
-    assertThat(result.stream().map(PartitionMetadata::id).map(PartitionId::id))
+    assertThat(result.stream().map(PartitionMetadata::id).map(PartitionId::number))
         .containsExactlyInAnyOrder(1, 2, 3, 4, 5);
     assertThat(result)
         .hasSize(5)
@@ -397,13 +397,15 @@ Partition | us-east1_0 | us-east1_1 | us-west1_0
 
     // Sort partitions by numeric id for stable row order
     final List<PartitionMetadata> rows =
-        result.stream().sorted((a, b) -> Integer.compare(a.id().id(), b.id().id())).toList();
+        result.stream()
+            .sorted((a, b) -> Integer.compare(a.id().number(), b.id().number()))
+            .toList();
 
     // Compute column widths
     final int partitionColWidth =
         Math.max(
             "Partition".length(),
-            rows.stream().mapToInt(p -> String.valueOf(p.id().id()).length()).max().orElse(1));
+            rows.stream().mapToInt(p -> String.valueOf(p.id().number()).length()).max().orElse(1));
     final int[] brokerColWidths =
         columns.stream().mapToInt(m -> Math.max(m.id().length(), 3)).toArray();
 
@@ -425,7 +427,7 @@ Partition | us-east1_0 | us-east1_1 | us-west1_0
     final var dataRows = new StringBuilder();
     for (final PartitionMetadata pm : rows) {
       final var row = new StringBuilder();
-      row.append(padLeft(String.valueOf(pm.id().id()), partitionColWidth));
+      row.append(padLeft(String.valueOf(pm.id().number()), partitionColWidth));
       for (int c = 0; c < columns.size(); c++) {
         final int priority = pm.getPriority(columns.get(c));
         row.append(" | ").append(center(String.valueOf(priority), brokerColWidths[c]));

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
@@ -103,7 +103,7 @@ public final class StubBroker implements AutoCloseable {
 
     channelHandler = new StubRequestHandler(msgPackHelper);
     serverTransport.subscribe(
-        PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, partitionId),
+        new PartitionId(Protocol.DEFAULT_PARTITION_GROUP_NAME, partitionId),
         RequestType.COMMAND,
         channelHandler);
 

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -56,7 +56,7 @@ public class PartitionRestoreService {
       final CRC32CChecksumProvider checksumProvider,
       final MeterRegistry meterRegistry) {
     this.backupStore = backupStore;
-    partitionId = partition.id().id();
+    partitionId = partition.id().number();
     rootDirectory = partition.dataDirectory().toPath();
     this.partition = partition;
     this.brokerId = brokerId;
@@ -245,7 +245,7 @@ public class PartitionRestoreService {
     final RestorableSnapshotStore snapshotStore =
         new FileBasedSnapshotStore(
             brokerId,
-            partition.id().id(),
+            partition.id().number(),
             partition.dataDirectory().toPath(),
             checksumProvider,
             meterRegistry);

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -240,7 +240,7 @@ public class RestoreManager implements CloseableSilently {
       final var partitionsToRestore = collectPartitions();
       final var tasks = new ArrayList<Callable<Void>>(partitionsToRestore.size());
       for (final var partition : partitionsToRestore) {
-        final var partitionId = partition.partition().id().id();
+        final var partitionId = partition.partition().id().number();
         final var backupIds = backupIdsByPartition.get(partitionId);
         if (backupIds == null || backupIds.length == 0) {
           throw new IllegalArgumentException("No backup IDs provided for partition " + partitionId);
@@ -314,7 +314,7 @@ public class RestoreManager implements CloseableSilently {
       restoreService.restore(backupIds, validator);
       LOG.info(
           "Successfully restored partition {} from backups {}.",
-          raftPartition.id().id(),
+          raftPartition.id().number(),
           backupIds);
     } finally {
       MicrometerUtil.close(registry);
@@ -338,7 +338,7 @@ public class RestoreManager implements CloseableSilently {
 
   private InstrumentedRaftPartition createRaftPartition(
       final PartitionMetadata metadata, final RaftPartitionFactory factory) {
-    final var partitionId = metadata.id().id();
+    final var partitionId = metadata.id().number();
     final var partitionRegistry =
         MicrometerUtil.wrap(meterRegistry, PartitionKeyNames.tags(partitionId));
 

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -99,7 +99,7 @@ class PartitionRestoreServiceTest {
 
     final var partitionMetadata =
         new PartitionMetadata(
-            PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
+            new PartitionId("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
     final var raftPartition =
         new RaftPartition(partitionMetadata, null, dataDirectoryToRestore.toFile(), meterRegistry);
     restoreService =

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreValidatorTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreValidatorTest.java
@@ -163,7 +163,7 @@ class RestoreValidatorTest {
 
   private Path getPartitionDir(final int partitionId) {
     return RaftPartitionFactory.getPartitionDirectory(
-        PartitionId.from(PartitionManagerImpl.DEFAULT_GROUP_NAME, partitionId),
+        new PartitionId(PartitionManagerImpl.DEFAULT_GROUP_NAME, partitionId),
         dataDirectory.toString());
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -104,10 +104,10 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   }
 
   private List<String> topicNames(final PartitionId partitionId, final RequestType requestType) {
-    final var topic = topicName(partitionId.group(), partitionId.id(), requestType);
+    final var topic = topicName(partitionId.group(), partitionId.number(), requestType);
     if (receiveOnLegacySubject
         && Protocol.DEFAULT_PARTITION_GROUP_NAME.equals(partitionId.group())) {
-      return List.of(topic, legacyTopicName(partitionId.id(), requestType));
+      return List.of(topic, legacyTopicName(partitionId.number(), requestType));
     }
     return List.of(topic);
   }
@@ -144,7 +144,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
           try {
             requestHandler.onRequest(
                 this,
-                partitionId.id(),
+                partitionId.number(),
                 requestId,
                 new UnsafeBuffer(requestBytes),
                 0,

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -194,7 +194,7 @@ public class AtomixTransportTest {
   public void beforeTest() {
     clientTransport = clientTransportFunction.apply(cluster);
     serverTransport = serverTransportFunction.apply(cluster);
-    partitionId = PartitionId.from(topicPrefix, 0);
+    partitionId = new PartitionId(topicPrefix, 0);
     request = new Request(MESSAGE_CONTENT).withPartitionGroup(topicPrefix);
   }
 
@@ -344,7 +344,7 @@ public class AtomixTransportTest {
         transportFactory.createServerTransport(
             cluster.getMessagingService(), new SnowflakeIdGenerator(1), false);
     try {
-      final var partition = PartitionId.from(Protocol.DEFAULT_PARTITION_GROUP_NAME, 5);
+      final var partition = new PartitionId(Protocol.DEFAULT_PARTITION_GROUP_NAME, 5);
       transport.subscribe(partition, RequestType.COMMAND, new DirectlyResponder()).join();
       final var serverAddress = cluster.getMessagingService().address();
 


### PR DESCRIPTION
Converts the previously rather complex `PartitionId` type to a simple record holding a group name and a number.