### PR TITLE
ci: remove legacy label from Operate/Tasklist CI and fix flaky ITs

### DIFF
--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -1,8 +1,8 @@
-# description: Runs legacy integration CI tests
+# description: Runs integration CI tests
 # test location: operate/qa/integration-tests
 # type: CI
 # owner: @camunda/core-features, @camunda/data-layer
-name: "[Legacy] Operate"
+name: "Operate Integration Tests"
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -61,13 +61,14 @@ jobs:
     env:
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
       TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
-      # IT classes are split across two shards balanced by measured runtime (not class count),
-      # so the slowest shard stays under target. TaskControllerIT alone dominates (~25 min of
-      # method time) so it sits in shard 1 with only light fillers. The "Verify shard coverage"
-      # step fails the build if a new/renamed IT class is missing from both lists, which on this
-      # frozen stable branch is the only maintenance trigger.
-      SHARD1_CLASSES: "TaskControllerIT,UsageMetricIT,MetricIT,ZeebeConnectorIT,ProcessCacheIT,VariableSearchTermsQueryChunkIT,FeatureFlagIT,ElasticsearchConnectorIT,OpensearchConnectorIT,OldRoutesRedirectionControllerConsolidatedAuthIT,OldRoutesRedirectionControllerIT,HealthCheckIT,ClientConfigRestServiceIT"
-      SHARD2_CLASSES: "ProcessInternalControllerIT,FormControllerIT,VariablesControllerIT,TaskStorePerfIT,ZeebeUserTaskIT,ProcessExternalControllerIT,ProbesTestIT,ZeebeMigrateProcessTaskIT,TaskCompletionConcurrencyIT,ZeebeAdHocSubProcessIT,ZeebeMultipleProcessesIT,ElasticsearchConnectorSSLAuthIT,ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT,ElasticsearchConnectorBasicAuthIT,ZeebeConnectorSecureIT,GenerateOpenApiIT,DevUtilExternalControllerIT,ModesWithTasklistUiDisabledIT,OnlyWebappIT,ModesWithTasklistDisabledIT,OpenSearchConnectorBasicAuthIT,StartupIT,OpenSearchConnectorSSLAuthIT,NoWebappIT,IndexControllerIT"
+      # TaskControllerIT is a ~10 min monolith that a single fork cannot split, so it sets the
+      # floor for whichever shard holds it. Isolate it in shard 1; shard 2 runs the remaining 37
+      # classes, which fan out across the forks so their critical path is TaskStorePerfIT (~6 min)
+      # rather than their sum. The "Verify shard coverage" step fails the build if a new/renamed IT
+      # class is missing from both lists, which on this frozen stable branch is the only
+      # maintenance trigger.
+      SHARD1_CLASSES: "TaskControllerIT"
+      SHARD2_CLASSES: "UsageMetricIT,MetricIT,ZeebeConnectorIT,ProcessCacheIT,VariableSearchTermsQueryChunkIT,FeatureFlagIT,ElasticsearchConnectorIT,OpensearchConnectorIT,OldRoutesRedirectionControllerConsolidatedAuthIT,OldRoutesRedirectionControllerIT,HealthCheckIT,ClientConfigRestServiceIT,ProcessInternalControllerIT,FormControllerIT,VariablesControllerIT,TaskStorePerfIT,ZeebeUserTaskIT,ProcessExternalControllerIT,ProbesTestIT,ZeebeMigrateProcessTaskIT,TaskCompletionConcurrencyIT,ZeebeAdHocSubProcessIT,ZeebeMultipleProcessesIT,ElasticsearchConnectorSSLAuthIT,ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT,ElasticsearchConnectorBasicAuthIT,ZeebeConnectorSecureIT,GenerateOpenApiIT,DevUtilExternalControllerIT,ModesWithTasklistUiDisabledIT,OnlyWebappIT,ModesWithTasklistDisabledIT,OpenSearchConnectorBasicAuthIT,StartupIT,OpenSearchConnectorSSLAuthIT,NoWebappIT,IndexControllerIT"
     services:
       # local registry is used as this job needs to push its docker image to be used by IT
       registry:

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -61,7 +61,13 @@ jobs:
     env:
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
       TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
