### PR TITLE
docs: add Grafana MCP section to load-test-ops skill

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -165,14 +165,17 @@ manual port-forward required.
 1. Active Teleport session with kubectl access to the benchmark cluster.
 2. A Grafana service account token. Generate one in the Grafana UI under
    *Administration → Service Accounts*, with the `Viewer` role. Store it locally:
+
    ```bash
    echo "<YOUR_TOKEN>" > ~/.grafana-sa-token
    ```
 3. Install the `mcp-grafana` binary:
+
    ```bash
    pip install mcp-grafana
    ```
 4. Create a wrapper script at `~/.local/bin/grafana-mcp-wrapper.sh`:
+
    ```bash
    #!/bin/bash
    set -e
@@ -188,13 +191,16 @@ manual port-forward required.
    sleep 2
    mcp-grafana "$@"
    ```
+
    ```bash
    chmod +x ~/.local/bin/grafana-mcp-wrapper.sh
    ```
 5. Register it as an MCP server in Claude Code:
+
    ```bash
    claude mcp add -s user grafana -- ~/.local/bin/grafana-mcp-wrapper.sh
    ```
+
    Restart Claude Code for the change to take effect.
 
 **Usage in Claude Code sessions:**

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -154,6 +154,69 @@ More details about observability can be read [here](../docs/observability.md).
 
 For a full list of Prometheus metrics, SLO targets, and PromQL queries used to evaluate load tests, see [docs/metrics.md](docs/metrics.md).
 
+### Accessing metrics via Claude Code (Grafana MCP)
+
+If you are using Claude Code and have kubectl access to the benchmark cluster, you can query
+Prometheus directly inside a Claude session using the `mcp__grafana__*` tools — no browser or
+manual port-forward required.
+
+**Prerequisites:**
+
+1. Active Teleport session with kubectl access to the benchmark cluster.
+2. A Grafana service account token. Generate one in the Grafana UI under
+   *Administration → Service Accounts*, with the `Viewer` role. Store it locally:
+   ```bash
+   echo "<YOUR_TOKEN>" > ~/.grafana-sa-token
+   ```
+3. Install the `mcp-grafana` binary:
+   ```bash
+   pip install mcp-grafana
+   ```
+4. Create a wrapper script at `~/.local/bin/grafana-mcp-wrapper.sh`:
+   ```bash
+   #!/bin/bash
+   set -e
+   export GRAFANA_SERVICE_ACCOUNT_TOKEN=$(cat "$HOME/.grafana-sa-token")
+   export GRAFANA_URL="http://localhost:3000"
+
+   # Port-forward bypasses the Vouch SSO proxy in front of dashboard.benchmark.camunda.cloud
+   kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80 \
+     >>/tmp/grafana-pf.log 2>&1 &
+   PF_PID=$!
+   trap "kill $PF_PID 2>/dev/null" EXIT TERM INT
+
+   sleep 2
+   mcp-grafana "$@"
+   ```
+   ```bash
+   chmod +x ~/.local/bin/grafana-mcp-wrapper.sh
+   ```
+5. Register it as an MCP server in Claude Code:
+   ```bash
+   claude mcp add -s user grafana -- ~/.local/bin/grafana-mcp-wrapper.sh
+   ```
+   Restart Claude Code for the change to take effect.
+
+**Usage in Claude Code sessions:**
+
+```
+# Verify connection
+mcp__grafana__check_datasources_health()
+  → datasourceUid: "prometheus" should show status: OK
+
+# Always discover metric names before writing queries — guessed names return empty silently
+mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="zeebe.*", limit=50)
+
+# Discover active namespaces
+mcp__grafana__list_prometheus_label_values(
+  datasourceUid="prometheus", labelName="namespace",
+  matches=[{filters: [{name: "__name__", value: "zeebe_.*", type: "=~"}]}],
+  startRfc3339="now-24h")
+```
+
+The `load-test-ops` skill (see [skills/load-test-ops/SKILL.md](skills/load-test-ops/SKILL.md))
+documents confirmed metric names and known dashboard UIDs for the benchmark cluster.
+
 ## Test Scenarios
 
 We have different scenarios targeting different use cases and versions. All use the same [setup](#setup) and [endurance test variants](../docs/testing/reliability-testing.md#endurance-test-variants) defined in the reliability testing documentation.

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -199,23 +199,17 @@ manual port-forward required.
 
 **Usage in Claude Code sessions:**
 
-```
-# Verify connection
-mcp__grafana__check_datasources_health()
-  → datasourceUid: "prometheus" should show status: OK
+Always call `mcp__grafana__check_datasources_health()` first to confirm the `prometheus`
+datasource is reachable. Then discover metric names before writing any PromQL query — guessed
+names return empty results silently:
 
-# Always discover metric names before writing queries — guessed names return empty silently
+```bash
 mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="zeebe.*", limit=50)
