### PR TITLE
feat: add Elasticsearch/OpenSearch connection pool tuning properties

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -51,6 +51,26 @@ camunda.data.secondary-storage.elasticsearch.socket-timeout=10s
 
 If the unit of measure is missing, then milliseconds are used by default.
 
+### Connection pool tuning (Elasticsearch / OpenSearch)
+
+The HTTP client used to talk to the secondary storage exposes two connection-pool limits that can
+be tuned for high-throughput deployments:
+
+```
+camunda.data.secondary-storage.elasticsearch.max-connections=<int>
+camunda.data.secondary-storage.elasticsearch.max-connections-per-route=<int>
+```
+
+(and the equivalent `camunda.data.secondary-storage.opensearch.*` keys)
+
+* `max-connections` — total number of connections allowed in the client connection pool.
+* `max-connections-per-route` — maximum number of connections allowed per route. For Camunda this
+  is typically set to the same value as `max-connections`.
+
+Both default to unset, in which case the underlying Apache HttpClient defaults apply. They are
+useful when a component consumes many connections (e.g. running the archiver with a high thread
+count), which can otherwise exhaust the pool and throttle other operations such as health checks.
+
 ### Backwards compatibility with legacy configuration keys
 
 The Unified Configuration system replaces the legacy configuration properties. Nevertheless, in various cases, it is designed to work well even for Customers that have legacy configuration already defined, if possible.

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -36,6 +36,12 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   /** The connection timeout for ES and OS connector */
   private Duration connectionTimeout;
 
+  /** Total number of connections allowed in the ES and OS connector connection pool. */
+  private Integer maxConnections;
+
+  /** Maximum number of connections allowed per route in the ES and OS connector connection pool. */
+  private Integer maxConnectionsPerRoute;
+
   /** How many shards the search engine database uses for all indices. */
   private int numberOfShards = 1;
 
@@ -350,6 +356,22 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   public void setConnectionTimeout(final Duration connectionTimeout) {
     this.connectionTimeout = connectionTimeout;
+  }
+
+  public Integer getMaxConnections() {
+    return maxConnections;
+  }
+
+  public void setMaxConnections(final Integer maxConnections) {
+    this.maxConnections = maxConnections;
+  }
+
+  public Integer getMaxConnectionsPerRoute() {
+    return maxConnectionsPerRoute;
+  }
+
+  public void setMaxConnectionsPerRoute(final Integer maxConnectionsPerRoute) {
+    this.maxConnectionsPerRoute = maxConnectionsPerRoute;
   }
 
   public int getNumberOfReplicas() {

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -358,7 +358,11 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     this.connectionTimeout = connectionTimeout;
   }
 
+  /**
+   * @throws IllegalArgumentException if configured with a non-positive value
+   */
   public Integer getMaxConnections() {
+    validatePositive(".max-connections", maxConnections);
     return maxConnections;
   }
 
@@ -366,12 +370,29 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     this.maxConnections = maxConnections;
   }
 