-      SHARD_TOTAL: 2
+      # IT classes are split across two shards balanced by measured runtime (not class count),
+      # so the slowest shard stays under target. TaskControllerIT alone dominates (~25 min of
+      # method time) so it sits in shard 1 with only light fillers. The "Verify shard coverage"
+      # step fails the build if a new/renamed IT class is missing from both lists, which on this
+      # frozen stable branch is the only maintenance trigger.
+      SHARD1_CLASSES: "TaskControllerIT,UsageMetricIT,MetricIT,ZeebeConnectorIT,ProcessCacheIT,VariableSearchTermsQueryChunkIT,FeatureFlagIT,ElasticsearchConnectorIT,OpensearchConnectorIT,OldRoutesRedirectionControllerConsolidatedAuthIT,OldRoutesRedirectionControllerIT,HealthCheckIT,ClientConfigRestServiceIT"
+      SHARD2_CLASSES: "ProcessInternalControllerIT,FormControllerIT,VariablesControllerIT,TaskStorePerfIT,ZeebeUserTaskIT,ProcessExternalControllerIT,ProbesTestIT,ZeebeMigrateProcessTaskIT,TaskCompletionConcurrencyIT,ZeebeAdHocSubProcessIT,ZeebeMultipleProcessesIT,ElasticsearchConnectorSSLAuthIT,ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT,ElasticsearchConnectorBasicAuthIT,ZeebeConnectorSecureIT,GenerateOpenApiIT,DevUtilExternalControllerIT,ModesWithTasklistUiDisabledIT,OnlyWebappIT,ModesWithTasklistDisabledIT,OpenSearchConnectorBasicAuthIT,StartupIT,OpenSearchConnectorSSLAuthIT,NoWebappIT,IndexControllerIT"
     services:
       # local registry is used as this job needs to push its docker image to be used by IT
       registry:
@@ -90,19 +96,20 @@ jobs:
         id: build-camunda
         run: ./mvnw -B -T1C -DskipTests -DskipChecks install -pl tasklist/qa/integration-tests -am -PskipFrontendBuild
 
-      # Deterministically split the IT classes for this shard so the test phase stays under target
-      - name: Compute IT shard
+      # Fail fast if the committed shard lists no longer cover every IT class (new/renamed test).
+      - name: Verify shard coverage
         id: shard
         run: |
-          mapfile -t classes < <(find tasklist/qa/integration-tests/src/test/java -name '*IT.java' -printf '%f\n' | sed 's/\.java$//' | sort)
-          selected=()
-          for i in "${!classes[@]}"; do
-            if [ $(( i % SHARD_TOTAL )) -eq $(( ${{ matrix.shardIndex }} - 1 )) ]; then
-              selected+=("${classes[$i]}")
-            fi
-          done
-          tests=$(IFS=,; echo "${selected[*]}")
-          echo "Shard ${{ matrix.shardIndex }}/${SHARD_TOTAL} runs ${#selected[@]} IT classes: ${tests}"
+          mapfile -t found < <(find tasklist/qa/integration-tests/src/test/java -name '*IT.java' -printf '%f\n' | sed 's/\.java$//' | sort)
+          known=$(printf '%s,%s' "$SHARD1_CLASSES" "$SHARD2_CLASSES" | tr ',' '\n' | sort)
+          missing=$(comm -23 <(printf '%s\n' "${found[@]}") <(printf '%s\n' "$known"))
+          if [ -n "$missing" ]; then
+            echo "::error::IT classes not assigned to any shard (update SHARD1_CLASSES/SHARD2_CLASSES):"
+            echo "$missing"
+            exit 1
+          fi
+          if [ "${{ matrix.shardIndex }}" = "1" ]; then tests="$SHARD1_CLASSES"; else tests="$SHARD2_CLASSES"; fi
+          echo "Shard ${{ matrix.shardIndex }} runs: ${tests}"
           echo "tests=${tests}" >> "$GITHUB_OUTPUT"
 
       # Run this shard's integration tests in parallel. Unit tests are covered by the unified

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -31,7 +31,7 @@ on:
       forkCount:
         description: "The number of VMs to fork in parallel in order to execute the tests"
         required: false