-
-# Discover active namespaces
-mcp__grafana__list_prometheus_label_values(
-  datasourceUid="prometheus", labelName="namespace",
-  matches=[{filters: [{name: "__name__", value: "zeebe_.*", type: "=~"}]}],
-  startRfc3339="now-24h")
 ```
 
-The `load-test-ops` skill (see [skills/load-test-ops/SKILL.md](skills/load-test-ops/SKILL.md))
-documents confirmed metric names and known dashboard UIDs for the benchmark cluster.
+For the full list of metric names and PromQL queries, see [docs/metrics.md](docs/metrics.md).
+The `load-test-ops` skill ([skills/load-test-ops/SKILL.md](skills/load-test-ops/SKILL.md))
+documents known dashboard UIDs for the benchmark cluster.
 
 ## Test Scenarios
 

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -395,9 +395,7 @@ mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="ze
 - `optmetrics` — Optimize performance investigation (26 panels); key: id=15 CPU, id=6 import time MAX
 - `prhrb87` — Optimize Dashboard; key: id=37 ES disk, id=34 data availability latency heatmap
 
-For multi-namespace Optimize investigations, use `optimize-extract-metrics.py` from
-`~/config/dotfiles/scripts/camunda/` — queries all 6 `c8-ck-optimize-*` namespaces via
-`$GRAFANA_URL` and writes `/tmp/optimize-metrics-raw.md`.
+See `load-tests/README.md` → **Accessing metrics via Claude Code (Grafana MCP)** for setup instructions.
 
 ### Via local script (kubectl + port-forward)
 

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -390,6 +390,8 @@ mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="ze
 - `zeebe_exporter_exporting_duration_seconds_bucket` — exporter flush latency histogram
 - `zeebe_dropped_request_count_total` — dropped/backpressure requests
 
+For the full list of metrics and PromQL queries, see [load-tests/docs/metrics.md](../../docs/metrics.md).
+
 **Known benchmark cluster dashboards:**
 - `camunda-performance` — general throughput/latency/resource overview (namespace variable)
 - `optmetrics` — Optimize performance investigation (26 panels); key: id=15 CPU, id=6 import time MAX

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -353,6 +353,52 @@ gh run view "$RUN_ID" --repo camunda/camunda
 for a ~20-min window. Results render in the job summary; the workflow is also reusable via
 `workflow_call` and exposes `results-json` for downstream jobs (e.g. analyze → delete).
 
+### Via Grafana MCP (in Claude Code sessions — no port-forward needed)
+
+Use `mcp__grafana__*` tools directly when running inside Claude Code. Confirm tools are active
+with `mcp__grafana__check_datasources_health` at session start.
+
+**Rule: always run `list_prometheus_metric_names` before writing any PromQL query.** Guessed
+metric names return empty results silently — one discovery call eliminates all name-guess failures.
+
+**Session startup:**
+```
+mcp__grafana__check_datasources_health()
+  → datasourceUid: "prometheus" should show status: OK
+
+mcp__grafana__list_prometheus_label_values(
+  datasourceUid="prometheus", labelName="namespace",
+  matches=[{filters: [{name: "__name__", value: "zeebe_.*", type: "=~"}]}],
+  startRfc3339="now-24h")
+  → lists all namespaces with recent Zeebe data
+```
+
+**Metric name discovery:**
+```
+mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="optimize.*", limit=50)
+mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="zeebe.*process.*", limit=20)
+```
+
+**Confirmed metric names on benchmark cluster (verified 2026-06-25):**
+- `optimize_import_overallImportTime_seconds_max` — Optimize overall import time
+- `optimize_import_indexingDuration_seconds_max` — Optimize indexing duration
+- `elasticsearch_indices_store_size_bytes_primary` — ES primary index size
+- `elasticsearch_filesystem_data_size_bytes` / `elasticsearch_filesystem_data_available_bytes`
+- `node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m` — CPU by namespace
+- `container_memory_working_set_bytes` — memory (use `container!=""` to exclude pause containers)
+- `zeebe_process_instance_creations_total` — PI creation rate
+- `zeebe_exporter_exporting_duration_seconds_bucket` — exporter flush latency histogram
+- `zeebe_dropped_request_count_total` — dropped/backpressure requests
+
+**Known benchmark cluster dashboards:**
+- `camunda-performance` — general throughput/latency/resource overview (namespace variable)
+- `optmetrics` — Optimize performance investigation (26 panels); key: id=15 CPU, id=6 import time MAX
+- `prhrb87` — Optimize Dashboard; key: id=37 ES disk, id=34 data availability latency heatmap
+
+For multi-namespace Optimize investigations, use `optimize-extract-metrics.py` from
+`~/config/dotfiles/scripts/camunda/` — queries all 6 `c8-ck-optimize-*` namespaces via
+`$GRAFANA_URL` and writes `/tmp/optimize-metrics-raw.md`.
+
 ### Via local script (kubectl + port-forward)
 
 Faster when you have cluster access. First port-forward the monitoring Prometheus pod, then run

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -379,23 +379,11 @@ mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="op
 mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="zeebe.*process.*", limit=20)
 ```
 
