### PR TITLE
fix: remove redundant page from required in Job Statistics result schemas

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -283,7 +283,6 @@ components:
       description: Job type statistics query result.
       type: object
       required:
-        - page
         - items
       allOf:
         - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
@@ -362,7 +361,6 @@ components:
       description: Job worker statistics query result.
       type: object
       required:
-        - page
         - items
       allOf:
         - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
@@ -441,7 +439,6 @@ components:
       description: Job time-series statistics query result.
       type: object
       required:
-        - page
         - items
       allOf:
         - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
@@ -523,7 +520,6 @@ components:
       description: Job error statistics query result.
       type: object
       required:
-        - page
         - items
       allOf:
         - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -303,7 +303,6 @@ components:
       description: Job type statistics query result.
       type: object
       required:
-        - page
         - items
       allOf:
         - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
@@ -382,7 +381,6 @@ components:
       description: Job worker statistics query result.
       type: object
       required:
-        - page
         - items
       allOf:
         - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
@@ -461,7 +459,6 @@ components:
       description: Job time-series statistics query result.
       type: object
       required:
-        - page
         - items
       allOf:
         - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
@@ -543,7 +540,6 @@ components:
       description: Job error statistics query result.
       type: object
       required:
-        - page
         - items
       allOf:
         - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"


### PR DESCRIPTION
## Description

The four Job Statistics OpenAPI v2 result schemas in
`zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml` each declared `page`
in their local `required` array **and** composed
`search-models.yaml#/components/schemas/SearchQueryResponse` via `allOf`. That
composed schema already declares `required: [page]`, so after the spec is
bundled/dereferenced `required` ends up listing `page` twice — the duplicate
that `oas3-schema` linting flags.

This change removes the redundant local `- page` entry from each of:

- `JobTypeStatisticsQueryResult`
- `JobWorkerStatisticsQueryResult`
- `JobTimeSeriesStatisticsQueryResult`
- `JobErrorStatisticsQueryResult`

`page` remains required in every one of these schemas via the `allOf`
`SearchQueryResponse` composition, so the generated client contract is
unchanged. The local `- items` entry is left in place (it is a locally defined,
genuinely required property). `GlobalJobStatisticsQueryResult`, which does not
use the `allOf` + local-`page` pattern, is untouched.

## Why this matters

The duplicated `page` produces `oas3-schema` ("duplicate items" in `required`)
violations in the bundled spec, which can break strict Spectral / OpenAPI
codegen tooling even though runtime behavior is unaffected. Deduplicating the
`required` array keeps the published spec lint-clean. See #55782.

## Testing

- Verified by reading the composition: `SearchQueryResponse`
  (`search-models.yaml`) declares `required: [page]`, so each result schema
  still inherits `page` as required through `allOf` after the local entry is
  removed — no field loses its required status.
- Ran `@camunda8/spectral-cli lint` with the repository ruleset
  (`zeebe/gateway-protocol/.spectral.yaml`) against both the individual file and
  the bundled entry spec (`rest-api.yaml`): **no results with a severity of
  'error'** after the change. The YAML also parses cleanly.
- The diff is exactly the four redundant `- page` deletions and nothing else.
- No Java build was run — this is a pure spec-level redundant-key removal scoped
  to a single YAML file.

## Checklist

- [ ] Enable backports when necessary (fex. for bug fixes, for CI changes, or
  for documentation changes).

## Related issues

closes #55782
