### PR TITLE
refactor: move commonly used DB strings to constants

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DefinitionReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/DefinitionReaderES.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.optimize.service.db.es.reader;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.DatabaseConstants.DECISION_DEFINITION_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
 import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.VERSION_FOR_SORTING_AGGREGATION;
 import static io.camunda.optimize.service.db.es.writer.ElasticsearchWriterUtil.createDefaultScript;
 import static io.camunda.optimize.service.db.schema.index.AbstractDefinitionIndex.DATA_SOURCE;
 import static io.camunda.optimize.service.db.schema.index.AbstractDefinitionIndex.DEFINITION_DELETED;
@@ -777,11 +779,14 @@ public class DefinitionReaderES implements DefinitionReader {
                         t ->
                             t.field(DEFINITION_VERSION)
                                 .size(1) // only return bucket for latest version
-                                .order(List.of(NamedValue.of("versionForSorting", SortOrder.Desc))))
+                                .order(
+                                    List.of(
+                                        NamedValue.of(
+                                            VERSION_FOR_SORTING_AGGREGATION, SortOrder.Desc))))
                     // custom sort agg to sort by numeric version value (instead of string bucket
                     // key)
                     .aggregations(
-                        "versionForSorting",
+                        VERSION_FOR_SORTING_AGGREGATION,
                         Aggregation.of(a1 -> a1.min(m -> m.script(numericVersionScript))))
                     .aggregations(
                         // return top hit in latest version bucket, should only be one
@@ -835,7 +840,7 @@ public class DefinitionReaderES implements DefinitionReader {
                 b.field(DEFINITION_TENANT_ID)
                     .size(LIST_FETCH_LIMIT)
                     .missing(TENANT_NOT_DEFINED_VALUE)
-                    .order(List.of(NamedValue.of("_key", SortOrder.Asc))));
+                    .order(List.of(NamedValue.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))));
     // 2.2 group by name (should only be one)
     final Aggregation nameAggregation =
         Aggregation.of(
@@ -845,9 +850,11 @@ public class DefinitionReaderES implements DefinitionReader {
                             b ->
                                 b.field(DEFINITION_NAME)
                                     .size(1)
-                                    .order(NamedValue.of("versionForSorting", SortOrder.Desc))))
+                                    .order(
+                                        NamedValue.of(
+                                            VERSION_FOR_SORTING_AGGREGATION, SortOrder.Desc))))
                     .aggregations(
-                        "versionForSorting",
+                        VERSION_FOR_SORTING_AGGREGATION,
                         Aggregation.of(
                             a1 ->
                                 a1.min(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/distributedby/process/ProcessDistributedByProcessInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/distributedby/process/ProcessDistributedByProcessInterpreterES.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.distributedby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessDistributedBy.PROCESS_DISTRIBUTED_BY_PROCESS;
 
 import co.elastic.clients.elasticsearch._types.SortOrder;
@@ -72,7 +73,7 @@ public class ProcessDistributedByProcessInterpreterES
                             configurationService
                                 .getElasticSearchConfiguration()
                                 .getAggregationBucketLimit())
-                        .order(NamedValue.of("_key", SortOrder.Asc))
+                        .order(NamedValue.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))
                         .missing(MISSING_TENANT_KEY)
                         .field(tenantField(context)));
 
@@ -90,7 +91,7 @@ public class ProcessDistributedByProcessInterpreterES
                             configurationService
                                 .getElasticSearchConfiguration()
                                 .getAggregationBucketLimit())
-                        .order(NamedValue.of("_key", SortOrder.Asc))
+                        .order(NamedValue.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))
                         .field(definitionKeyField(context)))
             .aggregations(
                 PROC_DEF_VERSION_AGG,
@@ -102,7 +103,7 @@ public class ProcessDistributedByProcessInterpreterES
                                             configurationService
                                                 .getElasticSearchConfiguration()
                                                 .getAggregationBucketLimit())
-                                        .order(NamedValue.of("_key", SortOrder.Asc))
+                                        .order(NamedValue.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))
                                         .field(definitionVersionField(context)))
                             .aggregations(TENANT_AGG, builder.build()))));
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/distributedby/process/identity/AbstractProcessDistributedByIdentityInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/distributedby/process/identity/AbstractProcessDistributedByIdentityInterpreterES.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.identity;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.FILTERED_USER_TASKS_AGGREGATION;
 import static io.camunda.optimize.service.db.es.filter.util.ModelElementFilterQueryUtilES.createInclusiveFlowNodeIdFilterQuery;
 import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.DistributedByResult.createDistributedByResult;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_INSTANCES;
@@ -42,7 +44,6 @@ import java.util.stream.Collectors;
 public abstract class AbstractProcessDistributedByIdentityInterpreterES
     extends AbstractProcessDistributedByInterpreterES {
   private static final String DISTRIBUTE_BY_IDENTITY_TERMS_AGGREGATION = "identity";
-  private static final String FILTERED_USER_TASKS_AGGREGATION = "userTasksFilterAggregation";
 
   protected abstract ConfigurationService getConfigurationService();
 
@@ -61,7 +62,7 @@ public abstract class AbstractProcessDistributedByIdentityInterpreterES
     final TermsAggregation.Builder builder = new TermsAggregation.Builder();
     builder
         .size(getConfigurationService().getElasticSearchConfiguration().getAggregationBucketLimit())
-        .order(NamedValue.of("_key", SortOrder.Asc))
+        .order(NamedValue.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))
         .field(FLOW_NODE_INSTANCES + "." + getIdentityField())
         .missing(ProcessDistributedByIdentityInterpreter.DISTRIBUTE_BY_IDENTITY_MISSING_KEY);
     final Aggregation.Builder.ContainerBuilder identityTermsAggregation =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/distributedby/process/model/AbstractProcessDistributedByModelElementInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/distributedby/process/model/AbstractProcessDistributedByModelElementInterpreterES.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.model;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.DistributedByResult.createDistributedByResult;
 
 import co.elastic.clients.elasticsearch._types.SortOrder;