+  /**
+   * @throws IllegalArgumentException if configured with a non-positive value
+   */
   public Integer getMaxConnectionsPerRoute() {
+    validatePositive(".max-connections-per-route", maxConnectionsPerRoute);
     return maxConnectionsPerRoute;
   }
 
   public void setMaxConnectionsPerRoute(final Integer maxConnectionsPerRoute) {
     this.maxConnectionsPerRoute = maxConnectionsPerRoute;
+  }
+
+  /**
+   * Validates that a connection-pool limit, when set, is a positive value. A value of zero or less
+   * is a misconfiguration that would otherwise fail later with a cryptic Apache HttpClient error.
+   *
+   * @throws IllegalArgumentException if the value is set and not positive
+   */
+  private void validatePositive(final String propertySuffix, final Integer value) {
+    if (value != null && value <= 0) {
+      throw new IllegalArgumentException(
+          prefix() + propertySuffix + " must be a positive value, but was " + value);
+    }
   }
 
   public int getNumberOfReplicas() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -132,6 +132,14 @@ public class SearchEngineConnectPropertiesOverride {
       if (connectionTimeout != null) {
         override.setConnectTimeout(Math.toIntExact(connectionTimeout.toMillis()));
       }
+      final var maxConnections = database.getMaxConnections();
+      if (maxConnections != null) {
+        override.setMaxConnections(maxConnections);
+      }
+      final var maxConnectionsPerRoute = database.getMaxConnectionsPerRoute();
+      if (maxConnectionsPerRoute != null) {
+        override.setMaxConnectionsPerRoute(maxConnectionsPerRoute);
+      }
       override.setIndexPrefix(database.getIndexPrefix());
       override.setProxy(database.getProxy());
     }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageConnectionPoolValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageConnectionPoolValidationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for validating the Elasticsearch/OpenSearch connection-pool limits ({@code max-connections}
+ * and {@code max-connections-per-route}) in document-based secondary storage databases.
+ */
+public class SecondaryStorageConnectionPoolValidationTest {
+
+  /** Test implementation of DocumentBasedSecondaryStorageDatabase for unit testing. */
+  private static final class TestDocumentBasedDatabase
+      extends DocumentBasedSecondaryStorageDatabase {
+
+    @Override
+    public String databaseName() {
+      return "TestDatabase";
+    }
+  }
+
+  @Nested
+  class WhenMaxConnectionsIsNotPositive {
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, -10})
+    void shouldThrowExceptionWhenAccessingMaxConnections(final int value) {
+      // given
+      final var database = new TestDocumentBasedDatabase();
+      database.setMaxConnections(value);
+
+      // when/then
+      assertThatThrownBy(database::getMaxConnections)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("max-connections")
+          .hasMessageContaining("must be a positive value");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, -10})
+    void shouldThrowExceptionWhenAccessingMaxConnectionsPerRoute(final int value) {
+      // given
+      final var database = new TestDocumentBasedDatabase();
+      database.setMaxConnectionsPerRoute(value);
+
+      // when/then
+      assertThatThrownBy(database::getMaxConnectionsPerRoute)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("max-connections-per-route")
+          .hasMessageContaining("must be a positive value");
+    }
+  }
+
+  @Nested
+  class WhenConnectionPoolLimitsAreValid {
+
+    @Test
+    void shouldAllowPositiveValues() {
+      // given
+      final var database = new TestDocumentBasedDatabase();
+      database.setMaxConnections(50);
+      database.setMaxConnectionsPerRoute(25);
+
+      // when/then
+      assertThatNoException().isThrownBy(database::getMaxConnections);
+      assertThatNoException().isThrownBy(database::getMaxConnectionsPerRoute);
+      assertThat(database.getMaxConnections()).isEqualTo(50);
+      assertThat(database.getMaxConnectionsPerRoute()).isEqualTo(25);
+    }
+
+    @Test
+    void shouldAllowUnsetValues() {
+      // given
+      final var database = new TestDocumentBasedDatabase();
+
+      // when/then
+      assertThatNoException().isThrownBy(database::getMaxConnections);
+      assertThatNoException().isThrownBy(database::getMaxConnectionsPerRoute);
+      assertThat(database.getMaxConnections()).isNull();
+      assertThat(database.getMaxConnectionsPerRoute()).isNull();
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -51,6 +51,8 @@ public class SecondaryStorageElasticsearchTest {
   private static final String EXPECTED_DATE_FORMAT = "date-format";
   private static final int EXPECTED_SOCKET_TIMEOUT = 20;
   private static final int EXPECTED_CONNECTION_TIMEOUT = 30;
+  private static final int EXPECTED_MAX_CONNECTIONS = 50;
+  private static final int EXPECTED_MAX_CONNECTIONS_PER_ROUTE = 50;
   private static final String EXPECTED_INDEX_PREFIX = "sample-index-prefix";
 
   private static final String EXPECTED_USERNAME = "testUsername";
@@ -135,6 +137,9 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.data.secondary-storage.elasticsearch.connection-timeout="
             + EXPECTED_CONNECTION_TIMEOUT
             + "ms",
+        "camunda.data.secondary-storage.elasticsearch.max-connections=" + EXPECTED_MAX_CONNECTIONS,
+        "camunda.data.secondary-storage.elasticsearch.max-connections-per-route="
+            + EXPECTED_MAX_CONNECTIONS_PER_ROUTE,
         "camunda.data.secondary-storage.elasticsearch.history.els-rollover-date-format="
             + EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT,
         "camunda.data.secondary-storage.elasticsearch.history.rollover-interval="
@@ -348,6 +353,10 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(searchEngineConnectProperties.getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(searchEngineConnectProperties.getMaxConnections())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS);
+      assertThat(searchEngineConnectProperties.getMaxConnectionsPerRoute())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS_PER_ROUTE);
     }
 
     @Test
@@ -483,6 +492,9 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.data.secondary-storage.elasticsearch.connection-timeout="
             + EXPECTED_CONNECTION_TIMEOUT
             + "ms",
+        "camunda.data.secondary-storage.elasticsearch.max-connections=" + EXPECTED_MAX_CONNECTIONS,
+        "camunda.data.secondary-storage.elasticsearch.max-connections-per-route="
+            + EXPECTED_MAX_CONNECTIONS_PER_ROUTE,
         "camunda.data.connectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
         "camunda.tasklist.elasticsearch.connectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
         "camunda.operate.elasticsearch.connectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
@@ -664,6 +676,10 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(searchEngineConnectProperties.getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(searchEngineConnectProperties.getMaxConnections())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS);
+      assertThat(searchEngineConnectProperties.getMaxConnectionsPerRoute())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS_PER_ROUTE);
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -51,6 +51,8 @@ public class SecondaryStorageOpensearchTest {
   private static final String EXPECTED_DATE_FORMAT = "date-format";
   private static final int EXPECTED_SOCKET_TIMEOUT = 20;
   private static final int EXPECTED_CONNECTION_TIMEOUT = 30;
+  private static final int EXPECTED_MAX_CONNECTIONS = 50;
+  private static final int EXPECTED_MAX_CONNECTIONS_PER_ROUTE = 50;
   private static final String EXPECTED_INDEX_PREFIX = "sample-index-prefix";
 
   private static final String EXPECTED_USERNAME = "testUsername";
@@ -133,6 +135,9 @@ public class SecondaryStorageOpensearchTest {
         "camunda.data.secondary-storage.opensearch.connection-timeout="
             + EXPECTED_CONNECTION_TIMEOUT
             + "ms",
+        "camunda.data.secondary-storage.opensearch.max-connections=" + EXPECTED_MAX_CONNECTIONS,
+        "camunda.data.secondary-storage.opensearch.max-connections-per-route="
+            + EXPECTED_MAX_CONNECTIONS_PER_ROUTE,
         "camunda.data.secondary-storage.opensearch.history.els-rollover-date-format="
             + EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT,
         "camunda.data.secondary-storage.opensearch.history.rollover-interval="
@@ -481,6 +486,9 @@ public class SecondaryStorageOpensearchTest {
         "camunda.data.secondary-storage.opensearch.connection-timeout="
             + EXPECTED_CONNECTION_TIMEOUT
             + "ms",
+        "camunda.data.secondary-storage.opensearch.max-connections=" + EXPECTED_MAX_CONNECTIONS,
+        "camunda.data.secondary-storage.opensearch.max-connections-per-route="
+            + EXPECTED_MAX_CONNECTIONS_PER_ROUTE,
         "camunda.data.socketConnectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
         "camunda.tasklist.opensearch.connectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
         "camunda.operate.opensearch.connectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
@@ -660,6 +668,10 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(searchEngineConnectProperties.getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(searchEngineConnectProperties.getMaxConnections())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS);
+      assertThat(searchEngineConnectProperties.getMaxConnectionsPerRoute())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS_PER_ROUTE);
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverrideConverterTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverrideConverterTest.java
@@ -55,6 +55,8 @@ class SearchEngineConnectPropertiesOverrideConverterTest {
     elasticsearch.setDateFormat("yyyy");
     elasticsearch.setSocketTimeout(Duration.ofSeconds(7));
     elasticsearch.setConnectionTimeout(Duration.ofSeconds(11));
+    elasticsearch.setMaxConnections(64);
+    elasticsearch.setMaxConnectionsPerRoute(32);
     elasticsearch.setIndexPrefix("es-prefix");
     elasticsearch.getSecurity().setEnabled(true);
     elasticsearch.getSecurity().setCertificatePath("/etc/cert.pem");
@@ -73,6 +75,8 @@ class SearchEngineConnectPropertiesOverrideConverterTest {
     assertThat(result.getDateFormat()).isEqualTo("yyyy");
     assertThat(result.getSocketTimeout()).isEqualTo(7_000);
     assertThat(result.getConnectTimeout()).isEqualTo(11_000);
+    assertThat(result.getMaxConnections()).isEqualTo(64);
+    assertThat(result.getMaxConnectionsPerRoute()).isEqualTo(32);
     assertThat(result.getIndexPrefix()).isEqualTo("es-prefix");
     assertThat(result.getSecurity().isEnabled()).isTrue();
     assertThat(result.getSecurity().getCertificatePath()).isEqualTo("/etc/cert.pem");

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -111,6 +111,8 @@ data.secondary-storage.elasticsearch.history.database-name
 data.secondary-storage.elasticsearch.incident-notifier.database-name
 data.secondary-storage.elasticsearch.index-prefix
 data.secondary-storage.elasticsearch.interceptor-plugins
+data.secondary-storage.elasticsearch.max-connections
+data.secondary-storage.elasticsearch.max-connections-per-route
 data.secondary-storage.elasticsearch.number-of-replicas
 data.secondary-storage.elasticsearch.number-of-replicas-per-index
 data.secondary-storage.elasticsearch.number-of-shards
@@ -153,6 +155,8 @@ data.secondary-storage.opensearch.history.database-name
 data.secondary-storage.opensearch.incident-notifier.database-name
 data.secondary-storage.opensearch.index-prefix
 data.secondary-storage.opensearch.interceptor-plugins
+data.secondary-storage.opensearch.max-connections
+data.secondary-storage.opensearch.max-connections-per-route
 data.secondary-storage.opensearch.number-of-replicas
 data.secondary-storage.opensearch.number-of-replicas-per-index
 data.secondary-storage.opensearch.number-of-shards

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
@@ -24,6 +24,8 @@ public class ConnectConfiguration {
   private String fieldDateFormat = FIELD_DATE_FORMAT_DEFAULT;
   private Integer socketTimeout;
   private Integer connectTimeout;
+  private Integer maxConnections;
+  private Integer maxConnectionsPerRoute;
   private String url = URL_DEFAULT;
   private List<String> urls = new ArrayList<>();
   private String username;
@@ -94,6 +96,22 @@ public class ConnectConfiguration {
 
   public void setConnectTimeout(final Integer connectTimeout) {
     this.connectTimeout = connectTimeout;
+  }
+
+  public Integer getMaxConnections() {
+    return maxConnections;
+  }
+
+  public void setMaxConnections(final Integer maxConnections) {
+    this.maxConnections = maxConnections;
+  }
+
+  public Integer getMaxConnectionsPerRoute() {
+    return maxConnectionsPerRoute;
+  }
+
+  public void setMaxConnectionsPerRoute(final Integer maxConnectionsPerRoute) {
+    this.maxConnectionsPerRoute = maxConnectionsPerRoute;
   }
 
   public String getUrl() {

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
@@ -131,6 +131,8 @@ public final class ElasticsearchConnector {
       setupSSLContext(httpAsyncClientBuilder, security);
     }
 
+    setupConnectionPool(httpAsyncClientBuilder, configuration);
+
     for (final HttpRequestInterceptor interceptor : interceptors) {
       httpAsyncClientBuilder.addInterceptorLast(interceptor);
     }
@@ -155,6 +157,16 @@ public final class ElasticsearchConnector {
       }
     } catch (final Exception e) {
       LOGGER.error("Error in setting up SSLContext", e);
+    }
+  }
+
+  private void setupConnectionPool(
+      final HttpAsyncClientBuilder httpAsyncClientBuilder, final ConnectConfiguration elsConfig) {
+    if (elsConfig.getMaxConnections() != null) {
+      httpAsyncClientBuilder.setMaxConnTotal(elsConfig.getMaxConnections());
+    }
+    if (elsConfig.getMaxConnectionsPerRoute() != null) {
+      httpAsyncClientBuilder.setMaxConnPerRoute(elsConfig.getMaxConnectionsPerRoute());
     }
   }
 

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -30,6 +30,7 @@ import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.util.Timeout;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -192,9 +193,7 @@ public final class OpensearchConnector {
       httpAsyncClientBuilder.addRequestInterceptorLast(interceptor);
     }
 
-    if (osConfig.getSecurity() != null && osConfig.getSecurity().isEnabled()) {
-      setupSSLContext(httpAsyncClientBuilder, osConfig.getSecurity());
-    }
+    setupConnectionManager(httpAsyncClientBuilder, osConfig);
 
     final var proxyConfig = osConfig.getProxy();
     if (proxyConfig != null && proxyConfig.isEnabled()) {
@@ -271,9 +270,42 @@ public final class OpensearchConnector {
     LOGGER.debug("Preemptive proxy authentication enabled for proxy");
   }
 
-  private void setupSSLContext(
-      final HttpAsyncClientBuilder httpAsyncClientBuilder,
-      final SecurityConfiguration configuration) {
+  /**
+   * Builds and assigns a {@link
+   * org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager} when TLS or connection
+   * pool limits need to be configured. When neither is configured the builder is left untouched so
+   * the Apache HttpClient defaults remain in effect.
+   */
+  private void setupConnectionManager(
+      final HttpAsyncClientBuilder httpAsyncClientBuilder, final ConnectConfiguration osConfig) {
+    final var security = osConfig.getSecurity();
+    final boolean securityEnabled = security != null && security.isEnabled();
+    final boolean poolConfigured =
+        osConfig.getMaxConnections() != null || osConfig.getMaxConnectionsPerRoute() != null;
+
+    if (!securityEnabled && !poolConfigured) {
+      return;
+    }
+
+    final var connectionManagerBuilder = PoolingAsyncClientConnectionManagerBuilder.create();
+
+    if (securityEnabled) {
+      final var tlsStrategy = buildTlsStrategy(security);
+      if (tlsStrategy != null) {
+        connectionManagerBuilder.setTlsStrategy(tlsStrategy);
+      }
+    }
+    if (osConfig.getMaxConnections() != null) {
+      connectionManagerBuilder.setMaxConnTotal(osConfig.getMaxConnections());
+    }
+    if (osConfig.getMaxConnectionsPerRoute() != null) {
+      connectionManagerBuilder.setMaxConnPerRoute(osConfig.getMaxConnectionsPerRoute());
+    }
+
+    httpAsyncClientBuilder.setConnectionManager(connectionManagerBuilder.build());
+  }
+
+  private TlsStrategy buildTlsStrategy(final SecurityConfiguration configuration) {
     try {
       final var tlsStrategyBuilder = ClientTlsStrategyBuilder.create();
       final var sslContext = SecurityUtil.getSSLContext(configuration, "opensearch-host");
@@ -283,14 +315,10 @@ public final class OpensearchConnector {
         tlsStrategyBuilder.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
       }
 
-      final var tlsStrategy = tlsStrategyBuilder.build();
-      final var connectionManager =
-          PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
-
-      httpAsyncClientBuilder.setConnectionManager(connectionManager);
-
+      return tlsStrategyBuilder.build();
     } catch (final Exception e) {
       LOGGER.error("Error in setting up SSLContext", e);
+      return null;
     }
   }
 }

--- a/search/search-client-connect/src/test/java/io/camunda/search/connect/es/ElasticsearchConnectorTest.java
+++ b/search/search-client-connect/src/test/java/io/camunda/search/connect/es/ElasticsearchConnectorTest.java
@@ -26,6 +26,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestWrapper;
 import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.protocol.BasicHttpContext;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -88,6 +89,40 @@ class ElasticsearchConnectorTest {
 
     assertThat(reqWrapper.getFirstHeader(KEY_CUSTOM_HEADER).getValue())
         .isEqualTo(VALUE_CUSTOM_HEADER);
+  }
+
+  @Test
+  void shouldConfigureConnectionPoolLimitsWhenSet() {
+    // given
+    final var configuration = new ConnectConfiguration();
+    configuration.setMaxConnections(75);
+    configuration.setMaxConnectionsPerRoute(40);
+    final var connector =
+        new ElasticsearchConnector(configuration, new ObjectMapper(), new PluginRepository());
+    final var builder = Mockito.mock(HttpAsyncClientBuilder.class);
+
+    // when
+    connector.configureHttpClient(builder, configuration);
+
+    // then
+    Mockito.verify(builder).setMaxConnTotal(75);
+    Mockito.verify(builder).setMaxConnPerRoute(40);
+  }
+
+  @Test
+  void shouldNotConfigureConnectionPoolLimitsWhenUnset() {
+    // given
+    final var configuration = new ConnectConfiguration();
+    final var connector =
+        new ElasticsearchConnector(configuration, new ObjectMapper(), new PluginRepository());
+    final var builder = Mockito.mock(HttpAsyncClientBuilder.class);
+
+    // when
+    connector.configureHttpClient(builder, configuration);
+
+    // then
+    Mockito.verify(builder, Mockito.never()).setMaxConnTotal(Mockito.anyInt());
+    Mockito.verify(builder, Mockito.never()).setMaxConnPerRoute(Mockito.anyInt());
   }
 
   private static final class NoopCallback implements FutureCallback<HttpResponse> {

--- a/search/search-client-connect/src/test/java/io/camunda/search/connect/os/OpensearchConnectorTest.java
+++ b/search/search-client-connect/src/test/java/io/camunda/search/connect/os/OpensearchConnectorTest.java
@@ -24,6 +24,9 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.nio.AsyncClientConnectionManager;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.HttpHost;
@@ -33,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.client.transport.aws.AwsSdk2Transport;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5Transport;
@@ -171,6 +175,42 @@ class OpensearchConnectorTest {
             credentialsProvider.getCredentials(
                 new AuthScope(new HttpHost("http", "opensearch-2", 9206)), context))
         .isNotNull();
+  }
+
+  @Test
+  void shouldConfigureConnectionPoolLimitsWhenSet() {
+    // given
+    final var configuration = new ConnectConfiguration();
+    configuration.setMaxConnections(75);
+    configuration.setMaxConnectionsPerRoute(40);
+    final var connector =
+        new OpensearchConnector(configuration, new ObjectMapper(), null, new PluginRepository());
+    final var builder = Mockito.mock(HttpAsyncClientBuilder.class);
+
+    // when
+    connector.configureHttpClient(builder, configuration);
+
+    // then
+    final var captor = ArgumentCaptor.forClass(AsyncClientConnectionManager.class);
+    Mockito.verify(builder).setConnectionManager(captor.capture());
+    final var connectionManager = (PoolingAsyncClientConnectionManager) captor.getValue();
+    Assertions.assertThat(connectionManager.getMaxTotal()).isEqualTo(75);
+    Assertions.assertThat(connectionManager.getDefaultMaxPerRoute()).isEqualTo(40);
+  }
+
+  @Test
+  void shouldNotConfigureConnectionManagerWhenNothingSet() {
+    // given
+    final var configuration = new ConnectConfiguration();
+    final var connector =
+        new OpensearchConnector(configuration, new ObjectMapper(), null, new PluginRepository());
+    final var builder = Mockito.mock(HttpAsyncClientBuilder.class);
+
+    // when
+    connector.configureHttpClient(builder, configuration);
+
+    // then
+    Mockito.verify(builder, Mockito.never()).setConnectionManager(Mockito.any());
   }
 
   private static CloseableHttpAsyncClient getOpensearchApacheClient(


### PR DESCRIPTION
## Description

Add two configurable connection-pool limits to the unified search client so operators can tune the HTTP client for high-throughput deployments:
- camunda.data.secondary-storage.{elasticsearch,opensearch}.max-connections -> setMaxConnTotal (total connections in the pool)
- camunda.data.secondary-storage.{elasticsearch,opensearch}.max-connections-per-route -> setMaxConnPerRoute (connections allowed per route) Without these, the clients fall back to the Apache HttpClient defaults, which can be exhausted when a component uses many connections (e.g. running the archiver with a high thread count), throttling other operations such as health checks. Both properties default to unset, preserving current behaviour. The OpenSearch connector is refactored so the PoolingAsyncClientConnectionManager is built once and carries both the TLS strategy and the pool limits, instead of only being created when TLS is enabled.

## Related issues

closes #55080 
