### PR TITLE
fix: update tile label

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticKpiTilesIT.java
@@ -77,7 +77,7 @@ class AgenticKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   // ---------------------------------------------------------------------------
-  // Completed agent runs
+  // Total Executions (completed agent runs)
   // ---------------------------------------------------------------------------
 
   @Test

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -1573,7 +1573,7 @@
   "agenticControl": {
     "agenticControlPlaneDashboardName": "Agentic Control Dashboard",
     "report": {
-      "agenticKpiExecutionCompletedName": "Abgeschlossene Agenten-Läufe",
+      "agenticKpiExecutionCompletedName": "Abgeschlossene Ausführungen",
       "agenticKpiExecutionCompletedDescription": "Gesamtanzahl der abgeschlossenen agentischen Prozessinstanzen im gewählten Zeitraum.",
       "agenticKpiExecutionAvgDurationName": "Durchschnittliche Ausführungsdauer",
       "agenticKpiExecutionAvgDurationDescription": "Durchschnittliche Ausführungsdauer abgeschlossener agentischer Prozessinstanzen im gewählten Zeitraum.",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -1573,7 +1573,7 @@
   "agenticControl": {
     "agenticControlPlaneDashboardName": "Agentic Control Dashboard",
     "report": {
-      "agenticKpiExecutionCompletedName": "Completed agent runs",
+      "agenticKpiExecutionCompletedName": "Total Executions",
       "agenticKpiExecutionCompletedDescription": "Total number of completed agentic process instances in the selected period.",
       "agenticKpiExecutionAvgDurationName": "Avg execution duration",
       "agenticKpiExecutionAvgDurationDescription": "Average execution duration of completed agentic process instances in the selected period.",


### PR DESCRIPTION
related to #55837

## Description

Fix tile label to "Total Executions" instead of "Completed agent runs"

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55837