@@ -53,7 +54,7 @@ public abstract class AbstractProcessDistributedByModelElementInterpreterES
                             getConfigurationService()
                                 .getElasticSearchConfiguration()
                                 .getAggregationBucketLimit())
-                        .order(NamedValue.of("_key", SortOrder.Asc))
+                        .order(NamedValue.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))
                         .field(getModelElementIdPath()));
 
     getViewInterpreter()

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterES.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_KEY_AGGREGATION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_AGENT_PROCESS_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
 
@@ -47,7 +48,6 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterES
 
   // Must match the aggregation name used by the superclass so the inherited result handling finds
   // the buckets.
-  private static final String PROCESS_DEFINITION_KEY_AGGREGATION = "processDefinitionKeyAgg";
   private static final String PROCESS_DEFINITION_KEY_COUNT_AGGREGATION =
       "processDefinitionKeyCountAgg";
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterES.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_KEY_AGGREGATION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
@@ -38,8 +40,6 @@ import org.springframework.stereotype.Component;
 @Conditional(ElasticSearchCondition.class)
 public class ProcessGroupByProcessDefinitionKeyInterpreterES
     extends AbstractProcessGroupByInterpreterES {
-
-  private static final String PROCESS_DEFINITION_KEY_AGGREGATION = "processDefinitionKeyAgg";
 
   private final ConfigurationService configurationService;
   private final ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
@@ -73,7 +73,7 @@ public class ProcessGroupByProcessDefinitionKeyInterpreterES
                                 .getElasticSearchConfiguration()
                                 .getAggregationBucketLimit())
                         .field(PROCESS_DEFINITION_KEY)
-                        .order(NamedValue.of("_key", SortOrder.Asc)));
+                        .order(NamedValue.of(AGGREGATION_FIELD_KEY, SortOrder.Asc)));
     distributedByInterpreter
         .createAggregations(context, boolQuery)
         .forEach((key, value) -> builder.aggregations(key, value.build()));

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterES.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_VERSION_AGGREGATION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
 import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
@@ -40,9 +42,6 @@ import org.springframework.stereotype.Component;
 @Conditional(ElasticSearchCondition.class)
 public class ProcessGroupByProcessDefinitionVersionInterpreterES
     extends AbstractProcessGroupByInterpreterES {
-
-  private static final String PROCESS_DEFINITION_VERSION_AGGREGATION =
-      "processDefinitionVersionAgg";
 
   private final ConfigurationService configurationService;
   private final ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
@@ -87,7 +86,7 @@ public class ProcessGroupByProcessDefinitionVersionInterpreterES
                                 .getElasticSearchConfiguration()
                                 .getAggregationBucketLimit())
                         .field(PROCESS_DEFINITION_VERSION)
-                        .order(NamedValue.of("_key", SortOrder.Asc)));
+                        .order(NamedValue.of(AGGREGATION_FIELD_KEY, SortOrder.Asc)));
     distributedByInterpreter
         .createAggregations(context, boolQuery)
         .forEach((key, value) -> builder.aggregations(key, value.build()));

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/date/AbstractProcessGroupByModelElementDateInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/date/AbstractProcessGroupByModelElementDateInterpreterES.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.groupby.process.date;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.ELEMENT_AGGREGATION;
 import static io.camunda.optimize.service.db.es.report.interpreter.util.FilterLimitedAggregationUtilES.unwrapFilterLimitedAggregations;
 import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
 