-**Confirmed metric names on benchmark cluster (verified 2026-06-25):**
-- `optimize_import_overallImportTime_seconds_max` — Optimize overall import time
-- `optimize_import_indexingDuration_seconds_max` — Optimize indexing duration
-- `elasticsearch_indices_store_size_bytes_primary` — ES primary index size
-- `elasticsearch_filesystem_data_size_bytes` / `elasticsearch_filesystem_data_available_bytes`
-- `node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m` — CPU by namespace
-- `container_memory_working_set_bytes` — memory (use `container!=""` to exclude pause containers)
-- `zeebe_process_instance_creations_total` — PI creation rate
-- `zeebe_exporter_exporting_duration_seconds_bucket` — exporter flush latency histogram
-- `zeebe_dropped_request_count_total` — dropped/backpressure requests
-
-For the full list of metrics and PromQL queries, see [load-tests/docs/metrics.md](../../docs/metrics.md).
+For metric names and PromQL queries, see [load-tests/docs/metrics.md](../../docs/metrics.md).
 
 **Known benchmark cluster dashboards:**
 - `camunda-performance` — general throughput/latency/resource overview (namespace variable)
-- `optmetrics` — Optimize performance investigation (26 panels); key: id=15 CPU, id=6 import time MAX
-- `prhrb87` — Optimize Dashboard; key: id=37 ES disk, id=34 data availability latency heatmap
+- `zeebe-dashboard` — deep dive into Zeebe internals (backpressure, partitions, exporters)
 
 See `load-tests/README.md` → **Accessing metrics via Claude Code (Grafana MCP)** for setup instructions.
 


### PR DESCRIPTION
## Summary

- Adds a new **Via Grafana MCP** subsection to the `## Analyze metrics` section of the load-test-ops skill
- Documents the discovery-first rule: always run `list_prometheus_metric_names` before any PromQL query — guessed names return empty results silently
- References known dashboard UIDs (`camunda-performance`, `zeebe`)
- Adds explanation how to setup on the README

This enables Claude Code sessions to query Prometheus metrics directly via the Grafana MCP 

🤖 Generated with [Claude Code](https://claude.com/claude-code)