### PR TITLE
ci: fix ownership gaps and sort-instability bugs in .codeowners

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -23,7 +23,6 @@ CODEOWNERS                  @camunda/orchestration-cluster
 AGENTS.md                   @camunda/orchestration-cluster
 CLAUDE.md                   @camunda/orchestration-cluster
 /.claude/                   @camunda/orchestration-cluster
-/.claude/skills/            @camunda/orchestration-cluster
 CHANGELOG.md                @camunda/orchestration-cluster
 CODE_OF_CONDUCT.md          @camunda/orchestration-cluster
 CONTRIBUTING.md             @camunda/orchestration-cluster

--- a/.codeowners
+++ b/.codeowners
@@ -384,6 +384,7 @@ optimize.Dockerfile         @camunda/core-features
 # Note: trailing /* (wildcard) not trailing / (globstar) — ensures these override the broad
 # /qa/ rule regardless of codeowners-plus sort order. Add new subdirs explicitly as they appear.
 /qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/*              @camunda/data-layer
+/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/*/*            @camunda/data-layer
 /qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/*        @camunda/data-layer
 /qa/acceptance-tests/src/test/java/io/camunda/it/schema/*                @camunda/data-layer
 /qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/*       @camunda/data-layer

--- a/.codeowners
+++ b/.codeowners
@@ -1,6 +1,15 @@
 # Each line is a file pattern followed by one or more owners.
 # If you'd like to be added as an owner, open a Pull Request and contact an existing owner.
 # Ownership information is used for attributing e.g. failing or flaky tests, broken CI workflows, etc.
+#
+# File is organized by team. To view all rules for your team:
+#   grep "@camunda/TEAM" .codeowners
+# To view effective ownership per file (resolves cascading rules):
+#   codeowners-cli map --by owner --root ./ | jq '."@camunda/TEAM"'
+#
+# Ordering: codeowners-plus uses last-match-wins within each pattern priority tier.
+# When a specific path must override a broader rule from another section, put it
+# in the "Late overrides" section at the bottom of this file.
 
 ################################
 ## @camunda/orchestration-cluster
@@ -13,9 +22,8 @@ CODEOWNERS                  @camunda/orchestration-cluster
 
 AGENTS.md                   @camunda/orchestration-cluster
 CLAUDE.md                   @camunda/orchestration-cluster
-/.claude/skills/README.md   @camunda/orchestration-cluster
-/.claude/skills/create-issue/ @camunda/orchestration-cluster
-/.claude/skills/grill-me/   @camunda/orchestration-cluster
+/.claude/                   @camunda/orchestration-cluster
+/.claude/skills/            @camunda/orchestration-cluster
 CHANGELOG.md                @camunda/orchestration-cluster
 CODE_OF_CONDUCT.md          @camunda/orchestration-cluster
 CONTRIBUTING.md             @camunda/orchestration-cluster
@@ -181,12 +189,8 @@ mwnw*                       @camunda/monorepo-devops-team
 /zeebe/test-util/ @camunda/core-features @camunda/zeebe-distributed-platform
 /zeebe/util/ @camunda/core-features @camunda/zeebe-distributed-platform
 
-# Zeebe integration tests
-/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/ @camunda/zeebe-distributed-platform
-/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/ @camunda/core-features @camunda/zeebe-distributed-platform
-/zeebe/qa/integration-tests/src/main/java/io/camunda/zeebe/it/shared/ @camunda/core-features @camunda/zeebe-distributed-platform
-/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ @camunda/core-features @camunda/zeebe-distributed-platform
-/zeebe/qa/integration-tests/src/main/java/io/camunda/zeebe/it/util/ @camunda/core-features @camunda/zeebe-distributed-platform
+# Zeebe integration tests: specific overrides are in the Late overrides section
+# (must come after /zeebe/qa/integration-tests/ @core-features defined in the core-features section)
 
 # Acceptance tests
 /qa/acceptance-tests/src/test/java/io/camunda/it/cluster/    @camunda/zeebe-distributed-platform
@@ -377,10 +381,14 @@ optimize.Dockerfile         @camunda/core-features
 /tasklist/importer-common/  @camunda/data-layer
 
 # Acceptance tests
-/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/      @camunda/data-layer
-/qa/acceptance-tests/src/test/java/io/camunda/it/schema/     @camunda/data-layer
-/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/       @camunda/data-layer
-/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/ @camunda/data-layer
+# Note: trailing /* (wildcard) not trailing / (globstar) — ensures these override the broad
+# /qa/ rule regardless of codeowners-plus sort order. Add new subdirs explicitly as they appear.
+/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/*              @camunda/data-layer
+/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/*        @camunda/data-layer
+/qa/acceptance-tests/src/test/java/io/camunda/it/schema/*                @camunda/data-layer
+/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/*       @camunda/data-layer
+/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/*                  @camunda/data-layer
+/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/*        @camunda/data-layer
 
 # CI/CD Workflows
 /.github/actions/rdbms/* @camunda/data-layer
@@ -415,3 +423,13 @@ optimize.Dockerfile         @camunda/core-features
 /.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml @camunda/camundaex
 /.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml @camunda/qa-engineering
 /.github/workflows/zeebe-release-stable-dry-run.yml @camunda/monorepo-devops-team
+
+# Zeebe integration tests: zeebe-distributed-platform owns cluster/shared/util;
+# core-features owns everything else via /zeebe/qa/integration-tests/ above.
+# These must be last to override that broad rule (last-match-wins).
+# Tracking: https://github.com/multimediallc/codeowners-plus/issues/154
+/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/ @camunda/zeebe-distributed-platform
+/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/ @camunda/core-features @camunda/zeebe-distributed-platform
+/zeebe/qa/integration-tests/src/main/java/io/camunda/zeebe/it/shared/ @camunda/core-features @camunda/zeebe-distributed-platform
+/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ @camunda/core-features @camunda/zeebe-distributed-platform
+/zeebe/qa/integration-tests/src/main/java/io/camunda/zeebe/it/util/ @camunda/core-features @camunda/zeebe-distributed-platform

--- a/.github/scripts/test-codeowners.sh
+++ b/.github/scripts/test-codeowners.sh
@@ -5,9 +5,13 @@ set -euo pipefail
 
 WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
 # codeowners-cli requires a real .git directory; git worktrees have a .git file.
-# Fall back to the common git dir's parent (the main checkout) when in a worktree.
+# Fall back to the common git dir's parent (the main checkout) when in a worktree,
+# but copy the current branch's .codeowners there so we validate the right file.
 if [[ -f "${WORKTREE_ROOT}/.git" ]]; then
   REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
+  _ORIG_CODEOWNERS="$(cat "${REPO_ROOT}/.codeowners")"
+  cp "${WORKTREE_ROOT}/.codeowners" "${REPO_ROOT}/.codeowners"
+  trap 'printf "%s" "${_ORIG_CODEOWNERS}" > "${REPO_ROOT}/.codeowners"' EXIT
 else
   REPO_ROOT="${WORKTREE_ROOT}"
 fi
@@ -30,21 +34,26 @@ assert_owner() {
   shift 2
   local expected=("$@")
 
-  local json stderr_out exit_code=0
-  json=$("${CODEOWNERS_CLI}" owner --root "${REPO_ROOT}" --format json "${file}" 2>/tmp/_co_stderr) || exit_code=$?
-  stderr_out=$(cat /tmp/_co_stderr 2>/dev/null || true)
-  if [[ $exit_code -ne 0 ]] || echo "${stderr_out}" | grep -q "^Error:"; then
+  local _stderr _json _exit_code=0
+  _stderr="$(mktemp)"
+  _json=$("${CODEOWNERS_CLI}" owner --root "${REPO_ROOT}" --format json "${file}" 2>"${_stderr}") || _exit_code=$?
+  local stderr_out
+  stderr_out=$(cat "${_stderr}"); rm -f "${_stderr}"
+  if [[ $_exit_code -ne 0 ]] || echo "${stderr_out}" | grep -q "^Error:"; then
     echo -e "  ${RED}ERROR${NC}: ${description} (${file}): CLI error: ${stderr_out}"
     (( FAIL++ )) || true
     return
   fi
 
-  local actual_required
-  actual_required=$(echo "${json}" | jq -r --arg f "${file}" '.[$f].required[]?' | sort | tr '\n' ' ' | sed 's/ $//')
+  # OR-groups are returned as "ownerA or ownerB" in a single array entry.
+  # Split on " or " so each name becomes its own line for exact matching.
+  local actual_required_lines actual_required
+  actual_required_lines=$(echo "${_json}" | jq -r --arg f "${file}" '.[$f].required[]?' | sed 's/ or /\n/g' | sort)
+  actual_required=$(echo "${actual_required_lines}" | tr '\n' ' ' | sed 's/ $//')
 
   local missing=()
   for owner in "${expected[@]}"; do
-    if ! echo "${actual_required}" | grep -qF "${owner}"; then
+    if ! echo "${actual_required_lines}" | grep -qxF "${owner}"; then
       missing+=("${owner}")
     fi
   done
@@ -70,21 +79,26 @@ assert_owner_bug() {
   shift 2
   local expected=("$@")
 
-  local json stderr_out exit_code=0
-  json=$("${CODEOWNERS_CLI}" owner --root "${REPO_ROOT}" --format json "${file}" 2>/tmp/_co_stderr) || exit_code=$?
-  stderr_out=$(cat /tmp/_co_stderr 2>/dev/null || true)
-  if [[ $exit_code -ne 0 ]] || echo "${stderr_out}" | grep -q "^Error:"; then
+  local _stderr _json _exit_code=0
+  _stderr="$(mktemp)"
+  _json=$("${CODEOWNERS_CLI}" owner --root "${REPO_ROOT}" --format json "${file}" 2>"${_stderr}") || _exit_code=$?
+  local stderr_out
+  stderr_out=$(cat "${_stderr}"); rm -f "${_stderr}"
+  if [[ $_exit_code -ne 0 ]] || echo "${stderr_out}" | grep -q "^Error:"; then
     echo -e "  ${RED}ERROR${NC} [BUG]: ${description}: CLI error"
     (( BUGS++ )) || true
     return
   fi
 
-  local actual_required
-  actual_required=$(echo "${json}" | jq -r --arg f "${file}" '.[$f].required[]?' | sort | tr '\n' ' ' | sed 's/ $//')
+  # OR-groups are returned as "ownerA or ownerB" in a single array entry.
+  # Split on " or " so each name becomes its own line for exact matching.
+  local actual_required_lines actual_required
+  actual_required_lines=$(echo "${_json}" | jq -r --arg f "${file}" '.[$f].required[]?' | sed 's/ or /\n/g' | sort)
+  actual_required=$(echo "${actual_required_lines}" | tr '\n' ' ' | sed 's/ $//')
 
   local missing=()
   for owner in "${expected[@]}"; do
-    if ! echo "${actual_required}" | grep -qF "${owner}"; then
+    if ! echo "${actual_required_lines}" | grep -qxF "${owner}"; then
       missing+=("${owner}")
     fi
   done

--- a/.github/scripts/test-codeowners.sh
+++ b/.github/scripts/test-codeowners.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# Tests for .codeowners ownership rules using codeowners-plus CLI.
+# Run from the repo root: .github/scripts/test-codeowners.sh
+set -euo pipefail
+
+WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
+# codeowners-cli requires a real .git directory; git worktrees have a .git file.
+# Fall back to the common git dir's parent (the main checkout) when in a worktree.
+if [[ -f "${WORKTREE_ROOT}/.git" ]]; then
+  REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
+else
+  REPO_ROOT="${WORKTREE_ROOT}"
+fi
+CODEOWNERS_CLI="${CODEOWNERS_CLI:-codeowners-cli}"
+PASS=0
+FAIL=0
+BUGS=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# assert_owner <description> <file> <expected_owners...>
+# Checks that all expected owners appear in the 'required' list.
+assert_owner() {
+  local description="$1"
+  local file="$2"
+  shift 2
+  local expected=("$@")
+
+  local json stderr_out
+  json=$("${CODEOWNERS_CLI}" owner --root "${REPO_ROOT}" --format json "${file}" 2>/tmp/_co_stderr) || true
+  stderr_out=$(cat /tmp/_co_stderr 2>/dev/null || true)
+  if echo "${stderr_out}" | grep -q "^Error:"; then
+    echo -e "  ${RED}ERROR${NC}: ${description} (${file}): CLI error: ${stderr_out}"
+    (( FAIL++ )) || true
+    return
+  fi
+
+  local actual_required
+  actual_required=$(echo "${json}" | jq -r --arg f "${file}" '.[$f].required[]?' | sort | tr '\n' ' ' | sed 's/ $//')
+
+  local missing=()
+  for owner in "${expected[@]}"; do
+    if ! echo "${actual_required}" | grep -qF "${owner}"; then
+      missing+=("${owner}")
+    fi
+  done
+
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    echo -e "  ${GREEN}PASS${NC}: ${description}"
+    (( PASS++ )) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: ${description}"
+    echo -e "        file:     ${file}"
+    echo -e "        expected: ${expected[*]}"
+    echo -e "        actual:   ${actual_required:-"(none)"}"
+    echo -e "        missing:  ${missing[*]}"
+    (( FAIL++ )) || true
+  fi
+}
+
+# assert_owner_bug: same as assert_owner but marks it as a known bug.
+# Test is expected to FAIL — it documents broken behavior.
+assert_owner_bug() {
+  local description="$1"
+  local file="$2"
+  shift 2
+  local expected=("$@")
+
+  local json stderr_out
+  json=$("${CODEOWNERS_CLI}" owner --root "${REPO_ROOT}" --format json "${file}" 2>/tmp/_co_stderr) || true
+  stderr_out=$(cat /tmp/_co_stderr 2>/dev/null || true)
+  if echo "${stderr_out}" | grep -q "^Error:"; then
+    echo -e "  ${RED}ERROR${NC} [BUG]: ${description}: CLI error"
+    (( BUGS++ )) || true
+    return
+  fi
+
+  local actual_required
+  actual_required=$(echo "${json}" | jq -r --arg f "${file}" '.[$f].required[]?' | sort | tr '\n' ' ' | sed 's/ $//')
+
+  local missing=()
+  for owner in "${expected[@]}"; do
+    if ! echo "${actual_required}" | grep -qF "${owner}"; then
+      missing+=("${owner}")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo -e "  ${YELLOW}BUG CONFIRMED${NC}: ${description}"
+    echo -e "        file:     ${file}"
+    echo -e "        expected: ${expected[*]}"
+    echo -e "        actual:   ${actual_required:-"(none)"}"
+    echo -e "        missing (shadowed): ${missing[*]}"
+    (( BUGS++ )) || true
+  else
+    echo -e "  ${GREEN}BUG FIXED${NC}: ${description} — expected owners now present"
+    (( PASS++ )) || true
+  fi
+}
+
+echo ""
+echo "========================================"
+echo " .codeowners ownership tests"
+echo "========================================"
+
+# ── /qa/ default ownership ────────────────────────────────────────────────────
+echo ""
+echo "── /qa/ default (qa-engineering) ──"
+
+assert_owner \
+  "qa/pom.xml → qa-engineering" \
+  "qa/pom.xml" \
+  "@camunda/qa-engineering"
+
+# ── /qa/ overrides: orchestration-cluster ────────────────────────────────────
+echo ""
+echo "── /qa/ overrides → orchestration-cluster ──"
+
+assert_owner \
+  "qa/archunit-tests/ → orchestration-cluster" \
+  "qa/archunit-tests/src/test/java/io/camunda/ForbidSpringProblemDetailArchTest.java" \
+  "@camunda/orchestration-cluster"
+
+assert_owner \
+  "qa/util/ → orchestration-cluster" \
+  "qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java" \
+  "@camunda/orchestration-cluster"
+
+# ── /qa/acceptance-tests dual ownership: util/ ───────────────────────────────
+echo ""
+echo "── /qa/acceptance-tests/util/ → dual ownership ──"
+
+assert_owner \
+  "acceptance-tests util/ → qa-engineering AND orchestration-cluster" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java" \
+  "@camunda/qa-engineering" "@camunda/orchestration-cluster"
+
+# ── /qa/acceptance-tests → camundaex ─────────────────────────────────────────
+echo ""
+echo "── /qa/acceptance-tests → camundaex ──"
+
+assert_owner \
+  "acceptance-tests client/ → camundaex" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/client/UnassignClientFromTenantIT.java" \
+  "@camunda/camundaex"
+
+assert_owner \
+  "acceptance-tests spring/ → camundaex" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/spring/AbstractSpringDependenciesTest.java" \
+  "@camunda/camundaex"
+
+# ── /qa/acceptance-tests → identity ──────────────────────────────────────────
+echo ""
+echo "── /qa/acceptance-tests → identity ──"
+
+assert_owner \
+  "acceptance-tests identity/ → identity" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeInvalidTenantIT.java" \
+  "@camunda/identity"
+
+assert_owner \
+  "acceptance-tests auth/ → identity" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/auth/UsageMetricAuthorizationIT.java" \
+  "@camunda/identity"
+
+assert_owner \
+  "acceptance-tests oidc/ → identity" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/oidc/OverlappingUsernameAndClientIdClaimTest.java" \
+  "@camunda/identity"
+
+assert_owner \
+  "acceptance-tests csrf/ → identity" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/csrf/CsrfTokenIT.java" \
+  "@camunda/identity"
+
+assert_owner \
+  "acceptance-tests logout/ → identity" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/logout/BasicAuthLogoutIT.java" \
+  "@camunda/identity"
+
+# ── /qa/acceptance-tests → zeebe-distributed-platform ───────────────────────
+echo ""
+echo "── /qa/acceptance-tests → zeebe-distributed-platform ──"
+
+assert_owner \
+  "acceptance-tests cluster/ → zeebe-distributed-platform" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeMultiDbIT.java" \
+  "@camunda/zeebe-distributed-platform"
+
+assert_owner \
+  "acceptance-tests backup/ → zeebe-distributed-platform" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/backup/AbstractBackupRestoreIT.java" \
+  "@camunda/zeebe-distributed-platform"
+
+assert_owner \
+  "acceptance-tests network/ → zeebe-distributed-platform" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java" \
+  "@camunda/zeebe-distributed-platform"
+
+# ── /qa/acceptance-tests → data-layer ────────────────────────────────────────
+echo ""
+echo "── /qa/acceptance-tests → data-layer ──"
+
+assert_owner \
+  "acceptance-tests rdbms/db/ → data-layer" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java" \
+  "@camunda/data-layer"
+
+assert_owner \
+  "acceptance-tests schema/ → data-layer" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java" \
+  "@camunda/data-layer"
+
+assert_owner \
+  "acceptance-tests nodb/ → data-layer" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/nodb/BasicAuthNoSecondaryStorageTest.java" \
+  "@camunda/data-layer"
+
+assert_owner \
+  "acceptance-tests historycleanup/ → data-layer" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java" \
+  "@camunda/data-layer"
+
+# ── /qa/acceptance-tests → core-features ─────────────────────────────────────
+echo ""
+echo "── /qa/acceptance-tests → core-features ──"
+
+assert_owner \
+  "acceptance-tests task/ → core-features" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java" \
+  "@camunda/core-features"
+
+assert_owner \
+  "acceptance-tests orchestration/ → core-features" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/JobIT.java" \
+  "@camunda/core-features"
+
+assert_owner \
+  "acceptance-tests mcp/ → core-features" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java" \
+  "@camunda/core-features"
+
+assert_owner \
+  "acceptance-tests tenancy/ → core-features" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java" \
+  "@camunda/core-features"
+
+assert_owner \
+  "acceptance-tests auditlog/ → core-features" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogWithoutAuthorizationsIT.java" \
+  "@camunda/core-features"
+
+assert_owner \
+  "acceptance-tests historydeletion/ → core-features" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionInstanceHistoryIT.java" \
+  "@camunda/core-features"
+
+assert_owner \
+  "acceptance-tests document/ → core-features" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java" \
+  "@camunda/core-features"
+
+# ── /zeebe/qa/integration-tests ordering bug ─────────────────────────────────
+echo ""
+echo "── /zeebe/qa/integration-tests ownership ──"
+echo "   (cluster/shared/util → zeebe-distributed-platform pending https://github.com/multimediallc/codeowners-plus/issues/154)"
+
+assert_owner_bug \
+  "zeebe IT cluster/ → zeebe-distributed-platform (pending codeowners-plus sort fix)" \
+  "zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/config/IdleStrategyConfigIT.java" \
+  "@camunda/zeebe-distributed-platform"
+
+assert_owner_bug \
+  "zeebe IT shared/ → zeebe-distributed-platform (pending codeowners-plus sort fix)" \
+  "zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/smoke/NoSecondaryStorageSmokeIT.java" \
+  "@camunda/zeebe-distributed-platform"
+
+assert_owner_bug \
+  "zeebe IT util/ → zeebe-distributed-platform (pending codeowners-plus sort fix)" \
+  "zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeContainerUtil.java" \
+  "@camunda/zeebe-distributed-platform"
+
+assert_owner \
+  "zeebe IT engine/ → core-features" \
+  "zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java" \
+  "@camunda/core-features"
+
+assert_owner \
+  "zeebe IT exporter/ → core-features" \
+  "zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/AnalyticsExporterIT.java" \
+  "@camunda/core-features"
+
+# ── .claude/skills overrides ──────────────────────────────────────────────────
+echo ""
+echo "── .claude/skills overrides ──"
+
+assert_owner \
+  ".claude/skills/engine-expert/ → core-features (overrides orchestration-cluster)" \
+  ".claude/skills/engine-expert/SKILL.md" \
+  "@camunda/core-features"
+
+assert_owner \
+  ".claude/skills/load-test-ops/ → reliability-testing (overrides orchestration-cluster)" \
+  ".claude/skills/load-test-ops/SKILL.md" \
+  "@camunda/reliability-testing"
+
+assert_owner \
+  ".claude/skills/ci-validation/ → monorepo-devops-team (overrides orchestration-cluster)" \
+  ".claude/skills/ci-validation/SKILL.md" \
+  "@camunda/monorepo-devops-team"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "========================================"
+echo " Results"
+echo "========================================"
+echo -e "  ${GREEN}PASS${NC}:          ${PASS}"
+echo -e "  ${RED}FAIL${NC}:          ${FAIL}"
+echo -e "  ${YELLOW}BUGS CONFIRMED${NC}: ${BUGS}"
+echo ""
+
+if [[ ${FAIL} -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/.github/scripts/test-codeowners.sh
+++ b/.github/scripts/test-codeowners.sh
@@ -9,9 +9,10 @@ WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
 # but copy the current branch's .codeowners there so we validate the right file.
 if [[ -f "${WORKTREE_ROOT}/.git" ]]; then
   REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
-  _ORIG_CODEOWNERS="$(cat "${REPO_ROOT}/.codeowners")"
+  _ORIG_CODEOWNERS_BACKUP="$(mktemp)"
+  cp "${REPO_ROOT}/.codeowners" "${_ORIG_CODEOWNERS_BACKUP}"
   cp "${WORKTREE_ROOT}/.codeowners" "${REPO_ROOT}/.codeowners"
-  trap 'printf "%s" "${_ORIG_CODEOWNERS}" > "${REPO_ROOT}/.codeowners"' EXIT
+  trap 'cp "${_ORIG_CODEOWNERS_BACKUP}" "${REPO_ROOT}/.codeowners"; rm -f "${_ORIG_CODEOWNERS_BACKUP}"' EXIT
 else
   REPO_ROOT="${WORKTREE_ROOT}"
 fi

--- a/.github/scripts/test-codeowners.sh
+++ b/.github/scripts/test-codeowners.sh
@@ -30,10 +30,10 @@ assert_owner() {
   shift 2
   local expected=("$@")
 
-  local json stderr_out
-  json=$("${CODEOWNERS_CLI}" owner --root "${REPO_ROOT}" --format json "${file}" 2>/tmp/_co_stderr) || true
+  local json stderr_out exit_code=0
+  json=$("${CODEOWNERS_CLI}" owner --root "${REPO_ROOT}" --format json "${file}" 2>/tmp/_co_stderr) || exit_code=$?
   stderr_out=$(cat /tmp/_co_stderr 2>/dev/null || true)
-  if echo "${stderr_out}" | grep -q "^Error:"; then
+  if [[ $exit_code -ne 0 ]] || echo "${stderr_out}" | grep -q "^Error:"; then
     echo -e "  ${RED}ERROR${NC}: ${description} (${file}): CLI error: ${stderr_out}"
     (( FAIL++ )) || true
     return
@@ -70,10 +70,10 @@ assert_owner_bug() {
   shift 2
   local expected=("$@")
 
-  local json stderr_out
-  json=$("${CODEOWNERS_CLI}" owner --root "${REPO_ROOT}" --format json "${file}" 2>/tmp/_co_stderr) || true
+  local json stderr_out exit_code=0
+  json=$("${CODEOWNERS_CLI}" owner --root "${REPO_ROOT}" --format json "${file}" 2>/tmp/_co_stderr) || exit_code=$?
   stderr_out=$(cat /tmp/_co_stderr 2>/dev/null || true)
-  if echo "${stderr_out}" | grep -q "^Error:"; then
+  if [[ $exit_code -ne 0 ]] || echo "${stderr_out}" | grep -q "^Error:"; then
     echo -e "  ${RED}ERROR${NC} [BUG]: ${description}: CLI error"
     (( BUGS++ )) || true
     return
@@ -206,8 +206,13 @@ echo ""
 echo "── /qa/acceptance-tests → data-layer ──"
 
 assert_owner \
-  "acceptance-tests rdbms/db/ → data-layer" \
+  "acceptance-tests rdbms/db/ → data-layer (direct file)" \
   "qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java" \
+  "@camunda/data-layer"
+
+assert_owner \
+  "acceptance-tests rdbms/db/subdir/ → data-layer (nested file)" \
+  "qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java" \
   "@camunda/data-layer"
 
 assert_owner \


### PR DESCRIPTION
## Summary

Found and fixed two bug classes in `.codeowners` using `codeowners-cli` and a new automated test suite (`.github/scripts/test-codeowners.sh`).

### Bug 1 — data-layer acceptance tests shadowed by `qa/**` (fixed)

`rdbms/`, `schema/`, `nodb/`, `historycleanup/` under `qa/acceptance-tests/` were resolving to `@camunda/qa-engineering` instead of `@camunda/data-layer`.

**Root cause:** `codeowners-plus` converts trailing-`/` patterns to `/**` (globstar). With 400+ rules in the file, Go's `sort.Sort` (not stable) scrambles the order of same-priority globstar patterns, causing the earlier-declared `qa/**` to win over the later-declared specific overrides.

**Fix:** Use `/*` (wildcard, higher priority tier than globstar) with explicit subdir enumeration. This reliably overrides `qa/**` regardless of sort order.

**Upstream bug filed:** https://github.com/multimediallc/codeowners-plus/issues/154 (fix: `sort.Sort` → `sort.Stable` in `reader.go`)

### Bug 2 — zeebe IT cluster/shared/util shadowed by broad core-features rule (structured correctly, pending upstream fix)

`/zeebe/qa/integration-tests/src/.../cluster/`, `.../shared/`, `.../util/` were resolving to `@camunda/core-features` instead of `@camunda/zeebe-distributed-platform`, because the specific overrides in the zeebe-distributed-platform section came *before* the broad `/zeebe/qa/integration-tests/` rule in core-features.

**Fix:** Move the specific overrides to the Late overrides section (must be last-declared to win). Will work correctly once the upstream sort bug is fixed.

### Additional

- Add `/.claude/` ownership (`@camunda/orchestration-cluster`) — hooks and scripts were previously unowned
- Add header comment with grep/CLI map recipes for team-based filtering
- Add `.github/scripts/test-codeowners.sh`: 30-case test suite covering all ownership overrides

## Test plan

- [ ] Run `CODEOWNERS_CLI=$(which codeowners-cli) bash .github/scripts/test-codeowners.sh` — should show 30 PASS, 0 FAIL, 3 BUGS CONFIRMED (the 3 are zeebe IT entries pending upstream fix)
- [ ] Verify `codeowners-cli unowned --root ./` returns only `.claude/` ephemera (worktrees, memory files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)