-        default: 4
+        default: 12
         type: number
 
 defaults:
@@ -52,6 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         database: [ elasticsearch, opensearch ]
+        shardIndex: [ 1, 2 ]
         include:
           - database: elasticsearch
             testProfile: docker-es
@@ -60,6 +61,7 @@ jobs:
     env:
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
       TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
+      SHARD_TOTAL: 2
     services:
       # local registry is used as this job needs to push its docker image to be used by IT
       registry:
@@ -72,7 +74,7 @@ jobs:
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           ref: refs/heads/${{ inputs.branch }}
-          fetch-depth: 0 # fetches all history for all branches and tags
+          fetch-depth: 1
 
       # Setup: configure Java, Maven, settings.xml
       - uses: ./.github/actions/setup-build
@@ -84,19 +86,36 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
-      - uses: ./.github/actions/build-zeebe
+      - name: Build Camunda (scoped)
         id: build-camunda
-        with:
-          maven-extra-args: -PskipFrontendBuild
+        run: ./mvnw -B -T1C -DskipTests -DskipChecks install -pl tasklist/qa/integration-tests -am -PskipFrontendBuild
 
-      # Run integration tests in parallel
+      # Deterministically split the IT classes for this shard so the test phase stays under target
+      - name: Compute IT shard
+        id: shard
+        run: |
+          mapfile -t classes < <(find tasklist/qa/integration-tests/src/test/java -name '*IT.java' -printf '%f\n' | sed 's/\.java$//' | sort)
+          selected=()
+          for i in "${!classes[@]}"; do
+            if [ $(( i % SHARD_TOTAL )) -eq $(( ${{ matrix.shardIndex }} - 1 )) ]; then
+              selected+=("${classes[$i]}")
+            fi
+          done
+          tests=$(IFS=,; echo "${selected[*]}")
+          echo "Shard ${{ matrix.shardIndex }}/${SHARD_TOTAL} runs ${#selected[@]} IT classes: ${tests}"
+          echo "tests=${tests}" >> "$GITHUB_OUTPUT"
+
+      # Run this shard's integration tests in parallel. Unit tests are covered by the unified
+      # Tasklist CI, so only the integration-tests module is exercised here.
       - name: Run Integration Tests
         run: |
           ./mvnw verify \
-            -f tasklist \
+            -pl tasklist/qa/integration-tests \
             -T${{ env.LIMITS_CPU }} \
             -P ${{ matrix.testProfile }},skipFrontendBuild \
             -B --fail-at-end \
+            -Dit.test=${{ steps.shard.outputs.tests }} \
+            -Dsurefire.failIfNoSpecifiedTests=false \
             -Dfailsafe.rerunFailingTestsCount=2 \
             -Dcamunda.data.secondary-storage.type=${{ matrix.database }} \
             -Dtasklist.currentVersion.docker.tag=${{ env.TASKLIST_TEST_DOCKER_IMAGE_TAG }} \
@@ -113,7 +132,7 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: failure() || cancelled()
         with:
-          name: tasklist-test-results-${{ matrix.database }}
+          name: tasklist-test-results-${{ matrix.database }}-${{ matrix.shardIndex }}
           path: |
             **/failsafe-reports/
             **/surefire-reports/
@@ -124,7 +143,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if: ${{ (success() || failure()) }}
         with:
-          name: jacoco-report-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.database }}
+          name: jacoco-report-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.database }}-${{ matrix.shardIndex }}
           path: ${{ github.workspace }}/test-coverage/target/site/jacoco-aggregate/
           retention-days: 2
 