@@ -40,7 +41,6 @@ import org.slf4j.Logger;
 public abstract class AbstractProcessGroupByModelElementDateInterpreterES
     extends AbstractProcessGroupByInterpreterES {
 
-  private static final String ELEMENT_AGGREGATION = "elementAggregation";
   private static final String FILTERED_ELEMENTS_AGGREGATION = "filteredElements";
   private static final String MODEL_ELEMENT_TYPE_FILTER_AGGREGATION = "filteredElementsByType";
   private static final Logger LOG =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/flownode/GroupByIncidentFlowNodeInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/flownode/GroupByIncidentFlowNodeInterpreterES.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.groupby.process.flownode;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.FILTERED_INCIDENT_AGGREGATION;
+import static io.camunda.optimize.service.db.DatabaseConstants.GROUPED_BY_FLOW_NODE_ID_AGGREGATION;
+import static io.camunda.optimize.service.db.DatabaseConstants.NESTED_INCIDENT_AGGREGATION;
 import static io.camunda.optimize.service.db.es.filter.util.IncidentFilterQueryUtilES.createIncidentAggregationFilter;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_INCIDENT_FLOW_NODE;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.INCIDENTS;
@@ -41,10 +44,6 @@ import org.springframework.stereotype.Component;
 @Conditional(ElasticSearchCondition.class)
 public class GroupByIncidentFlowNodeInterpreterES extends AbstractGroupByFlowNodeInterpreterES {
 
-  private static final String NESTED_INCIDENT_AGGREGATION = "nestedIncidentAggregation";
-  private static final String GROUPED_BY_FLOW_NODE_ID_AGGREGATION =
-      "groupedByFlowNodeIdAggregation";
-  private static final String FILTERED_INCIDENT_AGGREGATION = "filteredIncidentAggregation";
   final ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
   final ProcessViewInterpreterFacadeES viewInterpreter;
   private final ConfigurationService configurationService;

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/identity/AbstractProcessGroupByIdentityInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/identity/AbstractProcessGroupByIdentityInterpreterES.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.groupby.process.identity;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.es.filter.util.ModelElementFilterQueryUtilES.createUserTaskFlowNodeTypeFilter;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_INSTANCES;
 
@@ -108,7 +109,7 @@ public abstract class AbstractProcessGroupByIdentityInterpreterES
                                                                       + getIdentityField())
                                                               .order(
                                                                   NamedValue.of(
-                                                                      "_key",
+                                                                      AGGREGATION_FIELD_KEY,
                                                                       co.elastic.clients
                                                                           .elasticsearch._types
                                                                           .SortOrder.Asc))

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/none/ProcessIncidentGroupByNoneInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/none/ProcessIncidentGroupByNoneInterpreterES.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.groupby.process.none;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.FILTERED_INCIDENT_AGGREGATION;
 import static io.camunda.optimize.service.db.es.filter.util.IncidentFilterQueryUtilES.createIncidentAggregationFilter;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.INCIDENTS;
 
@@ -40,7 +41,6 @@ public class ProcessIncidentGroupByNoneInterpreterES extends AbstractProcessGrou
     implements ProcessGroupByInterpreterES {
 
   private static final String NESTED_INCIDENT_AGGREGATION = "incidentAggregation";
-  private static final String FILTERED_INCIDENT_AGGREGATION = "filteredIncidentAggregation";
 
   private final ProcessViewInterpreterFacadeES viewInterpreter;
   private final ProcessDistributedByInterpreterFacadeES distributedByInterpreter;

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterES.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.plan.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.DatabaseConstants.VERSION_BASELINE_AGGREGATION;
 import static java.util.stream.Collectors.toMap;
 
@@ -120,7 +121,9 @@ public class GenericProcessExecutionPlanInterpreterES
                                                       getConfigurationService()
                                                           .getElasticSearchConfiguration()
                                                           .getAggregationBucketLimit())
-                                                  .order(NamedValue.of("_key", SortOrder.Asc))))),
+                                                  .order(
+                                                      NamedValue.of(
+                                                          AGGREGATION_FIELD_KEY, SortOrder.Asc))))),
                   Object.class);
     } catch (final IOException e) {
       throw new OptimizeRuntimeException("Could not retrieve per-version baseline counts", e);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/ProcessViewVariableInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/ProcessViewVariableInterpreterES.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.view.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.NESTED_VARIABLE_AGGREGATION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_VARIABLE;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.VARIABLES;
 import static io.camunda.optimize.service.db.util.ProcessVariableHelper.getNestedVariableNameField;
@@ -39,7 +40,6 @@ import org.springframework.stereotype.Component;
 public class ProcessViewVariableInterpreterES
     extends AbstractProcessViewMultiAggregationInterpreterES {
 
-  private static final String NESTED_VARIABLE_AGGREGATION = "nestedVariableAggregation";
   private static final String FILTERED_VARIABLES_AGGREGATION = "filteredVariables";
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/service/DateAggregationServiceES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/service/DateAggregationServiceES.java
@@ -8,6 +8,8 @@
 package io.camunda.optimize.service.db.es.report.service;
 
 import static io.camunda.optimize.rest.util.TimeZoneUtil.formatToCorrectTimezone;
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.DATE_AGGREGATION;
 import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_DATA_POINTS_FOR_AUTOMATIC_INTERVAL_SELECTION;
 import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FORMAT;
 import static io.camunda.optimize.service.db.es.filter.util.DateHistogramFilterUtilES.createModelElementDateHistogramLimitingFilterFor;
@@ -58,7 +60,6 @@ import org.springframework.stereotype.Component;
 @Conditional(ElasticSearchCondition.class)
 public class DateAggregationServiceES extends DateAggregationService {
 
-  private static final String DATE_AGGREGATION = "dateAggregation";
   private static final String UNSUPPORTED_UNIT_STRING = "Unsupported unit: ";
 
   private final DateTimeFormatter dateTimeFormatter;
@@ -195,7 +196,7 @@ public class DateAggregationServiceES extends DateAggregationService {
         .format(OPTIMIZE_DATE_FORMAT)
         .calendarInterval(mapToCalendarInterval(context.getAggregateByDateUnit()))
         .timeZone(context.getTimezone().toString())
-        .order(NamedValue.of("_key", SortOrder.Desc));
+        .order(NamedValue.of(AGGREGATION_FIELD_KEY, SortOrder.Desc));
 
     if (context.isExtendBoundsToMinMaxStats()
         && context.getMinMaxStats().isMaxValid()
@@ -218,7 +219,7 @@ public class DateAggregationServiceES extends DateAggregationService {
         .format(OPTIMIZE_DATE_FORMAT)
         .calendarInterval(mapToCalendarInterval(context.getAggregateByDateUnit()))
         .timeZone(context.getTimezone().toString())
-        .order(NamedValue.of("_key", SortOrder.Desc));
+        .order(NamedValue.of(AGGREGATION_FIELD_KEY, SortOrder.Desc));
 
     final Aggregation.Builder.ContainerBuilder abuilder =
         new Aggregation.Builder().dateHistogram(builder.build());

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionReaderOS.java
@@ -704,7 +704,6 @@ public class DefinitionReaderOS implements DefinitionReader {
             .build();
 
     // custom sort agg to sort by numeric version value (instead of string bucket key)
-    // VERSION_FOR_SORTING_AGGREGATION
     final Aggregation nameAggregationSub =
         AggregationDSL.withSubaggregations(
             nameAggregation,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionReaderOS.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.optimize.service.db.os.reader;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.DatabaseConstants.DECISION_DEFINITION_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
 import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.VERSION_FOR_SORTING_AGGREGATION;
 import static io.camunda.optimize.service.db.os.writer.OpenSearchWriterUtil.createDefaultScript;
 import static io.camunda.optimize.service.db.schema.index.AbstractDefinitionIndex.DATA_SOURCE;
 import static io.camunda.optimize.service.db.schema.index.AbstractDefinitionIndex.DEFINITION_DELETED;
@@ -637,14 +639,14 @@ public class DefinitionReaderOS implements DefinitionReader {
             .field(DEFINITION_VERSION)
             .size(1)
             // only return bucket for latest version
-            .order(Collections.singletonMap("versionForSorting", SortOrder.Desc))
+            .order(Collections.singletonMap(VERSION_FOR_SORTING_AGGREGATION, SortOrder.Desc))
             // custom sort agg to sort by numeric version value (instead of string bucket key)
             .build();
 
     final Map<String, Aggregation> subAggregations = new HashMap<>();
 
     subAggregations.put(
-        "versionForSorting",
+        VERSION_FOR_SORTING_AGGREGATION,
         AggregationBuilders.min().script(numericVersionScript).build().toAggregation());
 
     subAggregations.put(
@@ -690,7 +692,7 @@ public class DefinitionReaderOS implements DefinitionReader {
             .field(DEFINITION_TENANT_ID)
             .size(LIST_FETCH_LIMIT)
             .missing(FieldValue.of(TENANT_NOT_DEFINED_VALUE))
-            .order(Collections.singletonMap("_key", SortOrder.Asc))
+            .order(Collections.singletonMap(AGGREGATION_FIELD_KEY, SortOrder.Asc))
             .build();
 
     // 2.2 group by name (should only be one)
@@ -698,16 +700,16 @@ public class DefinitionReaderOS implements DefinitionReader {
         new TermsAggregation.Builder()
             .field(DEFINITION_NAME)
             .size(1)
-            .order(Collections.singletonMap("versionForSorting", SortOrder.Desc))
+            .order(Collections.singletonMap(VERSION_FOR_SORTING_AGGREGATION, SortOrder.Desc))
             .build();
 
     // custom sort agg to sort by numeric version value (instead of string bucket key)
-    // "versionForSorting"
+    // VERSION_FOR_SORTING_AGGREGATION
     final Aggregation nameAggregationSub =
         AggregationDSL.withSubaggregations(
             nameAggregation,
             Collections.singletonMap(
-                "versionForSorting",
+                VERSION_FOR_SORTING_AGGREGATION,
                 AggregationBuilders.min()
                     .script(createDefaultScript("Integer.parseInt(doc['version'].value)"))
                     .build()

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/distributedby/process/ProcessDistributedByProcessInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/distributedby/process/ProcessDistributedByProcessInterpreterOS.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.distributedby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.termAggregation;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.withSubaggregations;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessDistributedBy.PROCESS_DISTRIBUTED_BY_PROCESS;
@@ -70,7 +71,7 @@ public class ProcessDistributedByProcessInterpreterOS
       final Query baseQuery) {
     final Integer size =
         configurationService.getOpenSearchConfiguration().getAggregationBucketLimit();
-    final Map<String, SortOrder> order = Map.of("_key", SortOrder.Asc);
+    final Map<String, SortOrder> order = Map.of(AGGREGATION_FIELD_KEY, SortOrder.Asc);
     final Aggregation tenantAgg =
         new Aggregation.Builder()
             .terms(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/distributedby/process/identity/AbstractProcessDistributedByIdentityInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/distributedby/process/identity/AbstractProcessDistributedByIdentityInterpreterOS.java
@@ -63,9 +63,7 @@ public abstract class AbstractProcessDistributedByIdentityInterpreterOS
     final TermsAggregation termsAggregation =
         new TermsAggregation.Builder()
             .size(
-                getConfigurationService()
-                    .getElasticSearchConfiguration()
-                    .getAggregationBucketLimit())
+                getConfigurationService().getOpenSearchConfiguration().getAggregationBucketLimit())
             .order(Map.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))
             .field(FLOW_NODE_INSTANCES + "." + getIdentityField())
             .missing(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/distributedby/process/identity/AbstractProcessDistributedByIdentityInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/distributedby/process/identity/AbstractProcessDistributedByIdentityInterpreterOS.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.identity;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.FILTERED_USER_TASKS_AGGREGATION;
 import static io.camunda.optimize.service.db.os.report.filter.util.ModelElementFilterQueryUtilOS.createInclusiveFlowNodeIdFilterQuery;
 import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.DistributedByResult.createDistributedByResult;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_INSTANCES;
@@ -43,7 +45,6 @@ import org.opensearch.client.opensearch.core.SearchResponse;
 public abstract class AbstractProcessDistributedByIdentityInterpreterOS
     extends AbstractProcessDistributedByInterpreterOS {
   private static final String DISTRIBUTE_BY_IDENTITY_TERMS_AGGREGATION = "identity";
-  private static final String FILTERED_USER_TASKS_AGGREGATION = "userTasksFilterAggregation";
 
   protected abstract ConfigurationService getConfigurationService();
 
@@ -65,7 +66,7 @@ public abstract class AbstractProcessDistributedByIdentityInterpreterOS
                 getConfigurationService()
                     .getElasticSearchConfiguration()
                     .getAggregationBucketLimit())
-            .order(Map.of("_key", SortOrder.Asc))
+            .order(Map.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))
             .field(FLOW_NODE_INSTANCES + "." + getIdentityField())
             .missing(
                 FieldValue.of(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/distributedby/process/model/AbstractProcessDistributedByModelElementInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/distributedby/process/model/AbstractProcessDistributedByModelElementInterpreterOS.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.model;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.DistributedByResult.createDistributedByResult;
 
 import io.camunda.optimize.dto.optimize.DefinitionOptimizeResponseDto;
@@ -51,7 +52,7 @@ public abstract class AbstractProcessDistributedByModelElementInterpreterOS
         new TermsAggregation.Builder()
             .size(
                 getConfigurationService().getOpenSearchConfiguration().getAggregationBucketLimit())
-            .order(Map.of("_key", SortOrder.Asc))
+            .order(Map.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))
             .field(getModelElementIdPath())
             .build();
     final Aggregation aggregation =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterOS.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.groupby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_KEY_AGGREGATION;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.termAggregation;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.withSubaggregations;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_AGENT_PROCESS_DEFINITION_KEY;
@@ -50,7 +51,6 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterOS
 
   // Must match the aggregation name used by the superclass so the inherited result handling finds
   // the buckets.
-  private static final String PROCESS_DEFINITION_KEY_AGGREGATION = "processDefinitionKeyAgg";
   private static final String PROCESS_DEFINITION_KEY_COUNT_AGGREGATION =
       "processDefinitionKeyCountAgg";
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOS.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.groupby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_KEY_AGGREGATION;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.termAggregation;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.withSubaggregations;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
@@ -41,8 +43,6 @@ import org.springframework.stereotype.Component;
 public class ProcessGroupByProcessDefinitionKeyInterpreterOS
     extends AbstractProcessGroupByInterpreterOS {
 
-  private static final String PROCESS_DEFINITION_KEY_AGGREGATION = "processDefinitionKeyAgg";
-
   private final ConfigurationService configurationService;
   private final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter;
   private final ProcessViewInterpreterFacadeOS viewInterpreter;
@@ -66,7 +66,7 @@ public class ProcessGroupByProcessDefinitionKeyInterpreterOS
       final Query query,
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
     final int size = configurationService.getOpenSearchConfiguration().getAggregationBucketLimit();
-    final Map<String, SortOrder> order = Map.of("_key", SortOrder.Asc);
+    final Map<String, SortOrder> order = Map.of(AGGREGATION_FIELD_KEY, SortOrder.Asc);
     final Aggregation processDefinitionKeyAggregation =
         withSubaggregations(
             termAggregation(PROCESS_DEFINITION_KEY, size, order),

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOS.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.groupby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_VERSION_AGGREGATION;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.termAggregation;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.withSubaggregations;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
@@ -43,9 +45,6 @@ import org.springframework.stereotype.Component;
 public class ProcessGroupByProcessDefinitionVersionInterpreterOS
     extends AbstractProcessGroupByInterpreterOS {
 
-  private static final String PROCESS_DEFINITION_VERSION_AGGREGATION =
-      "processDefinitionVersionAgg";
-
   private final ConfigurationService configurationService;
   private final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter;
   private final ProcessViewInterpreterFacadeOS viewInterpreter;
@@ -80,7 +79,7 @@ public class ProcessGroupByProcessDefinitionVersionInterpreterOS
       final Query query,
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
     final int size = configurationService.getOpenSearchConfiguration().getAggregationBucketLimit();
-    final Map<String, SortOrder> order = Map.of("_key", SortOrder.Asc);
+    final Map<String, SortOrder> order = Map.of(AGGREGATION_FIELD_KEY, SortOrder.Asc);
     final Aggregation processDefinitionVersionAggregation =
         withSubaggregations(
             termAggregation(PROCESS_DEFINITION_VERSION, size, order),

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/date/AbstractProcessGroupByModelElementDateInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/date/AbstractProcessGroupByModelElementDateInterpreterOS.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.groupby.process.date;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.ELEMENT_AGGREGATION;
 import static io.camunda.optimize.service.db.os.report.interpreter.util.FilterLimitedAggregationUtilOS.unwrapFilterLimitedAggregations;
 import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
 
@@ -40,7 +41,6 @@ import org.opensearch.client.opensearch.core.SearchResponse;
 
 public abstract class AbstractProcessGroupByModelElementDateInterpreterOS
     extends AbstractProcessGroupByInterpreterOS {
-  private static final String ELEMENT_AGGREGATION = "elementAggregation";
   private static final String FILTERED_ELEMENTS_AGGREGATION = "filteredElements";
   private static final String MODEL_ELEMENT_TYPE_FILTER_AGGREGATION = "filteredElementsByType";
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/flownode/GroupByIncidentFlowNodeInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/flownode/GroupByIncidentFlowNodeInterpreterOS.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.groupby.process.flownode;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.FILTERED_INCIDENT_AGGREGATION;
+import static io.camunda.optimize.service.db.DatabaseConstants.GROUPED_BY_FLOW_NODE_ID_AGGREGATION;
+import static io.camunda.optimize.service.db.DatabaseConstants.NESTED_INCIDENT_AGGREGATION;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.termAggregation;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_INCIDENT_FLOW_NODE;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.INCIDENTS;
@@ -43,10 +46,6 @@ import org.springframework.stereotype.Component;
 @Conditional(OpenSearchCondition.class)
 public class GroupByIncidentFlowNodeInterpreterOS extends AbstractGroupByFlowNodeInterpreterOS {
 
-  private static final String NESTED_INCIDENT_AGGREGATION = "nestedIncidentAggregation";
-  private static final String GROUPED_BY_FLOW_NODE_ID_AGGREGATION =
-      "groupedByFlowNodeIdAggregation";
-  private static final String FILTERED_INCIDENT_AGGREGATION = "filteredIncidentAggregation";
   final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter;
   final ProcessViewInterpreterFacadeOS viewInterpreter;
   private final ConfigurationService configurationService;

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/identity/AbstractProcessGroupByIdentityInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/identity/AbstractProcessGroupByIdentityInterpreterOS.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.groupby.process.identity;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.os.report.filter.util.ModelElementFilterQueryUtilOS.createUserTaskFlowNodeTypeFilter;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_INSTANCES;
 
@@ -68,7 +69,9 @@ public abstract class AbstractProcessGroupByIdentityInterpreterOS
             .size(
                 getConfigurationService().getOpenSearchConfiguration().getAggregationBucketLimit())
             .field(FLOW_NODE_INSTANCES + "." + getIdentityField())
-            .order(Map.of("_key", org.opensearch.client.opensearch._types.SortOrder.Asc))
+            .order(
+                Map.of(
+                    AGGREGATION_FIELD_KEY, org.opensearch.client.opensearch._types.SortOrder.Asc))
             .missing(FieldValue.of(GROUP_BY_IDENTITY_MISSING_KEY))
             .build();
     final Aggregation groupByIdentityTermsAggregation =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/none/ProcessIncidentGroupByNoneInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/none/ProcessIncidentGroupByNoneInterpreterOS.java
@@ -8,6 +8,7 @@
 
 package io.camunda.optimize.service.db.os.report.interpreter.groupby.process.none;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.FILTERED_INCIDENT_AGGREGATION;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.INCIDENTS;
 
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
@@ -41,7 +42,6 @@ public class ProcessIncidentGroupByNoneInterpreterOS extends AbstractProcessGrou
     implements ProcessGroupByInterpreterOS {
 
   private static final String NESTED_INCIDENT_AGGREGATION = "incidentAggregation";
-  private static final String FILTERED_INCIDENT_AGGREGATION = "filteredIncidentAggregation";
 
   private final ProcessViewInterpreterFacadeOS viewInterpreter;
   private final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter;

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreterOS.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.plan.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.DatabaseConstants.VERSION_BASELINE_AGGREGATION;
 import static java.util.stream.Collectors.toMap;
 
@@ -113,7 +114,7 @@ public class GenericProcessExecutionPlanInterpreterOS
                                     getConfigurationService()
                                         .getOpenSearchConfiguration()
                                         .getAggregationBucketLimit())
-                                .order(Map.of("_key", SortOrder.Asc))));
+                                .order(Map.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))));
     final SearchResponse<?> response =
         getOsClient()
             .searchWithFixedAggregations(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/ProcessViewVariableInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/ProcessViewVariableInterpreterOS.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.view.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.NESTED_VARIABLE_AGGREGATION;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.and;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.exists;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.term;
@@ -44,7 +45,6 @@ import org.springframework.stereotype.Component;
 public class ProcessViewVariableInterpreterOS
     extends AbstractProcessViewMultiAggregationInterpreterOS {
 
-  private static final String NESTED_VARIABLE_AGGREGATION = "nestedVariableAggregation";
   private static final String FILTERED_VARIABLES_AGGREGATION = "filteredVariables";
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/service/DateAggregationServiceOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/service/DateAggregationServiceOS.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.db.os.report.service;
 
 import static io.camunda.optimize.rest.util.TimeZoneUtil.formatToCorrectTimezone;
+import static io.camunda.optimize.service.db.DatabaseConstants.DATE_AGGREGATION;
 import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FORMAT;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.fieldDateMath;
 import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.filtersAggregation;
@@ -70,8 +71,6 @@ import org.springframework.stereotype.Component;
 @Component
 @Conditional(OpenSearchCondition.class)
 public class DateAggregationServiceOS extends DateAggregationService {
-
-  private static final String DATE_AGGREGATION = "dateAggregation";
 
   private final DateTimeFormatter dateTimeFormatter;
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/VariableRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/VariableRepositoryES.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.db.repository.es;
 import static io.camunda.optimize.dto.optimize.DefinitionType.DECISION;
 import static io.camunda.optimize.dto.optimize.DefinitionType.PROCESS;
 import static io.camunda.optimize.dto.optimize.ReportConstants.APPLIED_TO_ALL_DEFINITIONS;
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.DatabaseConstants.EXTERNAL_PROCESS_VARIABLE_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.MAX_GRAM;
 import static io.camunda.optimize.service.db.DatabaseConstants.MAX_RESPONSE_SIZE_LIMIT;
@@ -691,7 +692,10 @@ public class VariableRepositoryES implements VariableRepository {
                                                     getVariableValueFieldForType(
                                                         variablePath, type))
                                                 .size(MAX_RESPONSE_SIZE_LIMIT)
-                                                .order(NamedValue.of("_key", SortOrder.Asc))))))));
+                                                .order(
+                                                    NamedValue.of(
+                                                        AGGREGATION_FIELD_KEY,
+                                                        SortOrder.Asc))))))));
   }
 
   private Map<String, Aggregation> getProcessVariableValueFilterAggregation(
@@ -715,7 +719,10 @@ public class VariableRepositoryES implements VariableRepository {
                                         t ->
                                             t.field(getVariableValueFieldForType(VARIABLES, type))
                                                 .size(MAX_RESPONSE_SIZE_LIMIT)
-                                                .order(NamedValue.of("_key", SortOrder.Asc))))))));
+                                                .order(
+                                                    NamedValue.of(
+                                                        AGGREGATION_FIELD_KEY,
+                                                        SortOrder.Asc))))))));
   }
 
   private void addValueFilter(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/VariableRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/VariableRepositoryOS.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.db.repository.os;
 import static io.camunda.optimize.dto.optimize.DefinitionType.DECISION;
 import static io.camunda.optimize.dto.optimize.DefinitionType.PROCESS;
 import static io.camunda.optimize.dto.optimize.ReportConstants.APPLIED_TO_ALL_DEFINITIONS;
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
 import static io.camunda.optimize.service.db.DatabaseConstants.EXTERNAL_PROCESS_VARIABLE_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.MAX_GRAM;
 import static io.camunda.optimize.service.db.DatabaseConstants.MAX_RESPONSE_SIZE_LIMIT;
@@ -561,7 +562,7 @@ public class VariableRepositoryOS implements VariableRepository {
         new TermsAggregation.Builder()
             .field(getVariableValueFieldForType(variablePath, variableType))
             .size(MAX_RESPONSE_SIZE_LIMIT)
-            .order(Map.of("_key", SortOrder.Asc))
+            .order(Map.of(AGGREGATION_FIELD_KEY, SortOrder.Asc))
             .build();
 
     filterForVariableWithGivenIdAndPrefix.aggregations(

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterESTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_KEY_AGGREGATION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,7 +75,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
 
     final Map<String, Aggregation.Builder.ContainerBuilder> result =
         underTest.createAggregation(mock(BoolQuery.class), context);
-    final Aggregation aggregation = result.get("processDefinitionKeyAgg").build();
+    final Aggregation aggregation = result.get(PROCESS_DEFINITION_KEY_AGGREGATION).build();
 
     assertThat(aggregation._kind()).isEqualTo(Aggregation.Kind.Terms);
     assertThat(aggregation.terms().field()).isEqualTo(PROCESS_DEFINITION_KEY);
@@ -81,7 +83,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
         .singleElement()
         .satisfies(
             order -> {
-              assertThat(order.name()).isEqualTo("_key");
+              assertThat(order.name()).isEqualTo(AGGREGATION_FIELD_KEY);
               assertThat(order.value()).isEqualTo(SortOrder.Asc);
             });
   }
@@ -93,7 +95,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
     when(response.aggregations())
         .thenReturn(
             Map.of(
-                "processDefinitionKeyAgg",
+                PROCESS_DEFINITION_KEY_AGGREGATION,
                 stringTermsAggregate("invoice-process", "order-process", "payment-process")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
@@ -112,7 +114,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
   void shouldReturnEmptyGroupsWhenNoBuckets() {
     final ResponseBody<?> response = mock(ResponseBody.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionKeyAgg", stringTermsAggregate()));
+        .thenReturn(Map.of(PROCESS_DEFINITION_KEY_AGGREGATION, stringTermsAggregate()));
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
     final CompositeCommandResult result =
@@ -127,7 +129,8 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
   void shouldReturnSingleGroupResultForOneBucket() {
     final ResponseBody<?> response = mock(ResponseBody.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionKeyAgg", stringTermsAggregate("single-process")));
+        .thenReturn(
+            Map.of(PROCESS_DEFINITION_KEY_AGGREGATION, stringTermsAggregate("single-process")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterESTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_VERSION_AGGREGATION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -97,7 +99,7 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
 
     final Map<String, Aggregation.Builder.ContainerBuilder> result =
         underTest.createAggregation(mock(BoolQuery.class), context);
-    final Aggregation aggregation = result.get("processDefinitionVersionAgg").build();
+    final Aggregation aggregation = result.get(PROCESS_DEFINITION_VERSION_AGGREGATION).build();
 
     assertThat(aggregation._kind()).isEqualTo(Aggregation.Kind.Terms);
     assertThat(aggregation.terms().field()).isEqualTo(PROCESS_DEFINITION_VERSION);
@@ -105,7 +107,7 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
         .singleElement()
         .satisfies(
             order -> {
-              assertThat(order.name()).isEqualTo("_key");
+              assertThat(order.name()).isEqualTo(AGGREGATION_FIELD_KEY);
               assertThat(order.value()).isEqualTo(SortOrder.Asc);
             });
   }
@@ -115,7 +117,8 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
   void shouldMapMultipleBucketsToGroupByResults() {
     final ResponseBody<?> response = mock(ResponseBody.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate("1", "2", "3")));
+        .thenReturn(
+            Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, stringTermsAggregate("1", "2", "3")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
@@ -133,7 +136,7 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
   void shouldReturnEmptyGroupsWhenNoBuckets() {
     final ResponseBody<?> response = mock(ResponseBody.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate()));
+        .thenReturn(Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, stringTermsAggregate()));
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
     final CompositeCommandResult result =
@@ -148,7 +151,7 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
   void shouldReturnSingleGroupResultForOneBucket() {
     final ResponseBody<?> response = mock(ResponseBody.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate("42")));
+        .thenReturn(Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, stringTermsAggregate("42")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
@@ -165,7 +168,7 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
   void shouldSetGroupByKeyOfNumericTypeToTrue() {
     final ResponseBody<?> response = mock(ResponseBody.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate()));
+        .thenReturn(Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, stringTermsAggregate()));
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
     final CompositeCommandResult result =
@@ -180,7 +183,7 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
   void shouldRestoreGlobalBaselineCountWhenDistributedByRetrievalFails() {
     final ResponseBody<?> response = mock(ResponseBody.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate("1")));
+        .thenReturn(Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, stringTermsAggregate("1")));
     when(context.getUnfilteredTotalInstanceCount()).thenReturn(10L);
     when(context.getUnfilteredInstanceCountsByGroupKey()).thenReturn(Map.of("1", 3L));
     when(distributedByInterpreter.retrieveResult(any(), any(), any()))

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOSTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.groupby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_KEY_AGGREGATION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,11 +74,12 @@ class ProcessGroupByProcessDefinitionKeyInterpreterOSTest {
     when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
 
     final Map<String, Aggregation> result = underTest.createAggregation(mock(Query.class), context);
-    final Aggregation aggregation = result.get("processDefinitionKeyAgg");
+    final Aggregation aggregation = result.get(PROCESS_DEFINITION_KEY_AGGREGATION);
 
     assertThat(aggregation._kind()).isEqualTo(Aggregation.Kind.Terms);
     assertThat(aggregation.terms().field()).isEqualTo(PROCESS_DEFINITION_KEY);
-    assertThat(aggregation.terms().order()).containsExactly(Map.of("_key", SortOrder.Asc));
+    assertThat(aggregation.terms().order())
+        .containsExactly(Map.of(AGGREGATION_FIELD_KEY, SortOrder.Asc));
   }
 
   @Test
@@ -86,7 +89,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterOSTest {
     when(response.aggregations())
         .thenReturn(
             Map.of(
-                "processDefinitionKeyAgg",
+                PROCESS_DEFINITION_KEY_AGGREGATION,
                 stringTermsAggregate("invoice-process", "order-process", "payment-process")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
@@ -105,7 +108,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterOSTest {
   void shouldReturnEmptyGroupsWhenNoBuckets() {
     final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionKeyAgg", stringTermsAggregate()));
+        .thenReturn(Map.of(PROCESS_DEFINITION_KEY_AGGREGATION, stringTermsAggregate()));
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
     final CompositeCommandResult result =
@@ -120,7 +123,8 @@ class ProcessGroupByProcessDefinitionKeyInterpreterOSTest {
   void shouldReturnSingleGroupResultForOneBucket() {
     final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionKeyAgg", stringTermsAggregate("single-process")));
+        .thenReturn(
+            Map.of(PROCESS_DEFINITION_KEY_AGGREGATION, stringTermsAggregate("single-process")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOSTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.db.os.report.interpreter.groupby.process;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.AGGREGATION_FIELD_KEY;
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_VERSION_AGGREGATION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,11 +95,12 @@ class ProcessGroupByProcessDefinitionVersionInterpreterOSTest {
     when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
 
     final Map<String, Aggregation> result = underTest.createAggregation(mock(Query.class), context);
-    final Aggregation aggregation = result.get("processDefinitionVersionAgg");
+    final Aggregation aggregation = result.get(PROCESS_DEFINITION_VERSION_AGGREGATION);
 
     assertThat(aggregation._kind()).isEqualTo(Aggregation.Kind.Terms);
     assertThat(aggregation.terms().field()).isEqualTo(PROCESS_DEFINITION_VERSION);
-    assertThat(aggregation.terms().order()).containsExactly(Map.of("_key", SortOrder.Asc));
+    assertThat(aggregation.terms().order())
+        .containsExactly(Map.of(AGGREGATION_FIELD_KEY, SortOrder.Asc));
   }
 
   @Test
@@ -105,7 +108,8 @@ class ProcessGroupByProcessDefinitionVersionInterpreterOSTest {
   void shouldMapMultipleBucketsToGroupByResults() {
     final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate("1", "2", "3")));
+        .thenReturn(
+            Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, stringTermsAggregate("1", "2", "3")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
@@ -123,7 +127,7 @@ class ProcessGroupByProcessDefinitionVersionInterpreterOSTest {
   void shouldReturnEmptyGroupsWhenNoBuckets() {
     final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate()));
+        .thenReturn(Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, stringTermsAggregate()));
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
     final CompositeCommandResult result =
@@ -138,7 +142,7 @@ class ProcessGroupByProcessDefinitionVersionInterpreterOSTest {
   void shouldReturnSingleGroupResultForOneBucket() {
     final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate("42")));
+        .thenReturn(Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, stringTermsAggregate("42")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
@@ -155,7 +159,7 @@ class ProcessGroupByProcessDefinitionVersionInterpreterOSTest {
   void shouldSetGroupByKeyOfNumericTypeToTrue() {
     final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate()));
+        .thenReturn(Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, stringTermsAggregate()));
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
     final CompositeCommandResult result =

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
@@ -78,8 +78,19 @@ public final class DatabaseConstants {
   public static final String ZEEBE_DATA_SOURCE = "zeebe";
   public static final String INGESTED_DATA_SOURCE = "ingested";
   // Aggregation constants
+  public static final String AGGREGATION_FIELD_KEY = "_key";
+  public static final String DATE_AGGREGATION = "dateAggregation";
+  public static final String ELEMENT_AGGREGATION = "elementAggregation";
+  public static final String FILTERED_INCIDENT_AGGREGATION = "filteredIncidentAggregation";
+  public static final String FILTERED_USER_TASKS_AGGREGATION = "userTasksFilterAggregation";
   public static final String FREQUENCY_AGGREGATION = "_frequency";
+  public static final String GROUPED_BY_FLOW_NODE_ID_AGGREGATION = "groupedByFlowNodeIdAggregation";
+  public static final String NESTED_INCIDENT_AGGREGATION = "nestedIncidentAggregation";
+  public static final String NESTED_VARIABLE_AGGREGATION = "nestedVariableAggregation";
+  public static final String PROCESS_DEFINITION_KEY_AGGREGATION = "processDefinitionKeyAgg";
+  public static final String PROCESS_DEFINITION_VERSION_AGGREGATION = "processDefinitionVersionAgg";
   public static final String VERSION_BASELINE_AGGREGATION = "versionBaselineAgg";
+  public static final String VERSION_FOR_SORTING_AGGREGATION = "versionForSorting";
   // Units
   public static final String GB_UNIT = "gb";
 


### PR DESCRIPTION
related to #55433

## Description

Move repeated DB related string literals into DB constants.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #https://github.com/camunda/camunda/issues/55433