@@ -134,7 +153,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "integration-tests/${{ matrix.database }}"
+          job_name: "integration-tests/${{ matrix.database }}-${{ matrix.shardIndex }}"
           build_status: ${{ job.status }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -3,7 +3,7 @@
 # type: CI
 # owner: @camunda/core-features
 ---
-name: "[Legacy] Tasklist"
+name: "Tasklist Integration Tests"
 on:
   workflow_dispatch:
   push:

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -213,6 +213,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       final int numberOfInstances = 3;
 
       createTask(bpmnProcessId, flowNodeBpmnId, numberOfInstances);
+      tester.tasksAreCreated(flowNodeBpmnId, numberOfInstances);
 
       // when
       final var result =
@@ -308,6 +309,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       createTaskWithCandidateGroup(bpmnProcessId, flowNodeBpmnId, numberOfInstances, "Admins");
       createTaskWithCandidateGroup(bpmnProcessId, flowNodeBpmnId, numberOfInstances, "Users");
       createTaskWithCandidateGroup(bpmnProcessId, flowNodeBpmnId, numberOfInstances, "Sales");
+      tester.tasksAreCreated(flowNodeBpmnId, numberOfInstances * 3);
       when(userGroupService.getUserGroups()).thenReturn(List.of("Admins", "Users", "Sales"));
       when(groupServices.search(any(), any()))
           .thenReturn(
@@ -338,6 +340,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       createTaskWithAssignee(bpmnProcessId, flowNodeBpmnId, numberOfInstances, "demo");
       createTaskWithAssignee(bpmnProcessId, flowNodeBpmnId, numberOfInstances, "admin");
       createTaskWithAssignee(bpmnProcessId, flowNodeBpmnId, numberOfInstances, "sales");
+      tester.tasksAreCreated(flowNodeBpmnId, numberOfInstances * 3);
 
       final var searchQuery = new TaskQueryDTO().setAssignees(new String[] {"demo", "sales"});
 
@@ -382,6 +385,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
           .startProcessInstances(bpmnProcessId, numberOfInstances)
           .then()
           .taskIsCreated(flowNodeBpmnId);
+      tester.tasksAreCreated(flowNodeBpmnId, numberOfInstances * 3);
       // when(identityAuthorizationService.getUserGroups()).thenReturn(List.of("Admins", "Users",
       // "Sales"));
 
@@ -793,6 +797,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
 
       createTaskWithCandidateGroup(bpmnProcessId, flowNodeBpmnId, numberOfInstances, "Admins");
       createTaskWithCandidateGroup(bpmnProcessId, flowNodeBpmnId, numberOfInstances, "Users");
+      tester.tasksAreCreated(flowNodeBpmnId, numberOfInstances * 2);
 
       // Mock identity service behaviour
       identityProperties.setUserAccessRestrictionsEnabled(true);
@@ -831,6 +836,9 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       createTaskWithCandidateGroup(bpmnProcessId, flowNodeBpmnId, numberOfInstancesAdmin, "Admins");
       createTaskWithCandidateGroup(bpmnProcessId, flowNodeBpmnId, numberOfInstancesUser, "Users");
       createTask(bpmnProcessId, flowNodeBpmnId, numberOfInstancesAllUsers);
+      tester.tasksAreCreated(
+          flowNodeBpmnId,
+          numberOfInstancesAdmin + numberOfInstancesUser + numberOfInstancesAllUsers);
 
       // Mock identity service behaviour
       identityProperties.setUserAccessRestrictionsEnabled(true);
@@ -867,7 +875,11 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
 
       createTaskWithCandidateGroup(bpmnProcessId, flowNodeBpmnId, numberOfInstancesAdmin, "Admins");
       createTaskWithCandidateGroup(bpmnProcessId, flowNodeBpmnId, numberOfInstancesUser, "Users");
-      createTaskWithCandidateUser(bpmnProcessId, flowNodeBpmnId, numberOfInstancesUser, "demo");
+      createTaskWithCandidateUser(
+          bpmnProcessId, flowNodeBpmnId, numberOfInstancesCandidateUser, "demo");
+      tester.tasksAreCreated(
+          flowNodeBpmnId,
+          numberOfInstancesAdmin + numberOfInstancesUser + numberOfInstancesCandidateUser);
 
       // Mock identity service behaviour
       identityProperties.setUserAccessRestrictionsEnabled(true);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalControllerIT.java
@@ -27,11 +27,13 @@ import io.camunda.tasklist.webapp.dto.ProcessInstanceDTO;
 import io.camunda.tasklist.webapp.dto.VariableInputDTO;
 import io.camunda.tasklist.webapp.security.TasklistURIs;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -488,20 +490,30 @@ public class ProcessInternalControllerIT extends TasklistZeebeIntegrationTest {
           ZeebeTestUtil.deployProcess(camundaClient, "startedByFormProcessWithoutPublic.bpmn");
       databaseTestExtension.waitFor(processIsDeployedCheck, processId1);
 
-      final var result =
-          mockMvcHelper.doRequest(get(TasklistURIs.PROCESSES_URL_V1).param("query", bpmnProcessId));
+      // the embedded start-event form is indexed independently of the process, so poll until the
+      // process response carries the linked form id instead of asserting on a single request
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(30))
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                final var result =
+                    mockMvcHelper.doRequest(
+                        get(TasklistURIs.PROCESSES_URL_V1).param("query", bpmnProcessId));
 
-      assertThat(result)
-          .hasOkHttpStatus()
-          .hasApplicationJsonContentType()
-          .extractingListContent(objectMapper, ProcessResponse.class)
-          .singleElement()
-          .satisfies(
-              process -> {
-                assertThat(process.getId()).isEqualTo(processId1);
-                assertThat(process.getBpmnProcessId()).isEqualTo("startedByFormWithoutPublic");
-                assertThat(process.getStartEventFormId()).isEqualTo("testForm");
-                assertThat(process.getVersion()).isEqualTo(1);
+                assertThat(result)
+                    .hasOkHttpStatus()
+                    .hasApplicationJsonContentType()
+                    .extractingListContent(objectMapper, ProcessResponse.class)
+                    .singleElement()
+                    .satisfies(
+                        process -> {
+                          assertThat(process.getId()).isEqualTo(processId1);
+                          assertThat(process.getBpmnProcessId())
+                              .isEqualTo("startedByFormWithoutPublic");
+                          assertThat(process.getStartEventFormId()).isEqualTo("testForm");
+                          assertThat(process.getVersion()).isEqualTo(1);
+                        });
               });
     }
   }


### PR DESCRIPTION
## Description

Discovery for #55320 showed both `operate-ci.yml` and `tasklist-ci.yml` provide integration test coverage **not** present in the unified `ci-operate.yml` / `ci-tasklist.yml` on `stable/8.9` (Operate Core Features + OpenSearch ITs; the Tasklist V1 API ITs). V1 is still active on 8.9, so both workflows are **kept** rather than deleted, and de-labeled from `[Legacy]`.

Three commits:

1. **`ci: remove legacy label`** — drop the `[Legacy]` prefix/wording from both workflow names and descriptions.
2. **`ci: speed up tasklist integration tests`** — scope the build to the `integration-tests` subgraph, shallow checkout, raise fork count to match the 16-core runner, and shard the IT classes across a `database × shardIndex` matrix (4 parallel jobs). Wall-clock ~20 min → ~14 min.
3. **`test: stabilize tasklist V1 search integration tests`** — fix export-lag flakiness: add cumulative `tasksAreCreated` waits before each count assertion in `TaskControllerIT`, and poll until the embedded start-event form is indexed in `ProcessInternalControllerIT`.

Verified on CI: all 4 shards green, slowest ~14.4 min, no flaky reruns; `Operate Integration Tests` green.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #55320
